### PR TITLE
docs: #1663 approval reopen 옵션 SSOT를 실제 Click(--body/--params)로 정정

### DIFF
--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -535,7 +535,7 @@ ante approval review <approval_id> --result pass|warn|fail [--detail <text>]  # 
 ante approval cancel <approval_id>          # 승인 요청 취소
 ante approval approve <approval_id>         # 승인 요청 승인
 ante approval reject <approval_id>          # 승인 요청 거부
-ante approval reopen <approval_id> [--data <json>]  # 거절된 요청 재상신 (params/body 수정 가능)
+ante approval reopen <approval_id> [--body <text>] [--params <json>]  # 거절된 요청 재상신 (params/body 수정 가능)
 ante approval audit-types [--status <상태>]   # legacy invalid-type row 식별 (#1472, scope approval:read)
 ante approval cancel-invalid <approval_id>    # legacy invalid-type row administrative cleanup (#1472, scope approval:admin)
 ```


### PR DESCRIPTION
Closes #1663

## Summary
- `docs/specs/cli/03-commands.md:538` approval reopen 옵션 SSOT가 실제 Click command와 drift: `[--data <json>]` 안내 → 실제 `reopen`은 `--body`/`--params`(+root `--format`)만 정의, `--data`는 `No such option` (oracle A7).
- introspection·소스·스펙 어디에도 `--data` alias 계약 없고 canonical `docs/specs/approval/09-cli.md`가 이미 `--body`/`--params` 형태 → SSOT 문서 정정(이슈 옵션 B). CLI alias 신설은 Non-Goal.
- 단일 셀 1라인 교체: `[--data <json>]` → `[--body <text>] [--params <json>]` (같은 파일 531행 `approval request` 스타일 1:1 미러, 트레일링 주석 `# 거절된 요청 재상신 (params/body 수정 가능)` 유지). 1 file, 1+/1-.
- guide/cli.md 생성물(옵션테이블 자동정확)·ipc.md 매핑·approval.md heading = OUT 무변경, 09-cli.md = B-untouched canonical.

## Test Plan
- introspection-driven parser-script(complete-by-construction) baseline=1(현 main 실측, plan-preflight) → 픽스 후 `REOPEN_OPT_DRIFT_HITS=0`, `REOPEN_OPTS={--body,--format,--params}` 불변
- pytest 회귀 69 passed (test_generate_cli_reference / test_cli_approval_params_shape / test_cli_config_approval_broker_ipc / test_cold_path_terminology)
- reviewer-diff: Non-Goal/OUT 파일 전부 무변경 (정확히 1 file changed)
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 = PASS (no material findings)
