### PR TITLE
fix: #1721 ante init이 ANTE_DB_ENCRYPTION_KEY를 생성·persist + Config.load env export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ docs/superpowers/
 
 # Secrets
 config/secrets.env
+config/secrets.env.bak.*
 config/system.toml
 .env
 .env.*

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-05-22 (KST)
+> 마지막 생성 시점: 2026-05-23 (KST)
 
 ## 최상위 구조
 
@@ -546,7 +546,8 @@ tests/
 │   ├── test_cli_signal_connect.py
 │   ├── test_bot_info.py
 │   ├── test_cli_bot_lifecycle.py
-│   └── test_ipc_bot_lifecycle.py
+│   ├── test_ipc_bot_lifecycle.py
+│   └── test_cli_init_secret_leak.py
 └── __init__.py
 ```
 

--- a/docs/specs/account/06-database-schema.md
+++ b/docs/specs/account/06-database-schema.md
@@ -62,3 +62,5 @@ backfill 한다. NULL/unknown broker_type 도 보수적으로 default 0.005 를
 ### credentials 암호화
 
 credentials는 APP KEY, APP SECRET 등 민감 정보를 포함한다. DB에는 암호화된 JSON 문자열로 저장하며, 복호화는 런타임에만 수행한다. Fernet 대칭 암호화를 사용하고, 마스터 키는 `secrets.env`의 `ANTE_DB_ENCRYPTION_KEY`에서 로드한다.
+
+`ante init`이 `ANTE_DB_ENCRYPTION_KEY`를 `secrets.env`에 생성·기입(또는 valid 환경변수 값으로 동기화)한다. 환경변수가 valid Fernet 키이면 그 값을 그대로 사용하고 동일 값을 file에도 기입하며, 환경변수가 비어있거나 invalid이면 `secrets.env`의 valid 라인을 우선 사용한다. 둘 다 invalid/없음이면 init이 새 Fernet 키를 생성한다. invalid 라인 교체 시에는 `secrets.env.bak.<UTC iso>` 백업을 0600 권한으로 원자적으로 만든다.

--- a/src/ante/account/crypto.py
+++ b/src/ante/account/crypto.py
@@ -8,6 +8,32 @@ import os
 from cryptography.fernet import Fernet
 
 
+def _validate_fernet_key(value: str | None) -> bool:
+    """주어진 문자열이 Ante canonical Fernet 키인지 검증한다.
+
+    Ante는 ``cryptography.fernet.Fernet.generate_key()`` 의 출력 형식만
+    canonical key로 인정한다. 해당 출력은 URL-safe base64로 인코딩된
+    32바이트 키이므로 항상 길이 44이고 ``"="`` 한 글자로 끝나는 문자열이다.
+    그 외 형식(빈 값/공백/길이 불일치/패딩 불일치/Fernet 생성자 실패)은
+    invalid로 분류된다.
+
+    Args:
+        value: 검사 대상 문자열. ``None`` 또는 빈 문자열은 invalid.
+
+    Returns:
+        True iff `value`가 Fernet 생성자에 전달 가능한 canonical key이다.
+    """
+    if not value:
+        return False
+    if len(value) != 44 or not value.endswith("="):
+        return False
+    try:
+        Fernet(value.encode())
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
 def _get_fernet() -> Fernet:
     """환경변수에서 Fernet 키를 읽어 인스턴스를 반환한다.
 

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -6,11 +6,14 @@ import asyncio
 import json
 import os
 import sys
+import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
 import click
 
+from ante.account.crypto import _validate_fernet_key
 from ante.cli.commands._password import generate_password
 from ante.cli.formatter import OutputFormatter
 from ante.cli.main import get_formatter
@@ -53,14 +56,241 @@ host = "0.0.0.0"
 port = 3982
 """
 
+_ENCRYPTION_KEY_NAME = "ANTE_DB_ENCRYPTION_KEY"
+
 SECRETS_ENV_TEMPLATE = """\
 # Ante 비밀값 설정
 # 환경변수가 이 파일보다 우선합니다.
+
+# DB credentials Fernet 마스터 키. `ante init`이 자동 생성합니다.
+# 수동으로 교체하려면 cryptography.fernet.Fernet.generate_key() 출력만 사용하세요.
+{encryption_key_line}
 
 # 텔레그램 알림 (선택) - 사용 시 주석 해제하고 값 채우기
 # TELEGRAM_BOT_TOKEN=
 # TELEGRAM_CHAT_ID=
 """
+
+
+def _generate_db_encryption_key() -> str:
+    """신규 Fernet 마스터 키를 생성한다.
+
+    구현은 ``cryptography.fernet.Fernet.generate_key()``를 그대로 호출하고
+    base64 문자열로 디코딩해 반환한다. 결과는 항상 ``_validate_fernet_key``
+    검증을 통과한다.
+    """
+    from cryptography.fernet import Fernet
+
+    return Fernet.generate_key().decode()
+
+
+def _resolve_effective_key(
+    env_value: str | None, file_value: str | None
+) -> tuple[str, bool, bool]:
+    """env/file의 키 분류 결과로부터 effective key와 파일 상태 플래그를 도출한다.
+
+    결정 행렬 (이슈 #1721 Implementation Plan v4):
+
+    - valid env + valid file (동일 값): env 사용, file 보존, 백업 없음.
+    - valid env + valid file (다른 값): env-wins. file을 env value로 교체하지만
+      이전 라인이 valid였으므로 **백업하지 않는다**.
+    - valid env + invalid/없음 file: env value를 file에 기입. invalid이었으면
+      ``file_was_invalid_replaced=True`` 로 표시해 호출자가 백업하게 한다.
+    - invalid/없음 env + valid file: file value를 effective key로 채택.
+    - invalid/없음 env + invalid/없음 file: 신규 Fernet 키 생성. invalid이었으면
+      ``file_was_invalid_replaced=True``.
+
+    Args:
+        env_value: ``os.environ.get("ANTE_DB_ENCRYPTION_KEY")`` 결과.
+        file_value: ``secrets.env`` 의 동일 키 라인 값 (없으면 ``None``).
+
+    Returns:
+        ``(effective_key, file_was_invalid_replaced, file_was_synced_from_env)``.
+
+        - ``effective_key``: 실제로 사용할 Fernet 키 문자열.
+        - ``file_was_invalid_replaced``: file에 non-empty invalid 값이 있어서
+          교체해야 한다는 신호. 호출자는 이 경우에만 백업 파일을 만든다.
+        - ``file_was_synced_from_env``: file을 env value로 동기화해야 한다는 신호.
+          (env가 valid이고 file이 invalid/없음 또는 다른 valid 값인 경우)
+    """
+    env_valid = _validate_fernet_key(env_value)
+    file_valid = _validate_fernet_key(file_value)
+    file_present_invalid = (file_value is not None) and (not file_valid)
+
+    if env_valid:
+        assert env_value is not None  # narrow type for mypy
+        if file_valid and file_value == env_value:
+            # NOP — file already in sync with env.
+            return env_value, False, False
+        # env-wins: file을 env value로 동기화.
+        # 백업은 invalid 라인 교체 시에만(valid→valid 교체는 백업 없음).
+        return env_value, file_present_invalid, True
+
+    # env invalid/없음.
+    if file_valid:
+        assert file_value is not None  # narrow type for mypy
+        return file_value, False, False
+
+    # env invalid/없음 + file invalid/없음 → 신규 키 생성.
+    new_key = _generate_db_encryption_key()
+    return new_key, file_present_invalid, True
+
+
+def _read_existing_encryption_key_line(secrets_env_path: Path) -> str | None:
+    """secrets.env에서 ANTE_DB_ENCRYPTION_KEY 라인의 값만 추출.
+
+    동일 키가 여러 번 있으면 **마지막 라인**의 값을 반환한다(`_load_dotenv`와
+    동일한 last-wins 의미). 라인이 전혀 없으면 ``None``. 주석(#)으로 시작하는
+    라인은 무시한다.
+    """
+    if not secrets_env_path.exists():
+        return None
+    last: str | None = None
+    for raw_line in secrets_env_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        if key.strip() != _ENCRYPTION_KEY_NAME:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        last = value
+    return last
+
+
+def _atomic_backup_secrets_env(secrets_env_path: Path) -> Path:
+    """기존 secrets.env 파일을 0600 권한으로 원자적 백업한다.
+
+    백업 파일명: ``secrets.env.bak.<UTC iso>`` (같은 디렉토리). tempfile에
+    내용을 0600으로 쓴 뒤 ``os.rename``으로 원자 이동한다. 기존 secrets.env는
+    그대로 유지된다(이 헬퍼는 백업만 담당).
+    """
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = secrets_env_path.parent / f"secrets.env.bak.{ts}"
+    content = secrets_env_path.read_bytes()
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".secrets.env.bak.", dir=str(secrets_env_path.parent)
+    )
+    try:
+        os.write(fd, content)
+        os.fchmod(fd, 0o600)
+    finally:
+        os.close(fd)
+    os.rename(tmp_path, backup_path)
+    return backup_path
+
+
+def _write_encryption_key_into_secrets_env(
+    secrets_env_path: Path, effective_key: str
+) -> None:
+    """secrets.env에 ANTE_DB_ENCRYPTION_KEY 라인을 갱신/추가한다.
+
+    - 파일이 없으면: ``SECRETS_ENV_TEMPLATE``을 채워 신규 생성(0600).
+    - 파일이 있는데 라인이 없으면: 파일 끝에 ``ANTE_DB_ENCRYPTION_KEY=…``
+      한 줄을 append하고 권한을 0600으로 다시 적용한다.
+    - 라인이 있으면: 마지막 발견 라인을 새 값으로 교체(주석 라인은 보존).
+
+    파일 갱신은 tempfile에 내용을 쓰고 0600 chmod 후 ``os.rename``으로
+    원자 이동한다. 이렇게 해야 부분 쓰기 상태에서 다른 프로세스가 키를 빈
+    상태로 읽지 않는다.
+    """
+    new_line = f"{_ENCRYPTION_KEY_NAME}={effective_key}"
+
+    if not secrets_env_path.exists():
+        secrets_env_path.parent.mkdir(parents=True, exist_ok=True)
+        content = SECRETS_ENV_TEMPLATE.format(encryption_key_line=new_line)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".secrets.env.", dir=str(secrets_env_path.parent)
+        )
+        try:
+            os.write(fd, content.encode())
+            os.fchmod(fd, 0o600)
+        finally:
+            os.close(fd)
+        os.rename(tmp_path, secrets_env_path)
+        return
+
+    existing = secrets_env_path.read_text()
+    lines = existing.splitlines()
+    # 마지막 ANTE_DB_ENCRYPTION_KEY 라인 인덱스 탐색 (last-wins 일관).
+    last_idx: int | None = None
+    for i, raw_line in enumerate(lines):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            continue
+        key, _, _ = stripped.partition("=")
+        if key.strip() == _ENCRYPTION_KEY_NAME:
+            last_idx = i
+
+    if last_idx is None:
+        lines.append(new_line)
+    else:
+        lines[last_idx] = new_line
+
+    trailing_newline = "\n" if existing.endswith("\n") else ""
+    new_content = "\n".join(lines) + trailing_newline
+
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".secrets.env.", dir=str(secrets_env_path.parent)
+    )
+    try:
+        os.write(fd, new_content.encode())
+        os.fchmod(fd, 0o600)
+    finally:
+        os.close(fd)
+    os.rename(tmp_path, secrets_env_path)
+
+
+def _ensure_encryption_key_in_secrets_env(secrets_env_path: Path) -> str:
+    """ANTE_DB_ENCRYPTION_KEY 5-state idempotent path.
+
+    5개 상태 분기:
+      1. secrets.env 파일 자체가 없음 → 신규 키 생성 + 파일 신규 생성(템플릿).
+      2. 파일은 있는데 라인이 없음 → 신규 키 생성 + 라인 append.
+      3. 라인은 있는데 값이 빈 문자열 → 신규 키 생성 + 라인 교체(백업 없음, 빈
+         값은 backup 가치 없음).
+      4. 라인이 있고 값이 non-empty이지만 Fernet 검증 실패(invalid) → 신규 키
+         생성 또는 valid env value로 교체. **invalid 값 backup 필수**.
+      5. 라인이 있고 값이 Fernet valid → env-wins 비교. 동일 값이면 NOP,
+         다른 valid env가 있으면 env value로 교체(valid→valid는 backup 없음),
+         env가 invalid/없음이면 file value 유지.
+
+    Args:
+        secrets_env_path: ``<config_dir>/secrets.env`` 경로.
+
+    Returns:
+        이 함수가 effective key로 결정한 Fernet 키 문자열. 호출자는 이 값을
+        ``os.environ[_ENCRYPTION_KEY_NAME]`` 에 set한다(이미 valid env가
+        있으면 set 생략).
+    """
+    env_value = os.environ.get(_ENCRYPTION_KEY_NAME)
+    file_value = _read_existing_encryption_key_line(secrets_env_path)
+
+    effective_key, file_was_invalid_replaced, file_was_synced_from_env = (
+        _resolve_effective_key(env_value, file_value)
+    )
+
+    # 빈 문자열은 backup 대상이 아니다 — invalid 분류이지만 보호할 데이터가 없음.
+    needs_backup = file_was_invalid_replaced and bool(file_value)
+    needs_write = file_was_synced_from_env or (
+        not _validate_fernet_key(file_value)
+        and _validate_fernet_key(effective_key)
+        and file_value != effective_key
+    )
+
+    if needs_backup and secrets_env_path.exists():
+        _atomic_backup_secrets_env(secrets_env_path)
+
+    if needs_write:
+        _write_encryption_key_into_secrets_env(secrets_env_path, effective_key)
+
+    return effective_key
 
 
 def _run(coro):  # noqa: ANN001, ANN202
@@ -362,8 +592,15 @@ def init(
     db_absolute = (config_path / _DB_FILENAME).resolve()
     system_toml_content = SYSTEM_TOML_TEMPLATE.format(db_path=str(db_absolute))
     _ensure_file(artifacts["system.toml"], system_toml_content)
-    _ensure_file(artifacts["secrets.env"], SECRETS_ENV_TEMPLATE)
+    # secrets.env는 ANTE_DB_ENCRYPTION_KEY를 보장하기 위해 별도 helper로 처리한다.
+    # 이미 존재하는 파일은 내용을 보존하면서 키 라인만 갱신/추가하며, 신규
+    # 생성 시에는 SECRETS_ENV_TEMPLATE을 사용해 만든다.
+    effective_key = _ensure_encryption_key_in_secrets_env(artifacts["secrets.env"])
     artifacts["secrets.env"].chmod(0o600)
+    # in-process os.environ 설정: 현재 환경변수가 invalid/empty/unset일 때만
+    # override하고, non-empty valid env는 그대로 보존한다(env-wins).
+    if not _validate_fernet_key(os.environ.get(_ENCRYPTION_KEY_NAME)):
+        os.environ[_ENCRYPTION_KEY_NAME] = effective_key
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
     token = ""

--- a/src/ante/config/config.py
+++ b/src/ante/config/config.py
@@ -106,10 +106,38 @@ class Config:
         config_dir이 None이면 resolve_config_dir()로 자동 탐색.
         해석된 디렉토리는 인스턴스에 보존되어 path-like 설정의
         ``resolve_path()`` 정규화 기준으로 사용된다.
+
+        부수효과: ``secrets.env`` 의 ``ANTE_DB_ENCRYPTION_KEY`` 값이
+        Fernet canonical 형식을 만족하고, 현재 ``os.environ``에는 valid한
+        ``ANTE_DB_ENCRYPTION_KEY`` 가 없으면(빈 문자열/invalid 포함),
+        파일 값을 ``os.environ`` 으로 export한다. ``src/ante/account/crypto.py``
+        가 ``os.environ`` 만 읽는 현재 contract를 깨지 않으면서 init이 만든
+        키가 후속 CLI/서비스에 자동 전파되도록 한다.
+
+        Spec: ``docs/specs/account/06-database-schema.md`` (마스터 키는
+        ``secrets.env`` 의 ``ANTE_DB_ENCRYPTION_KEY`` 에서 로드).
         """
+        # 지연 import: crypto 모듈은 cryptography에 의존하므로 import 순환을
+        # 회피하기 위해 함수 내부에서 가져온다.
+        from ante.account.crypto import _validate_fernet_key
+
         resolved = resolve_config_dir(config_dir)
         static = _load_toml(resolved / "system.toml")
         secrets = _load_dotenv(resolved / "secrets.env")
+
+        # ANTE_DB_ENCRYPTION_KEY 단일 키 export 패스.
+        # - valid env가 이미 있으면 export 비대상(env-wins, override 안 함).
+        # - file_key가 Fernet canonical 검증을 통과할 때만 export 대상.
+        #   (invalid file이 valid env를 덮어쓰지 않도록 게이트.)
+        file_key = secrets.get("ANTE_DB_ENCRYPTION_KEY")
+        existing = os.environ.get("ANTE_DB_ENCRYPTION_KEY")
+        if (
+            file_key
+            and _validate_fernet_key(file_key)
+            and not _validate_fernet_key(existing or "")
+        ):
+            os.environ["ANTE_DB_ENCRYPTION_KEY"] = file_key
+
         return cls(static=static, secrets=secrets, config_dir=resolved)
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import os
 import sqlite3
 import stat
 from pathlib import Path
@@ -461,7 +462,12 @@ class TestInitIdempotency:
     """시나리오 3 & 4: 멱등성 — 부분 누락 시 보완 (state 2/3/4/5)."""
 
     def test_init_skips_db_when_only_config_files_exist(self, runner, tmp_path):
-        """보완 케이스: secrets.env만 존재 → 나머지 생성 (state 5 경로)."""
+        """보완 케이스: secrets.env만 존재 → 나머지 생성 (state 5 경로).
+
+        이슈 #1721 이후: 기존 secrets.env에 ANTE_DB_ENCRYPTION_KEY 라인이 없으면
+        init이 신규 키 라인을 append한다(기존 콘텐츠는 보존). 따라서 기존 콘텐츠가
+        prefix로 보존되는지를 검증한다(전체 동일성이 아닌 prefix 보존).
+        """
         target = tmp_path / "config"
         target.mkdir()
         (target / "secrets.env").write_text("existing")
@@ -477,11 +483,19 @@ class TestInitIdempotency:
 
         assert result.exit_code == 0, result.output
         assert (target / "system.toml").exists()
-        # secrets.env 기존 내용 보존
-        assert (target / "secrets.env").read_text() == "existing"
+        # 기존 콘텐츠 보존 + 키 라인 추가
+        new_text = (target / "secrets.env").read_text()
+        assert new_text.startswith("existing"), (
+            f"기존 콘텐츠 'existing' prefix가 사라짐: {new_text!r}"
+        )
+        assert "ANTE_DB_ENCRYPTION_KEY=" in new_text
 
     def test_init_preserves_existing_config_files(self, runner, tmp_path):
-        """system.toml + secrets.env 있고 DB 없음 → DB 재생성, 설정 파일 보존."""
+        """system.toml + secrets.env 있고 DB 없음 → DB 재생성, 설정 파일 보존.
+
+        이슈 #1721 이후: secrets.env는 기존 콘텐츠를 보존하면서 부족한
+        ANTE_DB_ENCRYPTION_KEY 라인만 append한다.
+        """
         target = tmp_path / "config"
         target.mkdir()
         (target / "system.toml").write_text("# custom config\n")
@@ -497,9 +511,12 @@ class TestInitIdempotency:
                 p.stop()
 
         assert result.exit_code == 0, result.output
-        # 기존 설정 파일 보존
+        # 기존 설정 파일 보존 (system.toml은 _ensure_file 가드라 그대로)
         assert (target / "system.toml").read_text() == "# custom config\n"
-        assert (target / "secrets.env").read_text() == "CUSTOM=1\n"
+        # secrets.env는 기존 CUSTOM=1 라인 보존 + 키 라인 append
+        new_text = (target / "secrets.env").read_text()
+        assert "CUSTOM=1" in new_text
+        assert "ANTE_DB_ENCRYPTION_KEY=" in new_text
         # DB 재발급에 따른 토큰·recovery key 출력
         assert _MOCK_TOKEN in result.output
         assert _MOCK_RECOVERY_KEY in result.output
@@ -1270,3 +1287,339 @@ class TestInitSystemTomlRuntimeSection:
 
         assert config.runtime_pid_path() == tmp_path / "run" / "ante.pid"
         assert config.runtime_socket_path() == tmp_path / "run" / "ante.sock"
+
+
+# ── Issue #1721: ANTE_DB_ENCRYPTION_KEY 자동 생성/동기화 회귀 ───────────────
+
+
+_KEY_LINE_REGEX = r"^ANTE_DB_ENCRYPTION_KEY=[A-Za-z0-9_-]{43}=$"
+
+
+def _read_key_line(secrets_env_path: Path) -> str | None:
+    """secrets.env에서 ANTE_DB_ENCRYPTION_KEY 라인의 값만 추출."""
+    if not secrets_env_path.exists():
+        return None
+    last: str | None = None
+    for raw in secrets_env_path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        if key.strip() != "ANTE_DB_ENCRYPTION_KEY":
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        last = value
+    return last
+
+
+class TestInitDbEncryptionKeyAutoCreate:
+    """이슈 #1721 — ``ante init``이 ANTE_DB_ENCRYPTION_KEY를 생성·persist한다."""
+
+    def test_r1_fresh_init_creates_fernet_line(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R1: 신규 init이 secrets.env에 Fernet 형식 키 라인을 생성한다.
+
+        라인 형식 정규식 ``^ANTE_DB_ENCRYPTION_KEY=[A-Za-z0-9_-]{43}=$`` 매치.
+        """
+        import re
+
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        target = tmp_path / "fresh"
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        secrets_env = target / "secrets.env"
+        text = secrets_env.read_text()
+        matches = [
+            line
+            for line in text.splitlines()
+            if re.match(_KEY_LINE_REGEX, line.strip())
+        ]
+        assert matches, f"Fernet 키 라인 없음:\n{text}"
+
+    def test_r2a_file_missing_no_env_generates_new(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R2a: secrets.env 파일 없음 + env 없음 → 신규 키 생성."""
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        target = tmp_path / "no-file"
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+        assert result.exit_code == 0, result.output
+        value = _read_key_line(target / "secrets.env")
+        assert value is not None and len(value) == 44 and value.endswith("=")
+
+    def test_r2b_file_exists_no_key_line_appends_line(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R2b: secrets.env는 있으나 키 라인이 없음 → 라인 append."""
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        target = tmp_path / "file-no-line"
+        target.mkdir()
+        (target / "secrets.env").write_text("# user comment\nFOO=bar\n")
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        text = (target / "secrets.env").read_text()
+        # 기존 내용 보존
+        assert "# user comment" in text
+        assert "FOO=bar" in text
+        # 키 라인 추가
+        value = _read_key_line(target / "secrets.env")
+        assert value is not None and len(value) == 44 and value.endswith("=")
+
+    def test_r2c_file_has_empty_value_replaces(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R2c: 키 라인이 빈 값 → 신규 키로 교체 (빈 값은 backup 대상 아님)."""
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        target = tmp_path / "empty-value"
+        target.mkdir()
+        (target / "secrets.env").write_text("ANTE_DB_ENCRYPTION_KEY=\n")
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        value = _read_key_line(target / "secrets.env")
+        assert value is not None and len(value) == 44 and value.endswith("=")
+        # 빈 값은 backup 대상이 아님
+        backups = list(target.glob("secrets.env.bak.*"))
+        assert not backups, f"빈 값에 대해 backup이 생성됨: {backups}"
+
+    def test_r2d_file_has_invalid_value_backs_up_and_replaces(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R2d: 키 라인 값이 non-empty invalid → backup 후 신규 키 교체."""
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        target = tmp_path / "invalid-value"
+        target.mkdir()
+        (target / "secrets.env").write_text(
+            "ANTE_DB_ENCRYPTION_KEY=garbage-not-fernet-key\n"
+        )
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        value = _read_key_line(target / "secrets.env")
+        assert value is not None and len(value) == 44 and value.endswith("=")
+        # backup 생성 확인
+        backups = list(target.glob("secrets.env.bak.*"))
+        assert len(backups) == 1, f"backup이 정확히 1개 생성돼야 함: {backups}"
+        # backup 내용에 invalid 값이 보존되어야 함
+        assert "garbage-not-fernet-key" in backups[0].read_text()
+        # backup 권한 0600
+        assert stat.S_IMODE(backups[0].stat().st_mode) == 0o600
+
+    def test_r2e_file_has_valid_value_no_env_is_idempotent(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R2e: 키 라인이 valid + env 없음 → file 보존, idempotent."""
+        from cryptography.fernet import Fernet
+
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        target = tmp_path / "valid-file"
+        target.mkdir()
+        good = Fernet.generate_key().decode()
+        (target / "secrets.env").write_text(f"ANTE_DB_ENCRYPTION_KEY={good}\n")
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        value = _read_key_line(target / "secrets.env")
+        assert value == good
+        # backup 없음
+        assert not list(target.glob("secrets.env.bak.*"))
+
+    def test_r3_valid_env_no_file_syncs_to_file(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R3: non-empty valid env + secrets.env 라인 없음 → env value로 동기화."""
+        from cryptography.fernet import Fernet
+
+        env_key = Fernet.generate_key().decode()
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", env_key)
+        target = tmp_path / "env-sync"
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        value = _read_key_line(target / "secrets.env")
+        assert value == env_key
+
+    def test_r4_valid_env_invalid_file_replaces_with_backup(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R4: valid env + invalid file → env value 기입 + invalid backup."""
+        from cryptography.fernet import Fernet
+
+        env_key = Fernet.generate_key().decode()
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", env_key)
+        target = tmp_path / "env-replace"
+        target.mkdir()
+        (target / "secrets.env").write_text("ANTE_DB_ENCRYPTION_KEY=bad-bad-bad\n")
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        value = _read_key_line(target / "secrets.env")
+        assert value == env_key
+        # invalid backup 1개 생성, 내용 보존
+        backups = list(target.glob("secrets.env.bak.*"))
+        assert len(backups) == 1
+        assert "bad-bad-bad" in backups[0].read_text()
+
+    def test_r5_empty_env_creates_new_key(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R5: 빈 env (``ANTE_DB_ENCRYPTION_KEY=``) → exit 0 + 신규 라인 생성."""
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", "")
+        target = tmp_path / "empty-env"
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        value = _read_key_line(target / "secrets.env")
+        assert value is not None and len(value) == 44 and value.endswith("=")
+
+    def test_r6_e2e_subprocess_no_leak_stdout_or_stderr(self, tmp_path: Path) -> None:
+        """R6: 실제 subprocess로 e2e 실행 + stdout/stderr 분리 capture 후 키 leak 검사.
+
+        Codex v3 new-must-fix 3 / v4 narrow-to 2: 병합 캡처 금지.
+        """
+        import subprocess
+        import sys
+
+        target = tmp_path / "e2e-config"
+        env = {
+            "PATH": os.environ["PATH"],
+            "HOME": os.environ.get("HOME", str(tmp_path)),
+            "ANTE_CONFIG_DIR": str(target),
+            # member_token 미설정으로 stale 토큰 검증 우회
+        }
+        # PYTHONPATH 전파: src 트리에서 import 가능하게
+        repo_root = Path(__file__).resolve().parents[2]
+        env["PYTHONPATH"] = str(repo_root / "src")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ante", "--format", "json", "init", "--name", "E2E"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        assert result.returncode == 0, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        # secrets.env 라인 존재
+        value = _read_key_line(target / "secrets.env")
+        assert value is not None and len(value) == 44 and value.endswith("=")
+        # stdout/stderr 모두에서 키 부재 (분리 capture, 병합 금지)
+        assert value not in result.stdout, "stdout에 키 leak"
+        assert value not in result.stderr, "stderr에 키 leak"
+
+    def test_r7_invalid_env_preserves_valid_file(
+        self, runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R7 (Codex v3 new-must-fix 4): non-empty invalid env + valid file.
+
+        - env가 invalid이면 무시한다.
+        - file의 valid value를 effective key로 채택한다.
+        - file은 그대로 보존(env value가 file을 wipe하지 않음).
+        - invalid env value는 절대 file에 기록되지 않는다.
+        - backup 없음(file은 valid 상태로 유지).
+        """
+        from cryptography.fernet import Fernet
+
+        good = Fernet.generate_key().decode()
+        invalid_env = "garbage-not-fernet"
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", invalid_env)
+
+        target = tmp_path / "invalid-env-valid-file"
+        target.mkdir()
+        (target / "secrets.env").write_text(f"ANTE_DB_ENCRYPTION_KEY={good}\n")
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        value = _read_key_line(target / "secrets.env")
+        assert value == good, "valid file이 invalid env에 의해 덮어쓰여짐"
+        # invalid env value는 file 어디에도 기록되지 않음
+        text = (target / "secrets.env").read_text()
+        assert invalid_env not in text
+        # backup 없음
+        assert not list(target.glob("secrets.env.bak.*"))

--- a/tests/unit/test_cli_init_secret_leak.py
+++ b/tests/unit/test_cli_init_secret_leak.py
@@ -1,0 +1,288 @@
+"""이슈 #1721 R13: ANTE_DB_ENCRYPTION_KEY 7-채널 leak 검사.
+
+7 채널 (init은 file logger 미셋업이므로 log file 채널 제외 — known-limitation):
+1. stdout text mode
+2. stdout JSON mode payload
+3. stderr text mode error
+4. stderr JSON mode recovery event
+5. caplog records (level=DEBUG, propagation 강제 on)
+6. Click ``result.exception`` chain message
+7. ``test_account_failed`` 실패 메시지 본문
+
+성공 경로 + 실패 경로(``_create_test_account`` 가 raise) 둘 다 검증한다.
+
+Plan Preflight v4 narrow-scope 채택 — Codex v3 new-must-fix 3 흡수.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+
+
+def _split_stderr_runner() -> CliRunner:
+    """Click 8.1/8.3 양쪽에서 stderr 분리 캡처를 요청한다."""
+    if "mix_stderr" in inspect.signature(CliRunner).parameters:
+        return CliRunner(mix_stderr=False)
+    return CliRunner()
+
+
+def _read_key_line(secrets_env_path: Path) -> str | None:
+    if not secrets_env_path.exists():
+        return None
+    last: str | None = None
+    for raw in secrets_env_path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        if key.strip() != "ANTE_DB_ENCRYPTION_KEY":
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        last = value
+    return last
+
+
+_MOCK_TEST_ACCOUNT = {
+    "account_id": "test",
+    "broker_type": "test",
+    "exchange": "TEST",
+}
+
+_MOCK_MASTER_INFO = {
+    "member_id": "owner",
+    "name": "Owner",
+    "role": "master",
+    "emoji": "🦊",
+}
+_MOCK_TOKEN = "ante_hk_test_token_leak"
+_MOCK_RECOVERY_KEY = "ANTE-RK-LEAK-TEST-XXXX-YYYY-ZZZZ"
+
+
+def _mock_bootstrap(*args, **kwargs):
+    return _MOCK_MASTER_INFO, _MOCK_TOKEN, _MOCK_RECOVERY_KEY
+
+
+def _patch_init_success():
+    return [
+        patch(
+            "ante.cli.commands.init._bootstrap_master",
+            new=AsyncMock(side_effect=_mock_bootstrap),
+        ),
+        patch(
+            "ante.cli.commands.init._create_test_account",
+            new=AsyncMock(return_value=_MOCK_TEST_ACCOUNT),
+        ),
+        patch(
+            "ante.cli.commands.init._master_exists_in_db",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "ante.cli.commands.init._test_account_state",
+            new=AsyncMock(return_value="missing"),
+        ),
+        patch("ante.cli.main.authenticate_member"),
+    ]
+
+
+def _patch_init_failure():
+    return [
+        patch(
+            "ante.cli.commands.init._bootstrap_master",
+            new=AsyncMock(side_effect=_mock_bootstrap),
+        ),
+        patch(
+            "ante.cli.commands.init._create_test_account",
+            new=AsyncMock(side_effect=RuntimeError("synthetic test_account failure")),
+        ),
+        patch(
+            "ante.cli.commands.init._master_exists_in_db",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "ante.cli.commands.init._test_account_state",
+            new=AsyncMock(return_value="missing"),
+        ),
+        patch("ante.cli.main.authenticate_member"),
+    ]
+
+
+def _assert_key_not_in(value: str, *, where: str, blob: str) -> None:
+    """주어진 ``blob`` 텍스트에 ``value`` 부분 문자열이 없어야 한다."""
+    assert value not in blob, (
+        f"ANTE_DB_ENCRYPTION_KEY 누설 ({where})\n"
+        f"key={value!r}\n"
+        f"blob_excerpt={blob[:500]!r}"
+    )
+
+
+class TestInitR13EncryptionKeyNoLeak:
+    """R13: 생성된 ANTE_DB_ENCRYPTION_KEY 가 7개 노출 채널에 나타나지 않는다."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_env_and_logs(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """ANTE_DB_ENCRYPTION_KEY 환경변수 격리 + caplog propagation 강제.
+
+        conftest.py 세션 fixture가 세션 시작 시 ANTE_DB_ENCRYPTION_KEY를 set하므로
+        init이 자체적으로 키를 생성하는 경로를 검증하려면 명시적으로 delenv가 필요.
+        monkeypatch는 테스트 종료 시 환경을 복원하므로 다른 테스트에 영향이 없다.
+        """
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        ante_logger = logging.getLogger("ante")
+        prev = ante_logger.propagate
+        ante_logger.propagate = True
+        caplog.set_level(logging.DEBUG)
+        yield monkeypatch
+        ante_logger.propagate = prev
+
+    def test_success_path_no_leak_across_channels(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """성공 경로 — text+json 모드 모두 stdout/stderr/log/exception에 키 부재."""
+        runner = _split_stderr_runner()
+
+        # === text 모드 ===
+        target_text = tmp_path / "text-mode"
+        caplog.clear()
+        patches = _patch_init_success()
+        for p in patches:
+            p.start()
+        try:
+            result_text = runner.invoke(cli, ["init", "--dir", str(target_text)])
+        finally:
+            for p in patches:
+                p.stop()
+        assert result_text.exit_code == 0, result_text.output
+
+        text_key = _read_key_line(target_text / "secrets.env")
+        assert text_key is not None
+        _assert_key_not_in(text_key, where="text stdout", blob=result_text.stdout or "")
+        stderr_text_blob = result_text.stderr if result_text.stderr_bytes else ""
+        _assert_key_not_in(text_key, where="text stderr", blob=stderr_text_blob)
+        log_blob_text = "\n".join(r.getMessage() for r in caplog.records)
+        _assert_key_not_in(text_key, where="text caplog", blob=log_blob_text)
+        exc_text = "" if result_text.exception is None else repr(result_text.exception)
+        _assert_key_not_in(text_key, where="text exception", blob=exc_text)
+
+        # === JSON 모드 ===
+        # caplog 잔여 기록 제거 + 새 디렉토리에서 두 번째 실행.
+        caplog.clear()
+        target_json = tmp_path / "json-mode"
+        # ANTE_DB_ENCRYPTION_KEY는 앞 실행에서 init이 set했을 수 있으므로 다시 제거.
+        # monkeypatch를 통해 제거하면 테스트 종료 시 자동 복원된다.
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        patches = _patch_init_success()
+        for p in patches:
+            p.start()
+        try:
+            result_json = runner.invoke(
+                cli, ["--format", "json", "init", "--dir", str(target_json)]
+            )
+        finally:
+            for p in patches:
+                p.stop()
+        assert result_json.exit_code == 0, (
+            f"stdout={result_json.stdout}\nstderr={result_json.stderr}"
+        )
+
+        json_key = _read_key_line(target_json / "secrets.env")
+        assert json_key is not None
+        _assert_key_not_in(
+            json_key, where="json stdout payload", blob=result_json.stdout or ""
+        )
+        stderr_json_blob = result_json.stderr if result_json.stderr_bytes else ""
+        _assert_key_not_in(json_key, where="json stderr event", blob=stderr_json_blob)
+        log_blob_json = "\n".join(r.getMessage() for r in caplog.records)
+        _assert_key_not_in(json_key, where="json caplog", blob=log_blob_json)
+        exc_json = "" if result_json.exception is None else repr(result_json.exception)
+        _assert_key_not_in(json_key, where="json exception", blob=exc_json)
+
+    def test_failure_path_no_leak_in_test_account_failed_message(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """실패 경로 — ``test_account_failed`` 에러 메시지 본문에 키 부재.
+
+        7번째 채널 (실패 메시지 본문) 검증. ``_create_test_account``가 raise한
+        ``RuntimeError`` 메시지가 ``OutputFormatter.error``로 직렬화될 때 키가
+        절대 포함되면 안 된다.
+        """
+        runner = _split_stderr_runner()
+
+        # === text 모드 실패 ===
+        target_text = tmp_path / "fail-text"
+        caplog.clear()
+        patches = _patch_init_failure()
+        for p in patches:
+            p.start()
+        try:
+            result_text = runner.invoke(cli, ["init", "--dir", str(target_text)])
+        finally:
+            for p in patches:
+                p.stop()
+        assert result_text.exit_code == 1, result_text.output
+
+        text_key = _read_key_line(target_text / "secrets.env")
+        assert text_key is not None
+        # text 모드 stdout / stderr / log / exception 모두 검사
+        _assert_key_not_in(
+            text_key, where="fail text stdout", blob=result_text.stdout or ""
+        )
+        stderr_blob = result_text.stderr if result_text.stderr_bytes else ""
+        _assert_key_not_in(text_key, where="fail text stderr", blob=stderr_blob)
+        # test_account_failed 메시지 본문 검증 (stdout 또는 stderr 어느 한 쪽에 있음)
+        combined = (result_text.stdout or "") + stderr_blob
+        assert "테스트 계좌 생성 실패" in combined
+        _assert_key_not_in(
+            text_key,
+            where="fail text test_account_failed message",
+            blob=combined,
+        )
+        log_blob = "\n".join(r.getMessage() for r in caplog.records)
+        _assert_key_not_in(text_key, where="fail text caplog", blob=log_blob)
+        exc_text = "" if result_text.exception is None else repr(result_text.exception)
+        _assert_key_not_in(text_key, where="fail text exception", blob=exc_text)
+
+        # === JSON 모드 실패 ===
+        caplog.clear()
+        target_json = tmp_path / "fail-json"
+        # monkeypatch를 통해 제거하면 테스트 종료 시 자동 복원된다.
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        patches = _patch_init_failure()
+        for p in patches:
+            p.start()
+        try:
+            result_json = runner.invoke(
+                cli, ["--format", "json", "init", "--dir", str(target_json)]
+            )
+        finally:
+            for p in patches:
+                p.stop()
+        assert result_json.exit_code == 1
+        json_key = _read_key_line(target_json / "secrets.env")
+        assert json_key is not None
+        _assert_key_not_in(
+            json_key, where="fail json stdout", blob=result_json.stdout or ""
+        )
+        stderr_json = result_json.stderr if result_json.stderr_bytes else ""
+        _assert_key_not_in(json_key, where="fail json stderr", blob=stderr_json)
+        log_blob_j = "\n".join(r.getMessage() for r in caplog.records)
+        _assert_key_not_in(json_key, where="fail json caplog", blob=log_blob_j)
+        exc_json = "" if result_json.exception is None else repr(result_json.exception)
+        _assert_key_not_in(json_key, where="fail json exception", blob=exc_json)

--- a/tests/unit/test_config_path.py
+++ b/tests/unit/test_config_path.py
@@ -1,5 +1,6 @@
 """Config 경로 탐색 및 ante init 테스트."""
 
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -191,3 +192,112 @@ class TestInitCommand:
                 p.stop()
         assert result.exit_code == 0, result.output
         assert (tmp_path / ".config" / "ante" / "system.toml").exists()
+
+
+# ── Issue #1721: Config.load의 ANTE_DB_ENCRYPTION_KEY export 패스 ───────────
+
+
+class TestConfigLoadExportsEncryptionKey:
+    """``Config.load`` 부수효과 — ``secrets.env`` 의 ``ANTE_DB_ENCRYPTION_KEY``
+    를 ``os.environ`` 에 export하는 단일 키 패스 회귀.
+
+    이슈 #1721 행렬 (Config.load 행):
+
+    - valid env + (무관)              → export 비대상.
+    - invalid/없음 env + valid file   → file value를 ``os.environ`` 에 set.
+    - invalid/없음 env + invalid/없음 file → export 비대상.
+    """
+
+    def test_r8_only_encryption_key_is_exported(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R8: ANTE_DB_ENCRYPTION_KEY만 export하고 다른 secret은 건드리지 않는다."""
+        from cryptography.fernet import Fernet
+
+        from ante.config import Config
+
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        monkeypatch.delenv("FOO_OTHER_SECRET", raising=False)
+        good = Fernet.generate_key().decode()
+        (tmp_path / "secrets.env").write_text(
+            f"ANTE_DB_ENCRYPTION_KEY={good}\nFOO_OTHER_SECRET=baz\n"
+        )
+
+        Config.load(config_dir=tmp_path)
+
+        assert os.environ.get("ANTE_DB_ENCRYPTION_KEY") == good
+        assert os.environ.get("FOO_OTHER_SECRET") is None
+
+    def test_r9_existing_valid_env_is_preserved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R9: 사전 set된 valid env는 보존되며 file value로 override되지 않는다."""
+        from cryptography.fernet import Fernet
+
+        from ante.config import Config
+
+        env_key = Fernet.generate_key().decode()
+        file_key = Fernet.generate_key().decode()
+        assert env_key != file_key
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", env_key)
+        (tmp_path / "secrets.env").write_text(f"ANTE_DB_ENCRYPTION_KEY={file_key}\n")
+
+        Config.load(config_dir=tmp_path)
+
+        assert os.environ["ANTE_DB_ENCRYPTION_KEY"] == env_key
+
+    def test_r10_empty_env_overridden_by_valid_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R10: 빈 env (또는 invalid env)는 file의 valid value로 override."""
+        from cryptography.fernet import Fernet
+
+        from ante.config import Config
+
+        file_key = Fernet.generate_key().decode()
+        (tmp_path / "secrets.env").write_text(f"ANTE_DB_ENCRYPTION_KEY={file_key}\n")
+
+        # 빈 env
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", "")
+        Config.load(config_dir=tmp_path)
+        assert os.environ["ANTE_DB_ENCRYPTION_KEY"] == file_key
+
+        # invalid env (non-empty이지만 Fernet 아님)
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", "garbage-not-fernet")
+        Config.load(config_dir=tmp_path)
+        assert os.environ["ANTE_DB_ENCRYPTION_KEY"] == file_key
+
+    def test_r11_invalid_or_empty_file_not_exported(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R11: file value가 빈 또는 invalid Fernet이면 export 비대상."""
+        from ante.config import Config
+
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+
+        # 빈 file 값
+        (tmp_path / "secrets.env").write_text("ANTE_DB_ENCRYPTION_KEY=\n")
+        Config.load(config_dir=tmp_path)
+        assert "ANTE_DB_ENCRYPTION_KEY" not in os.environ
+
+        # invalid file 값 — 다른 디렉토리에서 별도 테스트
+        target2 = tmp_path / "second"
+        target2.mkdir()
+        (target2 / "secrets.env").write_text(
+            "ANTE_DB_ENCRYPTION_KEY=garbage-not-fernet\n"
+        )
+        Config.load(config_dir=target2)
+        assert "ANTE_DB_ENCRYPTION_KEY" not in os.environ
+
+    def test_r12_missing_secrets_env_is_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R12: secrets.env 파일 자체가 없으면 export 비대상 (no-op)."""
+        from ante.config import Config
+
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        # secrets.env 없음
+        assert not (tmp_path / "secrets.env").exists()
+
+        Config.load(config_dir=tmp_path)
+        assert "ANTE_DB_ENCRYPTION_KEY" not in os.environ


### PR DESCRIPTION
Closes #1721

## Summary

`ante init`이 빈 config 디렉터리에서 `ANTE_DB_ENCRYPTION_KEY` 누락으로 `code=test_account_failed`로 실패하던 문제를 fix.

- **init**: Fernet 키 생성 + `secrets.env`에 기입 (5-state idempotent: 파일없음/라인없음/빈값/invalid/valid).
- **invalid 라인 교체**: tempfile 0600 → `os.rename` 원자적 `secrets.env.bak.<UTC iso>` 백업.
- **Config.load**: valid `file_key`만 `os.environ`에 export (env-wins, empty/invalid env는 unset 동치).
- **valid env + invalid/missing file**: file을 env value로 동기화.
- **invalid env**: file을 wipe하지 않음 (R7 회귀).
- **crypto.py**: `_validate_fernet_key` helper 추가 (canonical `Fernet.generate_key()` 형식).
- **secret leak 차단**: 회귀 R13이 7채널 (stdout text/JSON, stderr text/JSON, caplog, exception chain, failure message) × 성공/실패 경로 검사.

## Plan Preflight

이슈 본문 Implementation Plan v4 (narrow-scope) 기준. Codex Plan Review 4 라운드 (v1 revise-plan → v2 revise-plan → v3 revise-plan + bounded-soundness narrow-to → v4 narrow-scope), 16+ must-fix 항목 closed.

## Test Plan

- [x] \`pytest tests/unit/test_cli_init.py tests/unit/test_account_crypto.py tests/unit/test_config_path.py tests/unit/test_cli_init_secret_leak.py\` → 76 cases PASS
- [x] \`pytest\` 전체 unit suite → 4871 cases PASS (135.52s)
- [x] \`mypy src/\` → 216 source files PASS
- [x] \`ruff check . && ruff format --check .\` → PASS
- [x] \`python scripts/generate_project_structure.py --check\` → up to date
- [x] Manual #1 unset env fresh init → exit 0, regex match, perm 600
- [x] Manual #2 empty env (\`ANTE_DB_ENCRYPTION_KEY=\`) → regex match
- [x] Manual #3 valid env + 새 config → env value file 동기화
- [x] Manual #4 invalid env + valid file → file 보존, invalid env 미기록
- [x] Manual #5 secret leak grep (stdout/stderr 분리) → clean
- [x] Codex 브랜치 리뷰 (\`/codex:review --base main\`) PASS (0 blocking, 0 advisory)

## Non-Goals

- #1722 (account list DB key hang) — 별도 이슈
- crypto.py 리팩토링 / rotation / escrow / backup retention / 일반 subprocess env 정책 — follow-up