### PR TITLE
fix(cli): #1657 strategy performance invalid account_id를 VALIDATION_ERROR로 거부 (read-family)

### DIFF
--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import click
 
 from ante.account.errors import AccountNotFoundError
+from ante.cli._validators import reject_invalid_account_id
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
@@ -453,6 +454,10 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
             code="STRATEGY_MISSING_REQUIRED_ACCOUNT",
         )
         raise SystemExit(1)
+
+    account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.strategy.performance"
+    )
 
     async def _perf() -> dict | None:
         from ante.cli.main import get_db_path

--- a/tests/unit/test_cli_strategy.py
+++ b/tests/unit/test_cli_strategy.py
@@ -664,6 +664,146 @@ class TestStrategyPerformance:
         assert "ACCOUNT_NOT_FOUND" not in result.output
         tracker.calculate.assert_not_called()
 
+    # ── read-family follow-up: provided invalid account_id ingress 거부 ──
+    # (#1657, oracle A7 cli_strategy_performance_invalid_account_id)
+    #
+    # docs/specs/account/14-account-id-contract.md L295: ``ante strategy
+    # performance <name> --account-id <id>`` = read-family follow-up,
+    # 목표 에러코드 = ``VALIDATION_ERROR``. provided invalid account_id
+    # (``default``/``""``/패턴 위반)가 ``SELECT 1 FROM accounts`` 존재
+    # 조회 이전 ingress에서 거부되지 않아 ``ACCOUNT_NOT_FOUND``로
+    # 오분류되던 contract-drift를 ``reject_invalid_account_id`` 공유
+    # 가드로 차단한다. 에러코드 SSOT는 #1633 선결정 재사용(신 코드 0).
+    #
+    # 3-way 분리 불변:
+    #   invalid-format → VALIDATION_ERROR (본 픽스 목표)
+    #   valid-format absent → ACCOUNT_NOT_FOUND (보존)
+    #   omitted (--account-id 미지정) → STRATEGY_MISSING_REQUIRED_ACCOUNT (보존)
+    # #1634/#1655 테스트 구조 미러.
+
+    @pytest.mark.parametrize("invalid", ["default", "bad_id!", ""])
+    def test_performance_invalid_account_id_rejected(self, runner, invalid):
+        """(a) provided invalid account_id → VALIDATION_ERROR (ACCOUNT_NOT_FOUND 아님).
+
+        #1657: invalid-format/예약어 account_id가 존재 SELECT 이전 ingress
+        에서 거부되어 ``code=VALIDATION_ERROR``로 분류된다. 픽스 전 코드
+        에서는 ``code=ACCOUNT_NOT_FOUND``로 오분류되어 본 단언이 FAIL한다.
+        """
+        db = _mock_db()
+        registry = _mock_registry([_SAMPLE_RECORD])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "strategy",
+                    "performance",
+                    "momentum",
+                    "--account-id",
+                    invalid,
+                ],
+            )
+        assert result.exit_code != 0, result.output
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error", data
+        assert data["code"] == "VALIDATION_ERROR", data
+        # not-found 오분류 차단 — invalid-format을 not-found로 분류 금지.
+        assert data["code"] != "ACCOUNT_NOT_FOUND", data
+        assert "찾을 수 없" not in result.output, result.output
+        assert "Traceback" not in result.output, result.output
+
+    def test_performance_valid_absent_account_keeps_not_found(self, runner):
+        """(b) valid-format absent account_id → ACCOUNT_NOT_FOUND까지 실제 도달.
+
+        #1657: helper가 형식 정상·미존재 account_id를 통과시켜 기존
+        ``SELECT 1 FROM accounts`` → ``AccountNotFoundError`` →
+        ``code=ACCOUNT_NOT_FOUND`` 경로가 보존된다. helper 삽입이
+        non-None account_id 경로를 ``NameError`` 등으로 깨면 본 테스트가
+        즉시 FAIL한다(NameError류 회귀 차단).
+        """
+        p_db, p_path, p_reg, p_track, _db, tracker = self._patch_perf_internals(
+            records=[_SAMPLE_RECORD],
+            account_row=None,
+        )
+        with p_db, p_path, p_reg, p_track:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "strategy",
+                    "performance",
+                    "momentum",
+                    "--account-id",
+                    "acc-9999",
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "error", data
+        assert data["code"] == "ACCOUNT_NOT_FOUND", data
+        assert "acc-9999" in data["message"], data
+        tracker.calculate.assert_not_called()
+
+    def test_performance_omitted_account_keeps_missing_required(self, runner):
+        """(c) --account-id 미지정 → STRATEGY_MISSING_REQUIRED_ACCOUNT 보존.
+
+        #1657: omitted(account_id is None)는 helper 호출 이전
+        ``if account_id is None:`` 가드가 선차단하므로
+        ``STRATEGY_MISSING_REQUIRED_ACCOUNT`` 코드가 보존된다(helper는
+        그 가드 이후 호출되어 None에 도달하지 않는다).
+        """
+        db = _mock_db()
+        registry = _mock_registry([_SAMPLE_RECORD])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "strategy", "performance", "momentum"]
+            )
+        assert result.exit_code == 1, result.output
+        data = json.loads(result.output)
+        assert data["code"] == "STRATEGY_MISSING_REQUIRED_ACCOUNT", data
+
+    def test_performance_valid_present_account_succeeds(self, runner):
+        """(d) valid-format present account_id → 성공 경로 통과.
+
+        #1657: helper가 형식 정상·존재 account_id를 통과시켜 정상 성과
+        집계가 보존된다. helper 삽입이 non-None account_id 경로를
+        ``NameError`` 등으로 깨면 본 테스트가 즉시 FAIL한다.
+        """
+        p_db, p_path, p_reg, p_track, _db, tracker = self._patch_perf_internals(
+            records=[_SAMPLE_RECORD],
+            account_row={"1": 1},
+        )
+        with p_db, p_path, p_reg, p_track:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "strategy",
+                    "performance",
+                    "momentum",
+                    "--account-id",
+                    "acc-test",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["strategy_name"] == "momentum", data
+        assert data["metrics"]["total_trades"] == 10, data
+        tracker.calculate.assert_awaited_once()
+
 
 class TestStrategySubmit:
     """ante strategy submit 커맨드 테스트."""


