### PR TITLE
fix(cli): instrument import KRX symbol ingress 검증 (#1611)

### DIFF
--- a/src/ante/cli/commands/instrument.py
+++ b/src/ante/cli/commands/instrument.py
@@ -9,9 +9,14 @@ import click
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 from ante.core.exchange import CANONICAL_EXCHANGES, is_canonical
+from ante.core.market_data_vocab import is_krx_symbol
 
 # 비-canonical exchange 공통 거부 (list/sync/import 3 ingress).
 _INVALID_EXCHANGE_CODE = "INSTRUMENT_INVALID_EXCHANGE"
+# exchange == KRX 행의 비6자리 symbol 거부 (import row 경계 한정,
+# core.md ``### KRX symbol shape``). market_data_vocab.is_krx_symbol
+# SSOT 위임 — instrument.py에 private KRX regex를 두지 않는다.
+_INVALID_KRX_SYMBOL_CODE = "INSTRUMENT_INVALID_SYMBOL"
 # canonical이나 현재 sync source(KIS domestic/KRX)가 미지원 (sync 전용, 축 B).
 _SYNC_SOURCE_UNSUPPORTED_CODE = "INSTRUMENT_SYNC_SOURCE_UNSUPPORTED"
 # KIS sync source(KISDomesticAdapter=domestic-stock/KOSPI/KOSDAQ master)가
@@ -375,6 +380,25 @@ def instrument_import(
                 code=_INVALID_EXCHANGE_CODE,
             )
             ctx.exit(1)
+
+        # exchange == KRX 행은 symbol이 6자리 ASCII digit이어야 한다
+        # (core.md ``### KRX symbol shape`` — exchange == KRX 신규 입력
+        # 경계 한정). 비-KRX canonical(NYSE/NASDAQ/AMEX/TEST)은
+        # symbol-shape 검증 미적용 (1.0 비목표). is_krx_symbol은
+        # 비문자열 symbol(JSON list/dict/number/None 등)도 isinstance
+        # 가드로 False → KRX 행이면 동일 INVALID_SYMBOL 경로로 거부.
+        # 이 검증은 instruments build/dry-run preview/실저장 이전이므로
+        # --dry-run·실 import 양쪽에서 동일하게 차단된다.
+        if isinstance(row_exchange, str) and row_exchange == "KRX":
+            row_symbol = r.get("symbol", "")
+            if not is_krx_symbol(row_symbol):
+                fmt.error(
+                    f"유효하지 않은 종목 코드: {row_symbol!r} "
+                    f"(행 {idx + 1}, exchange={row_exchange!r}, "
+                    f"KRX 6자리 숫자).",
+                    code=_INVALID_KRX_SYMBOL_CODE,
+                )
+                ctx.exit(1)
 
     instruments = [
         Instrument(

--- a/tests/unit/test_cli_instrument_import_exit.py
+++ b/tests/unit/test_cli_instrument_import_exit.py
@@ -17,6 +17,13 @@
     4. 빈 데이터 (`[]`)
     5. 필수 컬럼 누락 (symbol/exchange 부재)
 - 회귀 보존: valid `--dry-run`은 exit 0 유지.
+
+#1611 (split #1598 oracle A7 cli_instrument_import_invalid_krx_symbol):
+exchange == KRX 행의 비6자리 symbol(예: ``ABCDEF``)을 dry-run/실 import
+양쪽에서 ``INSTRUMENT_INVALID_SYMBOL`` 구조화 에러로 거부한다. 검증은
+``core.market_data_vocab.is_krx_symbol`` SSOT(#1613) 위임이며 기존
+exchange per-row 검증 루프(#1577)에 동형 확장한다. 비-KRX canonical
+(NYSE/NASDAQ/AMEX/TEST)은 symbol-shape 미적용 (core.md 1.0 비목표).
 """
 
 from __future__ import annotations
@@ -284,3 +291,335 @@ class TestValidDryRunRegression:
         payload = json.loads(result.stdout)
         assert payload["dry_run"] is True
         assert payload["total"] == 1
+
+
+# ── 7. exchange == KRX 행의 비6자리 symbol → exit 1 (#1611) ──
+
+
+class TestKrxInvalidSymbolExit:
+    """``exchange=KRX`` + 비6자리 ``symbol`` → exit 1 + 구조화 error code.
+
+    #1598 oracle probe 재현: ``[{"symbol":"ABCDEF","exchange":"KRX"}]`` 가
+    dry-run preview/실 import로 수락되던 ingress drift를 닫는다. dry-run·
+    실 import 양쪽에서 instruments build/저장 이전에 거부된다.
+    """
+
+    def test_invalid_krx_symbol_dry_run_json_envelope(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        """oracle probe 시그니처: ``--format json ... --dry-run``."""
+        json_file = tmp_path / "inv_sym.json"
+        json_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "symbol": "ABCDEF",
+                        "exchange": "KRX",
+                        "name": "Oracle Invalid Symbol",
+                    }
+                ]
+            )
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "instrument",
+                "import",
+                str(json_file),
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 1, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == "INSTRUMENT_INVALID_SYMBOL"
+        assert "ABCDEF" in payload["message"]
+
+    def test_invalid_krx_symbol_dry_run_text(self, runner: CliRunner, tmp_path) -> None:
+        json_file = tmp_path / "inv_sym.json"
+        json_file.write_text(
+            json.dumps([{"symbol": "ABCDEF", "exchange": "KRX", "name": "x"}])
+        )
+
+        result = runner.invoke(
+            cli,
+            ["instrument", "import", str(json_file), "--dry-run"],
+        )
+
+        assert result.exit_code == 1, result.stderr
+        assert "유효하지 않은 종목 코드" in result.stderr
+
+    def test_invalid_krx_symbol_real_import_not_reached(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        """dry-run 없이도 import 미수행 + 동일 error contract.
+
+        ``asyncio.run`` (``_import()`` 진입점)이 호출되지 않아야 한다 —
+        검증이 InstrumentService/저장 이전에 차단함을 잠근다.
+        """
+        json_file = tmp_path / "inv_sym.json"
+        json_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "symbol": "ABCDEF",
+                        "exchange": "KRX",
+                        "name": "Oracle Invalid Symbol",
+                    }
+                ]
+            )
+        )
+
+        with patch("asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "instrument", "import", str(json_file)],
+            )
+
+        assert result.exit_code == 1, result.stdout
+        mock_run.assert_not_called()
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == "INSTRUMENT_INVALID_SYMBOL"
+
+    def test_non_string_krx_symbol_rejected_structured(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        """KRX 행의 비문자열 symbol(JSON list/dict/number/None)도
+        traceback이 아닌 구조화 ``INSTRUMENT_INVALID_SYMBOL`` exit 1.
+
+        ``is_krx_symbol`` 의 ``isinstance(str)`` 가드가 ``re.fullmatch``
+        의 ``TypeError`` 를 fail-closed False로 잠근다.
+        """
+        json_file = tmp_path / "nonstr_sym.json"
+        json_file.write_text(
+            json.dumps([{"symbol": 5930, "exchange": "KRX", "name": "x"}])
+        )
+
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "instrument", "import", str(json_file)],
+        )
+
+        assert result.exit_code == 1, result.stdout
+        assert result.exception is None or isinstance(result.exception, SystemExit), (
+            result.exception
+        )
+        payload = json.loads(result.stdout)
+        assert payload["code"] == "INSTRUMENT_INVALID_SYMBOL"
+
+    def test_invalid_krx_symbol_among_valid_rows_rejected(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        """유효 KRX 행 뒤에 섞인 비6자리 KRX symbol 행도 식별·거부."""
+        json_file = tmp_path / "mixed_sym.json"
+        json_file.write_text(
+            json.dumps(
+                [
+                    {"symbol": "005930", "exchange": "KRX"},
+                    {"symbol": "12345", "exchange": "KRX"},
+                ]
+            )
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "instrument",
+                "import",
+                str(json_file),
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 1, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["code"] == "INSTRUMENT_INVALID_SYMBOL"
+        assert "12345" in payload["message"]
+
+
+# ── 8. valid KRX symbol → 기존 preview/import 경로 회귀 보존 (#1611) ──
+
+
+class TestValidKrxSymbolRegression:
+    """``[{"symbol":"005930","exchange":"KRX",...}]`` 는 기존 동작 유지."""
+
+    def test_valid_krx_symbol_dry_run_exits_zero(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        json_file = tmp_path / "ok_krx.json"
+        json_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "symbol": "005930",
+                        "exchange": "KRX",
+                        "name": "Samsung Electronics",
+                    }
+                ]
+            )
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "instrument",
+                "import",
+                str(json_file),
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["dry_run"] is True
+        assert payload["total"] == 1
+
+    def test_valid_krx_symbol_real_import_reaches_service(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        """유효 KRX symbol은 검증 통과 후 ``_import()`` (asyncio.run) 도달."""
+        json_file = tmp_path / "ok_krx.json"
+        json_file.write_text(
+            json.dumps([{"symbol": "005930", "exchange": "KRX", "name": "삼성전자"}])
+        )
+
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = 1
+            result = runner.invoke(
+                cli,
+                ["instrument", "import", str(json_file)],
+            )
+
+        assert result.exit_code == 0, result.stderr
+        mock_run.assert_called_once()
+
+    def test_valid_krx_symbol_csv_dry_run_exits_zero(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        """CSV 경로(symbol 항상 str)도 유효 6자리 → exit 0 회귀 보존."""
+        csv_file = tmp_path / "ok_krx.csv"
+        csv_file.write_text("symbol,exchange,name\n005930,KRX,삼성전자\n")
+
+        result = runner.invoke(
+            cli,
+            ["instrument", "import", str(csv_file), "--dry-run"],
+        )
+
+        assert result.exit_code == 0, result.stderr
+        assert "005930" in result.stdout
+
+
+# ── 9. 비-KRX canonical은 KRX symbol-shape 미적용 (#1611) ──
+
+
+class TestNonKrxSymbolShapeNotApplied:
+    """비-KRX canonical(NYSE/NASDAQ/AMEX/TEST)은 symbol-shape 미적용.
+
+    core.md ``### KRX symbol shape`` — exchange == KRX 한정. 비-KRX
+    symbol format 정의는 1.0 비목표이므로 ``AAPL`` 같은 비6자리
+    alphabetic symbol도 canonical exchange면 거부하지 않는다.
+    """
+
+    def test_non_krx_alpha_symbol_dry_run_exits_zero(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        json_file = tmp_path / "nyse.json"
+        json_file.write_text(
+            json.dumps([{"symbol": "AAPL", "exchange": "NYSE", "name": "Apple Inc."}])
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "instrument",
+                "import",
+                str(json_file),
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["dry_run"] is True
+        assert payload["total"] == 1
+
+    def test_non_krx_symbol_with_valid_krx_row_mixed_exits_zero(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        """비-KRX 비6자리 + 유효 KRX 6자리 혼합 → 전부 통과 (exit 0)."""
+        json_file = tmp_path / "mixed_ex.json"
+        json_file.write_text(
+            json.dumps(
+                [
+                    {"symbol": "005930", "exchange": "KRX"},
+                    {"symbol": "AAPL", "exchange": "NASDAQ"},
+                ]
+            )
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "instrument",
+                "import",
+                str(json_file),
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["total"] == 2
+
+
+# ── 10. exchange invalid 검증 회귀 비파손 (#1577 보존, #1611) ──
+
+
+class TestExchangeInvalidRegressionUnbroken:
+    """KRX symbol 검증 추가 후에도 기존 exchange invalid 회귀 보존.
+
+    exchange 검증이 KRX symbol 검증보다 먼저 차단하므로 invalid
+    exchange row는 여전히 ``INSTRUMENT_INVALID_EXCHANGE`` 로 거부된다.
+    """
+
+    def test_invalid_exchange_still_invalid_exchange_code(
+        self, runner: CliRunner, tmp_path
+    ) -> None:
+        json_file = tmp_path / "inv_ex.json"
+        json_file.write_text(
+            json.dumps(
+                [{"symbol": "ABCDEF", "exchange": "ORACLE_INVALID", "name": "x"}]
+            )
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "instrument",
+                "import",
+                str(json_file),
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 1, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        # exchange 검증이 먼저 차단 — symbol 검증 코드가 아님.
+        assert payload["code"] == "INSTRUMENT_INVALID_EXCHANGE"
+        assert payload["code"] != "INSTRUMENT_INVALID_SYMBOL"


### PR DESCRIPTION
Closes #1611

## Summary
- `ante instrument import`의 기존 per-row exchange canonical 검증 루프(#1577)에 **exchange=KRX 행 symbol shape 검증** 동형 추가 — KRX 비6자리 symbol(`ABCDEF`)을 dry-run·실 import 양쪽에서 `INSTRUMENT_INVALID_SYMBOL`로 거부 (#1598 oracle 폐쇄)
- #1613 SSOT helper(`is_krx_symbol`) 위임 — instrument.py 신규 private KRX regex 없음(AC). `_INVALID_KRX_SYMBOL_CODE` 모듈 상수(`_INVALID_EXCHANGE_CODE` 규약 미러)
- **비-KRX canonical exchange(NYSE/NASDAQ/AMEX/TEST)는 symbol-shape 미적용**(core.md `### KRX symbol shape` 1.0 비목표). 기존 exchange canonical 검증 회귀 보존(같은 루프 통합)

## 범위/불변
- 단일 import row 경계. instrument list/sync·service/store 계층·형제 표면 제외. 유효 `005930`/KRX 기존 preview/import 유지

## Test Plan
- Plan Preflight 1R → Codex `approve-implement`; 브랜치 리뷰 attempt 1 PASS
- `pytest test_instrument_import.py test_cli_instrument_import_exit.py test_instrument_exchange_validation` 56 + `pytest -k instrument` 135 회귀 + `mypy src/` 241 clean + ruff clean
- AC(ABCDEF dry-run/real exit1+code, JSON 비-str symbol fail-closed, valid 005930 CSV/JSON 유지, non-KRX AAPL 비거부, exchange invalid `INSTRUMENT_INVALID_EXCHANGE` 회귀, JSON/text) 잠금

## 운영 메모
구현 중 dev agent bash cwd reset로 1차 커밋이 main 인입 → format-patch+`git reset --hard`+am 자가복구. 오케스트레이터 독립 검증: 로컬 main=origin/main(clean, stray 커밋 0), 본 작업 feature 브랜치 정상 격리 — main 무결성 확인 완료.