### PR TITLE
docs: #1711 bot start/stop/status CLI·IPC 계약 스펙 확정 (Web API 라우트 정렬)

### DIFF
--- a/docs/specs/account/05-eventbus-integration.md
+++ b/docs/specs/account/05-eventbus-integration.md
@@ -43,5 +43,6 @@ ante system clear-halt              # 전역 정지 해제 (모든 SUSPENDED 계
 - `AccountSuspendedEvent`: BotManager가 해당 계좌의 소속 봇을 중지한다.
 - `AccountActivatedEvent`: BotManager는 계좌 상태 변화를 인지하고 로깅만 수행한다. 자동 재시작은 수행하지 않는다.
 
-재시작은 운영자가 명시적으로 `ante bot start <bot_id>` 또는 동등 IPC 명령으로 수행한다.
-단 `ante bot start` CLI command은 미구현 (follow-up)이며 wiring은 별도 follow-up이다.
+재시작은 운영자가 명시적으로 `ante bot start <bot_id>` CLI 또는 Web API `POST
+/api/bots/{bot_id}/start`로 수행한다. 두 경로는 같은 BotManager 인스턴스를 통해 같은
+검증·실행·이벤트·감사 경로를 사용한다.

--- a/docs/specs/audit/audit.md
+++ b/docs/specs/audit/audit.md
@@ -165,9 +165,11 @@ AuditLogger는 인프라(기록·조회)만 제공한다. 실제 기록은 **Web
 | `ante member reset-password` | `member.reset_password` | `member:{member_id}` |
 | `ante member regenerate-recovery-key` | `member.regenerate_recovery_key` | `member:{member_id}` |
 
-> **미구현 (follow-up)**: 위 표의 `ante bot start`(`bot.start`)·`ante bot
-> stop`(`bot.stop`) 행은 audit action 매핑 계약이다. 해당 CLI command는 현재
-> 미등록이며 wiring은 별도 follow-up이다. 그때까지 이 두 매핑은 도달 불가다.
+`ante bot start`/`ante bot stop`은 Web API `POST /api/bots/{bot_id}/start` /
+`POST /api/bots/{bot_id}/stop`과 같은 audit action(`bot.start`/`bot.stop`) 이름을
+공유한다. CLI/IPC와 Web API 양쪽 호출자의 봇 생애주기 변경이 단일 audit action
+namespace로 모인다. `ante bot status`는 read-only live 조회이므로 audit 대상이 아니다
+(상태 변경 액션만 기록하는 audit 기록 원칙).
 
 ### 구현 방식 — 이중 구조
 

--- a/docs/specs/bot/03-design-decisions.md
+++ b/docs/specs/bot/03-design-decisions.md
@@ -207,8 +207,16 @@ BotManager.start_bot(bot_id)
 CLI의 `bot create/start/stop`과 `bot signal-key --rotate`는 위 흐름을 서버
 프로세스 안에서 실행해야 하므로 런타임 IPC 전용이다. 직접 DB 수정으로 봇 status나
 signal key를 바꾸면 `_bots`, 실행 task, EventBus 구독, 외부 signal channel이
-어긋나므로 허용하지 않는다. 단 `ante bot start`/`ante bot stop` CLI command은
-미구현 (follow-up)이며 wiring은 별도 follow-up이다.
+어긋나므로 허용하지 않는다.
+
+`ante bot start/stop/status`의 CLI/IPC 계약은 Web API 봇 라우트(`POST
+/api/bots/{bot_id}/start`, `POST /api/bots/{bot_id}/stop`, `GET /api/bots/{bot_id}`)와
+1:1 정렬된다. CLI/IPC가 같은 BotManager 인스턴스를 통해 같은 검증·실행·이벤트·감사
+경로를 사용해야, Web API와 CLI 양쪽 호출자가 같은 봇에 대해 같은 결과를 얻고 같은
+audit trail을 남기기 때문이다. `start`의 `app_key` 사전 검증, `BotError` → 409 의미의
+state conflict 매핑, `bot.start`/`bot.stop` audit action 이름, `BotDetailResponse`
+envelope (`{"bot": ...}`)은 모두 Web API 라우트의 동작에서 가져온다. cold-path
+fallback이나 직접 DB 수정으로 봇을 시작/중지하는 경로는 양쪽 모두 허용하지 않는다.
 
 `bot remove`는 예외적으로 서버 실행 중에는 런타임 IPC, 서버 정지 상태에서는
 cold-path cleanup을 허용한다. cold-path 삭제는 BotManager를 만들지 않고 DB에

