### PR TITLE
docs: #1699 account-id-contract historical narrative에서 broker health/price `ante` prefix 제거

### DIFF
--- a/docs/specs/account/14-account-id-contract.md
+++ b/docs/specs/account/14-account-id-contract.md
@@ -361,8 +361,8 @@ C=#1636 / D follow-up / E follow-up / read-family follow-up /
 > [결정표](#결정표)의 현재형 정적 inventory 집계에는 포함되지
 > 않는다(현재형 동치 = 21/21/0).
 >
-> #1633 시점에는 ``ante broker health`` · ``ante broker price
-> <symbol>`` 가 03-commands.md 등 CLI/런타임-IPC 스펙에 공개 명령으로
+> #1633 시점에는 ``broker health`` · ``broker price <symbol>``
+> 가 03-commands.md 등 CLI/런타임-IPC 스펙에 공개 명령으로
 > 기재되어 있으나 ``src/ante/cli/commands/broker.py`` 에는
 > ``status``/``balance``/``positions``/``reconcile`` 만 등록되어 있어
 > ``spec-only`` (코드 표면 없음)로 분류되었고, 처리 결정은


### PR DESCRIPTION
Closes #1699

## Summary

`docs/specs/account/14-account-id-contract.md`의 #1633 historical 결정 narrative에 남은 `ante broker health` / `ante broker price <symbol>` 리터럴이 oracle probe `cli_broker_spec_only_commands` 재발견을 일으켰다. `ante ` prefix 2건만 제거해 invocation 형태를 끊고, historical 결정 의미(spec-only 분류, #1659 문서수정 처리)는 그대로 보존한다.

normative invariant:

- tracked, non-ignored 파일에서 `ante broker (health|price)` invocation 토큰이 등장하지 않는다.
- #1633/#1659 historical 결정 narrative 의미는 보존된다.
- Click 트리(`broker {status,balance,positions,reconcile}`) 무변경, 새 CLI alias 신설 없음.

before:
```
> #1633 시점에는 ``ante broker health`` · ``ante broker price
> <symbol>`` 가 03-commands.md 등 ...
```

after:
```
> #1633 시점에는 ``broker health`` · ``broker price <symbol>``
> 가 03-commands.md 등 ...
```

## Test Plan

worktree(`/Users/jingulee/Projects/ante-worktrees/issue-1699`) 로컬:

- `git grep -nE "ante broker (health|price)" -- ':!docs/temp/' ':!*.lock'` → **0건**
- `git grep -nE "broker (health|price)" docs/specs/cli/ docs/specs/broker-adapter/ docs/specs/ipc/ guide/cli.md` → **0건** (#1659 정합 유지)
- `pytest tests/unit/` → 6749 passed, 2 skipped
- `mypy src/` → Success (242 files)
- `ruff check && ruff format --check` → clean

게이트:
- Codex Plan Review v1: approve-implement (findings 0)
- Codex 브랜치 리뷰: PASS (2차 attempt — 1차에 공유 .venv `config/db/pip_freeze_v1.0.0.txt` 환경 drift 검출되어 amend로 제외, 본 PR diff는 1 file +2/-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
