### PR TITLE
feat: #1713 ante bot start/stop/status CLI leaf command 등록 (#1698 epic 완료)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -98,7 +98,8 @@ src/ante/
 │   │   ├── virtual.py                # VirtualProvider — 가상 실행 봇 데이터 공급
 │   │   └── __init__.py
 │   ├── __init__.py
-│   └── cold_path.py
+│   ├── cold_path.py
+│   └── info.py
 ├── strategy/
 │   ├── base.py                       # Strategy ABC, StrategyMeta, TradeHistoryView
 │   ├── context.py                    # StrategyContext — 전략 실행 컨텍스트 (파일 접근, 로깅, 거래 이력)
@@ -261,7 +262,7 @@ src/ante/
 │   │   ├── approval.py               # ante approval approve/audit-types/cancel/cancel-invalid/info/list/reject/reopen/request/review
 │   │   ├── audit.py                  # ante audit — 감사 로그 조회
 │   │   ├── backtest.py               # ante backtest history/run
-│   │   ├── bot.py                    # ante bot create/info/list/positions/remove/signal-key (start/stop/status 미구현 follow-up)
+│   │   ├── bot.py                    # ante bot create/info/list/positions/remove/signal-key/start/stop/status
 │   │   ├── broker.py                 # ante broker balance/positions/reconcile/status
 │   │   ├── config.py                 # ante config get/history/set
 │   │   ├── data.py                   # ante data list/schema/storage/validate
@@ -644,7 +645,10 @@ tests/
 │   │   ├── __init__.py
 │   │   └── test_validator_source_read_parse_no_reflection.py
 │   ├── test_cli_notification_hidden.py
