### PR TITLE
fix: #1673 config set invalid log_level을 CONFIG_VALIDATION_ERROR JSON envelope로 정리

### DIFF
--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -117,6 +117,7 @@ JSON 모드(`--format json`)에서는 `{status: "error", code: "...", message: "
 | `UPDATE_SERVER_RUNNING` | `ante update --force` 없이 서버가 실행 중 | `update` |
 | `APPROVAL_VALIDATION_ERROR` | `approval request --type` 값이 SSOT enum에 없음 | `approval request` |
 | `REPORT_VALIDATION_ERROR` | report 명령 입력 계약 위반 (제출 리포트 JSON/스키마 위반, `report performance --period monthly --year` 가 비양수 calendar year) | `report submit`, `report performance` |
+| `CONFIG_VALIDATION_ERROR` | `config set <key> <value>` 의 key-invariant 위반 (enum SSOT가 정의된 키에 invalid 값, 예 `system.log_level` 이 `_VALID_LOG_LEVELS` 비멤버) | `config set` |
 
 `--broker-config`는 1.0 범위에서 free-form pass-through(아래 silent ignore trade-off
 참조)이므로 본 이슈에서는 `UNKNOWN_BROKER_CONFIG_KEY`를 정의하지 않는다.

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -122,7 +122,7 @@ allowlist 후보에서 제거한다.
 | `ante feed init/status/config/inject/run ...` | `offline` | canonical data root의 feed 작업 |
 | `ante feed start [--data-path <path>]` | `external process` | 장기 실행 feed scheduler |
 | `ante config get [key]` | `offline` | static/dynamic config 조회 |
-| `ante config set <key> <value>` | `runtime IPC` | 서버 DynamicConfigService + EventBus |
+| `ante config set <key> <value>` | `runtime IPC` | 서버 DynamicConfigService + EventBus. enum SSOT가 정의된 키(예 `system.log_level`)에 invalid 값 → `CONFIG_VALIDATION_ERROR` + `--format json` 시 `{status:"error",code,message}` envelope (exit 1, traceback 미노출) |
 | `ante config history <key>` | `offline` | dynamic config history 조회 |
 | `ante approval request/approve/reject/cancel/reopen ...` | `runtime IPC` | 서버 ApprovalService + Notification/EventBus |
 | `ante approval list/info/review ...` | `offline` | approval 저장소 조회 |

--- a/src/ante/cli/commands/config.py
+++ b/src/ante/cli/commands/config.py
@@ -146,8 +146,32 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
 
     try:
         result = _run(_run_set())
-    except click.ClickException:
-        raise
+    except click.ClickException as e:
+        # #1673 oracle A7: invalid log_level 같은 서비스 경계 입력 오류는
+        # ipc_send 가 error envelope를 ClickException 으로 변환한다. bare
+        # 재raise 하면 Click 기본 처리가 ``Error: ...`` 를 stderr 로 출력하고
+        # exit 1 로 종료해 JSON 모드 stdout 이 비어 envelope 계약이 깨진다
+        # (probe stdout_status=None). #1655-1657 envelope discipline 미러:
+        # ipc_send 가 부착한 원본 code/message 를 split 없이 복원해
+        # text/JSON 공용으로 구조화된 에러를 출력하고 SystemExit(1) 한다
+        # (_validators.reject_invalid_account_id 패턴).
+        code = getattr(e, "ipc_error_code", "")
+        message = getattr(e, "ipc_error_message", None)
+        if message is None:
+            # 비-IPC ClickException(서버 미기동/타임아웃 등): code 속성이
+            # 없으면 ``str(e)`` 가 사람용 메시지 그대로다.
+            message = str(e)
+        if fmt.is_json:
+            # probe 계약: stdout 으로 {status,code,message} 분리 필드.
+            fmt.error(message, code=code)
+        else:
+            # 텍스트 모드는 ``OutputFormatter.error`` 가 code 를 출력하지
+            # 않으므로, 기존 Click 기본 처리(``Error: {code}: {message}``)
+            # 와 동치가 되도록 code 를 message 에 prefix 한다
+            # (test_config_set_server_error 톤 보존).
+            text = f"{code}: {message}" if code else message
+            fmt.error(text)
+        raise SystemExit(1) from e
     except Exception as e:
         fmt.error(str(e))
         return

--- a/src/ante/cli/commands/ipc_helpers.py
+++ b/src/ante/cli/commands/ipc_helpers.py
@@ -82,7 +82,16 @@ async def ipc_send(
         error = response.get("error", {})
         code = error.get("code", "UNKNOWN")
         message = error.get("message", "알 수 없는 오류")
-        raise click.ClickException(f"{code}: {message}")
+        # 기존 소비자 호환: ``str(exc)`` 는 종전과 동일하게
+        # ``"{code}: {message}"`` 를 반환한다(동작 불변, 순수 additive).
+        # config set 처럼 JSON envelope를 직접 만들어야 하는 호출자가
+        # 원본 code/message 를 split 없이 복원할 수 있도록 속성을
+        # 부착한다 (#1673 택A — ipc_send 변경이 다수 명령에 회귀를
+        # 유발하지 않도록 raise 문자열·시그니처는 그대로 둔다).
+        exc = click.ClickException(f"{code}: {message}")
+        exc.ipc_error_code = code  # type: ignore[attr-defined]
+        exc.ipc_error_message = message  # type: ignore[attr-defined]
+        raise exc
 
     # "result" 키가 있으면 inner result만, 없으면 전체 응답 반환
     return response.get("result", response)

--- a/src/ante/config/__init__.py
+++ b/src/ante/config/__init__.py
@@ -3,11 +3,12 @@
 from ante.config.config import Config, resolve_config_dir
 from ante.config.defaults import DEFAULTS
 from ante.config.dynamic import DynamicConfigService
-from ante.config.exceptions import ConfigError
+from ante.config.exceptions import ConfigError, ConfigValidationError
 
 __all__ = [
     "Config",
     "ConfigError",
+    "ConfigValidationError",
     "DEFAULTS",
     "DynamicConfigService",
     "resolve_config_dir",

--- a/src/ante/config/dynamic.py
+++ b/src/ante/config/dynamic.py
@@ -20,7 +20,7 @@ import logging
 import math
 from typing import TYPE_CHECKING, Any
 
-from ante.config.exceptions import ConfigError
+from ante.config.exceptions import ConfigError, ConfigValidationError
 
 if TYPE_CHECKING:
     from ante.core.database import Database
@@ -96,10 +96,17 @@ def validate_value(key: str, value: Any) -> None:
     ``"debug"`` 같은 소문자 입력은 ValueError 로 거부된다 (#1379 oracle A7).
 
     Raises:
-        ValueError: 키별 invariant 또는 numeric finite invariant 를 위반한 경우.
-            호출자(web/IPC/CLI)는 이를 422 등 도메인 응답으로 변환해야 한다.
+        ValueError: numeric finite invariant 를 위반한 경우 (#1412, generic
+            가드 — 별 multi-consumer 표면이라 코드화 비목표).
+        ConfigValidationError: ``system.log_level`` 같은 키별 enum invariant
+            를 위반한 경우. ``ValueError`` 서브클래스이므로 web 글로벌
+            핸들러는 그대로 422로 변환하고, IPC 서버는 ``.code`` 속성으로
+            ``CONFIG_VALIDATION_ERROR`` 안정코드를 envelope에 노출한다
+            (#1673). 호출자(web/IPC/CLI)는 이를 도메인 응답으로 변환한다.
     """
     # Generic numeric finite 가드 (#1412). dict/list 내부까지 재귀 검사한다.
+    # 이 ValueError 는 별 multi-consumer 표면이므로 코드화하지 않는다 (#1673
+    # Non-Goal). 무변경.
     ok, bad = _is_value_finite(value)
     if not ok:
         raise ValueError(
@@ -109,7 +116,10 @@ def validate_value(key: str, value: Any) -> None:
 
     if key == "system.log_level":
         if not isinstance(value, str) or value not in _VALID_LOG_LEVELS:
-            raise ValueError(
+            # 메시지 문구·대소문자 정책 불변 (#1379 테스트 보존). 예외
+            # 타입만 ConfigValidationError(≤ValueError)로 승격해 CLI/IPC가
+            # CONFIG_VALIDATION_ERROR JSON envelope로 정리하도록 한다 (#1673).
+            raise ConfigValidationError(
                 "system.log_level은 _VALID_LOG_LEVELS 멤버여야 합니다 (대소문자 구분)."
             )
 

--- a/src/ante/config/exceptions.py
+++ b/src/ante/config/exceptions.py
@@ -5,3 +5,28 @@ class ConfigError(Exception):
     """Config 기본 예외."""
 
     pass
+
+
+class ConfigValidationError(ValueError):
+    """동적 설정 키-invariant 위반 (write 경계 입력 오류).
+
+    ``validate_value`` 에서 ``system.log_level`` 처럼 enum SSOT가 정의된
+    키가 invalid 값을 받았을 때 raise된다 (#1673 oracle A7).
+
+    이중 계약 (호출자별 변환):
+
+    - **web**: ``ValueError`` 서브클래스이므로 ``src/ante/web/errors.py`` 의
+      글로벌 ``@app.exception_handler(ValueError)`` 가 그대로 잡아 **422**
+      로 변환한다 (응답 스키마/거부값 노출 정책은 기존 그대로, 본 이슈
+      비목표). **반드시 ``ValueError`` 서브클래스로 유지**해야 한다 —
+      기존 service-boundary 테스트(``pytest.raises(ValueError, ...)``)와
+      web 422 핸들러가 이 불변조건에 의존한다(비회귀).
+    - **IPC**: 서버 ``src/ante/ipc/server.py`` 의 ``except Exception`` 핸들러가
+      ``getattr(e, "code", "EXECUTION_ERROR")`` 로 안정 에러코드를 산출한다
+      (#1144 S5). ``code`` 클래스 속성을 보유하므로 입력 오류가
+      ``EXECUTION_ERROR`` 로 오분류되지 않고 ``CONFIG_VALIDATION_ERROR``
+      로 envelope에 노출된다. CLI 클라이언트는 이 코드를 그대로
+      ``{status:"error", code, message}`` 로 stdout에 출력한다.
+    """
+
+    code = "CONFIG_VALIDATION_ERROR"

--- a/tests/unit/test_cli_config_approval_broker_ipc.py
+++ b/tests/unit/test_cli_config_approval_broker_ipc.py
@@ -6,6 +6,7 @@ broker reconcile --fix 커맨드가 IPCClient를 통해 서버에 전달되는�
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -98,6 +99,69 @@ class TestConfigSetIPC:
 
         assert result.exit_code != 0
         assert "STATIC_CONFIG" in result.output
+
+    def test_config_set_invalid_log_level_json_envelope(
+        self, runner: CliRunner
+    ) -> None:
+        """#1673 oracle A7: invalid log_level → clean JSON error envelope.
+
+        traceback/Click ``Error:`` 누출 없이 stdout 으로
+        ``{status:"error",code:"CONFIG_VALIDATION_ERROR",message}`` +
+        exit 1 을 반환해야 한다.
+        """
+        mock_client, ipc_cls_patch, socket_patch = _patch_ipc()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {
+                "code": "CONFIG_VALIDATION_ERROR",
+                "message": (
+                    "system.log_level은 _VALID_LOG_LEVELS 멤버여야 합니다 "
+                    "(대소문자 구분)."
+                ),
+            },
+        }
+
+        with ipc_cls_patch, socket_patch:
+            result = runner.invoke(
+                cli,
+                ["config", "set", "system.log_level", "debug", "--format", "json"],
+            )
+
+        assert result.exit_code == 1, result.output
+        data = json.loads(result.stdout)
+        assert data == {
+            "status": "error",
+            "code": "CONFIG_VALIDATION_ERROR",
+            "message": (
+                "system.log_level은 _VALID_LOG_LEVELS 멤버여야 합니다 (대소문자 구분)."
+            ),
+        }
+        # traceback / Click 기본 ``Error:`` stderr 누출이 없어야 한다.
+        assert "Traceback" not in result.output
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+
+    def test_config_set_invalid_log_level_text_mode(self, runner: CliRunner) -> None:
+        """텍스트 모드 동치: exit 1 + 코드/메시지 stderr (server_error 톤 보존)."""
+        mock_client, ipc_cls_patch, socket_patch = _patch_ipc()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {
+                "code": "CONFIG_VALIDATION_ERROR",
+                "message": (
+                    "system.log_level은 _VALID_LOG_LEVELS 멤버여야 합니다 "
+                    "(대소문자 구분)."
+                ),
+            },
+        }
+
+        with ipc_cls_patch, socket_patch:
+            result = runner.invoke(cli, ["config", "set", "system.log_level", "debug"])
+
+        assert result.exit_code == 1, result.output
+        assert "CONFIG_VALIDATION_ERROR" in result.output
+        assert "Traceback" not in result.output
 
 
 # ── Approval IPC ────────────────────────────────

--- a/tests/unit/test_dynamic_config.py
+++ b/tests/unit/test_dynamic_config.py
@@ -4,7 +4,7 @@ import math
 
 import pytest
 
-from ante.config import ConfigError, DynamicConfigService
+from ante.config import ConfigError, ConfigValidationError, DynamicConfigService
 from ante.config.dynamic import _is_value_finite, validate_value
 from ante.core import Database
 from ante.eventbus.events import ConfigChangedEvent
@@ -172,6 +172,58 @@ async def test_set_non_string_log_level_raises_value_error(service, eventbus):
         await service.set("system.log_level", 10, category="system")
     with pytest.raises(ValueError, match="system.log_level"):
         await service.set("system.log_level", None, category="system")
+
+    assert not await service.exists("system.log_level")
+    assert eventbus.published == []
+
+
+# ── #1673 oracle A7: ConfigValidationError 이중 계약 보증 ────────────
+
+
+def test_config_validation_error_is_value_error_subclass():
+    """``ConfigValidationError`` 는 ``ValueError`` 서브클래스여야 한다.
+
+    비회귀 불변조건 — web 글로벌 ``@app.exception_handler(ValueError)``
+    422 핸들러와 기존 service-boundary 테스트(``pytest.raises(ValueError)``)
+    가 이 관계에 의존한다 (#1673).
+    """
+    assert isinstance(ConfigValidationError(), ValueError) is True
+    assert issubclass(ConfigValidationError, ValueError)
+
+
+def test_config_validation_error_has_stable_code():
+    """IPC 서버 ``getattr(e, "code", ...)`` 안정코드 계약 (#1144 S5 / #1673)."""
+    assert ConfigValidationError.code == "CONFIG_VALIDATION_ERROR"
+    assert ConfigValidationError("msg").code == "CONFIG_VALIDATION_ERROR"
+
+
+def test_validate_value_invalid_log_level_raises_config_validation_error():
+    """invalid ``system.log_level`` → ``ConfigValidationError`` (#1673).
+
+    예외 타입만 승격됐고 메시지 문구·대소문자 정책은 불변이라 기존
+    ``pytest.raises(ValueError, match=...)`` 테스트가 그대로 통과한다.
+    generic numeric-finite ValueError(#1412)는 무변경(별 표면).
+    """
+    with pytest.raises(ConfigValidationError, match="system.log_level"):
+        validate_value("system.log_level", "ORACLE_INVALID_LEVEL")
+    with pytest.raises(ConfigValidationError, match="대소문자 구분"):
+        validate_value("system.log_level", "debug")
+    with pytest.raises(ConfigValidationError, match="system.log_level"):
+        validate_value("system.log_level", 10)
+    with pytest.raises(ConfigValidationError, match="system.log_level"):
+        validate_value("system.log_level", None)
+
+    # generic numeric-finite 가드는 ConfigValidationError 가 아닌 plain
+    # ValueError 로 유지된다 (#1412 무변경, #1673 Non-Goal).
+    with pytest.raises(ValueError, match="finite") as exc_info:
+        validate_value("risk.max_mdd_pct", float("nan"))
+    assert not isinstance(exc_info.value, ConfigValidationError)
+
+
+async def test_set_invalid_log_level_raises_config_validation_error(service, eventbus):
+    """서비스 경계도 ``ConfigValidationError`` 를 전파한다 (#1673)."""
+    with pytest.raises(ConfigValidationError, match="system.log_level"):
+        await service.set("system.log_level", "ORACLE_INVALID_LEVEL", category="system")
 
     assert not await service.exists("system.log_level")
     assert eventbus.published == []


### PR DESCRIPTION
Closes #1673

## Summary
- oracle A7 invalid-input: `ante --format json config set system.log_level <invalid>`가 traceback/빈 stdout(exit 1) 대신 clean JSON envelope `{status:"error",code:"CONFIG_VALIDATION_ERROR",message}`를 stdout으로 반환하도록 정리.
- coordinated single-invariant 다층 수정: `ConfigValidationError(ValueError)` 신설(`code="CONFIG_VALIDATION_ERROR"`, **ValueError 서브클래스 불변조건** → web 422 핸들러/기존 service 테스트 비회귀) → `validate_value` log_level key-invariant가 이를 raise → 서버 #1144 S5 `getattr(e,"code")`가 자동 안정코드 노출 → `config_set` `except click.ClickException` 분기를 `fmt.error(message,code)`+`SystemExit(1)`로 (JSON/텍스트 공용, #1655-1657 envelope discipline 미러).
- ipc_send 택A: error envelope ClickException에 `.ipc_error_code`/`.ipc_error_message` additive 부착(`str(exc)` 불변 → ipc 소비명령 회귀 0).
- 스펙 SSOT: `02-design-decisions.md` 에러코드 표 `CONFIG_VALIDATION_ERROR` 행 + `03-commands.md` config set 계약 명시.

## Test Plan
- 회귀 5스위트 183 pass / ipc 소비명령(bot·treasury·system·approval·config) 77 pass(택A 회귀 0) / web 422 log_level 비회귀 3 pass / mypy src/ 전체 Success / ruff check+format pass
- 기존 `pytest.raises(ValueError, match="system.log_level"/"대소문자 구분")` 3건 보존(서브클래스 보증)
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 = PASS (회귀·계약위반 미발견)
