### PR TITLE
docs: #1679 비활성 /api/notifications를 paginated-route 주장에서 제거 (#1660 dual-fix)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -230,7 +230,7 @@ src/ante/
 │   │   ├── config.py                 # /api/config 라우트 (동적 설정 조회/변경)
 │   │   ├── data.py                   # /api/data 라우트
 │   │   ├── members.py                # /api/members 라우트 (멤버 관리)
-│   │   ├── notifications.py          # /api/notifications 라우트 (cursor 페이지네이션)
+│   │   ├── notifications.py          # 알림 API (stub, 이력 조회 삭제·텔레그램 이관)
 │   │   ├── portfolio.py              # /api/portfolio 라우트 (자산 가치/추이)
 │   │   ├── reports.py                # /api/reports 라우트 (cursor 페이지네이션)
 │   │   ├── strategies.py             # /api/strategies 라우트

--- a/docs/specs/web-api/06-pagination.md
+++ b/docs/specs/web-api/06-pagination.md
@@ -14,4 +14,4 @@
 | `decode_cursor(cursor)` | 인코딩된 커서를 디코딩. strict URL-safe base64 + canonical 동치(`encode_cursor(decode(c))==c`); 빈/비canonical/undecodable → `ValueError('invalid cursor')` → 400 (#1356 동형). 빈 cursor_field 값의 next_cursor emit 정합은 별 follow-up |
 | `paginate(items, cursor_field, limit, cursor)` | 아이템 목록에서 커서 이후 limit건 추출. `{"items": [...], "next_cursor": ... \| None}` 반환 |
 
-적용 엔드포인트: `/api/bots`, `/api/trades`, `/api/notifications`, `/api/reports`
+적용 엔드포인트: `/api/bots`, `/api/trades`, `/api/reports`

--- a/scripts/generate_project_structure.py
+++ b/scripts/generate_project_structure.py
@@ -102,6 +102,9 @@ DEFAULT_DESCRIPTIONS: dict[str, str] = {
         "ante bot create/info/list/positions/remove/signal-key "
         "(start/stop/status 미구현 follow-up)"
     ),
+    "src/ante/web/routes/notifications.py": (
+        "알림 API (stub, 이력 조회 삭제·텔레그램 이관)"
+    ),
     "strategies": "전략 템플릿과 예제",
     "tests": "단위·통합 테스트",
 }


### PR DESCRIPTION
Closes #1679

## Summary
- oracle A7 docs-drift: 비활성 `/api/notifications`(텔레그램 이관·라우터 비활성, route NONE)를 cursor pagination active route로 주장하던 두 표면을 #1660 dual-fix로 동시 정정.
  - 수기 SSOT `docs/specs/web-api/06-pagination.md:17`: 적용 endpoint 목록에서 `/api/notifications` 제거(02-design-decisions.md:27 정 SSOT 정렬).
  - 생성 INDEX `docs/architecture/generated/project-structure.md:233` notifications.py comment 정정 + `scripts/generate_project_structure.py` DEFAULT_DESCRIPTIONS 동기화 → correct-by-generation + generation-independent 증명.
- 02-design-decisions.md:27(정 SSOT)·notifications.py stub·생성기 `_comment_for` 알고리즘 무변경.

## Test Plan
- sweep `git ls-files '*.md' | xargs grep "/api/notifications"` → 02-design:27(정 SSOT, 무변경)만; 06-pagination·project-structure false paginated-route assert 0
- #1660 dual-fix: correct-by-generation(`--check` diff에 notifications 라인 미출현=생성기 산출 일치) + generation-independent(comment 제거→DEFAULT_DESCRIPTIONS fallback 동일·stale 미부활)
- ruff check/format, mypy src/(242) Success
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 = PASS (회귀/실행경로 버그 없음)

## 비고
- `generate_project_structure.py --check` 전체는 notifications와 **무관한 사전존재 stale**(clean main a6be538 자체도 --check fail·79라인: #1614+ core/exchange·market_data_vocab·account_params·test 21건·D-016/D-017 미반영)로 fail. `--check`는 CI 워크플로 미등록=비차단 advisory. 본 PR은 plan Stop Condition대로 notifications 셀 한정, broader project-structure 재동기화는 #1680 도메인으로 분리.
