### PR TITLE
docs: #1662 account-scoped CLI 필수 --account를 required 형태로 정렬

### DIFF
--- a/docs/specs/broker-adapter/14-cli.md
+++ b/docs/specs/broker-adapter/14-cli.md
@@ -14,16 +14,16 @@ Broker Adapter 관점의 런타임 경계만 설명한다.
 
 ```bash
 # 연결 상태 확인
-ante broker status [--account domestic]
+ante broker status --account <account_id>
 
 # 잔고 조회
-ante broker balance [--account domestic]
+ante broker balance --account <account_id>
 
 # 포지션 조회
-ante broker positions [--account domestic]
+ante broker positions --account <account_id>
 
 # 포지션 대사
-ante broker reconcile [--account domestic] [--fix]
+ante broker reconcile --account <account_id> [--fix]
 ```
 
 historical/public market data 조회는 `data` 또는 `feed` 계열 커맨드가 담당한다.

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -105,16 +105,16 @@ allowlist 후보에서 제거한다.
 | `ante strategy list` | `offline` | StrategyRegistry 조회 |
 | `ante strategy info <name>` | `offline` | StrategyRegistry 조회 |
 | `ante strategy performance <name> [--account-id <account_id>]` | `offline` | 성과 DB 집계 |
-| `ante treasury status [--account <account_id>]` | `offline` | persisted treasury 상태 조회 |
+| `ante treasury status --account <account_id>` | `offline` | persisted treasury 상태 조회 (`--account` 필수) |
 | `ante treasury allocate <bot_id> <amount> --account <account_id>` | `runtime IPC` | 서버 TreasuryManager 캐시 갱신 |
 | `ante treasury deallocate <bot_id> <amount> --account <account_id>` | `runtime IPC` | 서버 TreasuryManager 캐시 갱신 |
-| `ante treasury snapshot ...` | `offline` | 일별 snapshot 조회 |
+| `ante treasury snapshot --account <account_id> ...` | `offline` | 일별 snapshot 조회 (`--account` 필수) |
 | `ante rule list --account <account_id> [--scope global|strategy]` | `offline` | rule 설정 조회 (`--account` 필수) |
 | `ante rule info <rule_id> --account <account_id>` | `offline` | rule 설정 조회 (`--account` 필수) |
-| `ante broker status [--account <account_id>]` | `runtime IPC` | 서버 BrokerAdapter live 상태 |
-| `ante broker balance [--account <account_id>]` | `runtime IPC` | 서버 BrokerAdapter live 조회 |
-| `ante broker positions [--account <account_id>]` | `runtime IPC` | 서버 BrokerAdapter live 조회 |
-| `ante broker reconcile [--account <account_id>] [--fix]` | `runtime IPC` | 서버 PositionReconciler |
+| `ante broker status --account <account_id>` | `runtime IPC` | 서버 BrokerAdapter live 상태 (`--account` 필수) |
+| `ante broker balance --account <account_id>` | `runtime IPC` | 서버 BrokerAdapter live 조회 (`--account` 필수) |
+| `ante broker positions --account <account_id>` | `runtime IPC` | 서버 BrokerAdapter live 조회 (`--account` 필수) |
+| `ante broker reconcile --account <account_id> [--fix]` | `runtime IPC` | 서버 PositionReconciler (`--account` 필수) |
 | `ante data list/schema/storage/validate ...` | `offline` | canonical data root 또는 명시 data path 대상 |
 | `ante backtest run <strategy_path> ...` | `offline` | 서버와 분리된 백테스트 실행 |
 | `ante backtest history <strategy_name> [--limit N]` | `offline` | BacktestRunStore 조회 |
@@ -376,14 +376,14 @@ ante strategy performance <name> [--account-id <account_id>]  # 전략 전체 �
 ### `ante treasury` — 자금 관리
 
 ```bash
-ante treasury status [--account <account_id>]    # 자금 현황 (계좌별 필터링)
+ante treasury status --account <account_id>      # 자금 현황 (계좌별 필터링)
 ante treasury allocate <bot_id> <금액> --account <account_id>    # 봇에 자금 할당
 ante treasury deallocate <bot_id> <금액> --account <account_id>  # 봇 자금 회수
 
 # 일별 자산 스냅샷 조회
-ante treasury snapshot [--account <account_id>]                        # 최근 스냅샷 (대시보드 D-1)
-ante treasury snapshot --from <날짜> --to <날짜> [--account <account_id>]  # 기간별 스냅샷 (대시보드 D-2 차트)
-ante treasury snapshot --date <날짜> [--account <account_id>]          # 특정일 스냅샷
+ante --format json treasury snapshot --account <account_id>                        # 최근 스냅샷 (대시보드 D-1)
+ante --format json treasury snapshot --from <날짜> --to <날짜> --account <account_id>  # 기간별 스냅샷 (대시보드 D-2 차트)
+ante --format json treasury snapshot --date <날짜> --account <account_id>          # 특정일 스냅샷
 ```
 
 `treasury snapshot`의 `--from`/`--to`가 모두 지정되고 시작일(`--from`)이
