### PR TITLE
fix: #1701 report schema/data list/bot list/member info에 @format_option decorator 추가

### DIFF
--- a/guide/cli.md
+++ b/guide/cli.md
@@ -2,7 +2,7 @@
 
 Ante가 제공하는 모든 CLI 명령어를 정리한 문서입니다. 각 명령어의 사용법, 옵션, 필수 권한(scope)을 확인할 수 있습니다.
 
-> 마지막 갱신: 2026-05-20
+> 마지막 갱신: 2026-05-21
 
 ## 목차
 
@@ -814,6 +814,7 @@ ante bot list [OPTIONS]
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
 | `--account` | - | TEXT | — | 계좌 ID로 필터링 |
+| `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
 ### ante bot info
@@ -1213,6 +1214,7 @@ ante data list [OPTIONS]
 |------|------|------|--------|------|
 | `--data-path` | - | TEXT | data/ | 데이터 디렉토리 경로 |
 | `--db-path` | - | TEXT | — | DB 경로 (미지정 시 config_dir 기반) |
+| `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
 ### ante data schema
@@ -1344,8 +1346,14 @@ ante backtest history <STRATEGY_NAME> [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante report schema
+ante report schema [OPTIONS]
 ```
+
+**Options:**
+
+| 옵션 | 필수 | 타입 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
 ### ante report submit
@@ -1566,7 +1574,7 @@ ante member list [OPTIONS]
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
 
 ```bash
-ante member info <MEMBER_ID>
+ante member info <MEMBER_ID> [OPTIONS]
 ```
 
 **Arguments:**
@@ -1574,6 +1582,12 @@ ante member info <MEMBER_ID>
 | 인자 | 필수 | 설명 |
 |------|------|------|
 | `<MEMBER_ID>` | O |  |
+
+**Options:**
+
+| 옵션 | 필수 | 타입 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
 ### ante member list-invalid-roles

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -11,6 +11,7 @@ import click
 
 from ante.cli._validators import reject_invalid_account_id
 from ante.cli.cold_path import is_active_runtime
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 
@@ -78,6 +79,7 @@ async def _run_bot_remove_cold_path(bot_id: str) -> dict:
 
 @bot.command("list")
 @click.option("--account", "account_id", default=None, help="계좌 ID로 필터링")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("bot:read")

--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import click
 
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 
@@ -16,6 +17,7 @@ def data() -> None:
 @data.command("list")
 @click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
 @click.option("--db-path", default=None, help="DB 경로 (미지정 시 config_dir 기반)")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("data:read")

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -196,6 +196,7 @@ def member_list(
 
 @member.command("info")
 @click.argument("member_id")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("member:read")

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -9,6 +9,7 @@ import click
 from pydantic import ValidationError
 
 from ante.cli._validators import reject_inverted_date_range, validate_iso_date
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 from ante.report.models import ReportStatus
@@ -27,6 +28,7 @@ def report() -> None:
 
 
 @report.command()
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("report:read")

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -2,6 +2,11 @@
 
 이슈 #632: `ante account list --format json` 형태로 호출할 때
 서브커맨드 뒤의 --format 옵션이 올바르게 동작하는지 검증한다.
+
+이슈 #1701: ``report schema``, ``data list``, ``bot list``, ``member info`` 4개
+trailing 명령에도 ``@format_option`` 누락이 잔존해 ``Error: No such option:
+--format`` 으로 거부되던 ingress drift를 닫는다. 4 case (+ default text
+회귀 1건)는 본 파일의 #632 패턴을 그대로 미러한다 (additive backward-compat).
 """
 
 from __future__ import annotations
@@ -9,9 +14,14 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
+from ante.cli.commands.bot import bot_list
+from ante.cli.commands.data import data_list
+from ante.cli.commands.member import member_info
+from ante.cli.commands.report import schema as report_schema
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 
@@ -565,3 +575,140 @@ class TestAccountSetCredentialsNonInteractive:
             assert creds["app_key"] == "my-key"
             assert creds["app_secret"] == "my-secret"
             assert creds["account_no"] == "50123456-01"
+
+
+# ── #1701: trailing 4 commands 정적 + runtime 회귀 ─────────────
+
+
+_TRAILING_SUBCOMMANDS_1701 = [
+    ("report schema", report_schema),
+    ("data list", data_list),
+    ("bot list", bot_list),
+    ("member info", member_info),
+]
+
+
+class TestTrailingFormatOptionRegistered1701:
+    """#1701: 4개 trailing 명령에 ``--format`` 옵션이 등록되어 있는지 정적 검증.
+
+    ``test_cli_approval_format_option`` 의 1:1 미러 패턴 (#1078 sibling).
+    decorator 누락 회귀를 click 메타데이터 레벨에서 감지한다.
+    """
+
+    @pytest.mark.parametrize(
+        "name,cmd",
+        _TRAILING_SUBCOMMANDS_1701,
+        ids=[s[0] for s in _TRAILING_SUBCOMMANDS_1701],
+    )
+    def test_format_option_exists(self, name: str, cmd: click.Command) -> None:
+        """``{name}`` 커맨드에 ``--format`` 옵션이 존재해야 한다."""
+        param_names = [p.name for p in cmd.params]
+        assert "output_format" in param_names, (
+            f"{name} 커맨드에 --format 옵션이 없습니다 (issue #1701)"
+        )
+
+    @pytest.mark.parametrize(
+        "name,cmd",
+        _TRAILING_SUBCOMMANDS_1701,
+        ids=[s[0] for s in _TRAILING_SUBCOMMANDS_1701],
+    )
+    def test_format_option_choices(self, name: str, cmd: click.Command) -> None:
+        """``--format`` 옵션은 text/json 중 선택 가능해야 한다."""
+        fmt_param = next(p for p in cmd.params if p.name == "output_format")
+        assert isinstance(fmt_param.type, click.Choice)
+        assert "json" in fmt_param.type.choices
+        assert "text" in fmt_param.type.choices
+
+
+class TestReportSchemaFormatOption1701:
+    """#1701: ``ante report schema --format json`` 은 exit 0 + valid JSON."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["report", "schema", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        # ReportStore.get_schema()는 dict를 반환하므로 JSON parse 가능해야 한다.
+        payload = json.loads(result.output)
+        assert isinstance(payload, dict)
+
+    def test_default_text_output_preserved(self, runner: CliRunner) -> None:
+        """``--format`` 미지정 시 기본 text 출력은 그대로 유지된다 (additive)."""
+        result = runner.invoke(cli, ["report", "schema"])
+
+        assert result.exit_code == 0, result.output
+        # text 모드는 ``OutputFormatter.output``이 ``str(data)`` 로 echo —
+        # JSON 모드의 indented dump (``{\n  "...":`` 패턴)와 구분된다.
+        assert not result.output.startswith("{\n  ")
+
+
+class TestDataListFormatOption1701:
+    """#1701: ``ante data list --format json`` 은 exit 0 + valid JSON."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        """ParquetStore가 빈 디렉토리를 반환하면 ``{datasets:[],count:0}`` 출력."""
+        mock_store = MagicMock()
+        mock_store.list_symbols.return_value = []
+
+        with patch("ante.data.store.ParquetStore", return_value=mock_store):
+            result = runner.invoke(cli, ["data", "list", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload == {"datasets": [], "count": 0}
+
+
+class TestBotListFormatOption1701:
+    """#1701: ``ante bot list --format json`` 은 exit 0 + valid JSON."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        """봇이 없을 때 ``{message:..., bots:[]}`` 출력."""
+        mock_db = _mock_db()
+        mock_db.fetch_all = AsyncMock(return_value=[])
+
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_db, None, None, None),
+        ):
+            result = runner.invoke(cli, ["bot", "list", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert "bots" in payload
+        assert payload["bots"] == []
+
+
+class TestMemberInfoFormatOption1701:
+    """#1701: ``ante member info <id> --format json`` 은 exit 0 + valid JSON.
+
+    기존 ``TestMemberInfoMissingExit.test_valid_exits_zero`` (#1515)는 루트 그룹
+    ``--format`` 을 사용했으나, #1701은 서브커맨드 위치 ``--format`` (member info
+    <id> --format json) 의 등록을 검증한다.
+    """
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        existing = Member(
+            member_id="m-1701",
+            type=MemberType.HUMAN,
+            role=MemberRole.DEFAULT,
+            org="default",
+            name="Existing",
+            status="active",
+            scopes=[],
+        )
+        svc = MagicMock()
+        svc.get = AsyncMock(return_value=existing)
+        db = _mock_db()
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(
+                cli, ["member", "info", "m-1701", "--format", "json"]
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["member_id"] == "m-1701"


### PR DESCRIPTION
Closes #1701

## Summary

4 CLI commands (`report schema`, `data list`, `bot list`, `member info`)에 `@format_option` decorator 추가. 이미 모든 4 함수 본문이 `fmt = get_formatter(ctx)` + `fmt.output/table/error` 패턴을 사용 중이지만 decorator 누락으로 trailing `--format json|text` invocation이 `No such option: --format`으로 거부됐다. sibling 명령(`member list`, `account list`, `strategy list/info`, `trade list` 등)과 일관성 회복.

scope (additive backward-compat):

- `src/ante/cli/commands/report.py`: `schema` 데코레이터 스택에 `@format_option` 추가 + `from ante.cli.formatter import format_option` import
- `src/ante/cli/commands/data.py`: `data_list` decorator + import
- `src/ante/cli/commands/bot.py`: `bot_list` decorator + import
- `src/ante/cli/commands/member.py`: `member_info` decorator (import 기존)
- `guide/cli.md`: 재생성 (4 detail section options table에 `--format` row + timestamp `2026-05-20 → 2026-05-21`)
- `tests/unit/test_cli_format_option.py`: #1701 회귀 5 클래스 / 13 케이스 추가 (정적 8 + runtime 5)

normative invariants:

- 성공 경로에서 trailing `--format json|text` parse + JSON/text 출력 정상.
- default(text) 동작 무변경, 출력 함수/내부 로직 무변경.
- 전역 `ante --format json <cmd>` 경로 무변경 (root-level option 그대로).

## Known Limitation (pre-existing global)

**Auth-gate text output**: `AuthenticatedGroup.invoke`의 인증 게이트는 leaf subcommand args 파싱 **전** 실행된다. 따라서 토큰 부재/권한 부족 시 trailing `--format json` 모드가 활성화되기 전 한국어 stderr text(`인증이 필요합니다. ...`)가 반환된다. 본 한계는 **본 PR 이전에도 모든 sibling 명령(`member list`/`account list`/`strategy list-info`/`trade list` 등 `@format_option` 보유 명령)에서 동일하게 발생**. 실측: `ante member list --format json` (no auth) → Korean text. 본 PR은 4 commands를 sibling 패턴과 정합시키는 additive 변경이며 새 contract drift 0.

**Workaround**: auth-fail JSON envelope 계약이 필요한 사용자는 leading `--format`을 사용한다 (`ante --format json <cmd>`). root group의 `--format`은 auth gate 전에 ctx에 반영되어 JSON envelope이 정상 반환된다.

**Follow-up**: `AuthenticatedGroup.invoke`가 leaf args의 마지막 `--format`을 peek해서 auth-fail 경로도 JSON envelope을 보장하도록 refactor하는 작업은 별 이슈로 분리(본 PR scope 밖). 본 PR과 backward-compatible.

## Test Plan

worktree(`/Users/jingulee/Projects/ante-worktrees/issue-1701`) 로컬:

- Direct CLI invocation (4 commands × `--format json`) → exit 0, JSON 출력 valid
- `pytest -q tests/unit/test_cli_format_option.py` → **29 passed** (기존 16 + 신규 13 #1701 회귀)
- `pytest -q tests/unit/` 전체 → **6762 passed, 2 skipped, 0 failed**
- `mypy src/` → Success (242 files)
- `ruff check && ruff format --check` → clean
- `git diff --stat guide/cli.md` → 4 cell options table에 `--format` row 추가 + timestamp 갱신, unintended drift 0
- `git grep -nE "@format_option" src/ante/cli/commands/{report,data,bot,member}.py` → 4 함수 모두 포함

게이트:
- Codex Plan Review v1: approve-implement (findings 0)
- Codex 브랜치 리뷰 attempt 1: [P2] pre-existing global auth-gate limitation 발견 → Known Limitation 섹션 추가로 normative bounded scope 선언, 본 PR scope 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
