### PR TITLE
fix(web): reject unsupported report submit `sections` field (#1632)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8730,18 +8730,6 @@
             "default": "{}",
             "title": "Detail Json",
             "type": "string"
-          },
-          "sections": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sections"
           }
         },
         "required": [

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3156,10 +3156,6 @@ export type components = {
              * @default
              */
             risks: string;
-            /** Sections */
-            sections?: {
-                [key: string]: unknown;
-            } | null;
             /** Sharpe Ratio */
             sharpe_ratio?: number | null;
             /** Strategy Name */

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -104,7 +104,15 @@ def submit(
     try:
         validated = ReportSubmitRequest.model_validate(report_data)
     except ValidationError as exc:
-        fmt.error(str(exc), code="REPORT_VALIDATION_ERROR")
+        # 거부된 입력 값/ctx 반사 금지 (보안 invariant #1629 L1 패턴 1:1 미러;
+        # reports.py:194 web sweep 와 동일 sanitizer). 2b 가 sections 미지원
+        # 필드를 ValidationError(extra_forbidden) 경로로 보내므로 ``str(exc)``
+        # 의 ``input_value={...}`` (제출한 sections rationale/evidence) 가
+        # 터미널/CI 로그에 반사되지 않도록 loc/type/msg 만 출력한다 (#1632).
+        fmt.error(
+            str(exc.errors(include_context=False, include_input=False)),
+            code="REPORT_VALIDATION_ERROR",
+        )
         raise SystemExit(1) from exc
 
     async def _submit() -> dict:

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -43,13 +43,9 @@ router = APIRouter()
 #   ``"default": None`` 만 있고 ``required`` 에서 빠지지 않으면
 #   openapi-typescript 가 ``number | null`` 필수 필드로 생성해 (``?`` 마커 없음),
 #   메트릭을 생략하는 정상 제출이 타입 오류로 막힌다.
-# - ``sections`` 가 런타임에 ``dict[str, Any] | None`` 인데 schema 에
-#   ``additionalProperties`` 를 명시하지 않으면 generated type 이
-#   ``Record<string, never> | null`` 이 되어 임의 section payload 를 보낼 수 없다.
 #
 # Pydantic 의 ``model_json_schema()`` 는 default 가 있는 필드를 ``required`` 에서
-# 자동으로 빼고, ``dict[str, Any]`` 를 ``additionalProperties: true`` 로 노출하며,
-# ``model_config = ConfigDict(extra="forbid")`` 를 top-level
+# 자동으로 빼고, ``model_config = ConfigDict(extra="forbid")`` 를 top-level
 # ``additionalProperties: false`` 로 반영한다. 다만 ``default=None`` 을 키 안에
 # 그대로 남기면 openapi-typescript 가 ``?`` 마커 대신 ``T | null`` 필수 필드로
 # 생성한다. FastAPI 자동 schema (``ReportSubmitRequest`` 가 라우트 시그니처에

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -749,7 +749,6 @@ class ReportSubmitRequest(BaseModel):
     risks: str = ""
     recommendations: str = ""
     detail_json: str = "{}"
-    sections: dict[str, Any] | None = None
 
 
 class ReportSubmitResponse(BaseModel):

--- a/tests/unit/test_cli_report_submit_invariant.py
+++ b/tests/unit/test_cli_report_submit_invariant.py
@@ -204,6 +204,74 @@ class TestExtraForbid:
         assert body["code"] == "REPORT_VALIDATION_ERROR"
 
 
+# ── #1632: sections 미지원 필드 거부 + CLI input-reflection 차단 ─────────
+
+
+class TestSectionsRejected:
+    """``sections``는 미지원 필드 — CLI도 Web API와 동일하게 거부 (#1632).
+
+    사용자 정책 판정(2026-05-17): ``sections``는 YAGNI → 미지원 필드로 확정해
+    422/exit 1로 거부한다 (option 2b). ``ante report submit`` CLI는 Web API와
+    동일한 ``ReportSubmitRequest`` (SSOT)를 사용하므로 ``sections``는
+    ``extra='forbid'``로 거부된다.
+
+    Codex Plan Review r2 [high]: 2b가 ``sections``를 ValidationError
+    (``extra_forbidden``) 경로로 보내므로 ``str(exc)``의 ``input_value={...}``
+    (제출한 sections rationale/evidence)가 터미널/CI 로그에 반사되는 신규
+    CLI input-reflection이 발생한다. ``report.py``를 #1629 L1 패턴
+    (``exc.errors(include_context=False, include_input=False)``)으로 정화해
+    sentinel/내용이 stdout에 반사되지 않음을 회귀 검증한다.
+    """
+
+    _SENTINEL = "oracle_payload_sections_marker"
+
+    def _sections_payload(self) -> dict[str, Any]:
+        return _base_payload(
+            sections={
+                self._SENTINEL: {
+                    "rationale": "secret-rationale-text",
+                    "evidence": ["secret-evidence-item"],
+                }
+            }
+        )
+
+    def test_sections_payload_rejected(self, runner, tmp_path) -> None:
+        """``sections`` 포함 JSON → exit 1 + REPORT_VALIDATION_ERROR."""
+        path = _write_payload(tmp_path, self._sections_payload())
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["status"] == "error"
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+
+    def test_sections_rejection_does_not_echo_input(self, runner, tmp_path) -> None:
+        """stdout 전체에 sections sentinel/내용이 반사되지 않는다.
+
+        #1629 L1 패턴 1:1 미러(``exc.errors(include_context=False,
+        include_input=False)``)가 CLI에 적용되어 거부된 sections payload가
+        터미널/CI 로그로 새지 않음을 회귀 검증한다.
+        """
+        path = _write_payload(tmp_path, self._sections_payload())
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 1, result.output
+        out = result.output
+        assert self._SENTINEL not in out, f"stdout에 sections sentinel이 반사됨: {out}"
+        assert "secret-rationale-text" not in out, (
+            f"stdout에 sections rationale이 반사됨: {out}"
+        )
+        assert "secret-evidence-item" not in out, (
+            f"stdout에 sections evidence가 반사됨: {out}"
+        )
+
+    def test_payload_without_sections_still_accepted(self, runner, tmp_path) -> None:
+        """``sections`` 없는 정상 JSON은 회귀 없이 정상 제출."""
+        path = _write_payload(tmp_path, _base_payload())
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert body["status"] == "ok"
+
+
 # ── CLI extras (submitted_by, backtest_run_id) ──────────────
 
 

--- a/tests/unit/test_report_submit_validation.py
+++ b/tests/unit/test_report_submit_validation.py
@@ -241,3 +241,96 @@ class TestExtraForbid:
             headers=_AUTH_HEADERS,
         )
         assert res.status_code == 422
+
+
+# ── #1632: sections 미지원 필드 (accept-and-drop → 422 거부) ────────────
+
+
+class TestSectionsRejected:
+    """``sections``는 미문서·미영속 accept-and-drop 버그였다 (#1632).
+
+    사용자 정책 판정(2026-05-17): ``sections``는 YAGNI → 1급 영속 feature를
+    구현하지 않고 미지원 필드로 확정해 422로 거부한다 (option 2b). 스키마에서
+    ``sections`` 선언을 제거하면 기존 ``extra='forbid'``가 ``sections`` 포함
+    payload를 자동 ``extra_forbidden`` 422로 거부한다. accept-and-drop(201 후
+    silent drop) 동작은 금지된다.
+
+    SSOT: ``docs/specs/report-store/report-store.md``(``sections`` 무언급),
+    ``src/ante/web/schemas.py::ReportSubmitRequest``.
+    """
+
+    # oracle host probe(report_sections_dropped)가 사용하는 sentinel marker.
+    _SENTINEL = "oracle_payload_sections_marker"
+
+    def test_sections_payload_rejected(self, client: TestClient) -> None:
+        """``sections`` 포함 payload → 422 (201 아님). accept-and-drop 금지."""
+        res = client.post(
+            "/api/reports",
+            json=_base_payload(
+                sections={
+                    self._SENTINEL: {
+                        "rationale": "secret-rationale-text",
+                        "evidence": ["secret-evidence-item"],
+                    }
+                }
+            ),
+            headers=_AUTH_HEADERS,
+        )
+        assert res.status_code == 422, (
+            f"sections 포함 payload는 422로 거부되어야 함 "
+            f"(got {res.status_code}): {res.text}"
+        )
+
+    def test_sections_rejection_does_not_echo_input(self, client: TestClient) -> None:
+        """거부 응답 detail에 sections sentinel/내용이 반사되지 않는다.
+
+        #1629 L1(``reports.py:194`` ``include_input=False``)이 작동해
+        ``extra_forbidden`` 에러의 ``input`` (제출한 sections rationale/
+        evidence) 이 echo되지 않음을 회귀 검증한다.
+        """
+        res = client.post(
+            "/api/reports",
+            json=_base_payload(
+                sections={
+                    self._SENTINEL: {
+                        "rationale": "secret-rationale-text",
+                        "evidence": ["secret-evidence-item"],
+                    }
+                }
+            ),
+            headers=_AUTH_HEADERS,
+        )
+        assert res.status_code == 422
+        body = res.text
+        assert self._SENTINEL not in body, (
+            f"거부 응답에 sections sentinel이 반사됨: {body}"
+        )
+        assert "secret-rationale-text" not in body, (
+            f"거부 응답에 sections rationale이 반사됨: {body}"
+        )
+        assert "secret-evidence-item" not in body, (
+            f"거부 응답에 sections evidence가 반사됨: {body}"
+        )
+
+    def test_sections_payload_not_persisted(self, client: TestClient) -> None:
+        """``sections`` 포함 payload는 거부되어 report가 생성되지 않는다."""
+        res = client.post(
+            "/api/reports",
+            json=_base_payload(sections={self._SENTINEL: {"x": 1}}),
+            headers=_AUTH_HEADERS,
+        )
+        assert res.status_code == 422
+        # 거부되었으므로 report_id 없음 → detail 조회 자체가 불가.
+        assert "report_id" not in res.text
+
+    def test_payload_without_sections_still_accepted(self, client: TestClient) -> None:
+        """``sections`` 없는 정상 payload는 회귀 없이 201."""
+        res = client.post(
+            "/api/reports",
+            json=_base_payload(),
+            headers=_AUTH_HEADERS,
+        )
+        assert res.status_code == 201, (
+            f"sections 없는 정상 payload는 201이어야 함 "
+            f"(got {res.status_code}): {res.text}"
+        )


### PR DESCRIPTION
Closes #1632

## Summary
- oracle A7: `POST /api/reports`가 미문서·미영속 `sections` 필드를 201로 수락 후 조용히 버리던 accept-and-drop 버그 — **사용자 정책 판정 = 미지원 필드로 확정, 422 거부**(persist 1급 영속 = YAGNI 제외)
- **2b**: `ReportSubmitRequest.sections` 선언 제거 → 기존 `extra="forbid"`가 `sections` payload를 자동 422 거부. report-store.md SSOT(sections 무언급)와 코드 정합
- **CLI 정화 (Codex r2 [high])**: `cli/commands/report.py` ValidationError 출력을 `exc.errors(include_context=False, include_input=False)` 기반으로 변경 — 2b가 sections를 ValidationError 경로로 보내면서 신규 발생하던 CLI input-reflection(`str(exc)`의 `input_value={...}` 터미널/CI 반사) 차단. #1629 L1 패턴 1:1 미러(HTTP는 #1629 L1 reports.py:187-195가 이미 sanitize)
- obsolete sections 주석 정리 + `frontend/openapi.json`·`api.generated.ts` 재생성(sections 제거 -12/-4 line, 무관 변동 0)

## Spec
- report-store.md SSOT 침묵(sections 미정의)와 코드 정합 — 1B contract-honesty. persist는 YAGNI 정책 제외(후속 미등록)

## Test Plan
- HTTP 회귀 4: `sections` 포함 → 422·report 미생성·detail에 sections/sentinel 부재(#1629 L1 sanitize 검증); 정상 payload 201
- CLI 회귀 3: `ante report submit <sections JSON>` → exit 1·REPORT_VALIDATION_ERROR·stdout sentinel 부재; 정상 JSON 정상 제출
- 타깃 70 + 인접 504 passed, `mypy src/` clean, `ruff` clean, generated sections-제거 only, oracle `sections_rejected` 계약 7건
- Codex 브랜치 리뷰 `--base main` PASS (attempt 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)