--- a/docs/specs/bot/06-cli-usage.md
+++ b/docs/specs/bot/06-cli-usage.md
@@ -15,11 +15,16 @@ EventBus 구독, 외부 signal channel에 영향을 주므로 런타임 IPC로 �
 DB의 persisted state를 직접 정리한다. 서버 실행 중 조회는 IPC로 live 상태를 우선
 조회하고, 서버 정지 중에는 DB에 저장된 persisted snapshot만 조회한다.
 
-> **미구현 (follow-up)**: `ante bot start`/`ante bot stop`/`ante bot status`
-> CLI command는 현재 등록되어 있지 않다. 아래 사용 예시의 `bot start`/
-> `bot stop`/`bot status` 라인은 설계 의도이며 현재 실행 불가다.
-> wiring은 별도 follow-up이다. 현재 실재 bot CLI는
-> `create/info/list/positions/remove/signal-key`.
+`ante bot start/stop/status`는 Web API 봇 제어 라우트(`POST /api/bots/{bot_id}/start`,
+`POST /api/bots/{bot_id}/stop`, `GET /api/bots/{bot_id}`)와 같은 live 서버 경로로 계약을
+정의한다. 세 명령 모두 서버가 실행 중일 때만 동작하며, cold-path fallback은 없다. 정렬
+계약은 [cli/03-commands.md](../cli/03-commands.md#ante-bot--봇-관리)에 있다.
+
+> **구현 진행 상황 (#1698 epic)**: 본 절은 그 계약을 사전에 확정하는 SSOT다. 현재
+> main(`8479e53`)의 `ante bot --help`에는 `start/stop/status`가 아직 노출되지 않으며,
+> 실행 시 `No such command`로 실패한다. IPC handler 등록은 #1712, Click command
+> 등록과 `guide/cli.md` 재생성은 #1713에서 수행한다. 아래 사용 예시는 #1712 + #1713
+> merge 후 실행 가능한 형태다.
 
 ```bash
 # 전략 등록 후 봇 생성 — --account 필수 옵션 (active 계좌가 정확히 1개일 때만 생략 가능, 자동 선택)
@@ -29,7 +34,7 @@ ante bot create --name "Momentum Bot" --strategy momentum_breakout_v1.0.0 --acco
 ante bot create --name "Agent Relay" --strategy agent_relay_v1.0.0 --account us-stock
 # → bot_id: bot_002, signal_key: sk_a1b2c3d4 (외부 시그널 수신 가능)
 
-# 봇 시작 — 미구현 (follow-up): CLI command 미등록
+# 봇 시작 — Web API POST /api/bots/{bot_id}/start와 같은 동작. app_key 사전 검증 + audit bot.start
 ante bot start bot_001
 
 # 봇 목록 조회
@@ -37,10 +42,10 @@ ante bot list
 ante bot list --account domestic         # 계좌별 필터
 ante --format json bot list              # JSON 출력은 root 전역 옵션
 
-# 봇 상태 조회 — 미구현 (follow-up): CLI command 미등록
+# 봇 상태 조회 — Web API GET /api/bots/{bot_id}와 같은 live 조회. {bot: ...} envelope
 ante bot status bot_001
 
-# 봇 중지 — 미구현 (follow-up): CLI command 미등록
+# 봇 중지 — Web API POST /api/bots/{bot_id}/stop과 같은 동작. audit bot.stop
 ante bot stop bot_001
 
 # 봇 삭제 — --yes 필수. 서버 실행 중이면 IPC, 서버 정지 중이면 cold-path cleanup

--- a/docs/specs/bot/08-cross-module-notes.md
+++ b/docs/specs/bot/08-cross-module-notes.md
@@ -9,5 +9,5 @@
 - **Data Pipeline 스펙 작성 시**: ContextFactory가 DataProvider를 StrategyContext에 주입
 - **Rule Engine 스펙 작성 시**: OrderRequestEvent에 bot_id, account_id 포함 — 봇별·계좌별 룰 조회에 활용
 - **Web API 스펙 작성 시**: BotManager의 create/start/stop/list를 REST API로 노출
-- **CLI/IPC 스펙 작성 시**: `bot create/start/stop/remove`와 `signal-key --rotate`는 런타임 IPC로 서버 BotManager에 위임한다. 실행 중 조회는 서버 live 상태가 필요하면 IPC를 우선 사용하고, 서버 정지 중에는 persisted snapshot만 조회한다. 단 `ante bot start/stop/status` CLI command은 미구현 (follow-up)이며 실재 bot CLI는 `create/info/list/positions/remove/signal-key`다.
+- **CLI/IPC 스펙 작성 시**: `bot create/start/stop/remove`와 `signal-key --rotate`는 런타임 IPC로 서버 BotManager에 위임한다. 실행 중 조회는 서버 live 상태가 필요하면 IPC를 우선 사용하고, 서버 정지 중에는 persisted snapshot만 조회한다. `ante bot start/stop/status`는 Web API 봇 라우트(`POST /api/bots/{bot_id}/start`, `POST /api/bots/{bot_id}/stop`, `GET /api/bots/{bot_id}`)와 1:1 정렬되며, `start`의 `app_key` credential preflight·`BotDetailResponse` envelope·`bot.start`/`bot.stop` audit action 이름은 Web API 라우트 동작과 같은 SSOT를 사용한다.
 - **Notification 스펙 작성 시**: BotErrorEvent 구독 → 텔레그램 알림 발송

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -90,12 +90,12 @@ allowlist 후보에서 제거한다.
 | `ante account activate <account_id>` | `runtime IPC` | 서버 AccountService + EventBus |
 | `ante bot list [--account <account_id>]` | `runtime IPC + snapshot fallback` | 서버 BotManager live 조회 우선 |
 | `ante bot info <bot_id>` | `runtime IPC + snapshot fallback` | 서버 BotManager live 조회 우선 |
-| `ante bot status <bot_id>` | `runtime IPC + snapshot fallback` | 서버 BotManager live 조회 우선. **미구현 (follow-up)**: `ante bot status` CLI command 부재 |
+| `ante bot status <bot_id>` | `runtime IPC` | Web API `GET /api/bots/{bot_id}`와 같은 live `BotManager.get_bot()` 조회. read-only. 응답은 `BotDetailResponse`와 같은 `{bot: ...}` envelope |
 | `ante bot positions <bot_id>` | `runtime IPC + snapshot fallback` | live 포지션 조회 우선 |
 | `ante bot signal-key <bot_id>` | `runtime IPC + snapshot fallback` | live signal key 상태 조회 우선 |
 | `ante bot create --name <name> --strategy <strategy_id> ...` | `runtime IPC` | 서버 BotManager 생성 |
-| `ante bot start <bot_id>` | `runtime IPC` | 서버 BotManager 실행 task 생성. **미구현 (follow-up)**: `ante bot start` CLI command 부재 |
-| `ante bot stop <bot_id>` | `runtime IPC` | 서버 BotManager 실행 task 중지. **미구현 (follow-up)**: `ante bot stop` CLI command 부재 |
+| `ante bot start <bot_id>` | `runtime IPC` | Web API `POST /api/bots/{bot_id}/start`와 같은 동작. `BotManager.start_bot()` 실행 task 생성. `app_key` 사전 검증 + audit `bot.start` |
+| `ante bot stop <bot_id>` | `runtime IPC` | Web API `POST /api/bots/{bot_id}/stop`과 같은 동작. `BotManager.stop_bot()` 실행 task 중지. audit `bot.stop` |
 | `ante bot remove <bot_id> --yes` | `runtime IPC + cold-path fallback` | 실행 중이면 서버 BotManager 정리, 정지 중이면 persisted bot cleanup |
 | `ante bot signal-key <bot_id> --rotate` | `runtime IPC` | 기존 signal channel 무효화 |
 | `ante trade list [--bot <bot_id>] [--from <date>] [--to <date>] [--limit N]` | `offline` | canonical DB 조회 |
@@ -318,22 +318,19 @@ JSON 출력이 필요하면 root 전역 옵션을 사용한다:
 
 ### `ante bot` — 봇 관리
 
+> **구현 진행 상황 (#1698 epic)**: `start/stop/status`의 IPC handler 등록은 #1712, Click command 등록과 `guide/cli.md` 재생성은 #1713에서 수행한다. 본 절은 그 계약을 사전에 확정하는 SSOT다. 현재 main(`8479e53`)의 `ante bot --help`에는 `start/stop/status`가 아직 노출되지 않는다 — 사용자/Agent는 #1712 + #1713 merge 후 실행 가능하다.
+
 ```bash
 ante bot list [--account <account_id>]  # 봇 목록 (계좌별 필터링)
 ante bot create --name <name> --strategy <strategy_id> [--account <account_id>] [--id <bot_id>] [--interval <초>] [--param key=value ...]
-ante bot start <bot_id>            # 봇 시작 — 미구현 (follow-up)
-ante bot stop <bot_id>             # 봇 중지 — 미구현 (follow-up)
+ante bot start <bot_id>            # 봇 시작 (Web API POST /api/bots/{bot_id}/start와 같은 동작)
+ante bot stop <bot_id>             # 봇 중지 (Web API POST /api/bots/{bot_id}/stop과 같은 동작)
 ante bot remove <bot_id> --yes     # 봇 삭제 (--yes 누락 시 CLI_CONFIRMATION_REQUIRED)
 ante bot info <bot_id>             # 봇 상세 정보
-ante bot status <bot_id>           # 봇 실행 상태 — 미구현 (follow-up)
+ante bot status <bot_id>           # 봇 실행 상태 (Web API GET /api/bots/{bot_id}와 같은 live 조회)
 ante bot positions <bot_id>        # 봇 현재 포지션
 ante bot signal-key <bot_id> [--rotate]  # 외부 시그널 키 조회·갱신
 ```
-
-> **미구현 (follow-up)**: `ante bot start`/`ante bot stop`/`ante bot status`
-> CLI command는 현재 등록되어 있지 않다. 위 매핑은 설계 계약이며 wiring은
-> 별도 follow-up이다. 현재 실재 bot CLI는
-> `create/info/list/positions/remove/signal-key`.
 
 `bot create`의 `--account` 생략 시 동작은 [위 절](#ante-bot-create의---account-생략-정책)을 따른다.
 
@@ -341,9 +338,36 @@ ante bot signal-key <bot_id> [--rotate]  # 외부 시그널 키 조회·갱신
 `_bots`, 실행 task, EventBus 구독, signal key 연결 상태를 바꾸므로 런타임 IPC 커맨드다.
 `bot remove`는 서버 실행 중에는 IPC로 BotManager에 위임하고, 서버 정지 중에는
 cold-path fallback으로 signal key, 전략 스냅샷, Treasury budget, `bots.status`만
-정리한다. 서버 실행 중 `bot list/info/status/positions/signal-key` 조회는 IPC로
+정리한다. 서버 실행 중 `bot list/info/positions/signal-key` 조회는 IPC로
 서버의 live 상태를 우선 조회한다. 서버가 정지된 상태에서는 DB의 persisted snapshot만
 읽을 수 있으며, `bot remove` 외 직접 DB 수정으로 봇 상태를 바꾸는 경로는 허용하지 않는다.
+
+`bot status`는 Web API `GET /api/bots/{bot_id}`와 1:1 정렬된 live-only 조회이며, snapshot
+fallback이 없다 — 서버가 정지된 상태에서는 `BotManager`가 부재하므로 `status`는 호출할 수
+없고, persisted 봇 메타데이터는 `bot list/info`로 조회한다.
+
+`bot start/stop/status`는 Web API 봇 라우트와 1:1 정렬된다.
+
+- `ante bot start <bot_id>` ≡ `POST /api/bots/{bot_id}/start`: live
+  `BotManager.get_bot(bot_id)`로 존재 확인 후, `account_service.get(bot.config.account_id)`로
+  `app_key` 사전 검증. `BotManager.start_bot()` 호출 후 audit action `bot.start`를 기록한다.
+  성공 응답은 `BotDetailResponse`와 같은 `{"bot": bot.get_info()}` envelope이다. cold-path
+  fallback은 없다.
+- `ante bot stop <bot_id>` ≡ `POST /api/bots/{bot_id}/stop`: live
+  `BotManager.get_bot(bot_id)` 후 `BotManager.stop_bot()` 호출, audit action `bot.stop`을
+  기록한다. 응답은 `{"bot": bot.get_info()}` envelope. cold-path fallback은 없다.
+- `ante bot status <bot_id>` ≡ `GET /api/bots/{bot_id}`: read-only live
+  `BotManager.get_bot(bot_id)` 조회. 응답은 `{"bot": info}` envelope이며 Web API 상세
+  조회와 같이 가능한 경우 `strategy_name`/`strategy_author_name`/`strategy_author_id`/
+  `strategy` (`strategy_registry` 보유 시), `budget` (`treasury_manager` 보유 시),
+  `positions` (`trade_service` 보유 시)를 보강한다. read-only audit 대상은 아니다.
+
+세 명령 모두 `BotManager.get_bot()`이 `None`을 반환하면 Web API 404와 같은 의미의
+stable error code `BOT_NOT_FOUND` (SSOT: `src/ante/bot/exceptions.py:BOT_NOT_FOUND_CODE`)
+로 실패한다. `start`에서 `app_key` 누락은 Web API 422와 같은 의미의 stable error code
+`BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`로 실패한다. `start`/`stop`에서 `BotError`는 Web
+API 409와 같은 의미의 stable error code `BOT_STATE_CONFLICT`로 매핑한다. JSON 모드는
+IPC error envelope에서 받은 `code`/`message`를 그대로 보존한다.
 
 `--strategy`는 등록된 `strategy_id`다. 전략 파일 경로를 직접 넘기려면 먼저
 `ante strategy submit <path>`로 등록해야 한다.

--- a/docs/specs/cli/06-cross-module-notes.md
+++ b/docs/specs/cli/06-cross-module-notes.md
@@ -6,7 +6,7 @@
 
 - **Web API 스펙**: CLI와 동일한 기능을 REST API로 노출, 내부 클라이언트 공유
 - **Account 스펙**: `ante account create/delete/set-credentials`는 cold-path structural 커맨드이므로 서버 실행 중 차단한다. `account suspend/activate`와 `system halt/clear-halt`는 IPC 런타임 커맨드다.
-- **Bot 스펙**: `ante bot create/start/stop/remove`와 `signal-key --rotate`는 IPC를 통해 서버의 BotManager를 호출하는 런타임 커맨드다. 실행 중 조회(`list/info/status/positions/signal-key`)도 서버 live 상태가 필요하면 IPC를 우선 사용한다. 단 `ante bot start/stop/status` CLI command은 미구현 (follow-up)이며 실재 bot CLI는 `create/info/list/positions/remove/signal-key`다. Bot 생성 시 `--strategy`는 등록된 `strategy_id`이며, 파일 경로를 직접 받지 않는다.
+- **Bot 스펙**: `ante bot create/start/stop/remove`와 `signal-key --rotate`는 IPC를 통해 서버의 BotManager를 호출하는 런타임 커맨드다. 실행 중 조회(`list/info/status/positions/signal-key`)도 서버 live 상태가 필요하면 IPC를 우선 사용한다. `ante bot start/stop/status`의 CLI/IPC 계약은 Web API 봇 라우트(`POST /api/bots/{bot_id}/start`, `POST /api/bots/{bot_id}/stop`, `GET /api/bots/{bot_id}`)와 1:1 정렬되며, `start`의 `app_key` credential preflight·`BotDetailResponse` envelope·`bot.start`/`bot.stop` audit action 이름은 Web API 라우트 동작과 같은 SSOT를 사용한다. Bot 생성 시 `--strategy`는 등록된 `strategy_id`이며, 파일 경로를 직접 받지 않는다.
 - **Broker Adapter 스펙**: `ante broker status/balance/positions/reconcile`은 서버가 보유한 BrokerAdapter 연결을 사용하는 런타임 IPC 커맨드다. 일반 운영 CLI에서 직접 broker adapter를 생성하거나 `broker order`를 제공하지 않는다.
 - **Member 스펙**: `member list/info`는 오프라인 조회가 가능하다. 등록, 상태 변경, 토큰/패스워드/복구키 변경은 서버 실행 중 IPC로 처리하고, 서버 정지 상태에서는 recovery/maintenance fallback만 허용한다.
 - **Strategy 스펙**: `ante strategy validate`는 StrategyValidator를 호출하고, `ante strategy submit <path>`는 검증 + 로드 테스트 + StrategyRegistry 등록을 수행한다. 등록 결과인 `strategy_id`가 `ante bot create --strategy` 입력이다.

--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -88,17 +88,23 @@ CLI 명령 시그니처와 전체 실행 분류의 SSOT는
 | CLI 커맨드 | IPC 커맨드 | 서비스 메서드 | IPC 필요 사유 |
 |-----------|-----------|-------------|-------------|
 | `ante bot create` | `bot.create` | `BotManager.create_bot()` | 등록된 `strategy_id`를 서버 StrategyRegistry에서 해석하고 BotManager 인메모리 `_bots` 반영 필요 |
-| `ante bot start` | `bot.start` | `BotManager.start_bot()` | asyncio task 생성 + `BotStartedEvent` 발행 |
-| `ante bot stop` | `bot.stop` | `BotManager.stop_bot()` | 실행 task 취소 + `BotStoppedEvent` 발행 |
+| `ante bot start <bot_id>` | `bot.start` | `BotManager.get_bot()` + `account_service.get()` + `BotManager.start_bot()` | Web API `POST /api/bots/{bot_id}/start`와 같은 동작. live 봇 존재 확인 + `app_key` credential preflight + asyncio task 생성 + `BotStartedEvent` 발행. 성공 시 audit `bot.start` 기록 |
+| `ante bot stop <bot_id>` | `bot.stop` | `BotManager.get_bot()` + `BotManager.stop_bot()` | Web API `POST /api/bots/{bot_id}/stop`과 같은 동작. live 봇 존재 확인 + 실행 task 취소 + `BotStoppedEvent` 발행. 성공 시 audit `bot.stop` 기록 |
+| `ante bot status <bot_id>` | `bot.status` | `BotManager.get_bot()` (read-only) | Web API `GET /api/bots/{bot_id}`와 같은 live 조회. 응답은 `BotDetailResponse`와 같은 `{"bot": info}` envelope이며 `strategy_registry`/`treasury_manager`/`trade_service`가 있는 경우 strategy/budget/positions를 동적으로 보강 |
 | `ante bot remove` | `bot.remove` (server running) / cold-path cleanup (server stopped) | `BotManager.remove_bot()` / `cold_path_remove_bot()` | 실행 중에는 봇 중지, EventBus 구독 해제, signal key 회수, 인메모리 제거 필요. 서버 정지 중에는 persisted cleanup만 수행 |
 | `ante bot signal-key --rotate` | `bot.signal_key.rotate` | `BotManager.rotate_signal_key()` | 기존 signal channel 즉시 차단 + 새 key 발급 |
 
-> **미구현 (follow-up)**: 위 표의 `bot.start`/`bot.stop` IPC handler 및 대응 CLI
-> command(`ante bot start`/`ante bot stop`)는 현재 등록되어 있지 않다. 또한
-> `ante bot status` CLI command도 부재다. 위 매핑은 설계 계약이며 wiring은
-> 별도 follow-up이다.
+`bot.start`/`bot.stop`은 mutating, `bot.status`는 read-only다. 세 명령 모두 다음 stable
+error code를 Web API 라우트의 의미와 동일하게 사용한다.
 
-서버 실행 중 `ante bot list/info/status/positions/signal-key`는 `bot.query` 계열 IPC로
+- `BOT_NOT_FOUND` (재사용 SSOT: `src/ante/bot/exceptions.py:BOT_NOT_FOUND_CODE`):
+  `BotManager.get_bot()`이 `None`을 반환. Web API 404와 같은 의미.
+- `BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED` (신규): `bot.start`에서
+  `account.credentials["app_key"]` 누락. Web API 422와 같은 의미.
+- `BOT_STATE_CONFLICT` (신규): `bot.start`/`bot.stop`의 `BotManager.start_bot()` /
+  `stop_bot()` 호출 중 `BotError`. Web API 409와 같은 의미.
+
+서버 실행 중 `ante bot list/info/positions/signal-key`는 `bot.query` 계열 IPC로
 서버의 live 상태를 우선 조회한다. 서버가 정지된 상태에서는 DB에 저장된 persisted
 snapshot 조회만 허용한다. 단, `ante bot remove`는 #1161 cold-path 예외로 server stopped
 상태에서 `signal_keys`, 전략 스냅샷, Treasury budget, `bots.status='deleted'`만 직접
@@ -247,14 +253,25 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 | `broker.balance` | read-only | `BrokerAdapter.get_account_balance()` live 조회 |
 | `broker.positions` | read-only | `BrokerAdapter.get_positions()` live 조회 |
 
+### 후속 IPC handler 계약 (#1712 등록 예정, 현재 미등록)
+
+아래 3 handler는 본 스펙에서 계약을 사전에 확정한다. **현재 `CommandRegistry.register_all_handlers()`에 미등록**이며, shutdown drain의 mutating/read-only 처리·taxonomy 카운트(현재 19) 산정 등 runtime invariants는 위 SSOT 19개에만 적용된다. 실제 등록은 #1712에서 수행한 뒤 본 절의 19 → 22 카운트와 taxonomy 표가 함께 갱신된다.
+
+| IPC 커맨드 | taxonomy | 근거 |
+|-----------|----------|------|
+| `bot.start` | mutating | `BotManager.start_bot()` 호출. Web API `POST /api/bots/{bot_id}/start` 정렬. `app_key` preflight + audit `bot.start` |
+| `bot.stop` | mutating | `BotManager.stop_bot()` 호출. Web API `POST /api/bots/{bot_id}/stop` 정렬. audit `bot.stop` |
+| `bot.status` | read-only | `BotManager.get_bot()` live 조회. Web API `GET /api/bots/{bot_id}` 정렬. `BotDetailResponse` envelope |
+
 `broker.reconcile`은 CLI `--fix=False` 경로에서도 같은 IPC command를 사용하지만, 한 command
 이름에 mutating/read-only 의미를 섞지 않고 일괄 mutating으로 분류한다. dry-run 전용
 IPC command 분리는 별도 이슈 범위다.
 
 `account.delete`처럼 1.0 IPC 계약에서 제외되어 `CommandRegistry`에 등록되지 않는 명령은
-taxonomy 대상이 아니다. `member.*`, `bot.start/stop`,
+taxonomy 대상이 아니다. `member.*`, `bot.start/stop/status`,
 `bot.signal_key.rotate`처럼 CLI/스펙 표에는 runtime IPC로 표현되어 있으나 현재
-`register_all_handlers()`에 없는 명령 추가도 별도 후속 범위다.
+`register_all_handlers()`에 없는 명령의 실제 wiring은 별도 후속 이슈(`bot.start/stop/status`는
+#1712)에서 다룬다. 본 스펙 표는 그때 사용할 계약 SSOT다.
 
 ## 통신 프로토콜
 

--- a/guide/strategy.md
+++ b/guide/strategy.md
@@ -134,7 +134,7 @@ self.ctx.modify_order(order_id="ORD-001", price=59000, reason="지정가 수정"
   ↓ ante strategy submit — 검증 후 Registry에 등록
   ↓
 봇 생성 (ante bot create --strategy <strategy_id>)
-  ↓ ante bot start — 봇 가동 (미구현 / follow-up: CLI command 미등록)
+  ↓ 봇 가동 — Web API `POST /api/bots/{bot_id}/start` 또는 `ante bot start <bot_id>` (#1712 + #1713 merge 후 실행 가능)
   ↓
 주기적 루프 (interval_seconds마다)
   ├─ on_step(context) 호출


### PR DESCRIPTION
Closes #1711
Part of #1698 epic.

## Summary

`ante bot start/stop/status` CLI·IPC 계약을 **Web API 라우트와 1:1 정렬**된 SSOT로 확정한다. spec-only PR — Click command 등록은 #1713, IPC handler 등록은 #1712에서 후속.

### Normative contract

| CLI | IPC | Web API alignment | taxonomy |
|---|---|---|---|
| `ante bot start <bot_id>` | `bot.start` | `POST /api/bots/{bot_id}/start` (live `BotManager.get_bot` → `app_key` preflight → `BotManager.start_bot` → audit `bot.start` → `{bot: info}`) | mutating |
| `ante bot stop <bot_id>` | `bot.stop` | `POST /api/bots/{bot_id}/stop` (live → `BotManager.stop_bot` → audit `bot.stop` → `{bot: info}`) | mutating |
| `ante bot status <bot_id>` | `bot.status` | `GET /api/bots/{bot_id}` (live → `BotDetailResponse` envelope + strategy/budget/positions 보강) | read-only, **live-only (snapshot fallback 없음)** |

에러 코드 SSOT:
- `BOT_NOT_FOUND` — 재사용 (`src/ante/bot/exceptions.py:BOT_NOT_FOUND_CODE`)
- `BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED` (신규, `bot.start` only)
- `BOT_STATE_CONFLICT` (신규, `bot.start`/`bot.stop`의 `BotError` → Web API 409 대응)

권한: `bot:read` (status), `bot:admin` (start/stop) — Web API와 일관.

## 변경 묶음 (9 docs/specs + guide, 96+/39-)

- `docs/specs/cli/03-commands.md`: inventory + 사용 예시 + 후속 narrative 모두 contract 표기로 갱신. 구현 진행 상황 caveat (`#1698 epic`) 명시.
- `docs/specs/bot/06-cli-usage.md`: 사용 예시 복구 + Web API 정렬 narrative + `#1712/#1713 merge 후 실행 가능` caveat 보존.
- `docs/specs/bot/03-design-decisions.md`: 미구현 follow-up 문장 제거, CLI/IPC가 Web API 동작 기준을 따르는 이유 narrative 추가.
- `docs/specs/bot/08-cross-module-notes.md`, `docs/specs/cli/06-cross-module-notes.md`: lifecycle Web API 정렬 반영.
- `docs/specs/account/05-eventbus-integration.md`: 미구현 문구 제거, CLI/Web API 양쪽 호출 안내.
- `docs/specs/ipc/ipc.md`: `bot.start/stop/status` 계약 row 추가 (taxonomy + 에러 코드 SSOT). **SSOT 19개 (등록)와 후속 3개 (#1712 등록 예정) 표를 명확히 분리**.
- `docs/specs/audit/audit.md`: CLI 기록 대상 표에 `bot.start/stop` 보존, 미구현 follow-up note block 제거 (구현 대상).
- `guide/strategy.md`: 봇 가동 흐름을 Web API + `ante bot start` (#1712/#1713 merge 후 실행 가능) caveat 포함.

**무변경** (분리 유지):
- `scripts/generate_project_structure.py`, `docs/architecture/generated/project-structure.md`: Click command 등록 후 #1713에서 함께 재생성.
- `src/ante/web/routes/bots.py`, `src/ante/bot/manager.py`, `src/ante/ipc/registry.py`, `src/ante/cli/commands/bot.py`: 코드 변경 없음 (spec-only PR).
- `guide/cli.md`: #1713에서 재생성.
- `docs/specs/web-api/05-resource-endpoints.md`, `docs/specs/web-api/11-route-scope-table.md`: 정렬 기준 (수정 대상 아님).

## Test Plan

worktree(`/Users/jingulee/Projects/ante-worktrees/issue-1711`) 로컬:

- `git grep -nE "ante bot (start|stop|status).*미구현|미구현.*ante bot (start|stop|status)" -- ':!docs/temp/'` → **0건** (미구현 follow-up 문구 제거 확인, 별도 "구현 #1712/#1713" caveat는 보존)
- `pytest -q tests/unit/` → **6772 passed, 2 skipped** (코드 무변경)
- `mypy src/`, `ruff check`, `ruff format --check` → clean
- `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check` → idempotent (현재 main 상태와 일치)

게이트:
- Codex Plan Review v1: approve-implement (findings 0, advisory 1)
- Codex 브랜치 리뷰: **PASS (4차 attempt)**
  - 1차/2차/3차에 [P2] findings 발견 (generator inventory 표시 / taxonomy 표 정합 / status snapshot fallback / guide caveat)
  - 모두 fix 후 4차 PASS — "변경은 문서/스펙 업데이트에 한정, 동작 깨뜨림/잘못된 계약 미발견"

## Follow-up

- **#1712**: `bot.start/stop/status` IPC handler 등록 + `ServiceRegistry`에 read-only `trade_service` 참조 추가 (status의 positions 보강용)
- **#1713**: Click command 등록 (`ante bot start/stop/status`) + `guide/cli.md` 재생성 + `scripts/generate_project_structure.py` DEFAULT_DESCRIPTIONS의 bot.py 항목에서 `(start/stop/status 미구현 follow-up)` 제거 + `docs/architecture/generated/project-structure.md` 재생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)
