### PR TITLE
fix: #1719 remove dashboard/Web API surface from Dockerfile and verify-install

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,10 +11,6 @@ dist/
 build/
 .coverage
 
-# Frontend (Stage 1에서 별도 빌드)
-frontend/node_modules/
-frontend/dist/
-
 # Runtime data
 data/
 db/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
-# Stage 1: 프론트엔드 빌드
-FROM node:20-alpine AS frontend-build
-WORKDIR /build
-COPY frontend/package.json frontend/package-lock.json ./
-RUN npm ci
-COPY frontend/ ./
-COPY pyproject.toml ../pyproject.toml
-RUN npm run build
-
-# Stage 2: Python 런타임
-FROM python:3.13-slim AS runtime
+# Python 런타임
+FROM python:3.13-slim
 WORKDIR /app
 
 # 시스템 의존성
@@ -27,18 +18,9 @@ ENV TZ=Asia/Seoul
 COPY pyproject.toml ./
 COPY src/ src/
 
-# 프론트엔드 빌드 산출물을 패키지 경로에 복사
-COPY --from=frontend-build /build/dist src/ante/web/static
-
 RUN pip install --no-cache-dir .
 
 # 런타임 디렉토리
 RUN mkdir -p config data db
-
-# 기본 설정 파일 복사 (Docker에서는 웹 대시보드 기본 활성화)
-COPY config/system.toml.example config/system.toml
-RUN sed -i 's/^enabled = false/enabled = true/' config/system.toml
-
-EXPOSE 3982
 
 ENTRYPOINT ["python", "-m", "ante.main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   ante:
     build: .
-    ports:
-      - "3982:3982"
     volumes:
       - ./config:/app/config
       - ante-data:/app/data

--- a/scripts/verify-install.py
+++ b/scripts/verify-install.py
@@ -298,7 +298,6 @@ def stage_install() -> bool:
         "ante.backtest",
         "ante.report",
         "ante.notification",
-        "ante.web",
     ]
 
     log_info("모듈 import 확인 중...")


### PR DESCRIPTION
Closes #1719

## Summary
- `Dockerfile`에서 frontend-build stage (Node.js npm ci/build) 전체, `COPY --from=frontend-build /build/dist src/ante/web/static`, `config/system.toml`로 `[web].enabled=true` 강제 sed, `EXPOSE 3982`를 제거하여 CLI/IPC-only 단일 stage Python runtime 이미지로 단순화.
- `.dockerignore`에서 더 이상 존재하지 않는 `frontend/node_modules/`, `frontend/dist/` 패턴과 stale 주석 제거.
- `docker-compose.yml`에서 외부 노출 대상이 사라진 `ports: "3982:3982"` 매핑 제거.
- `scripts/verify-install.py`에서 PR #1718이 삭제한 `ante.web` 모듈을 `modules_to_check` 리스트에서 제거. 현재 main에서는 verify-install이 항상 import 실패로 종료되는 상태 복구.
- 같은 root Dockerfile을 빌드하는 `.github/workflows/ci.yml` docker-build(release/* PR), `.github/workflows/publish.yml` `docker/build-push-action@v6` GHCR release image push, ante-oracle bootstrap 모두 같은 변경으로 정상 복원. publish.yml 파일 자체는 수정하지 않음.

## Test Plan
- [x] `docker build -t ante-test:1719 .` 성공 (단일 stage)
- [x] `docker run --rm --entrypoint python ante-test:1719 -c \"import ante.main\"` 성공
- [x] `docker run --rm --entrypoint python ante-test:1719 -m ante --help` 성공 (CLI smoke)
- [x] \`rg -n 'from ante\\\\.web|import ante\\\\.web|\"ante\\\\.web\"' src scripts pyproject.toml\` 0건
- [x] \`grep -n 'frontend\\|web/static\\|3982\\|frontend-build' Dockerfile .dockerignore docker-compose.yml\` 0건
- [x] `ruff check scripts/verify-install.py` 통과
- [x] Codex 브랜치 리뷰(`/codex:review --base main`) PASS — codex session 019e507c-e1d3-7853-a913-927ff53239c4