### PR TITLE
fix: #1722 account CLI crypto error → exit 1 + stable code, no aiosqlite hang

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -547,7 +547,8 @@ tests/
 │   ├── test_bot_info.py
 │   ├── test_cli_bot_lifecycle.py
 │   ├── test_ipc_bot_lifecycle.py
-│   └── test_cli_init_secret_leak.py
+│   ├── test_cli_init_secret_leak.py
+│   └── test_cli_account_crypto_error.py
 └── __init__.py
 ```
 

--- a/src/ante/account/crypto.py
+++ b/src/ante/account/crypto.py
@@ -1,11 +1,50 @@
-"""credentials Fernet 암호화."""
+"""credentials Fernet 암호화.
+
+키 오류는 두 가지 root cause로 구분된다(`docs/specs/account/06-database-schema.md`
+ANTE_DB_ENCRYPTION_KEY SSOT + `docs/specs/cli/02-design-decisions.md` CLI 에러
+코드 명명 규칙):
+
+- ``EncryptionKeyMissingError`` (``DB_ENCRYPTION_KEY_MISSING``): env가 미설정
+  또는 빈 문자열이고, ``Config.load``가 ``secrets.env`` fallback에서도 export하지
+  못한 경우.
+- ``EncryptionKeyInvalidError`` (``DB_ENCRYPTION_KEY_INVALID``): env에 값은 있으나
+  Fernet 형식(URL-safe base64, 44바이트, ``=``로 끝남)을 위반하거나, 형식은 맞으나
+  실제 decrypt 시 ``cryptography.fernet.InvalidToken``으로 키 불일치가 드러난 경우.
+
+기반 클래스 ``EncryptionKeyError``를 ``RuntimeError`` 서브로 두어 기존
+``except RuntimeError`` 사용처와 behavior preserving을 유지한다.
+"""
 
 from __future__ import annotations
 
 import json
 import os
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
+
+
+class EncryptionKeyError(RuntimeError):
+    """크립토 키 오류 기반 클래스.
+
+    ``RuntimeError`` 서브로 두어 기존 ``except RuntimeError`` 사용처와의
+    behavior preserving을 유지한다. 호출자는 typed 서브클래스
+    (``EncryptionKeyMissingError`` / ``EncryptionKeyInvalidError``)로 분기하거나
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드를 읽을 수 있다.
+    """
+
+    code: str = "DB_ENCRYPTION_KEY_ERROR"
+
+
+class EncryptionKeyMissingError(EncryptionKeyError):
+    """ANTE_DB_ENCRYPTION_KEY env가 미설정/빈 + secrets.env fallback 실패."""
+
+    code: str = "DB_ENCRYPTION_KEY_MISSING"
+
+
+class EncryptionKeyInvalidError(EncryptionKeyError):
+    """키가 설정되어 있으나 Fernet 형식 위반 또는 decrypt 실패(InvalidToken)."""
+
+    code: str = "DB_ENCRYPTION_KEY_INVALID"
 
 
 def _validate_fernet_key(value: str | None) -> bool:
@@ -38,11 +77,23 @@ def _get_fernet() -> Fernet:
     """환경변수에서 Fernet 키를 읽어 인스턴스를 반환한다.
 
     Raises:
-        RuntimeError: ANTE_DB_ENCRYPTION_KEY 환경변수가 설정되지 않은 경우.
+        EncryptionKeyMissingError: ANTE_DB_ENCRYPTION_KEY 환경변수가 미설정
+            이거나 빈 문자열인 경우 (``secrets.env`` fallback에서도 키가 export
+            되지 않은 상태). 메시지는 ``Config.load``의 fallback이 실패했음을
+            함께 안내한다.
+        EncryptionKeyInvalidError: 환경변수는 설정되어 있으나
+            ``_validate_fernet_key`` 검증을 통과하지 못한 경우(형식 위반).
     """
     key = os.environ.get("ANTE_DB_ENCRYPTION_KEY")
     if not key:
-        raise RuntimeError("ANTE_DB_ENCRYPTION_KEY 환경변수가 설정되지 않았습니다.")
+        raise EncryptionKeyMissingError(
+            "ANTE_DB_ENCRYPTION_KEY 환경변수가 설정되지 않았습니다."
+        )
+    if not _validate_fernet_key(key):
+        raise EncryptionKeyInvalidError(
+            "ANTE_DB_ENCRYPTION_KEY 형식이 유효하지 않습니다 "
+            "(Fernet.generate_key() 출력 형식이어야 합니다)."
+        )
     return Fernet(key.encode())
 
 
@@ -52,5 +103,19 @@ def encrypt_credentials(credentials: dict) -> str:
 
 
 def decrypt_credentials(encrypted: str) -> dict:
-    """Fernet 암호화된 문자열을 credentials dict로 복호화한다."""
-    return json.loads(_get_fernet().decrypt(encrypted.encode()).decode())
+    """Fernet 암호화된 문자열을 credentials dict로 복호화한다.
+
+    Raises:
+        EncryptionKeyMissingError: ``_get_fernet()``이 키 미설정/빈으로 raise.
+        EncryptionKeyInvalidError: ``_get_fernet()``이 형식 위반으로 raise하거나,
+            형식은 맞으나 실제 ``Fernet.decrypt()``가 ``InvalidToken``을 raise한
+            경우(다른 키로 암호화된 legacy row). 원본 예외는 ``__cause__``로
+            보존된다.
+    """
+    fernet = _get_fernet()
+    try:
+        return json.loads(fernet.decrypt(encrypted.encode()).decode())
+    except InvalidToken as e:
+        raise EncryptionKeyInvalidError(
+            "credentials decrypt 실패: 키가 일치하지 않습니다."
+        ) from e

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -86,17 +86,37 @@ def _assert_no_active_runtime(fmt: OutputFormatter) -> None:
 
 
 async def _create_account_service() -> tuple[AccountService, Database]:
-    """CLI에서 AccountService를 생성하는 헬퍼."""
+    """CLI에서 AccountService를 생성하는 헬퍼.
+
+    ``db.connect()`` 이후의 모든 라이프사이클(``AccountService.initialize`` 포함)을
+    ``except BaseException`` 블록으로 감싸 실패 시 ``db.close()``를 보장한다.
+    ``initialize`` 안에서 legacy row decrypt 실패 등으로 예외가 raise되면
+    aiosqlite 연결이 leak되어 asyncio 종료 시 busy_timeout 대기로 CLI 프로세스가
+    8초 가까이 hang하는 회귀를 차단한다(#1722). close 자체 실패는 inner
+    try/except로 흡수해 원본 예외를 가리지 않는다.
+    """
     from ante.account.service import AccountService
     from ante.cli.main import get_db_path
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
 
     db = Database(get_db_path())
-    await db.connect()
-    eventbus = EventBus()
-    account_service = AccountService(db=db, eventbus=eventbus)
-    await account_service.initialize()
+    try:
+        await db.connect()
+        eventbus = EventBus()
+        account_service = AccountService(db=db, eventbus=eventbus)
+        await account_service.initialize()
+    except BaseException:
+        try:
+            await db.close()
+        except Exception:
+            # close 실패는 상위 예외를 가리지 않고 무시한다 — 원본 예외(예:
+            # EncryptionKeyMissingError)가 호출자에게 안정 ``code``를 전달해야
+            # CLI가 stable JSON error로 종료할 수 있다.
+            logger.debug(
+                "db.close() after init failure raised — ignored", exc_info=True
+            )
+        raise
     return account_service, db
 
 
@@ -568,7 +588,7 @@ def account_create(
     try:
         created = _run(_do_create())
     except Exception as e:
-        fmt.error(str(e))
+        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
         raise SystemExit(1) from e
 
     fmt.success(
@@ -626,7 +646,7 @@ def account_list(ctx: click.Context, status_filter: str | None) -> None:
     try:
         rows = _run(_do_list())
     except Exception as e:
-        fmt.error(str(e))
+        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
         raise SystemExit(1) from e
 
     if not rows:
@@ -676,7 +696,7 @@ def account_info(ctx: click.Context, account_id: str) -> None:
     try:
         detail = _run(_do_info())
     except Exception as e:
-        fmt.error(str(e))
+        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
         raise SystemExit(1) from e
 
     if fmt.is_json:
@@ -835,7 +855,7 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e))
+        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
         raise SystemExit(1) from e
 
     fmt.success(f'계좌 "{account_id}" 삭제 완료')
@@ -872,7 +892,7 @@ def account_credentials(ctx: click.Context, account_id: str) -> None:
     try:
         masked = _run(_do_credentials())
     except Exception as e:
-        fmt.error(str(e))
+        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
         raise SystemExit(1) from e
 
     if not masked:
@@ -995,7 +1015,7 @@ def account_set_credentials(
     except SystemExit:
         raise
     except Exception as e:
-        fmt.error(str(e))
+        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
         raise SystemExit(1) from e
 
 
@@ -1075,7 +1095,7 @@ def account_repair_timezone(
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e))
+        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
         raise SystemExit(1) from e
 
     fmt.success(

--- a/tests/unit/test_account_crypto.py
+++ b/tests/unit/test_account_crypto.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import pytest
 from cryptography.fernet import Fernet, InvalidToken
 
-from ante.account.crypto import decrypt_credentials, encrypt_credentials
+from ante.account.crypto import (
+    EncryptionKeyError,
+    EncryptionKeyInvalidError,
+    EncryptionKeyMissingError,
+    decrypt_credentials,
+    encrypt_credentials,
+)
 
 
 class TestEncryptDecryptRoundtrip:
@@ -59,42 +65,84 @@ class TestEncryptOutput:
 
 
 class TestMissingKey:
-    """환경변수 미설정 시 에러 검증."""
+    """환경변수 미설정 시 에러 검증.
 
-    def test_encrypt_missing_key_raises(self, monkeypatch):
-        """ANTE_DB_ENCRYPTION_KEY 미설정 시 RuntimeError."""
+    ``EncryptionKeyMissingError`` 가 raise되고, behavior preserving을 위해
+    ``RuntimeError`` 서브클래스이며 안정 ``code`` 속성을 갖는다.
+    """
+
+    def test_encrypt_missing_key_raises_typed(self, monkeypatch):
+        """ANTE_DB_ENCRYPTION_KEY 미설정 시 EncryptionKeyMissingError."""
         monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
-        with pytest.raises(RuntimeError, match="ANTE_DB_ENCRYPTION_KEY"):
+        with pytest.raises(EncryptionKeyMissingError) as excinfo:
             encrypt_credentials({"key": "value"})
+        assert isinstance(excinfo.value, RuntimeError)  # behavior preserving
+        assert isinstance(excinfo.value, EncryptionKeyError)
+        assert excinfo.value.code == "DB_ENCRYPTION_KEY_MISSING"
+        assert "ANTE_DB_ENCRYPTION_KEY" in str(excinfo.value)
 
-    def test_decrypt_missing_key_raises(self, monkeypatch):
-        """ANTE_DB_ENCRYPTION_KEY 미설정 시 RuntimeError."""
+    def test_decrypt_missing_key_raises_typed(self, monkeypatch):
+        """ANTE_DB_ENCRYPTION_KEY 미설정 시 EncryptionKeyMissingError."""
         monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
-        with pytest.raises(RuntimeError, match="ANTE_DB_ENCRYPTION_KEY"):
+        with pytest.raises(EncryptionKeyMissingError) as excinfo:
+            decrypt_credentials("some-encrypted-string")
+        assert isinstance(excinfo.value, RuntimeError)
+        assert excinfo.value.code == "DB_ENCRYPTION_KEY_MISSING"
+
+    def test_empty_key_raises_typed(self, monkeypatch):
+        """빈 문자열 키도 EncryptionKeyMissingError."""
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", "")
+        with pytest.raises(EncryptionKeyMissingError) as excinfo:
+            encrypt_credentials({"key": "value"})
+        assert isinstance(excinfo.value, RuntimeError)
+        assert excinfo.value.code == "DB_ENCRYPTION_KEY_MISSING"
+
+
+class TestInvalidKeyFormat:
+    """Fernet 형식 위반 키는 EncryptionKeyInvalidError."""
+
+    def test_garbage_value_raises_invalid(self, monkeypatch):
+        """알 수 없는 garbage 문자열은 형식 위반으로 INVALID."""
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", "not-valid-base64")
+        with pytest.raises(EncryptionKeyInvalidError) as excinfo:
+            encrypt_credentials({"key": "value"})
+        assert isinstance(excinfo.value, RuntimeError)
+        assert isinstance(excinfo.value, EncryptionKeyError)
+        assert excinfo.value.code == "DB_ENCRYPTION_KEY_INVALID"
+        assert "ANTE_DB_ENCRYPTION_KEY" in str(excinfo.value)
+
+    def test_wrong_length_raises_invalid(self, monkeypatch):
+        """길이가 44가 아닌 값은 INVALID (44는 Fernet canonical key 길이)."""
+        # 길이 43 (44 - 1)이지만 ``=``로 끝나는 값.
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", "A" * 42 + "==")
+        with pytest.raises(EncryptionKeyInvalidError) as excinfo:
+            encrypt_credentials({"key": "value"})
+        assert excinfo.value.code == "DB_ENCRYPTION_KEY_INVALID"
+
+    def test_decrypt_invalid_format_raises_invalid(self, monkeypatch):
+        """decrypt 경로에서도 형식 위반은 INVALID."""
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", "not-valid-base64")
+        with pytest.raises(EncryptionKeyInvalidError):
             decrypt_credentials("some-encrypted-string")
 
 
-class TestWrongKey:
-    """다른 키로 복호화 시 에러 검증."""
+class TestWrongKeyDecrypt:
+    """valid 형식이지만 다른 키로 복호화 시 EncryptionKeyInvalidError."""
 
-    def test_wrong_key_raises(self, monkeypatch):
-        """암호화 시 사용한 키와 다른 키로 복호화하면 InvalidToken."""
+    def test_wrong_key_raises_invalid_chained(self, monkeypatch):
+        """암호화 시 사용한 키와 다른 valid Fernet 키로 복호화하면
+        EncryptionKeyInvalidError가 InvalidToken을 체이닝해 raise된다."""
         original = {"app_key": "my-key"}
         encrypted = encrypt_credentials(original)
 
-        # 다른 키로 변경
+        # 다른 valid key로 변경.
         new_key = Fernet.generate_key().decode()
         monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", new_key)
 
-        with pytest.raises(InvalidToken):
+        with pytest.raises(EncryptionKeyInvalidError) as excinfo:
             decrypt_credentials(encrypted)
-
-
-class TestEmptyKey:
-    """빈 키 처리."""
-
-    def test_empty_key_raises(self, monkeypatch):
-        """빈 문자열 키는 RuntimeError."""
-        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", "")
-        with pytest.raises(RuntimeError, match="ANTE_DB_ENCRYPTION_KEY"):
-            encrypt_credentials({"key": "value"})
+        assert isinstance(excinfo.value, RuntimeError)
+        assert isinstance(excinfo.value, EncryptionKeyError)
+        assert excinfo.value.code == "DB_ENCRYPTION_KEY_INVALID"
+        # 원본 InvalidToken은 __cause__로 보존된다.
+        assert isinstance(excinfo.value.__cause__, InvalidToken)

--- a/tests/unit/test_cli_account_crypto_error.py
+++ b/tests/unit/test_cli_account_crypto_error.py
@@ -1,0 +1,350 @@
+"""account CLI crypto 에러 contract 회귀 (#1722).
+
+다음 6개 회귀를 잠근다:
+
+- R1 hang 회귀: ``ante account list`` (env clean + secrets.env 키 라인 삭제) →
+  ``subprocess.run(timeout=5)`` 내 종료 + ``exit 1`` + JSON
+  ``code="DB_ENCRYPTION_KEY_MISSING"``.
+- R2 stable code 회귀: JSON ``code`` 필드 검증.
+- R3 cleanup 회귀: in-process unit test로 ``AccountService.initialize`` 가
+  raise할 때 ``Database.close`` 가 1회 await된다. 내부 필드 (``_writer`` /
+  ``_reader``) 직접 접근 금지 — public lifecycle ``Database.close`` 호출 사실로
+  검증 (Codex Plan v2 narrow-to 1).
+- R4 7-command 일관성: ``account create/list/info/delete/credentials/
+  set-credentials/repair-timezone`` 모두 동일 시나리오에서 같은 ``code`` +
+  ``exit 1`` + ``timeout=5`` 내 종료.
+- R5 invalid key 코드: env에 garbage value → ``code="DB_ENCRYPTION_KEY_INVALID"``.
+- R6 wrong key decrypt 코드: legacy DB row가 키 A로 암호화 + 현재 env에 키 B →
+  ``code="DB_ENCRYPTION_KEY_INVALID"``.
+
+conftest fixture 격리: 모든 subprocess 호출에 명시 ``env={"PATH": ...,
+"HOME": ..., "ANTE_CONFIG_DIR": ...}``만 전달한다. ``ANTE_DB_ENCRYPTION_KEY`` 는
+의도적으로 제외 (R5/R6 한정으로 garbage/wrong value 명시 포함).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+# subprocess timeout: hang 회귀를 5초 마진으로 차단한다. 정상 종료는 1-2초.
+_SUBPROCESS_TIMEOUT_S = 5.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _clean_env(
+    config_dir: Path, *, encryption_key: str | None = None, token: str | None = None
+) -> dict[str, str]:
+    """subprocess 환경 격리 헬퍼 (Codex Plan v2 must-fix 4).
+
+    Conftest fixture 격리 원칙: 부모 프로세스의 ``ANTE_DB_ENCRYPTION_KEY`` /
+    ``ANTE_MEMBER_TOKEN`` 등이 새는 것을 막기 위해 ``PATH`` / ``HOME`` /
+    ``ANTE_CONFIG_DIR`` 만 명시적으로 전달한다. ``PYTHONPATH`` 는 src 트리에서
+    ``-m ante`` 가 import 되도록 추가한다. ``ANTE_DB_ENCRYPTION_KEY`` 는
+    의도적으로 제외 (R5/R6 한정으로 ``encryption_key`` 인자로 명시 주입).
+    """
+    env: dict[str, str] = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(config_dir)),
+        "ANTE_CONFIG_DIR": str(config_dir),
+        "PYTHONPATH": str(_repo_root() / "src"),
+    }
+    if encryption_key is not None:
+        env["ANTE_DB_ENCRYPTION_KEY"] = encryption_key
+    if token is not None:
+        env["ANTE_MEMBER_TOKEN"] = token
+    return env
+
+
+def _strip_encryption_key_line(secrets_env_path: Path) -> None:
+    """secrets.env에서 ANTE_DB_ENCRYPTION_KEY 라인을 제거한다 (R1 재현)."""
+    if not secrets_env_path.exists():
+        return
+    lines = secrets_env_path.read_text().splitlines(keepends=True)
+    prefix = "ANTE_DB_ENCRYPTION_KEY="
+    kept = [line for line in lines if not line.lstrip().startswith(prefix)]
+    secrets_env_path.write_text("".join(kept))
+
+
+@pytest.fixture
+def initialized_config(tmp_path: Path) -> tuple[Path, str]:
+    """ante init을 완료한 config dir + member token 페어를 만든다.
+
+    `ante init` 의 결과 JSON에서 ``token`` 을 추출해 R1~R6 회귀에 재사용한다.
+    init 자체는 valid Fernet key로 정상 종료해야 하며, R1 재현은 호출자가
+    ``_strip_encryption_key_line`` 으로 secrets.env 라인을 삭제한 뒤
+    ``ANTE_DB_ENCRYPTION_KEY`` 를 env에서도 제외하여 키가 양쪽에 없는 상태를
+    만든다.
+    """
+    config_dir = tmp_path / "config"
+    key = Fernet.generate_key().decode()
+
+    init_env = _clean_env(config_dir, encryption_key=key)
+    result = subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", "init", "--name", "Repro"],
+        env=init_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"init 실패: exit={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    token = payload.get("token")
+    assert token, f"init 출력에 token 없음: {payload}"
+    return config_dir, token
+
+
+def _run_account_cli(
+    config_dir: Path,
+    token: str,
+    args: list[str],
+    *,
+    encryption_key: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """account CLI를 subprocess로 실행한다. timeout=5로 hang 회귀를 차단한다."""
+    env = _clean_env(config_dir, encryption_key=encryption_key, token=token)
+    return subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _parse_json_error(stdout: str) -> dict:
+    """JSON error payload 를 stdout 마지막 dict 라인에서 추출한다."""
+    # OutputFormatter.error 는 JSON 모드에서 한 줄로 dump 한다. 부가 출력이
+    # 있을 수 있으므로 마지막 JSON dict 라인을 찾는다.
+    last_obj: dict | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            last_obj = obj
+    assert last_obj is not None, f"JSON dict 라인을 stdout에서 찾지 못함: {stdout!r}"
+    return last_obj
+
+
+# ────────────────────────────────────────────────────────────────────
+# R1 / R2 — hang 회귀 + stable code (account list, missing key)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestAccountListMissingKeyNoHang:
+    def test_account_list_missing_key_exits_with_stable_code(
+        self, initialized_config: tuple[Path, str]
+    ) -> None:
+        """secrets.env 키 삭제 + env 미설정 → exit 1, code=MISSING, timeout 미발생."""
+        config_dir, token = initialized_config
+        _strip_encryption_key_line(config_dir / "secrets.env")
+
+        result = _run_account_cli(config_dir, token, ["account", "list"])
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_error(result.stdout)
+        assert payload.get("status") == "error"
+        assert payload.get("code") == "DB_ENCRYPTION_KEY_MISSING"
+
+
+# ────────────────────────────────────────────────────────────────────
+# R3 — cleanup 회귀 (in-process, Database.close spy)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestCreateAccountServiceCleanup:
+    @pytest.mark.asyncio
+    async def test_initialize_failure_calls_db_close(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``AccountService.initialize`` 가 raise하면 ``Database.close`` 1회 await.
+
+        내부 필드(``_writer`` / ``_reader``)는 들여다보지 않고 public lifecycle
+        method ``Database.close`` 호출 사실로 검증한다 (Codex Plan v2 narrow-to 1).
+        """
+        from ante.account.crypto import EncryptionKeyMissingError
+        from ante.cli.commands.account import _create_account_service
+        from ante.core.database import Database
+
+        # get_db_path는 ctx-less 경로에서 ANTE_CONFIG_DIR 기반으로 해석된다.
+        config_dir = tmp_path / "cfg"
+        (config_dir / "db").mkdir(parents=True)
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(config_dir))
+        # valid Fernet key를 env에 두어 db.connect까지는 통과시킨다.
+        # initialize 단계에서 명시 mock으로 raise.
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+        original_close = Database.close
+        close_call_count = {"count": 0}
+
+        async def spy_close(self: Database) -> None:
+            close_call_count["count"] += 1
+            await original_close(self)
+
+        # AccountService.initialize를 raise하도록 monkeypatch
+        from ante.account.service import AccountService
+
+        async def raising_initialize(self: AccountService) -> None:
+            raise EncryptionKeyMissingError(
+                "테스트: initialize 도중 키 누락 시뮬레이션"
+            )
+
+        with patch.object(Database, "close", spy_close):
+            monkeypatch.setattr(AccountService, "initialize", raising_initialize)
+
+            with pytest.raises(EncryptionKeyMissingError):
+                await _create_account_service()
+
+        count = close_call_count["count"]
+        assert count == 1, (
+            f"Database.close 가 정확히 1회 await되어야 한다 (count={count})"
+        )
+
+
+# ────────────────────────────────────────────────────────────────────
+# R4 — 7-command 일관성 회귀
+# ────────────────────────────────────────────────────────────────────
+
+
+# 7개 account 명령의 (args, code) 매트릭스. 모든 명령은 ``_create_account_service`` 를
+# 통해 DB+initialize 진입하므로, 키가 없으면 동일하게 DB_ENCRYPTION_KEY_MISSING 으로
+# 종료한다. 일부 명령은 ``_create_account_service`` 진입 전 별도 가드(예:
+# cold-path runtime, --yes confirmation)를 먼저 실행한다. 가드를 만족시키지 못하면
+# 다른 코드로 종료하므로, R4 매트릭스는 가드를 모두 통과하는 시나리오 인자를 쓴다.
+_ACCOUNT_COMMANDS_FOR_R4: list[tuple[str, list[str]]] = [
+    (
+        "create",
+        [
+            "account",
+            "create",
+            "--broker-type",
+            "test",
+            "--account-id",
+            "acc1",
+            "--name",
+            "A",
+            "--trading-mode",
+            "virtual",
+            "--credential",
+            "app_key=k",
+            "--credential",
+            "app_secret=s",
+        ],
+    ),
+    ("list", ["account", "list"]),
+    ("info", ["account", "info", "test"]),
+    ("delete", ["account", "delete", "test", "--yes"]),
+    ("credentials", ["account", "credentials", "test"]),
+    (
+        "set-credentials",
+        [
+            "account",
+            "set-credentials",
+            "test",
+            "--credential",
+            "app_key=k",
+            "--credential",
+            "app_secret=s",
+        ],
+    ),
+    ("repair-timezone", ["account", "repair-timezone", "test", "Asia/Seoul"]),
+]
+
+
+class TestSevenCommandConsistency:
+    @pytest.mark.parametrize(
+        ("name", "args"),
+        _ACCOUNT_COMMANDS_FOR_R4,
+        ids=[name for name, _ in _ACCOUNT_COMMANDS_FOR_R4],
+    )
+    def test_missing_key_consistent_code_no_hang(
+        self,
+        initialized_config: tuple[Path, str],
+        name: str,
+        args: list[str],
+    ) -> None:
+        """7개 account 명령 모두 동일 missing-key 시나리오에서 같은 코드 + exit 1."""
+        config_dir, token = initialized_config
+        _strip_encryption_key_line(config_dir / "secrets.env")
+
+        result = _run_account_cli(config_dir, token, args)
+        assert result.returncode == 1, (
+            f"[{name}] exit={result.returncode}\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_error(result.stdout)
+        assert payload.get("code") == "DB_ENCRYPTION_KEY_MISSING", (
+            f"[{name}] 예상 code=DB_ENCRYPTION_KEY_MISSING, 실제 payload={payload}"
+        )
+
+
+# ────────────────────────────────────────────────────────────────────
+# R5 — invalid key 형식 회귀
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestInvalidKeyFormat:
+    def test_invalid_key_format_returns_invalid_code(
+        self, initialized_config: tuple[Path, str]
+    ) -> None:
+        """env에 garbage value → exit 1, code=DB_ENCRYPTION_KEY_INVALID."""
+        config_dir, token = initialized_config
+        _strip_encryption_key_line(config_dir / "secrets.env")
+
+        result = _run_account_cli(
+            config_dir, token, ["account", "list"], encryption_key="garbage"
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_error(result.stdout)
+        assert payload.get("code") == "DB_ENCRYPTION_KEY_INVALID"
+
+
+# ────────────────────────────────────────────────────────────────────
+# R6 — wrong key decrypt 회귀
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestWrongKeyDecrypt:
+    def test_wrong_key_decrypt_returns_invalid_code(
+        self, initialized_config: tuple[Path, str]
+    ) -> None:
+        """legacy DB는 키 A로 암호화 + 현재 env에 valid 키 B → exit 1, code=INVALID.
+
+        init은 키 A로 ``test`` seed 계좌를 encrypt해 두었다. secrets.env 라인을
+        삭제하고 env에 다른 valid Fernet key (B)를 주입하면 initialize 중
+        ``_row_to_account`` 가 ``decrypt_credentials`` 를 호출해
+        ``InvalidToken`` → ``EncryptionKeyInvalidError`` 로 매핑된다.
+        """
+        config_dir, token = initialized_config
+        _strip_encryption_key_line(config_dir / "secrets.env")
+
+        wrong_key = Fernet.generate_key().decode()
+        result = _run_account_cli(
+            config_dir, token, ["account", "list"], encryption_key=wrong_key
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_error(result.stdout)
+        assert payload.get("code") == "DB_ENCRYPTION_KEY_INVALID"

--- a/tests/unit/test_cli_account_crypto_error.py
+++ b/tests/unit/test_cli_account_crypto_error.py
@@ -29,7 +29,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from cryptography.fernet import Fernet
@@ -193,13 +193,6 @@ class TestCreateAccountServiceCleanup:
         # initialize 단계에서 명시 mock으로 raise.
         monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", Fernet.generate_key().decode())
 
-        original_close = Database.close
-        close_call_count = {"count": 0}
-
-        async def spy_close(self: Database) -> None:
-            close_call_count["count"] += 1
-            await original_close(self)
-
         # AccountService.initialize를 raise하도록 monkeypatch
         from ante.account.service import AccountService
 
@@ -208,15 +201,19 @@ class TestCreateAccountServiceCleanup:
                 "테스트: initialize 도중 키 누락 시뮬레이션"
             )
 
-        with patch.object(Database, "close", spy_close):
+        # Plan v2 invariant #6: patch.object(Database, "close") spy를 AsyncMock으로
+        # 주입하고 await_count == 1로 검증한다. cleanup 호출 사실만 검증하면
+        # 충분하므로 실제 close 본체는 위임하지 않는다 (process 종료 시 임시
+        # 자원은 OS가 회수).
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
             monkeypatch.setattr(AccountService, "initialize", raising_initialize)
 
             with pytest.raises(EncryptionKeyMissingError):
                 await _create_account_service()
 
-        count = close_call_count["count"]
-        assert count == 1, (
-            f"Database.close 가 정확히 1회 await되어야 한다 (count={count})"
+        assert close_mock.await_count == 1, (
+            f"Database.close 가 정확히 1회 await되어야 한다 "
+            f"(await_count={close_mock.await_count})"
         )
 
 


### PR DESCRIPTION
Closes #1722

## Summary

`account list`와 6개 다른 account CLI(`create`, `info`, `delete`, `credentials`, `set-credentials`, `repair-timezone`)가 ANTE_DB_ENCRYPTION_KEY 부재/invalid 시 8초 hang(exit 124) + 빈 error code 반환하던 contract bug를 fix.

- **crypto.py 예외 계층 신규**: `EncryptionKeyError(RuntimeError)` base + `EncryptionKeyMissingError` (code `DB_ENCRYPTION_KEY_MISSING`) + `EncryptionKeyInvalidError` (code `DB_ENCRYPTION_KEY_INVALID`).
- **`_get_fernet`**: env unset/빈 → MISSING, Fernet 형식 위반 → INVALID.
- **`decrypt_credentials`**: `cryptography.fernet.InvalidToken` catch → INVALID chained.
- **`_create_account_service` cleanup**: `try connect+init / except BaseException: await db.close / re-raise`. \`connect()\` 실패까지 cleanup 보장. inner `try/except Exception` + `logger.debug`로 close 실패 흡수(원본 예외 propagate).
- **7 CLI except 통일**: `code=getattr(e, "code", "EXECUTION_ERROR")` 패턴. 기존 typed except 보존.
- **R3 cleanup spy**: `unittest.mock.patch.object(Database, "close", new_callable=AsyncMock)` + `await_count == 1` (Codex 브랜치 리뷰 v1 FAIL → v2 PASS).

## Plan Preflight

이슈 본문 Implementation Plan v2 (narrow-scope) 기준. Codex Plan Review 2 라운드(v1 revise-plan 4 must-fix → v2 narrow-scope 4/4 closed + 1 narrow-to 인라인). Codex 브랜치 리뷰 2 라운드(v1 FAIL R3 spy → v2 PASS).

## Test Plan

- [x] `pytest tests/unit/test_account_crypto.py tests/unit/test_cli_account_crypto_error.py` → 24/24 PASS
- [x] `pytest tests/unit/` 전체 → 4885 passed (139s)
- [x] `mypy src/` → 216 files PASS
- [x] `ruff check . && ruff format --check .` → PASS
- [x] `python scripts/generate_project_structure.py` → up to date
- [x] Manual hang reproduction (missing key): wall-clock 0.12s (was ~8s), exit 1, `code="DB_ENCRYPTION_KEY_MISSING"`
- [x] Manual invalid key (garbage env): wall-clock 0.12s, exit 1, `code="DB_ENCRYPTION_KEY_INVALID"`
- [x] 7-command consistency (create/list/info/delete/credentials/set-credentials/repair-timezone) — R4 매트릭스 PASS
- [x] Codex 브랜치 리뷰 v2 PASS (0 blocking)

## Non-Goals (별도 sweep/follow-up 이슈 후보)

- B 카테고리 typed exception에 `code` 속성 추가 (`AccountNotFoundError` 등 10개)
- 다른 CLI 모듈(rule/broker/bot 등) generic except 패턴 일관화
- `_create_account_service` async context manager 전면 리팩토링
- crypto.py `Config.secret()` 의존성 주입 리팩토링
- ANTE_DB_ENCRYPTION_KEY rotation/escrow/backup-restore UX