### PR TITLE
fix(ipc,cli): #1656 E bucket invalid account_id를 VALIDATION_ERROR로 거부 (#1623 E follow-up)

### DIFF
--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -252,6 +252,19 @@ def bot_create(
             fmt.error(str(e))
             raise SystemExit(1) from e
 
+    # #1656 E bucket defense-in-depth: provided invalid account_id
+    # (`default`/패턴 위반/`""`)를 omitted resolver / `ipc_send`
+    # (→`_handle_bot_create`) 이전에 거부한다. IPC handler가 1차
+    # 보증(handler-first require_account_id)하지만, CLI ingress 거부는 clean
+    # early exit(traceback 부재)이다. **provided-only**(`account_id is not
+    # None`)로만 검증해 `--account` 미지정(None) → 비대화형 resolver 분기를
+    # **보존**한다(omitted 불변, #1634 `bot_list`(L97) 동형, invalid-format ↔
+    # valid-absent/omitted 분리). 에러코드는 #1633 SSOT `VALIDATION_ERROR`.
+    if account_id is not None:
+        account_id = reject_invalid_account_id(
+            account_id, fmt, context="cli.bot.create"
+        )
+
     # 계좌 미지정 시 비대화형 resolver — 단일 active 계좌면 자동 선택,
     # 그 외(0개/2개 이상)에는 BOT_MISSING_REQUIRED_ACCOUNT로 실패한다.
     if account_id is None:

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -108,6 +108,16 @@ def allocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) ->
     fmt = get_formatter(ctx)
     actor = _get_member_id(ctx)
 
+    # #1656 E bucket defense-in-depth: invalid account_id(`default`/패턴
+    # 위반/`""`)를 `ipc_send`(→`_handle_treasury_allocate`) 이전에 거부한다.
+    # IPC handler가 1차 보증(handler-first require_account_id)하지만, CLI
+    # ingress 거부는 clean early exit(traceback 부재) + #1634/#1635 동형
+    # 방어선이다. `--account` required arg라 전 입력을 검증한다. 에러코드는
+    # #1633 SSOT `VALIDATION_ERROR`(helper가 `e.code` 재사용).
+    account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.treasury.allocate"
+    )
+
     async def _run_allocate() -> dict:
         from ante.cli.commands.ipc_helpers import ipc_send
 
@@ -148,6 +158,13 @@ def deallocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) 
     """봇 예산 회수."""
     fmt = get_formatter(ctx)
     actor = _get_member_id(ctx)
