### PR TITLE
docs: #1702 project-structure CLI inventory 8 항목 현행화 (DEFAULT_DESCRIPTIONS + md 재생성)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-05-20 (KST)
+> 마지막 생성 시점: 2026-05-22 (KST)
 
 ## 최상위 구조
 
@@ -258,24 +258,24 @@ src/ante/
 │   ├── formatter.py                  # OutputFormatter — table/json 출력
 │   ├── commands/
 │   │   ├── _password.py              # generate_password() — CLI용 랜덤 패스워드 유틸
-│   │   ├── approval.py               # ante approval request/list/info/review/cancel/approve/reject
+│   │   ├── approval.py               # ante approval approve/audit-types/cancel/cancel-invalid/info/list/reject/reopen/request/review
 │   │   ├── audit.py                  # ante audit — 감사 로그 조회
-│   │   ├── backtest.py               # ante backtest run (진행률 바, 성과 지표 테이블 포함)
+│   │   ├── backtest.py               # ante backtest history/run
 │   │   ├── bot.py                    # ante bot create/info/list/positions/remove/signal-key (start/stop/status 미구현 follow-up)
-│   │   ├── broker.py                 # ante broker 명령
-│   │   ├── config.py                 # ante config 명령
+│   │   ├── broker.py                 # ante broker balance/positions/reconcile/status
+│   │   ├── config.py                 # ante config get/history/set
 │   │   ├── data.py                   # ante data list/schema/storage/validate
 │   │   ├── init.py                   # ante init — 비대화형 최소 초기 설정 (master + 테스트 계좌)
 │   │   ├── instrument.py             # ante instrument list/search/sync/import (--listed-only)
 │   │   ├── member.py                 # ante member register/list/info/suspend/revoke/set-emoji/... (bootstrap은 init으로 통합)
 │   │   ├── notification.py           # 알림 CLI (public leaf 없음 — 텔레그램 이관)
 │   │   ├── report.py                 # ante report schema/submit/list/performance/view
-│   │   ├── rule.py                   # ante rule 명령
+│   │   ├── rule.py                   # ante rule info/list
 │   │   ├── signal.py                 # ante signal — 외부 시그널 채널 관리
 │   │   ├── strategy.py               # ante strategy validate/submit/list/info/performance
-│   │   ├── system.py                 # ante system 명령
-│   │   ├── trade.py                  # ante trade 명령
-│   │   ├── treasury.py               # ante treasury 명령
+│   │   ├── system.py                 # ante system clear-halt/halt/start/status/stop
+│   │   ├── trade.py                  # ante trade info/list
+│   │   ├── treasury.py               # ante treasury allocate/deallocate/snapshot/status
 │   │   ├── __init__.py
 │   │   ├── account.py
 │   │   ├── ipc_helpers.py
@@ -643,7 +643,8 @@ tests/
 │   ├── strategy/
 │   │   ├── __init__.py
 │   │   └── test_validator_source_read_parse_no_reflection.py
