### PR TITLE
fix(cli): broker IPC invalid account_id envelope alignment (#1636) (#1623 Split C, last)

### DIFF
--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -105,13 +105,20 @@ async def _ipc_broker_command(command: str, account_id: str, actor: str) -> dict
 @require_scope("broker:read")
 def status(ctx: click.Context, account_id: str) -> None:
     """증권사 연결 상태 조회."""
-    from ante.account.scoping import require_account_id
+    from ante.cli._validators import reject_invalid_account_id
     from ante.cli.middleware import get_member_id
 
     fmt = get_formatter(ctx)
 
-    # CLI 진입에서 account_id 검증 (fallback 금지, #1217 SPLIT-1).
-    validated_account_id = require_account_id(account_id, context="cli.broker.status")
+    # CLI ingress에서 invalid account_id를 IPC/_get_broker 이전에 명시 거부
+    # (fallback 금지, #1217 SPLIT-1 + #1623 Split C / #1634 helper 재사용).
+    # ``InvalidAccountIdError``는 non-Click ``AccountError``라 기존
+    # ``except click.ClickException`` fallback이 잡지 못해 traceback이 났다.
+    # helper가 ``InvalidAccountIdError``→``fmt.error(code=VALIDATION_ERROR)``+
+    # ``SystemExit(1)``로 변환하고 검증된 account_id를 반환한다.
+    validated_account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.broker.status"
+    )
 
     # IPC 우선 시도
     try:
@@ -167,13 +174,16 @@ def status(ctx: click.Context, account_id: str) -> None:
 @require_scope("broker:read")
 def balance(ctx: click.Context, account_id: str) -> None:
     """증권사 계좌 잔고 조회."""
-    from ante.account.scoping import require_account_id
+    from ante.cli._validators import reject_invalid_account_id
     from ante.cli.middleware import get_member_id
 
     fmt = get_formatter(ctx)
 
-    # CLI 진입에서 account_id 검증 (fallback 금지, #1217 SPLIT-1).
-    validated_account_id = require_account_id(account_id, context="cli.broker.balance")
+    # CLI ingress에서 invalid account_id를 IPC/_get_broker 이전에 명시 거부
+    # (fallback 금지, #1217 SPLIT-1 + #1623 Split C / #1634 helper 재사용).
+    validated_account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.broker.balance"
+    )
 
     # IPC 우선 시도
     try:
@@ -215,14 +225,15 @@ def balance(ctx: click.Context, account_id: str) -> None:
 @require_scope("broker:read")
 def positions(ctx: click.Context, account_id: str) -> None:
     """증권사 보유 종목 조회."""
-    from ante.account.scoping import require_account_id
+    from ante.cli._validators import reject_invalid_account_id
     from ante.cli.middleware import get_member_id
 
     fmt = get_formatter(ctx)
 
-    # CLI 진입에서 account_id 검증 (fallback 금지, #1217 SPLIT-1).
-    validated_account_id = require_account_id(
-        account_id, context="cli.broker.positions"
+    # CLI ingress에서 invalid account_id를 IPC/_get_broker 이전에 명시 거부
+    # (fallback 금지, #1217 SPLIT-1 + #1623 Split C / #1634 helper 재사용).
+    validated_account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.broker.positions"
     )
 
     # IPC 우선 시도
@@ -272,14 +283,15 @@ def positions(ctx: click.Context, account_id: str) -> None:
 @require_scope("broker:read")
 def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
     """내부 데이터와 증권사 데이터 대사."""
-    from ante.account.scoping import require_account_id
+    from ante.cli._validators import reject_invalid_account_id
     from ante.cli.middleware import get_member_id
 
     fmt = get_formatter(ctx)
 