-│   └── test_cli_signal_connect.py
+│   ├── test_cli_signal_connect.py
+│   ├── test_bot_info.py
+│   ├── test_cli_bot_lifecycle.py
+│   └── test_ipc_bot_lifecycle.py
 └── __init__.py
 ```
 

--- a/guide/cli.md
+++ b/guide/cli.md
@@ -2,7 +2,7 @@
 
 Ante가 제공하는 모든 CLI 명령어를 정리한 문서입니다. 각 명령어의 사용법, 옵션, 필수 권한(scope)을 확인할 수 있습니다.
 
-> 마지막 갱신: 2026-05-21
+> 마지막 갱신: 2026-05-22
 
 ## 목차
 
@@ -40,6 +40,9 @@ Ante가 제공하는 모든 CLI 명령어를 정리한 문서입니다. 각 명�
   - [ante bot remove](#ante-bot-remove)
   - [ante bot signal-key](#ante-bot-signal-key)
   - [ante bot positions](#ante-bot-positions)
+  - [ante bot start](#ante-bot-start)
+  - [ante bot stop](#ante-bot-stop)
+  - [ante bot status](#ante-bot-status)
 - [broker — 증권사 계좌 정보 조회.](#broker-증권사-계좌-정보-조회)
   - [ante broker status](#ante-broker-status)
   - [ante broker balance](#ante-broker-balance)
@@ -165,6 +168,9 @@ ante [OPTIONS] <command>
 | `ante bot remove` | 봇 삭제. | `bot:admin` | H·A |
 | `ante bot signal-key` | 봇 시그널 키 조회 또는 재발급. | `bot:admin` | H·A |
 | `ante bot positions` | 봇 보유 포지션 조회. | `bot:read` | H·A |
+| `ante bot start` | 봇 시작 (Web API ``POST /api/bots/{bot_id}/start``와 같은 동작). | `bot:admin` | H·A |
+| `ante bot stop` | 봇 중지 (Web API ``POST /api/bots/{bot_id}/stop``과 같은 동작). | `bot:admin` | H·A |
+| `ante bot status` | 봇 live 상태 조회 (Web API ``GET /api/bots/{bot_id}``와 같은 동작). | `bot:read` | H·A |
 | `ante broker status` | 증권사 연결 상태 조회. | `broker:read` | H·A |
 | `ante broker balance` | 증권사 계좌 잔고 조회. | `broker:read` | H·A |
 | `ante broker positions` | 증권사 보유 종목 조회. | `broker:read` | H·A |
@@ -926,6 +932,78 @@ ante bot positions <BOT_ID>
 | 인자 | 필수 | 설명 |
 |------|------|------|
 | `<BOT_ID>` | O |  |
+
+
+### ante bot start
+
+봇 시작 (Web API ``POST /api/bots/{bot_id}/start``와 같은 동작).
+
+- **필요 scope**: `bot:admin`
+- **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
+
+```bash
+ante bot start <BOT_ID> [OPTIONS]
+```
+
+**Arguments:**
+
+| 인자 | 필수 | 설명 |
+|------|------|------|
+| `<BOT_ID>` | O |  |
+
+**Options:**
+
+| 옵션 | 필수 | 타입 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
+
+
+### ante bot stop
+
+봇 중지 (Web API ``POST /api/bots/{bot_id}/stop``과 같은 동작).
+
+- **필요 scope**: `bot:admin`
+- **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
+
+```bash
+ante bot stop <BOT_ID> [OPTIONS]
+```
+
+**Arguments:**
+
+| 인자 | 필수 | 설명 |
+|------|------|------|
+| `<BOT_ID>` | O |  |
+
+**Options:**
+
+| 옵션 | 필수 | 타입 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
+
+
+### ante bot status
+
+봇 live 상태 조회 (Web API ``GET /api/bots/{bot_id}``와 같은 동작).
+
+- **필요 scope**: `bot:read`
+- **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
+
+```bash
+ante bot status <BOT_ID> [OPTIONS]
+```
+
+**Arguments:**
+
+| 인자 | 필수 | 설명 |
+|------|------|------|
+| `<BOT_ID>` | O |  |
+
+**Options:**
+
+| 옵션 | 필수 | 타입 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
 ---

--- a/scripts/generate_project_structure.py
+++ b/scripts/generate_project_structure.py
@@ -104,8 +104,7 @@ DEFAULT_DESCRIPTIONS: dict[str, str] = {
     ),
     "src/ante/cli/commands/backtest.py": "ante backtest history/run",
     "src/ante/cli/commands/bot.py": (
-        "ante bot create/info/list/positions/remove/signal-key "
-        "(start/stop/status 미구현 follow-up)"
+        "ante bot create/info/list/positions/remove/signal-key/start/stop/status"
     ),
     "src/ante/cli/commands/broker.py": "ante broker balance/positions/reconcile/status",
     "src/ante/cli/commands/config.py": "ante config get/history/set",

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -533,3 +533,158 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
         fmt.output({"positions": result})
     else:
         fmt.table(result, ["symbol", "quantity", "avg_entry_price", "realized_pnl"])
+
+
+# ── 봇 생명주기 leaf (#1713) ─────────────────────────────────────────────
+#
+# Refs #1713/#1712: ``bot.start``/``bot.stop``/``bot.status`` IPC handler가
+# Web API ``POST/GET /api/bots/{bot_id}/...``와 정렬된 거부 경로
+# (``BOT_NOT_FOUND`` / ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` /
+# ``BOT_STATE_CONFLICT``) coded exception을 raise한다. CLI ingress는 IPC
+# 단일-chokepoint를 그대로 사용하며 별도 cold-path fallback을 제공하지
+# 않는다(Non-Goal). 에러 envelope 안정성은 #1673 ``config set`` 패턴
+# (``ipc_send``가 ``ClickException``에 부착한 ``ipc_error_code``/
+# ``ipc_error_message``를 split 없이 복원) 1:1 미러로 보존한다.
+
+
+@bot.command("start")
+@click.argument("bot_id")
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("bot:admin")
+def bot_start(ctx: click.Context, bot_id: str) -> None:
+    """봇 시작 (Web API ``POST /api/bots/{bot_id}/start``와 같은 동작)."""
+    fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
+
+    async def _run_start() -> dict:
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        return await ipc_send("bot.start", {"bot_id": bot_id}, actor=actor)
+
+    try:
+        result = _run(_run_start())
+    except click.ClickException as e:
+        # #1673 미러: ipc_send가 부착한 원본 code/message를 split 없이
+        # 복원해 text/JSON 공용 envelope 안정성을 보존한다.
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        if fmt.is_json:
+            fmt.error(message, code=code)
+        else:
+            text = f"{code}: {message}" if code else message
+            fmt.error(text)
+        raise SystemExit(1) from e
+
+    # JSON 모드는 IPC `{bot: ...}` envelope 그대로 (BotDetailResponse 정합 —
+    # `bot status`와 동일 shape, agent 파싱 일관). text 모드만 사용자 친화적
+    # 성공 메시지.
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(f"봇 시작 완료: {bot_id}")
+
+
+@bot.command("stop")
+@click.argument("bot_id")
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("bot:admin")
+def bot_stop(ctx: click.Context, bot_id: str) -> None:
+    """봇 중지 (Web API ``POST /api/bots/{bot_id}/stop``과 같은 동작)."""
+    fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
+
+    async def _run_stop() -> dict:
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        return await ipc_send("bot.stop", {"bot_id": bot_id}, actor=actor)
+
+    try:
+        result = _run(_run_stop())
+    except click.ClickException as e:
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        if fmt.is_json:
+            fmt.error(message, code=code)
+        else:
+            text = f"{code}: {message}" if code else message
+            fmt.error(text)
+        raise SystemExit(1) from e
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(f"봇 중지 완료: {bot_id}")
+
+
+@bot.command("status")
+@click.argument("bot_id")
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("bot:read")
+def bot_status(ctx: click.Context, bot_id: str) -> None:
+    """봇 live 상태 조회 (Web API ``GET /api/bots/{bot_id}``와 같은 동작)."""
+    fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
+
+    async def _run_status() -> dict:
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        return await ipc_send("bot.status", {"bot_id": bot_id}, actor=actor)
+
+    try:
+        result = _run(_run_status())
+    except click.ClickException as e:
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        if fmt.is_json:
+            fmt.error(message, code=code)
+        else:
+            text = f"{code}: {message}" if code else message
+            fmt.error(text)
+        raise SystemExit(1) from e
+
+    # status 출력 계약:
+    # - JSON 모드: IPC result 그대로 (``BotDetailResponse``-equivalent
+    #   ``{"bot": info}`` envelope). 보강된 strategy/budget/positions까지
+    #   포함된다.
+    # - text 모드: ``bot info`` 스타일 detail + optional sections
+    #   (strategy_name/budget/positions). 의존성 부재로 키가 없으면
+    #   해당 section을 생략한다(#1712 read-only 정렬).
+    if fmt.is_json:
+        fmt.output(result)
+        return
+
+    info = result.get("bot", {})
+    click.echo(f"  Bot ID       : {info.get('bot_id')}")
+    click.echo(f"  Name         : {info.get('name')}")
+    click.echo(f"  Status       : {info.get('status')}")
+    click.echo(f"  Account ID   : {info.get('account_id')}")
+    click.echo(f"  Strategy ID  : {info.get('strategy_id')}")
+    if info.get("strategy_name"):
+        click.echo(f"  Strategy Name: {info.get('strategy_name')}")
+    if info.get("interval_seconds") is not None:
+        click.echo(f"  Interval     : {info.get('interval_seconds')}s")
+    if info.get("started_at"):
+        click.echo(f"  Started At   : {info.get('started_at')}")
+    if info.get("stopped_at"):
+        click.echo(f"  Stopped At   : {info.get('stopped_at')}")
+    if info.get("error_message"):
+        click.echo(f"  Error        : {info.get('error_message')}")
+    budget = info.get("budget")
+    if budget:
+        click.echo("  Budget:")
+        for k, v in budget.items():
+            click.echo(f"    {k}: {v}")
+    positions = info.get("positions")
+    if positions:
+        click.echo(f"  Positions ({len(positions)}):")
+        for p in positions:
+            click.echo(
+                f"    {p.get('symbol')}: qty={p.get('quantity')}, "
+                f"avg={p.get('avg_entry_price')}"
+            )

