### PR TITLE
docs: #1680 generated project-structure CLI inventory stale 정합 (#1660 dual-fix + 전체 재생성)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-05-15 (KST)
+> 마지막 생성 시점: 2026-05-20 (KST)
 
 ## 최상위 구조
 
@@ -49,7 +49,9 @@ src/ante/
 │   │   └── setup.py                  # setup_logging() stdout + JSONL 파일 핸들러 구성
 │   ├── __init__.py
 │   ├── registry.py
-│   └── time.py
+│   ├── time.py
+│   ├── exchange.py
+│   └── market_data_vocab.py
 ├── config/
 │   ├── config.py                     # ConfigService — 설정 로딩 (system.toml + secrets.env)
 │   ├── defaults.py                   # 기본 설정값
@@ -248,7 +250,8 @@ src/ante/
 │   ├── deps.py
 │   └── utils/
 │       ├── __init__.py
-│       └── date_params.py
+│       ├── date_params.py
+│       └── account_params.py
 ├── cli/
 │   ├── main.py                       # CLI 루트 그룹 (ante 커맨드)
 │   ├── middleware.py                 # 인증 미들웨어 (require_auth, require_scope)
@@ -261,15 +264,15 @@ src/ante/
 │   │   ├── bot.py                    # ante bot create/info/list/positions/remove/signal-key (start/stop/status 미구현 follow-up)
 │   │   ├── broker.py                 # ante broker 명령
 │   │   ├── config.py                 # ante config 명령
-│   │   ├── data.py                   # ante data list/schema/inject/validate
+│   │   ├── data.py                   # ante data list/schema/storage/validate
 │   │   ├── init.py                   # ante init — 비대화형 최소 초기 설정 (master + 테스트 계좌)
 │   │   ├── instrument.py             # ante instrument list/search/sync/import (--listed-only)
 │   │   ├── member.py                 # ante member register/list/info/suspend/revoke/set-emoji/... (bootstrap은 init으로 통합)
-│   │   ├── notification.py           # ante notification history
-│   │   ├── report.py                 # ante report list/show/schema/performance/view
+│   │   ├── notification.py           # 알림 CLI (public leaf 없음 — 텔레그램 이관)
+│   │   ├── report.py                 # ante report schema/submit/list/performance/view
 │   │   ├── rule.py                   # ante rule 명령
 │   │   ├── signal.py                 # ante signal — 외부 시그널 채널 관리
-│   │   ├── strategy.py               # ante strategy list/validate/load
+│   │   ├── strategy.py               # ante strategy validate/submit/list/info/performance
 │   │   ├── system.py                 # ante system 명령
 │   │   ├── trade.py                  # ante trade 명령
 │   │   ├── treasury.py               # ante treasury 명령
@@ -426,7 +429,8 @@ tests/
 │   │   ├── test_auth_format_json.py
 │   │   ├── test_bot_create_exit_code.py
 │   │   ├── test_broker_missing_account.py
-│   │   └── test_usage_error_json.py
+│   │   ├── test_usage_error_json.py
+│   │   └── test_instrument_exchange_validation.py
 │   ├── ipc/
 │   │   ├── __init__.py
 │   │   ├── test_protocol.py
@@ -610,7 +614,30 @@ tests/
 │   ├── test_cli_pagination_validation.py
 │   ├── test_cli_treasury_amount_validation.py
 │   ├── test_cli_member_master_only.py