-    # CLI 진입에서 account_id 검증 (fallback 금지, #1217 SPLIT-1).
-    validated_account_id = require_account_id(
-        account_id, context="cli.broker.reconcile"
+    # CLI ingress에서 invalid account_id를 IPC/_get_broker 이전에 명시 거부
+    # (fallback 금지, #1217 SPLIT-1 + #1623 Split C / #1634 helper 재사용).
+    validated_account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.broker.reconcile"
     )
 
     # --fix 옵션이 있으면 IPC로 서버에 위임 (상태 변경)

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -340,10 +340,18 @@ async def _handle_broker_reconcile(
     from ante.account.errors import InvalidAccountIdError
     from ante.account.scoping import require_account_id
 
-    bot_id = args["bot_id"]
+    # #1623 Split C / #1633 finding: ``require_account_id``를
+    # ``args["bot_id"]`` **이전**으로 둔다. 그래야 bot_id 없는
+    # invalid-account-only direct-IPC probe도 ``InvalidAccountIdError``
+    # (code="VALIDATION_ERROR", #1633 SSOT)로 raise되어 server.py:323
+    # ``getattr(e, "code", ...)``를 거쳐 VALIDATION_ERROR envelope이 된다.
+    # bot_id를 먼저 읽으면 ``KeyError``가 먼저 터져 EXECUTION_ERROR로
+    # 오분류된다. status/balance/positions handler는 이미 require_account_id
+    # 최우선이라 무변경 — reconcile만 ordering 대상.
     account_id = require_account_id(
         args.get("account_id"), context="ipc.broker.reconcile"
     )
+    bot_id = args["bot_id"]
 
     # Refs #1240 review (P2-1): BotManager로부터 봇의 실제 account_id를 조회해
     # 요청 payload의 account_id와 일치하지 않으면 거부한다. 잘못된 account_id가

--- a/tests/unit/cli/test_broker_missing_account.py
+++ b/tests/unit/cli/test_broker_missing_account.py
@@ -555,6 +555,227 @@ class TestStatusAndReconcileFollowupScope:
         assert "broker connection refused" in str(payload["error"]), payload
 
 
+# ── #1636 / #1623 Split C: invalid account_id ingress → VALIDATION_ERROR ────
+
+
+class TestBrokerInvalidAccountIdIngress:
+    """``broker {status,balance,positions,reconcile}`` 의 invalid ``account_id``
+    (``default`` 예약어 / ``bad_id`` 형식 위반 / ``""`` 빈 문자열)가 IPC 호출 /
+    ``_get_broker`` fallback **이전**에 ``VALIDATION_ERROR`` envelope + exit≠0
+    으로 거부됨을 검증 (#1636 / #1623 Split C).
+
+    회귀 모델:
+        이전에는 4 cmd가 bare ``require_account_id(account_id, ...)`` 를 호출했고,
+        그것이 raise하는 ``InvalidAccountIdError`` 는 non-Click ``AccountError``
+        라 기존 ``except click.ClickException`` fallback이 잡지 못해 **traceback**
+        (#1623 ``broker_balance_default``) 으로 누출됐다. #1636이 #1634
+        ``reject_invalid_account_id`` helper로 교체해 그 예외를
+        ``fmt.error(code="VALIDATION_ERROR")`` + ``SystemExit(1)`` 로 변환한다.
+
+    검증:
+        - 4 cmd × {default, bad_id, ""} × {json, text} → exit≠0
+        - JSON: ``{"status":"error","code":"VALIDATION_ERROR",...}``
+        - traceback 부재 (``result.exception`` 이 ``SystemExit`` 만)
+        - IPC / ``_create_account_service`` 가 **호출되지 않음** (ingress 차단)
+    """
+
+    _INVALID_IDS = ["default", "bad id!", ""]
+
+    @pytest.fixture
+    def _ipc_spy(self):  # noqa: ANN202
+        """IPC / account-service mock — invalid ingress면 호출되면 안 된다."""
+        ipc_mock = AsyncMock(
+            side_effect=AssertionError(
+                "invalid account_id가 IPC 호출까지 도달했다 (ingress 차단 실패)"
+            )
+        )
+        create_mock = AsyncMock(
+            side_effect=AssertionError(
+                "invalid account_id가 _create_account_service까지 도달했다"
+            )
+        )
+        ipc_send_mock = AsyncMock(
+            side_effect=AssertionError(
+                "invalid account_id가 ipc_send까지 도달했다 (reconcile ingress)"
+            )
+        )
+        return ipc_mock, create_mock, ipc_send_mock
+
+    def _invoke(
+        self,
+        runner: CliRunner,
+        _ipc_spy,  # noqa: ANN001
+        *,
+        cmd: str,
+        account_id: str,
+        fmt: str,
+    ) -> object:
+        ipc_mock, create_mock, ipc_send_mock = _ipc_spy
+        with (
+            patch("ante.cli.commands.broker._ipc_broker_command", ipc_mock),
+            patch("ante.cli.commands.broker._create_account_service", create_mock),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", ipc_send_mock),
+        ):
+            return runner.invoke(
+                cli,
+                ["--format", fmt, "broker", cmd, "--account", account_id],
+            )
+
+    @pytest.mark.parametrize("cmd", ["status", "balance", "positions", "reconcile"])
+    @pytest.mark.parametrize("account_id", _INVALID_IDS)
+    def test_invalid_account_id_json_emits_validation_error_envelope(
+        self,
+        runner: CliRunner,
+        _ipc_spy,  # noqa: ANN001
+        cmd: str,
+        account_id: str,
+    ) -> None:
+        """JSON 모드: invalid account_id → exit≠0 +
+        ``code=VALIDATION_ERROR`` envelope + traceback 부재."""
+        result = self._invoke(
+            runner, _ipc_spy, cmd=cmd, account_id=account_id, fmt="json"
+        )
+
+        assert result.exit_code != 0, (
+            f"[{cmd} --account {account_id!r}] expected exit≠0, "
+            f"got {result.exit_code}\nstdout={result.stdout!r}"
+        )
+        # traceback 부재: 예외가 있다면 SystemExit 만 허용.
+        if result.exception is not None:
+            assert isinstance(result.exception, SystemExit), (
+                f"[{cmd} --account {account_id!r}] 비-SystemExit 예외/traceback: "
+                f"{result.exception!r}"
+            )
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "VALIDATION_ERROR", payload
+
+    @pytest.mark.parametrize("cmd", ["status", "balance", "positions", "reconcile"])
+    @pytest.mark.parametrize("account_id", _INVALID_IDS)
+    def test_invalid_account_id_text_emits_stderr_and_nonzero_exit(
+        self,
+        runner: CliRunner,
+        _ipc_spy,  # noqa: ANN001
+        cmd: str,
+        account_id: str,
+    ) -> None:
+        """text 모드: invalid account_id → exit≠0 + stderr ``Error: ...`` +
+        stdout JSON 누출 없음 + traceback 부재."""
+        result = self._invoke(
+            runner, _ipc_spy, cmd=cmd, account_id=account_id, fmt="text"
+        )
+
+        assert result.exit_code != 0, (
+            f"[{cmd} --account {account_id!r}] expected exit≠0, "
+            f"got {result.exit_code}\nstderr={result.stderr!r}"
+        )
+        if result.exception is not None:
+            assert isinstance(result.exception, SystemExit), (
+                f"[{cmd} --account {account_id!r}] 비-SystemExit 예외/traceback: "
+                f"{result.exception!r}"
+            )
+        assert result.stdout.strip() == "", result.stdout
+        assert "Error:" in result.stderr, result.stderr
+
+
+# ── #1636: valid-absent per-command narrow (Codex r1 [medium]) ──────────────
+
+
+class TestBrokerValidAbsentPerCommandNarrow:
+    """Codex r1 [medium] narrow: helper swap 후 **valid-but-nonexistent**
+    account_id 의 기존 동작이 보존되는지 per-command 로 검증 (#1636).
+
+    ``reject_invalid_account_id`` helper는 ``require_account_id`` 계약을 그대로
+    재사용하므로 valid 패턴(``oracle-missing-account``)은 거부하지 않는다.
+    따라서 valid-but-nonexistent account_id 는 helper를 통과해 기존
+    not-found 경로로 흐른다:
+
+    - ``broker status`` = 기존 ``ACCOUNT_NOT_FOUND`` envelope 보존
+    - ``broker balance``/``positions``/``reconcile`` = ``VALIDATION_ERROR``
+      **오분류 아님** + 기존 동작 불변 (generic ``fmt.error(str(e))`` 등 —
+      ACCOUNT_NOT_FOUND 강제·추가 금지; balance/positions parity는 후속 후보).
+
+    이미 위 ``TestBrokerBalanceMissingAccount``/``TestBrokerPositionsMissingAccount``/
+    ``TestStatusAndReconcileFollowupScope`` 가 missing-account exit 1 + 메시지를
+    검증한다. 본 클래스는 helper swap이 그 경로에 **VALIDATION_ERROR 오분류를
+    주입하지 않음**을 추가로 못박는다.
+    """
+
+    def _invoke(
+        self,
+        runner: CliRunner,
+        *,
+        cmd: str,
+    ) -> object:
+        mock_db, mock_account_service = _patch_account_service_not_found()
+
+        async def _fake_create_service():  # noqa: ANN202
+            return mock_account_service, mock_db
+
+        if cmd == "reconcile":
+            ipc_patch = patch(
+                "ante.cli.commands.ipc_helpers.ipc_send",
+                AsyncMock(
+                    side_effect=click.ClickException("서버가 실행 중이 아닙니다.")
+                ),
+            )
+        else:
+            ipc_patch = patch(
+                "ante.cli.commands.broker._ipc_broker_command",
+                _build_ipc_unavailable_mock(),
+            )
+
+        with (
+            ipc_patch,
+            patch(
+                "ante.cli.commands.broker._create_account_service",
+                side_effect=_fake_create_service,
+            ),
+        ):
+            return runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "broker",
+                    cmd,
+                    "--account",
+                    _MISSING_ACCOUNT_ID,
+                ],
+            )
+
+    def test_status_valid_absent_keeps_account_not_found(
+        self, runner: CliRunner
+    ) -> None:
+        """``broker status`` valid-absent = ``ACCOUNT_NOT_FOUND`` 보존
+        (VALIDATION_ERROR 오분류 아님)."""
+        result = self._invoke(runner, cmd="status")
+
+        assert result.exit_code == 1, result.stdout
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "ACCOUNT_NOT_FOUND", payload
+        assert payload["code"] != "VALIDATION_ERROR", payload
+
+    @pytest.mark.parametrize("cmd", ["balance", "positions", "reconcile"])
+    def test_balance_positions_reconcile_valid_absent_not_validation_error(
+        self, runner: CliRunner, cmd: str
+    ) -> None:
+        """``broker balance``/``positions``/``reconcile`` valid-absent =
+        ``VALIDATION_ERROR`` **오분류 아님** + 기존 동작 불변. helper가
+        valid 패턴을 거부하지 않아 not-found 경로가 유지됨을 가드한다
+        (ACCOUNT_NOT_FOUND 강제 안 함 — balance/positions parity는 후속)."""
+        result = self._invoke(runner, cmd=cmd)
+
+        assert result.exit_code == 1, result.stdout
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        # helper swap이 valid-absent를 VALIDATION_ERROR로 오분류하면 안 된다.
+        assert payload["code"] != "VALIDATION_ERROR", payload
+        # 기존 not-found 메시지가 그대로 노출 (동작 불변).
+        assert _NOT_FOUND_MESSAGE in str(payload["message"]), payload
+
+
 # ── subprocess hang 회귀 (실제 프로세스 종료 확인) ──────────────────────────
 
 

