### PR TITLE
fix: #1725 treasury status/snapshot valid-but-missing account_id에 ACCOUNT_NOT_FOUND 반환 + hang 차단

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -551,7 +551,8 @@ tests/
 │   ├── test_cli_account_crypto_error.py
 │   ├── test_cli_account_reserve_buffer_validation.py
 │   ├── test_cli_validators.py
-│   └── test_cli_account_invalid_id_ingress.py
+│   ├── test_cli_account_invalid_id_ingress.py
+│   └── test_cli_treasury_account_not_found.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 
 import click
 
+from ante.account.errors import AccountNotFoundError
 from ante.cli._validators import (
     reject_invalid_account_id,
     reject_inverted_date_range,
@@ -20,6 +22,8 @@ from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id as _get_member_id
 from ante.cli.middleware import require_auth, require_scope
 
+logger = logging.getLogger(__name__)
+
 
 @click.group()
 def treasury() -> None:
@@ -31,6 +35,17 @@ def _run(coro):  # noqa: ANN001, ANN202
 
 
 async def _create_treasury(account_id: str | None = None):  # noqa: ANN202
+    """CLI에서 Treasury를 생성하는 헬퍼.
+
+    ``db.connect()`` 이후의 모든 라이프사이클(``AccountService.initialize`` /
+    ``AccountService.get`` / ``Treasury.initialize`` 포함)을 ``except
+    BaseException`` 블록으로 감싸 실패 시 ``db.close()``를 보장한다.
+    valid-but-missing account_id(예: ``acc-9999``)가 들어오면
+    ``account_service.get``이 :class:`AccountNotFoundError`를 raise하는데,
+    이 때 aiosqlite 연결이 leak되어 asyncio 종료 시 busy_timeout 대기로 CLI
+    프로세스가 6초 이상 hang하는 회귀를 차단한다(#1725). 본 패턴은
+    ``_create_account_service`` (#1722) byte-for-byte 동형이다.
+    """
     from ante.account.scoping import require_account_id
     from ante.account.service import AccountService
     from ante.cli.main import get_db_path
@@ -41,25 +56,40 @@ async def _create_treasury(account_id: str | None = None):  # noqa: ANN202
     validated_account_id = require_account_id(account_id, context="cli.treasury")
 
     db = Database(get_db_path())
-    await db.connect()
-    eventbus = EventBus()
-    account_service = AccountService(db=db, eventbus=eventbus)
-    await account_service.initialize()
-
-    account = await account_service.get(validated_account_id)
-    t = Treasury(
-        db,
-        eventbus,
-        account_id=account.account_id,
-        currency=account.currency,
-        buy_commission_rate=float(account.buy_commission_rate),
-        sell_commission_rate=float(account.sell_commission_rate),
-    )
-    await t.initialize()
+    try:
+        await db.connect()
+        eventbus = EventBus()
+        account_service = AccountService(db=db, eventbus=eventbus)
+        await account_service.initialize()
+        account = await account_service.get(validated_account_id)
+        t = Treasury(
+            db,
+            eventbus,
+            account_id=account.account_id,
+            currency=account.currency,
+            buy_commission_rate=float(account.buy_commission_rate),
+            sell_commission_rate=float(account.sell_commission_rate),
+        )
+        await t.initialize()
+    except BaseException:
+        try:
+            await db.close()
+        except Exception:
+            logger.debug(
+                "db.close() after init failure raised — ignored", exc_info=True
+            )
+        raise
     return t, db
 
 
 async def _create_treasury_manager():  # noqa: ANN202
+    """CLI에서 TreasuryManager를 생성하는 헬퍼.
+
+    ``_create_treasury`` 동형 cleanup 패턴(#1722). 현재 사용처
+    (``budgets``/``portfolio value`` no-account 분기)는 valid-but-missing
+    account_id를 직접 처리하지 않지만, defense-in-depth로 ``initialize_all``
+    / ``account_service.list`` 등 lifecycle 실패 시에도 db.close를 보장한다.
+    """
     from ante.account.service import AccountService
     from ante.cli.main import get_db_path
     from ante.core.database import Database
@@ -67,12 +97,21 @@ async def _create_treasury_manager():  # noqa: ANN202
     from ante.treasury.manager import TreasuryManager
 
     db = Database(get_db_path())
-    await db.connect()
-    eventbus = EventBus()
-    account_service = AccountService(db=db, eventbus=eventbus)
-    await account_service.initialize()
-    manager = TreasuryManager(db=db, eventbus=eventbus)
-    await manager.initialize_all(await account_service.list())
+    try:
+        await db.connect()
+        eventbus = EventBus()
+        account_service = AccountService(db=db, eventbus=eventbus)
+        await account_service.initialize()
+        manager = TreasuryManager(db=db, eventbus=eventbus)
+        await manager.initialize_all(await account_service.list())
+    except BaseException:
+        try:
+            await db.close()
+        except Exception:
+            logger.debug(
+                "db.close() after init failure raised — ignored", exc_info=True
+            )
+        raise
     return manager, db
 
 
@@ -101,7 +140,15 @@ def status(ctx: click.Context, account_id: str) -> None:
         finally:
             await db.close()
 
-    result = _run(_run_status())
+    # valid-but-missing account_id(예: `acc-9999`)는 `account_service.get`에서
+    # `AccountNotFoundError`로 raise된다. Click 기본 핸들러가 typed exception을
+    # 모르고 traceback/빈 stdout으로 새던 contract-drift를 본 매핑이 닫는다
+    # (#1725). 에러코드는 `ACCOUNT_NOT_FOUND` SSOT.
+    try:
+        result = _run(_run_status())
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
 
     if fmt.is_json:
         fmt.output(result)
@@ -492,7 +539,12 @@ def snapshot(
         finally:
             await db.close()
 
-    result = _run(_run_snapshot())
+    # valid-but-missing account_id 매핑은 status와 동형이다 (#1725).
+    try:
+        result = _run(_run_snapshot())
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
 
     if result is None:
         target = date_str or datetime.now(UTC).strftime("%Y-%m-%d")

--- a/tests/unit/test_cli_treasury_account_not_found.py
+++ b/tests/unit/test_cli_treasury_account_not_found.py
@@ -1,0 +1,304 @@
+"""treasury CLI valid-but-missing account_id contract 회귀 (#1725).
+
+다음 5개 회귀를 잠근다 (이슈 본문 v2 Implementation Plan):
+
+- R1 hang 회귀 (status): ``ante treasury status --account acc-9999`` →
+  ``subprocess.run(timeout=5)`` 내 종료 + ``exit 1`` + JSON
+  ``code="ACCOUNT_NOT_FOUND"``.
+- R2 hang 회귀 (snapshot): ``ante treasury snapshot --account acc-9999`` →
+  동일.
+- R3 cleanup 회귀: in-process unit test로 ``account_service.get`` 이
+  raise할 때 ``Database.close`` 가 1회 await된다. 내부 필드 (``_writer`` /
+  ``_reader``) 직접 접근 금지 — public lifecycle ``Database.close`` 호출 사실로
+  검증 (#1722 R3 동형).
+- R4 sanity (status, valid existing): ``--account test`` → exit 0, status
+  payload. ``test`` 계좌는 ``ante init``이 ``create_default_test_account()``
+  로 자동 생성한다 (``scoping.py:36`` "test는 ante init 경로 전용 예약어").
+- R5 sanity (status, invalid `default`): ``--account default`` → exit 1,
+  ``code="VALIDATION_ERROR"`` (기존 ``reject_invalid_account_id`` 동작 보존).
+
+conftest fixture 격리: 모든 subprocess 호출에 명시 ``env={"PATH": ...,
+"HOME": ..., "ANTE_CONFIG_DIR": ..., "PYTHONPATH": ...}`` 만 전달한다.
+``ANTE_DB_ENCRYPTION_KEY`` 와 ``ANTE_MEMBER_TOKEN`` 은 명시 인자로만 주입한다.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+# subprocess timeout: hang 회귀를 5초 마진으로 차단한다. 정상 종료는 1-2초.
+_SUBPROCESS_TIMEOUT_S = 5.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _clean_env(
+    config_dir: Path, *, encryption_key: str | None = None, token: str | None = None
+) -> dict[str, str]:
+    """subprocess 환경 격리 헬퍼.
+
+    부모 프로세스의 ``ANTE_DB_ENCRYPTION_KEY`` / ``ANTE_MEMBER_TOKEN`` 등이
+    새는 것을 막기 위해 ``PATH`` / ``HOME`` / ``ANTE_CONFIG_DIR`` /
+    ``PYTHONPATH`` 만 명시적으로 전달한다 (#1722 ``test_cli_account_crypto_error``
+    동형).
+    """
+    env: dict[str, str] = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(config_dir)),
+        "ANTE_CONFIG_DIR": str(config_dir),
+        "PYTHONPATH": str(_repo_root() / "src"),
+    }
+    if encryption_key is not None:
+        env["ANTE_DB_ENCRYPTION_KEY"] = encryption_key
+    if token is not None:
+        env["ANTE_MEMBER_TOKEN"] = token
+    return env
+
+
+@pytest.fixture
+def initialized_config(tmp_path: Path) -> tuple[Path, str, str]:
+    """ante init을 완료한 (config_dir, token, encryption_key) 튜플을 만든다.
+
+    init은 ``create_default_test_account()`` 경로로 ``account_id='test'`` 시드
+    계좌를 자동 생성한다 (``scoping.py:36`` 참조). R4 sanity가 이 시드 계좌를
+    재사용한다. token/key는 후속 subprocess 호출에서 인증/암복호화에 쓰인다.
+    """
+    config_dir = tmp_path / "config"
+    key = Fernet.generate_key().decode()
+
+    init_env = _clean_env(config_dir, encryption_key=key)
+    result = subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", "init", "--name", "Repro"],
+        env=init_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"init 실패: exit={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    token = payload.get("token")
+    assert token, f"init 출력에 token 없음: {payload}"
+    return config_dir, token, key
+
+
+def _run_treasury_cli(
+    config_dir: Path,
+    token: str,
+    encryption_key: str,
+    args: list[str],
+) -> subprocess.CompletedProcess[str]:
+    """treasury CLI를 subprocess로 실행한다. timeout=5로 hang 회귀를 차단한다."""
+    env = _clean_env(config_dir, encryption_key=encryption_key, token=token)
+    return subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _parse_json_last(stdout: str) -> dict:
+    """JSON dict payload를 stdout에서 추출한다.
+
+    ``OutputFormatter.error`` 는 single-line JSON 한 줄로 dump하지만
+    ``OutputFormatter.output`` 은 indent=2로 multi-line dump한다. 우선 전체
+    stdout을 한 번에 ``json.loads`` 로 시도하고(success path), 실패하면 라인별
+    스캔으로 마지막 dict 라인을 찾는다 (error path: single-line).
+    """
+    stripped = stdout.strip()
+    if stripped.startswith("{"):
+        try:
+            obj = json.loads(stripped)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    last_obj: dict | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            last_obj = obj
+    assert last_obj is not None, f"JSON dict 라인을 stdout에서 찾지 못함: {stdout!r}"
+    return last_obj
+
+
+# ────────────────────────────────────────────────────────────────────
+# R1 / R2 — hang 회귀 + stable ACCOUNT_NOT_FOUND code (status/snapshot)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasuryStatusValidAbsentAccount:
+    def test_status_acc9999_exits_with_account_not_found_no_hang(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R1: status --account acc-9999 → exit 1, code=ACCOUNT_NOT_FOUND, no hang."""
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "status", "--account", "acc-9999"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "ACCOUNT_NOT_FOUND", payload
+
+
+class TestTreasurySnapshotValidAbsentAccount:
+    def test_snapshot_acc9999_exits_with_account_not_found_no_hang(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R2: snapshot --account acc-9999 → exit 1, code=ACCOUNT_NOT_FOUND, no hang."""
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "snapshot", "--account", "acc-9999"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "ACCOUNT_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R3 — cleanup 회귀 (in-process, Database.close spy)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestCreateTreasuryCleanup:
+    @pytest.mark.asyncio
+    async def test_account_not_found_calls_db_close(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``account_service.get`` 가 raise하면 ``Database.close`` 1회 await.
+
+        내부 필드(``_writer`` / ``_reader``)는 들여다보지 않고 public lifecycle
+        method ``Database.close`` 호출 사실로 검증한다 (#1722 R3 동형,
+        ``test_cli_account_crypto_error.py:204`` 참조).
+        """
+        from ante.account.errors import AccountNotFoundError
+        from ante.account.service import AccountService
+        from ante.cli.commands.treasury import _create_treasury
+        from ante.core.database import Database
+
+        # get_db_path는 ctx-less 경로에서 ANTE_CONFIG_DIR 기반으로 해석된다.
+        config_dir = tmp_path / "cfg"
+        (config_dir / "db").mkdir(parents=True)
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(config_dir))
+        # valid Fernet key를 env에 두어 db.connect까지는 통과시킨다.
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+        # AccountService.initialize는 통과시키고, AccountService.get에서
+        # AccountNotFoundError를 raise해 _create_treasury의 cleanup 경로를 친다.
+        async def passing_initialize(self: AccountService) -> None:
+            return None
+
+        async def raising_get(self: AccountService, account_id: str) -> object:
+            raise AccountNotFoundError(f"계좌를 찾을 수 없습니다: {account_id}")
+
+        # Database.close 를 AsyncMock으로 주입하고 await_count == 1로 검증한다.
+        # cleanup 호출 사실만 검증하면 충분하므로 실제 close 본체는 위임하지
+        # 않는다 (process 종료 시 임시 자원은 OS가 회수).
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            monkeypatch.setattr(AccountService, "initialize", passing_initialize)
+            monkeypatch.setattr(AccountService, "get", raising_get)
+
+            with pytest.raises(AccountNotFoundError):
+                await _create_treasury("acc-9999")
+
+        assert close_mock.await_count == 1, (
+            f"Database.close 가 정확히 1회 await되어야 한다 "
+            f"(await_count={close_mock.await_count})"
+        )
+
+
+# ────────────────────────────────────────────────────────────────────
+# R4 — sanity: valid existing `test` 계좌는 exit 0 + status payload
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasuryStatusValidExistingAccount:
+    def test_status_test_account_exits_with_status_payload(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R4: status --account test → exit 0, status payload.
+
+        ``test`` 계좌는 ``ante init`` 이 ``create_default_test_account()`` 경로로
+        자동 생성한다 (``scoping.py:36`` "test는 ante init 경로 전용 예약어").
+        """
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "status", "--account", "test"],
+        )
+        assert result.returncode == 0, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        # status payload는 fmt.output(dict)으로 dump되므로 envelope 없이 핵심
+        # 필드가 노출된다 (`account_balance` 등). 회귀의 sanity 보장만 하면
+        # 충분하므로 dict 키 존재만 확인한다.
+        assert "account_balance" in payload, payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R5 — sanity: invalid `default` → VALIDATION_ERROR (기존 동작 보존)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasuryStatusInvalidDefaultAccount:
+    def test_status_default_account_exits_with_validation_error(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R5: status --account default → exit 1, code=VALIDATION_ERROR.
+
+        ``reject_invalid_account_id`` 가 ``default`` 예약어를 거부하는 기존 동작이
+        본 PR로 깨지지 않는지 확인한다 (#1635 Split B Layer 1).
+        """
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "status", "--account", "default"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "VALIDATION_ERROR", payload


### PR DESCRIPTION
Closes #1725

## Summary

oracle A7 sibling of #1722 (merged): `treasury status --account acc-9999` / `treasury snapshot --account acc-9999` (valid-but-missing id)가 6s timeout (exit 124) + 빈 error code로 종료하던 contract bug fix.

- **\`_create_treasury\` cleanup**: try `connect+init+get` / except BaseException / inner `db.close` + logger.debug on close failure / re-raise. #1722 `_create_account_service`와 byte-for-byte 동형.
- **\`_create_treasury_manager\` cleanup**: 동형 defense-in-depth.
- **status/snapshot 매핑**: `except AccountNotFoundError → code="ACCOUNT_NOT_FOUND" + SystemExit(1)`.
- **자동 적용 (cleanup만)**: budgets/set-balance/portfolio value/portfolio history은 cleanup 자동 적용으로 hang은 해소되지만 explicit code 매핑은 별도 follow-up.

## Plan Preflight

이슈 본문 Implementation Plan v2 (narrow-scope, orchestrator-attested final). Codex Plan Review v1 narrow-scope (3 must-fix + 2 should-fix) → 인라인 흡수. Codex 브랜치 리뷰 1 라운드 PASS (8 invariants).

## Test Plan

- [x] R1: \`treasury status --account acc-9999\` → exit 1, JSON \`code="ACCOUNT_NOT_FOUND"\`, subprocess timeout=5 hang 차단
- [x] R2: \`treasury snapshot --account acc-9999\` → 동일
- [x] R3: cleanup spy in-process — \`AsyncMock close\` + \`await_count == 1\`
- [x] R4 sanity: \`treasury status --account test\` → exit 0, status payload (\`test\` = init 자동 생성 seed)
- [x] R5 sanity: \`treasury status --account default\` → exit 1, \`code="VALIDATION_ERROR"\` (기존 \`reject_invalid_account_id\` 동작 보존)
- [x] \`pytest\` 5 PASS + 전체 unit 4917 passed (143s)
- [x] \`mypy src/\`: 216 files PASS
- [x] \`ruff check src/ tests/\` + \`ruff format --check src/ tests/\`: PASS
- [x] \`generate_project_structure.py\`: idempotent
- [x] Codex 브랜치 리뷰 PASS

## Non-Goals

- AccountNotFoundError class attr `code` 추가 (B-category sweep, #1722 동일)
- \`treasury budgets\`/\`set-balance\`/\`portfolio value\`/\`portfolio history\` explicit `ACCOUNT_NOT_FOUND` 매핑 (별도 follow-up; cleanup은 본 PR로 자동 적용)
- IPC layer / Treasury internal lifecycle / 다른 ingress validation