### PR TITLE
fix: #1674 feed backfill_since 4-surface clean-reject coded {CLI_INVALID_DATE, INVALID_DATE_RANGE}

### DIFF
--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -104,7 +104,7 @@ JSON 모드(`--format json`)에서는 `{status: "error", code: "...", message: "
 | `CLI_MISSING_REQUIRED_INPUT` | 필수 옵션·인자 누락 (도메인 명확 시 도메인 prefix specialize) | 모든 명령 |
 | `CLI_CONFIRMATION_REQUIRED` | 위험 명령에 `--yes`/`--force` 누락 | `account delete`, `bot remove`, `member revoke`, `update` |
 | `CLI_OPTION_CONFLICT` | 상호 배타적인 옵션을 동시 사용 (period별 전용 옵션을 다른 period와 함께 사용 등) | `report performance`, `treasury snapshot` |
-| `INVALID_DATE_RANGE` | 시작일 > 종료일 (inverted date range). **legacy/common 코드 — `CLI_*` 명명 규칙 예외**(위 예외 박스 참조) | `backtest run`, `audit list`, `trade list`, `treasury snapshot`, `report performance` |
+| `INVALID_DATE_RANGE` | 시작일 > 종료일 (inverted date range) 또는 effective 시작일이 미래(`feed run backfill --since` / `[schedule].backfill_since` > today). **legacy/common 코드 — `CLI_*` 명명 규칙 예외**(위 예외 박스 참조) | `backtest run`, `audit list`, `trade list`, `treasury snapshot`, `report performance`, `feed run backfill` |
 | `ACCOUNT_MISSING_REQUIRED_CREDENTIAL` | `BrokerPreset.required_credentials`에 정의된 credential key 누락 | `account create`, `account set-credentials` |
 | `ACCOUNT_UNKNOWN_CREDENTIAL_KEY` | broker preset의 `required_credentials`에 정의되지 않은 credential key 제공 | `account create`, `account set-credentials` |
 | `ACCOUNT_DUPLICATE_CREDENTIAL_KEY` | 같은 credential key를 `--credential`/`--credential-env`/`--credential-file` 중 둘 이상 채널로 중복 제공 | `account create`, `account set-credentials` |

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -515,6 +515,18 @@ ante feed run daily [--date <날짜>] [--data-path <경로>]      # 어제(또�
 ante feed start [--data-path <경로>]                          # 내장 스케줄러로 backfill/daily 자동 실행하는 상주 프로세스 (scope: data:write)
 ```
 