--- a/tests/unit/test_ipc_error_code_mapping.py
+++ b/tests/unit/test_ipc_error_code_mapping.py
@@ -286,3 +286,100 @@ async def test_ipc_dispatch_broker_status_account_scoped_returns_validation_erro
         assert response["error"]["code"] == "VALIDATION_ERROR"
     finally:
         await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_ipc_dispatch_broker_reconcile_invalid_account_only_validation_error(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """``broker.reconcile`` IPC dispatch에서 **bot_id 없는** invalid-account-only
+    payload도 ``VALIDATION_ERROR``로 매핑되는지 검증 (#1636 / #1623 Split C).
+
+    회귀 모델:
+        이전에는 ``_handle_broker_reconcile``이 ``bot_id = args["bot_id"]`` 를
+        ``require_account_id`` **이전**에 읽어, bot_id 없는 invalid-account-only
+        direct-IPC probe가 ``KeyError`` → server.py:323 ``getattr(e, "code",
+        "EXECUTION_ERROR")`` → ``EXECUTION_ERROR``로 잘못 노출되었다 (#1633
+        finding). #1636이 ``require_account_id``를 ``args["bot_id"]`` 이전으로
+        옮겨, invalid account_id가 ``InvalidAccountIdError``
+        (code="VALIDATION_ERROR", #1633 SSOT)로 먼저 raise되어
+        ``VALIDATION_ERROR`` envelope이 되도록 한다.
+
+    ``test_ipc_dispatch_broker_status_...`` (바로 위, broker.status만 커버)
+    옆에 reconcile ordering 가드를 추가한다 (#1633 메타리뷰 지적).
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+
+        # bot_id 없는 invalid-account-only: account_id 누락 → VALIDATION_ERROR
+        # (KeyError → EXECUTION_ERROR 회귀 차단)
+        response = await client.send("broker.reconcile", {}, actor="tester")
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+        assert response["error"]["code"] != "EXECUTION_ERROR", response
+        assert "ipc.broker.reconcile" in response["error"]["message"], response
+
+        # bot_id 없는 invalid-account-only: 'default' 예약어 → VALIDATION_ERROR
+        response = await client.send(
+            "broker.reconcile",
+            {"account_id": "default"},
+            actor="tester",
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+
+        # bot_id 없는 invalid-account-only: 빈 문자열 → VALIDATION_ERROR
+        response = await client.send(
+            "broker.reconcile",
+            {"account_id": ""},
+            actor="tester",
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_ipc_dispatch_broker_reconcile_missing_account_keeps_keyerror_path(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """#1556 회귀 유지: **valid** account_id로 reconcile하면
+    ``require_account_id``를 통과하므로 invalid-account 분기가 아니라 기존
+    경로(bot_id 부재 시 ``KeyError`` → EXECUTION_ERROR)를 그대로 탄다.
+
+    #1636은 invalid-account-only를 VALIDATION_ERROR로 정렬하되,
+    valid account_id의 기존 reconcile 동작(bot_id 누락 → KeyError →
+    EXECUTION_ERROR)은 **불변**이어야 한다. require_account_id를 bot_id
+    이전으로 옮긴 ordering 변경이 valid 경로의 KeyError 계약을 깨지
+    않음을 가드한다 (narrow scope: reconcile invalid만 변경, valid 불변).
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+
+        # valid account_id + bot_id 누락 → require_account_id 통과 후
+        # args["bot_id"] KeyError → EXECUTION_ERROR (기존 계약 불변)
+        response = await client.send(
+            "broker.reconcile",
+            {"account_id": "oracle-valid-account"},
+            actor="tester",
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "EXECUTION_ERROR", response
+        assert response["error"]["code"] != "VALIDATION_ERROR", response
+    finally:
+        await server.stop()


### PR DESCRIPTION
Closes #1636

## Summary (#1623 Split C — 마지막 split)
- oracle A7: `broker balance --account default`→traceback; broker IPC reconcile invalid-account-only→EXECUTION_ERROR. #1623 raw signature `broker_balance_default` 축
- 선행 #1633(에러코드 SSOT VALIDATION_ERROR+C inventory)·#1634(`reject_invalid_account_id` helper)·#1635 merged
- **CLI 4 broker cmd**(status/balance/positions/reconcile): bare `require_account_id`→#1634 `reject_invalid_account_id(account_id, fmt, context)` 교체(InvalidAccountIdError 미catch traceback 차단, helper가 검증 account_id str 반환→기존 흐름 보존). 기존 ClickException/AccountNotFound valid 분기 무변경
- **IPC `_handle_broker_reconcile`**: `require_account_id`를 `bot_id=args["bot_id"]` 이전 이동 → invalid-account-only direct-IPC도 VALIDATION_ERROR envelope(KeyError→EXECUTION_ERROR 차단). status/balance/positions IPC 무변경(이미 최우선). 신코드 0·IPC 계약 불변
- narrow: valid-absent per-command(status=ACCOUNT_NOT_FOUND 보존 / balance·positions·reconcile=기존 불변), balance/positions parity 후속 분리

## Test Plan
- 신규: test_ipc_error_code_mapping.py +97(broker.reconcile invalid-account-only→VALIDATION_ERROR 가드, broker.status 옆; 기존 missing-account ACCOUNT_NOT_FOUND 회귀 유지), cli/test_broker_missing_account.py +221
- broker CLI/IPC/adapter 237 + 계약 161 + 신규 49 passed, `mypy src/` clean, `ruff` clean, CLI/IPC 전용 generated no-op
- **마지막 split 6축 전수 soak**: #1634(account_info_default·account_info_bad_pattern·bot_list_default)+#1635(treasury_status_default·rule_list_default)+#1636(broker_balance_default) = #1623 `cli_account_id_invalid_contract` 전축 커버·잔여 0(계약 단언 입증; oracle harness 미설치)
- Codex 브랜치 리뷰 `--base main` PASS (attempt 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)