### PR TITLE
fix(cli): ante update confirmation gate precedence over server-running + UPDATE_SERVER_RUNNING code (#1626)

### DIFF
--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -75,6 +75,8 @@ CLI 코드에서 다음 API 사용을 금지한다.
 
 `ante update --check`는 PyPI 버전 조회만 수행하는 dry-run이므로 `--yes`가 필요하지 않다.
 
+`ante update`의 게이트 평가 우선순위는 **`--check` → `--yes` confirmation(`CLI_CONFIRMATION_REQUIRED`) → server-running/`--force`(`UPDATE_SERVER_RUNNING`) → 실제 update** 순서다. `--check`은 dry-run으로 `--yes`/server-running과 무관하며(`--check` 우선), 그 외 실제 update 호출은 server 상태·side-effect 검사 이전에 `--yes` 누락을 먼저 거부한다. 이 우선순위는 위 표 행 순서(`--yes` 행이 `--force` 행 앞)와 "누락 입력 처리: 즉시 종료" 해석에 의존하지 않는 normative 규칙이다. 위 표에서 `ante update [실제 실행]`(`--yes`/`CLI_CONFIRMATION_REQUIRED`)이 `ante update`(서버 실행 중)(`--force`/`UPDATE_SERVER_RUNNING`)보다 **앞에** 나열된 것은 이 우선순위와 일치한다.
+
 **누락 입력 처리**:
 
 필수 옵션·인자가 누락되면 prompt하지 않고 구조화된 에러로 즉시 종료한다(exit code 1).

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -661,4 +661,8 @@ ante update [--check] [--version <version>] [--yes] [--force]
 
 - `--check`은 단순 조회이므로 `--yes`/`--force` 영향 없음. `--check`과 `--yes`를 동시에 사용해도
   `--check`이 우선한다(충돌 정책: `--check` 우선).
+- 게이트 평가 우선순위는 **`--check` → `--yes` confirmation(`CLI_CONFIRMATION_REQUIRED`) →
+  server-running/`--force`(`UPDATE_SERVER_RUNNING`) → 실제 update** 순서다. 즉 실제 update 호출은
+  server 상태·side-effect 검사 이전에 `--yes` 누락을 먼저 거부한다(상세 normative 규칙은
+  `02-design-decisions.md` "위험 명령 확인 방식" 참조).
 - prompt 기반 확인 경로(`click.confirm`)는 제거되었다. 모든 확인은 옵션으로 명시한다.

--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -93,12 +93,18 @@ def update(
 ) -> None:
     """ante를 최신 버전으로 업데이트합니다.
 
-    `--check`은 PyPI 버전 조회만 수행한다 (`--yes` 불필요).
-    `--check`이 아닌 실제 업데이트 실행은 `--yes`가 반드시 필요하며,
-    누락 시 prompt 없이 ``CLI_CONFIRMATION_REQUIRED`` 에러로 종료한다.
-    `--yes` 게이트는 PyPI 조회 **앞에** 평가하므로, 네트워크 느림/실패
-    환경에서도 `--yes` 누락 호출은 PyPI 실패가 아닌 동일한 구조화 에러
-    코드로 거절된다.
+    게이트 평가 우선순위 (SSOT: docs/specs/cli/02-design-decisions.md
+    "위험 명령 확인 방식"):
+    ``--check`` → ``--yes`` confirmation(``CLI_CONFIRMATION_REQUIRED``)
+    → server-running/``--force``(``UPDATE_SERVER_RUNNING``) → 실제 update.
+
+    `--check`은 PyPI 버전 조회만 수행하는 dry-run이다 (`--yes`/server-running
+    무관, 최우선). `--check`이 아닌 실제 업데이트 실행은 `--yes`가 반드시
+    필요하며, 누락 시 prompt 없이 ``CLI_CONFIRMATION_REQUIRED`` 에러로
+    종료한다. `--yes` 게이트는 server 상태 검사와 PyPI 조회 **앞에**
+    평가하므로, 서버 실행/네트워크 느림·실패 환경에서도 `--yes` 누락
+    호출은 server-running 안내나 PyPI 실패가 아닌 동일한 구조화 에러
+    코드로 거절된다 (#1626 D1, Codex P2 2차).
     """
     from ante.update.checker import (
         get_current_version,
@@ -108,24 +114,22 @@ def update(
 
     fmt = get_formatter(ctx)
 
-    # 서버 실행 중 확인
-    if check_server_running():
-        if force:
-            if not fmt.is_json:
-                click.echo("서버를 중지합니다...")
-            # TODO: graceful shutdown
-        else:
-            fmt.error(
-                "서버가 실행 중입니다. "
-                "먼저 서버를 중지하거나 --force 옵션을 사용하세요."
-            )
-            raise SystemExit(1)
-
     current = get_current_version()
-    if not fmt.is_json:
-        click.echo(f"현재 버전: {current}")
 
+    # 게이트 평가 우선순위 (SSOT: docs/specs/cli/02-design-decisions.md
+    # "위험 명령 확인 방식" — precedence normative 규칙):
+    #   `--check` → `--yes` confirmation(``CLI_CONFIRMATION_REQUIRED``)
+    #   → server-running/`--force`(``UPDATE_SERVER_RUNNING``) → 실제 update
+    # `--check`은 dry-run으로 `--yes`/server-running과 무관(최우선,
+    # 충돌 정책: `--check` 우선). 그 외 실제 update 호출은 server 상태·
+    # side-effect 검사 **이전에** `--yes` 누락을 먼저 거부한다.
+
+    # 1) `--check`: PyPI 버전 조회만 수행하는 dry-run. `--yes`/server-running
+    #    상태와 무관하며 부수 효과가 없으므로 최우선으로 처리하고 반환한다
+    #    (`--check`+`--yes` 동시 사용 시에도 `--check` 우선 — 충돌 정책).
     if check:
+        if not fmt.is_json:
+            click.echo(f"현재 버전: {current}")
         latest = get_latest_version()
         if latest is None:
             fmt.error("PyPI 버전 확인 실패")
@@ -145,14 +149,18 @@ def update(
             click.echo("이미 최신 버전입니다")
         return
 
-    # 비대화형 입력 계약 (#1170, #1171 SSOT): `--check`이 아닌 실제 업데이트
-    # 실행 호출에는 `--yes`가 반드시 필요하다. 이 게이트는 PyPI 조회
-    # (`get_latest_version()`) **앞에** 위치해야 한다 — 그래야 네트워크
-    # 느림/실패 환경에서도 `--yes` 누락 호출이 PyPI 실패가 아닌
-    # ``CLI_CONFIRMATION_REQUIRED``로 거절된다 (Codex P2 finding 2차).
-    # 자동화는 네트워크 상태와 무관하게 동일한 구조화 에러 코드를 받는다.
-    # 게이트 통과 전이므로 PyPI 조회/backup/pip upgrade/migration 등
-    # 부수 효과는 일체 발생하지 않는다.
+    # 2) 비대화형 입력 계약 (#1170, #1171, #1626 SSOT): `--check`이 아닌 실제
+    #    업데이트 실행 호출에는 `--yes`가 반드시 필요하다. 이 게이트는
+    #    server 상태 검사(`check_server_running()`)와 PyPI 조회
+    #    (`get_latest_version()`) **앞에** 위치해야 한다 — 그래야:
+    #    (a) 서버 실행 환경에서도 `--yes` 누락 호출이 server-running 안내가
+    #        아닌 ``CLI_CONFIRMATION_REQUIRED``로 거절된다 (#1626 D1: spec
+    #        precedence — confirmation gate가 server 상태보다 우선).
+    #    (b) 네트워크 느림/실패 환경에서도 PyPI 실패가 아닌 동일한 구조화
+    #        에러 코드로 거절된다 (Codex P2 finding 2차).
+    #    자동화는 server/네트워크 상태와 무관하게 동일한 코드를 받는다.
+    #    게이트 통과 전이므로 server 상태 검사/PyPI 조회/backup/pip upgrade/
+    #    migration 등 부수 효과는 일체 발생하지 않는다.
     if not yes:
         fmt.error(
             f"업데이트 실행에는 --yes가 필요합니다 (현재 {current}). "
@@ -160,6 +168,27 @@ def update(
             code="CLI_CONFIRMATION_REQUIRED",
         )
         raise SystemExit(1)
+
+    # 3) 서버 실행 중 확인 — `--yes` 게이트 통과 후, 실제 update 부수 효과
+    #    이전에 평가한다. `--force` 없이 서버가 실행 중이면
+    #    ``UPDATE_SERVER_RUNNING``(#1626 D2: SSOT 02-design-decisions.md:115,
+    #    03-commands.md)으로 거절한다. `--force` 시 가드를 우회한다(현
+    #    graceful shutdown은 미구현 TODO — 본 이슈 범위 밖, 후속 후보).
+    if check_server_running():
+        if force:
+            if not fmt.is_json:
+                click.echo("서버를 중지합니다...")
+            # TODO: graceful shutdown
+        else:
+            fmt.error(
+                "서버가 실행 중입니다. "
+                "먼저 서버를 중지하거나 --force 옵션을 사용하세요.",
+                code="UPDATE_SERVER_RUNNING",
+            )
+            raise SystemExit(1)
+
+    if not fmt.is_json:
+        click.echo(f"현재 버전: {current}")
 
     # 업데이트 실행 — `--yes` 게이트 통과 후에만 PyPI를 조회한다.
     latest = target_version or get_latest_version()

--- a/tests/unit/test_cli_update.py
+++ b/tests/unit/test_cli_update.py
@@ -191,16 +191,57 @@ class TestUpdateFormatText:
 
 
 class TestUpdateFormatJsonError:
-    """JSON 모드 에러 출력 테스트."""
+    """JSON 모드 에러 출력 테스트.
 
-    def test_server_running_json_error(self, runner: CliRunner) -> None:
-        """서버 실행 중 에러도 JSON으로 출력된다."""
-        with patch("ante.cli.commands.update.check_server_running", return_value=True):
+    의도 변경(#1626 D2/D3): 이전 ``test_server_running_json_error``는
+    서버 실행 중 ``ante update --check --format json``이 exit 1 JSON
+    에러로 차단되는 buggy 순서를 정상으로 단언했다. SSOT(precedence
+    normative 규칙)는 ``--check``을 dry-run으로 server-running 무관하게
+    처리하도록 명시하므로, 본 케이스는 spec 정합 의미로 갱신한다 —
+    ``--check``은 차단되지 않고, server-running JSON 에러는 실제 update
+    경로(``--yes`` 게이트 통과 후)에서 ``UPDATE_SERVER_RUNNING`` 코드와
+    함께 노출된다.
+    """
+
+    def test_check_json_not_blocked_by_server_running(self, runner: CliRunner) -> None:
+        """서버 실행 중이어도 ``--check --format json`` dry-run은 성공한다.
+
+        #1626 D3: ``--check``은 server-running과 무관(최우선 dry-run).
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+        ):
             result = runner.invoke(cli, ["update", "--check", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["current_version"] == "0.6.1"
+        assert data["latest_version"] == "0.7.0"
+        assert data["update_available"] is True
+
+    def test_server_running_json_error_has_update_server_running_code(
+        self, runner: CliRunner
+    ) -> None:
+        """서버 실행 + ``--yes`` + ``--force`` 없음 → JSON ``UPDATE_SERVER_RUNNING``.
+
+        #1626 D2: server-running JSON 에러는 ``code`` 가 null 이 아닌
+        ``UPDATE_SERVER_RUNNING`` 이어야 한다 (이전 buggy 동작은 code=null).
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+        ):
+            result = runner.invoke(
+                cli, ["update", "--yes", "--format", "json"], input=None
+            )
 
         assert result.exit_code == 1
         data = json.loads(result.output)
         assert "message" in data
+        assert data["code"] == "UPDATE_SERVER_RUNNING"
+        assert data["code"] is not None
 
     def test_pypi_failure_json_error(self, runner: CliRunner) -> None:
         """PyPI 조회 실패 시 JSON 에러 출력."""
@@ -429,3 +470,243 @@ class TestUpdateNonInteractive:
 
         assert result.exit_code == 0
         mock_pip_upgrade.assert_not_called()
+
+
+class TestUpdateGatePrecedence:
+    """게이트 평가 우선순위 회귀 (#1626).
+
+    SSOT: ``docs/specs/cli/02-design-decisions.md`` "위험 명령 확인 방식"
+    precedence normative 규칙 —
+    ``--check`` → ``--yes`` confirmation(``CLI_CONFIRMATION_REQUIRED``)
+    → server-running/``--force``(``UPDATE_SERVER_RUNNING``) → 실제 update.
+
+    이전 buggy 순서(server-running 가드가 ``--yes`` 게이트보다 선행, 그리고
+    server-running ``fmt.error``에 ``code=`` 누락)를 정상으로 단언하던
+    ``test_update.py``/``test_cli_update.py`` 케이스를 spec 정합으로 갱신한
+    것과 별개로, oracle A7 contract-drift 재발 방지를 위한 직접 회귀를
+    여기에 잠근다.
+    """
+
+    def test_server_running_without_yes_yields_confirmation_required(
+        self, runner: CliRunner
+    ) -> None:
+        """서버 실행 + ``--yes`` 누락 → exit≠0, ``CLI_CONFIRMATION_REQUIRED``.
+
+        oracle probe(``cli_update_confirmation_gate_contract``) 재현 케이스:
+        서버 실행 중 ``ante --format json update``(no ``--yes``)는
+        server-running(code=null)이 아닌 confirmation gate로 거절되어야 한다.
+        server 상태 검사·PyPI 조회·side-effect 일체 미진입.
+        """
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running", return_value=True
+            ) as mock_srv,
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+            patch(
+                "ante.update.checker.get_latest_version", return_value="2.0.0"
+            ) as mock_latest,
+            patch("ante.update.executor.pip_upgrade") as mock_pip_upgrade,
+            patch("ante.db.backup.backup_db") as mock_backup,
+            patch("ante.update.executor.snapshot_dependencies") as mock_snapshot,
+            patch("ante.update.executor.run_post_update_migrations") as mock_migrate,
+        ):
+            result = runner.invoke(cli, ["--format", "json", "update"], input=None)
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
+        assert "--yes" in data["message"]
+        # confirmation gate가 server 상태 검사보다 우선 → server 검사 미진입.
+        mock_srv.assert_not_called()
+        mock_latest.assert_not_called()
+        mock_pip_upgrade.assert_not_called()
+        mock_backup.assert_not_called()
+        mock_snapshot.assert_not_called()
+        mock_migrate.assert_not_called()
+
+    def test_server_running_with_yes_no_force_yields_update_server_running(
+        self, runner: CliRunner
+    ) -> None:
+        """서버 실행 + ``--yes`` + ``--force`` 없음 → ``UPDATE_SERVER_RUNNING``.
+
+        #1626 D2: 이전 buggy 동작은 ``code=null`` 이었다. 이 회귀는 code 가
+        null 이 아닌 ``UPDATE_SERVER_RUNNING`` 임을 직접 단언한다. update
+        side-effect(pip/backup/migration)는 진입하지 않아야 한다.
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+            patch(
+                "ante.update.checker.get_latest_version", return_value="2.0.0"
+            ) as mock_latest,
+            patch("ante.update.executor.pip_upgrade") as mock_pip_upgrade,
+            patch("ante.db.backup.backup_db") as mock_backup,
+            patch("ante.update.executor.snapshot_dependencies") as mock_snapshot,
+            patch("ante.update.executor.run_post_update_migrations") as mock_migrate,
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "update", "--yes"], input=None
+            )
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["code"] == "UPDATE_SERVER_RUNNING"
+        assert data["code"] is not None
+        assert "서버가 실행 중입니다" in data["message"]
+        # server-running 가드는 update side-effect 이전에 평가됨.
+        mock_latest.assert_not_called()
+        mock_pip_upgrade.assert_not_called()
+        mock_backup.assert_not_called()
+        mock_snapshot.assert_not_called()
+        mock_migrate.assert_not_called()
+
+    def test_server_not_running_without_yes_yields_confirmation_required(
+        self, runner: CliRunner
+    ) -> None:
+        """서버 미실행 + ``--yes`` 누락 → ``CLI_CONFIRMATION_REQUIRED``.
+
+        server 상태와 무관하게 ``--yes`` 누락은 confirmation gate로 거절.
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=False),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+            patch(
+                "ante.update.checker.get_latest_version", return_value="2.0.0"
+            ) as mock_latest,
+        ):
+            result = runner.invoke(cli, ["--format", "json", "update"], input=None)
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
+        assert "--yes" in data["message"]
+        mock_latest.assert_not_called()
+
+    def test_check_with_server_running_dry_run_succeeds(
+        self, runner: CliRunner
+    ) -> None:
+        """충돌 정책 잠금: 서버 실행 + ``ante update --check`` → dry-run 성공.
+
+        #1626 D3: ``--check``은 server-running과 무관(미차단).
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+            patch("ante.update.checker.get_latest_version", return_value="2.0.0"),
+            patch("ante.update.executor.pip_upgrade") as mock_pip_upgrade,
+        ):
+            result = runner.invoke(cli, ["update", "--check", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["update_available"] is True
+        mock_pip_upgrade.assert_not_called()
+
+    def test_check_yes_json_check_wins_no_side_effect(self, runner: CliRunner) -> None:
+        """충돌 정책 잠금: ``ante update --check --yes --format json``.
+
+        ``--check`` 우선(충돌 정책: ``--check`` 우선). dry-run JSON 성공이며
+        ``check_server_running``/update side-effect 에 진입하지 않는다.
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running") as mock_srv,
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+            patch("ante.update.checker.get_latest_version", return_value="2.0.0"),
+            patch("ante.update.executor.pip_upgrade") as mock_pip_upgrade,
+            patch("ante.db.backup.backup_db") as mock_backup,
+            patch("ante.update.executor.run_post_update_migrations") as mock_migrate,
+        ):
+            result = runner.invoke(
+                cli, ["update", "--check", "--yes", "--format", "json"]
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["update_available"] is True
+        # `--check` 우선 → server 검사/side-effect 미진입.
+        mock_srv.assert_not_called()
+        mock_pip_upgrade.assert_not_called()
+        mock_backup.assert_not_called()
+        mock_migrate.assert_not_called()
+
+    def test_check_yes_server_running_check_wins(self, runner: CliRunner) -> None:
+        """충돌 정책 잠금: 서버 실행 + ``--check --yes`` → ``--check`` 우선.
+
+        server 실행 중이어도 ``--check``+``--yes`` 동시 사용 시 ``--check``
+        우선 dry-run 성공, side-effect 미진입.
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+            patch("ante.update.checker.get_latest_version", return_value="2.0.0"),
+            patch("ante.update.executor.pip_upgrade") as mock_pip_upgrade,
+        ):
+            result = runner.invoke(cli, ["update", "--check", "--yes"])
+
+        assert result.exit_code == 0
+        assert "서버가 실행 중입니다" not in result.output
+        assert "업데이트 가능: 1.0.0" in result.output
+        mock_pip_upgrade.assert_not_called()
+
+    def test_server_running_with_yes_and_force_bypasses_server_guard(
+        self, runner: CliRunner
+    ) -> None:
+        """서버 실행 + ``--yes`` + ``--force`` → ``UPDATE_SERVER_RUNNING`` 우회.
+
+        #1626 (Codex r1 [medium]): 본 케이스는 **``UPDATE_SERVER_RUNNING``
+        가드가 우회됨**(server-running으로 거절되지 **않음**)만 검증한다.
+        update 성공/실제 진행을 성공 의미로 단언하지 않는다 — graceful
+        shutdown 미구현은 본 acceptance 범위 밖(Non-Goal). 검증 방법:
+        server-running 거부 코드가 아니고, ``--yes`` 게이트도 통과하여
+        실제 update 경로(여기서는 PyPI 조회)로 진입함을 확인한다.
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+            patch(
+                "ante.update.checker.get_latest_version", return_value="2.0.0"
+            ) as mock_latest,
+            patch("ante.cli.commands.update.check_disk_space", return_value=(True, "")),
+            patch("ante.db.backup.backup_db"),
+            patch("ante.update.executor.snapshot_dependencies", return_value=None),
+            patch("ante.update.executor.pip_upgrade", return_value=True),
+            patch("ante.update.executor.run_post_update_migrations", return_value=True),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "update", "--yes", "--force"], input=None
+            )
+
+        # server-running 거부가 아님 — 가드 우회 검증 (성공 의미 단언 아님).
+        if result.output.strip():
+            try:
+                data = json.loads(result.output)
+            except json.JSONDecodeError:
+                data = {}
+            assert data.get("code") != "UPDATE_SERVER_RUNNING"
+            assert data.get("code") != "CLI_CONFIRMATION_REQUIRED"
+        # `--yes`+`--force` 게이트 통과 → 실제 update 경로(PyPI 조회) 진입.
+        mock_latest.assert_called_once()
+
+    def test_output_shape_json_vs_text(self, runner: CliRunner) -> None:
+        """JSON/text 양쪽 출력 shape 1케이스 (server-running 거부).
+
+        JSON: ``{status, code, message}`` 구조. text: 사람이 읽는 메시지.
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+        ):
+            json_result = runner.invoke(
+                cli, ["--format", "json", "update", "--yes"], input=None
+            )
+            text_result = runner.invoke(cli, ["update", "--yes"], input=None)
+
+        assert json_result.exit_code != 0
+        jdata = json.loads(json_result.output)
+        assert jdata["status"] == "error"
+        assert jdata["code"] == "UPDATE_SERVER_RUNNING"
+        assert "message" in jdata
+
+        assert text_result.exit_code != 0
+        assert "서버가 실행 중입니다" in text_result.output

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -77,15 +78,76 @@ class TestUpdateCheckFlag:
 
 
 class TestServerRunningBlock:
-    """서버 실행 중 차단 테스트."""
+    """서버 실행 중 게이트 우선순위 테스트 (#1626).
 
-    def test_server_running_blocks_update(self, runner: CliRunner) -> None:
-        """서버가 실행 중이면 exit code 1로 종료한다."""
-        with patch("ante.cli.commands.update.check_server_running", return_value=True):
+    의도 변경(#1626 D1/D3): 이전 ``test_server_running_blocks_update``는
+    서버 실행 중 ``ante update --check``이 server-running으로 차단(exit 1)
+    되는 buggy 순서를 정상으로 단언했다. 그러나 SSOT
+    (``docs/specs/cli/02-design-decisions.md`` 위험 명령 확인 방식 +
+    precedence normative 규칙)는 ``--check``을 dry-run으로 server-running과
+    무관하게(최우선) 처리하도록 명시한다. 따라서 본 클래스는 spec 정합
+    의미로 갱신한다 — server-running 차단이 적용되는 경로는 ``--check``이
+    아닌 실제 update 호출(``--yes`` 게이트 통과 후)이다.
+    """
+
+    def test_check_not_blocked_by_server_running(self, runner: CliRunner) -> None:
+        """서버 실행 중이어도 ``--check`` dry-run은 차단되지 않는다 (#1626 D3).
+
+        SSOT: ``--check``은 PyPI 버전 조회만 수행하는 dry-run으로
+        ``--yes``/server-running과 무관하며 최우선으로 처리된다.
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+            patch("ante.update.checker.get_latest_version", return_value="2.0.0"),
+        ):
             result = runner.invoke(cli, ["update", "--check"])
 
+        assert result.exit_code == 0
+        assert "서버가 실행 중입니다" not in result.output
+        assert "업데이트 가능: 1.0.0" in result.output
+
+    def test_server_running_without_yes_returns_confirmation_required(
+        self, runner: CliRunner
+    ) -> None:
+        """서버 실행 + ``--yes`` 누락 → ``CLI_CONFIRMATION_REQUIRED`` (#1626 D1).
+
+        spec precedence: confirmation gate가 server 상태 검사보다 우선.
+        server-running 안내(``UPDATE_SERVER_RUNNING``)가 아닌
+        ``CLI_CONFIRMATION_REQUIRED``로 거절되어야 한다.
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+        ):
+            result = runner.invoke(cli, ["--format", "json", "update"], input=None)
+
         assert result.exit_code == 1
-        assert "서버가 실행 중입니다" in result.output
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
+        assert "--yes" in data["message"]
+
+    def test_server_running_with_yes_without_force_returns_server_running(
+        self, runner: CliRunner
+    ) -> None:
+        """서버 실행 + ``--yes`` + ``--force`` 없음 → ``UPDATE_SERVER_RUNNING``.
+
+        #1626 D2: server-running 에러 코드는 ``UPDATE_SERVER_RUNNING``이며
+        ``code`` 가 null 이 아니어야 한다 (이전 buggy 동작은 code=null).
+        """
+        with (
+            patch("ante.cli.commands.update.check_server_running", return_value=True),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "update", "--yes"], input=None
+            )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["code"] == "UPDATE_SERVER_RUNNING"
+        assert data["code"] is not None
+        assert "서버가 실행 중입니다" in data["message"]
 
 
 class TestUpdateChecker:


### PR DESCRIPTION
Closes #1626

## Summary
- oracle A7 contract-drift: `ante update`가 `--yes` 누락보다 server-running 오류(stdout code=null)를 먼저 반환하던 문제 수정
- `update.py` 단일 가드 블록 재배치: **`--check` dry-run return → `--yes`(`CLI_CONFIRMATION_REQUIRED`) → `check_server_running() and not force`(`code="UPDATE_SERVER_RUNNING"`) → 실제 update**
- D1 순서(이슈 core) + D2 server-running 에러 `UPDATE_SERVER_RUNNING` 코드 부여(spec 02-design:74/115, 03-commands:660) + D3 `--check` dry-run이 server-running과 무관(충돌정책 `--check 우선` 보존)
- precedence SSOT 1줄 선반영: `docs/specs/cli/02-design-decisions.md` + `03-commands.md` 교차참조 (표 순서/즉시종료 해석 의존 제거)
- `--force` 분기 동작 불변(`# TODO: graceful shutdown` 보존 — 본 PR은 가드 우회만 검증, 서버 실행 중 update 안전성 미승인; graceful shutdown 실제 구현은 후속 후보)

## Spec
- SSOT `docs/specs/cli/02-design-decisions.md` 비대화형 입력 계약 + `03-commands.md:648-664` (1B + bundled doc clarification)

## Test Plan
- 신규 `TestUpdateGatePrecedence` 8케이스: server+no-yes→CLI_CONFIRMATION_REQUIRED / server+yes+no-force→UPDATE_SERVER_RUNNING(code≠null 직접 단언) / no-server+no-yes→CLI_CONFIRMATION_REQUIRED / --check 충돌정책(server+--check, --check --yes --format json, server+--check --yes: dry-run 성공·side-effect 미진입) / server+yes+force→가드 우회만 / JSON·text shape
- 의도변경 갱신: `test_update.py` TestServerRunningBlock, `test_cli_update.py` TestUpdateFormatJsonError (기존 buggy 순서 단언 → spec 정합)
- 6 영향파일+신규 71 passed, `mypy src/` 전체 clean, `ruff check/format` 통과
- Codex 브랜치 리뷰 `--base main` PASS (attempt 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)