@@ -417,10 +417,10 @@ ante rule info <rule_id> --account <account_id>           # 룰 상세
 ### `ante broker` — 증권사 연동
 
 ```bash
-ante broker status [--account <account_id>]      # 증권사 연결 상태
-ante broker balance [--account <account_id>]     # 실제 증권사 잔고 조회
-ante broker positions [--account <account_id>]   # 실제 증권사 포지션 조회
-ante broker reconcile [--account <account_id>] [--fix]  # 시스템↔증권사 포지션 대사
+ante broker status --account <account_id>        # 증권사 연결 상태
+ante broker balance --account <account_id>       # 실제 증권사 잔고 조회
+ante broker positions --account <account_id>     # 실제 증권사 포지션 조회
+ante broker reconcile --account <account_id> [--fix]  # 시스템↔증권사 포지션 대사
 ```
 
 모든 `broker` live 커맨드는 서버가 시작 시 생성한 BrokerAdapter를 통해 실행하는

--- a/docs/specs/rule-engine/12-cli.md
+++ b/docs/specs/rule-engine/12-cli.md
@@ -10,10 +10,10 @@ Rule Engine 관점의 조회 예시만 제공한다.
 
 ```bash
 # 룰 목록 조회
-ante rule list [--scope global|strategy]
+ante rule list --account <account_id> [--scope global|strategy]
 
 # 룰 상세 조회
-ante rule info <rule_id>
+ante rule info <rule_id> --account <account_id>
 ```
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조

--- a/docs/specs/treasury/07-cli.md
+++ b/docs/specs/treasury/07-cli.md
@@ -10,7 +10,7 @@ Treasury 관점의 사용 예시만 제공한다.
 
 ```bash
 # 자금 현황 조회
-ante treasury status [--account domestic]
+ante treasury status --account <account_id>
 
 # 자금 할당/회수
 ante treasury allocate <bot_id> <amount> --account domestic

--- a/docs/specs/treasury/08-daily-asset-snapshots.md
+++ b/docs/specs/treasury/08-daily-asset-snapshots.md
@@ -118,11 +118,11 @@ Treasury 퍼블릭 메서드:
 
 ```bash
 # 최근 스냅샷 조회
-ante treasury snapshot --format json
+ante --format json treasury snapshot --account <account_id>
 
 # 기간별 스냅샷 조회 (차트 데이터)
-ante treasury snapshot --from 2026-01-01 --to 2026-03-21 --format json
+ante --format json treasury snapshot --from 2026-01-01 --to 2026-03-21 --account <account_id>
 
 # 특정일 스냅샷 조회
-ante treasury snapshot --date 2026-03-20 --format json
+ante --format json treasury snapshot --date 2026-03-20 --account <account_id>
 ```


### PR DESCRIPTION
Closes #1662

## Summary
- account-scoped CLI 명령의 필수 `--account`를 docs/specs 5개 .md에서 `[--account ...]` 선택표기/누락 → `--account <account_id>` 필수형으로 정렬 (introspection SSOT × root-option-aware parser-script × 4-bucket)
- 변경: broker-adapter/14-cli.md, cli/03-commands.md, rule-engine/12-cli.md, treasury/07-cli.md, treasury/08-daily-asset-snapshots.md (5 files, 24+/24-)
- introspection REQ = Click `required=True` `--account` 10개 명령(broker balance/positions/reconcile/status, rule info/list, treasury allocate/deallocate/snapshot/status). strategy performance `--account-id`는 Click `required=False`(semantic-required) → parser 자동제외, narrow-scope Non-Goal (follow-up 후보)
- #1661 root-form 정합 유지(treasury snapshot `ante --format json treasury snapshot ... --account <account_id>`)
- OUT 31건(guide/cli.md 카탈로그·ipc/audit 매핑·SSOT prose·dashboard) 규칙대로 무변경

## Test Plan
- parser-script(root-option-aware) baseline 55 raw hits → 픽스 후 A/B-clarify class 잔존 **0**, OUT-only 31 무변경
- introspection REQ=10 재확인 (strategy performance 자동제외 검증)
- docs/spec pytest 48 + account 103 passed, 0 failed
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 = PASS (approve, No material findings)
