### PR TITLE
docs: #1661 ROOT-ONLY 명령 trailing --format json 예시 root form 정렬 (parser-script SSOT)

### DIFF
--- a/.agent/agents/strategy-dev.md
+++ b/.agent/agents/strategy-dev.md
@@ -37,21 +37,24 @@ AGENTS.md와 전략 관련 스펙 문서에 정의된 전략 개발 원칙을 �
 
 ## 주요 CLI 명령
 
+JSON 출력은 root 전역 옵션 `ante --format json <command>`로 지정한다
+(`--format`은 root 옵션이므로 서브커맨드 뒤가 아니라 `ante` 바로 뒤에 둔다).
+
 ```bash
 # 1. 데이터 탐색
-ante data list --format json
-ante data schema --format json
+ante --format json data list
+ante --format json data schema
 
 # 2. 전략 검증
-ante strategy validate strategies/my_strategy.py --format json
+ante --format json strategy validate strategies/my_strategy.py
 
 # 3. 백테스트
-ante backtest run strategies/my_strategy.py \
+ante --format json backtest run strategies/my_strategy.py \
   --start 2024-01-01 --end 2026-03-01 \
-  --symbols 005930 --balance 10000000 --format json
+  --symbols 005930 --balance 10000000
 
 # 4. 리포트 제출
-ante report submit report.json --format json
+ante --format json report submit report.json
 ```
 
 ## 전략 작성 규칙