+`feed run backfill --since`와 `[schedule].backfill_since`(config TOML)는 모두
+strict `YYYY-MM-DD`(zero-padded gregorian) 형식만 허용한다. basic ISO
+(`20260510`)·ISO week date(`2026-W19-1`)·non-zero-padded(`2026-1-1`) 등
+변형은 `CLI_INVALID_DATE` exit code 1로 거부한다. strict parse 통과 이후
+effective 시작일이 오늘(`today`, KST)보다 미래이면 backfill 수집/체크포인트
+접근 이전에 `INVALID_DATE_RANGE` 에러 코드와 exit code 1로 거부한다(체크포인트
+resume·수집 진입 없이 단일 `{status:"error", code, message}` envelope만 출력).
+`feed start` 상주 스케줄러도 동일한 두 코드 관측 시 "Backfill 완료" 메시지를
+출력하지 않고 명시 오류를 echo/log한다. 기존 비날짜 `config_errors`(API 키
+누락, lock 경합, rate-limit 등)의 CLI 출력·exit code·scheduler 완료 표시는
+이 코드에 매핑되지 않으며 현행 동작을 유지한다.
+
 > 상세: [data-feed.md](../data-feed/data-feed.md)
 
 ### `ante config` — 설정 관리

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -250,6 +250,11 @@ def run_backfill(
 
     from ante.feed.cli_output import format_backfill_result
     from ante.feed.config import FeedConfig
+    from ante.feed.pipeline.backfill_runner import (
+        BACKFILL_DATE_ERROR_CODES,
+        CONFIG_ERROR_CODE_INVALID_DATE_RANGE,
+        validate_backfill_since,
+    )
 
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
@@ -262,6 +267,21 @@ def run_backfill(
 
     if until is not None:
         _validate_iso_date(until, "--until", fmt)
+
+    # `--since` strict parse 통과 이후 effective start가 미래이면
+    # orchestrator 호출 전에 INVALID_DATE_RANGE로 즉시 거부한다.
+    # malformed는 위 `_validate_iso_date`가 이미 CLI_INVALID_DATE로
+    # 처리했으므로 여기서는 future-check만 책임진다.
+    if since is not None:
+        _parsed, since_err = validate_backfill_since(since)
+        if since_err is not None and since_err.get("code") == (
+            CONFIG_ERROR_CODE_INVALID_DATE_RANGE
+        ):
+            fmt.error(
+                f"잘못된 --since 날짜: {since_err['error']}",
+                code=CONFIG_ERROR_CODE_INVALID_DATE_RANGE,
+            )
+            raise SystemExit(1)
 
     config = cfg.load_config()
 
@@ -279,6 +299,18 @@ def run_backfill(
             config=config,
         )
     )
+
+    # 수렴점(BackfillRunner)에서 coded date config_error를 담아왔다면
+    # 성공 result 출력 없이 단일 envelope + exit 1로 매핑한다. 기존
+    # 비날짜 config_errors(소스 누락·lock 경합·rate-limit 등)는 code
+    # 키가 없으므로 이 분기에 진입하지 않고 현행 출력 흐름을 유지한다.
+    for entry in result.config_errors:
+        if not isinstance(entry, dict):
+            continue
+        code = entry.get("code")
+        if code in BACKFILL_DATE_ERROR_CODES:
+            fmt.error(str(entry.get("error", "")), code=str(code))
+            raise SystemExit(1)
 
     format_backfill_result(result, fmt)
 

--- a/src/ante/feed/cli_scheduler.py
+++ b/src/ante/feed/cli_scheduler.py
@@ -110,13 +110,39 @@ async def _run_backfill_job(
     config: dict[str, Any],
     current_date: str,
 ) -> None:
-    """Backfill 수집 작업을 1회 실행한다."""
+    """Backfill 수집 작업을 1회 실행한다.
+
+    `result.config_errors`에 coded date error(CLI_INVALID_DATE /
+    INVALID_DATE_RANGE)가 포함된 경우 "Backfill 완료" 메시지를 출력하지
+    않고 명시 오류를 echo/log한다. 기존 비날짜 config_errors(소스 누락·
+    lock 경합·rate-limit 등)는 현행 완료 메시지 흐름을 유지한다.
+    """
+    from ante.feed.pipeline.backfill_runner import BACKFILL_DATE_ERROR_CODES
+
     logger.info("Backfill 수집 시작 (%s)", current_date)
     try:
         result = await orchestrator.run_backfill(
             data_path=Path(data_path),
             config=config,
         )
+        coded_date_errors = [
+            entry
+            for entry in result.config_errors
+            if isinstance(entry, dict)
+            and entry.get("code") in BACKFILL_DATE_ERROR_CODES
+        ]
+        if coded_date_errors:
+            for entry in coded_date_errors:
+                code = entry.get("code")
+                message = entry.get("error", "")
+                logger.error(
+                    "Backfill 차단 (%s): code=%s, error=%s",
+                    current_date,
+                    code,
+                    message,
+                )
+                click.echo(f"[{current_date}] Backfill 차단: {code} — {message}")
+            return
         click.echo(
             f"[{current_date}] Backfill 완료: "
             f"{result.symbols_success}/{result.symbols_total} 종목, "

--- a/src/ante/feed/pipeline/backfill_runner.py
+++ b/src/ante/feed/pipeline/backfill_runner.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+import re
+from datetime import UTC, date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +31,89 @@ from ante.feed.sources.data_go_kr import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_BACKFILL_SINCE = "2015-01-01"
+
+# zero-padded YYYY-MM-DD만 허용. date.fromisoformat()은 3.11+에서
+# basic ISO(20260510)·ISO week date(2026-W19-1) 등 변형도 수락하므로
+# 형태를 정규식으로 먼저 고정한 뒤 캘린더 유효성만 검증한다.
+# CLI `--since`(feed/cli.py::_validate_iso_date)와 동일한 strictness를
+# 사용해 두 진입 표면을 정합시킨다(이슈 #1674).
+_BACKFILL_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+# coded config_error 코드. CLI/scheduler가 이 코드를 관측해 분기하므로,
+# 기존 비날짜 config_errors(`code` 키 없는 dict)와 명확히 구분된다.
+CONFIG_ERROR_CODE_INVALID_DATE = "CLI_INVALID_DATE"
+CONFIG_ERROR_CODE_INVALID_DATE_RANGE = "INVALID_DATE_RANGE"
+
+# 신설 coded config_errors의 코드 집합. CLI/scheduler에서 이 집합으로만
+# 새 envelope/차단 분기를 trigger한다 (기존 비날짜 entries 보존).
+BACKFILL_DATE_ERROR_CODES = frozenset(
+    {
+        CONFIG_ERROR_CODE_INVALID_DATE,
+        CONFIG_ERROR_CODE_INVALID_DATE_RANGE,
+    }
+)
+
+# `today`는 KST 캘린더 기준으로 산출한다. backfill_since는 거래일 단위
+# 날짜이며 cli_scheduler도 KST(UTC+9)로 동작한다(see cli_scheduler.KST).
+_KST = timezone(timedelta(hours=9))
+
+
+def _parse_strict_backfill_since(value: str) -> date | None:
+    """``backfill_since`` 값을 strict ``YYYY-MM-DD``로 파싱한다.
+
+    backfill 진입 표면(CLI ``--since`` / config TOML ``backfill_since``)이
+    공유하는 helper. 형태가 어긋나거나 캘린더상 유효하지 않으면 ``None`` 을
+    반환한다(호출 측이 ``CLI_INVALID_DATE`` config_error로 변환).
+
+    feed-local 사용에 한정한다 — 전역 validators 통합 금지(이슈 #1674
+    Stop Condition).
+    """
+    if not isinstance(value, str):
+        return None
+    if _BACKFILL_ISO_DATE_RE.fullmatch(value) is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _today_kst() -> date:
+    """오늘 날짜(KST 캘린더)를 반환한다."""
+    return datetime.now(tz=_KST).date()
+
+
+def validate_backfill_since(
+    value: str,
+) -> tuple[date | None, dict[str, str] | None]:
+    """``backfill_since`` 값을 strict 검증한다.
+
+    반환값:
+        ``(parsed_date, None)`` — strict ``YYYY-MM-DD`` + ``start <= today``
+        ``(None, {"code": "CLI_INVALID_DATE", "error": ...})`` — 형태/캘린더 위반
+        ``(None, {"code": "INVALID_DATE_RANGE", "error": ...})`` — ``start > today``
+
+    config_error dict는 ``CollectionResult.config_errors`` 에 그대로
+    삽입할 수 있는 shape이다(``code`` 키 존재로 비날짜 error와 구분).
+    """
+    parsed = _parse_strict_backfill_since(value)
+    if parsed is None:
+        return None, {
+            "code": CONFIG_ERROR_CODE_INVALID_DATE,
+            "error": (
+                f"잘못된 backfill_since 날짜 형식: '{value}' (YYYY-MM-DD 형식 필요)"
+            ),
+        }
+
+    today = _today_kst()
+    if parsed > today:
+        return None, {
+            "code": CONFIG_ERROR_CODE_INVALID_DATE_RANGE,
+            "error": (
+                f"backfill_since가 오늘({today.isoformat()})보다 미래입니다: '{value}'"
+            ),
+        }
+    return parsed, None
 
 
 class BackfillRunner:
@@ -59,7 +143,27 @@ class BackfillRunner:
         started_at: datetime,
         is_blocked: Any,
     ) -> CollectionResult:
-        """Backfill 내부 구현. data.go.kr + DART 수집 후 지표 계산."""
+        """Backfill 내부 구현. data.go.kr + DART 수집 후 지표 계산.
+
+        backfill_since strict 검증은 수렴점이므로 수집 메서드 진입 전
+        가장 먼저 수행한다. malformed/future일 때는 체크포인트·소스
+        접근 없이 coded config_error만 담은 result를 즉시 반환한다.
+        """
+        # strict 날짜 검증을 가장 먼저 수행해 malformed/future config가
+        # checkpoint/소스/지표 어디에도 도달하지 않도록 한다.
+        coded_date_error = self._validate_backfill_since(config)
+        if coded_date_error is not None:
+            logger.warning(
+                "Backfill 차단: backfill_since 검증 실패 (code=%s, error=%s)",
+                coded_date_error.get("code"),
+                coded_date_error.get("error"),
+            )
+            return _make_result(
+                "backfill",
+                started_at,
+                config_errors=[coded_date_error],
+            )
+
         ctx = _RunContext()
         store = self._store or ParquetStore(base_path=data_path)
 
@@ -92,6 +196,37 @@ class BackfillRunner:
         self._compute_indicators(store, ctx)
 
         return ctx.to_result("backfill", started_at)
+
+    @staticmethod
+    def _validate_backfill_since(
+        config: dict[str, Any],
+    ) -> dict[str, str] | None:
+        """``[schedule].backfill_since``를 strict 검증한다.
+
+        config에 ``backfill_since`` 가 명시되어 있을 때만 검증한다.
+        키 부재 시에는 ``DEFAULT_BACKFILL_SINCE`` (`2015-01-01`)가
+        쓰이며 정의상 strict + past이므로 검증을 건너뛴다.
+
+        Returns:
+            None이면 strict 통과 (수집 진입 가능).
+            dict이면 coded config_error (``code`` 키 = CLI_INVALID_DATE /
+            INVALID_DATE_RANGE).
+        """
+        schedule = config.get("schedule")
+        if not isinstance(schedule, dict):
+            return None
+        if "backfill_since" not in schedule:
+            return None
+        raw = schedule.get("backfill_since")
+        if not isinstance(raw, str):
+            return {
+                "code": CONFIG_ERROR_CODE_INVALID_DATE,
+                "error": (
+                    f"잘못된 backfill_since 날짜 형식: {raw!r} (YYYY-MM-DD 형식 필요)"
+                ),
+            }
+        _parsed, error = validate_backfill_since(raw)
+        return error
 
     @staticmethod
     def _resolve_dates(

--- a/src/ante/feed/pipeline/orchestrator.py
+++ b/src/ante/feed/pipeline/orchestrator.py
@@ -15,7 +15,10 @@ from typing import Any
 from ante.data.normalizer import DARTNormalizer, DataGoKrNormalizer
 from ante.data.store import ParquetStore
 from ante.feed.models.result import CollectionResult
-from ante.feed.pipeline.backfill_runner import BackfillRunner, _make_result
+from ante.feed.pipeline.backfill_runner import (
+    BackfillRunner,
+    _make_result,
+)
 from ante.feed.pipeline.daily_runner import DailyRunner
 from ante.feed.pipeline.dart_collector import DARTCollector
 from ante.feed.pipeline.data_go_kr_collector import DataGoKrCollector
@@ -73,9 +76,28 @@ class FeedOrchestrator:
         data_path: Path,
         config: dict[str, Any],
     ) -> CollectionResult:
-        """과거 데이터 대량 수집 (backfill 모드)."""
+        """과거 데이터 대량 수집 (backfill 모드).
+
+        ``[schedule].backfill_since`` strict 검증은 lock acquire 이전에
+        수행한다. malformed/future일 때는 lock 파일을 만들지 않고
+        coded config_error만 담은 결과를 즉시 반환한다(체크포인트·소스
+        진입 차단).
+        """
         feed_dir = data_path / ".feed"
         started_at = datetime.now(tz=UTC)
+
+        coded_date_error = BackfillRunner._validate_backfill_since(config)
+        if coded_date_error is not None:
+            logger.warning(
+                "Backfill 차단(orchestrator): code=%s, error=%s",
+                coded_date_error.get("code"),
+                coded_date_error.get("error"),
+            )
+            return _make_result(
+                "backfill",
+                started_at,
+                config_errors=[coded_date_error],
+            )
 
         if not self._acquire_lock(feed_dir):
             return _make_result(

--- a/tests/unit/feed/test_backfill_since_clean_reject.py
+++ b/tests/unit/feed/test_backfill_since_clean_reject.py
@@ -1,0 +1,654 @@
+"""feed backfill_since 4-surface clean-reject 검증 (이슈 #1674).
+
+검증 범위:
+1. CLI `--since` malformed → `CLI_INVALID_DATE` (기존 `_validate_iso_date`
+   선순위 유지).
+2. CLI `--since` future → `INVALID_DATE_RANGE`, orchestrator 미호출.
+3. config TOML `backfill_since` malformed/non-strict/future →
+   수렴점에서 `CLI_INVALID_DATE`/`INVALID_DATE_RANGE` config_error,
+   체크포인트·소스·lock 미진입.
+4. CLI JSON 모드는 coded date config_error envelope만 출력 + exit 1.
+5. resident `feed start` `_run_backfill_job`은 coded scope에서만
+   완료 메시지 차단 + 명시 오류 echo/log.
+6. 비날짜 config_errors(missing source / lock 경합) 회귀 — CLI/scheduler
+   출력 및 exit 코드가 현행 유지.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.feed.models.result import CollectionResult
+from ante.feed.pipeline.backfill_runner import (
+    BACKFILL_DATE_ERROR_CODES,
+    CONFIG_ERROR_CODE_INVALID_DATE,
+    CONFIG_ERROR_CODE_INVALID_DATE_RANGE,
+    BackfillRunner,
+    validate_backfill_since,
+)
+from ante.feed.pipeline.orchestrator import FeedOrchestrator
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+def _make_collection_result(
+    config_errors: list[dict[str, Any]] | None = None,
+) -> CollectionResult:
+    return CollectionResult(
+        mode="backfill",
+        started_at="2026-05-20T00:00:00Z",
+        finished_at="2026-05-20T00:00:01Z",
+        duration_seconds=1.0,
+        symbols_total=0,
+        symbols_success=0,
+        symbols_failed=0,
+        rows_written=0,
+        data_types=[],
+        failures=[],
+        warnings=[],
+        config_errors=config_errors or [],
+    )
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner. stderr 분리 캡처."""
+    r = CliRunner(mix_stderr=False)
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx: object) -> None:
+                import click
+
+                ctx = click.get_current_context()
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+@pytest.fixture
+def initialized_data_path(tmp_path: Path) -> str:
+    """초기화된 데이터 디렉토리 경로 (config는 시나리오별로 덮어쓴다)."""
+    data_dir = tmp_path / "data"
+    feed_dir = data_dir / ".feed"
+    feed_dir.mkdir(parents=True)
+    (feed_dir / "checkpoints").mkdir()
+    (feed_dir / "reports").mkdir()
+
+    # 기본 config (정상 case): backfill_since=2024-01-01 (과거)
+    (feed_dir / "config.toml").write_text(
+        "[schedule]\n"
+        'daily_at = "16:00"\n'
+        'backfill_at = "01:00"\n'
+        'backfill_since = "2024-01-01"\n'
+        "\n"
+        "[guard]\n"
+        "blocked_days = []\n"
+        'blocked_hours = ["09:00-15:30"]\n'
+        "pause_during_trading = true\n"
+    )
+
+    return str(data_dir)
+
+
+def _write_config(data_path: str, backfill_since: str | None) -> None:
+    """config.toml의 backfill_since를 임의 값으로 덮어쓴다."""
+    feed_dir = Path(data_path) / ".feed"
+    if backfill_since is None:
+        body = "[schedule]\n"
+    else:
+        body = f'[schedule]\nbackfill_since = "{backfill_since}"\n'
+    body += "\n[guard]\nblocked_days = []\n"
+    (feed_dir / "config.toml").write_text(body)
+
+
+# ── (1) validate_backfill_since helper 단위 검증 ──────────────────────────
+
+
+class TestValidateBackfillSinceHelper:
+    """공유 strict parser/future-check helper 단위 검증."""
+
+    def test_valid_past_date(self) -> None:
+        parsed, error = validate_backfill_since("2024-01-01")
+        assert parsed == date(2024, 1, 1)
+        assert error is None
+
+    def test_valid_today(self) -> None:
+        # today 자체는 미래가 아니므로 정상.
+        # KST 기준이지만 helper는 datetime을 고정하지 않으므로
+        # 실제 today를 사용한다.
+        from ante.feed.pipeline.backfill_runner import _today_kst
+
+        today = _today_kst()
+        parsed, error = validate_backfill_since(today.isoformat())
+        assert parsed == today
+        assert error is None
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "20260510",  # basic ISO (no separator)
+            "2026-W19-1",  # ISO week date
+            "2026-1-1",  # non-zero-padded
+            "2026-13-01",  # invalid month
+            "not-a-date",
+            "",
+            "2026/05/10",
+            "2026-05-32",  # invalid day
+        ],
+    )
+    def test_malformed_returns_invalid_date(self, bad_value: str) -> None:
+        parsed, error = validate_backfill_since(bad_value)
+        assert parsed is None
+        assert error is not None
+        assert error["code"] == CONFIG_ERROR_CODE_INVALID_DATE
+
+    def test_future_returns_invalid_date_range(self) -> None:
+        from ante.feed.pipeline.backfill_runner import _today_kst
+
+        future = (_today_kst() + timedelta(days=365 * 30)).isoformat()
+        parsed, error = validate_backfill_since(future)
+        assert parsed is None
+        assert error is not None
+        assert error["code"] == CONFIG_ERROR_CODE_INVALID_DATE_RANGE
+        assert future in error["error"]
+
+
+# ── (2) CLI `--since` future early reject ─────────────────────────────────
+
+
+class TestCliSinceFutureReject:
+    """CLI `--since`가 future일 때 orchestrator 호출 전에 거부."""
+
+    def test_future_since_json_envelope_only(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """`--since 2999-01-01 --format json` → exit 1, 단일 envelope,
+        성공 result 미출력, orchestrator 미호출."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_make_collection_result())
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    "2999-01-01",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            # stdout는 단일 envelope만; 성공 result(`mode`/`symbols_total`
+            # 등)는 출력되어서는 안 된다.
+            payload = json.loads(result.stdout)
+            assert payload["status"] == "error"
+            assert payload["code"] == CONFIG_ERROR_CODE_INVALID_DATE_RANGE
+            assert "2999-01-01" in payload["message"]
+            mock_orch.run_backfill.assert_not_awaited()
+
+    def test_future_since_text_mode_writes_error(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_make_collection_result())
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    "2999-01-01",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            assert "Error:" in (result.stderr or "")
+            assert "2999-01-01" in (result.stderr or "")
+            mock_orch.run_backfill.assert_not_awaited()
+
+    def test_malformed_since_still_priority_invalid_date(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """malformed `--since`는 기존 CLI_INVALID_DATE 선순위 유지."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_make_collection_result())
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    "2020-13-01",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            payload = json.loads(result.stdout)
+            assert payload["code"] == CONFIG_ERROR_CODE_INVALID_DATE
+            mock_orch.run_backfill.assert_not_awaited()
+
+
+# ── (3) CLI config TOML backfill_since 검증 ───────────────────────────────
+
+
+class TestCliConfigTomlBackfillSince:
+    """config.toml backfill_since malformed/non-strict/future → 수렴점에서
+    coded config_error, CLI 단일 envelope."""
+
+    @pytest.mark.parametrize(
+        ("bad_value", "expected_code"),
+        [
+            ("2020-13-01", CONFIG_ERROR_CODE_INVALID_DATE),
+            ("20260510", CONFIG_ERROR_CODE_INVALID_DATE),
+            ("2026-W19-1", CONFIG_ERROR_CODE_INVALID_DATE),
+            ("2026-1-1", CONFIG_ERROR_CODE_INVALID_DATE),
+            ("not-a-date", CONFIG_ERROR_CODE_INVALID_DATE),
+            ("2999-01-01", CONFIG_ERROR_CODE_INVALID_DATE_RANGE),
+        ],
+    )
+    def test_config_backfill_since_coded_error(
+        self,
+        runner: CliRunner,
+        initialized_data_path: str,
+        bad_value: str,
+        expected_code: str,
+    ) -> None:
+        _write_config(initialized_data_path, bad_value)
+
+        # _build_orchestrator는 실제 FeedOrchestrator를 만들도록 둔다.
+        # (수렴점에서 검증되므로 외부 IO는 발생하지 않는다.)
+        # 다만 BackfillRunner.run이 호출되지 않아야 함을 확인하기 위해
+        # BackfillRunner.run을 spy로 감싼다.
+        original_run = BackfillRunner.run
+        run_calls: list[int] = []
+
+        async def _spy_run(self, *args: Any, **kwargs: Any) -> CollectionResult:  # type: ignore[no-untyped-def]
+            run_calls.append(1)
+            return await original_run(self, *args, **kwargs)
+
+        with patch.object(BackfillRunner, "run", _spy_run):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == expected_code
+        # 수렴점(orchestrator.run_backfill)이 lock acquire 이전에
+        # short-circuit하므로 BackfillRunner.run 자체가 호출되지 않는다.
+        assert run_calls == []
+        # lock 파일도 생성되지 않아야 한다 (lock acquire 이전 차단).
+        lock_path = Path(initialized_data_path) / ".feed" / "lock"
+        assert not lock_path.exists()
+
+    def test_config_backfill_since_valid_past_passes(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """정상 과거 날짜는 기존 흐름 통과."""
+        _write_config(initialized_data_path, "2024-01-01")
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_make_collection_result())
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0
+            mock_orch.run_backfill.assert_awaited_once()
+
+
+# ── (4) 비날짜 config_errors 회귀 (CLI) ───────────────────────────────────
+
+
+class TestCliNonDateConfigErrorsRegression:
+    """기존 비날짜 config_errors(소스 누락 / lock 경합) 정책 보존."""
+
+    def test_non_date_config_error_does_not_map_to_clean_reject(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """소스 누락 같은 비날짜 config_errors는 envelope으로 잘못 매핑되어선
+        안 되고, 현행 정상 출력 흐름을 유지한다."""
+        legacy_errors = [
+            {"error": "data.go.kr API 키 미설정", "source": "data_go_kr"},
+            {"error": "DART API 키 미설정", "source": "dart"},
+        ]
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(
+                return_value=_make_collection_result(config_errors=legacy_errors)
+            )
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                ],
+                catch_exceptions=False,
+            )
+
+            # 비날짜 config_errors는 현행과 동일하게 성공 result 출력 + exit 0.
+            assert result.exit_code == 0
+            payload = json.loads(result.stdout)
+            # 단일 error envelope이 아니라 성공 result dict.
+            assert "status" not in payload or payload.get("status") != "error"
+            assert payload.get("mode") == "backfill"
+            assert payload.get("config_errors") == legacy_errors
+
+    def test_lock_busy_error_does_not_map_to_clean_reject(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """lock 경합 config_error도 새 분기를 trigger하지 않는다."""
+        legacy_errors = [{"error": "다른 수집 프로세스가 이미 실행 중"}]
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(
+                return_value=_make_collection_result(config_errors=legacy_errors)
+            )
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0
+            payload = json.loads(result.stdout)
+            assert payload.get("config_errors") == legacy_errors
+
+
+# ── (5) BackfillRunner._validate_backfill_since 단위 ─────────────────────
+
+
+class TestBackfillRunnerInternalValidation:
+    """수렴점 helper가 올바른 coded shape를 반환하는지 확인."""
+
+    def test_missing_backfill_since_returns_none(self) -> None:
+        # config에 [schedule]만 있고 backfill_since 키가 없을 때는
+        # DEFAULT(과거)가 적용되므로 검증을 건너뛴다.
+        assert BackfillRunner._validate_backfill_since({"schedule": {}}) is None
+        assert BackfillRunner._validate_backfill_since({}) is None
+
+    @pytest.mark.parametrize(
+        ("value", "expected_code"),
+        [
+            ("2020-13-01", CONFIG_ERROR_CODE_INVALID_DATE),
+            ("20260510", CONFIG_ERROR_CODE_INVALID_DATE),
+            ("2026-W19-1", CONFIG_ERROR_CODE_INVALID_DATE),
+            ("2999-01-01", CONFIG_ERROR_CODE_INVALID_DATE_RANGE),
+        ],
+    )
+    def test_invalid_backfill_since(self, value: str, expected_code: str) -> None:
+        config: dict[str, Any] = {"schedule": {"backfill_since": value}}
+        err = BackfillRunner._validate_backfill_since(config)
+        assert err is not None
+        assert err["code"] == expected_code
+
+    def test_non_string_backfill_since_returns_invalid_date(self) -> None:
+        # TOML 파서가 다른 타입을 넘기더라도 안전하게 차단.
+        config: dict[str, Any] = {"schedule": {"backfill_since": 20260510}}
+        err = BackfillRunner._validate_backfill_since(config)
+        assert err is not None
+        assert err["code"] == CONFIG_ERROR_CODE_INVALID_DATE
+
+
+# ── (6) orchestrator.run_backfill 수렴점 가드 ────────────────────────────
+
+
+class TestOrchestratorBackfillGate:
+    """`run_backfill` 진입 시점에 future/malformed config가 lock acquire
+    이전에 차단되어 체크포인트/소스/수집이 일절 호출되지 않는지 검증."""
+
+    def test_future_config_short_circuits_before_lock(self, tmp_path: Path) -> None:
+        data_path = tmp_path / "data"
+        feed_dir = data_path / ".feed"
+        feed_dir.mkdir(parents=True)
+
+        orchestrator = FeedOrchestrator()
+
+        async def _exercise() -> CollectionResult:
+            return await orchestrator.run_backfill(
+                data_path=data_path,
+                config={"schedule": {"backfill_since": "2999-01-01"}},
+            )
+
+        result = asyncio.run(_exercise())
+
+        assert any(
+            isinstance(entry, dict)
+            and entry.get("code") == CONFIG_ERROR_CODE_INVALID_DATE_RANGE
+            for entry in result.config_errors
+        )
+        # lock 파일이 만들어지지 않았어야 한다.
+        assert not (feed_dir / "lock").exists()
+
+    def test_malformed_config_short_circuits_before_lock(self, tmp_path: Path) -> None:
+        data_path = tmp_path / "data"
+        feed_dir = data_path / ".feed"
+        feed_dir.mkdir(parents=True)
+
+        orchestrator = FeedOrchestrator()
+
+        async def _exercise() -> CollectionResult:
+            return await orchestrator.run_backfill(
+                data_path=data_path,
+                config={"schedule": {"backfill_since": "2026-W19-1"}},
+            )
+
+        result = asyncio.run(_exercise())
+        assert any(
+            isinstance(entry, dict)
+            and entry.get("code") == CONFIG_ERROR_CODE_INVALID_DATE
+            for entry in result.config_errors
+        )
+        assert not (feed_dir / "lock").exists()
+
+    def test_valid_past_config_proceeds_into_runner(self, tmp_path: Path) -> None:
+        data_path = tmp_path / "data"
+        feed_dir = data_path / ".feed"
+        feed_dir.mkdir(parents=True)
+
+        orchestrator = FeedOrchestrator()  # 소스 없음 → ctx config_errors만
+
+        async def _exercise() -> CollectionResult:
+            return await orchestrator.run_backfill(
+                data_path=data_path,
+                config={"schedule": {"backfill_since": "2024-01-01"}},
+            )
+
+        result = asyncio.run(_exercise())
+        # coded date error는 없어야 하고, 비날짜 source-missing 에러만 있어야 한다.
+        codes = {
+            entry.get("code")
+            for entry in result.config_errors
+            if isinstance(entry, dict)
+        }
+        assert not (codes & BACKFILL_DATE_ERROR_CODES)
+
+
+# ── (7) cli_scheduler _run_backfill_job 차단 + 비날짜 회귀 ──────────────
+
+
+class TestSchedulerBackfillJobCodedGate:
+    """resident scheduler가 coded date scope에서만 완료 차단."""
+
+    def test_coded_date_error_blocks_completion_message(self) -> None:
+        from ante.feed import cli_scheduler
+
+        mock_orch = MagicMock()
+        mock_orch.run_backfill = AsyncMock(
+            return_value=_make_collection_result(
+                config_errors=[
+                    {
+                        "code": CONFIG_ERROR_CODE_INVALID_DATE_RANGE,
+                        "error": "backfill_since가 미래입니다",
+                    }
+                ]
+            )
+        )
+
+        echoed: list[str] = []
+        with patch.object(cli_scheduler.click, "echo", side_effect=echoed.append):
+            asyncio.run(
+                cli_scheduler._run_backfill_job(mock_orch, "data/", {}, "2026-05-20")
+            )
+
+        # 완료 메시지 미출력
+        assert not any("Backfill 완료" in line for line in echoed)
+        # 명시 오류 라인 출력
+        assert any(CONFIG_ERROR_CODE_INVALID_DATE_RANGE in line for line in echoed)
+
+    def test_malformed_coded_error_blocks_completion_message(self) -> None:
+        from ante.feed import cli_scheduler
+
+        mock_orch = MagicMock()
+        mock_orch.run_backfill = AsyncMock(
+            return_value=_make_collection_result(
+                config_errors=[
+                    {
+                        "code": CONFIG_ERROR_CODE_INVALID_DATE,
+                        "error": "잘못된 형식",
+                    }
+                ]
+            )
+        )
+
+        echoed: list[str] = []
+        with patch.object(cli_scheduler.click, "echo", side_effect=echoed.append):
+            asyncio.run(
+                cli_scheduler._run_backfill_job(mock_orch, "data/", {}, "2026-05-20")
+            )
+
+        assert not any("Backfill 완료" in line for line in echoed)
+        assert any(CONFIG_ERROR_CODE_INVALID_DATE in line for line in echoed)
+
+    def test_non_date_config_error_keeps_legacy_completion_message(
+        self,
+    ) -> None:
+        """비날짜 config_errors만 있을 때는 현행 완료 메시지 그대로."""
+        from ante.feed import cli_scheduler
+
+        mock_orch = MagicMock()
+        mock_orch.run_backfill = AsyncMock(
+            return_value=_make_collection_result(
+                config_errors=[
+                    {"error": "data.go.kr API 키 미설정", "source": "data_go_kr"},
+                    {"error": "다른 수집 프로세스가 이미 실행 중"},
+                ]
+            )
+        )
+
+        echoed: list[str] = []
+        with patch.object(cli_scheduler.click, "echo", side_effect=echoed.append):
+            asyncio.run(
+                cli_scheduler._run_backfill_job(mock_orch, "data/", {}, "2026-05-20")
+            )
+
+        # 현행 동작: "Backfill 완료" 메시지는 그대로 출력된다.
+        assert any("Backfill 완료" in line for line in echoed)
+        # 신설 차단 분기가 trigger되어선 안 된다.
+        assert not any(
+            CONFIG_ERROR_CODE_INVALID_DATE in line
+            or CONFIG_ERROR_CODE_INVALID_DATE_RANGE in line
+            for line in echoed
+        )
+
+    def test_no_config_errors_keeps_legacy_completion_message(self) -> None:
+        from ante.feed import cli_scheduler
+
+        mock_orch = MagicMock()
+        mock_orch.run_backfill = AsyncMock(return_value=_make_collection_result())
+
+        echoed: list[str] = []
+        with patch.object(cli_scheduler.click, "echo", side_effect=echoed.append):
+            asyncio.run(
+                cli_scheduler._run_backfill_job(mock_orch, "data/", {}, "2026-05-20")
+            )
+
+        assert any("Backfill 완료" in line for line in echoed)


### PR DESCRIPTION
Closes #1674

## Summary

`ante feed run backfill --since` (CLI flag), `.feed/config.toml [schedule].backfill_since`, scheduler `_run_backfill_job`, and direct `orchestrator.run_backfill` — 이 4개 표면에서 `backfill_since`가 malformed(strict `YYYY-MM-DD` 위반)이거나 future(`start > today`)이면 수집 진입 전 clean error로 즉시 거부한다.

- malformed → `CLI_INVALID_DATE`
- future → `INVALID_DATE_RANGE`

clean-reject 트리거는 `result.config_errors` 중 **`code ∈ {CLI_INVALID_DATE, INVALID_DATE_RANGE}`** 항목으로만 작동한다. 기존 비날짜 `config_errors`(missing source/API key, lock 경합, rate-limit 등 `{"error": "…"}` shape)의 CLI 출력/exit/scheduler 완료 메시지·로그 동작은 그대로 유지된다.

수렴점 `BackfillRunner._validate_backfill_since`가 lock acquire 이전에 검증을 수행해 lock 파일 사이드이팩트 없이 short-circuit한다. feed-local strict parser는 backfill 경로 안에 캡슐화하며 전역 `_validators` 통합은 별도로 다루지 않는다.

스펙은 `docs/specs/cli/02-design-decisions.md`의 `INVALID_DATE_RANGE` consumer에 `feed run backfill` future effective start를 추가하고, `docs/specs/cli/03-commands.md`에 `feed run backfill --since` / `[schedule].backfill_since` strict+future clean-reject 계약을 명문화했다.

`--until` 코드 옵션 제거는 본 PR의 비목표이며 #1690에서 처리한다.

## Test Plan

worktree(`/Users/jingulee/Projects/ante-worktrees/issue-1674`) 로컬:

- `pytest tests/unit/feed` → 351 passed (신설 `tests/unit/feed/test_backfill_since_clean_reject.py` 포함)
- `pytest tests/unit/cli` → 159 passed
- `mypy src/` → Success: no issues found in 242 source files
- `ruff check` → All checks passed
- `ruff format --check` → 567 files already formatted

신설 회귀 케이스:
- CLI `--since` future → `INVALID_DATE_RANGE`, orchestrator 미진입, lock 파일 미생성
- CLI `--since` malformed → 기존 `_validate_iso_date` `CLI_INVALID_DATE` 선순위
- CLI config-TOML malformed / non-strict(`20260510`, `2026-W19-1`) / future → 코드별 envelope
- scheduler `_run_backfill_job` coded date error → 완료 메시지 차단, 명시 오류 echo/logger
- **비날짜 config_error 회귀 (CLI)**: 기존 `{"error": ...}` shape entries는 신설 envelope으로 잘못 매핑되지 않고 현행 동작 유지
- **비날짜 config_error 회귀 (scheduler)**: 비날짜 entries만 있을 때 신설 차단 분기 미진입, 현행 완료 메시지/로그 유지
- 비회귀: `--since 2015-01-01` / since 미지정 + config default → 정상 backfill 흐름

게이트:
- Codex Plan Review v6: approve-implement (findings 0)
- Codex 브랜치 리뷰 (`/codex:review --base main`): PASS (회귀·실행 차단 버그 미발견)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