-│   └── test_cli_notification_hidden.py
+│   ├── test_cli_notification_hidden.py
+│   └── test_cli_signal_connect.py
 └── __init__.py
 ```
 

--- a/scripts/generate_project_structure.py
+++ b/scripts/generate_project_structure.py
@@ -98,10 +98,17 @@ DEFAULT_DESCRIPTIONS: dict[str, str] = {
     "scripts/generate_db_schema.py": "DB 스키마 문서 자동 생성",
     "scripts/generate_project_structure.py": "프로젝트 구조 Agent INDEX 생성/check",
     "src/ante": "Python 백엔드 패키지",
+    "src/ante/cli/commands/approval.py": (
+        "ante approval approve/audit-types/cancel/cancel-invalid/info/list/"
+        "reject/reopen/request/review"
+    ),
+    "src/ante/cli/commands/backtest.py": "ante backtest history/run",
     "src/ante/cli/commands/bot.py": (
         "ante bot create/info/list/positions/remove/signal-key "
         "(start/stop/status 미구현 follow-up)"
     ),
+    "src/ante/cli/commands/broker.py": "ante broker balance/positions/reconcile/status",
+    "src/ante/cli/commands/config.py": "ante config get/history/set",
     "src/ante/cli/commands/data.py": "ante data list/schema/storage/validate",
     "src/ante/cli/commands/notification.py": (
         "알림 CLI (public leaf 없음 — 텔레그램 이관)"
@@ -109,8 +116,14 @@ DEFAULT_DESCRIPTIONS: dict[str, str] = {
     "src/ante/cli/commands/report.py": (
         "ante report schema/submit/list/performance/view"
     ),
+    "src/ante/cli/commands/rule.py": "ante rule info/list",
     "src/ante/cli/commands/strategy.py": (
         "ante strategy validate/submit/list/info/performance"
+    ),
+    "src/ante/cli/commands/system.py": "ante system clear-halt/halt/start/status/stop",
+    "src/ante/cli/commands/trade.py": "ante trade info/list",
+    "src/ante/cli/commands/treasury.py": (
+        "ante treasury allocate/deallocate/snapshot/status"
     ),
     "src/ante/web/routes/notifications.py": (
         "알림 API (stub, 이력 조회 삭제·텔레그램 이관)"


### PR DESCRIPTION
Closes #1702

## Summary

사용자 지시(2026-05-22)에 따라 `docs/architecture/generated/project-structure.md`의 CLI inventory 8 항목을 실제 Click 트리와 정합화. Oracle 원래 probe (notification history/data inject/report show/strategy load)는 이미 #1680에서 처리되어 정합 상태였으나, 그 외 inventory drift 8 항목 발견:

- **approval.py**: 3 누락 (`audit-types`, `cancel-invalid`, `reopen`) → 10 명령 enumerate
- **backtest.py**: 1 누락 (`history`) → `history/run` (narrative `(진행률 바, ...)` 제거, sibling leaf-only 일관성)
- **broker/config/rule/system/trade/treasury**: 6 weak narrative → 구체 명령 enumerate

generator precedence (`_comment_for(path, comments) = comments.get(path) or DEFAULT_DESCRIPTIONS.get(path)`)로 인해 기존 generated md comment가 dict override. 따라서 2단계 dual-fix:

1. `scripts/generate_project_structure.py:DEFAULT_DESCRIPTIONS`에 8 항목 추가
2. `docs/architecture/generated/project-structure.md`에서 8 stale comment 라인의 `# ...` 부분만 제거 → 재생성 시 fallback 활성화

`bot.py` 라인의 `(start/stop/status 미구현 follow-up)` 표기는 #1698 영역(별 이슈)으로 보존.

scope (2 files):
- `scripts/generate_project_structure.py` (+13/-0)
- `docs/architecture/generated/project-structure.md` (+11/-10)

의도된 diff:
- 8 line `# ante <group> <leafs>` 갱신
- 1 timestamp `2026-05-20 → 2026-05-22`
- 1 `test_cli_signal_connect.py` tree node 추가 (#1705 pre-existing drift, 본 PR 명시 소유, memory `project_generated_artifact_full_regen` 5축 #3)

## Test Plan

worktree(`/Users/jingulee/Projects/ante-worktrees/issue-1702`) 로컬:

- `pytest -q tests/unit/` → **6772 passed, 2 skipped** in 213.88s
- `mypy src/` → Success (242 files)
- `ruff check && ruff format --check` → clean
- `grep -nE "ante (approval|backtest|broker|config|rule|system|trade|treasury|bot)" docs/architecture/generated/project-structure.md` → **9 매치** (8 갱신 + bot follow-up 보존)
- 재생성 idempotence: 2회 실행 결과 동일
- main HEAD 불변 (`945971c`)

게이트:
- Codex Plan Review v3: approve-implement (findings 0)
- Codex 브랜치 리뷰 (`/codex:review --base main`): PASS (1차 attempt — 동작 깨뜨림 결함 미발견)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