--- a/docs/specs/audit/audit.md
+++ b/docs/specs/audit/audit.md
@@ -93,14 +93,16 @@ GET /api/audit?member_id=agent-01&action=bot.&from_date=2026-03-12&to_date=2026-
 CLI 명령 시그니처와 실행 분류의 SSOT는
 [cli/03-commands.md](../cli/03-commands.md#ante-audit--감사-로그-조회)다.
 
+`--format`은 root 전역 옵션(`--format text|json`, `table` 미지원)이므로
+`ante` 바로 뒤에 둔다.
+
 ```
-ante audit list \
+ante --format json audit list \
   [--member agent-01] \
   [--action "bot."] \
   [--from-date 2026-03-12] \
   [--to-date 2026-03-19] \
-  [--limit 100] [--offset 0] \
-  [--format json|table]
+  [--limit 100] [--offset 0]
 ```
 
 ## 감사 로그 기록 지점

--- a/docs/specs/backtest/03-cli-usage.md
+++ b/docs/specs/backtest/03-cli-usage.md
@@ -8,14 +8,15 @@ CLI 명령 시그니처와 실행 분류의 SSOT는
 [cli/03-commands.md](../cli/03-commands.md#ante-backtest--백테스트)다. 이 문서는
 Backtest 관점의 실행 예시만 제공한다.
 
+`--format`은 root 전역 옵션이므로 `ante` 바로 뒤에 둔다.
+
 ```bash
 # 백테스트 실행
-ante backtest run strategies/my_strategy.py \
+ante --format json backtest run strategies/my_strategy.py \
   --start 2025-01-01 --end 2025-12-31 \
   --balance 10000000 \
   --symbols 005930,000660 \
-  --timeframe 1d \
-  --format json
+  --timeframe 1d
 ```
 
 `--data-path`를 생략하면 Config의 `data.path`를 사용한다. 다른 데이터셋을 검증할 때만

--- a/docs/specs/bot/06-cli-usage.md
+++ b/docs/specs/bot/06-cli-usage.md
@@ -35,7 +35,7 @@ ante bot start bot_001
 # 봇 목록 조회
 ante bot list
 ante bot list --account domestic         # 계좌별 필터
-ante bot list --format json
+ante --format json bot list              # JSON 출력은 root 전역 옵션
 
 # 봇 상태 조회 — 미구현 (follow-up): CLI command 미등록
 ante bot status bot_001

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -291,9 +291,11 @@ ante bot create --name <name> --strategy <strategy_id> [--account <account_id>] 
 ```bash
 ante member reset-password \
   --recovery-key <key> \
-  (--new-password-env ENV_NAME | --new-password-file PATH) \
-  [--format json]
+  (--new-password-env ENV_NAME | --new-password-file PATH)
 ```
+
+JSON 출력이 필요하면 root 전역 옵션을 사용한다:
+`ante --format json member reset-password ...`.
 
 - `--new-password-env` 또는 `--new-password-file` 중 정확히 하나를 사용한다.
 - 직접 `--new-password` 값 옵션은 shell history 노출 우려로 본 이슈에서 권장 채널에서 제외한다
@@ -305,9 +307,11 @@ ante member reset-password \
 
 ```bash
 ante member regenerate-recovery-key \
-  (--password-env ENV_NAME | --password-file PATH) \
-  [--format json]
+  (--password-env ENV_NAME | --password-file PATH)
 ```
+
+JSON 출력이 필요하면 root 전역 옵션을 사용한다:
+`ante --format json member regenerate-recovery-key ...`.
 
 - `--password-env` 또는 `--password-file` 중 정확히 하나를 사용한다.
 - prompt 기반 현재 패스워드 입력은 제거되었다.

--- a/docs/specs/cli/04-agent-workflows.md
+++ b/docs/specs/cli/04-agent-workflows.md
@@ -4,26 +4,32 @@
 
 # Agent 워크플로우 예시
 
+`--format json`은 root 전역 옵션이므로 `ante` 바로 뒤에 둔다
+(`strategy validate`, `data list`, `backtest run`, `report schema`,
+`report submit`, `bot positions`, `strategy performance`는 서브커맨드 자체에
+`--format`이 없어 leaf 위치 사용 시 `No such option: --format`으로 실패한다).
+`trade list`처럼 서브커맨드가 `--format`을 직접 지원하는 명령은 trailing 형태도 유효하다.
+
 ```bash
 # 1. 전략 개발 후 검증
-ante strategy validate strategies/my_strategy.py --format json
+ante --format json strategy validate strategies/my_strategy.py
 
 # 2. 보유 데이터 확인
-ante data list --format json
+ante --format json data list
 
 # 3. 백테스트 실행
-ante backtest run strategies/my_strategy.py \
+ante --format json backtest run strategies/my_strategy.py \
     --start 2024-01-01 --end 2026-03-01 \
-    --symbols 005930,000660 --format json
+    --symbols 005930,000660
 
 # 4. 리포트 스키마 확인 후 제출
-ante report schema --format json
-ante report submit report_draft.json --format json
+ante --format json report schema
+ante --format json report submit report_draft.json
 
 # 5. (채택 후) 실전 성과 확인 — Agent 피드백 루프
 ante trade list --bot bot_001 --from 2026-03-01 --to 2026-03-31 --format json
-ante bot positions bot_001 --format json
-ante strategy performance my_strategy --format json
+ante --format json bot positions bot_001
+ante --format json strategy performance my_strategy
 ```
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조

--- a/docs/specs/member/06-cli.md
+++ b/docs/specs/member/06-cli.md
@@ -53,10 +53,16 @@ ante member list [--type human|agent] [--org strategy-lab] [--status active] [--
 
 출력에 각 멤버의 이모지가 표시된다.
 
+> JSON 출력은 root 전역 옵션으로 지정한다: `ante --format json member <subcommand> ...`.
+> `member list`처럼 서브커맨드 자체가 `--format`을 받는 명령은 trailing 형태도
+> 유효하지만, `member info/set-emoji/suspend/reactivate/revoke/rotate-token` 등
+> 아래 명령은 서브커맨드에 `--format`이 없으므로 leaf 위치 사용 시
+> `No such option: --format`으로 실패한다.
+
 ### `ante member info <member_id>`
 
 ```
-ante member info strategy-dev-01 [--format json]
+ante member info strategy-dev-01
 ```
 
 출력에 멤버의 이모지가 표시된다.
@@ -85,7 +91,7 @@ ante member register \
 ### `ante member set-emoji <member_id> <emoji>`
 
 ```
-ante member set-emoji strategy-dev-01 🦊 [--format json]
+ante member set-emoji strategy-dev-01 🦊
 ```
 
 ### `ante member suspend <member_id>`
@@ -93,7 +99,7 @@ ante member set-emoji strategy-dev-01 🦊 [--format json]
 **권한: master-only**. agent token이면 service layer `_assert_master`에서 거부된다.
 
 ```
-ante member suspend strategy-dev-01 [--format json]
+ante member suspend strategy-dev-01
 ```
 
 ### `ante member reactivate <member_id>`
@@ -101,7 +107,7 @@ ante member suspend strategy-dev-01 [--format json]
 **권한: master-only**. agent token이면 service layer `_assert_master`에서 거부된다.
 
 ```
-ante member reactivate strategy-dev-01 [--format json]
+ante member reactivate strategy-dev-01
 ```
 
 ### `ante member revoke <member_id> --yes`
@@ -109,7 +115,7 @@ ante member reactivate strategy-dev-01 [--format json]
 **권한: master-only**. agent token이면 service layer `_assert_master`에서 거부된다.
 
 ```
-ante member revoke strategy-dev-01 --yes [--format json]
+ante member revoke strategy-dev-01 --yes
 # ⚠️ 이 작업은 되돌릴 수 없습니다. --yes 누락 시 CLI_CONFIRMATION_REQUIRED로 실패합니다.
 ```
 
@@ -118,7 +124,7 @@ ante member revoke strategy-dev-01 --yes [--format json]
 **권한: master-only**. agent token이면 service layer `_assert_master`에서 거부된다.
 
 ```
-ante member rotate-token strategy-dev-01 [--format json]
+ante member rotate-token strategy-dev-01
 # 기존 토큰이 즉시 무효화됩니다.
 # 새 토큰: ante_ak_3f7x...
 ```

--- a/docs/specs/report-store/report-store.md
+++ b/docs/specs/report-store/report-store.md
@@ -104,7 +104,7 @@ AI Agent가 전략 백테스트 후 리포트를 제출하면 시스템에 축�
 
 ### 리포트 제출 스키마 (Agent 참조용)
 
-`ante report schema --format json` 으로 조회 가능한 스키마:
+`ante --format json report schema` 로 조회 가능한 스키마 (`--format`은 root 전역 옵션):
 
 ```json
 {


### PR DESCRIPTION
Closes #1661

## Summary
- 문서/Agent workflow의 trailing/bracketed/multiline `--format json` 예시 중 @format_option 미보유(ROOT-ONLY) 명령의 것을 root form `ante --format json <cmd>`로 정렬. introspection-driven parser-script가 권위 메커니즘(전체 추적 .md docs/guide/.agent+AGENTS/README · inline/fenced/multiline · 현 main baseline 24 → 픽스 후 RO_LEAF_FORMAT_HITS=0 기계검증).
- 8 .md(.agent/agents/strategy-dev.md·audit·backtest/03-cli·bot/06-cli·cli/03-commands·cli/04-agent-workflows·member/06-cli·report-store). 코드 변경 0.
- `audit list [--format json|table]`: root 정렬 + 미지원 `table` 제거(root formatter는 text/json만). false-positive 가드(member reset-password/regenerate-recovery-key). TRAIL-OK(strategy list/info, trade list, treasury snapshot, member list-invalid-roles:613 등) 무변경.
- Plan Preflight: approve-implement (6R 수렴: v1/v2 regex→v3 parser-script→v4 broadened(.agent+inline)→v5/v6 stale-baseline 텍스트).

## Test Plan
- parser-script 기계검증: baseline 24 → post-fix RO_LEAF_FORMAT_HITS=0 (3회 일관)
- TRAIL-OK 무변경 `git diff` 검증 · false-positive 가드 적용
- docs/cli pytest `-k "docs or cli or spec or format"` 1456 passed·0 failed
- Codex 브랜치 리뷰 (attempt 1): PASS

## Non-Goals (별도 follow-up 후보)
- 모든 명령 `@format_option` 추가 / root formatter `table` 지원 = 코드 변경, 본 PR 비대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)