### PR TITLE
refactor(core): ante.core.market_data_vocab SSOT 도입 + behavior-preserving 소비자 위임 (#1613)

### DIFF
--- a/src/ante/core/market_data_vocab.py
+++ b/src/ante/core/market_data_vocab.py
@@ -1,0 +1,74 @@
+r"""Canonical symbol/timeframe vocabulary — 코드 레벨 SSOT.
+
+이 모듈은 Ante 전역에서 OHLCV bar `timeframe`과 신규 입력 KRX `symbol`이
+의미하는 canonical vocabulary의 **코드 레벨 단일 출처(SSOT)** 다. 계약
+본문은 스펙에 있으며 본 모듈은 그 값 집합·검증 헬퍼를 코드에서 단일화한다:
+
+    docs/specs/core/core.md ``## Canonical Symbol/Timeframe Vocabulary``
+    docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md
+
+범위 불변식 (#1613 narrow-scope):
+    - 본 모듈은 **축 A — OHLCV bar timeframe canonical set** (고정 5종·
+      고정 순서) 과 **축 E — 신규 입력 KRX symbol shape** (`^[0-9]{6}$`,
+      exchange == KRX 신규 입력 한정) 의 값 집합·검증 헬퍼만 정의한다.
+    - surface별 enforcement·에러 계층·신규 표면 validation 추가는 본
+      모듈의 범위가 아니다 (#1603/#1604/#1605/#1606/#1611/#1614,
+      #1594 잔여 symbol filter).
+    - alias(예: `1min`/`D`/`daily`/`1D`)·대소문자 정규화·사용자 정의
+      timeframe set은 1.0 비목표다 (core.md ``### Canonical timeframe
+      set``). 입력은 아래 canonical 리터럴과 **정확히 일치**해야 한다 —
+      본 모듈의 헬퍼는 어떤 변환도(no-alias·no-normalization) 하지 않는다.
+    - 축 E 분리: 신규 입력 strict ASCII 검증(본 모듈)과 legacy parquet
+      path migration 판별(`src/ante/data/store.py` `\d` Unicode 보존)은
+      별개 축이다 (core.md ``### Legacy out-of-vocabulary 호환 정책``).
+      legacy 판별 regex는 본 SSOT로 위임·대체·강화되지 않는다.
+"""
+
+from __future__ import annotations
+
+import re
+
+# canonical OHLCV bar timeframe — 고정 집합·고정 순서 5종
+# (core.md ``### Canonical timeframe set``). 표기 순서
+# (`1m → 5m → 15m → 1h → 1d`)는 순서 의존 소비자(예:
+# `src/ante/cli/commands/data.py`의 iteration)를 위해 계약상 고정한다.
+# 따라서 순서가 의미를 갖는 tuple로 둔다 — 신규 입력 검증 vocabulary
+# 전체이며 불변이다.
+CANONICAL_TIMEFRAMES: tuple[str, ...] = ("1m", "5m", "15m", "1h", "1d")
+
+# 멤버십(in) 검증용 집합. 값은 ``CANONICAL_TIMEFRAMES`` 와 동일하며
+# 순서 비의존 소비자(예: `retention.py`)가 위임한다.
+TIMEFRAME_SET: frozenset[str] = frozenset(CANONICAL_TIMEFRAMES)
+
+# 신규 입력 KRX symbol shape: 6자리 ASCII digit (core.md
+# ``### KRX symbol shape`` — exchange == KRX 신규 입력 경계 한정).
+# ``\A...\Z`` 앵커 + ``fullmatch`` 는 trailing ``\n`` 까지 거부한다
+# (``re.match(r"^[0-9]{6}$", "123456\n")`` 는 True이므로 ``^...$``+
+# ``match`` 로는 #1299 fail-closed 회귀. fullmatch 엄격도 유지).
+_KRX_SYMBOL_REGEX: re.Pattern[str] = re.compile(r"\A[0-9]{6}\Z")
+
+
+def is_valid_timeframe(value: str) -> bool:
+    """``value`` 가 canonical OHLCV bar timeframe 5종 중 하나인지.
+
+    exact-literal 멤버십만 본다. alias(`1min`/`D`/`daily`/`1D`)·
+    대소문자 정규화는 수행하지 않는다 — 입력은 canonical 리터럴과
+    정확히 일치해야 한다 (core.md ``### Canonical timeframe set``).
+    """
+    return value in TIMEFRAME_SET
+
+
+def is_krx_symbol(value: str) -> bool:
+    r"""``value`` 가 신규 입력 KRX symbol shape(`^[0-9]{6}$`)인지.
+
+    ``fullmatch`` 로 검사하여 leading/trailing whitespace·trailing
+    ``\n`` 을 모두 거부한다 (core.md ``### KRX symbol shape``,
+    #1299 fail-closed 엄격도 유지). 비문자열 입력은 ``re`` 가
+    ``TypeError`` 를 던지므로 ``isinstance`` 로 선검사 후 ``False`` 로
+    잠근다. 이 헬퍼는 어떤 정규화도(no-normalization) 하지 않으며
+    Unicode digit(예: `１２３４５６`)은 ASCII `[0-9]` 가 아니므로
+    거부된다. resolved exchange == KRX인 신규 입력 경계에서만 적용해야
+    하며(비-KRX exchange symbol format은 1.0 비목표), exchange 귀속
+    판정은 호출자 책임이다.
+    """
+    return isinstance(value, str) and _KRX_SYMBOL_REGEX.fullmatch(value) is not None

--- a/src/ante/data/retention.py
+++ b/src/ante/data/retention.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 
+from ante.core.market_data_vocab import TIMEFRAME_SET
 from ante.data.store import ParquetStore
 
 logger = logging.getLogger(__name__)
 
-# OHLCV 타임프레임 집합 — retention key가 여기 속하면 data_type="ohlcv"
-_OHLCV_TIMEFRAMES: frozenset[str] = frozenset({"1m", "5m", "15m", "1h", "1d"})
+# OHLCV 타임프레임 집합 — retention key가 여기 속하면 data_type="ohlcv".
+# 코드 레벨 SSOT(`ante.core.market_data_vocab.TIMEFRAME_SET`)에 위임한다.
+# 값(canonical 5종 frozenset)·`_resolve_data_type()` 동작은 위임 전과
+# 완전히 동일하다(#1613 narrow-scope: behavior-preserving).
+_OHLCV_TIMEFRAMES: frozenset[str] = TIMEFRAME_SET
 
 
 def _resolve_data_type(key: str) -> tuple[str, str]:

--- a/src/ante/data/schemas.py
+++ b/src/ante/data/schemas.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import polars as pl
 
+from ante.core.market_data_vocab import CANONICAL_TIMEFRAMES
+
 # 모든 시세 데이터의 공통 스키마 (OHLCV)
 OHLCV_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
     "timestamp": pl.Datetime("ns"),
@@ -52,8 +54,11 @@ FUNDAMENTAL_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
 
 FUNDAMENTAL_COLUMNS: list[str] = list(FUNDAMENTAL_SCHEMA.keys())
 
-# 지원되는 타임프레임
-TIMEFRAMES: list[str] = ["1m", "5m", "15m", "1h", "1d"]
+# 지원되는 타임프레임 — 코드 레벨 SSOT(`ante.core.market_data_vocab`)에
+# 위임한다. 타입(`list`)·순서는 위임 전과 동일하다 — 순서 의존 소비자
+# (`src/ante/cli/commands/data.py` iteration)를 위해 계약상 고정 순서를
+# 보존한다(#1613 narrow-scope: behavior-preserving).
+TIMEFRAMES: list[str] = list(CANONICAL_TIMEFRAMES)
 
 
 def validate_ohlcv(df: pl.DataFrame) -> bool:

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -30,8 +30,17 @@ _TIME_COLUMN: dict[str, str] = {
 # 전과 완전히 동일하다(#1576 narrow-scope: zero-change).
 _KNOWN_EXCHANGES: frozenset[str] = CANONICAL_EXCHANGES
 
-# KRX 심볼 형식: 6자리 숫자
-_KRX_SYMBOL_PATTERN: re.Pattern[str] = re.compile(r"^\d{6}$")
+# legacy parquet path migration 판별용 KRX 심볼 형식: 6자리 숫자.
+# **신규 입력 ASCII 검증과 별개 축이다**(core.md
+# ``### symbol/timeframe 축 구분`` 축 E · ``### Legacy out-of-vocabulary
+# 호환 정책``). `\d` 는 Unicode digit까지 매치하며, 이는 6자리 Unicode-digit
+# legacy dir이 `migrate_parquet_paths()` 로 `KRX/` 하위로 이동되던 기존
+# 동작을 보존하기 위해 **의도적으로** 유지된다. 신규 입력 KRX symbol
+# 검증(`ante.core.market_data_vocab._KRX_SYMBOL_REGEX`, ASCII `[0-9]`,
+# fullmatch)으로 위임·대체·강화하지 않는다 — 위임 시 Unicode-digit
+# legacy dir migration이 silent 회귀한다(#1613 narrow-scope: legacy 무손상
+# 보존, 축 E 분리).
+_LEGACY_KRX_SYMBOL_PATTERN: re.Pattern[str] = re.compile(r"^\d{6}$")
 
 
 def _get_actual_dir_name(parent: Path, name: str) -> str | None:
@@ -61,6 +70,13 @@ def migrate_parquet_paths(data_path: Path) -> int:
     # ohlcv 디렉토리 마이그레이션
     ohlcv_path = data_path / "ohlcv"
     if ohlcv_path.exists():
+        # 불변식(#1613 R1-F2): timeframe dir 순회는 `TIMEFRAME_SET`/canonical
+        # 필터를 적용하지 않는다. 어떤 set 검사도 없이 모든 timeframe dir의
+        # legacy symbol dir을 `KRX/` 하위로 이동한다. 필터를 추가하면
+        # `ohlcv/<non-canonical_tf>/<6digit>/`(예: `ohlcv/2h/005930/`)가
+        # exchange-less 위치에 잔존해 `read(symbol,<tf>,exchange='KRX')`
+        # 에서 silent 비가시가 된다(legacy non-canonical timeframe migration
+        # 동작 보존 — core.md ``### Legacy out-of-vocabulary 호환 정책``).
         for timeframe_dir in ohlcv_path.iterdir():
             if not timeframe_dir.is_dir():
                 continue
@@ -70,8 +86,9 @@ def migrate_parquet_paths(data_path: Path) -> int:
                 # 이미 exchange 디렉토리면 스킵
                 if symbol_dir.name in _KNOWN_EXCHANGES:
                     continue
-                # KRX 심볼은 6자리 숫자 형식 검증
-                if not _KRX_SYMBOL_PATTERN.match(symbol_dir.name):
+                # KRX 심볼은 6자리 숫자 형식 검증 (legacy `\d` Unicode 판별,
+                # 신규 입력 ASCII 검증과 별개 축 — 위 상수 주석 참조)
+                if not _LEGACY_KRX_SYMBOL_PATTERN.match(symbol_dir.name):
                     logger.warning(
                         "마이그레이션 스킵: %s — KRX 심볼 형식(6자리 숫자)이 아님",
                         symbol_dir,

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import logging
 import math
-import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeGuard
 
+from ante.core.market_data_vocab import is_krx_symbol
 from ante.rule.base import (
     EvaluationResult,
     Rule,
@@ -52,7 +52,12 @@ _VALID_ORDER_TYPES: frozenset[str] = frozenset(
 # 6자리 numeric 단축코드를 가정한다. "INVALID" 같은 비수치 symbol이 RuleEngine을
 # 통과하면 KIS 40070000(매매불가 종목)을 유발하므로(#1299 A7 oracle 회귀), 룰 평가
 # 이전에 fail-closed로 거부한다.
-_KRX_NUMERIC_SYMBOL_PATTERN = re.compile(r"^[0-9]{6}$")
+#
+# 형태 검증은 코드 레벨 SSOT(`ante.core.market_data_vocab.is_krx_symbol`)에
+# 위임한다. `is_krx_symbol` 은 `\A[0-9]{6}\Z` + `fullmatch` + non-str
+# 선검사로 구현되어 위임 전 `_KRX_NUMERIC_SYMBOL_PATTERN.fullmatch` 와
+# 엄격도가 동일하다 — `123456\n`·leading/trailing whitespace·비문자열은
+# 위임 전후 모두 fail-closed로 거부된다(#1613 narrow-scope: #1299 동작 불변).
 
 
 def _is_finite_quantity(value: object) -> TypeGuard[int | float]:
@@ -661,10 +666,7 @@ class RuleEngine:
             # 6자리 숫자 PDNO(예: "005930", "069500")만 가정하므로, 그 형식을
             # 만족하지 않는 KRX symbol은 룰 평가/Treasury 조회 이전에 fail-closed로
             # 거부한다. 비-KRX exchange는 broker adapter에 위임한다.
-            if event.exchange == "KRX" and (
-                not isinstance(event.symbol, str)
-                or not _KRX_NUMERIC_SYMBOL_PATTERN.fullmatch(event.symbol)
-            ):
+            if event.exchange == "KRX" and not is_krx_symbol(event.symbol):
                 reason = (
                     f"Invalid KRX numeric symbol: {_safe_repr(event.symbol)} "
                     f"(expected 6-digit numeric per current Ante "

--- a/tests/unit/test_market_data_vocab.py
+++ b/tests/unit/test_market_data_vocab.py
@@ -1,0 +1,260 @@
+"""Unit tests — `ante.core.market_data_vocab` SSOT (#1613).
+
+본 모듈은 두 가지를 못 박는다:
+  1. SSOT 모듈 자체의 불변식 (canonical timeframe 값·순서·타입,
+     exact-literal·no-alias·no-normalization 검증 헬퍼, KRX symbol
+     fullmatch 엄격도 — R1-F1).
+  2. 위임 후 behavior-preserving 회귀 — `data.schemas.TIMEFRAMES`
+     (타입 `list`·순서 불변), `data.retention._OHLCV_TIMEFRAMES`/
+     `DEFAULT_RETENTION` (drift 계약), `rule.engine` KRX preflight
+     (#1299 fail-closed 불변), `data.store` legacy migration (축 E
+     `\\d` Unicode 보존 — R1-F2 timeframe 무필터).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ante.core.market_data_vocab import (
+    CANONICAL_TIMEFRAMES,
+    TIMEFRAME_SET,
+    is_krx_symbol,
+    is_valid_timeframe,
+)
+
+
+class TestCanonicalTimeframes:
+    """canonical timeframe 고정 집합·고정 순서·타입 (core.md
+    ``### Canonical timeframe set``)."""
+
+    def test_canonical_timeframes_exact_value_and_order(self):
+        # 고정 순서: 1m → 5m → 15m → 1h → 1d (순서 의존 소비자 계약).
+        assert CANONICAL_TIMEFRAMES == ("1m", "5m", "15m", "1h", "1d")
+
+    def test_canonical_timeframes_is_tuple(self):
+        # 순서가 의미를 가지므로 tuple 이어야 한다.
+        assert isinstance(CANONICAL_TIMEFRAMES, tuple)
+
+    def test_timeframe_set_value(self):
+        assert TIMEFRAME_SET == frozenset({"1m", "5m", "15m", "1h", "1d"})
+        assert TIMEFRAME_SET == frozenset(CANONICAL_TIMEFRAMES)
+
+    def test_timeframe_set_is_frozenset(self):
+        assert isinstance(TIMEFRAME_SET, frozenset)
+
+    def test_timeframe_set_immutable(self):
+        with pytest.raises(AttributeError):
+            TIMEFRAME_SET.add("2h")  # type: ignore[attr-defined]
+
+
+class TestIsValidTimeframe:
+    """``is_valid_timeframe`` — exact-literal, no-alias, no-normalization."""
+
+    @pytest.mark.parametrize("value", ["1m", "5m", "15m", "1h", "1d"])
+    def test_canonical_values_true(self, value):
+        assert is_valid_timeframe(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        # alias·대소문자·subminute(축 B)·fundamental cadence(축 F)·빈값
+        [
+            "1min",
+            "D",
+            "daily",
+            "1D",
+            "1H",
+            "1M",
+            "10s",
+            "30s",
+            "quarterly",
+            "annual",
+            "",
+            " 1m",
+            "1m ",
+        ],
+        ids=[
+            "alias-1min",
+            "alias-D",
+            "alias-daily",
+            "uppercase-1D",
+            "uppercase-1H",
+            "uppercase-1M",
+            "subminute-10s",
+            "subminute-30s",
+            "cadence-quarterly",
+            "cadence-annual",
+            "empty",
+            "leading-space",
+            "trailing-space",
+        ],
+    )
+    def test_non_canonical_values_false(self, value):
+        assert is_valid_timeframe(value) is False
+
+
+class TestIsKrxSymbol:
+    """``is_krx_symbol`` — fullmatch 엄격도 (R1-F1), ASCII-only, non-str 안전."""
+
+    @pytest.mark.parametrize("value", ["005930", "069500", "000660", "123456"])
+    def test_valid_six_digit_ascii_true(self, value):
+        assert is_krx_symbol(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["12345", "1234567", "05A123", "AAPL", "", "12-456"],
+        ids=["too-short", "too-long", "alpha-mixed", "non-numeric", "empty", "hyphen"],
+    )
+    def test_invalid_shape_false(self, value):
+        assert is_krx_symbol(value) is False
+
+    def test_unicode_digit_rejected(self):
+        # 신규 입력은 ASCII `[0-9]` 만 허용 — 전각 Unicode digit 거부.
+        # (legacy migration `\\d` Unicode 판별과 별개 축 — store.py 보존.)
+        assert is_krx_symbol("１２３４５６") is False
+
+    @pytest.mark.parametrize(
+        "value",
+        ["123456\n", "\n123456", "123456\t", " 005930", "005930 ", "  005930  "],
+        ids=[
+            "trailing-newline",
+            "leading-newline",
+            "trailing-tab",
+            "leading-space",
+            "trailing-space",
+            "surrounding-space",
+        ],
+    )
+    def test_fullmatch_rejects_whitespace_padding(self, value):
+        # R1-F1: `^...$`+`re.match` 는 `123456\n` 을 통과시키므로(#1299
+        # fail-closed 회귀) helper 는 `\\A...\\Z`+`fullmatch` 엄격도여야 한다.
+        assert is_krx_symbol(value) is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, 123456, 5930.0, [], {}, set(), b"005930", True],
+        ids=["none", "int", "float", "list", "dict", "set", "bytes", "bool"],
+    )
+    def test_non_str_input_safe_false(self, value):
+        # 비문자열은 `re` TypeError 없이 isinstance 선검사로 False.
+        assert is_krx_symbol(value) is False  # type: ignore[arg-type]
+
+
+class TestSchemasTimeframesDelegation:
+    """`data.schemas.TIMEFRAMES` 가 SSOT 위임 — 타입 `list`·순서 불변."""
+
+    def test_timeframes_value_and_order(self):
+        from ante.data.schemas import TIMEFRAMES
+
+        # 위임 전 값·순서 그대로 (순서 의존 소비자 cli/commands/data.py 보존).
+        assert TIMEFRAMES == ["1m", "5m", "15m", "1h", "1d"]
+        assert TIMEFRAMES == list(CANONICAL_TIMEFRAMES)
+
+    def test_timeframes_type_preserved(self):
+        from ante.data.schemas import TIMEFRAMES
+
+        # 위임 전 타입(mutable list[str])을 그대로 유지한다.
+        assert type(TIMEFRAMES) is list
+
+    def test_timeframes_independent_list_instance(self):
+        # `list(...)` 파생이므로 SSOT tuple 과 분리된 인스턴스여야 한다
+        # (소비자가 mutate 해도 SSOT 불변).
+        from ante.data.schemas import TIMEFRAMES
+
+        assert TIMEFRAMES is not CANONICAL_TIMEFRAMES
+
+
+class TestRetentionDelegation:
+    """`data.retention` 위임 + `DEFAULT_RETENTION` drift 계약."""
+
+    def test_ohlcv_timeframes_delegates_to_ssot(self):
+        from ante.data.retention import _OHLCV_TIMEFRAMES
+
+        assert _OHLCV_TIMEFRAMES is TIMEFRAME_SET
+        assert _OHLCV_TIMEFRAMES == frozenset({"1m", "5m", "15m", "1h", "1d"})
+
+    def test_default_retention_key_drift_contract(self):
+        # 보존 기간 수치는 retention 정책 고유지만, timeframe key 집합은
+        # SSOT 와 drift 하면 안 된다 (core.md 소비자 매핑 #1613).
+        from ante.data.retention import RetentionPolicy
+
+        assert set(RetentionPolicy.DEFAULT_RETENTION) == TIMEFRAME_SET | {"fundamental"}
+
+    def test_default_retention_values_unchanged(self):
+        # 위임은 behavior-preserving — 보존 기간 수치 불변.
+        from ante.data.retention import RetentionPolicy
+
+        assert RetentionPolicy.DEFAULT_RETENTION == {
+            "1m": 365,
+            "5m": 365,
+            "15m": 365,
+            "1h": 365,
+            "1d": 3650,
+            "fundamental": -1,
+        }
+
+    def test_resolve_data_type_behavior_unchanged(self):
+        from ante.data.retention import _resolve_data_type
+
+        assert _resolve_data_type("1m") == ("ohlcv", "1m")
+        assert _resolve_data_type("1d") == ("ohlcv", "1d")
+        assert _resolve_data_type("fundamental") == ("fundamental", "")
+        # non-canonical key 는 ohlcv 가 아님 (위임 전후 동일).
+        assert _resolve_data_type("2h") == ("2h", "")
+
+
+class TestStoreLegacyMigrationAxisE:
+    """store.py legacy `\\d` migration 보존 (축 E) — R1-F2 timeframe 무필터."""
+
+    def test_legacy_pattern_preserves_unicode_digit(self):
+        # 신규 입력 SSOT 로 위임하지 않고 legacy `\\d`(Unicode) 보존.
+        from ante.data.store import _LEGACY_KRX_SYMBOL_PATTERN
+
+        assert _LEGACY_KRX_SYMBOL_PATTERN.match("005930") is not None
+        # `\\d` 는 전각 Unicode digit 도 매치 (신규 입력 ASCII 와 별개 축).
+        assert _LEGACY_KRX_SYMBOL_PATTERN.match("１２３４５６") is not None
+
+    def test_legacy_pattern_distinct_from_ssot(self):
+        # 축 E 분리: legacy 판별은 신규 입력 ASCII fullmatch 와 의미가 다르다.
+        from ante.data.store import _LEGACY_KRX_SYMBOL_PATTERN
+
+        assert _LEGACY_KRX_SYMBOL_PATTERN.match("１２３４５６") is not None
+        assert is_krx_symbol("１２３４５６") is False
+
+    def test_migrate_unicode_digit_legacy_dir_still_moved(self, tmp_path: Path):
+        # (a) 6자리 Unicode-digit legacy dir 이 여전히 KRX/ 로 이동.
+        from ante.data.store import migrate_parquet_paths
+
+        old_path = tmp_path / "ohlcv" / "1d" / "１２３４５６"
+        old_path.mkdir(parents=True)
+        (old_path / "2026-01.parquet").write_bytes(b"dummy")
+
+        moved = migrate_parquet_paths(tmp_path)
+
+        assert moved == 1
+        assert not old_path.exists()
+        new_path = tmp_path / "ohlcv" / "1d" / "KRX" / "１２３４５６"
+        assert new_path.exists()
+        assert (new_path / "2026-01.parquet").exists()
+
+    def test_migrate_non_canonical_timeframe_legacy_dir_still_moved(
+        self, tmp_path: Path
+    ):
+        # (b) R1-F2: `ohlcv/<non-canonical_tf>/<6digit>/` legacy dir 도
+        # 여전히 KRX/ 로 이동 — migrate_parquet_paths 가 timeframe dir 을
+        # TIMEFRAME_SET/canonical 로 필터하지 않음을 잠근다 (필터 추가 시
+        # exchange-less 위치에 silent 잔존 → read 비가시 회귀).
+        from ante.data.store import migrate_parquet_paths
+
+        old_path = tmp_path / "ohlcv" / "2h" / "005930"
+        old_path.mkdir(parents=True)
+        (old_path / "2026-01.parquet").write_bytes(b"dummy")
+
+        moved = migrate_parquet_paths(tmp_path)
+
+        assert moved == 1
+        assert not old_path.exists()
+        new_path = tmp_path / "ohlcv" / "2h" / "KRX" / "005930"
+        assert new_path.exists()
+        assert (new_path / "2026-01.parquet").exists()

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -1535,6 +1535,74 @@ class TestRuleEngineEventBus:
         assert len(validated) == 1
         assert validated[0].symbol == "AAPL"
 
+    @pytest.mark.parametrize(
+        "bad_symbol",
+        ["123456\n", "\n123456", "123456\t", " 005930", "005930 ", "  005930  "],
+        ids=[
+            "trailing-newline",
+            "leading-newline",
+            "trailing-tab",
+            "leading-space",
+            "trailing-space",
+            "surrounding-space",
+        ],
+    )
+    async def test_rule_engine_rejects_krx_symbol_with_whitespace_padding(
+        self, engine, eventbus, monkeypatch, bad_symbol
+    ):
+        """R1-F1(#1613): whitespace padding KRX symbol을 fail-closed 거부한다.
+
+        `is_krx_symbol` 위임 후에도 `\\A...\\Z`+`fullmatch` 엄격도가
+        유지되어 `123456\\n`(`re.match(r'^[0-9]{6}$', ...)` 이면 통과)·
+        leading/trailing whitespace 가 위임 전과 동일하게 거부됨을 잠근다
+        (#1299 fail-closed 회귀 방지).
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid KRX symbol")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for invalid KRX symbol"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol=bad_symbol,
+            side="buy",
+            quantity=10.0,
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="R1-F1 fullmatch whitespace-padding regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid KRX numeric symbol" in ev.reason
+        assert isinstance(ev.symbol, str)
+        assert ev.symbol == bad_symbol
+        assert ev.exchange == "KRX"
+
     @pytest.mark.parametrize("side", ["buy", "sell"])
     async def test_rule_engine_rejects_limit_order_without_price(
         self, engine, eventbus, monkeypatch, side


### PR DESCRIPTION
Closes #1613

## Summary
- 신설 `src/ante/core/market_data_vocab.py` — symbol/timeframe 코드 SSOT (`ante.core.exchange`/#1576 패턴 1:1 미러). `CANONICAL_TIMEFRAMES` tuple(고정 순서)·`TIMEFRAME_SET` frozenset·`is_valid_timeframe`(exact-literal)·`is_krx_symbol`(`\A[0-9]{6}\Z` fullmatch)
- behavior-preserving 소비자 위임: `schemas.py TIMEFRAMES=list(CANONICAL_TIMEFRAMES)`(타입·순서 불변), `retention.py _OHLCV_TIMEFRAMES=TIMEFRAME_SET`, `rule/engine.py` #1299 preflight→`is_krx_symbol`(fullmatch 엄격도 불변)
- 축 E 분리: `store.py` legacy `_LEGACY_KRX_SYMBOL_PATTERN`(`\d` Unicode) SSOT 미위임·보존, `migrate_parquet_paths` timeframe 무필터 불변식
- 계약/회귀 테스트: SSOT unit, `DEFAULT_RETENTION` drift, R1-F1(`123456\n`/whitespace fail-closed), R1-F2(non-canonical legacy tf migration 보존), Unicode-digit legacy dir migration 보존, #1299 동작 불변

## 범위/불변
- 계약 본문은 #1612(core.md `## Canonical Symbol/Timeframe Vocabulary`+D-017) — 본 PR 미수정
- 동작/값/타입/순서/정규식 의미 불변 (behavior-preserving). 표면 enforcement는 #1603~1611/#1614/#1594 범위
- API/스키마/생성 산출물 미변경

## Test Plan
- Plan Preflight 2라운드 → Codex `approve-implement` (no material findings)
- Codex 브랜치 리뷰 attempt 1 PASS
- `pytest tests/core tests/data tests/rule tests/web/routes/test_data.py tests/cli/commands/test_data.py` 497 passed, `mypy src/` 241 files clean, `ruff check/format` clean, grep invariant(신규 vocabulary 복제 0)