--- a/tests/unit/test_cli_bot_lifecycle.py
+++ b/tests/unit/test_cli_bot_lifecycle.py
@@ -1,0 +1,505 @@
+"""``ante bot start/stop/status`` CLI leaf 회귀 테스트 (#1713).
+
+Refs #1713/#1712: Web API ``POST/GET /api/bots/{bot_id}/...`` 와 정렬된 IPC
+handler(``bot.start``/``bot.stop``/``bot.status``)를 CLI ingress로 노출한다.
+회귀 매트릭스:
+
+- 성공 경로 (start/stop/status: BotInfo or detail envelope 반환).
+- 에러 envelope (``BOT_NOT_FOUND`` / ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED``
+  / ``BOT_STATE_CONFLICT``): JSON 모드는 {status,code,message} 분리 필드, text
+  모드는 ``Error: {code}: {message}`` 톤.
+- ``--format`` option 노출 (`format_option` 데코레이터 적용 확인).
+- ``ante bot --help`` 에 start/stop/status 표시.
+- status text-mode 출력의 optional sections (strategy/budget/positions).
+- trade_service=None 환경 (positions 키 부재) 정상 처리.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+
+def _make_member():
+    member = MagicMock()
+    member.member_id = "test-user"
+    from ante.member.models import MemberType
+
+    member.type = MemberType.HUMAN
+    return member
+
+
+def _mock_authenticate(ctx):
+    ctx.obj["member"] = _make_member()
+
+
+def _invoke_cli(args: list[str]):
+    """CLI 호출 헬퍼 (인증 우회)."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    with patch("ante.cli.main.authenticate_member", side_effect=_mock_authenticate):
+        result = runner.invoke(
+            cli,
+            args,
+            obj={"member": _make_member()},
+            env={"ANTE_MEMBER_TOKEN": ""},
+            catch_exceptions=False,
+        )
+    return result
+
+
+# ── Click 노출 (help / --format) ──────────────────────────────────────────
+
+
+class TestBotLifecycleClickRegistration:
+    """``ante bot --help`` 에 신규 leaf 가 노출되고 ``--format`` option 이 동작한다."""
+
+    def test_bot_help_lists_start_stop_status(self) -> None:
+        """``ante bot --help`` 결과에 start/stop/status가 표시된다."""
+        result = _invoke_cli(["bot", "--help"])
+        assert result.exit_code == 0
+        # Click subcommand 리스트에 3개 명령 노출
+        assert "start" in result.output
+        assert "stop" in result.output
+        assert "status" in result.output
+
+    def test_bot_start_has_format_option(self) -> None:
+        """``ante bot start --help`` 에 ``--format`` 옵션이 노출된다."""
+        result = _invoke_cli(["bot", "start", "--help"])
+        assert result.exit_code == 0
+        assert "--format" in result.output
+
+    def test_bot_stop_has_format_option(self) -> None:
+        """``ante bot stop --help`` 에 ``--format`` 옵션이 노출된다."""
+        result = _invoke_cli(["bot", "stop", "--help"])
+        assert result.exit_code == 0
+        assert "--format" in result.output
+
+    def test_bot_status_has_format_option(self) -> None:
+        """``ante bot status --help`` 에 ``--format`` 옵션이 노출된다."""
+        result = _invoke_cli(["bot", "status", "--help"])
+        assert result.exit_code == 0
+        assert "--format" in result.output
+
+
+# ── bot start ────────────────────────────────────────────────────────────
+
+
+class TestBotStart:
+    """``ante bot start`` 성공/에러 envelope."""
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_start_success(self, mock_ipc_cls, mock_socket) -> None:
+        """성공: ``bot.start`` IPC 호출 + ``{bot: info}`` result + exit 0.
+
+        text 모드는 ``봇 시작 완료: {bot_id}`` 메시지만 출력한다 (Codex P2 fix).
+        """
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot": {"bot_id": "bot-1", "status": "running"}},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["bot", "start", "bot-1"])
+
+        assert result.exit_code == 0
+        assert "봇 시작 완료: bot-1" in result.output
+        mock_client.send.assert_awaited_once()
+        call_args = mock_client.send.call_args
+        assert call_args[0][0] == "bot.start"
+        assert call_args[0][1] == {"bot_id": "bot-1"}
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_start_success_json_passthrough(
+        self, mock_ipc_cls, mock_socket
+    ) -> None:
+        """JSON 모드: IPC result(``{bot: info}``) envelope 그대로 출력 — ``bot
+        status``와 동일 shape, agent 파싱 일관성 보장 (Codex P2 fix)."""
+        info = {"bot_id": "bot-1", "status": "running"}
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot": info},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["--format", "json", "bot", "start", "bot-1"])
+
+        assert result.exit_code == 0
+        import json as _json
+
+        data = _json.loads(result.output)
+        # passthrough: ``{"bot": info}`` 그대로 (success wrapper 부착 금지)
+        assert data == {"bot": info}
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_start_not_found_json_envelope(self, mock_ipc_cls, mock_socket) -> None:
+        """missing bot: ``BOT_NOT_FOUND`` envelope (JSON) + exit 1."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {"code": "BOT_NOT_FOUND", "message": "Bot not found: bot-x"},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["--format", "json", "bot", "start", "bot-x"])
+
+        assert result.exit_code == 1
+        import json as _json
+
+        data = _json.loads(result.output)
+        assert data["status"] == "error"
+        assert data["code"] == "BOT_NOT_FOUND"
+        assert "Bot not found" in data["message"]
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_start_credentials_missing_envelope(
+        self, mock_ipc_cls, mock_socket
+    ) -> None:
+        """app_key 부재: ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` envelope."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {
+                "code": "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED",
+                "message": "계좌에 인증정보(app_key)가 설정되지 않았습니다",
+            },
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["--format", "json", "bot", "start", "bot-1"])
+
+        assert result.exit_code == 1
+        import json as _json
+
+        data = _json.loads(result.output)
+        assert data["code"] == "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED"
+        assert "인증정보" in data["message"]
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_start_state_conflict_envelope(self, mock_ipc_cls, mock_socket) -> None:
+        """상태머신 거부: ``BOT_STATE_CONFLICT`` envelope."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {
+                "code": "BOT_STATE_CONFLICT",
+                "message": "이미 실행 중인 봇입니다",
+            },
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["--format", "json", "bot", "start", "bot-1"])
+
+        assert result.exit_code == 1
+        import json as _json
+
+        data = _json.loads(result.output)
+        assert data["code"] == "BOT_STATE_CONFLICT"
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_start_error_text_mode_carries_code_prefix(
+        self, mock_ipc_cls, mock_socket
+    ) -> None:
+        """text 모드 에러는 ``{code}: {message}`` 톤 + exit 1 (#1673 미러)."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {"code": "BOT_NOT_FOUND", "message": "Bot not found: bot-x"},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["bot", "start", "bot-x"])
+
+        assert result.exit_code == 1
+        # text 모드에서는 ``Error: {code}: {message}`` (stderr).
+        assert "BOT_NOT_FOUND" in result.output
+        assert "Bot not found" in result.output
+
+
+# ── bot stop ─────────────────────────────────────────────────────────────
+
+
+class TestBotStop:
+    """``ante bot stop`` 성공/에러 envelope."""
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_stop_success(self, mock_ipc_cls, mock_socket) -> None:
+        """성공: ``bot.stop`` IPC 호출 + result + exit 0.
+
+        text 모드는 ``봇 중지 완료: {bot_id}`` 메시지만 출력 (Codex P2 fix)."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot": {"bot_id": "bot-1", "status": "stopped"}},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["bot", "stop", "bot-1"])
+
+        assert result.exit_code == 0
+        assert "봇 중지 완료: bot-1" in result.output
+        mock_client.send.assert_awaited_once()
+        call_args = mock_client.send.call_args
+        assert call_args[0][0] == "bot.stop"
+        assert call_args[0][1] == {"bot_id": "bot-1"}
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_stop_success_json_passthrough(self, mock_ipc_cls, mock_socket) -> None:
+        """JSON 모드: IPC result envelope 그대로 출력 (Codex P2 fix)."""
+        info = {"bot_id": "bot-1", "status": "stopped"}
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot": info},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["--format", "json", "bot", "stop", "bot-1"])
+
+        assert result.exit_code == 0
+        import json as _json
+
+        data = _json.loads(result.output)
+        assert data == {"bot": info}
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_stop_not_found_json_envelope(self, mock_ipc_cls, mock_socket) -> None:
+        """missing bot: ``BOT_NOT_FOUND`` JSON envelope + exit 1."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {"code": "BOT_NOT_FOUND", "message": "Bot not found: bot-x"},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["--format", "json", "bot", "stop", "bot-x"])
+
+        assert result.exit_code == 1
+        import json as _json
+
+        data = _json.loads(result.output)
+        assert data["code"] == "BOT_NOT_FOUND"
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_stop_state_conflict_envelope(self, mock_ipc_cls, mock_socket) -> None:
+        """상태머신 거부: ``BOT_STATE_CONFLICT`` envelope (이미 정지된 봇 등)."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {
+                "code": "BOT_STATE_CONFLICT",
+                "message": "정지할 수 없는 상태입니다",
+            },
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["--format", "json", "bot", "stop", "bot-1"])
+
+        assert result.exit_code == 1
+        import json as _json
+
+        data = _json.loads(result.output)
+        assert data["code"] == "BOT_STATE_CONFLICT"
+
+
+# ── bot status ───────────────────────────────────────────────────────────
+
+
+class TestBotStatus:
+    """``ante bot status`` 성공/에러 envelope 및 출력 계약."""
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_status_success_json_passthrough(
+        self, mock_ipc_cls, mock_socket
+    ) -> None:
+        """JSON 모드: IPC result(``{bot: info}``) 를 그대로 출력한다."""
+        info = {
+            "bot_id": "bot-1",
+            "name": "테스트봇",
+            "status": "running",
+            "account_id": "acc-1",
+            "strategy_id": "strat-1",
+            "strategy_name": "MA Cross",
+            "interval_seconds": 60,
+            "started_at": "2026-05-22T00:00:00Z",
+            "budget": {"allocated": 1000000, "available": 750000},
+            "positions": [
+                {"symbol": "005930", "quantity": 10, "avg_entry_price": 75000.0},
+            ],
+        }
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot": info},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["--format", "json", "bot", "status", "bot-1"])
+
+        assert result.exit_code == 0
+        import json as _json
+
+        data = _json.loads(result.output)
+        # passthrough: ``{"bot": info}`` 그대로
+        assert data == {"bot": info}
+        mock_client.send.assert_awaited_once()
+        call_args = mock_client.send.call_args
+        assert call_args[0][0] == "bot.status"
+        assert call_args[0][1] == {"bot_id": "bot-1"}
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_status_success_text_full_sections(
+        self, mock_ipc_cls, mock_socket
+    ) -> None:
+        """text 모드: detail + optional strategy/budget/positions section 출력."""
+        info = {
+            "bot_id": "bot-1",
+            "name": "테스트봇",
+            "status": "running",
+            "account_id": "acc-1",
+            "strategy_id": "strat-1",
+            "strategy_name": "MA Cross",
+            "interval_seconds": 60,
+            "started_at": "2026-05-22T00:00:00Z",
+            "budget": {"allocated": 1000000, "available": 750000},
+            "positions": [
+                {"symbol": "005930", "quantity": 10, "avg_entry_price": 75000.0},
+            ],
+        }
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot": info},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["bot", "status", "bot-1"])
+
+        assert result.exit_code == 0
+        # detail fields
+        assert "bot-1" in result.output
+        assert "테스트봇" in result.output
+        assert "running" in result.output
+        assert "strat-1" in result.output
+        # optional sections
+        assert "MA Cross" in result.output
+        assert "Budget" in result.output
+        assert "allocated" in result.output
+        assert "Positions (1)" in result.output
+        assert "005930" in result.output
+        # positions avg는 IPC ``avg_entry_price`` 키를 정확히 반영해야 한다
+        # (Codex P2 fix — 기존 ``avg_price`` 조회는 항상 None 반환 버그).
+        assert "avg=75000" in result.output
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_status_text_omits_missing_optional_sections(
+        self, mock_ipc_cls, mock_socket
+    ) -> None:
+        """trade_service=None: positions 키 부재. budget/strategy_name 부재도 정상."""
+        info = {
+            "bot_id": "bot-1",
+            "name": "테스트봇",
+            "status": "running",
+            "account_id": "acc-1",
+            "strategy_id": "strat-1",
+            "interval_seconds": 60,
+            # strategy_name, budget, positions 모두 부재 (cold-path/optional deps)
+        }
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot": info},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["bot", "status", "bot-1"])
+
+        assert result.exit_code == 0
+        # detail 필드는 정상 표시
+        assert "bot-1" in result.output
+        assert "테스트봇" in result.output
+        # 부재 section 은 출력되지 않음
+        assert "Budget" not in result.output
+        assert "Positions" not in result.output
+        assert "Strategy Name" not in result.output
+
+    @patch(
+        "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
+    )
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_status_not_found_json_envelope(
+        self, mock_ipc_cls, mock_socket
+    ) -> None:
+        """missing bot: ``BOT_NOT_FOUND`` JSON envelope + exit 1."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {"code": "BOT_NOT_FOUND", "message": "Bot not found: bot-x"},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["--format", "json", "bot", "status", "bot-x"])
+
+        assert result.exit_code == 1
+        import json as _json
+
+        data = _json.loads(result.output)
+        assert data["status"] == "error"
+        assert data["code"] == "BOT_NOT_FOUND"


### PR DESCRIPTION
Closes #1713
Closes #1698 epic.

## Summary

`ante bot start`, `ante bot stop`, `ante bot status` CLI leaf command 3개를 등록한다. Click tree에 노출되고 `ipc_send`를 통해 #1712에서 등록한 IPC handler를 호출하며, Web API `BotDetailResponse`와 동등한 `{"bot": info}` envelope를 JSON 모드에서 그대로 반환한다.

### 변경 묶음 (5 files, 680+/6-)

- **`src/ante/cli/commands/bot.py`** (+146): 3 신규 leaf command
  - `bot start <bot_id>` (`bot:admin`, `@format_option`) → `ipc_send("bot.start", ...)`
  - `bot stop <bot_id>` (`bot:admin`) → `ipc_send("bot.stop", ...)`
  - `bot status <bot_id>` (`bot:read`) → `ipc_send("bot.status", ...)` → JSON `{bot: info}` passthrough / text detail+sections
  - JSON error envelope 안정성: `ClickException` catch + `ipc_error_code/message` 복원 + `fmt.error(...)` + `SystemExit(1)` (#1673 pattern)
  - JSON 성공 envelope: `start/stop` 모두 IPC `{bot: info}` 그대로 (status와 동일 shape, agent 파싱 일관) — Codex P2 fix
  - text 모드: `봇 시작 완료: {bot_id}` / `봇 중지 완료: {bot_id}` 단순 메시지, `status`는 detail + optional `strategy/budget/positions` section
  - `positions`의 평균가 키는 `avg_entry_price` (helper SSOT 정렬) — Codex P2 fix
- **`tests/unit/test_cli_bot_lifecycle.py`** (+447, 신규): 18 cases (성공 + missing + credential + state conflict + JSON envelope passthrough + text sections + IPC error fallback + 4 envelope class)
- **`scripts/generate_project_structure.py`**: `DEFAULT_DESCRIPTIONS`의 `src/ante/cli/commands/bot.py` 항목에서 `(start/stop/status 미구현 follow-up)` 제거 → `ante bot create/info/list/positions/remove/signal-key/start/stop/status`
- **`docs/architecture/generated/project-structure.md`**: bot.py 라인 stale comment 제거 + 재생성 (DEFAULT_DESCRIPTIONS fallback 활성화) + #1712에서 누락된 신규 테스트 파일 tree node 흡수 (pre-existing drift, memory 5축 #3)
- **`guide/cli.md`**: 재생성 (3 detail section + 인벤토리 표 3 row + timestamp)

### Codex 게이트

- Plan Review v2: approve-implement (findings 0)
- Branch Review 1차: [P2] x2 (JSON envelope fmt.success로 감싸짐 + status positions `avg_price` 잘못된 키)
- Branch Review 2차: **PASS** (3 P2 fix amend 후 — bot start/stop/status CLI를 IPC 경로로 노출, JSON 오류 코드 보존 및 출력 계약 테스트로 커버, 동작 깨뜨림 버그 미발견)

## Test Plan

worktree(`/Users/jingulee/Projects/ante-worktrees/issue-1713`) 로컬:

- `pytest -q tests/unit/test_cli_bot_lifecycle.py` → **18 passed** in 0.26s
- `pytest -q tests/unit/` 전체 → **6821 passed, 2 skipped** in 209.31s
- `mypy src/` → Success (243 files)
- `ruff check && ruff format --check` → clean (571 files)
- `frontend npm run build` → OK
- `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check` → up to date

신규 회귀 매트릭스:
- `bot.start/stop` 성공 JSON: IPC `{bot: info}` envelope passthrough
- `bot.start/stop` 성공 text: `봇 {시작|중지} 완료: {bot_id}` 단순 메시지
- `bot.start/stop` error: missing/credential/state conflict 각각 안정 envelope + exit 1
- `bot.status` 성공 JSON: IPC result passthrough
- `bot.status` 성공 text: detail + strategy/budget/positions section (avg_entry_price 정확 표시)
- `bot.status` trade_service 부재: positions 키 부재 + 다른 필드 정상
- `bot.status` missing bot: BOT_NOT_FOUND envelope + exit 1
- IPC_ERROR fallback (서버 미기동/timeout)

## 운영 메모리 5축 적용

- correct-by-generation: guide/cli.md + project-structure.md 재생성으로만 갱신
- dual-fix: source (Click 트리 + DEFAULT_DESCRIPTIONS) + generated 두 표면 동시
- pre-existing drift 명시 소유: #1712에서 누락된 `src/ante/bot/info.py`, `tests/unit/test_bot_info.py`, `test_ipc_bot_lifecycle.py` tree node가 함께 표면화 (본 PR이 흡수)
- timestamp 비결정 소유: `guide/cli.md` 마지막 갱신: 2026-05-22
- repo-root-safe: PYTHONPATH=`$(git rev-parse --show-toplevel)/src` 사용

## #1698 epic 완료

본 PR이 머지되면 #1698 epic 완료:
- #1711 ✅ CLI·IPC 계약 스펙 확정 (merged `cf1e32b`)
- #1712 ✅ IPC handler 등록 (merged `8605926`)
- #1713 ✅ CLI leaf command 등록 (본 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