+
+    # #1656 E bucket defense-in-depth: `allocate`와 동형 — invalid account_id를
+    # `ipc_send`(→`_handle_treasury_deallocate`) 이전에 거부한다(required arg
+    # 전검증, clean early exit). 에러코드는 #1633 SSOT `VALIDATION_ERROR`.
+    account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.treasury.deallocate"
+    )
 
     async def _run_deallocate() -> dict:
         from ante.cli.commands.ipc_helpers import ipc_send

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -145,6 +145,17 @@ async def _handle_bot_create(
     from ante.bot.config import BotConfig
     from ante.strategy.loader import StrategyLoader
 
+    # #1656 E bucket / #1633 finding: ``require_account_id``를 함수
+    # **최상단**(strategy_registry.get / StrategyLoader.load 이전)으로 둔다.
+    # 그래야 invalid/missing account_id direct-IPC payload가 strategy
+    # lookup/load 오류(ValueError / 파일 IO)나 늦은 검증에 가리지 않고
+    # ``InvalidAccountIdError``(code="VALIDATION_ERROR", #1633 SSOT)로 먼저
+    # raise되어 server.py:323 ``getattr(e, "code", ...)``를 거쳐
+    # VALIDATION_ERROR envelope이 된다. #1636 broker handlers(account_id-first)
+    # 1:1 동형. Refs #1217 → #1241 SPLIT-2: account_id fallback 제거 — IPC
+    # routing 진입점에서 ``ipc.bot.create`` context로 명시 검증한다.
+    account_id = require_account_id(args.get("account_id"), context="ipc.bot.create")
+
     strategy_id = args["strategy_id"]
     record = await svc.strategy_registry.get(strategy_id)
     if record is None:
@@ -153,11 +164,6 @@ async def _handle_bot_create(
 
     strategy_cls = StrategyLoader.load(Path(record.filepath))
 
-    # Refs #1217 → #1241 SPLIT-2: account_id fallback 제거.
-    # ``BotConfig.__post_init__`` 의 require_account_id 와 중복되지만
-    # IPC routing 진입점에서 한 번 더 명시 검증해 ``InvalidAccountIdError`` 의
-    # context 를 ``ipc.bot.create`` 로 표시한다.
-    account_id = require_account_id(args.get("account_id"), context="ipc.bot.create")
     config = BotConfig(
         bot_id=args.get("bot_id", ""),
         strategy_id=strategy_id,
@@ -185,7 +191,20 @@ async def _handle_bot_remove(
 async def _handle_treasury_allocate(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    account_id = args["account_id"]
+    from ante.account.scoping import require_account_id
+
+    # #1656 E bucket / #1633 finding: ``require_account_id``를 함수 **첫
+    # 문장**으로(``args["bot_id"]``/``args["amount"]`` 이전) 둔다. raw
+    # ``args["account_id"]`` 직접 인덱싱은 account_id 키 생략 payload에서
+    # ``KeyError``가 먼저 터져 server.py:323 ``getattr(e, "code",
+    # "EXECUTION_ERROR")``로 오분류된다. ``args.get`` +
+    # ``require_account_id``로 invalid/missing 모두 ``InvalidAccountIdError``
+    # (code="VALIDATION_ERROR", #1633 SSOT)로 먼저 raise되어
+    # VALIDATION_ERROR envelope이 된다. #1636 broker handlers(args["bot_id"]
+    # 이전 require_account_id) 1:1 동형.
+    account_id = require_account_id(
+        args.get("account_id"), context="ipc.treasury.allocate"
+    )
     bot_id = args["bot_id"]
     amount = args["amount"]
     treasury = svc.treasury_manager.get(account_id)
@@ -196,7 +215,15 @@ async def _handle_treasury_allocate(
 async def _handle_treasury_deallocate(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    account_id = args["account_id"]
+    from ante.account.scoping import require_account_id
+
+    # #1656 E bucket / #1633 finding: ``_handle_treasury_allocate``와 동형 —
+    # ``require_account_id``를 첫 문장으로(``args["bot_id"]``/``args["amount"]``
+    # 이전, ``args.get``). 키 생략 payload의 ``KeyError`` →
+    # EXECUTION_ERROR 누수 차단, invalid/missing 모두 VALIDATION_ERROR.
+    account_id = require_account_id(
+        args.get("account_id"), context="ipc.treasury.deallocate"
+    )
     bot_id = args["bot_id"]
     amount = args["amount"]
     treasury = svc.treasury_manager.get(account_id)

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -181,7 +181,16 @@ class TestHandleBotCreate:
         assert call_kwargs["config"].interval_seconds == 30
 
     async def test_raises_when_strategy_not_found(self):
-        """미등록 strategy_id → ValueError."""
+        """미등록 strategy_id → ValueError.
+
+        #1656 E bucket: ``_handle_bot_create`` 가 ``require_account_id`` 를
+        함수 최상단(strategy lookup 이전)으로 옮겼으므로, 순수
+        strategy-not-found ``ValueError`` 경로를 검증하려면 **valid**
+        account_id 를 payload에 포함해야 한다(account 검증을 통과한 뒤
+        strategy lookup 도달). account_id 누락 시 #1656 validate-first 로
+        ``InvalidAccountIdError`` 가 먼저 raise되어 본 테스트 의도(순수
+        strategy-not-found)가 가려진다.
+        """
         from unittest.mock import AsyncMock, MagicMock
 
         from ante.ipc.registry import _handle_bot_create
@@ -195,70 +204,107 @@ class TestHandleBotCreate:
         with pytest.raises(ValueError, match="전략을 찾을 수 없습니다"):
             await _handle_bot_create(
                 svc,
-                {"strategy_id": "nonexistent"},
+                {"strategy_id": "nonexistent", "account_id": "acct-1"},
                 "cli-user",
             )
 
     async def test_ipc_bot_create_account_scoped_required(self):
-        """Refs #1217 → #1241 SPLIT-2: ``args["account_id"]`` 누락/invalid 시
+        """Refs #1217 → #1241 SPLIT-2 / #1656: invalid/missing ``account_id`` 시
         ``InvalidAccountIdError`` 로 거부한다.
 
-        ``args.get("account_id", "")`` fallback 이 제거되어 IPC routing
-        진입점에서 즉시 거부된다. ``BotConfig.__post_init__`` 까지 도달하기
-        전에 ``ipc.bot.create`` context 로 실패한다.
+        ``args.get("account_id")`` fallback 이 제거되어 IPC routing 진입점에서
+        즉시 거부된다. #1656 E bucket: ``require_account_id`` 가 함수 최상단
+        (strategy_registry.get / StrategyLoader.load 이전)으로 이동했으므로
+        strategy mock / StrategyLoader monkeypatch workaround 없이도(실제
+        strategy 처리 이전) ``ipc.bot.create`` context 로 먼저 실패한다.
         """
-        from dataclasses import dataclass
         from unittest.mock import AsyncMock, MagicMock
 
         from ante.account.errors import InvalidAccountIdError
         from ante.ipc.registry import _handle_bot_create
 
-        @dataclass
-        class FakeRecord:
-            filepath: str = "/tmp/strategy.py"
-
-        fake_registry = AsyncMock()
-        fake_registry.get.return_value = FakeRecord()
-
         fake_bot_manager = AsyncMock()
 
         svc = MagicMock()
-        svc.strategy_registry = fake_registry
         svc.bot_manager = fake_bot_manager
+
+        # 누락 → 거부 (validate-first: strategy mock 불필요)
+        with pytest.raises(InvalidAccountIdError, match="ipc.bot.create"):
+            await _handle_bot_create(
+                svc,
+                {"strategy_id": "strat-1"},
+                "cli-user",
+            )
+
+        # 빈 문자열 → 거부
+        with pytest.raises(InvalidAccountIdError):
+            await _handle_bot_create(
+                svc,
+                {"strategy_id": "strat-1", "account_id": ""},
+                "cli-user",
+            )
+
+        # 'default' 예약어 → 거부
+        with pytest.raises(InvalidAccountIdError):
+            await _handle_bot_create(
+                svc,
+                {"strategy_id": "strat-1", "account_id": "default"},
+                "cli-user",
+            )
+
+        # 패턴 위반 → 거부
+        with pytest.raises(InvalidAccountIdError):
+            await _handle_bot_create(
+                svc,
+                {"strategy_id": "strat-1", "account_id": "bad_id!"},
+                "cli-user",
+            )
+
+        # bot_manager.create_bot 까지 절대 도달하지 않아야 한다
+        fake_bot_manager.create_bot.assert_not_called()
+
+    async def test_bot_create_validate_first_skips_strategy_lookup_and_load(self):
+        """#1656 E bucket validate-first 회귀: invalid/missing ``account_id`` 면
+        ``strategy_registry.get`` 과 ``StrategyLoader.load`` 가 **호출되지
+        않는다**(account 검증이 strategy 처리보다 먼저).
+
+        ``_handle_bot_create`` 가 ``require_account_id`` 를 함수 최상단으로
+        옮긴 계약(strategy lookup/load 이전)을 spy 로 고정한다. 이전 순서
+        (strategy lookup → load → 늦은 require_account_id)에서는 invalid
+        account_id 라도 strategy_registry.get / StrategyLoader.load 가 먼저
+        호출되어 본 단언이 실패한다(failing check before fix).
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.account.errors import InvalidAccountIdError
+        from ante.ipc.registry import _handle_bot_create
+
+        fake_registry = AsyncMock()
+
+        svc = MagicMock()
+        svc.strategy_registry = fake_registry
 
         import ante.strategy.loader
 
+        load_calls: list = []
         original_load = ante.strategy.loader.StrategyLoader.load
-        ante.strategy.loader.StrategyLoader.load = MagicMock(
-            return_value=type("FakeStrategy", (), {})
+        ante.strategy.loader.StrategyLoader.load = (  # type: ignore[assignment]
+            lambda path: load_calls.append(path)
         )
         try:
-            # 누락 → 거부
-            with pytest.raises(InvalidAccountIdError, match="ipc.bot.create"):
-                await _handle_bot_create(
-                    svc,
-                    {"strategy_id": "strat-1"},
-                    "cli-user",
-                )
+            for bad_args in (
+                {"strategy_id": "strat-1"},  # account_id 키 생략
+                {"strategy_id": "strat-1", "account_id": ""},
+                {"strategy_id": "strat-1", "account_id": "default"},
+                {"strategy_id": "strat-1", "account_id": "bad_id!"},
+            ):
+                with pytest.raises(InvalidAccountIdError):
+                    await _handle_bot_create(svc, bad_args, "cli-user")
 
-            # 빈 문자열 → 거부
-            with pytest.raises(InvalidAccountIdError):
-                await _handle_bot_create(
-                    svc,
-                    {"strategy_id": "strat-1", "account_id": ""},
-                    "cli-user",
-                )
-
-            # 'default' 예약어 → 거부
-            with pytest.raises(InvalidAccountIdError):
-                await _handle_bot_create(
-                    svc,
-                    {"strategy_id": "strat-1", "account_id": "default"},
-                    "cli-user",
-                )
-
-            # bot_manager.create_bot 까지 절대 도달하지 않아야 한다
-            fake_bot_manager.create_bot.assert_not_called()
+            # validate-first: account 검증이 먼저 raise되어 strategy lookup /
+            # load 가 절대 호출되지 않는다.
+            fake_registry.get.assert_not_called()
+            assert load_calls == [], load_calls
         finally:
             ante.strategy.loader.StrategyLoader.load = original_load
 

--- a/tests/unit/test_cli_e_bucket_mutating_ipc_account_id.py
+++ b/tests/unit/test_cli_e_bucket_mutating_ipc_account_id.py
@@ -1,0 +1,378 @@
+"""E bucket — non-broker mutating IPC CLI invalid ``account_id`` ingress 거부 회귀.
+
+(#1656, E bucket — #1623 oracle probe ``treasury_allocate_default``/
+``treasury_deallocate_default``/``bot_create_default`` 축)
+
+account-scoped **non-broker mutating IPC** CLI 표면 —
+``treasury allocate <bot_id> <amount> --account <id>``,
+``treasury deallocate <bot_id> <amount> --account <id>``,
+``bot create --account <id>`` — 이 제공된 runtime-invalid ``account_id``
+(``"default"``/패턴 위반/``""``)를 ``docs/specs/account/14-account-id-contract.md``
+E row(L249) "Runtime invalid (어떤 시점에도 거부)" 계약대로
+``ipc_send``(→ ``_handle_treasury_allocate``/``_handle_treasury_deallocate``/
+``_handle_bot_create``) **이전** ingress 에서 거부하지 않고
+``ipc_send``→``InvalidAccountIdError``(non-Click ``AccountError``) 미catch
+traceback 으로 종료하던 contract-drift 를
+``ante.cli._validators.reject_invalid_account_id`` 공유 가드로 차단한다.
+
+1차 보증은 IPC handler-first ``require_account_id``(별도
+``test_ipc_error_code_mapping.py`` direct-IPC 회귀)이며, 본 파일은 CLI
+defense-in-depth(clean early exit + ``ipc_send`` 미호출)를 #1634/#1635
+구조 미러로 고정한다.
+
+에러 코드 SSOT 는 #1633 선결정으로 고정된
+``InvalidAccountIdError.code == "VALIDATION_ERROR"`` 를 재사용한다(신 코드 0).
+
+검증축:
+
+1. 3 표면 × {``default``, ``bad_id!``(패턴 위반), ``""``} → exit ≠ 0 + JSON
+   ``code="VALIDATION_ERROR"`` + traceback **부재**
+2. invalid 입력에서 ``ipc_send`` / ``IPCClient.send`` **미호출** 단언
+3. ``bot create`` omitted-vs-provided 경계: ``--account`` 미지정(``None``) →
+   비대화형 resolver 분기 **보존**(omitted 불변, invalid 검증 우회)
+4. valid-pattern but absent(``acc-9999``) → ingress 통과(VALIDATION_ERROR
+   오분류 아님, invalid-format ↔ valid-absent 분리)
+5. 정상 account_id → 3 표면 ``ipc_send`` 도달(회귀 0)
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+# 제공된 runtime-invalid account_id 입력 — 14-account-id-contract.md
+# "Runtime invalid (어떤 시점에도 거부)" + scoping.is_invalid_account_id
+# (""/"default"/패턴 위반). required `--account` 표면(treasury)은 omitted 가
+# 없어 3종 전부 provided. bot create omitted(None)는 별도 경계 케이스.
+_INVALID_INPUTS = ["default", "bad_id!", ""]
+
+# 패턴 유효(^[a-zA-Z0-9-]{3,30}$)·미존재 account_id. invalid-format ↔
+# valid-absent 분리 — VALIDATION_ERROR 과적용 0 회귀.
+_VALID_ABSENT = "acc-9999"
+
+# 정상 account_id (회귀 0 검증).
+_VALID_PRESENT = "domestic"
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _patch_ipc_send():
+    """``ipc_send`` 를 spy AsyncMock 으로 패치.
+
+    invalid 가 ingress 에서 막히면 ``ipc_send`` 가 호출되지 않아야 한다.
+    treasury / bot 커맨드는 ``from ante.cli.commands.ipc_helpers import
+    ipc_send`` 를 함수 내부에서 import 하므로 원본 심볼을 패치한다.
+    """
+    spy = AsyncMock(return_value={"success": True, "bot_id": "bot-x"})
+    return patch("ante.cli.commands.ipc_helpers.ipc_send", new=spy), spy
+
+
+def _assert_validation_error_envelope(result) -> None:
+    """invalid account_id 거부 공통 단언.
+
+    - exit ≠ 0
+    - JSON envelope ``status=error`` + ``code="VALIDATION_ERROR"``
+    - traceback 부재 (mutating IPC 미catch traceback drift 차단)
+    """
+    assert result.exit_code != 0, result.output
+    payload = json.loads(result.output.strip())
+    assert payload["status"] == "error", payload
+    assert payload["code"] == "VALIDATION_ERROR", payload
+    assert "유효한 account_id" in payload["message"], payload
+    assert "Traceback" not in result.output, result.output
+
+
+# ── 축 1+2: 3 표면 × invalid → VALIDATION_ERROR + ipc_send 미호출 ────
+
+
+class TestTreasuryAllocateInvalidRejected:
+    """``treasury allocate`` invalid ingress 거부 (traceback/ipc_send 차단)."""
+
+    @pytest.mark.parametrize("invalid", _INVALID_INPUTS)
+    def test_invalid_rejected_before_ipc_send(self, runner, invalid: str) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "allocate",
+                    "bot-1",
+                    "1000",
+                    "--account",
+                    invalid,
+                ],
+            )
+        _assert_validation_error_envelope(result)
+        # ingress 거부 — ipc_send 미호출 (traceback drift 차단).
+        spy.assert_not_called()
+
+
+class TestTreasuryDeallocateInvalidRejected:
+    """``treasury deallocate`` invalid ingress 거부."""
+
+    @pytest.mark.parametrize("invalid", _INVALID_INPUTS)
+    def test_invalid_rejected_before_ipc_send(self, runner, invalid: str) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "deallocate",
+                    "bot-1",
+                    "1000",
+                    "--account",
+                    invalid,
+                ],
+            )
+        _assert_validation_error_envelope(result)
+        spy.assert_not_called()
+
+
+class TestBotCreateInvalidRejected:
+    """``bot create --account`` (provided) invalid ingress 거부."""
+
+    @pytest.mark.parametrize("invalid", _INVALID_INPUTS)
+    def test_invalid_rejected_before_ipc_send(self, runner, invalid: str) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "create",
+                    "--name",
+                    "Probe",
+                    "--strategy",
+                    "s1",
+                    "--account",
+                    invalid,
+                ],
+            )
+        _assert_validation_error_envelope(result)
+        spy.assert_not_called()
+
+
+# ── 축 3: bot create omitted-vs-provided 경계 (resolver 보존 불변) ──
+
+
+class TestBotCreateOmittedResolverPreserved:
+    """``bot create`` ``--account`` 미지정(None) → 비대화형 resolver 분기 보존.
+
+    omitted(None) 는 invalid 검증을 우회하고 ``_resolve_account_non_interactive``
+    경로로 흘러야 한다(provided-only 검증, #1634 ``bot_list`` 동형). 본
+    테스트는 단일 active 계좌가 없을 때 resolver 가 도달해
+    ``BOT_MISSING_REQUIRED_ACCOUNT`` 로 실패함을 확인한다(VALIDATION_ERROR
+    아님 — invalid-format 거부가 omitted 를 삼키지 않음).
+    """
+
+    def test_account_omitted_reaches_resolver_not_validation_error(
+        self, runner
+    ) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+
+        async def _list_accounts():
+            db = AsyncMock()
+            account_service = AsyncMock()
+            account_service.list = AsyncMock(return_value=[])  # active 0개
+            return db, MagicMock(), MagicMock(), account_service
+
+        with (
+            ipc_patch,
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new=_list_accounts,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "create",
+                    "--name",
+                    "Probe",
+                    "--strategy",
+                    "s1",
+                ],
+            )
+        # resolver 도달 → BOT_MISSING_REQUIRED_ACCOUNT (omitted 보존).
+        assert result.exit_code != 0, result.output
+        payload = json.loads(result.output.strip())
+        assert payload.get("code") != "VALIDATION_ERROR", payload
+        assert payload.get("code") == "BOT_MISSING_REQUIRED_ACCOUNT", payload
+        # invalid 검증 우회 → ipc_send 도 미호출(resolver 단계에서 종료).
+        spy.assert_not_called()
+
+
+# ── 축 4: valid-pattern but absent → ingress 통과 (오분류 아님) ──────
+
+
+class TestValidButAbsentNotMisclassified:
+    """패턴 유효·미존재 account_id 는 invalid-format 으로 오분류되지 않는다.
+
+    valid-absent 는 ingress 통과 → ``ipc_send`` 도달(VALIDATION_ERROR 아님,
+    invalid-format ↔ valid-absent 분리). server-side 결과는 mock 으로
+    고정하고 ingress 통과(ipc_send 호출)만 검증한다.
+    """
+
+    def test_treasury_allocate_valid_absent_reaches_ipc_send(self, runner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        spy.return_value = {"success": True}
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "allocate",
+                    "bot-1",
+                    "1000",
+                    "--account",
+                    _VALID_ABSENT,
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        # ingress 통과 → ipc_send 도달 (account_id 파라미터 바인딩).
+        spy.assert_awaited_once()
+        sent_args = spy.await_args[0][1]
+        assert sent_args["account_id"] == _VALID_ABSENT, sent_args
+
+    def test_bot_create_valid_absent_reaches_ipc_send(self, runner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        spy.return_value = {"bot_id": "bot-x"}
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "create",
+                    "--name",
+                    "Probe",
+                    "--strategy",
+                    "s1",
+                    "--account",
+                    _VALID_ABSENT,
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        spy.assert_awaited_once()
+        sent_args = spy.await_args[0][1]
+        assert sent_args["account_id"] == _VALID_ABSENT, sent_args
+
+
+# ── 축 5: 정상 account_id → ipc_send 도달 (회귀 0) ──────────────────
+
+
+class TestValidAccountIdRegression:
+    """정상 account_id 는 3 표면 모두 ``ipc_send`` 에 도달한다(회귀 0)."""
+
+    def test_treasury_allocate_valid_ok(self, runner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        spy.return_value = {"success": True}
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "allocate",
+                    "bot-1",
+                    "1000",
+                    "--account",
+                    _VALID_PRESENT,
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        spy.assert_awaited_once()
+        assert spy.await_args[0][1]["account_id"] == _VALID_PRESENT
+
+    def test_treasury_deallocate_valid_ok(self, runner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        spy.return_value = {"success": True}
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "deallocate",
+                    "bot-1",
+                    "1000",
+                    "--account",
+                    _VALID_PRESENT,
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        spy.assert_awaited_once()
+        assert spy.await_args[0][1]["account_id"] == _VALID_PRESENT
+
+    def test_bot_create_valid_ok(self, runner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        spy.return_value = {"bot_id": "bot-x"}
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "create",
+                    "--name",
+                    "Probe",
+                    "--strategy",
+                    "s1",
+                    "--account",
+                    _VALID_PRESENT,
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        spy.assert_awaited_once()
+        assert spy.await_args[0][1]["account_id"] == _VALID_PRESENT

--- a/tests/unit/test_ipc_error_code_mapping.py
+++ b/tests/unit/test_ipc_error_code_mapping.py
@@ -176,7 +176,7 @@ def test_invalid_account_id_error_carries_validation_error_code() -> None:
 async def test_ipc_dispatch_bot_create_account_scoped_returns_validation_error_code(
     socket_path: str, service_registry: ServiceRegistry
 ) -> None:
-    """``bot.create`` IPC dispatch 경로에서 ``account_id`` 누락/빈 문자열은
+    """``bot.create`` IPC dispatch 경로에서 invalid/missing ``account_id`` 는
     ``InvalidAccountIdError`` 로 raise되고, IPC server가 ``getattr(e, "code", ...)``
     폴백을 통해 응답 ``error.code == "VALIDATION_ERROR"`` 로 노출한다.
 
@@ -184,6 +184,13 @@ async def test_ipc_dispatch_bot_create_account_scoped_returns_validation_error_c
     이전에는 ``InvalidAccountIdError`` 에 ``code`` 속성이 없어 응답이
     ``EXECUTION_ERROR`` 로 잘못 노출되었다. ``_handle_bot_create`` 단위 테스트가
     예외 raise 자체는 잡았지만 IPC dispatch 매핑 회귀는 잡지 못했다.
+
+    #1656 E bucket: ``_handle_bot_create`` 는 ``require_account_id`` 를 함수
+    **최상단**(strategy_registry.get / StrategyLoader.load 이전)으로 옮겼다.
+    따라서 strategy_registry / StrategyLoader workaround 없이도(실제 strategy
+    가 존재하더라도) invalid/missing account_id면 strategy 처리 **이전**에
+    VALIDATION_ERROR 가 먼저 발생한다. strategy_registry mock 을 명시
+    하지 않아 validate-first 순서가 진짜로 동작함을 함께 가드한다.
 
     실제 ``register_all_handlers`` 등록 경로를 사용해 `bot.create`가 mutating
     으로 등록되는지, dispatch가 fallback 코드 매핑을 거치는지 함께 검증한다.
@@ -198,51 +205,222 @@ async def test_ipc_dispatch_bot_create_account_scoped_returns_validation_error_c
     try:
         client = IPCClient(socket_path, timeout=5.0)
 
-        # Case 1: account_id 누락 → VALIDATION_ERROR
-        # strategy_registry.get은 None을 반환해 require_account_id 도달 전에
-        # ValueError가 raise되므로, strategy_registry를 명시 mock한다.
-        from dataclasses import dataclass
-        from unittest.mock import AsyncMock
+        # validate-first: strategy_registry / StrategyLoader workaround 없이
+        # (실제 strategy 존재 여부와 무관) invalid/missing account_id 면
+        # strategy 처리 **이전**에 VALIDATION_ERROR.
 
-        @dataclass
-        class FakeRecord:
-            filepath: str = "/tmp/strategy.py"
-
-        # strategy_registry.get은 dispatch 시점에 호출되므로 fixture mock 위에
-        # 명시적으로 AsyncMock을 덮어쓴다. StrategyLoader.load는 dispatch 시
-        # 호출되지만, account_id 검증이 그 다음 줄에서 실행되므로 monkeypatch가
-        # 없어도 InvalidAccountIdError가 먼저 raise된다... 실제로는 load가 먼저
-        # 호출되어 파일 경로 IO 실패가 발생할 수 있어 patch가 필요하다.
-        import ante.strategy.loader
-
-        fake_strategy_registry = AsyncMock()
-        fake_strategy_registry.get.return_value = FakeRecord()
-        service_registry.strategy_registry = fake_strategy_registry  # type: ignore[misc]
-
-        original_load = ante.strategy.loader.StrategyLoader.load
-        ante.strategy.loader.StrategyLoader.load = lambda _path: type(  # type: ignore[assignment]
-            "FakeStrategy", (), {}
+        # Case 1: account_id 키 생략 → VALIDATION_ERROR (EXECUTION_ERROR 아님)
+        response = await client.send(
+            "bot.create",
+            {"strategy_id": "strat-1"},
+            actor="tester",
         )
-        try:
-            response = await client.send(
-                "bot.create",
-                {"strategy_id": "strat-1"},
-                actor="tester",
-            )
-            assert response["status"] == "error"
-            assert response["error"]["code"] == "VALIDATION_ERROR"
-            assert "ipc.bot.create" in response["error"]["message"]
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+        assert response["error"]["code"] != "EXECUTION_ERROR", response
+        assert "ipc.bot.create" in response["error"]["message"]
 
-            # Case 2: 빈 문자열 account_id → VALIDATION_ERROR
+        # Case 2: 빈 문자열 account_id → VALIDATION_ERROR
+        response = await client.send(
+            "bot.create",
+            {"strategy_id": "strat-1", "account_id": ""},
+            actor="tester",
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+
+        # Case 3: 'default' 예약어 → VALIDATION_ERROR
+        response = await client.send(
+            "bot.create",
+            {"strategy_id": "strat-1", "account_id": "default"},
+            actor="tester",
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+
+        # Case 4: 패턴 위반 account_id → VALIDATION_ERROR
+        response = await client.send(
+            "bot.create",
+            {"strategy_id": "strat-1", "account_id": "bad_id!"},
+            actor="tester",
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_ipc_dispatch_bot_create_valid_account_missing_other_arg_not_validation(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """#1656 불변 가드: **valid** account_id + 다른 필수 인자(strategy_id) 누락은
+    account 검증 최우선화 이후에도 기존 **non-VALIDATION_ERROR** 경로를 유지한다.
+
+    account 검증만 핸들러 최우선으로 이동하고, 타 raw arg(``args["strategy_id"]``)
+    계약은 불변이어야 한다. valid account_id 면 ``require_account_id`` 를
+    통과한 뒤 ``strategy_id = args["strategy_id"]`` 에서 ``KeyError`` 가 터져
+    server.py:323 ``getattr(e, "code", "EXECUTION_ERROR")`` 폴백으로
+    EXECUTION_ERROR 가 된다(VALIDATION_ERROR 과적용 0).
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+
+        # valid account_id + strategy_id 누락 → require_account_id 통과 후
+        # args["strategy_id"] KeyError → EXECUTION_ERROR (기존 계약 불변)
+        response = await client.send(
+            "bot.create",
+            {"account_id": "oracle-valid-account"},
+            actor="tester",
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "EXECUTION_ERROR", response
+        assert response["error"]["code"] != "VALIDATION_ERROR", response
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_ipc_dispatch_treasury_allocate_invalid_account_validation_error(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """#1656 E bucket: ``treasury.allocate`` IPC dispatch에서 (a) invalid
+    account_id 및 (b) account_id 키 생략 payload 둘 다 ``VALIDATION_ERROR``로
+    매핑되는지 검증.
+
+    회귀 모델:
+        이전에는 ``_handle_treasury_allocate`` 가 ``account_id =
+        args["account_id"]`` raw 인덱싱 후 ``svc.treasury_manager.get`` 으로
+        흘려, invalid account_id 는 manager 오류로 / account_id 키 생략은
+        ``KeyError`` 로 → server.py:323 ``getattr(e, "code",
+        "EXECUTION_ERROR")`` → ``EXECUTION_ERROR`` 로 오분류되었다.
+        #1656 이 ``require_account_id(args.get("account_id"), ...)`` 를 함수
+        첫 문장으로 옮겨, invalid/missing 모두 ``InvalidAccountIdError``
+        (code="VALIDATION_ERROR", #1633 SSOT)로 먼저 raise → VALIDATION_ERROR
+        envelope이 되도록 한다. #1636 broker 1:1 동형.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+
+        # (a) invalid account_id: 'default'/패턴위반/'' (bot_id/amount 동반)
+        for invalid in ("default", "bad_id!", ""):
             response = await client.send(
-                "bot.create",
-                {"strategy_id": "strat-1", "account_id": ""},
+                "treasury.allocate",
+                {"account_id": invalid, "bot_id": "bot-1", "amount": 1000.0},
                 actor="tester",
             )
-            assert response["status"] == "error"
-            assert response["error"]["code"] == "VALIDATION_ERROR"
-        finally:
-            ante.strategy.loader.StrategyLoader.load = original_load
+            assert response["status"] == "error", response
+            assert response["error"]["code"] == "VALIDATION_ERROR", response
+            assert response["error"]["code"] != "EXECUTION_ERROR", response
+            assert "ipc.treasury.allocate" in response["error"]["message"], response
+
+        # (b) account_id 키 생략 → KeyError → EXECUTION_ERROR 회귀 차단
+        response = await client.send(
+            "treasury.allocate",
+            {"bot_id": "bot-1", "amount": 1000.0},
+            actor="tester",
+        )
+        assert response["status"] == "error", response
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+        assert response["error"]["code"] != "EXECUTION_ERROR", response
+        assert "ipc.treasury.allocate" in response["error"]["message"], response
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_ipc_dispatch_treasury_deallocate_invalid_account_validation_error(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """#1656 E bucket: ``treasury.deallocate`` IPC dispatch에서 (a) invalid
+    account_id 및 (b) account_id 키 생략 둘 다 ``VALIDATION_ERROR``.
+
+    ``treasury.allocate`` 와 동형 — handler-first ``require_account_id``
+    (``args.get`` + 첫 문장)로 invalid/missing 모두 VALIDATION_ERROR.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+
+        # (a) invalid account_id
+        for invalid in ("default", "bad_id!", ""):
+            response = await client.send(
+                "treasury.deallocate",
+                {"account_id": invalid, "bot_id": "bot-1", "amount": 1000.0},
+                actor="tester",
+            )
+            assert response["status"] == "error", response
+            assert response["error"]["code"] == "VALIDATION_ERROR", response
+            assert response["error"]["code"] != "EXECUTION_ERROR", response
+            assert "ipc.treasury.deallocate" in response["error"]["message"], response
+
+        # (b) account_id 키 생략 → KeyError → EXECUTION_ERROR 회귀 차단
+        response = await client.send(
+            "treasury.deallocate",
+            {"bot_id": "bot-1", "amount": 1000.0},
+            actor="tester",
+        )
+        assert response["status"] == "error", response
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+        assert response["error"]["code"] != "EXECUTION_ERROR", response
+        assert "ipc.treasury.deallocate" in response["error"]["message"], response
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_ipc_dispatch_treasury_valid_account_missing_other_arg_not_validation(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """#1656 불변 가드: **valid** account_id + 다른 필수 인자(bot_id/amount)
+    누락은 account 검증 최우선화 이후에도 기존 **non-VALIDATION_ERROR** 경로
+    (``args["bot_id"]`` KeyError → EXECUTION_ERROR)를 유지한다.
+
+    account 검증만 핸들러 최우선으로 이동하고, 타 raw arg
+    (``args["bot_id"]``/``args["amount"]``) 계약은 불변이어야 한다
+    (VALIDATION_ERROR 과적용 0). allocate/deallocate 양쪽 가드.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+
+        for command in ("treasury.allocate", "treasury.deallocate"):
+            # valid account_id + bot_id/amount 누락 → require_account_id
+            # 통과 후 args["bot_id"] KeyError → EXECUTION_ERROR (기존 계약 불변)
+            response = await client.send(
+                command,
+                {"account_id": "oracle-valid-account"},
+                actor="tester",
+            )
+            assert response["status"] == "error", response
+            assert response["error"]["code"] == "EXECUTION_ERROR", response
+            assert response["error"]["code"] != "VALIDATION_ERROR", response
     finally:
         await server.stop()
 
@@ -255,10 +433,12 @@ async def test_ipc_dispatch_broker_status_account_scoped_returns_validation_erro
     ``VALIDATION_ERROR`` 매핑이 동작하는지 검증.
 
     ``bot.create`` 외의 모든 ``require_account_id`` 호출 경로가 ``code`` 속성
-    추가로 자동 정렬되었는지 회귀 가드. ``treasury.allocate``는
-    ``require_account_id`` 를 호출하지 않으므로 (KeyError 직접 raise) 본 회귀
-    보호 대상이 아니다 — read-only side에서 동등한 매핑이 작동하는지를
-    ``broker.status`` 로 대신 검증한다.
+    추가로 자동 정렬되었는지 회귀 가드. (#1656에서 ``treasury.allocate``/
+    ``treasury.deallocate`` 도 handler-first ``require_account_id`` 로 정렬되어
+    별도 테스트가 추가되었다 —
+    ``test_ipc_dispatch_treasury_allocate_invalid_account_validation_error`` 등.)
+    여기서는 read-only side에서 동등한 매핑이 작동하는지를 ``broker.status`` 로
+    검증한다.
     """
     from ante.ipc.registry import register_all_handlers
 


### PR DESCRIPTION
Closes #1656

## Summary
- E bucket(`treasury allocate`/`deallocate`, `bot create`) invalid/missing account_id → clean `VALIDATION_ERROR`(#1633 SSOT), resource work 이전 차단. `docs/specs/account/14-account-id-contract.md` E row(L249).
- **IPC handler 1차** (`src/ante/ipc/registry.py`): `_handle_treasury_allocate`/`_handle_treasury_deallocate` 첫 문장 `require_account_id(args.get("account_id"), context=...)`; `_handle_bot_create` validate-first 이동(중복 제거). IPC server.py:323 `getattr(e,"code")` + `InvalidAccountIdError.code=VALIDATION_ERROR` 자동 envelope(server.py 무수정). #1636 broker IPC 1:1 동형.
- **CLI defense-in-depth**: treasury allocate/deallocate `reject_invalid_account_id`(required); bot_create provided-only(omitted resolver 보존).
- 테스트: direct-IPC invalid+missing→VALIDATION_ERROR, valid+other-arg-missing=non-VALIDATION_ERROR 불변, test_registry validate-first 보정, CLI 회귀. Plan Preflight 3R 수렴(approve-implement).

## Test Plan
- HARD failing check: 픽스 전 14 FAIL → 후 전부 PASS
- HARD passing check: 타깃 100 passed / 광역 `-k "ipc or treasury or bot or account_id"` 1492 passed·0 failed / `mypy src/` clean(242) / `ruff check`·`format` clean / OpenAPI 무영향
- Codex 브랜치 리뷰 (`/codex:review --base main`, attempt 1): PASS

## Note
- pre-existing `tests/unit/test_cli_date_validation.py` base hang(#1564 영역, 본 changeset 무관·미수정)은 별도 triage 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)