### PR TITLE
fix(web): reject provided runtime-invalid account_id at read-API ingress (#1624)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1371,8 +1371,8 @@
               }
             }
           },
-          "503": {
-            "description": "Treasury not available",
+          "422": {
+            "description": "Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 all-account 집계 분기로 통과한다 (#1218 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1381,12 +1381,12 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
+          "503": {
+            "description": "Treasury not available",
             "content": {
-              "application/json": {
+              "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1464,7 +1464,7 @@
             }
           },
           "422": {
-            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595).",
+            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). 제공된 runtime-invalid ``account_id`` (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)도 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 all-account 집계 분기로 통과한다 (#1218 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2882,7 +2882,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Performance",
-        "description": "전략 성과 지표 조회. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "전략 성과 지표 조회. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\n제공된 runtime-invalid ``account_id`` (``\"\"``/``\"default\"``/패턴 위반)는\naccount 해석/lookup **이전**에 422로 거부한다 (#1624). ``account_id``\n미지정(``None``)은 가드를 통과해 봇 추출 fallback → (추출 불가 시) 400으로\n이어진다 — #1218이 정렬한 omitted query 정책을 보존한다. valid-pattern\nbut absent(``acc-9999``)는 가드를 통과해 기존 단건 존재 검증 404로\n이어진다 (invalid-format ↔ genuine not-found 분리).",
         "operationId": "get_strategy_performance_api_strategies__strategy_id__performance_get",
         "parameters": [
           {
@@ -2922,8 +2922,28 @@
               }
             }
           },
+          "400": {
+            "description": "account_id를 결정할 수 없음 (``account_id`` 미지정 + 전략에 연결된 봇 없음). #1218 query 정책 — fallback 없이 명시 실패.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Strategy not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은 account 해석/lookup 이전에 422로 거부된다. ``account_id`` 미지정(``None``)은 봇 추출 fallback으로 통과하며, 추출 불가 시 400이다 (#1218 omitted 정책 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2938,16 +2958,6 @@
               "application/problem+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -3824,7 +3834,7 @@
           "trades"
         ],
         "summary": "List Trades",
-        "description": "거래 기록 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``trade:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
+        "description": "거래 기록 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``trade:read`` scope 를 보유한 agent 만 호출 가능 (#1407).\n\n제공된 runtime-invalid ``account_id`` (``\"\"``/``\"default\"``/패턴 위반)는\nservice 위임 **이전**에 422로 거부한다 (#1624). 가드가 없으면\n``TradeService.get_trades`` downstream의 ``require_account_id``가\n``InvalidAccountIdError``를 raise하고, Web generic exception handler가\n이를 500 `An unexpected error occurred.`로 흘려 invalid-input ↔\nserver-failure 구분이 깨진다. ``account_id`` 미지정(``None``)은\n전체 필터로 통과한다 (#1218 보존).",
         "operationId": "list_trades_api_trades_get",
         "parameters": [
           {
@@ -3915,8 +3925,8 @@
               }
             }
           },
-          "503": {
-            "description": "Trade service not available",
+          "422": {
+            "description": "Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은 service 위임 이전에 422로 거부된다 — downstream ``InvalidAccountIdError``가 generic 500으로 escape하던 경로를 차단한다. ``account_id`` 미지정은 전체 필터로 통과한다 (#1218 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -3925,12 +3935,12 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
+          "503": {
+            "description": "Trade service not available",
             "content": {
-              "application/json": {
+              "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3944,7 +3954,7 @@
           "bots"
         ],
         "summary": "List Bots",
-        "description": "봇 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``bot:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
+        "description": "봇 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``bot:read`` scope 를 보유한 agent 만 호출 가능 (#1407).\n\n제공된 runtime-invalid ``account_id`` (``\"\"``/``\"default\"``/패턴 위반)는\n필터링 **이전**에 422로 거부한다 (#1624). 기존 ``if account_id`` truthy\n분기는 provided-``\"\"``를 omitted처럼 흡수(전체 반환)하고 ``\"default\"``/\n패턴위반은 빈 목록으로 흡수하던 contract-drift였다. 이제 ingress 가드 +\n``account_id is not None`` 명시 필터로 교체해 ``None``(미지정)만 전체\n반환 분기로 통과시킨다 (#1218 보존). valid-pattern but absent\n(``acc-9999``)는 가드를 통과해 기존 200 empty(매칭 0건)를 유지한다.",
         "operationId": "list_bots_api_bots_get",
         "parameters": [
           {
@@ -4003,8 +4013,8 @@
               }
             }
           },
-          "503": {
-            "description": "Bot manager not available",
+          "422": {
+            "description": "Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은 필터링 이전에 422로 거부된다 — ``if account_id`` truthy 분기가 provided-``\"\"``/invalid를 빈 목록/전체 반환으로 흡수하던 contract-drift를 차단한다. ``account_id`` 미지정(``None``)은 전체 봇 반환으로 통과한다 (#1218 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4013,12 +4023,12 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
+          "503": {
+            "description": "Bot manager not available",
             "content": {
-              "application/json": {
+              "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4670,7 +4680,7 @@
           "treasury"
         ],
         "summary": "Get Summary",
-        "description": "자금 현황 요약. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\naccount_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.\n미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).",
+        "description": "자금 현황 요약. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\naccount_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.\n미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).\n\n제공된 runtime-invalid ``account_id`` (``\"\"``/``\"default\"``/패턴 위반)는\nlookup 이전에 422로 거부한다 (#1624). ``account_id`` 미지정(``None``)은\n기본 Treasury 분기로 통과한다 (#1218 보존).",
         "operationId": "get_summary_api_treasury_get",
         "parameters": [
           {
@@ -4711,8 +4721,8 @@
               }
             }
           },
-          "503": {
-            "description": "Treasury not available",
+          "422": {
+            "description": "Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 Treasury 요약으로 통과한다 (#1218 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4721,12 +4731,12 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
+          "503": {
+            "description": "Treasury not available",
             "content": {
-              "application/json": {
+              "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4740,7 +4750,7 @@
           "treasury"
         ],
         "summary": "List Transactions",
-        "description": "자금 변동 이력 조회. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\n``start_date``/``end_date``는 ISO ``YYYY-MM-DD`` (date-only)만 허용한다.\n파싱 실패 또는 캘린더 invalid는 422로 거부된다. 내부적으로 SQLite\n``datetime('now')`` 저장 포맷(``YYYY-MM-DD HH:MM:SS``)에 맞춰\n``start_date``는 ``00:00:00``, ``end_date``는 ``23:59:59``로 확장된 뒤\nSQL 텍스트 비교에 사용된다 (#1440).\n\n``type`` query는 ``TRANSACTION_TYPE_VOCABULARY`` (#1476)를 SSOT로 하는\n``Literal``로 좁혀, vocabulary 외 값을 FastAPI 단계에서 422로 거부한다\n(#1477). invalid 값이 200 + empty result로 통과하던 oracle A7 host probe\n회귀(fingerprint ``a4f6744a44f5``)를 차단한다.",
+        "description": "자금 변동 이력 조회. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\n``start_date``/``end_date``는 ISO ``YYYY-MM-DD`` (date-only)만 허용한다.\n파싱 실패 또는 캘린더 invalid는 422로 거부된다. 내부적으로 SQLite\n``datetime('now')`` 저장 포맷(``YYYY-MM-DD HH:MM:SS``)에 맞춰\n``start_date``는 ``00:00:00``, ``end_date``는 ``23:59:59``로 확장된 뒤\nSQL 텍스트 비교에 사용된다 (#1440).\n\n``type`` query는 ``TRANSACTION_TYPE_VOCABULARY`` (#1476)를 SSOT로 하는\n``Literal``로 좁혀, vocabulary 외 값을 FastAPI 단계에서 422로 거부한다\n(#1477). invalid 값이 200 + empty result로 통과하던 oracle A7 host probe\n회귀(fingerprint ``a4f6744a44f5``)를 차단한다.\n\n제공된 runtime-invalid ``account_id`` (``\"\"``/``\"default\"``/패턴 위반)는\nSQL WHERE 구성 **이전**에 422로 거부한다 (#1624) — invalid 값이 200 +\nempty result로 흡수되던 contract-drift를 차단한다. ``account_id``\n미지정(``None``)은 전체 필터로 통과한다 (#1218 보존).",
         "operationId": "list_transactions_api_treasury_transactions_get",
         "parameters": [
           {
@@ -4868,7 +4878,7 @@
             }
           },
           "422": {
-            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_transactions.created_at``은 SQLite ``datetime('now')`` 포맷(``YYYY-MM-DD HH:MM:SS``)으로 저장되며, 검증된 boundary로만 비교한다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). ``type`` query는 정규 vocabulary ``{allocate, deallocate, release, fill, bot_stopped_release}`` (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477).",
+            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_transactions.created_at``은 SQLite ``datetime('now')`` 포맷(``YYYY-MM-DD HH:MM:SS``)으로 저장되며, 검증된 boundary로만 비교한다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). ``type`` query는 정규 vocabulary ``{allocate, deallocate, release, fill, bot_stopped_release}`` (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477). 제공된 runtime-invalid ``account_id`` (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)도 SQL WHERE 구성 이전에 422로 거부된다. ``account_id`` 미지정은 전체 필터로 통과한다 (#1218 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5257,8 +5267,8 @@
               }
             }
           },
-          "503": {
-            "description": "Treasury not available",
+          "422": {
+            "description": "Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 Treasury 분기로 통과한다 (#1218 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5267,12 +5277,12 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
+          "503": {
+            "description": "Treasury not available",
             "content": {
-              "application/json": {
+              "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -5350,7 +5360,7 @@
             }
           },
           "422": {
-            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595).",
+            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). 제공된 runtime-invalid ``account_id`` (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)도 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 Treasury 분기로 통과한다 (#1218 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5432,7 +5442,7 @@
             }
           },
           "422": {
-            "description": "Invalid ``date`` path param (ISO ``YYYY-MM-DD`` required). malformed/캘린더 invalid path는 404가 아닌 422로 거부된다 (#1440).",
+            "description": "Invalid ``date`` path param (ISO ``YYYY-MM-DD`` required). malformed/캘린더 invalid path는 404가 아닌 422로 거부된다 (#1440). 제공된 runtime-invalid ``account_id`` query (``\"\"``/``\"default\"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)도 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 Treasury 분기로 통과한다 (#1218 보존, #1624).",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -482,6 +482,14 @@ export type paths = {
          * List Bots
          * @description 봇 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
          *     ``bot:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
+         *
+         *     제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+         *     필터링 **이전**에 422로 거부한다 (#1624). 기존 ``if account_id`` truthy
+         *     분기는 provided-``""``를 omitted처럼 흡수(전체 반환)하고 ``"default"``/
+         *     패턴위반은 빈 목록으로 흡수하던 contract-drift였다. 이제 ingress 가드 +
+         *     ``account_id is not None`` 명시 필터로 교체해 ``None``(미지정)만 전체
+         *     반환 분기로 통과시킨다 (#1218 보존). valid-pattern but absent
+         *     (``acc-9999``)는 가드를 통과해 기존 200 empty(매칭 0건)를 유지한다.
          */
         get: operations["list_bots_api_bots_get"];
         put?: never;
@@ -1320,6 +1328,13 @@ export type paths = {
          * Get Strategy Performance
          * @description 전략 성과 지표 조회. 인증된 master/human 또는 ``strategy:read`` scope 를
          *     보유한 agent 만 호출 가능 (#1407).
+         *
+         *     제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+         *     account 해석/lookup **이전**에 422로 거부한다 (#1624). ``account_id``
+         *     미지정(``None``)은 가드를 통과해 봇 추출 fallback → (추출 불가 시) 400으로
+         *     이어진다 — #1218이 정렬한 omitted query 정책을 보존한다. valid-pattern
+         *     but absent(``acc-9999``)는 가드를 통과해 기존 단건 존재 검증 404로
+         *     이어진다 (invalid-format ↔ genuine not-found 분리).
          */
         get: operations["get_strategy_performance_api_strategies__strategy_id__performance_get"];
         put?: never;
@@ -1575,6 +1590,14 @@ export type paths = {
          * List Trades
          * @description 거래 기록 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
          *     ``trade:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
+         *
+         *     제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+         *     service 위임 **이전**에 422로 거부한다 (#1624). 가드가 없으면
+         *     ``TradeService.get_trades`` downstream의 ``require_account_id``가
+         *     ``InvalidAccountIdError``를 raise하고, Web generic exception handler가
+         *     이를 500 `An unexpected error occurred.`로 흘려 invalid-input ↔
+         *     server-failure 구분이 깨진다. ``account_id`` 미지정(``None``)은
+         *     전체 필터로 통과한다 (#1218 보존).
          */
         get: operations["list_trades_api_trades_get"];
         put?: never;
@@ -1599,6 +1622,10 @@ export type paths = {
          *
          *     account_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.
          *     미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).
+         *
+         *     제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+         *     lookup 이전에 422로 거부한다 (#1624). ``account_id`` 미지정(``None``)은
+         *     기본 Treasury 분기로 통과한다 (#1218 보존).
          */
         get: operations["get_summary_api_treasury_get"];
         put?: never;
@@ -1821,6 +1848,11 @@ export type paths = {
          *     ``Literal``로 좁혀, vocabulary 외 값을 FastAPI 단계에서 422로 거부한다
          *     (#1477). invalid 값이 200 + empty result로 통과하던 oracle A7 host probe
          *     회귀(fingerprint ``a4f6744a44f5``)를 차단한다.
+         *
+         *     제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+         *     SQL WHERE 구성 **이전**에 422로 거부한다 (#1624) — invalid 값이 200 +
+         *     empty result로 흡수되던 contract-drift를 차단한다. ``account_id``
+         *     미지정(``None``)은 전체 필터로 통과한다 (#1218 보존).
          */
         get: operations["list_transactions_api_treasury_transactions_get"];
         put?: never;
@@ -4794,13 +4826,13 @@ export interface operations {
                     "application/json": components["schemas"]["BotListResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)은 필터링 이전에 422로 거부된다 — ``if account_id`` truthy 분기가 provided-``""``/invalid를 빈 목록/전체 반환으로 흡수하던 contract-drift를 차단한다. ``account_id`` 미지정(``None``)은 전체 봇 반환으로 통과한다 (#1218 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Bot manager not available */
@@ -6200,7 +6232,7 @@ export interface operations {
                     "application/json": components["schemas"]["PortfolioHistoryResponse"];
                 };
             };
-            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). */
+            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). 제공된 runtime-invalid ``account_id`` (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)도 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 all-account 집계 분기로 통과한다 (#1218 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6240,13 +6272,13 @@ export interface operations {
                     "application/json": components["schemas"]["PortfolioValueResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)은 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 all-account 집계 분기로 통과한다 (#1218 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Treasury not available */
@@ -6640,6 +6672,15 @@ export interface operations {
                     "application/json": components["schemas"]["StrategyPerformanceResponse"];
                 };
             };
+            /** @description account_id를 결정할 수 없음 (``account_id`` 미지정 + 전략에 연결된 봇 없음). #1218 query 정책 — fallback 없이 명시 실패. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
             /** @description Strategy not found */
             404: {
                 headers: {
@@ -6649,13 +6690,13 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)은 account 해석/lookup 이전에 422로 거부된다. ``account_id`` 미지정(``None``)은 봇 추출 fallback으로 통과하며, 추출 불가 시 400이다 (#1218 omitted 정책 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Strategy registry or database not available */
@@ -7092,13 +7133,13 @@ export interface operations {
                     "application/json": components["schemas"]["TradeListResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)은 service 위임 이전에 422로 거부된다 — downstream ``InvalidAccountIdError``가 generic 500으로 escape하던 경로를 차단한다. ``account_id`` 미지정은 전체 필터로 통과한다 (#1218 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Trade service not available */
@@ -7141,13 +7182,13 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)은 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 Treasury 요약으로 통과한다 (#1218 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Treasury not available */
@@ -7450,7 +7491,7 @@ export interface operations {
                     "application/json": components["schemas"]["SnapshotListResponse"];
                 };
             };
-            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). */
+            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). 제공된 runtime-invalid ``account_id`` (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)도 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 Treasury 분기로 통과한다 (#1218 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -7502,7 +7543,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Invalid ``date`` path param (ISO ``YYYY-MM-DD`` required). malformed/캘린더 invalid path는 404가 아닌 422로 거부된다 (#1440). */
+            /** @description Invalid ``date`` path param (ISO ``YYYY-MM-DD`` required). malformed/캘린더 invalid path는 404가 아닌 422로 거부된다 (#1440). 제공된 runtime-invalid ``account_id`` query (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)도 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 Treasury 분기로 통과한다 (#1218 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -7542,13 +7583,13 @@ export interface operations {
                     "application/json": components["schemas"]["SnapshotResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid ``account_id`` query. 제공된 runtime-invalid 값 (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)은 lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 Treasury 분기로 통과한다 (#1218 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Treasury not available */
@@ -7589,7 +7630,7 @@ export interface operations {
                     "application/json": components["schemas"]["TransactionListResponse"];
                 };
             };
-            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_transactions.created_at``은 SQLite ``datetime('now')`` 포맷(``YYYY-MM-DD HH:MM:SS``)으로 저장되며, 검증된 boundary로만 비교한다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). ``type`` query는 정규 vocabulary ``{allocate, deallocate, release, fill, bot_stopped_release}`` (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477). */
+            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_transactions.created_at``은 SQLite ``datetime('now')`` 포맷(``YYYY-MM-DD HH:MM:SS``)으로 저장되며, 검증된 boundary로만 비교한다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). ``type`` query는 정규 vocabulary ``{allocate, deallocate, release, fill, bot_stopped_release}`` (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477). 제공된 runtime-invalid ``account_id`` (``""``/``"default"``/``^[a-zA-Z0-9\-]{3,30}$`` 불일치)도 SQL WHERE 구성 이전에 422로 거부된다. ``account_id`` 미지정은 전체 필터로 통과한다 (#1218 보존, #1624). */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -28,6 +28,7 @@ from ante.web.schemas import (
     BotListResponse,
     BotUpdateRequest,
 )
+from ante.web.utils.account_params import reject_invalid_account_id
 from ante.web.utils.date_params import reject_inverted_date_range
 
 logger = logging.getLogger(__name__)
@@ -179,6 +180,21 @@ BOT_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
     "",
     response_model=BotListResponse,
     responses={
+        422: {
+            "description": (
+                "Invalid ``account_id`` query. 제공된 runtime-invalid 값"
+                ' (``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은'
+                " 필터링 이전에 422로 거부된다 — ``if account_id`` truthy 분기가"
+                ' provided-``""``/invalid를 빈 목록/전체 반환으로 흡수하던'
+                " contract-drift를 차단한다. ``account_id`` 미지정(``None``)은"
+                " 전체 봇 반환으로 통과한다 (#1218 보존, #1624)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         503: {
             "description": "Bot manager not available",
             "content": {
@@ -198,11 +214,21 @@ async def list_bots(
     cursor: str | None = None,
 ) -> dict:
     """봇 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
-    ``bot:read`` scope 를 보유한 agent 만 호출 가능 (#1407)."""
+    ``bot:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
+
+    제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+    필터링 **이전**에 422로 거부한다 (#1624). 기존 ``if account_id`` truthy
+    분기는 provided-``""``를 omitted처럼 흡수(전체 반환)하고 ``"default"``/
+    패턴위반은 빈 목록으로 흡수하던 contract-drift였다. 이제 ingress 가드 +
+    ``account_id is not None`` 명시 필터로 교체해 ``None``(미지정)만 전체
+    반환 분기로 통과시킨다 (#1218 보존). valid-pattern but absent
+    (``acc-9999``)는 가드를 통과해 기존 200 empty(매칭 0건)를 유지한다."""
     from ante.web.pagination import paginate
 
+    reject_invalid_account_id(account_id)
+
     bots = bot_manager.list_bots()
-    if account_id:
+    if account_id is not None:
         bots = [
             b
             for b in bots

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -17,6 +17,7 @@ from ante.web.schemas import (
     PortfolioHistoryResponse,
     PortfolioValueResponse,
 )
+from ante.web.utils.account_params import reject_invalid_account_id
 from ante.web.utils.date_params import (
     reject_inverted_date_range,
     validate_iso_date_only,
@@ -32,7 +33,13 @@ def _resolve_treasury(
     treasury_manager: Any | None,
     account_id: str | None,
 ) -> Any:
-    """account_id가 주어지면 해당 계좌의 Treasury를 반환한다."""
+    """account_id가 주어지면 해당 계좌의 Treasury를 반환한다.
+
+    제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+    lookup 이전에 422로 거부한다 (#1624, Account ID 계약 read-API ingress).
+    ``account_id is None`` (미지정)은 통과 — #1218 단일-treasury 분기 보존.
+    """
+    reject_invalid_account_id(account_id)
     if account_id and treasury_manager is not None:
         try:
             return treasury_manager.get(account_id)
@@ -49,6 +56,19 @@ def _resolve_treasury(
     response_model=PortfolioValueResponse,
     response_model_exclude_none=True,
     responses={
+        422: {
+            "description": (
+                "Invalid ``account_id`` query. 제공된 runtime-invalid 값"
+                ' (``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은'
+                " lookup 이전에 422로 거부된다. ``account_id`` 미지정은"
+                " all-account 집계 분기로 통과한다 (#1218 보존, #1624)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         503: {
             "description": "Treasury not available",
             "content": {
@@ -104,7 +124,10 @@ async def portfolio_value(
                 "``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 "
                 "저장되므로 임의 문자열을 허용하지 않는다 (#1440). "
                 "``start_date > end_date`` (inverted range)도 422로 거부한다 "
-                "(#1595)."
+                "(#1595). 제공된 runtime-invalid ``account_id`` "
+                '(``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)도 '
+                "lookup 이전에 422로 거부된다. ``account_id`` 미지정은 "
+                "all-account 집계 분기로 통과한다 (#1218 보존, #1624)."
             ),
             "content": {
                 "application/problem+json": {

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -35,6 +35,7 @@ from ante.web.schemas import (
     StrategyValidateResponse,
     WeeklySummaryResponse,
 )
+from ante.web.utils.account_params import reject_invalid_account_id
 
 router = APIRouter()
 
@@ -569,8 +570,33 @@ async def get_strategy(
     "/{strategy_id}/performance",
     response_model=StrategyPerformanceResponse,
     responses={
+        400: {
+            "description": (
+                "account_id를 결정할 수 없음 (``account_id`` 미지정 + 전략에 "
+                "연결된 봇 없음). #1218 query 정책 — fallback 없이 명시 실패."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         404: {
             "description": "Strategy not found",
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
+        422: {
+            "description": (
+                "Invalid ``account_id`` query. 제공된 runtime-invalid 값"
+                ' (``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은'
+                " account 해석/lookup 이전에 422로 거부된다. ``account_id``"
+                " 미지정(``None``)은 봇 추출 fallback으로 통과하며, 추출 불가 시"
+                " 400이다 (#1218 omitted 정책 보존, #1624)."
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -597,10 +623,19 @@ async def get_strategy_performance(
     account_id: str | None = None,
 ) -> dict:
     """전략 성과 지표 조회. 인증된 master/human 또는 ``strategy:read`` scope 를
-    보유한 agent 만 호출 가능 (#1407)."""
+    보유한 agent 만 호출 가능 (#1407).
+
+    제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+    account 해석/lookup **이전**에 422로 거부한다 (#1624). ``account_id``
+    미지정(``None``)은 가드를 통과해 봇 추출 fallback → (추출 불가 시) 400으로
+    이어진다 — #1218이 정렬한 omitted query 정책을 보존한다. valid-pattern
+    but absent(``acc-9999``)는 가드를 통과해 기존 단건 존재 검증 404로
+    이어진다 (invalid-format ↔ genuine not-found 분리)."""
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
+
+    reject_invalid_account_id(account_id)
 
     # account_id 결정: 쿼리 파라미터 우선, 없으면 봇에서 추출.
     # 둘 다 실패하면 `"default"` fallback 없이 400으로 명시 실패한다 (#1218 query 정책).

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -630,12 +630,17 @@ async def get_strategy_performance(
     미지정(``None``)은 가드를 통과해 봇 추출 fallback → (추출 불가 시) 400으로
     이어진다 — #1218이 정렬한 omitted query 정책을 보존한다. valid-pattern
     but absent(``acc-9999``)는 가드를 통과해 기존 단건 존재 검증 404로
-    이어진다 (invalid-format ↔ genuine not-found 분리)."""
+    이어진다 (invalid-format ↔ genuine not-found 분리).
+
+    가드는 함수 진입 직후, strategy 레지스트리/봇 조회 **이전**에 실행한다.
+    그래야 존재하지 않는 ``strategy_id`` + provided-invalid ``account_id``
+    조합에서도 account_id 422 계약이 strategy 존재 여부에 종속되지 않는다
+    (#1624 ingress invariant)."""
+    reject_invalid_account_id(account_id)
+
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
-
-    reject_invalid_account_id(account_id)
 
     # account_id 결정: 쿼리 파라미터 우선, 없으면 봇에서 추출.
     # 둘 다 실패하면 `"default"` fallback 없이 400으로 명시 실패한다 (#1218 query 정책).

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Query
 
 from ante.web.deps import get_trade_service, require_trade_read
 from ante.web.schemas import TradeListResponse
+from ante.web.utils.account_params import reject_invalid_account_id
 
 router = APIRouter()
 
@@ -16,6 +17,21 @@ router = APIRouter()
     "",
     response_model=TradeListResponse,
     responses={
+        422: {
+            "description": (
+                "Invalid ``account_id`` query. 제공된 runtime-invalid 값"
+                ' (``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은'
+                " service 위임 이전에 422로 거부된다 — downstream"
+                " ``InvalidAccountIdError``가 generic 500으로 escape하던 경로를"
+                " 차단한다. ``account_id`` 미지정은 전체 필터로 통과한다"
+                " (#1218 보존, #1624)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         503: {
             "description": "Trade service not available",
             "content": {
@@ -36,8 +52,18 @@ async def list_trades(
     cursor: str | None = None,
 ) -> dict:
     """거래 기록 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
-    ``trade:read`` scope 를 보유한 agent 만 호출 가능 (#1407)."""
+    ``trade:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
+
+    제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+    service 위임 **이전**에 422로 거부한다 (#1624). 가드가 없으면
+    ``TradeService.get_trades`` downstream의 ``require_account_id``가
+    ``InvalidAccountIdError``를 raise하고, Web generic exception handler가
+    이를 500 `An unexpected error occurred.`로 흘려 invalid-input ↔
+    server-failure 구분이 깨진다. ``account_id`` 미지정(``None``)은
+    전체 필터로 통과한다 (#1218 보존)."""
     from ante.web.pagination import paginate
+
+    reject_invalid_account_id(account_id)
 
     trades = await trade_service.get_trades(
         account_id=account_id,

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -28,6 +28,7 @@ from ante.web.schemas import (
     TransactionListResponse,
     TreasurySummaryResponse,
 )
+from ante.web.utils.account_params import reject_invalid_account_id
 from ante.web.utils.date_params import (
     reject_inverted_date_range,
     validate_iso_date_only,
@@ -169,6 +170,19 @@ BALANCE_SET_REQUEST_SCHEMA: dict[str, Any] = {
                 },
             },
         },
+        422: {
+            "description": (
+                "Invalid ``account_id`` query. 제공된 runtime-invalid 값"
+                ' (``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은'
+                " lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본"
+                " Treasury 요약으로 통과한다 (#1218 보존, #1624)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         503: {
             "description": "Treasury not available",
             "content": {
@@ -191,7 +205,12 @@ async def get_summary(
 
     account_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.
     미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).
+
+    제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+    lookup 이전에 422로 거부한다 (#1624). ``account_id`` 미지정(``None``)은
+    기본 Treasury 분기로 통과한다 (#1218 보존).
     """
+    reject_invalid_account_id(account_id)
     target_treasury = treasury
     if account_id and treasury_manager is not None:
         try:
@@ -271,6 +290,10 @@ async def get_summary(
                 " 422로 거부한다 (#1595). ``type`` query는 정규 vocabulary"
                 " ``{allocate, deallocate, release, fill, bot_stopped_release}``"
                 " (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477)."
+                " 제공된 runtime-invalid ``account_id``"
+                ' (``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)도'
+                " SQL WHERE 구성 이전에 422로 거부된다. ``account_id`` 미지정은"
+                " 전체 필터로 통과한다 (#1218 보존, #1624)."
             ),
             "content": {
                 "application/problem+json": {
@@ -323,7 +346,13 @@ async def list_transactions(
     ``Literal``로 좁혀, vocabulary 외 값을 FastAPI 단계에서 422로 거부한다
     (#1477). invalid 값이 200 + empty result로 통과하던 oracle A7 host probe
     회귀(fingerprint ``a4f6744a44f5``)를 차단한다.
+
+    제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+    SQL WHERE 구성 **이전**에 422로 거부한다 (#1624) — invalid 값이 200 +
+    empty result로 흡수되던 contract-drift를 차단한다. ``account_id``
+    미지정(``None``)은 전체 필터로 통과한다 (#1218 보존).
     """
+    reject_invalid_account_id(account_id)
     start_bound = validate_iso_date_param_for_sql_datetime(
         start_date, "start_date", end_of_day=False
     )
@@ -874,7 +903,15 @@ def _resolve_treasury(
     treasury_manager: Any | None,
     account_id: str | None,
 ) -> Any:
-    """account_id가 주어지면 해당 계좌의 Treasury를 반환한다."""
+    """account_id가 주어지면 해당 계좌의 Treasury를 반환한다.
+
+    제공된 runtime-invalid ``account_id`` (``""``/``"default"``/패턴 위반)는
+    lookup 이전에 422로 거부한다 (#1624). 이 1지점 가드가 공유 호출자
+    ``get_latest_snapshot``(#7) / ``list_snapshots``(#6) /
+    ``get_snapshot_by_date``(#8)를 모두 커버한다. ``account_id``
+    미지정(``None``)은 기본 Treasury 분기로 통과한다 (#1218 보존).
+    """
+    reject_invalid_account_id(account_id)
     if account_id and treasury_manager is not None:
         try:
             return treasury_manager.get(account_id)
@@ -890,6 +927,19 @@ def _resolve_treasury(
     "/snapshots/latest",
     response_model=SnapshotResponse,
     responses={
+        422: {
+            "description": (
+                "Invalid ``account_id`` query. 제공된 runtime-invalid 값"
+                ' (``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)은'
+                " lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본"
+                " Treasury 분기로 통과한다 (#1218 보존, #1624)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         503: {
             "description": "Treasury not available",
             "content": {
@@ -947,7 +997,10 @@ async def get_latest_snapshot(
                 "``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 "
                 "저장되므로 임의 문자열을 허용하지 않는다 (#1440). "
                 "``start_date > end_date`` (inverted range)도 422로 거부한다 "
-                "(#1595)."
+                "(#1595). 제공된 runtime-invalid ``account_id`` "
+                '(``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)도 '
+                "lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 "
+                "Treasury 분기로 통과한다 (#1218 보존, #1624)."
             ),
             "content": {
                 "application/problem+json": {
@@ -1010,7 +1063,11 @@ async def list_snapshots(
         422: {
             "description": (
                 "Invalid ``date`` path param (ISO ``YYYY-MM-DD`` required). "
-                "malformed/캘린더 invalid path는 404가 아닌 422로 거부된다 (#1440)."
+                "malformed/캘린더 invalid path는 404가 아닌 422로 거부된다 (#1440). "
+                "제공된 runtime-invalid ``account_id`` query "
+                '(``""``/``"default"``/``^[a-zA-Z0-9\\-]{3,30}$`` 불일치)도 '
+                "lookup 이전에 422로 거부된다. ``account_id`` 미지정은 기본 "
+                "Treasury 분기로 통과한다 (#1218 보존, #1624)."
             ),
             "content": {
                 "application/problem+json": {

--- a/src/ante/web/utils/__init__.py
+++ b/src/ante/web/utils/__init__.py
@@ -8,12 +8,14 @@
 서비스 레이어 검증 강화는 별도 이슈로 분리한다.
 """
 
+from ante.web.utils.account_params import reject_invalid_account_id
 from ante.web.utils.date_params import (
     validate_iso_date_only,
     validate_iso_date_param_for_sql_datetime,
 )
 
 __all__ = [
+    "reject_invalid_account_id",
     "validate_iso_date_only",
     "validate_iso_date_param_for_sql_datetime",
 ]

--- a/src/ante/web/utils/account_params.py
+++ b/src/ante/web/utils/account_params.py
@@ -1,0 +1,88 @@
+"""account_id query 파라미터의 runtime-invalid 거부 헬퍼 (#1624).
+
+account-scoped Web **READ** API 표면(portfolio value/history, trades list,
+treasury summary/transactions/snapshots, strategy performance, bots list)은
+모두 ``account_id`` query 파라미터를 받는다. Account ID 계약
+(``docs/specs/account/14-account-id-contract.md`` **"Runtime invalid (어떤
+시점에도 거부)"**)은 ``None``/``""``/``"default"``/``ACCOUNT_ID_PATTERN`` 불일치
+값을 account-scoped 진입점에서 **항상** 거부하도록 정의한다.
+
+그러나 본 PR 이전에는 *제공된*-invalid ``account_id`` (``?account_id=default``,
+``?account_id=bad_id``, ``?account_id=``)가 ingress에서 거부되지 않고
+404(`계좌를 찾을 수 없습니다`)/500(`An unexpected error occurred.`)/200
+(empty-success)로 흘렀다 (oracle A7 contract-drift, fingerprint
+``46e7221b5bac``). 클라이언트가 malformed/fallback account_id를 genuine
+not-found/successful-empty/server-failure와 구분할 수 없는 SSOT 계약 위반이다.
+
+본 모듈은 그 read-API ingress invariant의 SSOT다. 비교는 SSOT helper
+:func:`ante.account.scoping.is_invalid_account_id` 단 한 번이며, 422
+``HTTPException``으로 변환된다 (``ante.web.errors``가 자동으로
+``application/problem+json``, ``type=/errors/validation``으로 정규화).
+
+#1218 경계 보존
+~~~~~~~~~~~~~~~
+
+``account_id`` **미지정**(query 파라미터 부재 → ``account_id is None``)은
+#1218(Edge resolver)이 확정한 **all-account/단일-treasury 집계** 분기다.
+본 가드는 ``None``을 통과시켜 그 분기 동작·응답 schema를 보존한다
+(``account_id is not None and is_invalid_account_id(account_id)`` 조건).
+*제공된* 빈 문자열(``?account_id=`` → ``account_id == ""``)은 미지정이
+아니라 "Runtime invalid"이므로 422로 거부한다 (provided-empty ≠ omitted).
+
+**valid-pattern but absent**(예 ``acc-9999``, 패턴 일치·미존재)는
+``is_invalid_account_id``가 ``False``이므로 가드를 통과한다 — invalid-format/
+fallback ↔ genuine not-found 분리가 본 가드의 핵심이며, 미존재 의미론은
+각 엔드포인트의 기존 lookup(404 / 200 empty)이 그대로 처리한다.
+
+본 모듈은 ``ante.web.utils.date_params``와 동일하게 의도적으로 ``ante.web.*``
++ ``ante.account.scoping`` SSOT 외 의존성을 갖지 않는다. service/DB/IPC
+lifecycle 계약은 본 헬퍼 scope 외다 (라우트 ingress 한정, #1623 split 영역
+별개).
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from ante.account.scoping import is_invalid_account_id
+
+__all__ = [
+    "reject_invalid_account_id",
+]
+
+
+def reject_invalid_account_id(account_id: str | None) -> None:
+    """*제공된* runtime-invalid ``account_id``면 ``HTTPException(422)``.
+
+    Account ID 계약(``docs/specs/account/14-account-id-contract.md``
+    "Runtime invalid")의 read-API ingress 가드. 각 account-scoped read 라우트
+    핸들러가 lookup/SQL/service 호출 **이전**에 호출해야 한다.
+
+    - ``account_id is None`` (query 파라미터 미지정): 통과시킨다. #1218이
+      확정한 all-account/단일-treasury 집계 분기 보존 (동작·schema 불변).
+    - ``account_id``가 제공됐고 :func:`is_invalid_account_id`가 ``True``
+      (``""``/``"default"``/``ACCOUNT_ID_PATTERN`` 불일치): 422로 거부.
+    - valid-pattern but absent (``acc-9999`` 등): ``is_invalid_account_id``가
+      ``False`` → 통과. genuine not-found 의미론은 caller의 기존 lookup이
+      처리한다.
+
+    Args:
+        account_id: 검증할 query 파라미터 값 또는 ``None`` (미지정).
+
+    Raises:
+        HTTPException(422): ``account_id``가 제공됐고 runtime-invalid일 때.
+            detail은 형식 위반 시 SSOT 보존 메시지(``ante account create``
+            CLI ``str(e)`` contract와 동일 형식), fallback 예약어(``default``)/
+            빈 문자열은 그에 준하는 메시지를 사용한다. traceback은 노출하지
+            않는다.
+    """
+    if account_id is None or not is_invalid_account_id(account_id):
+        return
+    raise HTTPException(
+        status_code=422,
+        detail=(
+            f"account_id 형식이 올바르지 않습니다: '{account_id}'. "
+            "영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다. "
+            "fallback 예약어('default')와 빈 문자열은 사용할 수 없습니다."
+        ),
+    )

--- a/tests/unit/test_api_account_id_invalid_contract.py
+++ b/tests/unit/test_api_account_id_invalid_contract.py
@@ -1,0 +1,370 @@
+"""제공된 runtime-invalid ``account_id`` read-API ingress 422 회귀 (#1624, oracle A7).
+
+account-scoped Web **READ** API query 표면(inventory #1~#10)이 제공된
+runtime-invalid ``account_id`` (``"default"``/패턴위반/``""``)를
+``docs/specs/account/14-account-id-contract.md`` "Runtime invalid (어떤 시점에도
+거부)" 계약대로 ingress에서 거부하지 않고 404/500/200-empty로 흘리던
+contract-drift(fingerprint ``46e7221b5bac``)를
+``ante.web.utils.account_params.reject_invalid_account_id`` 공유 가드로 차단한다.
+
+검증축 (이슈 Verification SSOT):
+
+1. inventory #1~#10 × {``default``, ``bad_id``(패턴위반), ``""``} → 422 +
+   ``application/problem+json`` + ``type=/errors/validation``
+2. ``account_id`` 미지정(query 파라미터 부재 → ``None``) → 기존 응답/status
+   동일 (#1218 omitted all-account/단일-treasury 분기 회귀 0)
+3. valid-pattern but absent(``acc-9999``, 패턴 일치·미존재) per-flow 기대값
+   고정 — resolver/detail 계열(#1/#2/#4/#6/#7/#8)=404, list-filter 계열
+   (#3 trades/#5 transactions/#10 bots)=기존 200 empty, #9 strategy
+   performance=404 (invalid-format/fallback ↔ genuine not-found 분리, 422
+   과적용 0)
+
+#3 trades는 특히 ingress 가드가 ``TradeService.get_trades`` downstream의
+``require_account_id`` → ``InvalidAccountIdError`` → Web generic 500 escape
+경로보다 **먼저** 422를 반환함을 검증한다 (stub이 실제 recorder 계약 미러).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+
+from ante.account.scoping import require_account_id  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
+
+# 제공된 runtime-invalid 값 3종 (이슈 Verification 축 1).
+INVALID_VALUES = ["default", "bad_id!", ""]
+# 패턴 일치·미존재 (이슈 Verification 축 3 — 422 과적용 방지).
+ABSENT_VALID = "acc-9999"
+
+
+# ── 공유 stub ─────────────────────────────────────────────
+
+
+class _StubDB:
+    """``treasury._db`` + strategies ``get_db`` 자리.
+
+    - treasury transactions(#5): ``COUNT(*)`` → 0, 본문 → ``[]`` (200 empty).
+    - strategy performance(#9): ``SELECT 1 FROM accounts WHERE account_id=?``
+      → 항상 ``None`` (계좌 미존재 → 404). ``acc-9999`` 패턴 일치이나
+      미존재이므로 genuine not-found 404.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def fetch_one(self, query: str, params: tuple) -> dict | None:
+        self.calls.append(query)
+        if "COUNT(*)" in query:
+            return {"cnt": 0}
+        return None
+
+    async def fetch_all(self, query: str, params: tuple) -> list[dict]:
+        self.calls.append(query)
+        return []
+
+
+def _make_treasury() -> MagicMock:
+    mock = MagicMock()
+    mock._db = _StubDB()
+    mock.account_id = "test"
+    mock.currency = "KRW"
+    # response_model 정합: 미설정 시 MagicMock이 ``synced_at`` str 검증을
+    # 깨므로 None으로 둬 해당 optional 필드를 제외시킨다 (stub 충실도).
+    mock.last_synced_at = None
+    mock.buy_commission_rate = 0.00015
+    mock.sell_commission_rate = 0.00195
+    mock.get_summary.return_value = {
+        "total_evaluation": 0.0,
+        "total_profit_loss": 0.0,
+        "account_balance": 0.0,
+    }
+    mock.get_latest_snapshot = AsyncMock(return_value=None)
+    mock.get_snapshots = AsyncMock(return_value=[])
+    mock.get_daily_snapshot = AsyncMock(return_value=None)
+    return mock
+
+
+class _StubTreasuryManager:
+    """``treasury_manager`` 자리.
+
+    ``get(account_id)``: 미존재 계좌는 ``KeyError`` (resolver/get_summary가
+    404로 정규화). 어떤 valid account도 등록돼 있지 않으므로 ``acc-9999``는
+    KeyError → 404 (resolver/detail 계열 valid-absent 기대값).
+    """
+
+    def __init__(self) -> None:
+        self._t: dict[str, Any] = {}
+
+    def get(self, account_id: str) -> Any:
+        if account_id not in self._t:
+            raise KeyError(account_id)
+        return self._t[account_id]
+
+    def list_all(self) -> list[Any]:
+        return list(self._t.values())
+
+
+class _StubTradeService:
+    """``TradeService`` 자리 — ``recorder.get_trades`` 계약 미러.
+
+    실제 ``TradeRecorder.get_trades``는 ``account_id is not None``일 때
+    ``require_account_id``를 호출해 runtime-invalid면
+    ``InvalidAccountIdError``를 raise한다 (Web generic 500 escape 경로).
+    ingress 가드가 이 호출 **이전**에 422를 반환함을 검증하기 위해 동일
+    계약을 stub에 재현한다. valid account는 빈 목록 반환 (200 empty).
+    """
+
+    def __init__(self) -> None:
+        self.called_with: list[str | None] = []
+
+    async def get_trades(self, *, account_id: str | None = None, **_: Any) -> list[Any]:
+        self.called_with.append(account_id)
+        if account_id is not None:
+            require_account_id(account_id, context="trade_recorder.get_trades")
+        return []
+
+
+class _StubRegistry:
+    """``strategy_registry`` 자리. 전략은 존재하므로 strategy-not-found(404)
+    가 account 가드/검증을 가리지 않는다."""
+
+    def __init__(self) -> None:
+        self._record = MagicMock(
+            name="strat-x",
+            author_name="a",
+            author_id="a",
+        )
+
+    async def get(self, strategy_id: str) -> Any:
+        return self._record
+
+
+class _StubBotManager:
+    """``bot_manager`` 자리.
+
+    - list_bots(#10): valid account 필터는 매칭 0건 → 200 empty.
+    - get_strategy_performance(#9): ``_find_bot_for_strategy``가 봇을 찾지
+      못하도록 빈 목록 — query account_id 경로만 검증 (omitted→400 분기는
+      #1218 보존, 별도 케이스).
+    """
+
+    def list_bots(self) -> list[dict]:
+        return [{"bot_id": "b1", "account_id": "test", "strategy_id": ""}]
+
+
+# ── fixtures ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def treasury() -> MagicMock:
+    return _make_treasury()
+
+
+@pytest.fixture
+def trade_service() -> _StubTradeService:
+    return _StubTradeService()
+
+
+@pytest.fixture
+def app_client(treasury: MagicMock, trade_service: _StubTradeService):
+    """inventory #1~#10 전체를 한 app에 마운트한 authed client."""
+    app = create_app(
+        treasury=treasury,
+        treasury_manager=_StubTreasuryManager(),
+        trade_service=trade_service,
+        strategy_registry=_StubRegistry(),
+        bot_manager=_StubBotManager(),
+        db=_StubDB(),
+        member_service=make_master_member_service(),
+    )
+    return make_authed_client(app)
+
+
+# inventory # → (method path, extra params). account_id는 케이스에서 주입.
+INVENTORY: dict[int, tuple[str, dict[str, Any]]] = {
+    1: ("/api/portfolio/value", {}),
+    2: ("/api/portfolio/history", {}),
+    3: ("/api/trades", {"limit": 1}),
+    4: ("/api/treasury", {}),
+    5: ("/api/treasury/transactions", {"limit": 1}),
+    6: ("/api/treasury/snapshots", {}),
+    7: ("/api/treasury/snapshots/latest", {}),
+    8: ("/api/treasury/snapshots/2026-01-15", {}),
+    9: ("/api/strategies/strat-x/performance", {}),
+    10: ("/api/bots", {"limit": 1}),
+}
+
+# valid-pattern but absent per-flow 기대값 (이슈 Verification 축 3).
+# resolver/detail 계열 + strategy perf = 404, list-filter 계열 = 200 empty.
+ABSENT_EXPECTED_STATUS: dict[int, int] = {
+    1: 404,
+    2: 404,
+    3: 200,
+    4: 404,
+    5: 200,
+    6: 404,
+    7: 404,
+    8: 404,
+    9: 404,
+    10: 200,
+}
+
+
+# ── 축 1: 제공된 runtime-invalid → 422 problem+json ───────
+
+
+class TestProvidedInvalidRejected422:
+    """inventory #1~#10 × {default, bad_id, ""} → 422 + problem+json +
+    ``type=/errors/validation``."""
+
+    @pytest.mark.parametrize("inv", sorted(INVENTORY))
+    @pytest.mark.parametrize("value", INVALID_VALUES)
+    def test_invalid_account_id_422(self, app_client, inv: int, value: str) -> None:
+        path, params = INVENTORY[inv]
+        resp = app_client.get(path, params={**params, "account_id": value})
+        assert resp.status_code == 422, (
+            f"inv#{inv} {path} account_id={value!r}: {resp.status_code} {resp.text}"
+        )
+        assert resp.headers["content-type"] == "application/problem+json", (
+            f"inv#{inv} ct={resp.headers.get('content-type')}"
+        )
+        body = resp.json()
+        assert body["type"] == "/errors/validation", f"inv#{inv} {body}"
+        assert body["status"] == 422, f"inv#{inv} {body}"
+        # traceback 노출 금지: detail은 스펙 보존 메시지여야 한다.
+        assert "Traceback" not in body["detail"], f"inv#{inv} {body}"
+        assert "account_id" in body["detail"], f"inv#{inv} {body}"
+
+    def test_trades_invalid_blocks_before_service_500_escape(
+        self, app_client, trade_service: _StubTradeService
+    ) -> None:
+        """#3: 가드가 ``TradeService.get_trades`` 위임 이전에 422를 반환 —
+        downstream ``InvalidAccountIdError`` → generic 500 escape 차단."""
+        resp = app_client.get(
+            "/api/trades", params={"account_id": "default", "limit": 1}
+        )
+        assert resp.status_code == 422, resp.text
+        # service가 아예 호출되지 않아야 한다 (ingress 차단 증명).
+        assert trade_service.called_with == [], trade_service.called_with
+
+
+# ── 축 2: omitted(None) → 기존 동작/status 불변 (#1218 회귀 0) ──
+
+
+class TestOmittedAccountIdRegression:
+    """``account_id`` query 파라미터 부재 → 가드 통과, 기존 status 유지.
+
+    #1/#2/#4/#6/#7/#10 = 200 (단일-treasury/all-account 분기), #3/#5 = 200
+    (전체 필터), #8 = 404 (snapshot 미존재, account 무관), #9 = 400
+    (#1218 omitted + 봇 추출 불가 정책 보존, **422 아님**)."""
+
+    OMITTED_EXPECTED: dict[int, int] = {
+        1: 200,
+        2: 200,
+        3: 200,
+        4: 200,
+        5: 200,
+        6: 200,
+        7: 200,
+        8: 404,
+        9: 400,
+        10: 200,
+    }
+
+    @pytest.mark.parametrize("inv", sorted(INVENTORY))
+    def test_omitted_account_id_preserved(self, app_client, inv: int) -> None:
+        path, params = INVENTORY[inv]
+        resp = app_client.get(path, params=params)
+        expected = self.OMITTED_EXPECTED[inv]
+        assert resp.status_code == expected, (
+            f"inv#{inv} {path} omitted: expected {expected} got "
+            f"{resp.status_code} {resp.text}"
+        )
+        # 핵심: omitted는 절대 422가 아니어야 한다 (#1218 회귀 0).
+        assert resp.status_code != 422, f"inv#{inv} omitted leaked 422"
+
+
+# ── 축 3: valid-pattern but absent → per-flow (422 과적용 0) ──
+
+
+class TestValidPatternButAbsentPerFlow:
+    """``account_id=acc-9999`` (패턴 일치·미존재): invalid-format ↔ genuine
+    not-found 분리. resolver/detail+strategy=404, list-filter=200 empty.
+    어느 경로도 422가 아니다 (가드 과적용 0)."""
+
+    @pytest.mark.parametrize("inv", sorted(INVENTORY))
+    def test_valid_absent_per_flow(self, app_client, inv: int) -> None:
+        path, params = INVENTORY[inv]
+        resp = app_client.get(path, params={**params, "account_id": ABSENT_VALID})
+        expected = ABSENT_EXPECTED_STATUS[inv]
+        assert resp.status_code == expected, (
+            f"inv#{inv} {path} account_id={ABSENT_VALID}: expected "
+            f"{expected} got {resp.status_code} {resp.text}"
+        )
+        # 핵심: valid-pattern은 절대 가드 422를 맞으면 안 된다 (과적용 0).
+        assert resp.status_code != 422, (
+            f"inv#{inv} valid-but-absent leaked 422 (가드 과적용)"
+        )
+
+    def test_trades_valid_absent_reaches_service_200(
+        self, app_client, trade_service: _StubTradeService
+    ) -> None:
+        """#3: valid-but-absent는 가드를 통과해 service에 도달, 200 empty.
+
+        ``TradeService.get_trades``가 ``acc-9999``로 호출되고
+        ``require_account_id``가 valid로 통과(빈 목록)함을 확인 —
+        invalid-format와 genuine-absent의 동작 분리 증명."""
+        resp = app_client.get(
+            "/api/trades",
+            params={"account_id": ABSENT_VALID, "limit": 1},
+        )
+        assert resp.status_code == 200, resp.text
+        assert trade_service.called_with == [ABSENT_VALID], trade_service.called_with
+        assert resp.json()["trades"] == []
+
+
+# ── OpenAPI 422 entry 동기 ────────────────────────────────
+
+
+class TestOpenAPI422Documented:
+    """inventory #1~#10 라우트가 OpenAPI ``responses``에 422 +
+    ``application/problem+json`` 매핑을 노출한다."""
+
+    OPENAPI_PATHS: dict[int, str] = {
+        1: "/api/portfolio/value",
+        2: "/api/portfolio/history",
+        3: "/api/trades",
+        4: "/api/treasury",
+        5: "/api/treasury/transactions",
+        6: "/api/treasury/snapshots",
+        7: "/api/treasury/snapshots/latest",
+        8: "/api/treasury/snapshots/{date}",
+        9: "/api/strategies/{strategy_id}/performance",
+        10: "/api/bots",
+    }
+
+    @pytest.mark.parametrize("inv", sorted(OPENAPI_PATHS))
+    def test_route_documents_422(self, app_client, inv: int) -> None:
+        schema = app_client.app.openapi()  # type: ignore[attr-defined]
+        path = self.OPENAPI_PATHS[inv]
+        get_spec = schema["paths"][path]["get"]
+        responses = get_spec["responses"]
+        assert "422" in responses, f"inv#{inv} {path} missing 422"
+        content = responses["422"]["content"]
+        assert "application/problem+json" in content, (
+            f"inv#{inv} {path} 422 missing problem+json: {content}"
+        )
+        ref = content["application/problem+json"]["schema"]["$ref"]
+        assert ref == "#/components/schemas/ErrorResponse", (
+            f"inv#{inv} {path} 422 ref={ref}"
+        )

--- a/tests/unit/test_api_account_id_invalid_contract.py
+++ b/tests/unit/test_api_account_id_invalid_contract.py
@@ -368,3 +368,94 @@ class TestOpenAPI422Documented:
         assert ref == "#/components/schemas/ErrorResponse", (
             f"inv#{inv} {path} 422 ref={ref}"
         )
+
+
+# ── 축 1 보강: #9 가드가 strategy 존재 여부에 종속되지 않음 (#1624) ──
+
+
+class _StubRegistryMissing:
+    """``strategy_registry`` 자리 — 전략이 **존재하지 않는다** (``get`` →
+    ``None``). 존재하지 않는 ``strategy_id`` + provided-invalid
+    ``account_id`` 조합에서 account_id 422 가드가 strategy-not-found(404)
+    보다 **먼저** 발동함을 검증하기 위한 stub (#1624 ingress invariant)."""
+
+    async def get(self, strategy_id: str) -> Any:
+        return None
+
+
+@pytest.fixture
+def app_client_missing_strategy(treasury: MagicMock, trade_service: _StubTradeService):
+    """#9 전용: strategy 레지스트리가 비어 있는(전략 미존재) authed client."""
+    app = create_app(
+        treasury=treasury,
+        treasury_manager=_StubTreasuryManager(),
+        trade_service=trade_service,
+        strategy_registry=_StubRegistryMissing(),
+        bot_manager=_StubBotManager(),
+        db=_StubDB(),
+        member_service=make_master_member_service(),
+    )
+    return make_authed_client(app)
+
+
+class TestStrategyPerfGuardIndependentOfStrategyExistence:
+    """#9 ``GET /api/strategies/{id}/performance``: account_id 422 가드는
+    strategy 레지스트리/봇 조회 **이전**에 실행되어, strategy 존재 여부와
+    무관하게 동작한다 (#1624 attempt 1 blocking finding 회귀 락).
+
+    핵심 회귀: 존재하지 않는 ``strategy_id`` + provided-invalid
+    ``account_id`` → **422** (404 아님). 가드가 ``registry.get`` 뒤에 있던
+    drift에서는 strategy 404가 422를 가렸다."""
+
+    MISSING_STRATEGY_PATH = "/api/strategies/no-such-strat/performance"
+
+    @pytest.mark.parametrize("value", INVALID_VALUES)
+    def test_missing_strategy_provided_invalid_is_422_not_404(
+        self, app_client_missing_strategy, value: str
+    ) -> None:
+        """존재하지 않는 strategy_id + provided-invalid account_id → 422.
+
+        strategy 404가 account_id 422를 가리면 안 된다 (가드 위치
+        invariant: lookup/SQL/service 호출 이전)."""
+        resp = app_client_missing_strategy.get(
+            self.MISSING_STRATEGY_PATH, params={"account_id": value}
+        )
+        assert resp.status_code == 422, (
+            f"missing strategy + account_id={value!r}: expected 422 "
+            f"(account_id ingress 가드 우선) got {resp.status_code} {resp.text}"
+        )
+        assert resp.headers["content-type"] == "application/problem+json", (
+            f"account_id={value!r} ct={resp.headers.get('content-type')}"
+        )
+        body = resp.json()
+        assert body["type"] == "/errors/validation", body
+        assert body["status"] == 422, body
+        assert "account_id" in body["detail"], body
+        assert "Traceback" not in body["detail"], body
+
+    def test_missing_strategy_omitted_account_id_still_404(
+        self, app_client_missing_strategy
+    ) -> None:
+        """#1218 omitted 보존: 가드는 ``account_id`` 미지정(``None``)을
+        통과시키므로 omitted → 기존 strategy-not-found 404가 그대로
+        반환된다 (가드가 omitted→통과 분기를 깨지 않음)."""
+        resp = app_client_missing_strategy.get(self.MISSING_STRATEGY_PATH)
+        assert resp.status_code == 404, (
+            f"missing strategy + omitted account_id: expected 404 "
+            f"(가드 통과 → strategy 404) got {resp.status_code} {resp.text}"
+        )
+        assert resp.status_code != 422, "omitted account_id leaked 422 (#1218)"
+
+    def test_missing_strategy_valid_absent_account_id_still_404(
+        self, app_client_missing_strategy
+    ) -> None:
+        """valid-pattern but absent(``acc-9999``)는 가드를 통과 → strategy
+        미존재 404 (가드 과적용 0, invalid-format ↔ not-found 분리)."""
+        resp = app_client_missing_strategy.get(
+            self.MISSING_STRATEGY_PATH, params={"account_id": ABSENT_VALID}
+        )
+        assert resp.status_code == 404, (
+            f"missing strategy + account_id={ABSENT_VALID}: expected 404 "
+            f"got {resp.status_code} {resp.text}"
+        )
+        assert resp.status_code != 422, "valid-but-absent leaked 422 (과적용)"


### PR DESCRIPTION
Closes #1624

## Summary
- oracle A7 contract-drift: account-scoped Web **READ** API query 표면이 제공된 runtime-invalid `account_id`(`default`/패턴위반/`""`)를 SSOT 계약대로 ingress에서 거부하지 않고 404/500/200-empty로 흘리던 문제 수정
- 공용 가드 helper `web/utils/account_params.reject_invalid_account_id` (`account_id is not None and is_invalid_account_id(account_id)` → `HTTPException(422)` 스펙 보존 메시지; `None`만 통과해 #1218 omitted all-account 분기 보존)
- inventory #1~#10 (portfolio value/history, trades list, treasury summary/transactions/snapshots/snapshots-latest/snapshots-{date}+공유 resolver, strategies performance, bots list) lookup/SQL/service 호출 **이전** 가드 삽입
- strategies performance 가드는 레지스트리 조회 이전 배치(계약이 strategy 존재 여부에 비종속)
- OpenAPI 422 entry 10라우트 + `frontend/openapi.json`·`frontend/src/types/api.generated.ts` 재생성

## Spec
- SSOT `docs/specs/account/14-account-id-contract.md` "Runtime invalid (어떤 시점에도 거부)" / `ante.account.scoping` / `ante.web.errors` problem+json
- 에러-상태 422 (모듈 기존 invalid-input 컨벤션 #1411/#1440/#1477/#1595 동형)

## Test Plan
- 신규 pytest 62 (#1~#10 × {default,bad_id,""} → 422 problem+json / omitted 회귀 0 / valid-absent per-flow: resolver-detail 404·list-filter 200empty·strategy-perf 404 / strategy 가드 strategy-존재 비종속)
- focused 회귀 196 (#1218/#1440/#1477/#1595 회귀 0)
- `mypy src/` 전체 clean, `ruff check/format` 통과
- Codex 브랜치 리뷰 `--base main` PASS (attempt 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)