### PR TITLE
fix(data): DataCollector symbol/timeframe ingress 검증 (#1614)

### DIFF
--- a/src/ante/data/collector.py
+++ b/src/ante/data/collector.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
+
+from ante.core.market_data_vocab import is_krx_symbol, is_valid_timeframe
 
 if TYPE_CHECKING:
     from ante.data.store import ParquetStore
@@ -54,6 +56,36 @@ class DataCollector:
     def buffer(self) -> dict[str, list[dict]]:
         return self._buffer
 
+    def _is_valid_ingress(self, symbol: object, timeframe: object) -> bool:
+        """canonical symbol/timeframe ingress 검증 (#1613 SSOT 위임).
+
+        통과 조건:
+        - ``timeframe`` 이 ``str`` 이고 (#1613 ``is_valid_timeframe``)
+          canonical OHLCV bar timeframe 5종 중 하나이며
+          (unhashable timeframe → ``is_valid_timeframe`` 호출 전 차단으로
+          TypeError 방지),
+        - ``timeframe != "1d"`` (``1d`` 는 DataFeed write-ownership 소유,
+          data-pipeline/02 — vocabulary regex가 아닌 write-ownership 경계
+          literal 비교. ``tick``/``oracle`` 등은 ``is_valid_timeframe``
+          이 False),
+        - exchange 가 KRX면 ``symbol`` 이 ``str`` 이고 신규 입력 KRX
+          symbol shape (#1613 ``is_krx_symbol``). ``isinstance(symbol,
+          str)`` 선검사는 ``is_krx_symbol`` 내장 ``isinstance(str)``
+          가드와 동일 결과(비-str symbol → KRX 거부)이며 #1613 SSOT
+          시그니처(``value: str``)와의 타입 정합을 위한 것이다.
+          비-KRX exchange 는 symbol-shape 미적용 (core.md
+          ``### KRX symbol shape`` 1.0 비목표).
+        """
+        return (
+            isinstance(timeframe, str)
+            and is_valid_timeframe(timeframe)
+            and timeframe != "1d"
+            and (
+                self._exchange != "KRX"
+                or (isinstance(symbol, str) and is_krx_symbol(symbol))
+            )
+        )
+
     def set_data_callback(self, callback: DataCallback) -> None:
         """데이터 수집 콜백 설정. 시그니처: async (symbol, tf) -> list[dict]."""
         self._data_callback = callback
@@ -91,6 +123,13 @@ class DataCollector:
 
     def add_data(self, symbol: str, timeframe: str, row: dict) -> None:
         """외부에서 직접 데이터를 추가 (이벤트 기반 수집 시 사용)."""
+        if not self._is_valid_ingress(symbol, timeframe):
+            logger.warning(
+                "DataCollector ingress reject (add_data): symbol=%r tf=%r — skip",
+                symbol,
+                timeframe,
+            )
+            return
         key = f"{symbol}:{timeframe}"
         if key not in self._buffer:
             self._buffer[key] = []
@@ -100,13 +139,16 @@ class DataCollector:
             self._flush(key)
 
     def flush_all(self) -> int:
-        """모든 버퍼 데이터를 Parquet에 flush. flush된 총 건수 반환."""
+        """모든 버퍼 데이터를 Parquet에 flush.
+
+        반환값 = "이번 호출에서 실제 append 성공한 row 수". invalid/
+        malformed key drop 과 append-exception(재버퍼링 retry 보존)은
+        둘 다 0 으로 집계되어 합산에서 자동 제외된다 (drop 된 invalid
+        rows·재버퍼링된 append-fail rows 미포함).
+        """
         total = 0
         for key in list(self._buffer.keys()):
-            if self._buffer[key]:
-                count = len(self._buffer[key])
-                self._flush(key)
-                total += count
+            total += self._flush(key)
         return total
 
     async def _collect_loop(self) -> None:
@@ -115,6 +157,14 @@ class DataCollector:
             if self._data_callback:
                 for symbol in self._symbols:
                     for tf in self._timeframes:
+                        if not self._is_valid_ingress(symbol, tf):
+                            logger.warning(
+                                "DataCollector ingress reject (collect): "
+                                "symbol=%r tf=%r — skip",
+                                symbol,
+                                tf,
+                            )
+                            continue
                         try:
                             rows = await self._data_callback(symbol, tf)
                             for row in rows:
@@ -140,18 +190,60 @@ class DataCollector:
                 raise
             self.flush_all()
 
-    def _flush(self, key: str) -> None:
-        """버퍼의 데이터를 Parquet에 적재."""
-        rows = self._buffer.pop(key, [])
+    def _flush(self, key: object) -> int:
+        """버퍼의 데이터를 Parquet에 적재. 실제 append 성공 row 수 반환.
+
+        반환 계약:
+        - **append 성공** → ``len(rows)``
+        - **invalid/malformed key drop** (non-str key / ``rsplit(":",1)``
+          len != 2 / ``_is_valid_ingress`` False) → ``0`` (이미 pop된
+          rows 는 의도된 invalid drop — **retry 안 함**)
+        - **``_store.append`` 예외** → 기존 재버퍼링 동작 보존
+          (``rows + self._buffer[key]`` — 같은 key 에 되돌려 다음 flush
+          재시도, rows 미유실) + ``return 0`` (이번 회차 append 0)
+
+        invalid/malformed key drop(retry 안 함)과 append-exception
+        (재버퍼링 retry 보존)을 명확히 구분한다. public ``buffer``
+        프로퍼티 직접 주입(임의 malformed/invalid key)에도 raise 없이
+        drop 하여 out-of-vocab ``ohlcv/<bad>/`` 경로를 만들지 않고
+        ``flush_all``/``stop`` 을 중단시키지 않는다.
+        """
+        # ``key`` 는 public ``buffer`` 직접 주입으로 non-str 일 수 있어
+        # ``object`` 로 받는다. ``dict.pop`` 은 hashable key 면 안전하며
+        # (정상 경로는 항상 str key), non-str 우회 주입분은 아래
+        # ``isinstance`` guard 가 drop 한다. cast 는 런타임 무동작.
+        buffer = cast("dict[object, list[dict]]", self._buffer)
+        rows = buffer.pop(key, [])
         if not rows:
-            return
-        symbol, tf = key.split(":")
+            return 0
+        if not isinstance(key, str):
+            logger.warning(
+                "DataCollector flush guard: drop non-str buffered key %r",
+                key,
+            )
+            return 0
+        parts = key.rsplit(":", 1)
+        if len(parts) != 2:
+            logger.warning(
+                "DataCollector flush guard: drop malformed buffered key %r",
+                key,
+            )
+            return 0
+        symbol, tf = parts
+        if not self._is_valid_ingress(symbol, tf):
+            logger.warning(
+                "DataCollector flush guard: drop invalid buffered key %r",
+                key,
+            )
+            return 0
         try:
             self._store.append(symbol, tf, rows, exchange=self._exchange)
             logger.debug("Flushed %d rows for %s/%s", len(rows), symbol, tf)
+            return len(rows)
         except Exception as e:
             logger.error("Failed to flush data for %s/%s: %s", symbol, tf, e)
-            # 실패 시 버퍼에 다시 넣기
+            # 실패 시 버퍼에 다시 넣기 (rows 미유실 — 다음 flush 재시도)
             if key not in self._buffer:
                 self._buffer[key] = []
             self._buffer[key] = rows + self._buffer[key]
+            return 0

--- a/tests/unit/test_data_collector_ingress_validation.py
+++ b/tests/unit/test_data_collector_ingress_validation.py
@@ -1,0 +1,315 @@
+"""DataCollector symbol/timeframe ingress 검증 단위 테스트 (#1614).
+
+선행: #1612(계약)·#1613(코드 SSOT). 공용 helper `_is_valid_ingress`
++ 3지점 defense-in-depth(`_collect_loop` pre-callback / `add_data` /
+`_flush` 최종 guard) + invalid-drop vs append-exception-retry 구분 +
+`flush_all` 이번 호출 append 성공분만 count 를 검증한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.data.collector import DataCollector
+
+
+def _row(minute: int = 0) -> dict:
+    return {
+        "timestamp": datetime(2026, 3, 1, 9, minute, tzinfo=UTC),
+        "symbol": "005930",
+        "open": 50000.0,
+        "high": 50100.0,
+        "low": 49900.0,
+        "close": 50050.0,
+        "volume": 1000,
+        "source": "test",
+    }
+
+
+def _make_collector(buffer_size: int = 100, exchange: str = "KRX") -> DataCollector:
+    """`_store` 를 MagicMock 으로 둔 collector (append 호출 정밀 검증용)."""
+    store = MagicMock()
+    eventbus = AsyncMock()
+    return DataCollector(
+        store=store,
+        eventbus=eventbus,
+        buffer_size=buffer_size,
+        exchange=exchange,
+    )
+
+
+# ── add_data ingress 거부 ────────────────────────────────
+
+
+class TestAddDataIngress:
+    def test_reject_non_krx_6digit_symbol(self, caplog):
+        c = _make_collector()
+        with caplog.at_level(logging.WARNING):
+            c.add_data("ABCDEF", "1m", _row())
+        assert "ABCDEF:1m" not in c.buffer
+        assert c.buffer == {}
+        c._store.append.assert_not_called()
+        assert "ingress reject (add_data)" in caplog.text
+
+    def test_reject_1d_write_ownership_boundary(self, caplog):
+        c = _make_collector()
+        with caplog.at_level(logging.WARNING):
+            c.add_data("005930", "1d", _row())
+        assert "005930:1d" not in c.buffer
+        c._store.append.assert_not_called()
+        assert "ingress reject (add_data)" in caplog.text
+
+    def test_reject_tick_no_ohlcv_path(self, caplog):
+        c = _make_collector()
+        with caplog.at_level(logging.WARNING):
+            c.add_data("005930", "tick", _row())
+        assert "005930:tick" not in c.buffer
+        c._store.append.assert_not_called()
+
+    def test_reject_oracle_invalid_timeframe(self, caplog):
+        c = _make_collector()
+        with caplog.at_level(logging.WARNING):
+            c.add_data("005930", "oracle-invalid-timeframe", _row())
+        assert c.buffer == {}
+        c._store.append.assert_not_called()
+
+    @pytest.mark.parametrize("tf", ["1m", "5m", "15m", "1h"])
+    def test_valid_canonical_timeframes_buffered(self, tf):
+        c = _make_collector()
+        c.add_data("005930", tf, _row())
+        assert c.buffer[f"005930:{tf}"] == [_row()]
+        c._store.append.assert_not_called()  # buffer_size 미달, flush 안 됨
+
+    def test_valid_input_flush_append_preserved(self):
+        c = _make_collector(buffer_size=2)
+        c.add_data("005930", "1m", _row(0))
+        assert "005930:1m" in c.buffer
+        c.add_data("005930", "1m", _row(1))  # buffer full → auto flush
+        assert "005930:1m" not in c.buffer
+        c._store.append.assert_called_once()
+        args, kwargs = c._store.append.call_args
+        assert args[0] == "005930"
+        assert args[1] == "1m"
+        assert len(args[2]) == 2
+        assert kwargs["exchange"] == "KRX"
+
+    def test_non_str_timeframe_list_no_typeerror(self, caplog):
+        c = _make_collector()
+        with caplog.at_level(logging.WARNING):
+            c.add_data("005930", ["1m"], _row())  # type: ignore[arg-type]
+        assert c.buffer == {}
+        c._store.append.assert_not_called()
+        assert "ingress reject (add_data)" in caplog.text
+
+    def test_non_str_timeframe_int_no_typeerror(self, caplog):
+        c = _make_collector()
+        with caplog.at_level(logging.WARNING):
+            c.add_data("005930", 1, _row())  # type: ignore[arg-type]
+        assert c.buffer == {}
+        c._store.append.assert_not_called()
+
+    def test_non_krx_exchange_skips_symbol_shape(self):
+        c = _make_collector(exchange="NASDAQ")
+        c.add_data("AAPL", "1m", _row())
+        assert c.buffer["AAPL:1m"] == [_row()]
+
+
+# ── _collect_loop pre-callback guard (R1-F1) ─────────────
+
+
+class TestCollectLoopGuard:
+    async def test_invalid_timeframe_callback_not_called(self):
+        c = _make_collector()
+        callback = AsyncMock(return_value=[_row()])
+        c.set_data_callback(callback)
+        c._collect_interval = 0.05
+
+        c.start(["005930"], ["oracle-invalid-timeframe"])
+        await asyncio.sleep(0.08)
+        c.stop()
+
+        callback.assert_not_called()
+        assert c.buffer == {}
+        c._store.append.assert_not_called()
+
+    async def test_mixed_valid_invalid_only_valid_collected(self):
+        c = _make_collector()
+        seen: list[tuple[str, str]] = []
+
+        async def cb(symbol, tf):
+            seen.append((symbol, tf))
+            return [_row()]
+
+        c.set_data_callback(cb)
+        c._collect_interval = 0.05
+        c.start(["005930", "BADSYM"], ["1m", "1d"])
+        await asyncio.sleep(0.08)
+        c.stop()
+
+        # 통과는 (005930, 1m) 만. BADSYM(비6자리)·1d(write-ownership) 거부
+        assert (("005930", "1m")) in seen
+        assert ("005930", "1d") not in seen
+        assert ("BADSYM", "1m") not in seen
+        assert ("BADSYM", "1d") not in seen
+        assert all(s == "005930" and t == "1m" for s, t in seen)
+
+
+# ── _flush 최종 guard + buffer 우회 + count (R1-F2/R2-F1/R3-F1) ──
+
+
+class TestFlushGuardAndCount:
+    def test_buffer_bypass_mixed_keys_only_valid_appended(self, caplog):
+        c = _make_collector()
+        n = 4
+        valid_rows = [_row(i) for i in range(n)]
+        # public buffer 프로퍼티 직접 주입 (add_data 검증 우회)
+        c.buffer["005930:oracle-invalid-timeframe"] = [_row()]  # invalid tf
+        c.buffer["badkey"] = [_row()]  # no-colon
+        c.buffer["005930:1m:extra"] = [_row()]  # extra-colon
+        c.buffer[("005930", "1m")] = [_row()]  # type: ignore[index]  # non-str key
+        c.buffer["AAPL:1m"] = [_row()]  # KRX 비6자리 symbol
+        c.buffer["005930:1m"] = valid_rows  # valid (rows=N)
+
+        with caplog.at_level(logging.WARNING):
+            total = c.flush_all()  # raise 없이 완주해야 함
+
+        # valid 키만 append, 정확히 rows=N
+        c._store.append.assert_called_once()
+        args, kwargs = c._store.append.call_args
+        assert args[0] == "005930"
+        assert args[1] == "1m"
+        assert len(args[2]) == n
+        # flush_all 반환 == valid append rows 수(N)만 (drop invalid 미포함)
+        assert total == n
+        # invalid 전부 drop (pop 됨)
+        assert c.buffer == {}
+        assert "flush guard: drop malformed buffered key" in caplog.text
+        assert "flush guard: drop non-str buffered key" in caplog.text
+        assert "flush guard: drop invalid buffered key" in caplog.text
+
+    def test_stop_via_flush_all_no_raise_on_malformed(self):
+        c = _make_collector()
+        c.buffer["badkey"] = [_row()]
+        c.buffer[("x",)] = [_row()]  # type: ignore[index]
+        # stop() → flush_all() 경유, raise 없이 완주
+        c.stop()
+        assert c.buffer == {}
+        c._store.append.assert_not_called()
+
+    def test_flush_returns_append_success_count(self):
+        c = _make_collector()
+        c.buffer["005930:5m"] = [_row(0), _row(1), _row(2)]
+        result = c._flush("005930:5m")
+        assert result == 3
+        c._store.append.assert_called_once()
+
+    def test_flush_empty_key_returns_zero(self):
+        c = _make_collector()
+        assert c._flush("005930:1m") == 0
+        assert c._flush("nonexistent:1m") == 0
+
+    def test_flush_invalid_key_drop_returns_zero_no_retry(self, caplog):
+        c = _make_collector()
+        c.buffer["005930:1d"] = [_row()]  # write-ownership 위반
+        with caplog.at_level(logging.WARNING):
+            result = c._flush("005930:1d")
+        assert result == 0
+        c._store.append.assert_not_called()
+        # invalid drop: pop 되어 사라짐 (retry 안 함)
+        assert "005930:1d" not in c.buffer
+        assert "flush guard: drop invalid buffered key" in caplog.text
+
+
+# ── append-failure retry 보존 (R4-F1) ────────────────────
+
+
+class TestAppendFailureRetryPreserved:
+    def test_append_exception_rebuffers_rows_for_retry(self, caplog):
+        c = _make_collector()
+        rows = [_row(0), _row(1)]
+        c.buffer["005930:1m"] = list(rows)
+        c._store.append.side_effect = RuntimeError("transient store error")
+
+        with caplog.at_level(logging.ERROR):
+            total = c.flush_all()
+
+        # 이번 회차 append 0
+        assert total == 0
+        # rows 미유실 — 같은 key 에 재버퍼링 (다음 flush 재시도 가능)
+        assert c.buffer["005930:1m"] == rows
+        assert "Failed to flush data" in caplog.text
+
+    def test_append_exception_preserves_rebuffer_order(self):
+        c = _make_collector()
+        first = [_row(0)]
+        c.buffer["005930:1m"] = list(first)
+        c._store.append.side_effect = RuntimeError("boom")
+        c.flush_all()
+        # append 실패 후 pending 에 새 row 추가됨
+        c.add_data("005930", "1m", _row(5))
+        c._store.append.side_effect = RuntimeError("boom2")
+        c.flush_all()
+        # 기존 rows + existing 순서 보존 (rows + self._buffer[key])
+        assert c.buffer["005930:1m"] == [_row(0), _row(5)]
+
+    def test_invalid_drop_vs_append_fail_distinguished(self, caplog):
+        """invalid-drop(pop·gone, retry 안 함) vs append-fail(retry 보존)."""
+        c = _make_collector()
+        # invalid: append-fail side_effect 와 무관하게 drop 되어야 함
+        c.buffer["005930:1d"] = [_row()]
+        # valid: append-fail 시 retry 보존
+        valid_rows = [_row(0), _row(1)]
+        c.buffer["005930:1m"] = list(valid_rows)
+        c._store.append.side_effect = RuntimeError("transient")
+
+        with caplog.at_level(logging.WARNING):
+            total = c.flush_all()
+
+        assert total == 0
+        # invalid: pop·gone (retry 안 함)
+        assert "005930:1d" not in c.buffer
+        # valid append-fail: rows 재버퍼링 (retry 보존)
+        assert c.buffer["005930:1m"] == valid_rows
+        # invalid 는 append 호출 자체가 없음 (1m 만 호출 시도됨)
+        for call in c._store.append.call_args_list:
+            assert call.args[1] != "1d"
+
+
+# ── 프로덕션 구성 경로 회귀 (main.py 초기화 → event-driven add_data) ──
+
+
+class TestProductionConfigPathRegression:
+    def test_main_py_style_init_and_event_driven_add_data(self):
+        """main.py:978 스타일 구성(exchange 기본 KRX) + 이벤트 기반 add_data.
+
+        프로덕션은 KRX 6자리 종목·canonical timeframe 이벤트를 직접
+        `add_data` 로 흘린다. 본 경로가 기존대로 버퍼링·flush 되는지 +
+        out-of-vocab 이벤트가 거부되는지 회귀.
+        """
+        store = MagicMock()
+        eventbus = AsyncMock()
+        # main.py:978 구성 형태 (기본 exchange="KRX")
+        collector = DataCollector(
+            store=store,
+            eventbus=eventbus,
+            buffer_size=2,
+        )
+
+        # event-driven 정상 시세 이벤트 (KRX 6자리 + canonical tf)
+        collector.add_data("005930", "1m", _row(0))
+        collector.add_data("005930", "1m", _row(1))  # buffer full → flush
+        store.append.assert_called_once()
+        assert store.append.call_args.args[0] == "005930"
+        assert store.append.call_args.args[1] == "1m"
+
+        # out-of-vocab 이벤트는 거부 (경로 미생성)
+        store.append.reset_mock()
+        collector.add_data("00593", "1m", _row(2))  # 5자리
+        collector.add_data("005930", "1d", _row(3))  # write-ownership
+        collector.flush_all()
+        store.append.assert_not_called()


### PR DESCRIPTION
Closes #1614

## Summary
- live `DataCollector` ingress에 #1613 SSOT 검증을 공용 helper `_is_valid_ingress` + **3지점 defense-in-depth**로 추가: ① `_collect_loop` `_data_callback` 호출 전(invalid start 키가 broker/feed로 안 나감) ② `add_data` 진입(이벤트 기반) ③ `_flush` 최종 guard(public `buffer` 직접 주입 우회 방어)
- OHLCV `{1m,5m,15m,1h}`만 통과(`1d`=DataFeed write-ownership 제외, `tick`=별도 data_type 제외, core.md `### KRX symbol shape` exchange=KRX 한정). per-key warning+skip, 수집 루프 미중단
- `_flush(self,key) -> int` 시그니처 + 안전 key parse(non-str/malformed drop). **invalid-drop(retry 안 함) vs `_store.append` 예외(기존 재버퍼링 retry 보존, collector.py:152-157 동작 정확 보존) 구분**. `flush_all`은 이번 호출 실제 append 성공 row만 count

## 범위/불변
- `collector.py` 단일. `ParquetStore`/write-ownership/tick-interface/형제 표면/lifecycle 불변. `buffer` 프로퍼티 시그니처 불변. private regex 0(#1613 위임)

## Test Plan
- Plan Preflight 5R(R1 구조→R2 _flush parse→R3 count→R4 retry 보존→R5 approve) → Codex `approve-implement`; 브랜치 리뷰 attempt 1 PASS
- `pytest -k collector` 40 + `-k "collector or data_pipeline"` 112 회귀 + `mypy src/` 241 clean + ruff clean
- callback 미호출/buffer 우회+malformed+count==N/append-fail retry vs invalid-drop 구분/non-str tf/mixed 루프 지속/프로덕션 경로 잠금