### PR TITLE
feat: #1712 bot.start/stop/status IPC handler 등록 (Web API 정렬 + behavior-preserving helper)

### DIFF
--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -228,7 +228,7 @@ BotManager/DB 종료 이후 lifecycle 마지막 단계에서만 호출된다.
 - **read-only**: 서버가 보유한 live adapter를 통해 상태를 조회하지만 서버/DB 상태를
   변경하지 않는 명령
 
-현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 19개가
+현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 22개가
 SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표를 함께 갱신해야 한다.
 
 | IPC 커맨드 | taxonomy | 근거 |
@@ -239,6 +239,8 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 | `account.activate` | mutating | `AccountService.activate()` 호출 |
 | `bot.create` | mutating | `BotManager.create_bot()` 호출 |
 | `bot.remove` | mutating | `BotManager.remove_bot()` 호출 |
+| `bot.start` | mutating | `BotManager.start_bot()` 호출. Web API `POST /api/bots/{bot_id}/start` 정렬. `app_key` preflight + audit `bot.start` (#1712) |
+| `bot.stop` | mutating | `BotManager.stop_bot()` 호출. Web API `POST /api/bots/{bot_id}/stop` 정렬. audit `bot.stop` (#1712) |
 | `treasury.allocate` | mutating | `Treasury.allocate()` 호출 |
 | `treasury.deallocate` | mutating | `Treasury.deallocate()` 호출 |
 | `config.set` | mutating | `DynamicConfigService.set()` 호출 |
@@ -252,26 +254,16 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 | `broker.status` | read-only | `BrokerAdapter.health_check()` live 조회 |
 | `broker.balance` | read-only | `BrokerAdapter.get_account_balance()` live 조회 |
 | `broker.positions` | read-only | `BrokerAdapter.get_positions()` live 조회 |
-
-### 후속 IPC handler 계약 (#1712 등록 예정, 현재 미등록)
-
-아래 3 handler는 본 스펙에서 계약을 사전에 확정한다. **현재 `CommandRegistry.register_all_handlers()`에 미등록**이며, shutdown drain의 mutating/read-only 처리·taxonomy 카운트(현재 19) 산정 등 runtime invariants는 위 SSOT 19개에만 적용된다. 실제 등록은 #1712에서 수행한 뒤 본 절의 19 → 22 카운트와 taxonomy 표가 함께 갱신된다.
-
-| IPC 커맨드 | taxonomy | 근거 |
-|-----------|----------|------|
-| `bot.start` | mutating | `BotManager.start_bot()` 호출. Web API `POST /api/bots/{bot_id}/start` 정렬. `app_key` preflight + audit `bot.start` |
-| `bot.stop` | mutating | `BotManager.stop_bot()` 호출. Web API `POST /api/bots/{bot_id}/stop` 정렬. audit `bot.stop` |
-| `bot.status` | read-only | `BotManager.get_bot()` live 조회. Web API `GET /api/bots/{bot_id}` 정렬. `BotDetailResponse` envelope |
+| `bot.status` | read-only | `BotManager.get_bot()` live 조회. Web API `GET /api/bots/{bot_id}` 정렬. `BotDetailResponse` envelope (#1712) |
 
 `broker.reconcile`은 CLI `--fix=False` 경로에서도 같은 IPC command를 사용하지만, 한 command
 이름에 mutating/read-only 의미를 섞지 않고 일괄 mutating으로 분류한다. dry-run 전용
 IPC command 분리는 별도 이슈 범위다.
 
 `account.delete`처럼 1.0 IPC 계약에서 제외되어 `CommandRegistry`에 등록되지 않는 명령은
-taxonomy 대상이 아니다. `member.*`, `bot.start/stop/status`,
-`bot.signal_key.rotate`처럼 CLI/스펙 표에는 runtime IPC로 표현되어 있으나 현재
-`register_all_handlers()`에 없는 명령의 실제 wiring은 별도 후속 이슈(`bot.start/stop/status`는
-#1712)에서 다룬다. 본 스펙 표는 그때 사용할 계약 SSOT다.
+taxonomy 대상이 아니다. `member.*`, `bot.signal_key.rotate`처럼 CLI/스펙 표에는 runtime IPC로
+표현되어 있으나 현재 `register_all_handlers()`에 없는 명령의 실제 wiring은 별도 후속 이슈에서
+다룬다.
 
 ## 통신 프로토콜
 

--- a/src/ante/bot/__init__.py
+++ b/src/ante/bot/__init__.py
@@ -9,18 +9,30 @@ from ante.bot.config import (
     validate_interval,
 )
 from ante.bot.context_factory import StrategyContextFactory
-from ante.bot.exceptions import BOT_NOT_FOUND_CODE, BotError, BotNotFoundError
+from ante.bot.exceptions import (
+    BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE,
+    BOT_NOT_FOUND_CODE,
+    BOT_STATE_CONFLICT_CODE,
+    BotAccountCredentialsNotConfigured,
+    BotError,
+    BotNotFoundError,
+    BotStateConflict,
+)
 from ante.bot.manager import BotManager
 from ante.bot.signal_key import SignalKeyManager
 
 __all__ = [
     "Bot",
+    "BotAccountCredentialsNotConfigured",
     "BotConfig",
     "BotError",
     "BotNotFoundError",
+    "BotStateConflict",
     "BotManager",
     "BotStatus",
+    "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE",
     "BOT_NOT_FOUND_CODE",
+    "BOT_STATE_CONFLICT_CODE",
     "MAX_INTERVAL_SECONDS",
     "MIN_INTERVAL_SECONDS",
     "SignalKeyManager",

--- a/src/ante/bot/exceptions.py
+++ b/src/ante/bot/exceptions.py
@@ -1,6 +1,17 @@
-"""Bot 모듈 예외."""
+"""Bot 모듈 예외.
+
+Refs #1712: ``bot.start``/``bot.stop`` IPC handler 가 Web API
+(``POST /api/bots/{bot_id}/start``/``/stop``) 와 동일한 거부 경로를 가지도록
+coded exception 두 개를 추가했다 — ``BotAccountCredentialsNotConfigured``
+(``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED``, app_key 부재 preflight 실패) /
+``BotStateConflict`` (``BOT_STATE_CONFLICT``, 상태머신 거부). IPC server.py
+의 ``getattr(e, "code", ...)`` envelope 정렬 패턴(``BOT_NOT_FOUND_CODE`` 와
+동형) 으로 일관된다.
+"""
 
 BOT_NOT_FOUND_CODE = "BOT_NOT_FOUND"
+BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE = "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED"
+BOT_STATE_CONFLICT_CODE = "BOT_STATE_CONFLICT"
 
 
 class BotError(Exception):
@@ -17,3 +28,27 @@ class BotNotFoundError(BotError):
     def __init__(self, bot_id: str) -> None:
         self.bot_id = bot_id
         super().__init__(f"Bot not found: {bot_id}")
+
+
+class BotAccountCredentialsNotConfigured(BotError):  # noqa: N818
+    """봇 시작 시 account 의 ``app_key`` 가 부재.
+
+    Refs #1712: ``POST /api/bots/{bot_id}/start`` 의 422 preflight 거부
+    (``계좌에 인증정보(app_key)가 설정되지 않았습니다``) 와 정렬되는 IPC
+    오류. IPC ``server.py`` 의 ``getattr(e, "code", ...)`` 가
+    ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` envelope 으로 변환한다.
+    """
+
+    code: str = BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE
+
+
+class BotStateConflict(BotError):  # noqa: N818
+    """봇 상태머신 충돌 (start_bot/stop_bot 가 ``BotError`` 로 거부).
+
+    Refs #1712: Web API ``POST /api/bots/{bot_id}/start``/``/stop`` 의 409
+    ``BotError`` → ``HTTPException`` 매핑과 정렬되는 IPC 오류. IPC
+    ``server.py`` 의 ``getattr(e, "code", ...)`` 가 ``BOT_STATE_CONFLICT``
+    envelope 으로 변환한다.
+    """
+
+    code: str = BOT_STATE_CONFLICT_CODE

--- a/src/ante/bot/info.py
+++ b/src/ante/bot/info.py
@@ -1,0 +1,100 @@
+"""Bot info enrichment helper — Web API + IPC 공유.
+
+Refs #1712: Web API ``GET /api/bots/{bot_id}`` 와 IPC ``bot.status`` 가
+동일한 ``bot`` info 보강 로직(strategy/budget/positions 조인) 을 공유하기
+위한 behavior-preserving extraction. Web API 라우트가 in-place 로 수행하던
+보강을 그대로 미러한다(응답 shape/field/key 순서 무변경).
+
+설계 원칙:
+- FastAPI / HTTPException 의존성을 import 하지 않는다 (Codex Plan Review v2
+  advisory). 본 helper 는 순수 도메인 dict 변환만 수행하며, HTTP / IPC 표면
+  매핑은 각 라우트/handler 가 담당한다.
+- 의존성은 모두 keyword-only optional — 보유한 객체만 보강에 기여한다. None
+  이면 해당 섹션은 skip 되며 dict 에 키가 추가되지 않는다(누락 vs. 빈 값
+  의미 구분).
+- ``trade_service`` 는 #1712 에서 ``ServiceRegistry`` 에 optional 로 도입
+  되었다. legacy / cold-path 환경에서 None 이면 ``positions`` 키 자체가
+  부재한다(회귀 lock).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def enrich_bot_info(
+    bot: Any,
+    *,
+    strategy_registry: Any | None = None,
+    treasury: Any | None = None,
+    trade_service: Any | None = None,
+) -> dict[str, Any]:
+    """``bot.get_info()`` 결과에 strategy/budget/positions 정보를 보강한다.
+
+    Refs #1712: Web API ``GET /api/bots/{bot_id}`` (``src/ante/web/routes/
+    bots.py`` ``get_bot``) 의 보강 로직을 그대로 미러한다. 응답 shape/field/
+    key 순서를 변경하지 않으며, 의존성 None 시 해당 섹션 키 자체가 부재한다.
+
+    Args:
+        bot: ``get_info()`` 메서드를 가진 Bot 인스턴스. info 의 ``strategy_id``
+            필드가 strategy 조인의 키로 사용된다.
+        strategy_registry: ``StrategyRegistry`` (또는 ``get``/``get_by_name``
+            await coroutine 을 노출하는 stub). None 이면 strategy_name /
+            strategy_author_* / strategy 키가 추가되지 않는다.
+        treasury: 단일 계좌의 ``Treasury`` 인스턴스(``.get_budget(bot_id)``
+            sync 메서드 보유). None 이면 ``budget`` 키가 추가되지 않는다.
+            IPC 호출 측은 ``svc.treasury_manager.get(bot.config.account_id)``
+            로 미리 resolve 한 뒤 전달한다.
+        trade_service: ``TradeService`` (또는 ``get_positions(bot_id=...,
+            include_closed=...)`` await coroutine 을 노출하는 stub). None
+            이면 ``positions`` 키가 추가되지 않는다(회귀 lock — #1712 cold-path
+            / legacy 환경 호환).
+
+    Returns:
+        ``bot.get_info()`` base dict + 보강 키 dict. Web API 라우트의 in-place
+        dict mutation 결과와 동일하다.
+    """
+    info: dict[str, Any] = bot.get_info()
+
+    # 전략 정보 추가 — strategy_id 미존재(빈 문자열) 시 lookup 자체를 skip.
+    if strategy_registry is not None:
+        record = await strategy_registry.get(info.get("strategy_id", ""))
+        if record:
+            info["strategy_name"] = record.name
+            info["strategy_author_name"] = record.author_name
+            info["strategy_author_id"] = record.author_id
+            info["strategy"] = {
+                "name": record.name,
+                "version": record.version,
+                "author_name": record.author_name,
+                "author_id": record.author_id,
+                "description": record.description,
+            }
+
+    # 예산 정보 추가 — Treasury.get_budget 은 sync, 부재 시 None.
+    if treasury is not None:
+        budget = treasury.get_budget(bot.bot_id)
+        if budget:
+            info["budget"] = {
+                "allocated": budget.allocated,
+                "spent": budget.spent,
+                "reserved": budget.reserved,
+                "available": budget.available,
+            }
+
+    # 포지션 정보 추가 — include_closed=True 보존.
+    if trade_service is not None:
+        positions = await trade_service.get_positions(
+            bot_id=bot.bot_id, include_closed=True
+        )
+        info["positions"] = [
+            {
+                "symbol": p.symbol,
+                "quantity": p.quantity,
+                "avg_entry_price": p.avg_entry_price,
+                "realized_pnl": p.realized_pnl,
+            }
+            for p in positions
+        ]
+
+    return info

--- a/src/ante/core/registry.py
+++ b/src/ante/core/registry.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from ante.eventbus import EventBus
     from ante.strategy.registry import StrategyRegistry
     from ante.trade.reconciler import PositionReconciler
+    from ante.trade.service import TradeService
     from ante.treasury.manager import TreasuryManager
 
 
@@ -29,6 +30,12 @@ class ServiceRegistry:
     mutation IPC (``approval.cancel_invalid``) 가 정상 환경에서 audit_log 테이블에
     기록을 남기기 위해 추가되었다. 테스트/legacy 환경에서는 ``None`` 이 허용되며,
     핸들러는 ``getattr(svc, "audit_logger", None)`` 패턴으로 안전하게 처리한다.
+
+    Refs #1712: ``trade_service`` 필드는 IPC ``bot.status`` handler 의
+    positions 보강 (``enrich_bot_info``) 을 Web API 와 정렬하기 위해 optional
+    로 추가되었다. ``audit_logger`` 와 동형으로 ``None`` 허용 + ``getattr``
+    safe-access 가 보장된다. legacy ServiceRegistry 호출자(``trade_service``
+    인자 미전달)는 그대로 동작하며, positions 키는 부재한다.
     """
 
     account: AccountService | Any
@@ -40,3 +47,4 @@ class ServiceRegistry:
     eventbus: EventBus | Any
     strategy_registry: StrategyRegistry | Any = field(default=None)
     audit_logger: AuditLogger | Any = field(default=None)
+    trade_service: TradeService | Any = field(default=None)

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -188,6 +188,138 @@ async def _handle_bot_remove(
     return {"bot_id": bot_id, "removed": True}
 
 
+async def _handle_bot_start(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """봇 시작 IPC handler — Web API ``POST /api/bots/{bot_id}/start`` 정렬.
+
+    Refs #1712: Web API 라우트의 거부 경로(404 bot 부재 / 422 app_key 부재 /
+    409 BotError) 와 1:1 매핑되는 coded exception 으로 raise 한다. IPC
+    ``server.py:323`` 의 ``getattr(e, "code", "EXECUTION_ERROR")`` envelope
+    이 ``BOT_NOT_FOUND`` / ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` /
+    ``BOT_STATE_CONFLICT`` 로 변환한다.
+
+    audit logger 가 주입된 환경에서는 ``approval.cancel_invalid`` 선례와 동형
+    으로 ``bot.start`` action 을 기록한다(``getattr`` safe-access).
+    """
+    from ante.bot.exceptions import (
+        BotAccountCredentialsNotConfigured,
+        BotError,
+        BotNotFoundError,
+        BotStateConflict,
+    )
+
+    bot_id = args["bot_id"]
+    bot = svc.bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise BotNotFoundError(bot_id)
+
+    # 계좌 인증정보 검증: app_key 가 없으면 봇 시작 거부 (Web API 와 동일).
+    account = await svc.account.get(bot.config.account_id)
+    if not account.credentials.get("app_key"):
+        raise BotAccountCredentialsNotConfigured(
+            "계좌에 인증정보(app_key)가 설정되지 않았습니다"
+        )
+
+    try:
+        await svc.bot_manager.start_bot(bot_id)
+    except BotError as e:
+        raise BotStateConflict(str(e)) from e
+
+    audit_logger = getattr(svc, "audit_logger", None)
+    if audit_logger is not None:
+        await audit_logger.log(
+            member_id=actor,
+            action="bot.start",
+            resource=f"bot:{bot_id}",
+            ip="",
+        )
+
+    return {"bot": bot.get_info()}
+
+
+async def _handle_bot_stop(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """봇 중지 IPC handler — Web API ``POST /api/bots/{bot_id}/stop`` 정렬.
+
+    Refs #1712: Web API 라우트의 거부 경로(404 bot 부재 / 409 BotError) 와
+    1:1 매핑. ``app_key`` preflight 는 stop 경로에 없다(Web API 정렬). audit
+    logger 가 주입된 환경에서는 ``bot.stop`` action 을 기록한다.
+    """
+    from ante.bot.exceptions import (
+        BotError,
+        BotNotFoundError,
+        BotStateConflict,
+    )
+
+    bot_id = args["bot_id"]
+    bot = svc.bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise BotNotFoundError(bot_id)
+
+    try:
+        await svc.bot_manager.stop_bot(bot_id)
+    except BotError as e:
+        raise BotStateConflict(str(e)) from e
+
+    audit_logger = getattr(svc, "audit_logger", None)
+    if audit_logger is not None:
+        await audit_logger.log(
+            member_id=actor,
+            action="bot.stop",
+            resource=f"bot:{bot_id}",
+            ip="",
+        )
+
+    return {"bot": bot.get_info()}
+
+
+async def _handle_bot_status(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """봇 상태 조회 IPC handler — Web API ``GET /api/bots/{bot_id}`` 정렬.
+
+    Refs #1712: read-only handler. ``enrich_bot_info`` 로 strategy/budget/
+    positions 보강 결과를 ``{"bot": info}`` envelope 으로 반환한다. Web API
+    라우트와 동일한 helper 를 공유하므로 응답 shape/field/key 순서가 보존된다.
+
+    의존성은 모두 ``getattr`` safe-access 로 optional 처리한다:
+    - ``strategy_registry`` 부재 시 strategy 키 부재.
+    - ``treasury_manager`` 부재(또는 해당 계좌 Treasury 미등록) 시 budget 키 부재.
+    - ``trade_service`` 부재(legacy ServiceRegistry) 시 positions 키 부재(회귀
+      lock — #1712 cold-path 호환).
+
+    read-only 분류이므로 audit logger 호출 없음.
+    """
+    from ante.bot.exceptions import BotNotFoundError
+    from ante.bot.info import enrich_bot_info
+
+    bot_id = args["bot_id"]
+    bot = svc.bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise BotNotFoundError(bot_id)
+
+    # 계좌별 Treasury resolve — Web API ``get_treasury_optional`` 가 단일
+    # Treasury 인스턴스를 노출하는 것과 정렬되도록 ``TreasuryManager.get`` 으로
+    # 봇의 account_id Treasury 를 가져온다. manager 부재 또는 미등록 시 None.
+    treasury_manager = getattr(svc, "treasury_manager", None)
+    treasury_for_bot: Any | None = None
+    if treasury_manager is not None:
+        try:
+            treasury_for_bot = treasury_manager.get(bot.config.account_id)
+        except KeyError:
+            treasury_for_bot = None
+
+    info = await enrich_bot_info(
+        bot,
+        strategy_registry=getattr(svc, "strategy_registry", None),
+        treasury=treasury_for_bot,
+        trade_service=getattr(svc, "trade_service", None),
+    )
+    return {"bot": info}
+
+
 async def _handle_treasury_allocate(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
@@ -404,9 +536,9 @@ async def _handle_broker_reconcile(
 
 
 def register_all_handlers(registry: CommandRegistry) -> None:
-    """19개 런타임 커맨드 핸들러를 일괄 등록.
+    """22개 런타임 커맨드 핸들러를 일괄 등록.
 
-    Refs #1184: 각 핸들러는 mutating(16개) 또는 read-only(3개)로 분류된다.
+    Refs #1184: 각 핸들러는 mutating(18개) 또는 read-only(4개)로 분류된다.
     분류는 ``docs/specs/ipc/ipc.md``의 "Handler taxonomy" 섹션과 동기화되어야
     한다. mutating 명령은 ``IPCServer``가 ``SHUTTING_DOWN`` 상태일 때
     ``SERVICE_UNAVAILABLE``로 거부된다.
@@ -415,14 +547,22 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     AccountService.delete()를 직접 호출하므로 IPC 라우팅 대상이 아니다.
 
     Refs #1418 → #1472 SPLIT-D: ``approval.cancel_invalid`` (mutating) 추가.
+
+    Refs #1712: ``bot.start`` / ``bot.stop`` (mutating) / ``bot.status``
+    (read-only) 추가. Web API ``POST /api/bots/{bot_id}/start``/``/stop`` /
+    ``GET /api/bots/{bot_id}`` 와 정렬되며, ``bot.start`` 는 ``app_key``
+    preflight + audit ``bot.start``, ``bot.stop`` 은 audit ``bot.stop``,
+    ``bot.status`` 는 ``enrich_bot_info`` 보강 후 ``{"bot": info}`` envelope.
     """
-    # ── mutating (16개): 서버 상태/DB를 변경 ──────────
+    # ── mutating (18개): 서버 상태/DB를 변경 ──────────
     registry.register("system.halt", _handle_system_halt, is_mutating=True)
     registry.register("system.clear_halt", _handle_system_clear_halt, is_mutating=True)
     registry.register("account.suspend", _handle_account_suspend, is_mutating=True)
     registry.register("account.activate", _handle_account_activate, is_mutating=True)
     registry.register("bot.create", _handle_bot_create, is_mutating=True)
     registry.register("bot.remove", _handle_bot_remove, is_mutating=True)
+    registry.register("bot.start", _handle_bot_start, is_mutating=True)
+    registry.register("bot.stop", _handle_bot_stop, is_mutating=True)
     registry.register("treasury.allocate", _handle_treasury_allocate, is_mutating=True)
     registry.register(
         "treasury.deallocate", _handle_treasury_deallocate, is_mutating=True
@@ -443,7 +583,8 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     # dryrun 분리는 후속 이슈.
     registry.register("broker.reconcile", _handle_broker_reconcile, is_mutating=True)
 
-    # ── read-only (3개): BrokerAdapter live 조회만 ────
+    # ── read-only (4개): live 조회만 ──────────────────
     registry.register("broker.status", _handle_broker_status, is_mutating=False)
     registry.register("broker.balance", _handle_broker_balance, is_mutating=False)
     registry.register("broker.positions", _handle_broker_positions, is_mutating=False)
+    registry.register("bot.status", _handle_bot_status, is_mutating=False)

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1560,6 +1560,10 @@ async def _init_ipc(s: Services) -> None:
         eventbus=s.eventbus,
         strategy_registry=s.strategy_registry,
         audit_logger=s.audit_logger,
+        # Refs #1712: IPC ``bot.status`` handler 의 positions 보강을 위해
+        # ``trade_service`` 를 주입한다. ``audit_logger`` 와 동형의 optional
+        # 필드이며, ``enrich_bot_info`` 가 None 시 positions 키를 부재시킨다.
+        trade_service=s.trade_service,
     )
 
     command_registry = CommandRegistry()

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -626,54 +626,25 @@ async def get_bot(
     trade_service: Annotated[Any | None, Depends(get_trade_service_optional)],
 ) -> dict:
     """봇 상세 조회. 인증된 master/human 또는 ``bot:read`` scope 를 보유한
-    agent 만 호출 가능 (#1407)."""
+    agent 만 호출 가능 (#1407).
+
+    Refs #1712: strategy/budget/positions 보강 로직은 ``ante.bot.info.
+    enrich_bot_info`` helper 로 추출되어 IPC ``bot.status`` handler 와 공유
+    된다. 응답 shape/field/key 순서는 그대로 보존된다(behavior-preserving
+    extraction).
+    """
+    from ante.bot.info import enrich_bot_info
+
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
         raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
-    info = bot.get_info()
-
-    # 전략 정보 추가
-    if registry is not None:
-        record = await registry.get(info.get("strategy_id", ""))
-        if record:
-            info["strategy_name"] = record.name
-            info["strategy_author_name"] = record.author_name
-            info["strategy_author_id"] = record.author_id
-            info["strategy"] = {
-                "name": record.name,
-                "version": record.version,
-                "author_name": record.author_name,
-                "author_id": record.author_id,
-                "description": record.description,
-            }
-
-    # 예산 정보 추가
-    if treasury is not None:
-        budget = treasury.get_budget(bot_id)
-        if budget:
-            info["budget"] = {
-                "allocated": budget.allocated,
-                "spent": budget.spent,
-                "reserved": budget.reserved,
-                "available": budget.available,
-            }
-
-    # 포지션 정보 추가
-    if trade_service is not None:
-        positions = await trade_service.get_positions(
-            bot_id=bot_id, include_closed=True
-        )
-        info["positions"] = [
-            {
-                "symbol": p.symbol,
-                "quantity": p.quantity,
-                "avg_entry_price": p.avg_entry_price,
-                "realized_pnl": p.realized_pnl,
-            }
-            for p in positions
-        ]
-
+    info = await enrich_bot_info(
+        bot,
+        strategy_registry=registry,
+        treasury=treasury,
+        trade_service=trade_service,
+    )
     return {"bot": info}
 
 

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -42,17 +42,20 @@ def test_commands_property(registry: CommandRegistry) -> None:
 
 
 def test_register_all_handlers() -> None:
-    """register_all_handlers가 19개 핸들러를 등록 (account.delete 제외).
+    """register_all_handlers가 22개 핸들러를 등록 (account.delete 제외).
 
     `account.delete`는 1.0 IPC 계약에서 제거되어 cold-path CLI에서 직접
     AccountService를 호출한다.
 
     Refs #1418 → #1472 SPLIT-D: ``approval.cancel_invalid`` 추가 (16번째
     mutating).
+
+    Refs #1712: ``bot.start`` / ``bot.stop`` (mutating, 17~18) /
+    ``bot.status`` (read-only, 4번째) 추가 — Web API 라우트 정렬.
     """
     registry = CommandRegistry()
     register_all_handlers(registry)
-    assert len(registry.commands) == 19
+    assert len(registry.commands) == 22
 
     expected = {
         "system.halt",
@@ -61,6 +64,9 @@ def test_register_all_handlers() -> None:
         "account.activate",
         "bot.create",
         "bot.remove",
+        "bot.start",
+        "bot.stop",
+        "bot.status",
         "treasury.allocate",
         "treasury.deallocate",
         "config.set",
@@ -83,7 +89,11 @@ def test_register_all_handlers() -> None:
 
 
 def test_register_all_handlers_taxonomy() -> None:
-    """등록된 19개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다."""
+    """등록된 22개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다.
+
+    Refs #1712: ``bot.start`` / ``bot.stop`` mutating, ``bot.status``
+    read-only — ``docs/specs/ipc/ipc.md`` Handler taxonomy SSOT 와 동기화.
+    """
     registry = CommandRegistry()
     register_all_handlers(registry)
 
@@ -94,6 +104,8 @@ def test_register_all_handlers_taxonomy() -> None:
         "account.activate",
         "bot.create",
         "bot.remove",
+        "bot.start",
+        "bot.stop",
         "treasury.allocate",
         "treasury.deallocate",
         "config.set",
@@ -105,10 +117,15 @@ def test_register_all_handlers_taxonomy() -> None:
         "approval.reopen",
         "broker.reconcile",
     }
-    read_only = {"broker.status", "broker.balance", "broker.positions"}
+    read_only = {
+        "broker.status",
+        "broker.balance",
+        "broker.positions",
+        "bot.status",
+    }
 
-    assert len(mutating) == 16
-    assert len(read_only) == 3
+    assert len(mutating) == 18
+    assert len(read_only) == 4
     assert mutating | read_only == set(registry.commands)
 
     for command in mutating:

--- a/tests/unit/ipc/test_service_registry.py
+++ b/tests/unit/ipc/test_service_registry.py
@@ -32,3 +32,28 @@ def test_service_registry_creation() -> None:
     assert reg.approval is approval
     assert reg.reconciler is reconciler
     assert reg.eventbus is eventbus
+    # Refs #1712: ``trade_service`` 는 optional default=None — 기존 호출
+    # 호환성 (audit_logger 와 동형). legacy ServiceRegistry 호출자
+    # (``trade_service`` 인자 미전달) 가 그대로 동작한다.
+    assert reg.trade_service is None
+
+
+def test_service_registry_accepts_trade_service() -> None:
+    """Refs #1712: ``trade_service`` 를 명시 전달하면 그대로 보관된다.
+
+    IPC ``bot.status`` handler 는 ``getattr(svc, "trade_service", None)`` 으로
+    optional access 하며, 주입된 경우 ``enrich_bot_info`` 가 positions 보강에
+    사용한다.
+    """
+    trade_service = MagicMock()
+    reg = ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=MagicMock(),
+        treasury_manager=MagicMock(),
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=MagicMock(),
+        trade_service=trade_service,
+    )
+    assert reg.trade_service is trade_service

--- a/tests/unit/test_bot_info.py
+++ b/tests/unit/test_bot_info.py
@@ -1,0 +1,201 @@
+"""``ante.bot.info.enrich_bot_info`` 검증 (#1712).
+
+검증 대상:
+- 모든 의존성 부재 시 ``bot.get_info()`` 결과를 그대로 반환(보강 키 부재).
+- 의존성별 보강 키 추가:
+  - ``strategy_registry`` → ``strategy_name`` / ``strategy_author_*`` / ``strategy``
+  - ``treasury`` (단일 인스턴스) → ``budget`` (allocated/spent/reserved/available)
+  - ``trade_service`` → ``positions`` (symbol/quantity/avg_entry_price/realized_pnl)
+- 응답 shape/field 가 Web API ``GET /api/bots/{bot_id}`` 라우트와 정렬
+  (behavior-preserving extraction 회귀 lock).
+- ``trade_service=None`` (legacy ServiceRegistry / cold-path) 시 ``positions``
+  키 부재 — 빈 리스트로 흡수되는 contract drift 차단.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from ante.bot.info import enrich_bot_info
+
+
+def _make_bot(
+    *,
+    bot_id: str = "bot-1",
+    info: dict | None = None,
+) -> SimpleNamespace:
+    base = (
+        info
+        if info is not None
+        else {
+            "bot_id": bot_id,
+            "status": "running",
+            "strategy_id": "",
+        }
+    )
+    return SimpleNamespace(bot_id=bot_id, get_info=MagicMock(return_value=base))
+
+
+class TestEnrichBotInfo:
+    async def test_no_dependencies_returns_base_info_only(self) -> None:
+        """의존성 모두 None → ``bot.get_info()`` 결과를 그대로 반환."""
+        bot = _make_bot(info={"bot_id": "bot-1", "status": "running"})
+        info = await enrich_bot_info(bot)
+
+        assert info == {"bot_id": "bot-1", "status": "running"}
+
+    async def test_strategy_registry_adds_strategy_keys(self) -> None:
+        """``strategy_registry`` 가 record 반환 → strategy 보강 4 키 추가."""
+        bot = _make_bot(info={"bot_id": "bot-1", "strategy_id": "strat-1"})
+        record = SimpleNamespace(
+            name="MyStrategy",
+            version="1.2",
+            author_name="alice",
+            author_id="ag-alice",
+            description="my desc",
+        )
+        registry = MagicMock()
+        registry.get = AsyncMock(return_value=record)
+
+        info = await enrich_bot_info(bot, strategy_registry=registry)
+
+        assert info["strategy_name"] == "MyStrategy"
+        assert info["strategy_author_name"] == "alice"
+        assert info["strategy_author_id"] == "ag-alice"
+        assert info["strategy"] == {
+            "name": "MyStrategy",
+            "version": "1.2",
+            "author_name": "alice",
+            "author_id": "ag-alice",
+            "description": "my desc",
+        }
+        registry.get.assert_awaited_once_with("strat-1")
+
+    async def test_strategy_registry_returns_none_omits_keys(self) -> None:
+        """``strategy_registry.get`` → None 이면 strategy 키 부재."""
+        bot = _make_bot(info={"bot_id": "bot-1", "strategy_id": "strat-missing"})
+        registry = MagicMock()
+        registry.get = AsyncMock(return_value=None)
+
+        info = await enrich_bot_info(bot, strategy_registry=registry)
+
+        assert "strategy_name" not in info
+        assert "strategy" not in info
+
+    async def test_treasury_adds_budget(self) -> None:
+        """``treasury.get_budget`` 가 BotBudget 반환 → budget 키 추가."""
+        bot = _make_bot()
+        budget = SimpleNamespace(
+            allocated=10000.0,
+            spent=2000.0,
+            reserved=500.0,
+            available=7500.0,
+        )
+        treasury = MagicMock()
+        treasury.get_budget = MagicMock(return_value=budget)
+
+        info = await enrich_bot_info(bot, treasury=treasury)
+
+        assert info["budget"] == {
+            "allocated": 10000.0,
+            "spent": 2000.0,
+            "reserved": 500.0,
+            "available": 7500.0,
+        }
+        treasury.get_budget.assert_called_once_with("bot-1")
+
+    async def test_treasury_returns_none_omits_budget(self) -> None:
+        """``treasury.get_budget`` → None 이면 budget 키 부재."""
+        bot = _make_bot()
+        treasury = MagicMock()
+        treasury.get_budget = MagicMock(return_value=None)
+
+        info = await enrich_bot_info(bot, treasury=treasury)
+
+        assert "budget" not in info
+
+    async def test_trade_service_adds_positions(self) -> None:
+        """``trade_service.get_positions`` 결과를 positions 키로 보강."""
+        bot = _make_bot()
+        position = SimpleNamespace(
+            symbol="005930",
+            quantity=10,
+            avg_entry_price=70000.0,
+            realized_pnl=1500.0,
+        )
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[position])
+
+        info = await enrich_bot_info(bot, trade_service=trade_service)
+
+        assert info["positions"] == [
+            {
+                "symbol": "005930",
+                "quantity": 10,
+                "avg_entry_price": 70000.0,
+                "realized_pnl": 1500.0,
+            }
+        ]
+        trade_service.get_positions.assert_awaited_once_with(
+            bot_id="bot-1", include_closed=True
+        )
+
+    async def test_trade_service_none_omits_positions(self) -> None:
+        """#1712 회귀 lock: ``trade_service=None`` 시 positions 키 부재.
+
+        legacy ServiceRegistry 호환 — 빈 리스트로 흡수되는 contract drift 차단.
+        """
+        bot = _make_bot()
+        info = await enrich_bot_info(bot, trade_service=None)
+
+        assert "positions" not in info
+
+    async def test_trade_service_empty_positions_returns_empty_list(self) -> None:
+        """``trade_service.get_positions`` → 빈 리스트면 positions=[] 키 존재."""
+        bot = _make_bot()
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[])
+
+        info = await enrich_bot_info(bot, trade_service=trade_service)
+
+        # positions 키는 존재(빈 리스트). 위 ``test_trade_service_none_omits_positions``
+        # 와 명확히 구분된다 — None 의존성 vs. 의존성 있지만 결과 빈 리스트.
+        assert info["positions"] == []
+
+    async def test_all_dependencies_compose_into_full_envelope(self) -> None:
+        """3 의존성 모두 주입 → strategy/budget/positions 모두 보강."""
+        bot = _make_bot(info={"bot_id": "bot-1", "strategy_id": "strat-1"})
+
+        record = SimpleNamespace(
+            name="S",
+            version="1",
+            author_name="a",
+            author_id="ag-a",
+            description="d",
+        )
+        registry = MagicMock()
+        registry.get = AsyncMock(return_value=record)
+
+        budget = SimpleNamespace(
+            allocated=100.0, spent=10.0, reserved=5.0, available=85.0
+        )
+        treasury = MagicMock()
+        treasury.get_budget = MagicMock(return_value=budget)
+
+        position = SimpleNamespace(
+            symbol="005930", quantity=1, avg_entry_price=1.0, realized_pnl=0.0
+        )
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[position])
+
+        info = await enrich_bot_info(
+            bot,
+            strategy_registry=registry,
+            treasury=treasury,
+            trade_service=trade_service,
+        )
+
+        assert info["strategy_name"] == "S"
+        assert info["budget"]["allocated"] == 100.0
+        assert info["positions"][0]["symbol"] == "005930"

--- a/tests/unit/test_cli_date_validation.py
+++ b/tests/unit/test_cli_date_validation.py
@@ -17,8 +17,10 @@ text stderr + exit 2 + **traceback 미노출**을 보장한다. trade list 케�
 스펙 / 분류:
 - `audit list`와 `treasury snapshot`은 `docs/specs/cli/03-commands.md`의 `offline`
   분류이며 IPC route가 없다 (`src/ante/ipc/registry.py`
-  `register_all_handlers()` 19개 handler 중 audit/snapshot route 부재).
-- `trade list` 역시 offline CLI (IPC registry 부재 — #1512에서 19 handler 확인).
+  `register_all_handlers()` 22개 handler 중 audit/snapshot route 부재 —
+  #1712 ``bot.start``/``bot.stop``/``bot.status`` 포함).
+- `trade list` 역시 offline CLI (IPC registry 부재 — #1512에서 19 handler 확인,
+  #1712 이후 22 handler).
   따라서 IPC integration 검증은 N/A이며 본 테스트는 CLI Click ingress 경로만
   검증한다.
 

--- a/tests/unit/test_cli_instrument_import_exit.py
+++ b/tests/unit/test_cli_instrument_import_exit.py
@@ -7,7 +7,8 @@
 
 분류 메모:
 - ``instrument import``는 spec ``docs/specs/cli/03-commands.md``상 offline CLI —
-  IPC route 없음 (handler 19개 외).
+  IPC route 없음 (handler 22개 외 — #1712 ``bot.start``/``bot.stop``/``bot.status``
+  포함).
 - ``Formatter.error()`` 자체는 미변경 — 출력은 호출자 책임, exit은 caller가
   ``ctx.exit(1)``로 강제.
 - 검증된 사이트 5개:

--- a/tests/unit/test_cli_pagination_validation.py
+++ b/tests/unit/test_cli_pagination_validation.py
@@ -7,8 +7,9 @@ exit 0으로 처리하던 ingress drift를 닫는다.
 스펙 참조:
 - 5개 명령은 모두 `docs/specs/cli/03-commands.md`의 `offline` 분류이며,
   `src/ante/ipc/registry.py:371-426` `register_all_handlers()`에 해당 IPC
-  route가 없다 (등록된 19개 handler: system/account/bot/treasury/config.set/
-  approval/broker만). 따라서 IPC integration test는 N/A.
+  route가 없다 (등록된 22개 handler: system/account/bot/treasury/config.set/
+  approval/broker만 — #1712 ``bot.start``/``bot.stop``/``bot.status`` 포함).
+  따라서 IPC integration test는 N/A.
 - 본 테스트는 CLI Click 데코레이터의 `IntRange` ingress 가드만 검증한다.
 - 서비스 직접 호출(`AuditLogger.query`, `TradeRecorder.get_trades`,
   `BacktestRunStore.list_by_strategy`, `InstrumentService.search`,

--- a/tests/unit/test_ipc_bot_lifecycle.py
+++ b/tests/unit/test_ipc_bot_lifecycle.py
@@ -1,0 +1,440 @@
+"""IPC handlers ``bot.start`` / ``bot.stop`` / ``bot.status`` 검증 (#1712).
+
+검증 대상:
+- 정상 경로: ``{bot: info}`` envelope 반환.
+- 거부 경로 coded exception:
+  - ``BotNotFoundError`` (code=BOT_NOT_FOUND) — Web API 404 정렬.
+  - ``BotAccountCredentialsNotConfigured``
+    (code=BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED) — Web API 422 정렬.
+  - ``BotStateConflict`` (code=BOT_STATE_CONFLICT) — Web API 409 정렬.
+- audit logger optional 처리:
+  - ``bot.start`` / ``bot.stop`` 성공 시 audit ``bot.start`` / ``bot.stop`` 기록.
+  - ``bot.status`` 는 read-only — audit 없음.
+  - ``audit_logger=None`` / 속성 부재 환경에서도 핸들러 정상 성공.
+- ``trade_service`` optional:
+  - 주입 시 positions 보강.
+  - 부재 시 ``positions`` 키 부재(회귀 lock, #1712 cold-path 호환).
+- ``CommandRegistry`` 등록 invariant: taxonomy(start/stop=mutating,
+  status=read-only), 22 count.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.bot.exceptions import (
+    BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE,
+    BOT_NOT_FOUND_CODE,
+    BOT_STATE_CONFLICT_CODE,
+    BotAccountCredentialsNotConfigured,
+    BotError,
+    BotNotFoundError,
+    BotStateConflict,
+)
+from ante.ipc.registry import (
+    CommandRegistry,
+    _handle_bot_start,
+    _handle_bot_status,
+    _handle_bot_stop,
+    register_all_handlers,
+)
+
+
+def _make_bot(
+    *,
+    bot_id: str = "bot-1",
+    account_id: str = "acc-1",
+    info: dict | None = None,
+) -> SimpleNamespace:
+    """Bot stub — ``get_info()`` / ``config.account_id`` / ``bot_id`` 노출."""
+    bot_info = info if info is not None else {"bot_id": bot_id, "status": "stopped"}
+    return SimpleNamespace(
+        bot_id=bot_id,
+        config=SimpleNamespace(account_id=account_id),
+        get_info=MagicMock(return_value=bot_info),
+    )
+
+
+def _make_svc(
+    *,
+    bot: SimpleNamespace | None,
+    account: SimpleNamespace | None = None,
+    start_side_effect: Exception | None = None,
+    stop_side_effect: Exception | None = None,
+    with_audit_logger: bool = True,
+    strategy_registry: object | None = None,
+    treasury_manager: object | None = None,
+    trade_service: object | None = None,
+) -> tuple[SimpleNamespace, AsyncMock | None]:
+    """ServiceRegistry-shaped stub.
+
+    ``svc.bot_manager.get_bot(bot_id)`` 는 주어진 ``bot`` 을 반환한다(None 가능).
+    """
+    bot_manager = MagicMock()
+    bot_manager.get_bot = MagicMock(return_value=bot)
+    bot_manager.start_bot = AsyncMock(side_effect=start_side_effect)
+    bot_manager.stop_bot = AsyncMock(side_effect=stop_side_effect)
+
+    account_service = MagicMock()
+    if account is not None:
+        account_service.get = AsyncMock(return_value=account)
+    else:
+        account_service.get = AsyncMock(return_value=None)
+
+    audit_log: AsyncMock | None
+    if with_audit_logger:
+        audit_logger = MagicMock()
+        audit_logger.log = AsyncMock()
+        audit_log = audit_logger.log
+    else:
+        audit_logger = None
+        audit_log = None
+
+    svc = SimpleNamespace(
+        bot_manager=bot_manager,
+        account=account_service,
+        audit_logger=audit_logger,
+        strategy_registry=strategy_registry,
+        treasury_manager=treasury_manager,
+        trade_service=trade_service,
+    )
+    return svc, audit_log
+
+
+# ── bot.start ────────────────────────────────────────
+
+
+class TestHandleBotStart:
+    """``_handle_bot_start`` 정상 + 거부 경로."""
+
+    async def test_success_returns_bot_envelope(self) -> None:
+        """성공 시 ``{"bot": info}`` envelope + audit ``bot.start`` 기록."""
+        bot = _make_bot(bot_id="bot-1", account_id="acc-1")
+        account = SimpleNamespace(credentials={"app_key": "AK-XYZ"})
+        svc, audit_log = _make_svc(bot=bot, account=account)
+
+        result = await _handle_bot_start(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert result == {"bot": {"bot_id": "bot-1", "status": "stopped"}}
+        svc.bot_manager.start_bot.assert_awaited_once_with("bot-1")
+        assert audit_log is not None
+        audit_log.assert_awaited_once_with(
+            member_id="admin-master",
+            action="bot.start",
+            resource="bot:bot-1",
+            ip="",
+        )
+
+    async def test_missing_bot_raises_bot_not_found(self) -> None:
+        """봇 부재 → ``BotNotFoundError`` (code=BOT_NOT_FOUND)."""
+        svc, _ = _make_svc(bot=None)
+
+        with pytest.raises(BotNotFoundError) as exc:
+            await _handle_bot_start(svc, {"bot_id": "missing"}, "admin-master")
+
+        assert exc.value.code == BOT_NOT_FOUND_CODE
+        svc.bot_manager.start_bot.assert_not_awaited()
+
+    async def test_missing_app_key_raises_credentials_error(self) -> None:
+        """app_key 부재 → ``BotAccountCredentialsNotConfigured`` (Web API 422 정렬)."""
+        bot = _make_bot()
+        account = SimpleNamespace(credentials={})  # app_key 누락
+        svc, audit_log = _make_svc(bot=bot, account=account)
+
+        with pytest.raises(BotAccountCredentialsNotConfigured) as exc:
+            await _handle_bot_start(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert exc.value.code == BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE
+        svc.bot_manager.start_bot.assert_not_awaited()
+        # 거부된 경우 audit 호출 없음
+        assert audit_log is not None
+        audit_log.assert_not_awaited()
+
+    async def test_bot_error_raises_state_conflict(self) -> None:
+        """``BotManager.start_bot`` 의 ``BotError`` → ``BotStateConflict``.
+
+        Web API ``POST /api/bots/{bot_id}/start`` 의 409 정렬.
+        """
+        bot = _make_bot()
+        account = SimpleNamespace(credentials={"app_key": "AK"})
+        svc, audit_log = _make_svc(
+            bot=bot,
+            account=account,
+            start_side_effect=BotError("이미 실행 중인 봇입니다: bot-1"),
+        )
+
+        with pytest.raises(BotStateConflict) as exc:
+            await _handle_bot_start(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert exc.value.code == BOT_STATE_CONFLICT_CODE
+        # raised from BotError
+        assert isinstance(exc.value.__cause__, BotError)
+        assert audit_log is not None
+        audit_log.assert_not_awaited()
+
+    async def test_succeeds_when_audit_logger_is_none(self) -> None:
+        """``audit_logger=None`` 환경에서도 핸들러는 정상 성공."""
+        bot = _make_bot()
+        account = SimpleNamespace(credentials={"app_key": "AK"})
+        svc, _ = _make_svc(bot=bot, account=account, with_audit_logger=False)
+
+        result = await _handle_bot_start(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert result == {"bot": {"bot_id": "bot-1", "status": "stopped"}}
+        svc.bot_manager.start_bot.assert_awaited_once_with("bot-1")
+
+
+# ── bot.stop ─────────────────────────────────────────
+
+
+class TestHandleBotStop:
+    """``_handle_bot_stop`` 정상 + 거부 경로."""
+
+    async def test_success_returns_bot_envelope(self) -> None:
+        """성공 시 ``{"bot": info}`` envelope + audit ``bot.stop`` 기록."""
+        bot = _make_bot(bot_id="bot-1")
+        svc, audit_log = _make_svc(bot=bot)
+
+        result = await _handle_bot_stop(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert result == {"bot": {"bot_id": "bot-1", "status": "stopped"}}
+        svc.bot_manager.stop_bot.assert_awaited_once_with("bot-1")
+        # ``bot.stop`` 은 app_key preflight 가 없다 — account_service.get 미호출.
+        svc.account.get.assert_not_awaited()
+        assert audit_log is not None
+        audit_log.assert_awaited_once_with(
+            member_id="admin-master",
+            action="bot.stop",
+            resource="bot:bot-1",
+            ip="",
+        )
+
+    async def test_missing_bot_raises_bot_not_found(self) -> None:
+        """봇 부재 → ``BotNotFoundError`` (code=BOT_NOT_FOUND)."""
+        svc, _ = _make_svc(bot=None)
+
+        with pytest.raises(BotNotFoundError) as exc:
+            await _handle_bot_stop(svc, {"bot_id": "missing"}, "admin-master")
+
+        assert exc.value.code == BOT_NOT_FOUND_CODE
+        svc.bot_manager.stop_bot.assert_not_awaited()
+
+    async def test_bot_error_raises_state_conflict(self) -> None:
+        """``BotManager.stop_bot`` 의 ``BotError`` → ``BotStateConflict``."""
+        bot = _make_bot()
+        svc, audit_log = _make_svc(
+            bot=bot,
+            stop_side_effect=BotError("실행 중이 아닙니다"),
+        )
+
+        with pytest.raises(BotStateConflict) as exc:
+            await _handle_bot_stop(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert exc.value.code == BOT_STATE_CONFLICT_CODE
+        assert isinstance(exc.value.__cause__, BotError)
+        assert audit_log is not None
+        audit_log.assert_not_awaited()
+
+    async def test_succeeds_when_audit_logger_is_none(self) -> None:
+        """``audit_logger=None`` 환경에서도 핸들러는 정상 성공."""
+        bot = _make_bot()
+        svc, _ = _make_svc(bot=bot, with_audit_logger=False)
+
+        result = await _handle_bot_stop(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert result == {"bot": {"bot_id": "bot-1", "status": "stopped"}}
+        svc.bot_manager.stop_bot.assert_awaited_once_with("bot-1")
+
+
+# ── bot.status ───────────────────────────────────────
+
+
+class TestHandleBotStatus:
+    """``_handle_bot_status`` read-only handler + ``enrich_bot_info`` 보강."""
+
+    async def test_success_with_trade_service_enriches_positions(self) -> None:
+        """``trade_service`` 주입 시 positions 보강."""
+        bot = _make_bot(
+            bot_id="bot-1",
+            account_id="acc-1",
+            info={"bot_id": "bot-1", "status": "running", "strategy_id": ""},
+        )
+
+        position = SimpleNamespace(
+            symbol="005930",
+            quantity=10,
+            avg_entry_price=70000.0,
+            realized_pnl=1500.0,
+        )
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[position])
+
+        svc, audit_log = _make_svc(bot=bot, trade_service=trade_service)
+
+        result = await _handle_bot_status(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert "positions" in result["bot"]
+        assert result["bot"]["positions"] == [
+            {
+                "symbol": "005930",
+                "quantity": 10,
+                "avg_entry_price": 70000.0,
+                "realized_pnl": 1500.0,
+            }
+        ]
+        trade_service.get_positions.assert_awaited_once_with(
+            bot_id="bot-1", include_closed=True
+        )
+        # read-only — audit 호출 없음
+        assert audit_log is not None
+        audit_log.assert_not_awaited()
+
+    async def test_success_without_trade_service_omits_positions(self) -> None:
+        """``trade_service=None`` 시 positions 키 부재 (회귀 lock)."""
+        bot = _make_bot(
+            bot_id="bot-1",
+            info={"bot_id": "bot-1", "status": "running", "strategy_id": ""},
+        )
+        svc, _ = _make_svc(bot=bot, trade_service=None)
+
+        result = await _handle_bot_status(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        # ``positions`` 키 자체가 부재 — 빈 리스트로 흡수되는 contract drift 차단.
+        assert "positions" not in result["bot"]
+
+    async def test_missing_bot_raises_bot_not_found(self) -> None:
+        """봇 부재 → ``BotNotFoundError`` (code=BOT_NOT_FOUND)."""
+        svc, _ = _make_svc(bot=None)
+
+        with pytest.raises(BotNotFoundError) as exc:
+            await _handle_bot_status(svc, {"bot_id": "missing"}, "admin-master")
+
+        assert exc.value.code == BOT_NOT_FOUND_CODE
+
+    async def test_read_only_does_not_call_audit(self) -> None:
+        """read-only handler 는 audit logger 가 주입돼도 호출하지 않는다."""
+        bot = _make_bot(info={"bot_id": "bot-1", "strategy_id": ""})
+        svc, audit_log = _make_svc(bot=bot)
+
+        await _handle_bot_status(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert audit_log is not None
+        audit_log.assert_not_awaited()
+
+    async def test_succeeds_when_audit_logger_is_none(self) -> None:
+        """``audit_logger=None`` 환경에서도 정상 성공 (read-only 일관성)."""
+        bot = _make_bot(info={"bot_id": "bot-1", "strategy_id": ""})
+        svc, _ = _make_svc(bot=bot, with_audit_logger=False)
+
+        result = await _handle_bot_status(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert result == {"bot": {"bot_id": "bot-1", "strategy_id": ""}}
+
+    async def test_strategy_registry_enriches_strategy_info(self) -> None:
+        """``strategy_registry`` 주입 시 strategy 필드 보강."""
+        bot = _make_bot(info={"bot_id": "bot-1", "strategy_id": "strat-1"})
+
+        record = SimpleNamespace(
+            name="MyStrategy",
+            version="1.0",
+            author_name="alice",
+            author_id="ag-alice",
+            description="desc",
+        )
+        strategy_registry = MagicMock()
+        strategy_registry.get = AsyncMock(return_value=record)
+
+        svc, _ = _make_svc(bot=bot, strategy_registry=strategy_registry)
+
+        result = await _handle_bot_status(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert result["bot"]["strategy_name"] == "MyStrategy"
+        assert result["bot"]["strategy_author_name"] == "alice"
+        assert result["bot"]["strategy_author_id"] == "ag-alice"
+        assert result["bot"]["strategy"]["version"] == "1.0"
+        strategy_registry.get.assert_awaited_once_with("strat-1")
+
+    async def test_treasury_manager_enriches_budget(self) -> None:
+        """``treasury_manager`` 가 해당 계좌 Treasury 를 반환하면 budget 보강."""
+        bot = _make_bot(account_id="acc-1", info={"bot_id": "bot-1", "strategy_id": ""})
+
+        budget = SimpleNamespace(
+            allocated=10000.0,
+            spent=2000.0,
+            reserved=500.0,
+            available=7500.0,
+        )
+        treasury = MagicMock()
+        treasury.get_budget = MagicMock(return_value=budget)
+
+        treasury_manager = MagicMock()
+        treasury_manager.get = MagicMock(return_value=treasury)
+
+        svc, _ = _make_svc(bot=bot, treasury_manager=treasury_manager)
+
+        result = await _handle_bot_status(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert result["bot"]["budget"] == {
+            "allocated": 10000.0,
+            "spent": 2000.0,
+            "reserved": 500.0,
+            "available": 7500.0,
+        }
+        treasury_manager.get.assert_called_once_with("acc-1")
+        treasury.get_budget.assert_called_once_with("bot-1")
+
+    async def test_treasury_manager_missing_account_omits_budget(self) -> None:
+        """``treasury_manager.get`` 가 ``KeyError`` 시 budget 키 부재."""
+        bot = _make_bot(account_id="acc-1", info={"bot_id": "bot-1", "strategy_id": ""})
+
+        treasury_manager = MagicMock()
+        treasury_manager.get = MagicMock(side_effect=KeyError("acc-1"))
+
+        svc, _ = _make_svc(bot=bot, treasury_manager=treasury_manager)
+
+        result = await _handle_bot_status(svc, {"bot_id": "bot-1"}, "admin-master")
+
+        assert "budget" not in result["bot"]
+
+
+# ── CommandRegistry 등록 invariant ───────────────────
+
+
+class TestRegistryRegistration:
+    """``bot.start`` / ``bot.stop`` / ``bot.status`` 등록 invariant (#1712)."""
+
+    def test_bot_start_registered_as_mutating(self) -> None:
+        registry = CommandRegistry()
+        register_all_handlers(registry)
+
+        spec = registry.get("bot.start")
+        assert spec is not None
+        assert spec.is_mutating is True
+        assert spec.handler is _handle_bot_start
+
+    def test_bot_stop_registered_as_mutating(self) -> None:
+        registry = CommandRegistry()
+        register_all_handlers(registry)
+
+        spec = registry.get("bot.stop")
+        assert spec is not None
+        assert spec.is_mutating is True
+        assert spec.handler is _handle_bot_stop
+
+    def test_bot_status_registered_as_read_only(self) -> None:
+        registry = CommandRegistry()
+        register_all_handlers(registry)
+
+        spec = registry.get("bot.status")
+        assert spec is not None
+        assert spec.is_mutating is False
+        assert spec.handler is _handle_bot_status
+
+    def test_total_command_count_is_22(self) -> None:
+        """#1712: 19 → 22 (bot.start/stop/status 3 추가)."""
+        registry = CommandRegistry()
+        register_all_handlers(registry)
+        assert len(registry.commands) == 22


### PR DESCRIPTION
Closes #1712
Part of #1698 epic. Selected #1711 (spec).

## Summary

`bot.start`, `bot.stop`, `bot.status` IPC handler 3개를 등록한다. Web API 라우트(`POST /api/bots/{id}/start|stop`, `GET /api/bots/{id}`)의 live BotManager 호출 + `BotDetailResponse` envelope + audit action을 IPC에 1:1 정렬한다. CLI command 등록은 #1713 후속.

핵심 변경:

- **IPC handler 3개 등록** (`src/ante/ipc/registry.py`):
  - `bot.start` (mutating): get_bot → app_key preflight → BotManager.start_bot → audit `bot.start` → `{bot: bot.get_info()}`
  - `bot.stop` (mutating): get_bot → BotManager.stop_bot → audit `bot.stop` → `{bot: bot.get_info()}`
  - `bot.status` (read-only): get_bot → `enrich_bot_info` helper → `{bot: info}` (audit 없음)
- **`src/ante/bot/info.py` 신설**: `enrich_bot_info(bot, *, strategy_registry, treasury_manager, trade_service)` helper. FastAPI/HTTPException 의존성 없는 순수 helper (Codex advisory). Web API + IPC 공유.
- **`src/ante/web/routes/bots.py`의 `get_bot` 라우트가 helper 호출로 치환** (behavior-preserving extraction, 응답 shape/field/key 순서 무변경).
- **`src/ante/core/registry.py`**: `ServiceRegistry.trade_service: Any = None` optional 추가. `src/ante/main.py`에서 주입.
- **`src/ante/bot/exceptions.py`**: 2 coded exception 신설:
  - `BotAccountCredentialsNotConfigured` (code: `BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`)
  - `BotStateConflict` (code: `BOT_STATE_CONFLICT`)
  - 기존 `BOT_NOT_FOUND_CODE` 재사용. `getattr(e, 'code', 'EXECUTION_ERROR')` forwarding 호환.
- **`docs/specs/ipc/ipc.md`**: taxonomy SSOT 표 19 → 22 통합 (#1712 등록 예정 후속 표 제거).

## Test Plan

worktree(`/Users/jingulee/Projects/ante-worktrees/issue-1712`) 로컬:

- `pytest -q tests/unit/` → **6803 passed, 2 skipped, 37 warnings in 217s**
- `mypy src/` → Success (243 files)
- `ruff check src/ tests/`, `ruff format --check src/ tests/` → clean (564 files)
- frontend `npm run build` → OK (480 modules, openapi 변경 없음 회귀 안전)

회귀 lock:
- `bot.start/stop` = mutating, `bot.status` = read-only (`is_mutating` SSOT 정렬)
- `bot.status` `trade_service=None` 시 positions 키 부재 (회귀 lock)
- audit logger None 환경에서도 3 handler 성공
- Web API `get_bot` 응답 shape/field/key 순서 무변경 (behavior-preserving helper extraction)

신규 회귀 테스트:
- `tests/unit/test_bot_info.py`: helper 9 case (각 enrichment 분기)
- `tests/unit/test_ipc_bot_lifecycle.py`: 3 handler 19 case (성공/missing/credential/conflict/audit optional/status trade_service None)
- `tests/unit/ipc/test_registry.py`: taxonomy 19 → 22, mutating/read-only 분류
- `tests/unit/ipc/test_service_registry.py`: trade_service optional 회귀

게이트:
- Codex Plan Review v2: approve-implement (findings 0, 7 confirmation)
- Codex 브랜치 리뷰: PASS (1차 attempt)

## Follow-up

- **#1713**: Click command 등록 (`ante bot start/stop/status` leaf command) + `ipc_send` 사용 + `guide/cli.md` 재생성 + `scripts/generate_project_structure.py` DEFAULT_DESCRIPTIONS의 bot.py 항목에서 `(start/stop/status 미구현 follow-up)` 제거 + `docs/architecture/generated/project-structure.md` 재생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)
