### PR TITLE
fix: #1682 빈 notification 그룹을 root help·guide/cli.md 양 public 표면에서 숨김 (hidden=True + 생성기 hidden-skip + 재생성)

### DIFF
--- a/guide/cli.md
+++ b/guide/cli.md
@@ -2,7 +2,7 @@
 
 Ante가 제공하는 모든 CLI 명령어를 정리한 문서입니다. 각 명령어의 사용법, 옵션, 필수 권한(scope)을 확인할 수 있습니다.
 
-> 마지막 갱신: 2026-05-15
+> 마지막 갱신: 2026-05-20
 
 ## 목차
 
@@ -86,7 +86,6 @@ Ante가 제공하는 모든 CLI 명령어를 정리한 문서입니다. 각 명�
   - [ante member rotate-token](#ante-member-rotate-token)
   - [ante member reset-password](#ante-member-reset-password)
   - [ante member regenerate-recovery-key](#ante-member-regenerate-recovery-key)
-- [notification — 알림 관리.](#notification-알림-관리)
 - [rule — 거래 룰 조회·관리.](#rule-거래-룰-조회관리)
   - [ante rule list](#ante-rule-list)
   - [ante rule info](#ante-rule-info)
@@ -1303,6 +1302,7 @@ ante backtest run <STRATEGY_PATH> [OPTIONS]
 | `--symbols` | - | TEXT | — | 종목 코드 (콤마 구분) |
 | `--balance` | - | FLOAT | 10000000 | 초기 자금 |
 | `--timeframe` | - | TEXT | 1d | 타임프레임 |
+| `--exchange` | - | TEXT | KRX | 거래소 (기본: KRX) |
 | `--data-path` | - | TEXT | data/ | 데이터 디렉토리 경로 |
 | `--db-path` | - | TEXT | — | DB 경로 (미지정 시 config_dir 기반) |
 
@@ -1780,10 +1780,6 @@ ante member regenerate-recovery-key [OPTIONS]
 
 ---
 
-## notification — 알림 관리.
-
----
-
 ## rule — 거래 룰 조회·관리.
 
 ### ante rule list
@@ -2092,12 +2088,18 @@ ante treasury snapshot [OPTIONS]
 
 ante를 최신 버전으로 업데이트합니다.
 
-`--check`은 PyPI 버전 조회만 수행한다 (`--yes` 불필요).
-`--check`이 아닌 실제 업데이트 실행은 `--yes`가 반드시 필요하며,
-누락 시 prompt 없이 ``CLI_CONFIRMATION_REQUIRED`` 에러로 종료한다.
-`--yes` 게이트는 PyPI 조회 **앞에** 평가하므로, 네트워크 느림/실패
-환경에서도 `--yes` 누락 호출은 PyPI 실패가 아닌 동일한 구조화 에러
-코드로 거절된다.
+게이트 평가 우선순위 (SSOT: docs/specs/cli/02-design-decisions.md
+"위험 명령 확인 방식"):
+``--check`` → ``--yes`` confirmation(``CLI_CONFIRMATION_REQUIRED``)
+→ server-running/``--force``(``UPDATE_SERVER_RUNNING``) → 실제 update.
+
+`--check`은 PyPI 버전 조회만 수행하는 dry-run이다 (`--yes`/server-running
+무관, 최우선). `--check`이 아닌 실제 업데이트 실행은 `--yes`가 반드시
+필요하며, 누락 시 prompt 없이 ``CLI_CONFIRMATION_REQUIRED`` 에러로
+종료한다. `--yes` 게이트는 server 상태 검사와 PyPI 조회 **앞에**
+평가하므로, 서버 실행/네트워크 느림·실패 환경에서도 `--yes` 누락
+호출은 server-running 안내나 PyPI 실패가 아닌 동일한 구조화 에러
+코드로 거절된다 (#1626 D1, Codex P2 2차).
 
 - **필요 scope**: —
 - **토큰**: 인증 불필요

--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -57,6 +57,12 @@ def _collect_commands(
         if cmd is None:
             continue
 
+        # hidden 명령은 public 표면(guide/cli.md)에서 제외한다.
+        # 그룹이 hidden이면 그룹 자체뿐 아니라 하위 재귀도 skip한다.
+        # generic·mechanism-agnostic: 임의의 hidden 명령을 자동 제외한다.
+        if getattr(cmd, "hidden", False):
+            continue
+
         full_name = f"{prefix} {name}".strip() if prefix else name
 
         if isinstance(cmd, click.Group):

--- a/src/ante/cli/commands/notification.py
+++ b/src/ante/cli/commands/notification.py
@@ -9,6 +9,6 @@ from __future__ import annotations
 import click
 
 
-@click.group()
+@click.group(hidden=True)
 def notification() -> None:
     """알림 관리."""

--- a/tests/unit/test_cli_notification_hidden.py
+++ b/tests/unit/test_cli_notification_hidden.py
@@ -1,0 +1,79 @@
+"""notification 빈 그룹의 public 표면(root help) 숨김 회귀 테스트 (#1682).
+
+oracle A7: `ante --help` 가 public leaf 가 없는 `notification` 그룹을
+광고하지만 `ante notification --help` 에는 실행 가능한 subcommand 가
+없었다(dead-end). `@click.group(hidden=True)` 로 root help 에서 숨기되,
+`cli.add_command(notification)` 은 유지하여 직접 invoke 는 보존한다.
+"""
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+
+
+def _commands_section_lines(help_text: str) -> list[str]:
+    """`--help` 출력의 ``Commands:`` 섹션 라인만 추출한다."""
+    lines = help_text.splitlines()
+    out: list[str] = []
+    in_section = False
+    for line in lines:
+        if line.strip() == "Commands:":
+            in_section = True
+            continue
+        if in_section:
+            # Click 은 Commands 섹션이 출력의 마지막 블록이다.
+            if line and not line.startswith(" "):
+                break
+            out.append(line)
+    return out
+
+
+class TestNotificationHidden:
+    """notification 그룹이 hidden 이지만 직접 invoke 는 보존됨을 검증."""
+
+    def test_notification_group_is_hidden(self) -> None:
+        """introspection: ``cli.commands['notification'].hidden is True``."""
+        notification = cli.commands["notification"]
+        assert isinstance(notification, click.Group)
+        assert notification.hidden is True
+
+    def test_root_help_does_not_advertise_notification(self) -> None:
+        """root ``--help`` 의 Commands 섹션에 notification 라인 부재.
+
+        oracle probe ``root_advertises_group`` 의 동치(→False).
+        """
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        section = _commands_section_lines(result.output)
+        # Commands 섹션 라인 단위로 notification 토큰 부재
+        for line in section:
+            tokens = line.split()
+            assert "notification" not in tokens, (
+                f"root help Commands 섹션에 notification 노출: {line!r}"
+            )
+        # 전체 출력에서도 command-list 항목으로 등장하지 않음
+        assert "\n  notification " not in result.output
+
+    def test_notification_direct_invoke_preserved(self) -> None:
+        """직접 invoke 보존: ``ante notification --help`` exit_code == 0."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["notification", "--help"])
+        assert result.exit_code == 0
+        assert "notification" in result.output
+
+    def test_other_groups_still_advertised(self) -> None:
+        """회귀 0: 다른 그룹은 여전히 root help 에 노출된다."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        for group_name in ("broker", "config", "bot", "strategy", "trade"):
+            grp = cli.commands[group_name]
+            assert isinstance(grp, click.Group)
+            assert grp.hidden is False
+            assert group_name in result.output, (
+                f"root help 에 {group_name} 그룹이 사라짐 (회귀)"
+            )

--- a/tests/unit/test_generate_cli_reference.py
+++ b/tests/unit/test_generate_cli_reference.py
@@ -84,6 +84,99 @@ class TestCollectCommands:
         names = [name for name, _ in result]
         assert "grp" in names
 
+    def test_hidden_leaf_command_excluded(self) -> None:
+        """hidden 리프 명령은 수집 결과에서 제외된다 (#1682)."""
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command()
+        def visible() -> None:
+            """노출."""
+
+        @root.command(hidden=True)
+        def secret() -> None:
+            """숨김."""
+
+        result = _collect_commands(root)
+        names = [name for name, _ in result]
+        assert "visible" in names
+        assert "secret" not in names
+
+    def test_hidden_group_and_subtree_excluded(self) -> None:
+        """hidden 그룹은 그룹 자체와 하위 재귀 전체가 제외된다 (#1682).
+
+        notification 빈 그룹을 ``@click.group(hidden=True)`` 로 숨기면
+        guide/cli.md(생성물)에서 그룹 heading 과 하위 명령이 모두
+        사라져야 한다. generic·mechanism-agnostic 검증.
+        """
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.group(name="shown")
+        def visible_grp() -> None:
+            """노출 그룹."""
+
+        @visible_grp.command(name="run")
+        def visible_leaf() -> None:
+            """노출 리프."""
+
+        @root.group(name="hidden", hidden=True)
+        def hidden_grp() -> None:
+            """숨김 그룹."""
+
+        @hidden_grp.command(name="buried")
+        def buried_leaf() -> None:
+            """숨김 그룹 하위 리프."""
+
+        result = _collect_commands(root)
+        names = [name for name, _ in result]
+        # hidden 그룹 자체 + 하위 재귀 전부 부재
+        assert "hidden" not in names
+        assert "hidden buried" not in names
+        # 노출 그룹과 그 하위는 영향 없음 (회귀 0)
+        assert "shown" in names
+        assert "shown run" in names
+
+    def test_hidden_group_absent_from_generated_markdown(self) -> None:
+        """hidden 그룹은 생성된 markdown TOC/heading 에 미포함 (#1682)."""
+
+        @click.group()
+        def root() -> None:
+            """루트."""
+
+        @root.group(hidden=True)
+        def notification() -> None:
+            """알림 관리."""
+
+        @root.group()
+        def shown() -> None:
+            """노출 그룹."""
+
+        @shown.command()
+        def run() -> None:
+            """실행."""
+
+        # get_cli 를 더미 트리로 패치하여 전체 생성 경로를 검증한다.
+        original_get_cli = _mod.get_cli
+        _mod.get_cli = lambda: root
+        try:
+            buf = io.StringIO()
+            generate_cli_reference(buf)
+            content = buf.getvalue()
+        finally:
+            _mod.get_cli = original_get_cli
+
+        assert "notification" not in content
+        assert "## notification" not in content
+        assert "](#notification" not in content
+        # 노출 그룹은 정상 생성 (회귀 0)
+        assert "## shown" in content
+        assert "ante shown run" in content
+
 
 class TestFormatParamType:
     """_format_param_type가 파라미터 타입을 올바르게 포맷팅하는지 검증."""


### PR DESCRIPTION
Closes #1682

## Summary
- oracle A7 CLI-behavior: 빈 `notification` 그룹(‎`notification_history` 제거·텔레그램 이관, public leaf 0)이 두 public 표면(`ante --help` + README-linked 생성 `guide/cli.md`)에 dead-end로 광고됨. 03-commands.md:144/661-663은 이미 "public leaf 없음" 명시(SSOT 정합) → CLI 동작 drift.
- #1680 동형 dual-fix: ① `src/ante/cli/commands/notification.py` `@click.group(hidden=True)`(root help 제외·직접 invoke 보존) ② `scripts/generate_cli_reference.py` `_collect_commands()` hidden-skip(group+재귀, generic·mechanism-agnostic) ③ `guide/cli.md` 전체 재생성(notification 제거 + 구현일 날짜 + backtest/update pre-existing mechanical Click-introspection drift 명시 소유, date-aware correct-by-generation).
- main.py·03-commands.md·cli.md·생성기 timestamp 로직 무변경. 그룹 제거/leaf 신설 비목표(hidden 충분·문서화 그룹 보존).

## Test Plan
- introspection: `notification.hidden=True`·root `--help` notification 부재·`ante notification --help` exit 0(직접 invoke 보존)·guide notification TOC/heading 부재 (오케스트레이터 독립 재확인 동일)
- date-aware correct-by-generation: 날짜 `마지막 갱신` 라인 외 content diff 0 (같은 날 fully clean)
- 신규 회귀: test_generate_cli_reference(hidden-skip group/재귀/markdown) + test_cli_notification_hidden(양 표면 부재·직접 invoke·타 그룹 회귀 0)
- pytest CLI·generator 204 passed·notification 53 passed, mypy src/(242) no issues, ruff check+format passed
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 = PASS
