### PR TITLE
fix: #1696 CLI reference usage line에 required option 인라인 표시 (generator dual-fix)

### DIFF
--- a/guide/cli.md
+++ b/guide/cli.md
@@ -519,7 +519,7 @@ ante audit list [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante approval request [OPTIONS]
+ante approval request --type <APPROVAL_TYPE> --title <TITLE> [OPTIONS]
 ```
 
 **Options:**
@@ -589,7 +589,7 @@ ante approval info <ID> [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante approval review <ID> [OPTIONS]
+ante approval review <ID> --result <REVIEW_RESULT> [OPTIONS]
 ```
 
 **Arguments:**
@@ -842,7 +842,7 @@ ante bot info <BOT_ID>
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante bot create [OPTIONS]
+ante bot create --name <NAME> --strategy <STRATEGY> [OPTIONS]
 ```
 
 **Options:**
@@ -939,7 +939,7 @@ ante bot positions <BOT_ID>
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante broker status [OPTIONS]
+ante broker status --account <ACCOUNT_ID>
 ```
 
 **Options:**
@@ -957,7 +957,7 @@ ante broker status [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante broker balance [OPTIONS]
+ante broker balance --account <ACCOUNT_ID>
 ```
 
 **Options:**
@@ -975,7 +975,7 @@ ante broker balance [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante broker positions [OPTIONS]
+ante broker positions --account <ACCOUNT_ID>
 ```
 
 **Options:**
@@ -993,7 +993,7 @@ ante broker positions [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante broker reconcile [OPTIONS]
+ante broker reconcile --account <ACCOUNT_ID> [OPTIONS]
 ```
 
 **Options:**
@@ -1284,7 +1284,7 @@ ante data validate [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante backtest run <STRATEGY_PATH> [OPTIONS]
+ante backtest run <STRATEGY_PATH> --start <START> --end <END> [OPTIONS]
 ```
 
 **Arguments:**
@@ -1617,7 +1617,7 @@ ante member list-invalid-roles [OPTIONS]
 - **토큰**: 🔑 Human master 전용 (#1543)
 
 ```bash
-ante member register [OPTIONS]
+ante member register --id <MEMBER_ID> --type <MEMBER_TYPE> [OPTIONS]
 ```
 
 **Options:**
@@ -1743,7 +1743,7 @@ Recovery Key로 패스워드 리셋 (인증 불필요).
 - **토큰**: 인증 불필요
 
 ```bash
-ante member reset-password [OPTIONS]
+ante member reset-password --recovery-key <RECOVERY_KEY> [OPTIONS]
 ```
 
 **Options:**
@@ -1790,7 +1790,7 @@ ante member regenerate-recovery-key [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante rule list [OPTIONS]
+ante rule list --account <ACCOUNT_ID> [OPTIONS]
 ```
 
 **Options:**
@@ -1809,7 +1809,7 @@ ante rule list [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante rule info <RULE_ID> [OPTIONS]
+ante rule info <RULE_ID> --account <ACCOUNT_ID>
 ```
 
 **Arguments:**
@@ -1837,7 +1837,7 @@ ante rule info <RULE_ID> [OPTIONS]
 - **토큰**: 인증 불필요
 
 ```bash
-ante signal connect [OPTIONS]
+ante signal connect --key <KEY>
 ```
 
 **Options:**
@@ -1997,7 +1997,7 @@ ante trade info <TRADE_ID> [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante treasury status [OPTIONS]
+ante treasury status --account <ACCOUNT_ID> [OPTIONS]
 ```
 
 **Options:**
@@ -2016,7 +2016,7 @@ ante treasury status [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante treasury allocate <BOT_ID> <AMOUNT> [OPTIONS]
+ante treasury allocate <BOT_ID> <AMOUNT> --account <ACCOUNT_ID>
 ```
 
 **Arguments:**
@@ -2041,7 +2041,7 @@ ante treasury allocate <BOT_ID> <AMOUNT> [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante treasury deallocate <BOT_ID> <AMOUNT> [OPTIONS]
+ante treasury deallocate <BOT_ID> <AMOUNT> --account <ACCOUNT_ID>
 ```
 
 **Arguments:**
@@ -2066,7 +2066,7 @@ ante treasury deallocate <BOT_ID> <AMOUNT> [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante treasury snapshot [OPTIONS]
+ante treasury snapshot --account <ACCOUNT_ID> [OPTIONS]
 ```
 
 **Options:**
@@ -2284,7 +2284,7 @@ ante feed status [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante feed inject <PATH> [OPTIONS]
+ante feed inject <PATH> --symbol <SYMBOL> [OPTIONS]
 ```
 
 **Arguments:**

--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -340,10 +340,18 @@ def _write_command_detail(
     options = [p for p in params if isinstance(p, click.Option)]
 
     # 사용법
+    # required option은 인라인 표시, non-required는 [OPTIONS]로 축약 (#1696).
     usage_parts = [f"ante {full_name}"]
     for arg in arguments:
-        usage_parts.append(f"<{arg.human_readable_name.upper()}>")
-    if options:
+        arg_mv = arg.metavar or (arg.human_readable_name or arg.name).upper()
+        usage_parts.append(f"<{arg_mv}>")
+    req_options = [o for o in options if o.required]
+    nonreq_options = [o for o in options if not o.required]
+    for opt in req_options:
+        opt_name = opt.opts[0] if opt.opts else f"--{opt.name.replace('_', '-')}"
+        opt_mv = opt.metavar or (opt.human_readable_name or opt.name).upper()
+        usage_parts.append(f"{opt_name} <{opt_mv}>")
+    if nonreq_options:
         usage_parts.append("[OPTIONS]")
     out.write(f"```bash\n{' '.join(usage_parts)}\n```\n\n")
 

--- a/tests/unit/test_generate_cli_reference.py
+++ b/tests/unit/test_generate_cli_reference.py
@@ -23,6 +23,7 @@ _get_params = _mod._get_params
 _get_required_scopes = _mod._get_required_scopes
 _format_scope_cell = _mod._format_scope_cell
 _format_token_cell = _mod._format_token_cell
+_write_command_detail = _mod._write_command_detail
 generate_cli_reference = _mod.generate_cli_reference
 
 # ── 헬퍼 함수 테스트 ─────────────────────────────────────────────────────────
@@ -445,3 +446,126 @@ class TestGenerateCliReference:
 
         blank = [cmd for cmd, desc in summary_rows if not desc.strip()]
         assert blank == [], f"설명이 비어 있는 명령어: {blank}"
+
+
+# ── usage line: required option 인라인 표시 (#1696) ─────────────────────────
+
+
+def _render_usage(cmd: click.Command, full_name: str) -> str:
+    """``_write_command_detail`` 의 usage line(```bash ... ```) 한 줄을 추출한다."""
+    buf = io.StringIO()
+    _write_command_detail(buf, full_name, cmd)
+    content = buf.getvalue()
+    # ```bash\n<usage>\n``` 패턴에서 usage 한 줄을 뽑는다.
+    marker = "```bash\n"
+    start = content.index(marker) + len(marker)
+    end = content.index("\n```", start)
+    return content[start:end]
+
+
+class TestUsageLineRequiredOptionInline:
+    """``_write_command_detail`` usage line이 required option을 인라인 표시 (#1696).
+
+    7 case A~G 매트릭스 (이슈 #1696 Implementation Plan v3.1):
+      A. required-only        → ``--account <ACCOUNT_ID>`` 인라인, ``[OPTIONS]`` 부재
+      B. 혼합                  → required 인라인 + ``[OPTIONS]``
+      C. non-required-only 회귀 → 기존 ``[OPTIONS]`` 유지
+      D. 다중 required, 인자 없음 → 다중 인라인 + ``[OPTIONS]``
+      E. metavar 변환          → ``--type`` → ``<APPROVAL_TYPE>``
+      F. 인자 + 단일 required  → 인자 + 인라인, ``[OPTIONS]`` 부재
+      G. 다중 인자 + 단일 required → 인자2 + 인라인, ``[OPTIONS]`` 부재
+    """
+
+    def test_case_a_required_only_no_options_token(self) -> None:
+        """A. required-only: ``ante broker status --account <ACCOUNT_ID>``."""
+
+        @click.command(name="status")
+        @click.option("--account", "account_id", required=True)
+        def status(account_id: str) -> None:
+            """잔고 상태."""
+
+        usage = _render_usage(status, "broker status")
+        assert usage == "ante broker status --account <ACCOUNT_ID>"
+        assert "[OPTIONS]" not in usage
+
+    def test_case_b_mixed_required_and_optional(self) -> None:
+        """B. 혼합: ``ante broker reconcile --account <ACCOUNT_ID> [OPTIONS]``."""
+
+        @click.command(name="reconcile")
+        @click.option("--account", "account_id", required=True)
+        @click.option("--force", is_flag=True, default=False)
+        def reconcile(account_id: str, force: bool) -> None:
+            """리컨실."""
+
+        usage = _render_usage(reconcile, "broker reconcile")
+        assert usage == "ante broker reconcile --account <ACCOUNT_ID> [OPTIONS]"
+
+    def test_case_c_nonrequired_only_regression(self) -> None:
+        """C. non-required-only 회귀: ``[OPTIONS]`` 유지, 인라인 없음."""
+
+        @click.command(name="list")
+        @click.option("--limit", type=int, default=50)
+        @click.option("--format", "output_format", default="text")
+        def list_cmd(limit: int, output_format: str) -> None:
+            """목록."""
+
+        usage = _render_usage(list_cmd, "audit list")
+        assert usage == "ante audit list [OPTIONS]"
+
+    def test_case_d_multi_required_no_arg(self) -> None:
+        """D. 다중 required, 인자 없음: bot create 형태."""
+
+        @click.command(name="create")
+        @click.option("--name", required=True)
+        @click.option("--strategy", required=True)
+        @click.option("--description", default=None)
+        def create(name: str, strategy: str, description: str | None) -> None:
+            """봇 생성."""
+
+        usage = _render_usage(create, "bot create")
+        assert usage == "ante bot create --name <NAME> --strategy <STRATEGY> [OPTIONS]"
+
+    def test_case_e_metavar_conversion_from_human_name(self) -> None:
+        """E. metavar 변환: ``--type`` (human_name=approval_type) → 대문자화."""
+
+        @click.command(name="request")
+        @click.option("--type", "approval_type", required=True)
+        @click.option("--title", required=True)
+        @click.option("--note", default=None)
+        def request_cmd(approval_type: str, title: str, note: str | None) -> None:
+            """승인 요청."""
+
+        usage = _render_usage(request_cmd, "approval request")
+        assert (
+            usage
+            == "ante approval request --type <APPROVAL_TYPE> --title <TITLE> [OPTIONS]"
+        )
+
+    def test_case_f_arg_plus_single_required_option(self) -> None:
+        """F. 인자 + required option: ``rule info <RULE_ID> --account <ACCOUNT_ID>``."""
+
+        @click.command(name="info")
+        @click.argument("rule_id")
+        @click.option("--account", "account_id", required=True)
+        def info(rule_id: str, account_id: str) -> None:
+            """룰 상세."""
+
+        usage = _render_usage(info, "rule info")
+        assert usage == "ante rule info <RULE_ID> --account <ACCOUNT_ID>"
+        assert "[OPTIONS]" not in usage
+
+    def test_case_g_multi_arg_plus_single_required_option(self) -> None:
+        """G. 다중 인자 + 단일 required: treasury allocate 형태."""
+
+        @click.command(name="allocate")
+        @click.argument("bot_id")
+        @click.argument("amount")
+        @click.option("--account", "account_id", required=True)
+        def allocate(bot_id: str, amount: str, account_id: str) -> None:
+            """예산 할당."""
+
+        usage = _render_usage(allocate, "treasury allocate")
+        assert (
+            usage == "ante treasury allocate <BOT_ID> <AMOUNT> --account <ACCOUNT_ID>"
+        )
+        assert "[OPTIONS]" not in usage


### PR DESCRIPTION
Closes #1696

## Summary

CLI 레퍼런스 생성기(`scripts/generate_cli_reference.py`)의 `_write_command_detail()` usage line이 required option을 `[OPTIONS]`로 묶어 가시성이 부족했다. account-required 8개 명령을 포함한 18개 required-option 보유 명령의 usage line에서 required option을 인라인으로 표시하도록 generator를 일반화한다.

normative invariant:

- 18개 required-option 보유 명령(account 8 + non-account 10)의 detail section usage line이 정확히 다음 형태:
  - required-only: `ante broker status --account <ACCOUNT_ID>` (`[OPTIONS]` 부재)
  - 혼합: `ante broker reconcile --account <ACCOUNT_ID> [OPTIONS]` (non-required `--fix` 존재)
  - 인자 + required option: `ante rule info <RULE_ID> --account <ACCOUNT_ID>`
- metavar 결정 규칙: `p.metavar or (p.human_readable_name or p.name).upper()` (예: `--account` → `<ACCOUNT_ID>`, `--recovery-key` → `<RECOVERY_KEY>`)
- `[OPTIONS]` 유지/생략 규칙: non-required option이 1개 이상 있으면 유지, 없으면 생략
- Click option 자체 무변경. summary table / narrative spec 무변경.

변경 묶음 (memory `project_generated_artifact_full_regen` 5축 dual-fix):

- `scripts/generate_cli_reference.py` — `_write_command_detail()` usage line에 required option 인라인 + argument metavar 일반화 로직 추가 (+10/-2)
- `tests/unit/test_generate_cli_reference.py` — `TestUsageLineRequiredOptionInline` 클래스 신설, 7 case A~G 매트릭스 (+124)
- `guide/cli.md` — 재생성 (+18/-18 = 18개 detail section usage line)

자연 변경 18개 명령:
- account-required 8: `broker {status,balance,positions,reconcile}`, `treasury {status,snapshot}`, `rule {list,info}`
- non-account 10: `approval {request,review}`, `bot create`, `backtest run`, `member {register,reset-password}`, `signal connect`, `treasury {allocate,deallocate}`, `feed inject`

## Test Plan

worktree(`/Users/jingulee/Projects/ante-worktrees/issue-1696`) 로컬:

- `pytest -q tests/unit/` → 6749 passed, 2 skipped
- `pytest -q tests/unit/test_generate_cli_reference.py` → 40 passed (7 신규 A~G + 33 회귀)
- `mypy src/` → Success (242 files)
- `ruff check && ruff format --check` → clean

신설 회귀 7 case (A~G):
- A (required-only): `ante broker status --account <ACCOUNT_ID>`, `[OPTIONS]` 부재
- B (혼합): `ante broker reconcile --account <ACCOUNT_ID> [OPTIONS]`
- C (non-required-only 회귀): required option 없는 명령은 기존 `[OPTIONS]` 유지
- D (다중 required, 인자 없음): `ante bot create --name <NAME> --strategy <STRATEGY> [OPTIONS]`
- E (metavar 변환): `--type` → `<APPROVAL_TYPE>` 변환 회귀
- F (인자 + required option): `ante rule info <RULE_ID> --account <ACCOUNT_ID>`, `[OPTIONS]` 부재
- G (다중 인자 + 단일 required): `ante treasury allocate <BOT_ID> <AMOUNT> --account <ACCOUNT_ID>`, `[OPTIONS]` 부재

grep 검증:
- account 7+1=8 (`(broker|treasury|rule) (status|snapshot|balance|positions|reconcile|list) --account` = 7, `rule info <RULE_ID> --account` = 1)
- generalization 18 (`^ante .* --[a-z-]+ <[A-Z_]+>`)

게이트:
- Codex Plan Review v3.1: approve-implement (narrow-scope verdict 후 v3.1 정정 완료, v3 표 = Click 트리 introspection 정확 매치)
- Codex 브랜치 리뷰 (`/codex:review --base main`): PASS (기존 동작 깨뜨림 결함 미발견)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
