### PR TITLE
fix: #1705 signal connect 4 validation 오류를 JSON envelope으로 normalize (_fail helper + @format_option)

### DIFF
--- a/guide/cli.md
+++ b/guide/cli.md
@@ -1851,7 +1851,7 @@ ante rule info <RULE_ID> --account <ACCOUNT_ID>
 - **토큰**: 인증 불필요
 
 ```bash
-ante signal connect --key <KEY>
+ante signal connect --key <KEY> [OPTIONS]
 ```
 
 **Options:**
@@ -1859,6 +1859,7 @@ ante signal connect --key <KEY>
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
 | `--key` | O | TEXT | — | 시그널 키 (sk_...) |
+| `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
 ---

--- a/src/ante/cli/commands/signal.py
+++ b/src/ante/cli/commands/signal.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from typing import NoReturn
 
 import click
 
+from ante.bot.exceptions import BOT_NOT_FOUND_CODE
+from ante.cli.formatter import OutputFormatter, format_option
 from ante.cli.middleware import require_auth
 
 
@@ -17,23 +20,25 @@ def signal() -> None:
 
 @signal.command("connect")
 @click.option("--key", required=True, help="시그널 키 (sk_...)")
+@format_option
 @click.pass_context
 @require_auth
 def signal_connect(ctx: click.Context, key: str) -> None:
     """양방향 JSON Lines 시그널 채널 수립."""
-    asyncio.run(_run_connect(key))
+    asyncio.run(_run_connect(ctx, key))
 
 
-async def _run_connect(key: str) -> None:
+async def _run_connect(ctx: click.Context, key: str) -> None:
     """시그널 채널 연결 및 실행."""
     from ante.bot.config import BotStatus
     from ante.bot.manager import BotManager
     from ante.bot.signal_channel import SignalChannel
     from ante.bot.signal_key import SignalKeyManager
-    from ante.cli.main import get_db_path
+    from ante.cli.main import get_db_path, get_formatter
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
 
+    fmt = get_formatter(ctx)
     db = Database(get_db_path())
     await db.connect()
 
@@ -44,8 +49,7 @@ async def _run_connect(key: str) -> None:
         # 1. 키 검증
         bot_id = await skm.validate_key(key)
         if not bot_id:
-            _err("Invalid signal key")
-            raise SystemExit(1)
+            _fail(fmt, "Invalid signal key", "INVALID_SIGNAL_KEY")
 
         # 2. 봇 존재 및 상태 확인
         eventbus = EventBus()
@@ -54,19 +58,24 @@ async def _run_connect(key: str) -> None:
 
         bot = manager.get_bot(bot_id)
         if not bot:
-            _err(f"Bot not found: {bot_id}")
-            raise SystemExit(1)
+            _fail(fmt, f"Bot not found: {bot_id}", BOT_NOT_FOUND_CODE)
 
         if bot.status != BotStatus.RUNNING:
-            _err(f"Bot is not running: {bot_id} (status: {bot.status.value})")
-            raise SystemExit(1)
+            _fail(
+                fmt,
+                f"Bot is not running: {bot_id} (status: {bot.status.value})",
+                "BOT_NOT_RUNNING",
+            )
 
         # 3. accepts_external_signals 확인
         if not bot.strategy or not bot.strategy.meta.accepts_external_signals:
-            _err(f"Bot {bot_id} does not accept external signals")
-            raise SystemExit(1)
+            _fail(
+                fmt,
+                f"Bot {bot_id} does not accept external signals",
+                "BOT_NOT_ACCEPTING_SIGNALS",
+            )
 
-        # 4. 채널 수립
+        # 4. 채널 수립 (informational stderr 유지)
         _err(f"Connected to bot {bot_id}")
         _err("Ready for JSON Lines communication on stdin/stdout")
 
@@ -79,6 +88,20 @@ async def _run_connect(key: str) -> None:
 
     finally:
         await db.close()
+
+
+def _fail(fmt: OutputFormatter, msg: str, code: str) -> NoReturn:
+    """validation 오류 종료.
+
+    JSON 모드는 stdout envelope (``{status,code,message}``),
+    text 모드는 기존 ``_err()`` raw stderr 동작을 그대로 보존한다
+    (no ``Error: `` prefix).
+    """
+    if fmt.is_json:
+        fmt.error(msg, code=code)
+    else:
+        _err(msg)
+    raise SystemExit(1)
 
 
 def _err(msg: str) -> None:

--- a/tests/unit/test_cli_signal_connect.py
+++ b/tests/unit/test_cli_signal_connect.py
@@ -1,0 +1,373 @@
+"""CLI ``ante signal connect`` JSON envelope 회귀 (#1705).
+
+기존 4 validation 오류 경로 — invalid key / bot not found / bot not running /
+bot not accepting signals — 가 raw stderr 로만 발화하여 ``--format json`` 호출이
+``Error: No such option: --format`` 으로 거부되거나 JSON envelope 으로 normalize
+되지 않던 ingress drift를 닫는다.
+
+본 파일은 #1701 ``test_cli_format_option.py`` 의 ``runner`` 인증 fixture 패턴을
+미러하여, ``ante.cli.main.authenticate_member`` 를 monkeypatch 해 leaf callback
+의 ``require_auth`` 가드를 통과시킨다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.bot.config import BotStatus
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner — ``mix_stderr=False`` 로 stderr 분리."""
+    r = CliRunner(mix_stderr=False)
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _mock_db() -> MagicMock:
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    return db
+
+
+def _patch_signal_deps(
+    *,
+    bot_id_for_key: str | None,
+    bot: MagicMock | None,
+):
+    """signal_connect 실행 환경의 Database/SignalKeyManager/BotManager mock 컨텍스트.
+
+    Args:
+        bot_id_for_key: ``validate_key(key)`` 반환값. ``None`` 이면 invalid key.
+        bot: ``BotManager.get_bot()`` 반환값. ``None`` 이면 bot not found.
+    """
+    db = _mock_db()
+    skm = MagicMock()
+    skm.initialize = AsyncMock()
+    skm.validate_key = AsyncMock(return_value=bot_id_for_key)
+
+    manager = MagicMock()
+    manager.initialize = AsyncMock()
+    manager.get_bot = MagicMock(return_value=bot)
+
+    patchers = [
+        patch("ante.core.database.Database", return_value=db),
+        patch("ante.bot.signal_key.SignalKeyManager", return_value=skm),
+        patch("ante.bot.manager.BotManager", return_value=manager),
+        patch("ante.eventbus.bus.EventBus", return_value=MagicMock()),
+        patch("ante.cli.main.get_db_path", return_value=":memory:"),
+    ]
+    return patchers
+
+
+def _make_bot(
+    *,
+    status: BotStatus = BotStatus.RUNNING,
+    accepts_external_signals: bool = True,
+    bot_id: str = "bot-1705",
+) -> MagicMock:
+    """validation-path mock Bot.
+
+    status + strategy.meta.accepts_external_signals 만 사용.
+    """
+    bot = MagicMock()
+    bot.status = status
+    if accepts_external_signals:
+        strategy = MagicMock()
+        strategy.meta = MagicMock()
+        strategy.meta.accepts_external_signals = True
+        bot.strategy = strategy
+    else:
+        strategy = MagicMock()
+        strategy.meta = MagicMock()
+        strategy.meta.accepts_external_signals = False
+        bot.strategy = strategy
+    bot._ctx = MagicMock()
+    return bot
+
+
+# ──────────────────────────────────────────────────────────────
+# A. 4 validation × JSON mode
+# ──────────────────────────────────────────────────────────────
+
+
+class TestSignalConnectJsonEnvelope1705:
+    """``--format json`` 모드: stdout JSON envelope + stderr empty + exit 1."""
+
+    def test_invalid_key(self, runner: CliRunner) -> None:
+        patchers = _patch_signal_deps(bot_id_for_key=None, bot=None)
+        for p in patchers:
+            p.start()
+        try:
+            result = runner.invoke(
+                cli,
+                ["signal", "connect", "--key", "sk_invalid", "--format", "json"],
+            )
+        finally:
+            for p in patchers:
+                p.stop()
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "status": "error",
+            "code": "INVALID_SIGNAL_KEY",
+            "message": "Invalid signal key",
+        }
+        assert result.stderr == ""
+
+    def test_bot_not_found(self, runner: CliRunner) -> None:
+        patchers = _patch_signal_deps(bot_id_for_key="bot-missing", bot=None)
+        for p in patchers:
+            p.start()
+        try:
+            result = runner.invoke(
+                cli,
+                ["signal", "connect", "--key", "sk_ok", "--format", "json"],
+            )
+        finally:
+            for p in patchers:
+                p.stop()
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "status": "error",
+            "code": "BOT_NOT_FOUND",
+            "message": "Bot not found: bot-missing",
+        }
+        assert result.stderr == ""
+
+    def test_bot_not_running(self, runner: CliRunner) -> None:
+        bot = _make_bot(status=BotStatus.STOPPED, bot_id="bot-1705")
+        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
+        for p in patchers:
+            p.start()
+        try:
+            result = runner.invoke(
+                cli,
+                ["signal", "connect", "--key", "sk_ok", "--format", "json"],
+            )
+        finally:
+            for p in patchers:
+                p.stop()
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "status": "error",
+            "code": "BOT_NOT_RUNNING",
+            "message": "Bot is not running: bot-1705 (status: stopped)",
+        }
+        assert result.stderr == ""
+
+    def test_bot_not_accepting_signals(self, runner: CliRunner) -> None:
+        bot = _make_bot(
+            status=BotStatus.RUNNING,
+            accepts_external_signals=False,
+            bot_id="bot-1705",
+        )
+        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
+        for p in patchers:
+            p.start()
+        try:
+            result = runner.invoke(
+                cli,
+                ["signal", "connect", "--key", "sk_ok", "--format", "json"],
+            )
+        finally:
+            for p in patchers:
+                p.stop()
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "status": "error",
+            "code": "BOT_NOT_ACCEPTING_SIGNALS",
+            "message": "Bot bot-1705 does not accept external signals",
+        }
+        assert result.stderr == ""
+
+
+# ──────────────────────────────────────────────────────────────
+# B. 4 validation × text mode (default — no Error: prefix)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestSignalConnectTextMode1705:
+    """default text 모드: stderr raw text + stdout empty + exit 1.
+
+    ``Error: `` prefix 가 붙지 않아야 하며, 기존 ``_err()`` 동작
+    (raw stderr + ``\\n``) 을 회귀 lock 한다.
+    """
+
+    def test_invalid_key_text(self, runner: CliRunner) -> None:
+        patchers = _patch_signal_deps(bot_id_for_key=None, bot=None)
+        for p in patchers:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["signal", "connect", "--key", "sk_invalid"])
+        finally:
+            for p in patchers:
+                p.stop()
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        assert result.stderr == "Invalid signal key\n"
+        assert result.stdout == ""
+
+    def test_bot_not_found_text(self, runner: CliRunner) -> None:
+        patchers = _patch_signal_deps(bot_id_for_key="bot-missing", bot=None)
+        for p in patchers:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
+        finally:
+            for p in patchers:
+                p.stop()
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        assert result.stderr == "Bot not found: bot-missing\n"
+        assert result.stdout == ""
+
+    def test_bot_not_running_text(self, runner: CliRunner) -> None:
+        bot = _make_bot(status=BotStatus.STOPPED, bot_id="bot-1705")
+        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
+        for p in patchers:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
+        finally:
+            for p in patchers:
+                p.stop()
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        assert result.stderr == "Bot is not running: bot-1705 (status: stopped)\n"
+        assert result.stdout == ""
+
+    def test_bot_not_accepting_signals_text(self, runner: CliRunner) -> None:
+        bot = _make_bot(
+            status=BotStatus.RUNNING,
+            accepts_external_signals=False,
+            bot_id="bot-1705",
+        )
+        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
+        for p in patchers:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
+        finally:
+            for p in patchers:
+                p.stop()
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        assert result.stderr == "Bot bot-1705 does not accept external signals\n"
+        assert result.stdout == ""
+
+
+# ──────────────────────────────────────────────────────────────
+# C. Informational stderr regression — 정상 path 의 2 informational 메시지
+# ──────────────────────────────────────────────────────────────
+
+
+class TestSignalConnectInformationalStderr1705:
+    """정상 path (valid key + running + accepts_external_signals) 에서
+    ``Connected to bot ...`` / ``Ready for JSON Lines ...`` 메시지가
+    stderr 에 그대로 출력됨을 lock. ``channel.run()`` 은 mock 해
+    채널 수립 직후 즉시 종료시킨다.
+    """
+
+    def test_informational_messages_to_stderr(self, runner: CliRunner) -> None:
+        bot = _make_bot(
+            status=BotStatus.RUNNING,
+            accepts_external_signals=True,
+            bot_id="bot-1705",
+        )
+        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
+        # SignalChannel.run() 을 즉시 종료시킨다.
+        mock_channel = MagicMock()
+        mock_channel.run = AsyncMock(return_value=None)
+        signal_channel_patch = patch(
+            "ante.bot.signal_channel.SignalChannel", return_value=mock_channel
+        )
+        for p in patchers:
+            p.start()
+        signal_channel_patch.start()
+        try:
+            result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
+        finally:
+            signal_channel_patch.stop()
+            for p in patchers:
+                p.stop()
+
+        assert result.exit_code == 0, (result.stdout, result.stderr)
+        assert "Connected to bot bot-1705" in result.stderr
+        assert "Ready for JSON Lines communication on stdin/stdout" in result.stderr
+
+
+# ──────────────────────────────────────────────────────────────
+# D. Optional auth-fail regression — root-level --format json
+# ──────────────────────────────────────────────────────────────
+
+
+class TestSignalConnectAuthFail1705:
+    """no-token + root-level ``--format json signal connect`` →
+    stdout ``auth_required`` JSON envelope (root-level Workaround sibling 정합).
+    """
+
+    def test_auth_required_json_envelope(self) -> None:
+        r = CliRunner(mix_stderr=False)
+        # authenticate_member 가 ctx.obj["member"] 를 채우지 않도록 monkeypatch.
+        # require_auth 가드는 member is None 시 _emit_auth_error 로 종료.
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _no_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = None
+
+            mock_auth.side_effect = _no_member
+            result = r.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "signal",
+                    "connect",
+                    "--key",
+                    "sk_anything",
+                ],
+            )
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == "auth_required"


### PR DESCRIPTION
Closes #1705

## Summary

`ante signal connect`의 4 pre-channel validation 오류(invalid key / bot not found / not running / not accepting signals)를 JSON 모드에서 stdout `{status:"error", code, message}` envelope으로 normalize. text 모드는 기존 `_err()` raw stderr 동작 정확 보존(no `Error: ` prefix). channel 수립 후 stdout JSON Lines protocol과 2 informational 메시지(stderr) 무변경.

normative invariants:

- 4 validation 오류 → `_fail(fmt, msg, code)` helper 통과: JSON → `fmt.error(msg, code=code)` stdout envelope, text → `_err(msg)` raw stderr (기존 정확 보존), 이후 `raise SystemExit(1)`
- 새 에러 코드 3종: `INVALID_SIGNAL_KEY`, `BOT_NOT_RUNNING`, `BOT_NOT_ACCEPTING_SIGNALS`
- 기존 vocab 재사용: `BOT_NOT_FOUND_CODE` (`src/ante/bot/exceptions.py`)
- sibling 패턴 일관: `@format_option` 추가 (`@click.pass_context` 위)

변경 묶음 (memory `project_generated_artifact_full_regen` 5축 dual-fix):

- `src/ante/cli/commands/signal.py` (+25/-7): imports 3건 추가, `@format_option` 데코레이터, ctx 전달, `_fail` helper 신설, 4 validation 변환
- `tests/unit/test_cli_signal_connect.py` (+371, 신설): 10 cases (4 validation × 2 mode + informational stderr + auth-fail regression)
- `guide/cli.md` (+2/-1): `signal connect` detail section options table에 `--format` row 추가 (재생성)

## Known Limitation (pre-existing global)

`AuthenticatedGroup.invoke`의 auth gate가 leaf args 파싱 전 실행됨. 토큰 부재 시:
- **subcommand-level** `ante signal connect ... --format json` → Korean text gap (sibling 명령과 정합, #1701 인지 사항)
- **root-level** `ante --format json signal connect ...` → `auth_required` JSON envelope (works, root group `--format`이 auth gate 전 ctx 반영)

본 PR 4 validation은 auth pass 후 도달이므로 위 gap의 영향 밖. Follow-up: auth-fail subcommand JSON envelope refactor는 별 이슈로 분리 (본 PR과 backward-compatible).

## Test Plan

worktree(`/Users/jingulee/Projects/ante-worktrees/issue-1705`) 로컬:

- `pytest -q tests/unit/test_cli_signal_connect.py` → **10 passed** in 0.21s
- `pytest -q tests/unit/` → **6772 passed, 2 skipped** in 213.75s
- `mypy src/` → clean (242 files)
- `ruff check && ruff format --check` → clean (571 files)
- Direct CLI invocation 4 validation × 2 mode 모두 의도대로 출력 확인 (PR 본문에 raw output 첨부 불요)

게이트:
- Codex Plan Review v3.1: approve-implement (findings 0)
- Codex 브랜치 리뷰 (`/codex:review --base main`): PASS (1차 attempt — 명확한 결함 미발견)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