-│   └── test_member_admin_master_only.py
+│   ├── test_member_admin_master_only.py
+│   ├── test_api_account_id_invalid_contract.py
+│   ├── test_api_inverted_date_range.py
+│   ├── test_backtest_exchange_plumbing.py
+│   ├── test_backtest_programmatic_vocab_validation.py
+│   ├── test_cli_account_id_construction_lifecycle.py
+│   ├── test_cli_account_id_invalid_contract.py
+│   ├── test_cli_backtest_exchange_validation.py
+│   ├── test_cli_backtest_symbol_timeframe_validation.py
+│   ├── test_cli_data_validate_symbol_timeframe_validation.py
+│   ├── test_cli_e_bucket_mutating_ipc_account_id.py
+│   ├── test_cli_feed_inject_symbol_timeframe_validation.py
+│   ├── test_cli_inverted_date_range.py
+│   ├── test_cli_report_performance_period_options.py
+│   ├── test_core_exchange_vocabulary.py
+│   ├── test_data_collector_ingress_validation.py
+│   ├── test_exchange_vocabulary_contract.py
+│   ├── test_market_data_vocab.py
+│   ├── test_member_create_invalid_type.py
+│   ├── test_pagination_cursor_no_reflection.py
+│   ├── test_report_required_fields_contract.py
+│   ├── test_store_path_safety.py
+│   ├── test_validation_input_reflection.py
+│   └── test_validation_surface_lock.py
 └── __init__.py
 ```
 
@@ -718,7 +745,9 @@ docs/
 │   ├── D-012.md
 │   ├── D-013.md
 │   ├── D-014.md
-│   └── D-015-default-deny-auth-gate.md
+│   ├── D-015-default-deny-auth-gate.md
+│   ├── D-016-canonical-exchange-vocabulary.md
+│   └── D-017-canonical-symbol-timeframe-vocabulary.md
 ├── references/                       # 외부 참조 문서
 │   └── dashboard/
 │       ├── dart-openapi.md

--- a/scripts/generate_project_structure.py
+++ b/scripts/generate_project_structure.py
@@ -102,6 +102,16 @@ DEFAULT_DESCRIPTIONS: dict[str, str] = {
         "ante bot create/info/list/positions/remove/signal-key "
         "(start/stop/status 미구현 follow-up)"
     ),
+    "src/ante/cli/commands/data.py": "ante data list/schema/storage/validate",
+    "src/ante/cli/commands/notification.py": (
+        "알림 CLI (public leaf 없음 — 텔레그램 이관)"
+    ),
+    "src/ante/cli/commands/report.py": (
+        "ante report schema/submit/list/performance/view"
+    ),
+    "src/ante/cli/commands/strategy.py": (
+        "ante strategy validate/submit/list/info/performance"
+    ),
     "src/ante/web/routes/notifications.py": (
         "알림 API (stub, 이력 조회 삭제·텔레그램 이관)"
     ),


### PR DESCRIPTION
Closes #1680

## Summary
- oracle A7 generated docs-drift: `docs/architecture/generated/project-structure.md` CLI inventory가 stale 명령 나열(‎`ante notification history`/`data inject`/`report show`/`strategy load` = No such command).
- #1660 dual-fix: 4 stale CLI 셀 comment를 Click-introspection 등록순으로 정정 + `scripts/generate_project_structure.py` DEFAULT_DESCRIPTIONS 4 엔트리 동기화(parsed-comment precedence 방어, generation-independent) + 전체 재생성.
  - data.py=`ante data list/schema/storage/validate`, notification.py=`알림 CLI (public leaf 없음 — 텔레그램 이관)`, report.py=`ante report schema/submit/list/performance/view`, strategy.py=`ante strategy validate/submit/list/info/performance`
- 전체 재생성으로 #1679-deferred broader project-structure stale(#1614+ file-tree)도 동반 정합 → `--check` exit=0(correct-by-generation). 생성기 알고리즘·03-commands·CLI 코드 무변경.

## Test Plan
- 4 라인 comment == Click introspection 등록순 정확 일치, stale sweep(`notification history|data .*inject|report .*show|strategy .*load`) 0
- `scripts/generate_project_structure.py --check` exit=0 (correct-by-generation, 재생성 결정적·추가 diff 0 독립확인)
- generation-independent 증명(4 comment 제거→재생성 DEFAULT_DESCRIPTIONS fallback 동일·stale 미부활)
- ruff check/format(생성기), mypy src/(242) Success
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 = PASS (python3.13 --check 독립확인, 회귀 없음)
