### PR TITLE
docs: #1678 #1213 머지 후 stale 구현상태 노트 제거 (web-api/04-system-endpoints + ipc 대칭)

### DIFF
--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -65,8 +65,6 @@ CLI 명령 시그니처와 전체 실행 분류의 SSOT는
 
 #### System
 
-> ⚠️ **구현 상태**: `system.halt` IPC 커맨드는 이미 `CommandRegistry`에 등록되어 동작한다. `system.clear_halt`는 본 이슈(#1212)에서 SSOT로 확정되었으나, `CommandRegistry.register_all_handlers()`와 CLI 송신 이름 정렬, legacy `system.activate` 제거는 [#1213](https://github.com/joshua-jingu-lee/ante/issues/1213)에서 구현된다. #1213 머지 전에는 기존 `system.activate`가 등록되어 있으며, `system.clear_halt`로 호출하면 unknown command가 된다.
-
 | CLI 커맨드 | IPC 커맨드 | 서비스 메서드 | IPC 필요 사유 |
 |-----------|-----------|-------------|-------------|
 | `ante system halt` | `system.halt` | `AccountService.suspend_all()` | `AccountSuspendedEvent` → BotManager 소속 봇 중지 |

--- a/docs/specs/web-api/04-system-endpoints.md
+++ b/docs/specs/web-api/04-system-endpoints.md
@@ -6,8 +6,6 @@
 
 > 각 엔드포인트의 요청/응답 스키마, 파라미터 상세, 에러 코드는 Swagger UI(`/docs`)를 참조한다. 아래 표는 전체 엔드포인트 목록과 용도를 요약한다.
 
-> ⚠️ **구현 상태**: `POST /api/system/halt` 라우트는 이미 동작한다 (base 코드 `src/ante/web/routes/system.py`에 등록됨). `POST /api/system/clear-halt`는 본 이슈(#1212)에서 SSOT로 확정되었으나, 실제 FastAPI 라우터·OpenAPI 생성·legacy `/api/system/activate` 제거는 [#1213](https://github.com/joshua-jingu-lee/ante/issues/1213)에서 구현된다. #1213 머지 전에는 기존 `/api/system/activate`가 동작하며, `/api/system/clear-halt`를 호출하면 404가 반환된다. 응답 shape(`status`, `accounts_changed`, `accounts[]`)는 본 SSOT를 기준으로 #1213이 구현한다.
-
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/api/system/status` | 시스템 상태 (status, version) |


### PR DESCRIPTION
Closes #1678

## Summary
- oracle A7 docs-drift: #1213 머지 후에도 `docs/specs/web-api/04-system-endpoints.md`(L9)와 isomorphic sibling `docs/specs/ipc/ipc.md`(L68)의 ⚠️ 구현상태 노트가 "#1213 머지 전 — clear-halt 404·activate 동작/등록"으로 ground truth(clear-halt/halt present·activate absent / system.clear_halt 등록·system.activate 미등록)와 정반대.
- 두 stale transitional 노트 단락을 대칭 제거(ground-truth-authoritative + 전 추적 .md axis-sweep로 isomorphic sibling 동반 처리). 코드·endpoint/IPC 테이블·Kill Switch 응답 SSOT·ci-cd.md 무변경.

## Test Plan
- 픽스 후 sweep `git ls-files '*.md' | xargs grep "#1213 머지 전|/api/system/activate|system.activate"` = 0건 (두 stale 노트 완전 제거)
- ground truth: registry.py:420-421 system.clear_halt 등록·system.activate 부재 / system.py:354,416 clear-halt — 코드 무변경 확정
- reviewer-diff: 2 files, 4 deletions, 0 insertions; 테이블/SSOT 섹션 무변경
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 = PASS (회귀 미발견)
