### PR TITLE
fix(web): block dataset_id path traversal — 2-layer path-safe defense (#1631)

### DIFF
--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -78,10 +78,10 @@
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/api/data/datasets` | 보유 데이터셋 목록 (필터: symbol, timeframe, data_type, offset, limit). `timeframe`은 OHLCV bar vocabulary(`1m, 5m, 15m, 1h, 1d`, 계약 SSOT: core.md `## Canonical Symbol/Timeframe Vocabulary` (코드 상수 위임 #1613))만 허용 — vocabulary 외 값은 400 거부 (#1594). `data_type`은 `ohlcv \| fundamental` enum, 외 값은 422. `symbol`은 별도 vocabulary 거부하지 않고 exact-match 필터로만 처리 — 매칭 데이터 미존재 시 200 empty, legacy out-of-vocab symbol dir(`ohlcv/<tf>/KRX/<sym>`)이 저장돼 있으면 그 dataset 반환(core.md Legacy out-of-vocabulary 호환 정책과 정합). `symbol` vocabulary 거부 자체는 exchange-aware symbol SSOT 후속(#1613 코드 SSOT 체인)에 위임 |
-| GET | `/api/data/datasets/{dataset_id}` | 데이터셋 상세 조회. 메타데이터(symbol, timeframe, 기간, 행 수) + 데이터 미리보기(최근 5행). dataset_id = `{symbol}__{timeframe}`. ParquetStore.read(limit=5) 활용 |
+| GET | `/api/data/datasets/{dataset_id}` | 데이터셋 상세 조회. 메타데이터(symbol, timeframe, 기간, 행 수) + 데이터 미리보기(최근 5행). dataset_id = `{symbol}__{timeframe}`. ParquetStore.read(limit=5) 활용. `symbol`/`timeframe` segment가 path traversal(`.`/`..`/`/`/`\` /NUL/절대경로)이면 400 (#1631 — parent 디렉토리를 dataset으로 해석하는 결함 방어). `symbol` vocabulary는 별도 거부하지 않으며 legacy out-of-vocab symbol dir은 정상 처리(`## 데이터` 절 Legacy 호환 정책 정합) |
 | GET | `/api/data/schema` | 데이터 스키마 (필터: data_type) |
 | GET | `/api/data/storage` | 저장 용량 현황 |
-| DELETE | `/api/data/datasets/{dataset_id}` | 데이터셋 삭제. `data_type` query는 `ohlcv \| fundamental` enum (기본 `ohlcv`), enum 외 값은 422 |
+| DELETE | `/api/data/datasets/{dataset_id}` | 데이터셋 삭제. `dataset_id` = `{symbol}__{timeframe}`. 삭제 대상 유형(kind)의 SSOT는 `dataset_id`의 timeframe segment(`__fundamental` → fundamental, 그 외 → ohlcv). `data_type` query는 `ohlcv \| fundamental` enum (선택, 고정 기본값 없음 — 생략 시 `dataset_id` segment에서 파생, 명시 시 파생값과 일치해야 하며 불일치는 400). enum 외 값은 422. `symbol`/`timeframe` segment가 path traversal(`.`/`..`/`/`/`\` /NUL/절대경로)이면 400 (#1631 — `shutil.rmtree` 임의 디렉토리 삭제 방어). `symbol` vocabulary는 별도 거부하지 않으며 legacy out-of-vocab symbol dir은 정상 처리(spec `## 데이터` 절 Legacy 호환 정책 정합) |
 | GET | `/api/data/feed-status` | Feed 파이프라인 상태 조회 |
 
 ## 결재 관리 (`/api/approvals`)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3658,7 +3658,7 @@
           "data"
         ],
         "summary": "Delete Dataset",
-        "description": "데이터셋 삭제. 인증된 master/human 또는 ``data:write`` scope 를 보유한\nagent 만 호출 가능 (#1407).\n\ndataset_id 형식: \"{symbol}__{timeframe}\" (예: \"005930__1d\")\nfundamental의 경우: \"{symbol}__fundamental\" (예: \"005930__fundamental\")",
+        "description": "데이터셋 삭제. 인증된 master/human 또는 ``data:write`` scope 를 보유한\nagent 만 호출 가능 (#1407).\n\ndataset_id 형식: \"{symbol}__{timeframe}\" (예: \"005930__1d\")\nfundamental의 경우: \"{symbol}__fundamental\" (예: \"005930__fundamental\")\n\n삭제 대상 유형(kind)의 SSOT는 dataset_id의 timeframe segment다.\n``data_type`` query는 생략 가능하며, 명시 시 파생값과 일치하지 않으면\n400으로 거부한다(`shutil.rmtree` 오삭제 방지, #1631).",
         "operationId": "delete_dataset_api_data_datasets__dataset_id__delete",
         "parameters": [
           {
@@ -3675,16 +3675,22 @@
             "in": "query",
             "required": false,
             "schema": {
-              "enum": [
-                "ohlcv",
-                "fundamental"
+              "anyOf": [
+                {
+                  "enum": [
+                    "ohlcv",
+                    "fundamental"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
               ],
-              "type": "string",
-              "description": "데이터 유형 (ohlcv, fundamental)",
-              "default": "ohlcv",
+              "description": "데이터 유형 (ohlcv, fundamental). 생략 시 dataset_id의 timeframe segment에서 파생(`__fundamental` → fundamental, 그 외 → ohlcv). 명시 시 파생값과 일치해야 하며 불일치는 400.",
               "title": "Data Type"
             },
-            "description": "데이터 유형 (ohlcv, fundamental)"
+            "description": "데이터 유형 (ohlcv, fundamental). 생략 시 dataset_id의 timeframe segment에서 파생(`__fundamental` → fundamental, 그 외 → ohlcv). 명시 시 파생값과 일치해야 하며 불일치는 400."
           }
         ],
         "responses": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -792,6 +792,10 @@ export type paths = {
          *
          *     dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
          *     fundamental의 경우: "{symbol}__fundamental" (예: "005930__fundamental")
+         *
+         *     삭제 대상 유형(kind)의 SSOT는 dataset_id의 timeframe segment다.
+         *     ``data_type`` query는 생략 가능하며, 명시 시 파생값과 일치하지 않으면
+         *     400으로 거부한다(`shutil.rmtree` 오삭제 방지, #1631).
          */
         delete: operations["delete_dataset_api_data_datasets__dataset_id__delete"];
         options?: never;
@@ -5486,8 +5490,8 @@ export interface operations {
     delete_dataset_api_data_datasets__dataset_id__delete: {
         parameters: {
             query?: {
-                /** @description 데이터 유형 (ohlcv, fundamental) */
-                data_type?: "ohlcv" | "fundamental";
+                /** @description 데이터 유형 (ohlcv, fundamental). 생략 시 dataset_id의 timeframe segment에서 파생(`__fundamental` → fundamental, 그 외 → ohlcv). 명시 시 파생값과 일치해야 하며 불일치는 400. */
+                data_type?: ("ohlcv" | "fundamental") | null;
             };
             header?: never;
             path: {

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 import shutil
 from pathlib import Path
@@ -13,6 +14,40 @@ import polars as pl
 from ante.core.exchange import CANONICAL_EXCHANGES, is_canonical
 
 logger = logging.getLogger(__name__)
+
+
+def _is_safe_path_segment(seg: str) -> bool:
+    """단일 path segment가 traversal-safe한지 판정.
+
+    저장소 경로(`base/.../{symbol}` 등)의 각 segment는 정확히 한 단계의
+    디렉토리 이름이어야 한다. 이 술어는 **vocabulary와 무관**하다 — KRX
+    6자리 형식이나 canonical timeframe 여부를 검사하지 않으며, legacy
+    out-of-vocabulary symbol(`ABCDEF`, `oracle-safe-symbol` 등)은 통과
+    한다(web-api spec `05-resource-endpoints.md:76` Legacy 호환 정책 정합).
+    오직 path traversal/escape 벡터만 거부한다.
+
+    거부 조건:
+      - 빈 문자열
+      - `.` 또는 `..` (현재/부모 디렉토리)
+      - `/`, `\\`, NUL 문자 포함 (경로 구분자/인젝션)
+      - 절대 경로 또는 드라이브 지정 (`os.path.isabs`)
+
+    Returns:
+        traversal-safe하면 True, 그 외 False.
+    """
+    if not seg:
+        return False
+    if seg in (".", ".."):
+        return False
+    if "/" in seg or "\\" in seg or "\x00" in seg:
+        return False
+    if os.path.isabs(seg):
+        return False
+    # Windows 드라이브/UNC(`C:`, `\\\\host`) 방어. POSIX에서는 no-op.
+    if os.path.splitdrive(seg)[0]:
+        return False
+    return True
+
 
 # write_parquet compression 타입
 CompressionType = Literal["lz4", "uncompressed", "snappy", "gzip", "brotli", "zstd"]
@@ -153,15 +188,62 @@ class ParquetStore:
         - ohlcv: {base}/ohlcv/{timeframe}/{exchange}/{symbol}/
         - fundamental: {base}/fundamental/{exchange}/{symbol}/
         - tick: {base}/tick/{exchange}/{symbol}/
+
+        path traversal 방어(#1631): 경로에 **실제로 사용되는** 각 segment
+        (`symbol`/`exchange`/`data_type`, ohlcv 계열은 `timeframe`)를
+        `_is_safe_path_segment`로 검증하고, resolved(`.resolve()` symlink
+        해소) 기준으로 candidate가 정확히 expected parent 직하위이며 base
+        하위에 포함되는지 단언한다. 위반 시 `ValueError`. legacy
+        out-of-vocabulary symbol 등 정상 caller는 모두 통과한다.
         """
+        used_segments: tuple[str, ...]
         if data_type == "ohlcv":
-            return self._base / "ohlcv" / timeframe / exchange / symbol
+            candidate = self._base / "ohlcv" / timeframe / exchange / symbol
+            expected_parent = self._base / "ohlcv" / timeframe / exchange
+            used_segments = (timeframe, exchange, symbol)
         elif data_type == "fundamental":
-            return self._base / "fundamental" / exchange / symbol
+            candidate = self._base / "fundamental" / exchange / symbol
+            expected_parent = self._base / "fundamental" / exchange
+            used_segments = (exchange, symbol)
         elif data_type == "tick":
-            return self._base / "tick" / exchange / symbol
+            candidate = self._base / "tick" / exchange / symbol
+            expected_parent = self._base / "tick" / exchange
+            used_segments = (exchange, symbol)
         else:
-            return self._base / data_type / timeframe / exchange / symbol
+            candidate = self._base / data_type / timeframe / exchange / symbol
+            expected_parent = self._base / data_type / timeframe / exchange
+            used_segments = (data_type, timeframe, exchange, symbol)
+
+        # data_type별 expected-parent 검증: 경로에 사용되지 않는 segment
+        # (fundamental/tick의 `timeframe=""`)는 검사 대상에서 제외한다.
+        for seg in used_segments:
+            if not _is_safe_path_segment(seg):
+                raise ValueError(
+                    f"path traversal 차단: 안전하지 않은 경로 segment '{seg}' "
+                    f"(data_type={data_type})"
+                )
+
+        # resolved(symlink 해소) containment 단언. lexical 검사만으로는
+        # 중간 디렉토리(`ohlcv/{tf}/{exchange}` 등)가 base 밖을 가리키는
+        # symlink면 통과해 `shutil.rmtree` 등이 base 밖으로 탈출할 수
+        # 있다. base/expected_parent/candidate를 동일하게 resolve한 뒤
+        # candidate가 expected_parent 직하위이며 base 하위인지 확인한다.
+        # data root 전체가 symlink인 정상 deployment는 base/candidate가
+        # 동일 resolve되어 통과한다(거부 대상은 resolved 후 base 밖 탈출).
+        resolved_base = self._base.resolve()
+        resolved_parent = expected_parent.resolve()
+        resolved_candidate = candidate.resolve()
+        if (
+            resolved_candidate.parent != resolved_parent
+            or not resolved_candidate.is_relative_to(resolved_base)
+        ):
+            raise ValueError(
+                f"path traversal 차단: 해석된 경로가 예상 위치를 벗어남 "
+                f"(symbol={symbol!r}, timeframe={timeframe!r}, "
+                f"data_type={data_type!r})"
+            )
+
+        return candidate
 
     def resolve_path(
         self,

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any, Literal
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from ante.data.schemas import TIMEFRAMES
+from ante.data.store import _is_safe_path_segment
 from ante.web.deps import (
     get_audit_logger_optional,
     get_data_store,
@@ -187,6 +188,16 @@ async def get_dataset_detail(
 
     symbol, timeframe = parts
 
+    # path traversal 방어(#1631): symbol/timeframe segment가 `..`/slash/
+    # 절대경로 등이면 거부. vocabulary(KRX 6자리·canonical tf)는 검사하지
+    # 않는다 — legacy out-of-vocab symbol은 통과(spec 05:76 호환 정책).
+    if not _is_safe_path_segment(symbol) or not _is_safe_path_segment(timeframe):
+        raise HTTPException(
+            status_code=400,
+            detail="dataset_id의 symbol/timeframe에 허용되지 않는 경로 문자가 "
+            "포함되어 있습니다",
+        )
+
     # fundamental 타입 판별
     is_fundamental = timeframe == "fundamental"
     data_type = "fundamental" if is_fundamental else "ohlcv"
@@ -332,8 +343,13 @@ async def delete_dataset(
     caller_id: Annotated[str, Depends(require_data_write)],
     store: Annotated[Any | None, Depends(get_data_store)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
-    data_type: Literal["ohlcv", "fundamental"] = Query(
-        "ohlcv", description="데이터 유형 (ohlcv, fundamental)"
+    data_type: Literal["ohlcv", "fundamental"] | None = Query(
+        None,
+        description=(
+            "데이터 유형 (ohlcv, fundamental). 생략 시 dataset_id의 "
+            "timeframe segment에서 파생(`__fundamental` → fundamental, "
+            "그 외 → ohlcv). 명시 시 파생값과 일치해야 하며 불일치는 400."
+        ),
     ),
 ) -> None:
     """데이터셋 삭제. 인증된 master/human 또는 ``data:write`` scope 를 보유한
@@ -341,6 +357,10 @@ async def delete_dataset(
 
     dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
     fundamental의 경우: "{symbol}__fundamental" (예: "005930__fundamental")
+
+    삭제 대상 유형(kind)의 SSOT는 dataset_id의 timeframe segment다.
+    ``data_type`` query는 생략 가능하며, 명시 시 파생값과 일치하지 않으면
+    400으로 거부한다(`shutil.rmtree` 오삭제 방지, #1631).
     """
     if store is None:
         raise HTTPException(status_code=503, detail="Data store not available")
@@ -354,7 +374,32 @@ async def delete_dataset(
 
     symbol, timeframe = parts
 
-    if data_type == "fundamental":
+    # path traversal 방어(#1631): symbol/timeframe segment 검증.
+    # vocabulary 미검사 — legacy out-of-vocab symbol 통과(spec 05:76).
+    if not _is_safe_path_segment(symbol) or not _is_safe_path_segment(timeframe):
+        raise HTTPException(
+            status_code=400,
+            detail="dataset_id의 symbol/timeframe에 허용되지 않는 경로 문자가 "
+            "포함되어 있습니다",
+        )
+
+    # kind SSOT = dataset_id timeframe segment. `__fundamental` →
+    # fundamental, 그 외(path-safe) → ohlcv.
+    derived_kind: Literal["ohlcv", "fundamental"] = (
+        "fundamental" if timeframe == "fundamental" else "ohlcv"
+    )
+    # data_type query: 생략(None) → 파생값 사용. 명시 → 파생값과 일치해야
+    # 함. 불일치 시 400(rmtree 오삭제 방지, #1631).
+    if data_type is not None and data_type != derived_kind:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"data_type='{data_type}'가 dataset_id에서 파생된 유형 "
+                f"'{derived_kind}'와 일치하지 않습니다"
+            ),
+        )
+
+    if derived_kind == "fundamental":
         path = store._resolve_path(symbol, "", data_type="fundamental")
     else:
         path = store._resolve_path(symbol, timeframe, data_type="ohlcv")

--- a/tests/unit/test_dataset_delete_api.py
+++ b/tests/unit/test_dataset_delete_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from unittest.mock import patch
 
 import polars as pl
 import pytest
@@ -206,6 +207,184 @@ class TestDeleteDataset:
             params={"data_type": "fundamental"},
         )
         assert resp.status_code == 404
+
+
+class TestDeleteDatasetPathTraversal:
+    """DELETE /api/data/datasets/{dataset_id} path traversal 방어 (#1631).
+
+    `..__1d` 등이 `shutil.rmtree`로 의도 디렉토리 밖을 삭제하던 destructive
+    결함을 400으로 거부하고 rmtree가 호출되지 않는지 검증한다.
+    """
+
+    def test_parent_traversal_rejected_and_rmtree_not_called(self, client, store):
+        """`..__1d` → 400 + `shutil.rmtree` 미호출."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        with patch("ante.web.routes.data.shutil.rmtree") as mock_rmtree:
+            resp = client.delete("/api/data/datasets/..__1d")
+        assert resp.status_code == 400, (
+            f"path traversal `..__1d` DELETE가 거부되지 않음: {resp.status_code}"
+        )
+        mock_rmtree.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "dataset_id",
+        [
+            "..__1d",
+            "005930__..",
+            "005930__.",
+            ".__1d",
+        ],
+    )
+    def test_no_slash_traversal_rejected_400_no_rmtree(self, client, dataset_id):
+        """slash 없는 traversal(`..`/`.`) → ingress 400 + rmtree 미호출."""
+        with patch("ante.web.routes.data.shutil.rmtree") as mock_rmtree:
+            resp = client.delete(f"/api/data/datasets/{dataset_id}")
+        assert resp.status_code == 400, (
+            f"traversal 변형 DELETE 거부 실패: {dataset_id} → {resp.status_code}"
+        )
+        mock_rmtree.assert_not_called()
+
+    def test_url_encoded_dotdot_decoded_rejected_400_no_rmtree(self, client):
+        """URL-encoded `%2e%2e`(slash 없음) → decode 후 400 + rmtree 미호출."""
+        with patch("ante.web.routes.data.shutil.rmtree") as mock_rmtree:
+            resp = client.delete("/api/data/datasets/%2e%2e__1d")
+        assert resp.status_code == 400
+        mock_rmtree.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "dataset_id",
+        [
+            "../../x__1d",
+            "a/b__1d",
+            "005930__../../x",
+            "005930__a/b",
+        ],
+    )
+    def test_slash_bearing_traversal_unreachable_no_rmtree(self, client, dataset_id):
+        """slash 포함 입력은 라우트 미매치로 handler 도달 불가 → rmtree
+        절대 미호출(404/400, destructive 코드 구조적 도달 불가).
+
+        400 강제는 catch-all 라우트/path-scheme 변경 필요 — Non-Goal.
+        보안 불변: rmtree 미호출 + 204 아님.
+        """
+        with patch("ante.web.routes.data.shutil.rmtree") as mock_rmtree:
+            resp = client.delete(f"/api/data/datasets/{dataset_id}")
+        assert resp.status_code != 204, f"slash traversal DELETE가 성공함: {dataset_id}"
+        assert resp.status_code in (400, 404)
+        mock_rmtree.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "raw_path",
+        [
+            "/api/data/datasets/005930__%2e%2e%2f%2e%2e%2fx",
+            "/api/data/datasets/%2e%2e%2f%2e%2e%2fx__1d",
+            "/api/data/datasets/%2fetc%2fpasswd__1d",
+        ],
+    )
+    def test_url_encoded_slash_traversal_no_rmtree(self, client, raw_path):
+        """URL-encoded slash(`%2f`) 포함 → rmtree 미호출 + 204 아님."""
+        with patch("ante.web.routes.data.shutil.rmtree") as mock_rmtree:
+            resp = client.delete(raw_path)
+        assert resp.status_code != 204
+        assert resp.status_code in (400, 404)
+        mock_rmtree.assert_not_called()
+
+    async def test_legacy_non_6digit_symbol_not_rejected(self, client, store):
+        """legacy out-of-vocab symbol(path-safe)은 400 아님 — 정상 삭제.
+
+        spec 05:76 legacy 호환 보존.
+        """
+        store.write("ABCDEF", "1d", _make_ohlcv_df())
+        resp = client.delete("/api/data/datasets/ABCDEF__1d")
+        assert resp.status_code == 204, (
+            f"legacy path-safe symbol DELETE가 회귀: {resp.status_code}"
+        )
+
+    def test_legacy_missing_symbol_404_not_400(self, client):
+        """미존재 legacy path-safe symbol DELETE → 404 (400 아님)."""
+        resp = client.delete("/api/data/datasets/ABCDEF__1d")
+        assert resp.status_code == 404
+
+
+class TestDeleteDatasetDataTypeContract:
+    """DELETE `data_type` ↔ dataset_id timeframe segment 일치 계약 (#1631).
+
+    kind SSOT = dataset_id timeframe segment. data_type query 생략 시 파생값
+    사용, 명시 시 파생값과 불일치하면 400(rmtree 오삭제 방지).
+    """
+
+    # ── omitted: 파생값 사용 ──
+    async def test_omitted_fundamental_segment_uses_fundamental(self, client, store):
+        """`005930__fundamental` (query 생략) → fundamental 정상 삭제."""
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.delete("/api/data/datasets/005930__fundamental")
+        assert resp.status_code == 204
+        listing = client.get("/api/data/datasets", params={"data_type": "fundamental"})
+        assert listing.json()["items"] == []
+
+    async def test_omitted_ohlcv_segment_uses_ohlcv(self, client, store):
+        """`005930__1d` (query 생략) → ohlcv 정상 삭제."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.delete("/api/data/datasets/005930__1d")
+        assert resp.status_code == 204
+
+    # ── 명시 일치: 정상 ──
+    async def test_explicit_match_fundamental(self, client, store):
+        """`005930__fundamental?data_type=fundamental` → 정상 삭제."""
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.delete(
+            "/api/data/datasets/005930__fundamental",
+            params={"data_type": "fundamental"},
+        )
+        assert resp.status_code == 204
+
+    async def test_explicit_match_ohlcv(self, client, store):
+        """`005930__1d?data_type=ohlcv` → 정상 삭제."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.delete(
+            "/api/data/datasets/005930__1d",
+            params={"data_type": "ohlcv"},
+        )
+        assert resp.status_code == 204
+
+    # ── 명시 mismatch: 400 + rmtree 미호출 ──
+    async def test_explicit_mismatch_fundamental_segment_ohlcv_query(
+        self, client, store
+    ):
+        """`005930__fundamental?data_type=ohlcv` → 400 + rmtree 미호출."""
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        with patch("ante.web.routes.data.shutil.rmtree") as mock_rmtree:
+            resp = client.delete(
+                "/api/data/datasets/005930__fundamental",
+                params={"data_type": "ohlcv"},
+            )
+        assert resp.status_code == 400, (
+            f"mismatch(fundamental seg / ohlcv query) 거부 실패: {resp.status_code}"
+        )
+        mock_rmtree.assert_not_called()
+
+    async def test_explicit_mismatch_ohlcv_segment_fundamental_query(
+        self, client, store
+    ):
+        """`005930__1d?data_type=fundamental` → 400 + rmtree 미호출."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        with patch("ante.web.routes.data.shutil.rmtree") as mock_rmtree:
+            resp = client.delete(
+                "/api/data/datasets/005930__1d",
+                params={"data_type": "fundamental"},
+            )
+        assert resp.status_code == 400, (
+            f"mismatch(ohlcv seg / fundamental query) 거부 실패: {resp.status_code}"
+        )
+        mock_rmtree.assert_not_called()
+
+    def test_invalid_enum_data_type_still_422(self, client):
+        """enum 외 data_type 값은 여전히 422 (#1438 회귀 보존)."""
+        resp = client.delete(
+            "/api/data/datasets/005930__1d",
+            params={"data_type": "oracle_invalid_type"},
+        )
+        assert resp.status_code == 422
 
 
 class TestFundamentalDatasets:

--- a/tests/unit/test_dataset_detail_api.py
+++ b/tests/unit/test_dataset_detail_api.py
@@ -148,3 +148,105 @@ class TestDatasetDetail:
         assert body["dataset"]["data_type"] == "fundamental"
         assert body["dataset"]["symbol"] == "005930"
         assert len(body["preview"]) > 0
+
+
+class TestDatasetDetailPathTraversal:
+    """GET /api/data/datasets/{dataset_id} path traversal 방어 (#1631).
+
+    `..__1d`(symbol=`..`) 등이 parent 디렉토리를 정상 dataset으로 해석해
+    200을 반환하던 보안 결함을 400으로 거부하는지 검증한다.
+    """
+
+    def test_parent_traversal_symbol_rejected(self, client, store):
+        """원 재현 벡터: `..__1d` (symbol=`..`) → 400 (200 아님)."""
+        # parent를 leaf로 해석하지 못하도록, parent dir이 실제 존재해도
+        # 거부되어야 한다.
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/..__1d")
+        assert resp.status_code == 400, (
+            f"path traversal `..__1d`가 거부되지 않음: {resp.status_code}"
+        )
+
+    @pytest.mark.parametrize(
+        "dataset_id",
+        [
+            "..__1d",
+            "005930__..",
+            "005930__.",
+            ".__1d",
+        ],
+    )
+    def test_no_slash_traversal_variants_rejected_400(self, client, dataset_id):
+        """slash 없는 traversal 변형(`..`/`.`) → ingress 400."""
+        resp = client.get(f"/api/data/datasets/{dataset_id}")
+        assert resp.status_code == 400, (
+            f"traversal 변형 거부 실패: {dataset_id} → {resp.status_code}"
+        )
+
+    def test_url_encoded_dotdot_decoded_and_rejected_400(self, client):
+        """URL-encoded `%2e%2e`(slash 없음) → decode 후 ingress 400."""
+        resp = client.get("/api/data/datasets/%2e%2e__1d")
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize(
+        "dataset_id",
+        [
+            "../../x__1d",
+            "a/b__1d",
+            "005930__../../x",
+            "005930__a/b",
+        ],
+    )
+    def test_slash_bearing_traversal_unreachable(self, client, dataset_id):
+        """slash 포함 입력은 path param이 `/`를 캡처하지 않아 라우트 자체가
+        매치되지 않음 → handler 도달 불가(404, 200 아님).
+
+        400을 강제하려면 catch-all 라우트/path-scheme 변경이 필요한데 이는
+        Non-Goal(`_resolve_path` 경로 스킴 구조 변경 금지). 200/메타데이터
+        노출이 발생하지 않는 것이 보안 불변.
+        """
+        resp = client.get(f"/api/data/datasets/{dataset_id}")
+        assert resp.status_code != 200, (
+            f"slash traversal이 200으로 노출됨: {dataset_id}"
+        )
+        assert resp.status_code in (400, 404)
+
+    @pytest.mark.parametrize(
+        "raw_path",
+        [
+            "/api/data/datasets/005930__%2e%2e%2f%2e%2e%2fx",
+            "/api/data/datasets/%2e%2e%2f%2e%2e%2fx__1d",
+            "/api/data/datasets/%2fetc%2fpasswd__1d",
+        ],
+    )
+    def test_url_encoded_slash_traversal_not_exposed(self, client, raw_path):
+        """URL-encoded slash(`%2f`) 포함 → 200 노출 안 됨(라우트 미매치)."""
+        resp = client.get(raw_path)
+        assert resp.status_code != 200, (
+            f"URL-encoded slash traversal이 200으로 노출됨: {raw_path}"
+        )
+        assert resp.status_code in (400, 404)
+
+    async def test_legacy_non_6digit_symbol_not_rejected(self, client, store):
+        """legacy out-of-vocab symbol(6자리 외, path-safe)은 400 아님.
+
+        `ABCDEF__1d`/`oracle-safe-symbol__1d`는 path-safe이므로 존재 시
+        정상 200, 미존재 시 404 — spec 05:76 legacy 호환 보존.
+        """
+        store.write("ABCDEF", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/ABCDEF__1d")
+        assert resp.status_code == 200
+        assert resp.json()["dataset"]["symbol"] == "ABCDEF"
+
+        # hyphen 포함 legacy symbol 디렉토리도 path-safe → 정상 동작
+        legacy_dir = store.base_path / "ohlcv" / "1d" / "KRX" / "oracle-safe-symbol"
+        legacy_dir.mkdir(parents=True, exist_ok=True)
+        resp2 = client.get("/api/data/datasets/oracle-safe-symbol__1d")
+        assert resp2.status_code != 400, (
+            f"legacy path-safe symbol이 400으로 회귀: {resp2.status_code}"
+        )
+
+    def test_legacy_missing_symbol_404_not_400(self, client):
+        """미존재 legacy path-safe symbol → 404 (400 아님)."""
+        resp = client.get("/api/data/datasets/ABCDEF__1d")
+        assert resp.status_code == 404

--- a/tests/unit/test_store_path_safety.py
+++ b/tests/unit/test_store_path_safety.py
@@ -1,0 +1,218 @@
+"""ParquetStore._resolve_path / _is_safe_path_segment path traversal 방어 (#1631).
+
+Layer 2 방어: route 우회 caller(public resolve_path, read/write/delete_file/
+retention/backtest)까지 보호하는 segment-level + resolved-containment 단언을
+검증한다. 정상 caller(legacy 6자리외 symbol, fundamental tf="", data root
+symlink deployment)는 전부 통과해야 한다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.data.store import ParquetStore, _is_safe_path_segment
+
+
+class TestIsSafePathSegment:
+    """`_is_safe_path_segment` 술어 — vocabulary 무관, traversal만 거부."""
+
+    @pytest.mark.parametrize(
+        "seg",
+        [
+            "005930",  # KRX 6자리
+            "ABCDEF",  # legacy out-of-vocab (6자리 외)
+            "oracle-safe-symbol",  # hyphen 포함 legacy
+            "1d",
+            "1m",
+            "fundamental",
+            "KRX",
+            "NASDAQ",
+            "A005930",
+            "005930.KS",  # dot 포함 (단일 `.`/`..`가 아님)
+        ],
+    )
+    def test_safe_segments_pass(self, seg):
+        """정상/legacy out-of-vocab segment는 통과 (vocabulary 미검사)."""
+        assert _is_safe_path_segment(seg) is True
+
+    @pytest.mark.parametrize(
+        "seg",
+        [
+            "",  # 빈 문자열
+            ".",  # 현재 디렉토리
+            "..",  # 부모 디렉토리 (원 재현 벡터)
+            "a/b",  # slash 포함
+            "../../x",  # 다단계 traversal
+            "a\\b",  # 백슬래시
+            "/etc/passwd",  # 절대경로
+            "a\x00b",  # NUL 인젝션
+            "..\\..\\x",
+        ],
+    )
+    def test_unsafe_segments_rejected(self, seg):
+        """traversal/escape 벡터는 거부."""
+        assert _is_safe_path_segment(seg) is False
+
+
+class TestResolvePathSegmentValidation:
+    """`_resolve_path` segment-level + expected-parent 단언."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        return ParquetStore(base_path=tmp_path / "data")
+
+    @pytest.mark.parametrize(
+        ("symbol", "timeframe", "data_type"),
+        [
+            ("..", "1d", "ohlcv"),
+            ("../../x", "1d", "ohlcv"),
+            ("a/b", "1d", "ohlcv"),
+            ("005930", "..", "ohlcv"),
+            ("005930", "../../x", "ohlcv"),
+            ("005930", "a/b", "ohlcv"),
+            ("..", "", "fundamental"),
+            ("/etc/passwd", "1d", "ohlcv"),
+            ("005930", "1d", "../evil"),  # data_type segment traversal
+        ],
+    )
+    def test_traversal_segment_raises_value_error(
+        self, store, symbol, timeframe, data_type
+    ):
+        """traversal segment → ValueError (rmtree 도달 전 차단)."""
+        with pytest.raises(ValueError, match="path traversal 차단"):
+            store._resolve_path(symbol, timeframe, data_type=data_type)
+
+    def test_normal_ohlcv_symbol_passes(self, store):
+        """정상 KRX symbol → 통과 + resolved leaf parent == expected parent."""
+        path = store._resolve_path("005930", "1d", data_type="ohlcv")
+        expected_parent = store.base_path / "ohlcv" / "1d" / "KRX"
+        assert path.resolve().parent == expected_parent.resolve()
+        assert path.name == "005930"
+
+    def test_legacy_non_6digit_symbol_passes(self, store):
+        """legacy out-of-vocab symbol(path-safe)은 통과 — 회귀 0."""
+        for sym in ("ABCDEF", "oracle-safe-symbol", "A005930"):
+            path = store._resolve_path(sym, "1d", data_type="ohlcv")
+            assert path.name == sym
+
+    def test_fundamental_empty_timeframe_passes(self, store):
+        """fundamental의 `timeframe=""`는 경로 미사용 → 통과."""
+        path = store._resolve_path("005930", "", data_type="fundamental")
+        expected_parent = store.base_path / "fundamental" / "KRX"
+        assert path.resolve().parent == expected_parent.resolve()
+
+    def test_tick_empty_timeframe_passes(self, store):
+        """tick의 `timeframe=""`도 경로 미사용 → 통과."""
+        path = store._resolve_path("005930", "", data_type="tick")
+        expected_parent = store.base_path / "tick" / "KRX"
+        assert path.resolve().parent == expected_parent.resolve()
+
+    def test_non_canonical_timeframe_passes(self, store):
+        """non-canonical timeframe(legacy `2h` 등 path-safe)은 통과.
+
+        vocabulary 검사를 하지 않으므로 legacy non-canonical tf dir
+        migration 동작이 보존된다.
+        """
+        path = store._resolve_path("005930", "2h", data_type="ohlcv")
+        assert path.name == "005930"
+        assert path.parent.name == "KRX"
+
+    def test_public_resolve_path_also_protected(self, store):
+        """public resolve_path도 동일 방어 — route 우회 caller 보호."""
+        with pytest.raises(ValueError, match="path traversal 차단"):
+            store.resolve_path("..", "1d")
+
+
+class TestResolvePathSymlinkContainment:
+    """resolved(symlink 해소) containment 단언 (Codex r2 [medium])."""
+
+    def test_intermediate_dir_symlink_outside_base_rejected(self, tmp_path):
+        """중간 dir(`ohlcv/1d/KRX`)이 base 밖 symlink → ValueError.
+
+        DELETE의 `shutil.rmtree` 도달 전 차단되어야 한다.
+        """
+        base = tmp_path / "data"
+        outside = tmp_path / "outside_target"
+        outside.mkdir(parents=True)
+        (base / "ohlcv" / "1d").mkdir(parents=True)
+        # ohlcv/1d/KRX → 외부 디렉토리 symlink (spelling은 base 하위)
+        (base / "ohlcv" / "1d" / "KRX").symlink_to(outside, target_is_directory=True)
+
+        store = ParquetStore(base_path=base)
+        with pytest.raises(ValueError, match="예상 위치를 벗어남"):
+            store._resolve_path("005930", "1d", data_type="ohlcv")
+
+    def test_symbol_leaf_symlink_outside_base_rejected(self, tmp_path):
+        """symbol-leaf가 base 밖을 가리키는 symlink → ValueError."""
+        base = tmp_path / "data"
+        outside = tmp_path / "outside_leaf"
+        outside.mkdir(parents=True)
+        krx = base / "ohlcv" / "1d" / "KRX"
+        krx.mkdir(parents=True)
+        (krx / "005930").symlink_to(outside, target_is_directory=True)
+
+        store = ParquetStore(base_path=base)
+        with pytest.raises(ValueError, match="예상 위치를 벗어남"):
+            store._resolve_path("005930", "1d", data_type="ohlcv")
+
+    def test_data_root_full_symlink_deployment_passes(self, tmp_path):
+        """data root 전체가 symlink인 정상 deployment → 통과.
+
+        base/candidate 양쪽이 동일 resolve되므로 거부되지 않아야 한다
+        (정상 deployment false-positive 방지 — Stop Condition).
+        """
+        real_data = tmp_path / "real_data"
+        real_data.mkdir(parents=True)
+        symlinked_base = tmp_path / "data"
+        symlinked_base.symlink_to(real_data, target_is_directory=True)
+
+        store = ParquetStore(base_path=symlinked_base)
+        # 예외 없이 정상 경로 반환
+        path = store._resolve_path("005930", "1d", data_type="ohlcv")
+        assert path.name == "005930"
+        # resolved 기준으로도 real_data 하위
+        assert path.resolve().is_relative_to(real_data.resolve())
+
+    def test_inside_base_symlink_passes(self, tmp_path):
+        """base 내부를 가리키는 symlink는 통과 (탈출 아님)."""
+        base = tmp_path / "data"
+        krx = base / "ohlcv" / "1d" / "KRX"
+        krx.mkdir(parents=True)
+        real_symbol = base / "ohlcv" / "1d" / "KRX" / "_real_005930"
+        real_symbol.mkdir()
+        (krx / "005930").symlink_to(real_symbol, target_is_directory=True)
+
+        store = ParquetStore(base_path=base)
+        # leaf symlink target이 base 하위 → 통과
+        path = store._resolve_path("005930", "1d", data_type="ohlcv")
+        assert path.resolve().is_relative_to(base.resolve())
+
+
+class TestLegacyMigrationUnaffected:
+    """legacy migration(store.py:73-101)이 _resolve_path 미경유 — 무영향."""
+
+    def test_migration_still_moves_legacy_dirs(self, tmp_path):
+        """`migrate_parquet_paths`가 6자리 legacy dir을 KRX/로 이동 (회귀 0)."""
+        from ante.data.store import migrate_parquet_paths
+
+        base = tmp_path / "data"
+        legacy = base / "ohlcv" / "1d" / "005930"
+        legacy.mkdir(parents=True)
+        (legacy / "2026-01.parquet").write_bytes(b"x")
+
+        moved = migrate_parquet_paths(base)
+        assert moved == 1
+        assert (base / "ohlcv" / "1d" / "KRX" / "005930").exists()
+        assert not (base / "ohlcv" / "1d" / "005930").exists()
+
+    def test_migration_skips_non_6digit(self, tmp_path):
+        """6자리 외 legacy dir은 migration 스킵 (기존 동작 보존)."""
+        from ante.data.store import migrate_parquet_paths
+
+        base = tmp_path / "data"
+        legacy = base / "ohlcv" / "1d" / "ABCDEF"
+        legacy.mkdir(parents=True)
+
+        moved = migrate_parquet_paths(base)
+        assert moved == 0
+        assert (base / "ohlcv" / "1d" / "ABCDEF").exists()


### PR DESCRIPTION
Closes #1631

## Summary (security / destructive)
- oracle A7: `GET/DELETE /api/data/datasets/{dataset_id}`가 `split("__")` 후 symbol/timeframe 미검증 → `..__1d`(symbol=`..`)가 부모 디렉토리 해석(GET 200 / DELETE `shutil.rmtree` 임의 삭제) 차단
- **2계층 defense-in-depth (path-safety only — vocabulary 아님)**:
  1. ingress(data.py detail/delete): `_is_safe_path_segment`(비어있지않음·`.`/`..` 아님·`/`·`\`·NUL 없음·non-absolute) → 400. legacy 6자리외 symbol 통과(web-api spec 05:76 호환 보존)
  2. `_resolve_path`(store.py): 사용 segment path-safe + **resolved(symlink 해소)** `resolved_candidate.parent==resolved_expected_parent AND is_relative_to(resolved_base)` → ValueError. ~10 caller/CLI/retention bypass 방어, rmtree 전 최종 안전망
- **DELETE `data_type` 계약 고정**: 시그니처 `Literal[...]|None=Query(None)`, kind=dataset_id segment SSOT 파생, omitted→파생/명시→일치 아니면 400 (rmtree 오삭제 방지)
- KRX symbol vocabulary enforcement는 web-api spec상 별도 후속(이슈 본문 후속 후보)

## Spec / generated
- web-api spec 05 DELETE row `data_type` 계약 갱신(optional·파생·명시 일치) + `frontend/openapi.json`·`api.generated.ts` 재생성(DELETE `data_type` `default:"ohlcv"` 제거·nullable)
- path-safety 자명 보안 invariant; symbol exact-match·legacy 호환은 spec 05:76 normative 보존

## Test Plan
- 신규 `test_store_path_safety.py` + detail/delete 확장: `..__1d`/`005930__..`/`%2e%2e__1d`→400·rmtree 미호출 / legacy `oracle-safe-symbol__1d`→400 아님(호환) / DELETE data_type 4조합 / _resolve_path resolved-containment·symlink(중간/leaf 거부, data-root-symlink 정상) / slash-variant 보안 불변(404·rmtree 미호출)
- dataset/store 106 + affected 264+355+86 passed(회귀 0), `mypy src/` clean, `ruff` clean, oracle 수동재현(`..__1d`→400 raw 소거)
- Codex 브랜치 리뷰 `--base main` PASS (attempt 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)