### PR TITLE
docs: #1659 broker health/price spec-only 등재 제거 (축별 전수 sweep)

### DIFF
--- a/docs/specs/account/14-account-id-contract.md
+++ b/docs/specs/account/14-account-id-contract.md
@@ -293,19 +293,16 @@ C=#1636 / D follow-up / E follow-up / read-family follow-up /
 | `ante bot create --account <account_id>` | option | `VALIDATION_ERROR` | match | **E — follow-up 후보** (mutating IPC `bot.create` handler `require_account_id`; 단 `--account` 생략 시 single-active resolver. #1623 probe 집합 아님; 구현 시 경로 확인 후 동 결정) |
 | `ante treasury snapshot --account <account_id>` | option | `VALIDATION_ERROR` | match | **B — #1635** (`treasury status` (`src/ante/cli/commands/treasury.py:64`) 와 **동일** `_create_treasury(account_id)` construction-lifecycle 경로 — snapshot 콜백 `src/ante/cli/commands/treasury.py:229` 가 `t, db = await _create_treasury(account_id)` 로, status 콜백 `:69` 와 동일 `_create_treasury`→`require_account_id` (`:37`) 경계를 공유하는 **구조**. ∴ B(#1635) construction-lifecycle 범위 (mutating IPC E 아님). 목표=`VALIDATION_ERROR`, 정렬·산출 확정은 #1635 probe 책임) |
 | `ante strategy performance <name> --account-id <account_id>` | option | `VALIDATION_ERROR` | match | **follow-up (read-family, 비-#1623-probe)** (읽기 표면 — `strategy_performance` CLI 콜백 (`src/ante/cli/commands/strategy.py:432`) 자체가 `account_id` 를 처리 (`account_id is None` → `STRATEGY_MISSING_REQUIRED_ACCOUNT`, `:450`) 하고 `PerformanceTracker` + 자체 `SELECT 1 FROM accounts` 단건 read 를 수행하는 **구조**. `_create_treasury`/`_create_rule_engine` construction(B) 도, broker/non-broker mutating IPC dispatch(C/E) 도 아니며, #1623-probe(`account info`/`bot list`) 비동형 → mutating IPC E 와 구분되는 **read-family follow-up**. 목표=`VALIDATION_ERROR`, 정렬·산출 확정은 read-family follow-up 책임) |
-| `ante broker health [--account <account_id>]` | option | `VALIDATION_ERROR` | **spec-only** (03-commands.md:114(`status/health` 합산 행)·410(bash 블록) 에 기재; `broker.py` 미등록 — status/balance/positions/reconcile 만 존재. **정적 사실**) | **문서수정** (03-commands.md drift 교정 후속; 코드 표면 없으므로 #1634/35/36 비대상) |
-| `ante broker price <symbol> [--account <account_id>]` | option | `VALIDATION_ERROR` | **spec-only** (03-commands.md:117·413(bash 블록) 에 기재; `broker.py` 미등록. **정적 사실**) | **문서수정** (03-commands.md drift 교정 후속; 코드 표면 없으므로 #1634/35/36 비대상) |
 
-> row-count 동치 검증 (정적): 위 표 결정 row 23개 = code 표면
-> 21개( 등재 상태 ``match`` ; ``code-only`` 0) + ``spec-only`` 2개
-> ( ``broker health`` / ``broker price`` ). enumerate된 unique CLI
-> command path 수 21개와 동치(누락 0). ``treasury snapshot`` ·
-> ``strategy performance`` 포함. **이 동치는 Click decorator 산출
-> 목록 vs 03-commands 기재의 정적 비교만으로 검증하며, 런타임 trace
-> 와 무관하다.**
+> row-count 동치 검증 (정적): 위 표 결정 row 21개 = code 표면
+> 21개( 등재 상태 ``match`` ; ``spec-only`` 0 / ``code-only`` 0).
+> enumerate된 unique CLI command path 수 21개와 동치(누락 0).
+> ``treasury snapshot`` · ``strategy performance`` 포함. **이 동치는
+> Click decorator 산출 목록 vs 03-commands 기재의 정적 비교만으로
+> 검증하며, 런타임 trace 와 무관하다.**
 >
 > match/spec-only/code-only 집계( **정적** ): ``match`` 21 /
-> ``spec-only`` 2 / ``code-only`` 0. ``rule list`` · ``rule info``
+> ``spec-only`` 0 / ``code-only`` 0. ``rule list`` · ``rule info``
 > 는 코드 ( ``src/ante/cli/commands/rule.py:93``/``:189`` 의
 > ``@click.option("--account","account_id",required=True)`` )에는
 > 존재하나 03-commands.md rule 섹션·offline 명령 표에는 미기재였으므로
@@ -315,8 +312,14 @@ C=#1636 / D follow-up / E follow-up / read-family follow-up /
 > **등재 상태**를 ``code-only → match`` 로 닫았다(일관 처리: 동일
 > docs-only 범위 내 03-commands.md drift 즉시 교정이 ``code-only``
 > 후속 항목을 별도로 미루는 것보다 정합적이고 row-count·집계 동치를
-> 보존). 따라서 보정 후 최종 ``code-only`` 0, 위 23/21/2 동치는
-> 유지된다. ``rule`` 행의 ``등재 상태`` 정정은 **정적 사실의 정정**일
+> 보존). 따라서 #1633 보정 후 최종 ``code-only`` 0 ( 그 시점 정적
+> 동치는 23/21/2: 결정 row 23 = code 표면 21 + ``spec-only`` 2 ).
+> 이후 #1659 가 ``broker health`` / ``broker price`` spec-only 2행을
+> 결정표에서 제거(코드·스펙 모두 부재로 확정 — 아래 [Resolved
+> (#1659)](#resolved-1659--broker-healthprice-분류-종결) 참조)하여
+> 현재형 정적 동치는 **21/21/0**( 결정 row 21 = code 표면 21,
+> ``spec-only`` 0 / ``code-only`` 0 )이다. ``rule`` 행의
+> ``등재 상태`` 정정은 **정적 사실의 정정**일
 > 뿐이며 그 표면이 지금 무엇을 내는지는 단정하지 않는다(목표
 > ``VALIDATION_ERROR`` 도달 정렬은 except/변환 **구조**상 **#1635**
 > 담당, [Non-Goal](#1633-non-goal--per-surface-런타임-trace는-split-책임)).
@@ -349,9 +352,30 @@ C=#1636 / D follow-up / E follow-up / read-family follow-up /
 > 인자 없음 )로 감싸는 **구조**상, ``validate_new_account_id`` 검증
 > 자체와 무관하게 그 cold-path CLI 래핑이 목표 ``VALIDATION_ERROR``
 > 도달을 보장하지 않으므로 D 통합 follow-up( account-lifecycle /
-> cold-path drift 점검 ) 후보에 포함된다. ``broker health`` /
-> ``broker price`` ( spec-only, 코드 표면 없음)만 follow-up 대상이
-> 아니다(처리는 ``문서수정``).
+> cold-path drift 점검 ) 후보에 포함된다.
+
+### Resolved (#1659) — broker health/price 분류 종결
+
+> **#1659 문서수정 완료 — ``broker health`` / ``broker price`` 는
+> 코드·스펙 모두 부재.** 본 절은 과거 분류 사실의 보존 기록이며 위
+> [결정표](#결정표)의 현재형 정적 inventory 집계에는 포함되지
+> 않는다(현재형 동치 = 21/21/0).
+>
+> #1633 시점에는 ``ante broker health`` · ``ante broker price
+> <symbol>`` 가 03-commands.md 등 CLI/런타임-IPC 스펙에 공개 명령으로
+> 기재되어 있으나 ``src/ante/cli/commands/broker.py`` 에는
+> ``status``/``balance``/``positions``/``reconcile`` 만 등록되어 있어
+> ``spec-only`` (코드 표면 없음)로 분류되었고, 처리 결정은
+> ``문서수정`` (코드 구현 비대상; #1634/35/36 비대상)이었다. follow-up
+> (D/E/read-family) 대상도 아니었다(처리는 ``문서수정``).
+>
+> #1659 가 SSOT 결정(``문서수정``)을 집행하여 03-commands.md ·
+> 06-cross-module-notes.md · broker-adapter/14-cli.md · ipc.md 의 모든
+> ``broker health`` / ``broker price`` CLI·런타임-IPC 명령 등재를
+> 제거하고, 본 결정표에서도 두 ``spec-only`` 행을 제거했다. 그 결과
+> 코드·스펙 양쪽에서 두 명령이 모두 부재하여 drift 가 해소되었다.
+> 잔존 broker 명령( ``status``/``balance``/``positions``/``reconcile``
+> )은 무변경 보존된다.
 
 ### #1633 Non-Goal — per-surface 런타임 trace는 split 책임
 

--- a/docs/specs/broker-adapter/14-cli.md
+++ b/docs/specs/broker-adapter/14-cli.md
@@ -15,7 +15,6 @@ Broker Adapter 관점의 런타임 경계만 설명한다.
 ```bash
 # 연결 상태 확인
 ante broker status [--account domestic]
-ante broker health [--account domestic]     # status alias
 
 # 잔고 조회
 ante broker balance [--account domestic]
@@ -23,15 +22,11 @@ ante broker balance [--account domestic]
 # 포지션 조회
 ante broker positions [--account domestic]
 
-# live 현재가 조회
-ante broker price <symbol> [--account domestic]
-
 # 포지션 대사
 ante broker reconcile [--account domestic] [--fix]
 ```
 
-`broker price`는 live broker quote만 의미한다. historical/public market data 조회는
-`data` 또는 `feed` 계열 커맨드가 담당한다.
+historical/public market data 조회는 `data` 또는 `feed` 계열 커맨드가 담당한다.
 
 일반 운영 CLI는 `broker order`를 제공하지 않는다. 주문은 Bot/Strategy → RuleEngine
 → BrokerAdapter 경로로만 들어가야 하며, 수동 주문 테스트가 필요하면 별도

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -111,10 +111,9 @@ allowlist 후보에서 제거한다.
 | `ante treasury snapshot ...` | `offline` | 일별 snapshot 조회 |
 | `ante rule list --account <account_id> [--scope global|strategy]` | `offline` | rule 설정 조회 (`--account` 필수) |
 | `ante rule info <rule_id> --account <account_id>` | `offline` | rule 설정 조회 (`--account` 필수) |
-| `ante broker status/health [--account <account_id>]` | `runtime IPC` | 서버 BrokerAdapter live 상태 |
+| `ante broker status [--account <account_id>]` | `runtime IPC` | 서버 BrokerAdapter live 상태 |
 | `ante broker balance [--account <account_id>]` | `runtime IPC` | 서버 BrokerAdapter live 조회 |
 | `ante broker positions [--account <account_id>]` | `runtime IPC` | 서버 BrokerAdapter live 조회 |
-| `ante broker price <symbol> [--account <account_id>]` | `runtime IPC` | live broker quote |
 | `ante broker reconcile [--account <account_id>] [--fix]` | `runtime IPC` | 서버 PositionReconciler |
 | `ante data list/schema/storage/validate ...` | `offline` | canonical data root 또는 명시 data path 대상 |
 | `ante backtest run <strategy_path> ...` | `offline` | 서버와 분리된 백테스트 실행 |
@@ -410,25 +409,17 @@ ante rule info <rule_id> --account <account_id>           # 룰 상세
 
 ```bash
 ante broker status [--account <account_id>]      # 증권사 연결 상태
-ante broker health [--account <account_id>]      # status alias
 ante broker balance [--account <account_id>]     # 실제 증권사 잔고 조회
 ante broker positions [--account <account_id>]   # 실제 증권사 포지션 조회
-ante broker price <symbol> [--account <account_id>]  # live 현재가 조회
 ante broker reconcile [--account <account_id>] [--fix]  # 시스템↔증권사 포지션 대사
 ```
 
 모든 `broker` live 커맨드는 서버가 시작 시 생성한 BrokerAdapter를 통해 실행하는
 런타임 IPC 커맨드다. CLI가 별도 adapter를 직접 생성하면 credentials 복호화, 연결
 상태, rate limit, circuit breaker, audit 경로가 서버와 분리되므로 허용하지 않는다.
-`broker price`는 live broker quote만 의미한다. 과거·공개 market data 조회는
-`data`/`feed` 계열 커맨드로 다룬다. `broker order`와 `broker stream prices`는
-일반 운영 CLI 범위가 아니며, 별도 maintenance/test 스펙 없이는 제공하지 않는다.
-
-> `broker health`/`broker price <symbol>`는 본 문서에 기재되어 있으나
-> `src/ante/cli/commands/broker.py`에는 `status`/`balance`/`positions`/`reconcile`
-> 만 등록되어 있다(spec-only drift). 처리 결정은
-> [account-id-contract.md — account-scoped CLI inventory 결정표](../account/14-account-id-contract.md#결정표)
-> 참조(문서수정 후속).
+과거·공개 market data 조회는 `data`/`feed` 계열 커맨드로 다룬다. `broker order`와
+`broker stream prices`는 일반 운영 CLI 범위가 아니며, 별도 maintenance/test 스펙
+없이는 제공하지 않는다.
 
 ### account-scoped `account_id` 입력 표면 — 14-account-id-contract 참조
 

--- a/docs/specs/cli/06-cross-module-notes.md
+++ b/docs/specs/cli/06-cross-module-notes.md
@@ -7,7 +7,7 @@
 - **Web API 스펙**: CLI와 동일한 기능을 REST API로 노출, 내부 클라이언트 공유
 - **Account 스펙**: `ante account create/delete/set-credentials`는 cold-path structural 커맨드이므로 서버 실행 중 차단한다. `account suspend/activate`와 `system halt/clear-halt`는 IPC 런타임 커맨드다.
 - **Bot 스펙**: `ante bot create/start/stop/remove`와 `signal-key --rotate`는 IPC를 통해 서버의 BotManager를 호출하는 런타임 커맨드다. 실행 중 조회(`list/info/status/positions/signal-key`)도 서버 live 상태가 필요하면 IPC를 우선 사용한다. Bot 생성 시 `--strategy`는 등록된 `strategy_id`이며, 파일 경로를 직접 받지 않는다.
-- **Broker Adapter 스펙**: `ante broker status/health/balance/positions/price/reconcile`은 서버가 보유한 BrokerAdapter 연결을 사용하는 런타임 IPC 커맨드다. 일반 운영 CLI에서 직접 broker adapter를 생성하거나 `broker order`를 제공하지 않는다.
+- **Broker Adapter 스펙**: `ante broker status/balance/positions/reconcile`은 서버가 보유한 BrokerAdapter 연결을 사용하는 런타임 IPC 커맨드다. 일반 운영 CLI에서 직접 broker adapter를 생성하거나 `broker order`를 제공하지 않는다.
 - **Member 스펙**: `member list/info`는 오프라인 조회가 가능하다. 등록, 상태 변경, 토큰/패스워드/복구키 변경은 서버 실행 중 IPC로 처리하고, 서버 정지 상태에서는 recovery/maintenance fallback만 허용한다.
 - **Strategy 스펙**: `ante strategy validate`는 StrategyValidator를 호출하고, `ante strategy submit <path>`는 검증 + 로드 테스트 + StrategyRegistry 등록을 수행한다. 등록 결과인 `strategy_id`가 `ante bot create --strategy` 입력이다.
 - **Report Store 스펙**: `ante report submit/schema` → ReportStore, PerformanceFeedback 호출

--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -130,10 +130,9 @@ cold-path 삭제는 항상 keep 의미다.
 
 | CLI 커맨드 | IPC 커맨드 | 서비스 메서드 | IPC 필요 사유 |
 |-----------|-----------|-------------|-------------|
-| `ante broker status` / `ante broker health` | `broker.status` | `BrokerAdapter.health_check()` | 서버가 보유한 BrokerAdapter 연결 상태와 circuit breaker 상태 조회 |
+| `ante broker status` | `broker.status` | `BrokerAdapter.health_check()` | 서버가 보유한 BrokerAdapter 연결 상태와 circuit breaker 상태 조회 |
 | `ante broker balance` | `broker.balance` | `BrokerAdapter.get_account_balance()` | 서버 시작 시 생성된 adapter/credentials/rate limit 상태 재사용 |
 | `ante broker positions` | `broker.positions` | `BrokerAdapter.get_positions()` | 서버 adapter 연결과 계좌 topology 기준으로 live 포지션 조회 |
-| `ante broker price` | `broker.price` | `BrokerAdapter.get_current_price()` | live broker quote 조회. historical/public data 조회와 분리 |
 | `ante broker reconcile --fix` | `broker.reconcile` | `PositionReconciler.reconcile()` | TradeService 인메모리 반영 + `NotificationEvent` 알림 |
 
 일반 운영 CLI는 broker adapter를 직접 생성하지 않는다. 직접 생성 경로는 서버의
@@ -162,7 +161,7 @@ maintenance/test 스펙 없이는 제공하지 않는다.
 
 조회 커맨드라도 서버가 가진 live 상태를 읽어야 하면 런타임 IPC 대상이다. 대표적으로
 `bot list/info/status/positions/signal-key`의 live 조회와
-`broker status/health/balance/positions/price`가 여기에 속한다.
+`broker status/balance/positions`가 여기에 속한다.
 
 ### Cold-path structural 커맨드
 
@@ -250,7 +249,7 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 IPC command 분리는 별도 이슈 범위다.
 
 `account.delete`처럼 1.0 IPC 계약에서 제외되어 `CommandRegistry`에 등록되지 않는 명령은
-taxonomy 대상이 아니다. `broker.price`, `member.*`, `bot.start/stop`,
+taxonomy 대상이 아니다. `member.*`, `bot.start/stop`,
 `bot.signal_key.rotate`처럼 CLI/스펙 표에는 runtime IPC로 표현되어 있으나 현재
 `register_all_handlers()`에 없는 명령 추가도 별도 후속 범위다.
 


### PR DESCRIPTION
Closes #1659

## Summary
- docs/specs가 `ante broker health`/`ante broker price`를 공개 CLI/런타임-IPC 명령으로 등재했으나 실제 broker CLI는 `{balance,positions,reconcile,status}`만 존재. SSOT `docs/specs/account/14-account-id-contract.md`(L352-353)가 spec-only·결정=문서수정으로 확정 → docs-only 축별 전수 sweep으로 제거/정합.
- 5 docs: 03-commands.md·06-cross-module-notes.md·broker-adapter/14-cli.md·ipc/ipc.md(표·compressed 열거·deferred-note의 broker.price만, member.*/bot.start/stop 보존)·14-account-id-contract.md(결정표 현재형 21/21/0 갱신 + 분류 근거를 active 표 밖 Resolved(#1659) note로 분리). 코드 변경 0.
- Plan Preflight: approve-implement (3R 수렴; SET-invariant array+quoted 게이트 현 main baseline 10/13/2 실측).

## Test Plan
- SET-invariant 게이트: baseline literal 10/compressed 13/IPC-key 2 FAIL → post-fix 0/0/0 **PASS**
- 실제 CLI 일치(`broker.commands.keys()==['balance','positions','reconcile','status']`)·잔존 4명령 보존·전역 sweep 0건
- docs/cli 회귀 테스트 48 passed · Codex 브랜치 리뷰 PASS

## Note
- guide/cli.md broker 섹션 이미 정합(재생성 diff는 pre-existing drift만 — 분리·미커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)