### PR DESCRIPTION
Closes #1657

## Summary
- `src/ante/cli/commands/strategy.py` `strategy_performance`: None-guard 직후·존재 SELECT 이전에 `reject_invalid_account_id(account_id, fmt, context="cli.strategy.performance")` ingress 추가(+module import). #1634 `account_info` 1:1 동형. invalid-format/예약어 account_id가 `ACCOUNT_NOT_FOUND`로 오분류되던 것을 #1633 SSOT `VALIDATION_ERROR`로 정렬. read-family follow-up (`docs/specs/account/14-account-id-contract.md` L295).
- 3-way 분리 불변 보존: invalid-format→VALIDATION_ERROR / valid-absent→ACCOUNT_NOT_FOUND / omitted→STRATEGY_MISSING_REQUIRED_ACCOUNT / valid-present→success.
- Plan Preflight: narrow-scope (bounded-ship; 반복된 context-literal Codex 지적은 focus-text transport 렌더링 artifact로 확정 — 실제 구현 코드는 `od -c` mirror 검증으로 `context="..."` 큰따옴표 string-literal 확정, #1634/#1655/#1656 MERGED 동형).

## Test Plan
- HARD failing check: 픽스 전 invalid account_id 3케이스(default/bad_id!/"") FAIL 확인 (ACCOUNT_NOT_FOUND 오분류 재현)
- HARD passing check: 신규 6 PASS / 타깃 93 passed / 광역 `-k "strategy or account_id or performance"` 808 passed·0 failed (valid-absent→ACCOUNT_NOT_FOUND·valid-present→success 통과로 NameError류 부재 입증) / `mypy src/` clean(242) / `ruff check`·`format` clean / 생성물 OpenAPI 무영향
- Codex 브랜치 리뷰 (`/codex:review --base main`, attempt 1): PASS

## Note
- 생성 docs 재생성 시 pre-existing base drift(날짜·#1626·backtest --exchange)는 본 PR과 분리·미수정. `tests/unit/test_cli_date_validation.py` base hang(#1564 영역)은 별도 triage 필요(기존 보고).

🤖 Generated with [Claude Code](https://claude.com/claude-code)