### PR TITLE
fix: #1724 cold-path account 4 명령에 invalid account_id ingress validation

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -550,7 +550,8 @@ tests/
 │   ├── test_cli_init_secret_leak.py
 │   ├── test_cli_account_crypto_error.py
 │   ├── test_cli_account_reserve_buffer_validation.py
-│   └── test_cli_validators.py
+│   ├── test_cli_validators.py
+│   └── test_cli_account_invalid_id_ingress.py
 └── __init__.py
 ```
 

--- a/src/ante/account/scoping.py
+++ b/src/ante/account/scoping.py
@@ -85,7 +85,7 @@ def require_account_id(account_id: str | None, *, context: str = "") -> str:
     return account_id  # type: ignore[return-value]
 
 
-def validate_new_account_id(account_id: str | None) -> str:
+def validate_new_account_id(account_id: str | None, *, context: str = "") -> str:
     """신규 Account 생성 정책 검증.
 
     형식 검사(:data:`ACCOUNT_ID_PATTERN`)와 RESTRICTED 거부
@@ -98,6 +98,10 @@ def validate_new_account_id(account_id: str | None) -> str:
 
     Args:
         account_id: 검증할 account_id.
+        context: 에러 메시지에 부착할 호출 위치 식별자
+            (:func:`require_account_id` 동형). 예: ``"cli.account.create"``.
+            기본값 ``""``는 기존 호출자(``AccountService.create``)와 호환되며
+            prefix를 출력하지 않는다.
 
     Returns:
         검증된 account_id.
@@ -106,23 +110,25 @@ def validate_new_account_id(account_id: str | None) -> str:
         InvalidAccountIdError: 형식 위반, 또는 RESTRICTED/INVALID_RUNTIME
             예약어와 일치할 때.
     """
+    prefix = f"({context}) " if context else ""
     if account_id is None or account_id == "":
         raise InvalidAccountIdError(
-            f"account_id 형식이 올바르지 않습니다: '{account_id}'. "
+            f"{prefix}account_id 형식이 올바르지 않습니다: '{account_id}'. "
             "영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다."
         )
     if account_id in RESTRICTED_NEW_ACCOUNT_IDS:
         raise InvalidAccountIdError(
-            f"account_id '{account_id}'는 ante init이 생성하는 시드 계좌로 "
+            f"{prefix}account_id '{account_id}'는 ante init이 생성하는 시드 계좌로 "
             "예약되어 있어 신규 생성이 불가합니다."
         )
     if account_id in INVALID_RUNTIME_ACCOUNT_IDS:
         raise InvalidAccountIdError(
-            f"account_id '{account_id}'는 fallback 예약어로 신규 생성이 불가합니다."
+            f"{prefix}account_id '{account_id}'는 fallback 예약어로 "
+            "신규 생성이 불가합니다."
         )
     if not ACCOUNT_ID_PATTERN.fullmatch(account_id):
         raise InvalidAccountIdError(
-            f"account_id 형식이 올바르지 않습니다: '{account_id}'. "
+            f"{prefix}account_id 형식이 올바르지 않습니다: '{account_id}'. "
             "영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다."
         )
     return account_id

--- a/src/ante/cli/_validators.py
+++ b/src/ante/cli/_validators.py
@@ -292,9 +292,8 @@ def reject_invalid_new_account_id(
         account_id: 검증할 신규 account_id (또는 ``None``).
         fmt: ``get_formatter(ctx)``로 얻은 출력 포맷터. text/json 모드에 따라
             구조화된 에러를 출력한다.
-        context: 호출 위치 식별자 (예: ``"cli.account.create"``). 현재
-            ``validate_new_account_id``는 context를 사용하지 않지만 sibling
-            helper 시그니처 정렬을 위해 보존한다.
+        context: ``validate_new_account_id``에 전달할 호출 위치 식별자
+            (예: ``"cli.account.create"``). 에러 메시지에 prefix로 부착된다.
 
     Returns:
         검증된 account_id. 호출 측 type narrow를 위해 ``str``로 반환된다.
@@ -305,9 +304,8 @@ def reject_invalid_new_account_id(
     from ante.account.errors import InvalidAccountIdError
     from ante.account.scoping import validate_new_account_id
 
-    del context  # sibling 시그니처 정렬용 — validate_new_account_id가 사용하지 않음.
     try:
-        return validate_new_account_id(account_id)
+        return validate_new_account_id(account_id, context=context)
     except InvalidAccountIdError as e:
         fmt.error(str(e), code=e.code)
         raise SystemExit(1) from e

--- a/src/ante/cli/_validators.py
+++ b/src/ante/cli/_validators.py
@@ -256,6 +256,63 @@ def reject_inverted_date_range(
         raise SystemExit(1)
 
 
+def reject_invalid_new_account_id(
+    account_id: str | None,
+    fmt: OutputFormatter,
+    *,
+    context: str = "",
+) -> str:
+    """공유 helper: create-path 신규 ``account_id``를 service 진입 이전에 거부.
+
+    오라클 #1724 finding(D follow-up — #1634 동형): cold-path
+    ``account create``가 invalid ``account_id``(``default`` RESTRICTED,
+    pattern 위반 ``bad_id``, ``""``/``None``)를 ``AccountService.create``
+    SQL 진입 이전에 거부하지 않아 일부는 ``ACCOUNT_NOT_FOUND``로 오분류되고
+    일부는 empty/``EXECUTION_ERROR``로 떨어지던 ingress drift가 있었다.
+    본 helper가 그 drift를 닫는다.
+
+    :func:`reject_invalid_account_id`와 byte-for-byte 동형이지만 내부
+    delegate가 다르다 — :func:`ante.account.scoping.validate_new_account_id`
+    (create-policy SSOT)를 호출하여 **형식 + RESTRICTED + INVALID_RUNTIME**
+    세 단계를 한 번에 검사한다. ``require_account_id``(lookup-policy)와의
+    차이는 RESTRICTED-aware라는 점이다 — ``test`` 같은 bootstrap seed id는
+    lookup은 허용되지만 신규 생성은 금지된다.
+
+    :func:`reject_invalid_account_id`와 마찬가지로
+    :class:`ante.account.errors.InvalidAccountIdError`는 non-Click
+    ``AccountError``이며, ``AuthenticatedGroup.main``
+    (``src/ante/cli/middleware.py:568-596``)은 ``click.UsageError``/``Abort``만
+    envelope 변환한다. 따라서 본 helper가 그 예외를 **명시적으로** catch해
+    ``fmt.error(str(e), code=e.code)`` + ``SystemExit(1)``로 변환한다.
+    에러 코드는 #1633 SSOT
+    (``InvalidAccountIdError.code == "VALIDATION_ERROR"``)를 그대로 재사용하며
+    신 코드를 도입하지 않는다.
+
+    Args:
+        account_id: 검증할 신규 account_id (또는 ``None``).
+        fmt: ``get_formatter(ctx)``로 얻은 출력 포맷터. text/json 모드에 따라
+            구조화된 에러를 출력한다.
+        context: 호출 위치 식별자 (예: ``"cli.account.create"``). 현재
+            ``validate_new_account_id``는 context를 사용하지 않지만 sibling
+            helper 시그니처 정렬을 위해 보존한다.
+
+    Returns:
+        검증된 account_id. 호출 측 type narrow를 위해 ``str``로 반환된다.
+
+    Raises:
+        SystemExit: invalid account_id일 때 exit code 1로 종료.
+    """
+    from ante.account.errors import InvalidAccountIdError
+    from ante.account.scoping import validate_new_account_id
+
+    del context  # sibling 시그니처 정렬용 — validate_new_account_id가 사용하지 않음.
+    try:
+        return validate_new_account_id(account_id)
+    except InvalidAccountIdError as e:
+        fmt.error(str(e), code=e.code)
+        raise SystemExit(1) from e
+
+
 def reject_invalid_account_id(
     account_id: str | None,
     fmt: OutputFormatter,
@@ -315,6 +372,7 @@ def reject_invalid_account_id(
 
 __all__ = [
     "reject_invalid_account_id",
+    "reject_invalid_new_account_id",
     "reject_inverted_date_range",
     "validate_iso_date",
     "validate_nonnegative_finite_amount",

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -26,6 +26,7 @@ import click
 from ante.account.models import AccountStatus
 from ante.cli._validators import (
     reject_invalid_account_id,
+    reject_invalid_new_account_id,
     validate_nonnegative_finite_amount,
 )
 from ante.cli.cold_path import (
@@ -525,6 +526,17 @@ def account_create(
     assert name_opt is not None
     assert trading_mode_opt is not None
 
+    # 1-b) account_id ingress 검증 (#1724, D follow-up — #1634 동형). invalid
+    # account_id(`default` RESTRICTED, pattern 위반 `bad_id`, ``""``)를
+    # ``AccountService.create`` SQL 진입 이전에 `VALIDATION_ERROR` + exit 1로
+    # 거부한다. 미적용 시 ``svc.create``가 `EXECUTION_ERROR`/empty로 떨어져
+    # invalid ingress가 not-found 의미와 구별되지 않는다.
+    # ``validate_new_account_id``는 RESTRICTED-aware라 lookup-policy의
+    # ``require_account_id``와 달리 ``test`` 같은 bootstrap seed id도 거부한다.
+    account_id_opt = reject_invalid_new_account_id(
+        account_id_opt, fmt, context="cli.account.create"
+    )
+
     # 2) broker_type enum 검증 (BROKER_REGISTRY SSOT)
     _validate_broker_type(fmt, broker_type)
 
@@ -831,6 +843,16 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
     # cold-path: confirm 통과 직후 active runtime 차단
     _assert_no_active_runtime(fmt)
 
+    # ingress 검증 (#1724, D follow-up — #1634 동형). invalid account_id
+    # (`default`/패턴 위반)를 ``AccountService.delete`` SQL 진입 이전에
+    # `VALIDATION_ERROR` + exit 1로 거부한다. 미적용 시 ``svc.delete``가
+    # ``AccountNotFoundError``로 raise되어 invalid ingress가 not-found 의미와
+    # 구별되지 않는다. positional required arg라 omitted가 없어 전 입력을
+    # 검증한다.
+    validated_account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.account.delete"
+    )
+
     from ante.account.errors import (
         AccountDeletedError,
         AccountHasActiveBotsError,
@@ -840,7 +862,7 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
     async def _do_delete() -> None:
         svc, db = await _create_account_service()
         try:
-            await svc.delete(account_id, deleted_by=member_id)
+            await svc.delete(validated_account_id, deleted_by=member_id)
         finally:
             await db.close()
 
@@ -863,7 +885,7 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
         fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
         raise SystemExit(1) from e
 
-    fmt.success(f'계좌 "{account_id}" 삭제 완료')
+    fmt.success(f'계좌 "{validated_account_id}" 삭제 완료')
 
 
 # ── credentials ──────────────────────────────────────
@@ -963,12 +985,21 @@ def account_set_credentials(
     # cold-path: active runtime이 있으면 진입 직후 차단
     _assert_no_active_runtime(fmt)
 
+    # ingress 검증 (#1724, D follow-up — #1634 동형). invalid account_id
+    # (`default`/패턴 위반)를 ``svc.get`` lookup 이전에 `VALIDATION_ERROR` +
+    # exit 1로 거부한다. 미적용 시 ``svc.get``이 ``AccountNotFoundError``로
+    # raise되어 invalid ingress가 not-found 의미와 구별되지 않는다. positional
+    # required arg라 omitted가 없어 전 입력을 검증한다.
+    validated_account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.account.set-credentials"
+    )
+
     from ante.account.presets import BROKER_PRESETS
 
     async def _do_set_credentials() -> None:
         svc, db = await _create_account_service()
         try:
-            acct = await svc.get(account_id)
+            acct = await svc.get(validated_account_id)
             preset = BROKER_PRESETS.get(acct.broker_type)
             if not preset or not preset.required_credentials:
                 # broker preset이 credentials를 요구하지 않는 경우(예: 향후 broker)
@@ -1010,8 +1041,8 @@ def account_set_credentials(
                 file_pairs=credentials_file,
             )
 
-            await svc.update(account_id, credentials=new_credentials)
-            fmt.success(f'계좌 "{account_id}" 인증 정보 재설정 완료')
+            await svc.update(validated_account_id, credentials=new_credentials)
+            fmt.success(f'계좌 "{validated_account_id}" 인증 정보 재설정 완료')
         finally:
             await db.close()
 
@@ -1060,6 +1091,16 @@ def account_repair_timezone(
     # ``_create_account_service`` 자체가 호출되지 않아야 한다.
     _assert_no_active_runtime(fmt)
 
+    # ingress 검증 (#1724, D follow-up — #1634 동형). invalid account_id
+    # (`default`/패턴 위반)를 ``svc.repair_timezone`` 진입 이전에
+    # `VALIDATION_ERROR` + exit 1로 거부한다. 미적용 시 service-layer가
+    # ``AccountNotFoundError``로 raise되어 invalid ingress가 not-found 의미와
+    # 구별되지 않는다. positional required arg라 omitted가 없어 전 입력을
+    # 검증한다.
+    validated_account_id = reject_invalid_account_id(
+        account_id, fmt, context="cli.account.repair-timezone"
+    )
+
     from ante.account.errors import (
         AccountDeletedError,
         AccountNotFoundError,
@@ -1069,7 +1110,7 @@ def account_repair_timezone(
     async def _do_repair() -> Account:
         svc, db = await _create_account_service()
         try:
-            return await svc.repair_timezone(account_id, new_timezone)
+            return await svc.repair_timezone(validated_account_id, new_timezone)
         finally:
             await db.close()
 

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -762,6 +762,10 @@ class TestAccountCreate:
         self, mock_account_service: AsyncMock, offline_runtime
     ) -> None:
         """``BROKER_REGISTRY`` 미등록 broker_type은 입력 단계에서 거부한다."""
+        # #1724: account-id ingress 검증이 _validate_broker_type 직전에 배치되어,
+        # invalid pattern (``"x"`` 1자)은 broker_type 검증에 도달하기 전에 먼저
+        # 거부된다. 본 테스트의 의도는 broker_type 거부이므로 account_id는 valid
+        # 패턴을 사용한다.
         result = _invoke(
             [
                 "account",
@@ -769,7 +773,7 @@ class TestAccountCreate:
                 "--broker-type",
                 "no-such-broker",
                 "--account-id",
-                "x",
+                "valid-x",
                 "--name",
                 "X",
                 "--trading-mode",

--- a/tests/unit/test_cli_account_invalid_id_ingress.py
+++ b/tests/unit/test_cli_account_invalid_id_ingress.py
@@ -1,0 +1,315 @@
+"""제공된 invalid ``account_id`` cold-path CLI ingress 거부 회귀 (#1724).
+
+#1634 Split A가 read-only account-scoped CLI(``account info``/``credentials``/
+``suspend``/``activate``)에 적용한 ``reject_invalid_account_id`` 패턴을
+나머지 cold-path 4 명령(``account create``/``delete``/``set-credentials``/
+``repair-timezone``)으로 동형 확장한다.
+
+본 PR 이전 상태(drift):
+
+- ``account create default`` → ``EXECUTION_ERROR`` raw or empty (svc.create
+  내부에서 RESTRICTED 차단 실패 메시지 노출).
+- ``account delete default`` → ``ACCOUNT_NOT_FOUND`` 오분류 (svc.delete
+  lookup이 SQL miss).
+- ``account set-credentials default`` → ``ACCOUNT_NOT_FOUND`` 오분류 (svc.get
+  lookup이 SQL miss).
+- ``account repair-timezone default`` → ``ACCOUNT_NOT_FOUND`` 오분류.
+
+본 PR이 적용된 후:
+
+- create-path는 :func:`reject_invalid_new_account_id` (RESTRICTED-aware)
+  helper로 거부 → ``VALIDATION_ERROR`` + exit 1.
+- delete/set-credentials/repair-timezone은 :func:`reject_invalid_account_id`
+  (lookup-policy) helper로 거부 → ``VALIDATION_ERROR`` + exit 1.
+
+검증축 (이슈 #1724 Verification SSOT, plan R1-R10 압축):
+
+- R1-R8: 4 명령 × {``default``, ``bad_id``} → ``VALIDATION_ERROR``
+  (parameterized; service-layer 미호출 단정).
+- R9: ``account delete nonexistent-acc-1 --yes`` (valid format, missing) →
+  ``ACCOUNT_NOT_FOUND`` 보존 (VALIDATION_ERROR 과적용 0).
+- R10: ``account create --account-id valid-acc-1 ...`` → 정상 생성 (회귀 0).
+
+에러 코드 SSOT는 #1633 선결정으로 고정된
+``InvalidAccountIdError.code == "VALIDATION_ERROR"``를 재사용한다(신 코드 0).
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+
+# 제공된 invalid account_id 입력:
+# - ``default``: RESTRICTED_NEW_ACCOUNT_IDS / lookup-invalid 양쪽 모두 거부.
+# - ``bad_id``: ``ACCOUNT_ID_PATTERN`` (``^[a-zA-Z0-9-]{3,30}$``) 위반 (underscore).
+# 8 명령 × 2 invalid = R1-R8.
+_INVALID_IDS = ["default", "bad_id"]
+
+# 패턴 유효(``^[a-zA-Z0-9-]{3,30}$``)·미존재 account_id. invalid-format ↔
+# valid-absent 분리 단정용 (R9).
+_VALID_ABSENT = "nonexistent-acc-1"
+
+# 정상 account_id (R10 회귀 0 검증).
+_VALID_PRESENT = "valid-acc-1"
+
+
+def _mock_account_obj(account_id: str = _VALID_PRESENT) -> Any:
+    """svc.create / svc.repair_timezone 반환값으로 사용할 Account stub."""
+    from ante.account.models import Account, AccountStatus, TradingMode
+
+    return Account(
+        account_id=account_id,
+        name="ValidAcc",
+        exchange="TEST",
+        currency="KRW",
+        broker_type="test",
+        status=AccountStatus("active"),
+        trading_mode=TradingMode("virtual"),
+        credentials={"app_key": "K", "app_secret": "S"},
+        buy_commission_rate=Decimal("0.00015"),
+        sell_commission_rate=Decimal("0.00195"),
+    )
+
+
+# ── fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """인증 우회 — ``test_cli_account_reserve_buffer_validation.py`` 패턴 동형."""
+    from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+    mock_member = Member(
+        member_id="tester",
+        name="테스터",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        status=MemberStatus.ACTIVE,
+        scopes=[],
+    )
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": mock_member}),
+    ):
+        yield
+
+
+@pytest.fixture
+def offline_runtime():
+    """cold-path active runtime guard 통과 — ingress 검증이 차단되어야 함을 단정.
+
+    cold-path 4 명령은 모두 ``_assert_no_active_runtime``을 호출하므로 본 PR의
+    ingress 검증이 그 이후에 동작한다. 본 fixture가 guard를 통과시키는 게
+    중요하다 (guard에서 미리 차단되면 ingress drift를 단정할 수 없다).
+    """
+    with (
+        patch("ante.main.read_pid_file", return_value=None),
+        patch(
+            "ante.cli.commands.ipc_helpers.get_socket_path",
+            return_value="/tmp/__ante_offline_invalid_id_ingress_test__.sock",
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_account_service():
+    """``_create_account_service``를 mock해 DB 접근을 차단한다."""
+    svc = AsyncMock()
+    db = AsyncMock()
+
+    async def _create_service():
+        return svc, db
+
+    with patch(
+        "ante.cli.commands.account._create_account_service", new=_create_service
+    ):
+        yield svc
+
+
+def _runner() -> CliRunner:
+    return CliRunner()
+
+
+def _invoke(args: list[str]) -> Any:
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return _runner().invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _assert_validation_error(result: Any) -> None:
+    """invalid account_id 거부 envelope 단정.
+
+    - exit code 1
+    - JSON envelope ``status=error`` + ``code="VALIDATION_ERROR"``
+    - not-found 오분류 어휘 부재 (raw traceback / NOT NULL 누출 부재)
+    """
+    assert result.exit_code == 1, (
+        f"expected exit=1, got exit={result.exit_code} output={result.output!r}"
+    )
+    # JSON envelope는 stdout의 마지막 라인이다 (text mode print 잔재 차단).
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["status"] == "error", payload
+    assert payload["code"] == "VALIDATION_ERROR", payload
+    # not-found 오분류 차단.
+    assert "ACCOUNT_NOT_FOUND" not in result.output, result.output
+    # raw traceback 누출 차단.
+    assert "Traceback" not in result.output, result.output
+
+
+# ── argv builders ────────────────────────────────────────────────────
+
+
+def _argv_create(account_id: str) -> list[str]:
+    """``account create --account-id <id> ...`` argv (option 표면)."""
+    return [
+        "--format",
+        "json",
+        "account",
+        "create",
+        "--broker-type",
+        "test",
+        "--account-id",
+        account_id,
+        "--name",
+        "X",
+        "--trading-mode",
+        "virtual",
+        "--credential",
+        "app_key=K",
+        "--credential",
+        "app_secret=S",
+    ]
+
+
+def _argv_delete(account_id: str) -> list[str]:
+    """``account delete <id> --yes`` argv (positional 표면)."""
+    return [
+        "--format",
+        "json",
+        "account",
+        "delete",
+        account_id,
+        "--yes",
+    ]
+
+
+def _argv_set_credentials(account_id: str) -> list[str]:
+    """``account set-credentials <id> --credential ...`` argv (positional 표면)."""
+    return [
+        "--format",
+        "json",
+        "account",
+        "set-credentials",
+        account_id,
+        "--credential",
+        "app_key=K",
+        "--credential",
+        "app_secret=S",
+    ]
+
+
+def _argv_repair_timezone(account_id: str) -> list[str]:
+    """``account repair-timezone <id> <new_timezone>`` argv (positional 표면)."""
+    return [
+        "--format",
+        "json",
+        "account",
+        "repair-timezone",
+        account_id,
+        "Asia/Seoul",
+    ]
+
+
+_ARGV_BUILDERS = {
+    "create": _argv_create,
+    "delete": _argv_delete,
+    "set-credentials": _argv_set_credentials,
+    "repair-timezone": _argv_repair_timezone,
+}
+
+
+# ── 축 1: R1-R8 — 4 cold-path 명령 × {default, bad_id} → VALIDATION_ERROR ──
+
+
+@pytest.mark.parametrize(
+    "subcommand",
+    ["create", "delete", "set-credentials", "repair-timezone"],
+)
+@pytest.mark.parametrize("invalid_id", _INVALID_IDS)
+class TestInvalidAccountIdRejected:
+    """4 cold-path 명령이 invalid account_id를 service 진입 이전에 거부.
+
+    parametrize 매트릭스 = 4 명령 × 2 invalid = R1-R8.
+    """
+
+    def test_invalid_id_returns_validation_error(
+        self,
+        mock_account_service: AsyncMock,
+        offline_runtime: Any,
+        subcommand: str,
+        invalid_id: str,
+    ) -> None:
+        """invalid account_id → exit 1, VALIDATION_ERROR, service 미호출."""
+        argv = _ARGV_BUILDERS[subcommand](invalid_id)
+        result = _invoke(argv)
+        _assert_validation_error(result)
+        # ingress 거부 → service 메서드는 어느 것도 호출되지 않아야 한다.
+        mock_account_service.create.assert_not_called()
+        mock_account_service.delete.assert_not_called()
+        mock_account_service.get.assert_not_called()
+        mock_account_service.update.assert_not_called()
+        mock_account_service.repair_timezone.assert_not_called()
+
+
+# ── 축 2: R9 — valid format / absent → ACCOUNT_NOT_FOUND 보존 ────────
+
+
+class TestValidButAbsentNotMisclassified:
+    """패턴 유효·미존재 account_id는 invalid-format으로 오분류되지 않는다.
+
+    (Codex next-step 동형: invalid-format ↔ valid-absent 분리, VALIDATION_ERROR
+    과적용 0)
+    """
+
+    def test_account_delete_valid_absent_keeps_not_found(
+        self, mock_account_service: AsyncMock, offline_runtime: Any
+    ) -> None:
+        """``account delete nonexistent-acc-1 --yes`` → ``ACCOUNT_NOT_FOUND`` 보존."""
+        from ante.account.errors import AccountNotFoundError
+
+        mock_account_service.delete.side_effect = AccountNotFoundError(
+            "계좌를 찾을 수 없습니다"
+        )
+        result = _invoke(_argv_delete(_VALID_ABSENT))
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output.strip().splitlines()[-1])
+        # ingress 통과 → not-found 경로 도달 (VALIDATION_ERROR 아님).
+        assert payload.get("code") != "VALIDATION_ERROR", payload
+        assert payload.get("code") == "ACCOUNT_NOT_FOUND", payload
+        mock_account_service.delete.assert_awaited_once()
+
+
+# ── 축 3: R10 — 정상 create → 정상 생성 (회귀 0) ──────────────────────
+
+
+class TestValidAccountIdRegression:
+    """정상 account_id ``account create``는 기존 동작을 유지한다."""
+
+    def test_account_create_valid_ok(
+        self, mock_account_service: AsyncMock, offline_runtime: Any
+    ) -> None:
+        """``account create --account-id valid-acc-1 ...`` → 정상 생성."""
+        mock_account_service.create.return_value = _mock_account_obj(_VALID_PRESENT)
+        result = _invoke(_argv_create(_VALID_PRESENT))
+        assert result.exit_code == 0, result.output
+        # ingress 통과 → svc.create 호출 + valid id 전달.
+        mock_account_service.create.assert_awaited_once()
+        new_account = mock_account_service.create.call_args.args[0]
+        assert new_account.account_id == _VALID_PRESENT

--- a/tests/unit/test_cli_validators.py
+++ b/tests/unit/test_cli_validators.py
@@ -13,12 +13,17 @@
 
 from __future__ import annotations
 
+import json
 import math
 
 import click
 import pytest
 
-from ante.cli._validators import validate_nonnegative_finite_amount
+from ante.cli._validators import (
+    reject_invalid_new_account_id,
+    validate_nonnegative_finite_amount,
+)
+from ante.cli.formatter import OutputFormatter
 
 
 class TestValidateNonnegativeFiniteAmount:
@@ -58,3 +63,73 @@ class TestValidateNonnegativeFiniteAmount:
     def test_none_passes_through(self) -> None:
         """``None``(옵션 미지정)은 그대로 ``None`` 반환 (분기 보존)."""
         assert validate_nonnegative_finite_amount(None, None, None) is None
+
+
+class TestRejectInvalidNewAccountId:
+    """``reject_invalid_new_account_id`` helper 단위 테스트 (#1724).
+
+    create-path 신규 account_id를 ``AccountService.create`` SQL 진입 이전에
+    `VALIDATION_ERROR` + `SystemExit(1)`로 거부하는지 단정한다. 동형 sibling
+    ``reject_invalid_account_id``와 달리 RESTRICTED-aware
+    (``validate_new_account_id`` 위임 — ``test`` 같은 bootstrap seed id도 거부).
+    """
+
+    def test_restricted_default_id_raises_system_exit(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``default``는 RESTRICTED → SystemExit(1), code=VALIDATION_ERROR."""
+        fmt = OutputFormatter(fmt="json")
+        with pytest.raises(SystemExit) as exc_info:
+            reject_invalid_new_account_id("default", fmt, context="cli.account.create")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out.strip().splitlines()[-1])
+        assert envelope["status"] == "error"
+        assert envelope["code"] == "VALIDATION_ERROR"
+
+    def test_pattern_violation_raises_system_exit(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``bad_id`` (underscore — 패턴 위반) → SystemExit(1), VALIDATION_ERROR."""
+        fmt = OutputFormatter(fmt="json")
+        with pytest.raises(SystemExit) as exc_info:
+            reject_invalid_new_account_id("bad_id", fmt, context="cli.account.create")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out.strip().splitlines()[-1])
+        assert envelope["code"] == "VALIDATION_ERROR"
+
+    def test_empty_string_raises_system_exit(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``""``는 형식 위반 → SystemExit(1), VALIDATION_ERROR."""
+        fmt = OutputFormatter(fmt="json")
+        with pytest.raises(SystemExit) as exc_info:
+            reject_invalid_new_account_id("", fmt, context="cli.account.create")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out.strip().splitlines()[-1])
+        assert envelope["code"] == "VALIDATION_ERROR"
+
+    def test_none_raises_system_exit(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """``None``은 형식 위반 → SystemExit(1), VALIDATION_ERROR.
+
+        ``reject_invalid_account_id``(lookup-policy)와 달리 create-path는
+        ``None``도 정상 입력으로 받지 않는다 (``validate_new_account_id``
+        계약).
+        """
+        fmt = OutputFormatter(fmt="json")
+        with pytest.raises(SystemExit) as exc_info:
+            reject_invalid_new_account_id(None, fmt, context="cli.account.create")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out.strip().splitlines()[-1])
+        assert envelope["code"] == "VALIDATION_ERROR"
+
+    def test_valid_account_id_returns_value(self) -> None:
+        """valid한 account_id는 그대로 반환 (정상 통과)."""
+        fmt = OutputFormatter(fmt="json")
+        result = reject_invalid_new_account_id(
+            "valid-acc-1", fmt, context="cli.account.create"
+        )
+        assert result == "valid-acc-1"


### PR DESCRIPTION
Closes #1724

## Summary

oracle A7 invalid-input contract enforcement: 4 cold-path account CLI 명령(`create`, `delete`, `set-credentials`, `repair-timezone`)이 `default`(RESTRICTED)/패턴 위반 `bad_id`를 ingress에서 거부하지 않아 `ACCOUNT_NOT_FOUND`(misroute) 또는 empty/EXECUTION_ERROR로 떨어지던 contract bug를 fix.

- **새 helper** `reject_invalid_new_account_id` (sibling `reject_invalid_account_id`와 byte-for-byte 동형, delegate만 `validate_new_account_id`).
- **scoping.py 정렬**: `validate_new_account_id`에 `*, context: str = ""` 파라미터 추가 (require_account_id 동형, backward-compatible).
- **4 명령 ingress**: account_create(\`validate_new_account_id\` wrapper), account_delete/set-credentials/repair-timezone(\`require_account_id\` wrapper).
- **기존 4 명령 (info/suspend/activate/credentials)**: #1634 Split A로 이미 SSOT 적용 — 변경 없음.

## Plan Preflight

이슈 본문 Implementation Plan v3 (narrow-scope, bounded-soundness orchestrator-attested). Codex Plan Review 3 라운드(v1 revise → v2 revise signature nitpick → v3 narrow-scope final). Codex 브랜치 리뷰 2 라운드(v1 FAIL byte-for-byte → v2 PASS).

## Test Plan

- [x] R1-R8 parameterized: 4 명령 × (default, bad_id) → exit 1, JSON \`code="VALIDATION_ERROR"\`
- [x] R9 sanity: \`account delete nonexistent-acc-1 --yes\` (valid-but-missing) → \`code="ACCOUNT_NOT_FOUND"\` (회귀 보존)
- [x] R10 sanity: \`account create --account-id valid-acc-1 ...\` → exit 0, 정상 생성
- [x] 새 helper 단위 테스트 5건 PASS
- [x] 기존 helper \`reject_invalid_account_id\` 회귀 0
- [x] \`pytest\` 좁은 범위 4 파일 (101 PASS) + 확장 회귀 14 파일 (315 PASS)
- [x] \`mypy src/\`: 216 files PASS
- [x] \`ruff check src/ tests/\` + \`ruff format --check src/ tests/\`: PASS
- [x] \`generate_project_structure.py\`: 신규 test 1 반영 정합
- [x] Codex 브랜치 리뷰 v2 PASS (9 invariants, 0 blocking)
- [x] 메인 repo HEAD 불변 확인 (8c2ec9b 유지)

## Non-Goals

- IPC layer ingress validation (현재 cold-path만)
- helper 일반화 (parametrized mode)
- \`validate_new_account_id\` RESTRICTED 정책 변경
- \`ACCOUNT_ID_PATTERN\` 변경
- 신규 IPC 핸들러 도입
- 기존 4 명령(info/suspend/activate/credentials) 변경