### PR TITLE
fix: #1723 account create reserve buffer inf/nan/negative 거부 (validate_nonnegative_finite_amount SSOT 적용)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -548,7 +548,9 @@ tests/
 │   ├── test_cli_bot_lifecycle.py
 │   ├── test_ipc_bot_lifecycle.py
 │   ├── test_cli_init_secret_leak.py
-│   └── test_cli_account_crypto_error.py
+│   ├── test_cli_account_crypto_error.py
+│   ├── test_cli_account_reserve_buffer_validation.py
+│   └── test_cli_validators.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/_validators.py
+++ b/src/ante/cli/_validators.py
@@ -135,6 +135,63 @@ def validate_positive_finite_amount(
     return value
 
 
+def validate_nonnegative_finite_amount(
+    ctx: click.Context | None,
+    param: click.Parameter | None,
+    value: float | None,
+) -> float | None:
+    """Click callback: 0 이상 finite float 검증 (NaN/Infinity/음수 거부).
+
+    오라클 A7 finding(#1517 — ``treasury set-balance`` amount): ``type=float``만
+    갖춰 ``float('nan')``/``float('inf')``/음수가 그대로 통과되던 ingress drift를
+    닫는다. 오라클 A7 finding(#1723 — ``account create
+    --market-order-reserve-buffer-rate``)도 동일 invariant를 요구하며, 본 SSOT는
+    두 호출 표면 공유 callback이다.
+
+    :func:`validate_positive_finite_amount`와의 차이는 **0 허용 boundary**다.
+    ``Account.market_order_reserve_buffer_rate``는 ``docs/specs/account/03-data-
+    model.md:55,147``에서 ``Decimal("0")`` 기본값을 명시하고 있어 0을 정상값으로
+    수용해야 한다 (#1333 cold-path structural field).
+
+    검증은 두 단계:
+
+    1. ``math.isnan(value) or math.isinf(value)`` — NaN/±Infinity 거부.
+    2. ``value < 0`` — 음수 거부.
+
+    ``None`` 입력은 그대로 ``None``을 반환한다 (옵션 미지정 분기 보존).
+    invalid 입력은 ``click.BadParameter``로 raise되어 click 표준 경로에서
+    text stderr + exit 2로 변환된다. ``--format json`` 모드에서는
+    ``AuthenticatedGroup.main`` middleware(``src/ante/cli/middleware.py:561-581``)가
+    UsageError를 ``CLI_USAGE_ERROR`` JSON envelope + exit 1로 변환한다.
+
+    Args:
+        ctx: Click 컨텍스트 (``click.option(callback=...)`` 인자).
+        param: Click 파라미터 메타데이터 (``click.option(callback=...)`` 인자).
+        value: 사용자가 입력한 float, 또는 ``None``.
+
+    Returns:
+        검증된 float을 그대로 반환, 또는 ``None`` (입력이 ``None``일 때).
+
+    Raises:
+        click.BadParameter: NaN/±Infinity 또는 음수.
+    """
+    if value is None:
+        return None
+    if math.isnan(value) or math.isinf(value):
+        raise click.BadParameter(
+            f"{value!r}은(는) finite number여야 합니다 (NaN/Infinity 거부).",
+            ctx=ctx,
+            param=param,
+        )
+    if value < 0:
+        raise click.BadParameter(
+            f"{value!r}은(는) 0 이상이어야 합니다.",
+            ctx=ctx,
+            param=param,
+        )
+    return value
+
+
 def reject_inverted_date_range(
     from_value: str | None,
     to_value: str | None,
@@ -260,5 +317,6 @@ __all__ = [
     "reject_invalid_account_id",
     "reject_inverted_date_range",
     "validate_iso_date",
+    "validate_nonnegative_finite_amount",
     "validate_positive_finite_amount",
 ]

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -24,7 +24,10 @@ from typing import TYPE_CHECKING, Any, NoReturn
 import click
 
 from ante.account.models import AccountStatus
-from ante.cli._validators import reject_invalid_account_id
+from ante.cli._validators import (
+    reject_invalid_account_id,
+    validate_nonnegative_finite_amount,
+)
 from ante.cli.cold_path import (
     ACCOUNT_COLD_PATH_BLOCKED_CODE,
     assert_no_active_runtime,
@@ -464,9 +467,11 @@ def _validate_broker_type(fmt: OutputFormatter, broker_type: str) -> None:
     "market_order_reserve_buffer_rate_opt",
     type=float,
     default=None,
+    callback=validate_nonnegative_finite_amount,
     help=(
         "시장가 매수 reserve buffer 비율 (예: 0.005=0.5%). "
-        "omit 시 BrokerPreset 기본값을 사용한다 (#1333)."
+        "omit 시 BrokerPreset 기본값을 사용한다 (#1333). "
+        "NaN/Infinity/음수는 거부된다 (#1723)."
     ),
 )
 @format_option

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import math
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 
@@ -13,6 +12,7 @@ from ante.cli._validators import (
     reject_invalid_account_id,
     reject_inverted_date_range,
     validate_iso_date,
+    validate_nonnegative_finite_amount,
     validate_positive_finite_amount,
 )
 from ante.cli.formatter import format_option
@@ -28,29 +28,6 @@ def treasury() -> None:
 
 def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
-
-
-def validate_nonnegative_finite_amount(
-    ctx: click.Context | None,
-    param: click.Parameter | None,
-    value: float | None,
-) -> float | None:
-    """Click callback: finite amount >= 0."""
-    if value is None:
-        return None
-    if math.isnan(value) or math.isinf(value):
-        raise click.BadParameter(
-            f"{value!r}은(는) finite number여야 합니다 (NaN/Infinity 거부).",
-            ctx=ctx,
-            param=param,
-        )
-    if value < 0:
-        raise click.BadParameter(
-            f"{value!r}은(는) 0 이상이어야 합니다.",
-            ctx=ctx,
-            param=param,
-        )
-    return value
 
 
 async def _create_treasury(account_id: str | None = None):  # noqa: ANN202

--- a/tests/unit/test_cli_account_reserve_buffer_validation.py
+++ b/tests/unit/test_cli_account_reserve_buffer_validation.py
@@ -1,0 +1,237 @@
+"""``account create --market-order-reserve-buffer-rate`` ingress 회귀 (#1723).
+
+오라클 A7 finding(``cli_account_reserve_buffer_contract``):
+``--market-order-reserve-buffer-rate``가 ``inf``/음수를 exit 0 status=ok로 통과
+시키고, ``nan``은 SQLite ``NOT NULL constraint`` raw 메시지 + 빈 code로 떨어졌다.
+본 PR은 ``validate_nonnegative_finite_amount`` callback을 부착해 그 ingress
+drift를 닫는다.
+
+본 테스트는 e2e Click runner 회귀 R1~R6을 단정한다:
+
+- R1: ``inf`` → exit 1, JSON ``code="CLI_USAGE_ERROR"``, "finite" 포함.
+- R2: ``nan`` → exit 1, JSON ``code="CLI_USAGE_ERROR"``.
+- R3: ``-0.1`` → exit 1, JSON ``code="CLI_USAGE_ERROR"``, "0 이상" 포함.
+- R4: ``0`` → exit 0, account 정상 생성 (boundary; ``Decimal("0")`` 기본값 SSOT).
+- R5: ``0.005`` → exit 0, account 정상 생성.
+- R6: ``1e-300`` → exit 0, account 정상 생성 (positive-near-zero boundary —
+  finite invariant 강조; subnormal float이지만 ``math.isfinite`` 통과).
+
+invalid 케이스는 click ``BadParameter`` 경로를 타고 ``AuthenticatedGroup.main``
+middleware(``src/ante/cli/middleware.py:561-581``)가 ``CLI_USAGE_ERROR`` JSON
+envelope + exit 1로 변환한다. R1~R3은 그 envelope을 단정한다. 정상 케이스
+R4~R6은 ``_create_account_service`` mock으로 DB 접근을 차단하고 ``Account.
+market_order_reserve_buffer_rate``가 정확한 ``Decimal``로 전달되는지를 단정한다.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+
+
+def _invoke(args: list[str]) -> Any:
+    """``ANTE_MEMBER_TOKEN``을 빈 문자열로 두고 ``CliRunner``로 실행한다.
+
+    인증은 ``bypass_auth`` fixture가 ``authenticate_member``를 patch해 우회한다
+    (``test_account_cli.py`` 패턴과 동형).
+    """
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _mock_account_obj(account_id: str = "oracle-buf") -> Any:
+    """정상 케이스(R4~R6)에서 ``svc.create`` 반환값으로 사용할 Account stub."""
+    from ante.account.models import Account, AccountStatus, TradingMode
+
+    return Account(
+        account_id=account_id,
+        name="OracleBuf",
+        exchange="TEST",
+        currency="KRW",
+        broker_type="test",
+        status=AccountStatus("active"),
+        trading_mode=TradingMode("virtual"),
+        credentials={},
+        buy_commission_rate=Decimal("0.00015"),
+        sell_commission_rate=Decimal("0.00195"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """인증 우회 — ``test_account_cli.py`` 패턴 동형."""
+    from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+    mock_member = Member(
+        member_id="tester",
+        name="테스터",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        status=MemberStatus.ACTIVE,
+        scopes=[],
+    )
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": mock_member}),
+    ):
+        yield
+
+
+@pytest.fixture
+def offline_runtime():
+    """cold-path active runtime guard 통과 — ``test_account_cli.py`` 패턴 동형."""
+    with (
+        patch("ante.main.read_pid_file", return_value=None),
+        patch(
+            "ante.cli.commands.ipc_helpers.get_socket_path",
+            return_value="/tmp/__ante_offline_runtime_buffer_test__.sock",
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_account_service():
+    """``_create_account_service``를 mock해 DB 접근을 차단한다."""
+    svc = AsyncMock()
+    db = AsyncMock()
+
+    async def _create_service():
+        return svc, db
+
+    with patch(
+        "ante.cli.commands.account._create_account_service", new=_create_service
+    ):
+        yield svc
+
+
+def _argv(value: str) -> list[str]:
+    """``account create`` argv (JSON 모드).
+
+    음수 토큰(``-0.1``)이 option 후보로 처리되어 "No such option"으로 reject되지
+    않도록 ``=`` 형태로 옵션-값을 결합한다. click은 ``--opt=-0.1`` 형태에서는
+    토큰 분리 없이 value로 직접 파싱한다.
+    """
+    return [
+        "--format",
+        "json",
+        "account",
+        "create",
+        "--broker-type",
+        "test",
+        "--account-id",
+        "oracle-buf",
+        "--name",
+        "OracleBuf",
+        "--trading-mode",
+        "virtual",
+        "--credential",
+        "app_key=K",
+        "--credential",
+        "app_secret=S",
+        f"--market-order-reserve-buffer-rate={value}",
+    ]
+
+
+def _assert_cli_usage_error(result: Any, *, expect_substr: str | None = None) -> None:
+    """invalid 입력에 대해 ``CLI_USAGE_ERROR`` envelope + exit 1을 단정."""
+    assert result.exit_code == 1, (
+        f"expected exit=1, got exit={result.exit_code} output={result.output!r}"
+    )
+    payload = json.loads(result.output.strip())
+    assert payload["status"] == "error"
+    assert payload["code"] == "CLI_USAGE_ERROR", (
+        f"expected code=CLI_USAGE_ERROR, got code={payload.get('code')!r}"
+    )
+    if expect_substr is not None:
+        assert expect_substr in payload["message"], (
+            f"expected substring {expect_substr!r} in message, "
+            f"got message={payload['message']!r}"
+        )
+    # raw SQLite 메시지 누출 회귀 차단 (#1723 root cause).
+    assert "NOT NULL constraint" not in payload["message"]
+
+
+class TestInvalidValuesRejected:
+    """R1~R3: invalid ingress가 ``CLI_USAGE_ERROR`` JSON envelope + exit 1로 거부."""
+
+    def test_r1_infinity_rejected(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """R1: ``inf`` → exit 1, ``CLI_USAGE_ERROR``, message에 ``finite`` 포함."""
+        result = _invoke(_argv("inf"))
+        _assert_cli_usage_error(result, expect_substr="finite")
+        # ingress에서 차단되므로 service.create는 호출되지 않아야 한다.
+        mock_account_service.create.assert_not_called()
+
+    def test_r2_nan_rejected(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """R2: ``nan`` → exit 1, ``CLI_USAGE_ERROR``.
+
+        기존 버그: SQLite ``NOT NULL constraint`` raw 메시지 + 빈 code로 누출.
+        callback 부착 후에는 ingress에서 차단되어야 한다.
+        """
+        result = _invoke(_argv("nan"))
+        _assert_cli_usage_error(result, expect_substr="finite")
+        mock_account_service.create.assert_not_called()
+
+    def test_r3_negative_rejected(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """R3: ``-0.1`` → exit 1, ``CLI_USAGE_ERROR``, message에 ``0 이상`` 포함."""
+        result = _invoke(_argv("-0.1"))
+        _assert_cli_usage_error(result, expect_substr="0 이상")
+        mock_account_service.create.assert_not_called()
+
+
+class TestValidValuesAccepted:
+    """R4~R6: valid ingress가 정상 통과해 account가 생성."""
+
+    def test_r4_zero_accepted_boundary(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """R4: ``0`` → exit 0 (boundary; ``Decimal("0")`` 기본값 SSOT, #1333).
+
+        ``validate_positive_finite_amount``와 달리 본 callback은 0을 허용한다.
+        """
+        mock_account_service.create.return_value = _mock_account_obj()
+        result = _invoke(_argv("0"))
+        assert result.exit_code == 0, result.output
+        new_account = mock_account_service.create.call_args.args[0]
+        assert new_account.market_order_reserve_buffer_rate == Decimal("0")
+
+    def test_r5_small_positive_accepted(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """R5: ``0.005`` → exit 0, account 정상 생성."""
+        mock_account_service.create.return_value = _mock_account_obj()
+        result = _invoke(_argv("0.005"))
+        assert result.exit_code == 0, result.output
+        new_account = mock_account_service.create.call_args.args[0]
+        assert new_account.market_order_reserve_buffer_rate == Decimal("0.005")
+
+    def test_r6_subnormal_finite_accepted(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """R6: ``1e-300`` → exit 0 (positive-near-zero boundary, finite invariant).
+
+        ``1e-300``은 IEEE-754 double subnormal이지만 ``math.isfinite``로 finite
+        판정된다. callback은 finite + 0 이상만 보장하므로 통과해야 한다.
+        ``Decimal(str(1e-300))``은 ``Decimal("1e-300")``으로 정확히 매핑된다.
+        """
+        mock_account_service.create.return_value = _mock_account_obj()
+        result = _invoke(_argv("1e-300"))
+        assert result.exit_code == 0, result.output
+        new_account = mock_account_service.create.call_args.args[0]
+        # ``Decimal(str(1e-300))`` == ``Decimal("1e-300")``.
+        assert new_account.market_order_reserve_buffer_rate == Decimal("1e-300")
+        assert isinstance(new_account.market_order_reserve_buffer_rate, Decimal)

--- a/tests/unit/test_cli_validators.py
+++ b/tests/unit/test_cli_validators.py
@@ -1,0 +1,60 @@
+"""CLI ``_validators.py`` 모듈 단위 테스트.
+
+본 모듈은 :mod:`ante.cli._validators`가 노출하는 공유 callback의 invariant를
+직접 호출 단위로 단정한다. e2e Click runner 회귀는 별도 파일에서 호출 표면별로
+검증한다 (예: ``tests/unit/test_cli_account_reserve_buffer_validation.py``,
+``tests/unit/test_cli_treasury_amount_validation.py``).
+
+오라클 A7 finding(#1723 — ``account create --market-order-reserve-buffer-rate``)에
+서 ``validate_nonnegative_finite_amount``가 ``treasury.py``에 정의돼 있어 account
+명령에서 직접 import 재사용이 어려웠다. 본 PR에서 SSOT를 ``_validators.py``로
+이동했으며, 본 테스트는 그 이동된 SSOT의 동작 invariant를 보존한다.
+"""
+
+from __future__ import annotations
+
+import math
+
+import click
+import pytest
+
+from ante.cli._validators import validate_nonnegative_finite_amount
+
+
+class TestValidateNonnegativeFiniteAmount:
+    """``validate_nonnegative_finite_amount`` callback 단위 테스트.
+
+    Click ``callback`` 시그니처는 ``(ctx, param, value)`` 3-tuple — ctx/param은
+    None을 전달해도 callback 자체 분기에는 영향이 없다 (이미 SSOT가 사용하는
+    동형 ``validate_positive_finite_amount`` 패턴과 동일).
+    """
+
+    def test_inf_raises_bad_parameter(self) -> None:
+        """``+Infinity``는 BadParameter (NaN/Infinity 거부)."""
+        with pytest.raises(click.BadParameter) as exc_info:
+            validate_nonnegative_finite_amount(None, None, math.inf)
+        assert "finite" in str(exc_info.value)
+
+    def test_nan_raises_bad_parameter(self) -> None:
+        """``NaN``은 BadParameter (NaN/Infinity 거부)."""
+        with pytest.raises(click.BadParameter) as exc_info:
+            validate_nonnegative_finite_amount(None, None, math.nan)
+        assert "finite" in str(exc_info.value)
+
+    def test_negative_raises_bad_parameter(self) -> None:
+        """음수는 BadParameter (0 이상이어야 함)."""
+        with pytest.raises(click.BadParameter) as exc_info:
+            validate_nonnegative_finite_amount(None, None, -0.1)
+        assert "0 이상" in str(exc_info.value)
+
+    def test_zero_passes(self) -> None:
+        """0은 boundary 정상값 (``Decimal('0')`` 기본값 SSOT, #1333)."""
+        assert validate_nonnegative_finite_amount(None, None, 0.0) == 0.0
+
+    def test_positive_passes(self) -> None:
+        """양수는 정상 통과."""
+        assert validate_nonnegative_finite_amount(None, None, 0.005) == 0.005
+
+    def test_none_passes_through(self) -> None:
+        """``None``(옵션 미지정)은 그대로 ``None`` 반환 (분기 보존)."""
+        assert validate_nonnegative_finite_amount(None, None, None) is None


### PR DESCRIPTION
Closes #1723

## Summary

`account create --market-order-reserve-buffer-rate`가 `inf`(exit 0), `-0.1`(exit 0), `nan`(exit 1 + 빈 code + SQLite raw 메시지)를 거부하지 않던 ingress validation drift를 fix.

- **SSOT consolidation**: `validate_nonnegative_finite_amount`를 `src/ante/cli/commands/treasury.py:33-53`에서 `src/ante/cli/_validators.py`로 이동. treasury.py는 import + unused `math` import 제거. behavior preserving.
- **account create**: `--market-order-reserve-buffer-rate`에 `callback=validate_nonnegative_finite_amount` 추가.
- **CLI envelope contract**: `click.BadParameter` → middleware → `CLI_USAGE_ERROR` JSON + exit 1 (동형 oracle A7 #1517 패턴 재사용).

## Plan Preflight

이슈 본문 Implementation Plan v2 (narrow-scope) 기준. Codex Plan Review 2 라운드(v1 revise-plan 1 must-fix + 3 should-fix → v2 narrow-scope 4/4 closed + 5 narrow-to 인라인). Codex 브랜치 리뷰 1 라운드 PASS.

## Test Plan

- [x] R1: \`--market-order-reserve-buffer-rate inf\` → exit 1, JSON \`code="CLI_USAGE_ERROR"\`, "finite" 메시지
- [x] R2: \`nan\` → exit 1, \`code="CLI_USAGE_ERROR"\`
- [x] R3: \`-0.1\` → exit 1, \`code="CLI_USAGE_ERROR"\`, "0 이상" 메시지
- [x] R4: \`0\` → exit 0, account 정상 생성 (boundary)
- [x] R5: \`0.005\` → exit 0, account 정상 생성
- [x] R6: \`1e-300\` → exit 0, account 정상 생성 (positive-near-zero boundary)
- [x] \`pytest\` 대상 3 파일 (validators/account/treasury): 40 PASS
- [x] \`pytest\` 전체 unit suite: 4897 passed (141s)
- [x] \`mypy src/\`: 216 files PASS
- [x] \`ruff check && ruff format --check\`: PASS
- [x] \`generate_project_structure.py\`: up to date
- [x] Codex 브랜치 리뷰 PASS (0 blocking, 8/8 invariants)

## Non-Goals (별도 follow-up 이슈 후보)

- 4-axis 다른 축: Account __post_init__ service guard, lifecycle invalid row tolerant load, runtime invalid-rate 처리, 상한(>1.0) 정책
- \`validate_positive_finite_amount\` 일반화 (0 허용 옵션)
- 다른 numeric option 검증 (이미 SSOT 적용)
- BrokerPreset 기본값 정책 변경
- \`CLI_USAGE_ERROR\` → \`VALIDATION_ERROR\` envelope code 일반화