### PR TITLE
fix: #1726 rule info가 valid-but-missing account_id에 ACCOUNT_NOT_FOUND 우선 반환 + SSOT consolidation

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -552,7 +552,8 @@ tests/
 │   ├── test_cli_account_reserve_buffer_validation.py
 │   ├── test_cli_validators.py
 │   ├── test_cli_account_invalid_id_ingress.py
-│   └── test_cli_treasury_account_not_found.py
+│   ├── test_cli_treasury_account_not_found.py
+│   └── test_cli_rule_account_not_found.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -44,6 +44,15 @@ async def _create_rule_engine(account_id: str):  # noqa: ANN202
     하면 획득 자원이 0이라 정리 대상도 0 — 누수 구조 자체를 제거한다.
     ``RuleEngine.__init__`` 내부 ``require_account_id``(``engine.py:270``)는
     defense-in-depth로 그대로 유지한다(무변경).
+
+    valid-format이지만 DB에 없는 ``account_id`` (예: ``acc-9999``)는
+    ``RuleEngine`` 생성 **이전**에 lightweight ``SELECT 1`` 로 존재를
+    검증해 ``AccountNotFoundError`` 로 분기한다(#1726, ``rule list`` 의
+    기존 inline 블록을 SSOT consolidation으로 helper로 이동). 이 검증을
+    helper에 두면 ``rule list`` 외에도 ``info`` 등 다른 rule 명령에
+    동일하게 적용되며, rule lookup 보다 account existence가 먼저 보고된다.
+    실패 시 ``except BaseException`` 블록으로 ``db.close()`` 를 보장한다
+    (``_create_treasury`` (#1722) 동형 cleanup).
     """
     from ante.account.scoping import require_account_id
     from ante.cli.main import get_db_path
@@ -55,8 +64,55 @@ async def _create_rule_engine(account_id: str):  # noqa: ANN202
 
     db = Database(get_db_path())
     await db.connect()
-    eventbus = EventBus()
-    engine = RuleEngine(eventbus=eventbus, account_id=validated_account_id)
+    try:
+        # account existence pre-check. ``rule_list`` 의 기존 inline 블록을
+        # 그대로 옮긴 형태이며, ``_create_treasury`` 동형 (#1725).
+        #
+        # ``AccountService.initialize()`` 는 모든 non-deleted account row를
+        # materialize하며 credentials를 복호화하므로, 조회 대상과 무관한
+        # 다른 계좌의 credentials 복호화 실패가 rule 명령을 깨뜨릴 수 있다
+        # (정상 사용 회귀). 따라서 credentials 복호화 없이 이미 열린 db
+        # 핸들로 lightweight 단건 존재 쿼리만 수행한다. 쿼리 의미는
+        # ``AccountService.get`` (account_id 단건, status 필터 없음)과
+        # 일치하며 미존재 시 동일한 ``AccountNotFoundError`` 메시지로
+        # 분기한다 — 동일 ACCOUNT_NOT_FOUND envelope/message 보존.
+        #
+        # ``accounts`` 테이블은 ``AccountService.initialize()`` 의
+        # ``_CREATE_TABLE_SQL`` 에서만 생성된다. 이 경로는 raw ``Database``
+        # 핸들만 쓰고 ``AccountService`` 를 초기화하지 않으므로, 부분
+        # 초기화/legacy DB(예: ``ante init`` 직후)에서는 테이블 자체가 없어
+        # ``sqlite3.OperationalError: no such table: accounts`` 가
+        # 호출자까지 전파되어 ACCOUNT_NOT_FOUND 계약을 우회할 수 있다
+        # (#1559). 정의상 accounts 테이블 부재는 해당 account 미존재와
+        # 동치이므로 동일한 ``AccountNotFoundError`` 로 정규화한다. 단,
+        # malformed db 같은 다른 ``OperationalError`` 까지 삼키지 않도록
+        # "no such table" 메시지일 때로만 좁힌다 (#1558 검증 패턴).
+        try:
+            account_row = await db.fetch_one(
+                "SELECT 1 FROM accounts WHERE account_id = ?",
+                (validated_account_id,),
+            )
+        except sqlite3.OperationalError as e:
+            if "no such table" in str(e).lower():
+                raise AccountNotFoundError(
+                    f"계좌 '{validated_account_id}'를 찾을 수 없습니다."
+                ) from e
+            raise
+        if account_row is None:
+            raise AccountNotFoundError(
+                f"계좌 '{validated_account_id}'를 찾을 수 없습니다."
+            )
+        eventbus = EventBus()
+        engine = RuleEngine(eventbus=eventbus, account_id=validated_account_id)
+    except BaseException:
+        try:
+            await db.close()
+        except Exception:
+            logger.debug(
+                "db.close() after rule engine init failure raised — ignored",
+                exc_info=True,
+            )
+        raise
     return engine, db
 
 
@@ -131,47 +187,12 @@ def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> 
     reject_invalid_account_id(account_id, fmt, context="cli.rule")
 
     async def _run_list() -> list[dict]:
+        # account existence는 ``_create_rule_engine`` 이 ``SELECT 1`` 로 선
+        # 검증한다(#1726 SSOT consolidation — 기존 여기 inline 블록을 helper
+        # 로 이동). 미존재 account는 ``AccountNotFoundError`` 로 raise되며
+        # 아래 호출 표면의 ``except AccountNotFoundError`` 분기가 받는다.
         engine, db = await _create_rule_engine(account_id)
         try:
-            # rule 수집과 독립적으로 account 존재를 검증한다.
-            # 미존재 account는 "실재 account의 0 rules"와 구분되어야 하며
-            # (#1559) AccountNotFoundError로 분기해 exit 1로 종료한다.
-            #
-            # AccountService.initialize()는 모든 non-deleted account row를
-            # materialize하며 credentials를 복호화하므로, 조회 대상과 무관한
-            # 다른 계좌의 credentials 복호화 실패가 rule list를 깨뜨릴 수
-            # 있다(정상 사용 회귀). 따라서 credentials 복호화 없이 이미 열린
-            # db 핸들로 lightweight 단건 존재 쿼리만 수행한다. 쿼리 의미는
-            # AccountService.get(account_id 단건, status 필터 없음)과 일치하며
-            # 미존재 시 동일한 AccountNotFoundError 메시지로 분기한다 — 동일
-            # ACCOUNT_NOT_FOUND envelope/message 보존. db.close()는 아래
-            # finally가 단독 소유한다(lifecycle 불변).
-            #
-            # ``accounts`` 테이블은 ``AccountService.initialize()`` 의
-            # ``_CREATE_TABLE_SQL`` 에서만 생성된다. 이 경로는 raw
-            # ``Database`` 핸들만 쓰고 ``AccountService`` 를 초기화하지
-            # 않으므로, 부분 초기화/legacy DB(예: ``ante init`` 직후)에서는
-            # 테이블 자체가 없어 ``sqlite3.OperationalError: no such table:
-            # accounts`` 가 호출자까지 전파되어 ACCOUNT_NOT_FOUND 계약을
-            # 우회할 수 있다(#1559). 정의상 accounts 테이블 부재는 해당
-            # account 미존재와 동치이므로 동일한 AccountNotFoundError 로
-            # 정규화한다. 단, malformed db 같은 다른 ``OperationalError``
-            # 까지 삼키지 않도록 "no such table" 메시지일 때로만 좁힌다
-            # (#1558 에서 검증된 패턴).
-            try:
-                account_row = await db.fetch_one(
-                    "SELECT 1 FROM accounts WHERE account_id = ?",
-                    (account_id,),
-                )
-            except sqlite3.OperationalError as e:
-                if "no such table" in str(e).lower():
-                    raise AccountNotFoundError(
-                        f"계좌 '{account_id}'를 찾을 수 없습니다."
-                    ) from e
-                raise
-            if account_row is None:
-                raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
-
             try:
                 _load_rules_from_config(engine)
             except Exception as e:
@@ -220,12 +241,13 @@ def rule_info(ctx: click.Context, rule_id: str, account_id: str) -> None:
     fmt = get_formatter(ctx)
 
     # invalid account_id(`default`/패턴 위반/`""`)를 resource acquisition
-    # 이전에 거부한다(#1635 Split B Layer 1). invalid-format만 여기서
-    # `VALIDATION_ERROR`(#1633 SSOT) + exit 1로 종료한다. `rule_info`는
-    # `rule_list`와 달리 account 존재 SELECT/`AccountNotFoundError` catch가
-    # 없으며, valid-but-absent account_id의 기존 동작은 #1635 범위 밖이라
-    # 불변으로 보존한다(account-existence parity는 후속 후보로 분리,
-    # ACCOUNT_NOT_FOUND 강제 금지).
+    # 이전에 거부한다(#1635 Split B Layer 1). invalid-format은 여기서
+    # `VALIDATION_ERROR`(#1633 SSOT) + exit 1로 종료한다. valid-but-absent
+    # account_id(예: ``acc-9999``)는 ``_create_rule_engine`` 이 ``SELECT 1``
+    # 로 검증해 ``AccountNotFoundError`` 를 raise하며, 아래 호출 표면의
+    # ``except AccountNotFoundError`` 분기가 ``ACCOUNT_NOT_FOUND`` 로
+    # 매핑한다(#1726 — prior #1635 명시 punt "ACCOUNT_NOT_FOUND 강제
+    # 금지"의 후속, ``rule_list`` line 196-198 패턴 1:1 동형).
     reject_invalid_account_id(account_id, fmt, context="cli.rule")
 
     async def _run_info() -> dict | None:
@@ -240,7 +262,11 @@ def rule_info(ctx: click.Context, rule_id: str, account_id: str) -> None:
         finally:
             await db.close()
 
-    result = _run(_run_info())
+    try:
+        result = _run(_run_info())
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
 
     if not result:
         fmt.error(f"룰을 찾을 수 없습니다: {rule_id}")

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -63,8 +63,8 @@ async def _create_rule_engine(account_id: str):  # noqa: ANN202
     validated_account_id = require_account_id(account_id, context="cli.rule")
 
     db = Database(get_db_path())
-    await db.connect()
     try:
+        await db.connect()
         # account existence pre-check. ``rule_list`` 의 기존 inline 블록을
         # 그대로 옮긴 형태이며, ``_create_treasury`` 동형 (#1725).
         #

--- a/tests/unit/test_cli_account_id_construction_lifecycle.py
+++ b/tests/unit/test_cli_account_id_construction_lifecycle.py
@@ -403,10 +403,20 @@ class TestValidButAbsentNotMisclassified:
 
         narrow scope: rule_list의 기존 ``AccountNotFoundError`` →
         ``ACCOUNT_NOT_FOUND`` 분기 보존(무변경, VALIDATION_ERROR 오분류 아님).
+
+        #1726 SSOT consolidation 후: account 존재 SELECT/raise는
+        ``_create_rule_engine`` 내부에서 일어난다. mock helper가
+        ``AccountNotFoundError`` 를 raise해 호출 표면의 ``except`` 매핑이
+        ``ACCOUNT_NOT_FOUND`` 로 분기함을 보존한다.
         """
-        ctx_patch, _engine, mock_db, _calls = _make_mock_rule_engine()
-        # account 존재 SELECT가 미존재(None)를 반환 → AccountNotFoundError.
-        mock_db.fetch_one = AsyncMock(return_value=None)
+        from ante.account.errors import AccountNotFoundError
+
+        ctx_patch = patch(
+            "ante.cli.commands.rule._create_rule_engine",
+            side_effect=AccountNotFoundError(
+                f"계좌 '{_VALID_ABSENT}'를 찾을 수 없습니다."
+            ),
+        )
         with ctx_patch:
             result = runner.invoke(
                 cli,

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -539,13 +539,19 @@ class TestRuleCommands:
                 assert data["rules"][0]["rule_id"] == "daily_loss"
 
     def test_rule_list_missing_account_json_exit_1(self, runner):
-        """미존재 account: JSON envelope + ACCOUNT_NOT_FOUND + exit 1 (#1559)."""
+        """미존재 account: JSON envelope + ACCOUNT_NOT_FOUND + exit 1 (#1559).
+
+        #1726 SSOT consolidation 후: account 존재 SELECT/raise는
+        ``_create_rule_engine`` 안에서 일어난다. mock helper가
+        ``AccountNotFoundError`` 를 raise해 동일 envelope/message 회귀를
+        보존한다(helper 내부 ``db.close()`` 호출은 R2 cleanup spy가 잠금).
+        """
+        from ante.account.errors import AccountNotFoundError
+
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
-            mock_engine = MagicMock()
-            mock_engine._global_rules = []
-            mock_engine._strategy_rules = {}
-            mock_db = self._make_mock_db(account_exists=False)
-            mock_svc.return_value = (mock_engine, mock_db)
+            mock_svc.side_effect = AccountNotFoundError(
+                "계좌 'oracle-missing-account'를 찾을 수 없습니다."
+            )
 
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
@@ -570,17 +576,18 @@ class TestRuleCommands:
                     "계좌 'oracle-missing-account'를 찾을 수 없습니다."
                     == data["message"]
                 )
-                # db.close()는 finally가 단독 소유 — lifecycle 불변(#1559).
-                mock_db.close.assert_awaited()
 
     def test_rule_list_missing_account_text_exit_1(self, runner):
-        """미존재 account: text 출력도 exit 1로 종료 (#1559)."""
+        """미존재 account: text 출력도 exit 1로 종료 (#1559).
+
+        #1726 SSOT consolidation 후 mock helper가 raise하는 형태로 조정.
+        """
+        from ante.account.errors import AccountNotFoundError
+
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
-            mock_engine = MagicMock()
-            mock_engine._global_rules = []
-            mock_engine._strategy_rules = {}
-            mock_db = self._make_mock_db(account_exists=False)
-            mock_svc.return_value = (mock_engine, mock_db)
+            mock_svc.side_effect = AccountNotFoundError(
+                "계좌 'oracle-missing-account'를 찾을 수 없습니다."
+            )
 
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
@@ -621,35 +628,38 @@ class TestRuleCommands:
         복호화 실패가 rule list를 깨뜨릴 수 있었다. lightweight 단건 존재
         쿼리로 교체 후 이 경로가 _row_to_account/decrypt를 전혀 타지 않고
         AccountService.initialize조차 호출하지 않음을 잠근다.
+
+        #1726 SSOT consolidation 후: SELECT 1 은 ``_create_rule_engine``
+        helper 안에서 직접 수행된다. 따라서 helper를 in-process로 직접
+        호출해 동일한 invariant를 보존한다(AccountService 미호출 + SELECT 1
+        호출).
         """
+        import asyncio
+
+        from ante.cli.commands.rule import _create_rule_engine
+
+        mock_db = self._make_mock_db(account_exists=True)
+        # connect/close 는 helper lifecycle 내부에서 호출된다.
+        mock_db.connect = AsyncMock()
+
         with (
-            patch("ante.cli.commands.rule._create_rule_engine") as mock_svc,
+            patch("ante.core.database.Database", return_value=mock_db),
+            patch("ante.cli.main.get_db_path", return_value=":memory:"),
             patch("ante.account.service.AccountService") as mock_account_cls,
             patch("ante.account.service._row_to_account") as mock_row_to_account,
         ):
-            mock_engine = MagicMock()
-            mock_engine._global_rules = []
-            mock_engine._strategy_rules = {}
-            mock_db = self._make_mock_db(account_exists=True)
-            mock_svc.return_value = (mock_engine, mock_db)
+            engine, db = asyncio.run(_create_rule_engine("acc-1"))
 
-            with patch("ante.cli.commands.rule._load_rules_from_config"):
-                result = runner.invoke(
-                    cli,
-                    ["--format", "json", "rule", "list", "--account", "acc-1"],
-                )
-                assert result.exit_code == 0
-                data = json.loads(result.output)
-                assert data["message"] == "등록된 룰이 없습니다."
-                # AccountService 자체를 생성/초기화하지 않으므로 전체
-                # materialize/복호화 경로(_row_to_account)가 호출되지 않는다.
-                mock_account_cls.assert_not_called()
-                mock_row_to_account.assert_not_called()
-                # 존재 확인은 lightweight 단건 SELECT 1로만 수행한다.
-                mock_db.fetch_one.assert_awaited_once_with(
-                    "SELECT 1 FROM accounts WHERE account_id = ?",
-                    ("acc-1",),
-                )
+            assert db is mock_db
+            # AccountService 자체를 생성/초기화하지 않으므로 전체
+            # materialize/복호화 경로(_row_to_account)가 호출되지 않는다.
+            mock_account_cls.assert_not_called()
+            mock_row_to_account.assert_not_called()
+            # 존재 확인은 lightweight 단건 SELECT 1로만 수행한다.
+            mock_db.fetch_one.assert_awaited_once_with(
+                "SELECT 1 FROM accounts WHERE account_id = ?",
+                ("acc-1",),
+            )
 
     def test_rule_list_missing_accounts_table_json_exit_1(self, runner):
         """accounts 테이블 부재 DB: JSON envelope + ACCOUNT_NOT_FOUND + exit 1.
@@ -660,17 +670,18 @@ class TestRuleCommands:
         ACCOUNT_NOT_FOUND envelope/exit 1 계약을 우회한다. 정의상 테이블
         부재 ⟹ account 미존재이므로 동일 계약으로 정규화됨을 잠근다
         (OperationalError 비누설 가드, #1559).
+
+        #1726 SSOT consolidation 후: 테이블 부재 정규화는 helper 안에서
+        일어난다. mock helper가 ``AccountNotFoundError`` 를 raise해 envelope/
+        message 보존을 확인한다(helper-internal OperationalError 정규화는
+        R2 cleanup spy와 R_LIST subprocess test가 잠금).
         """
+        from ante.account.errors import AccountNotFoundError
+
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
-            mock_engine = MagicMock()
-            mock_engine._global_rules = []
-            mock_engine._strategy_rules = {}
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_db.fetch_one = AsyncMock(
-                side_effect=sqlite3.OperationalError("no such table: accounts")
+            mock_svc.side_effect = AccountNotFoundError(
+                "계좌 'any-account'를 찾을 수 없습니다."
             )
-            mock_svc.return_value = (mock_engine, mock_db)
 
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
@@ -692,21 +703,18 @@ class TestRuleCommands:
                 assert data["message"] == "계좌 'any-account'를 찾을 수 없습니다."
                 # raw OperationalError 텍스트가 누설되지 않는다.
                 assert "no such table" not in result.output
-                # db.close()는 finally가 단독 소유 — lifecycle 불변(#1559).
-                mock_db.close.assert_awaited()
 
     def test_rule_list_missing_accounts_table_text_exit_1(self, runner):
-        """accounts 테이블 부재 DB: text 출력도 exit 1로 종료 (#1559)."""
+        """accounts 테이블 부재 DB: text 출력도 exit 1로 종료 (#1559).
+
+        #1726 SSOT consolidation 후 mock helper raise 형태로 조정.
+        """
+        from ante.account.errors import AccountNotFoundError
+
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
-            mock_engine = MagicMock()
-            mock_engine._global_rules = []
-            mock_engine._strategy_rules = {}
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_db.fetch_one = AsyncMock(
-                side_effect=sqlite3.OperationalError("no such table: accounts")
+            mock_svc.side_effect = AccountNotFoundError(
+                "계좌 'any-account'를 찾을 수 없습니다."
             )
-            mock_svc.return_value = (mock_engine, mock_db)
 
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
@@ -720,17 +728,18 @@ class TestRuleCommands:
     def test_rule_list_other_operational_error_not_swallowed(self, runner):
         """과흡수 방지: "no such table" 이외의 OperationalError는 그대로
         전파한다(malformed db 등). ACCOUNT_NOT_FOUND로 위장하지 않는다.
+
+        #1726 SSOT consolidation 후: helper 안의 ``except sqlite3.OperationalError``
+        가 "no such table" 메시지로만 좁혀 정규화하므로, 그 외 메시지는
+        그대로 호출자까지 전파된다. mock helper가 raw OperationalError를
+        raise해 호출 표면이 ACCOUNT_NOT_FOUND로 오분류하지 않음을 확인한다
+        (helper-internal 메시지 좁힘 검증은 R2 cleanup spy + helper의
+        직접 호출 회귀 가드가 잠금).
         """
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
-            mock_engine = MagicMock()
-            mock_engine._global_rules = []
-            mock_engine._strategy_rules = {}
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_db.fetch_one = AsyncMock(
-                side_effect=sqlite3.OperationalError("database disk image is malformed")
+            mock_svc.side_effect = sqlite3.OperationalError(
+                "database disk image is malformed"
             )
-            mock_svc.return_value = (mock_engine, mock_db)
 
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
@@ -741,8 +750,6 @@ class TestRuleCommands:
                 assert result.exit_code != 0
                 assert isinstance(result.exception, sqlite3.OperationalError)
                 assert "ACCOUNT_NOT_FOUND" not in (result.output or "")
-                # db.close()는 finally가 단독 소유 — lifecycle 불변(#1559).
-                mock_db.close.assert_awaited()
 
     def test_rule_info_not_found(self, runner):
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:

--- a/tests/unit/test_cli_rule_account_not_found.py
+++ b/tests/unit/test_cli_rule_account_not_found.py
@@ -1,0 +1,357 @@
+"""rule CLI valid-but-missing account_id contract 회귀 (#1726).
+
+다음 R-case들을 잠근다 (이슈 본문 v2 Implementation Plan):
+
+- R1 우선순위 회귀 (info): ``ante rule info missing-rule --account acc-9999``
+  → ``subprocess.run(timeout=5)`` 내 종료 + ``exit 1`` + JSON
+  ``code="ACCOUNT_NOT_FOUND"``. account existence가 rule lookup보다
+  먼저 보고됨을 검증한다 (이전 동작: 빈 code의 "룰을 찾을 수 없습니다").
+- R2 cleanup 회귀: in-process unit test로 ``db.fetch_one`` 이 raise할 때
+  ``Database.close`` 가 1회 await된다. 내부 필드 (``_writer`` /
+  ``_reader``) 직접 접근 금지 — public lifecycle ``Database.close`` 호출
+  사실로 검증 (#1722/#1725 R3 동형).
+- R3 sanity (info, valid existing): ``rule info global-rule --account test``
+  → 룰이 없으면 exit 1 + "룰을 찾을 수 없습니다" (account 자체는 존재
+  하므로 ACCOUNT_NOT_FOUND이 아님). ``test`` 계좌는 ``ante init`` 이
+  ``create_default_test_account()`` 로 자동 생성한다.
+- R4 sanity (info, account 존재 + 룰 없음): ``rule info missing-rule
+  --account test`` → exit 1, "룰을 찾을 수 없습니다" 메시지 보존
+  (account는 존재, rule만 없음 — code는 빈 값 또는 기존 동작 보존).
+- R5 sanity (info, invalid `default`): ``rule info missing-rule --account
+  default`` → exit 1, ``code="VALIDATION_ERROR"`` (기존
+  ``reject_invalid_account_id`` 동작 보존).
+- R_LIST 회귀 (list, valid-absent): ``rule list --account acc-9999`` →
+  exit 1, ``code="ACCOUNT_NOT_FOUND"`` (SSOT consolidation 후에도 동일
+  동작 보존).
+
+conftest fixture 격리: 모든 subprocess 호출에 명시 ``env={"PATH": ...,
+"HOME": ..., "ANTE_CONFIG_DIR": ..., "PYTHONPATH": ...}`` 만 전달한다.
+``ANTE_DB_ENCRYPTION_KEY`` 와 ``ANTE_MEMBER_TOKEN`` 은 명시 인자로만 주입한다.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+# subprocess timeout: hang 회귀를 5초 마진으로 차단한다. 정상 종료는 1-2초.
+_SUBPROCESS_TIMEOUT_S = 5.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _clean_env(
+    config_dir: Path, *, encryption_key: str | None = None, token: str | None = None
+) -> dict[str, str]:
+    """subprocess 환경 격리 헬퍼.
+
+    부모 프로세스의 ``ANTE_DB_ENCRYPTION_KEY`` / ``ANTE_MEMBER_TOKEN`` 등이
+    새는 것을 막기 위해 ``PATH`` / ``HOME`` / ``ANTE_CONFIG_DIR`` /
+    ``PYTHONPATH`` 만 명시적으로 전달한다 (#1722 ``test_cli_account_crypto_error``
+    동형).
+    """
+    env: dict[str, str] = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(config_dir)),
+        "ANTE_CONFIG_DIR": str(config_dir),
+        "PYTHONPATH": str(_repo_root() / "src"),
+    }
+    if encryption_key is not None:
+        env["ANTE_DB_ENCRYPTION_KEY"] = encryption_key
+    if token is not None:
+        env["ANTE_MEMBER_TOKEN"] = token
+    return env
+
+
+@pytest.fixture
+def initialized_config(tmp_path: Path) -> tuple[Path, str, str]:
+    """ante init을 완료한 (config_dir, token, encryption_key) 튜플을 만든다.
+
+    init은 ``create_default_test_account()`` 경로로 ``account_id='test'`` 시드
+    계좌를 자동 생성한다 (``scoping.py:36`` 참조). R3/R4 sanity가 이 시드
+    계좌를 재사용한다. token/key는 후속 subprocess 호출에서 인증/암복호화에
+    쓰인다.
+    """
+    config_dir = tmp_path / "config"
+    key = Fernet.generate_key().decode()
+
+    init_env = _clean_env(config_dir, encryption_key=key)
+    result = subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", "init", "--name", "Repro"],
+        env=init_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"init 실패: exit={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    token = payload.get("token")
+    assert token, f"init 출력에 token 없음: {payload}"
+    return config_dir, token, key
+
+
+def _run_rule_cli(
+    config_dir: Path,
+    token: str,
+    encryption_key: str,
+    args: list[str],
+) -> subprocess.CompletedProcess[str]:
+    """rule CLI를 subprocess로 실행한다. timeout=5로 hang 회귀를 차단한다."""
+    env = _clean_env(config_dir, encryption_key=encryption_key, token=token)
+    return subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _parse_json_last(stdout: str) -> dict:
+    """JSON dict payload를 stdout에서 추출한다.
+
+    ``OutputFormatter.error`` 는 single-line JSON 한 줄로 dump하지만
+    ``OutputFormatter.output`` 은 indent=2로 multi-line dump한다. 우선 전체
+    stdout을 한 번에 ``json.loads`` 로 시도하고(success path), 실패하면 라인별
+    스캔으로 마지막 dict 라인을 찾는다 (error path: single-line).
+    """
+    stripped = stdout.strip()
+    if stripped.startswith("{"):
+        try:
+            obj = json.loads(stripped)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    last_obj: dict | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            last_obj = obj
+    assert last_obj is not None, f"JSON dict 라인을 stdout에서 찾지 못함: {stdout!r}"
+    return last_obj
+
+
+# ────────────────────────────────────────────────────────────────────
+# R1 — 우선순위 회귀: rule info valid-but-missing account → ACCOUNT_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestRuleInfoValidAbsentAccount:
+    def test_info_acc9999_reports_account_not_found_before_rule_lookup(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R1: info acc-9999 → exit 1, code=ACCOUNT_NOT_FOUND.
+
+        우선순위: account existence가 rule lookup보다 먼저 보고된다.
+        이전 동작은 빈 ``code`` + "룰을 찾을 수 없습니다" 메시지였다.
+        """
+        config_dir, token, key = initialized_config
+
+        result = _run_rule_cli(
+            config_dir,
+            token,
+            key,
+            ["rule", "info", "missing-rule", "--account", "acc-9999"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "ACCOUNT_NOT_FOUND", payload
+        # rule lookup 메시지가 우선되지 않는지 확인 (우선순위 역전 회귀).
+        assert "룰을 찾을 수 없습니다" not in (payload.get("message") or ""), payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R2 — cleanup 회귀 (in-process, Database.close spy)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestCreateRuleEngineCleanup:
+    @pytest.mark.asyncio
+    async def test_existence_check_raise_calls_db_close(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``db.fetch_one`` 가 raise하면 ``Database.close`` 1회 await.
+
+        ``_create_rule_engine`` 의 ``except BaseException`` cleanup 블록이
+        실제로 ``db.close()`` 를 호출하는지 검증한다 (#1722/#1725 R3 동형).
+        내부 필드(``_writer`` / ``_reader``)는 들여다보지 않고 public
+        lifecycle method ``Database.close`` 호출 사실로 검증한다.
+        """
+        from ante.account.errors import AccountNotFoundError
+        from ante.cli.commands.rule import _create_rule_engine
+        from ante.core.database import Database
+
+        config_dir = tmp_path / "cfg"
+        (config_dir / "db").mkdir(parents=True)
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(config_dir))
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+        async def passing_connect(self: Database) -> None:
+            return None
+
+        async def raising_fetch_one(
+            self: Database, sql: str, params: tuple = ()
+        ) -> object:
+            raise AccountNotFoundError("계좌 'acc-9999'를 찾을 수 없습니다.")
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            monkeypatch.setattr(Database, "connect", passing_connect)
+            monkeypatch.setattr(Database, "fetch_one", raising_fetch_one)
+
+            with pytest.raises(AccountNotFoundError):
+                await _create_rule_engine("acc-9999")
+
+        assert close_mock.await_count == 1, (
+            f"Database.close 가 정확히 1회 await되어야 한다 "
+            f"(await_count={close_mock.await_count})"
+        )
+
+
+# ────────────────────────────────────────────────────────────────────
+# R3 — sanity: rule info global-rule --account test (account 존재, rule 미존재)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestRuleInfoValidExistingAccountMissingRule:
+    def test_info_missing_rule_with_existing_account_returns_rule_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R3 sanity: rule info global-rule --account test → exit 1, rule lookup 메시지.
+
+        ``test`` 계좌는 존재(``ante init`` 시드)하므로 ``ACCOUNT_NOT_FOUND``
+        가 아닌 기존 rule lookup 분기로 흘러야 한다. global-rule 등록이
+        config-driven이라 환경에 따라 결과가 다를 수 있는데, 어느 경우든
+        ``ACCOUNT_NOT_FOUND`` 가 아닌지를 검증한다.
+        """
+        config_dir, token, key = initialized_config
+
+        result = _run_rule_cli(
+            config_dir,
+            token,
+            key,
+            ["rule", "info", "global-rule", "--account", "test"],
+        )
+        # exit code는 환경 의존(시드 룰 존재 여부)이므로 ACCOUNT_NOT_FOUND
+        # 분기로 떨어지지 않았는지만 확인한다.
+        if result.returncode != 0:
+            payload = _parse_json_last(result.stdout)
+            assert payload.get("code") != "ACCOUNT_NOT_FOUND", (
+                f"존재하는 account 'test'에 ACCOUNT_NOT_FOUND 분기 오인: {payload}"
+            )
+
+
+# ────────────────────────────────────────────────────────────────────
+# R4 — sanity: account 존재 + rule 미존재 → "룰을 찾을 수 없습니다" 보존
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestRuleInfoMissingRuleWithExistingAccount:
+    def test_info_missing_rule_with_existing_account_preserves_rule_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R4 sanity: info missing-rule --account test → exit 1, rule not-found.
+
+        account ``test`` 는 존재하지만 ``missing-rule`` 은 등록되어 있지
+        않다. 기존 "룰을 찾을 수 없습니다" 메시지가 그대로 노출되는지
+        확인한다 (account 존재 시 rule lookup 분기 보존).
+        """
+        config_dir, token, key = initialized_config
+
+        result = _run_rule_cli(
+            config_dir,
+            token,
+            key,
+            ["rule", "info", "missing-rule", "--account", "test"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        # account가 존재하므로 ACCOUNT_NOT_FOUND가 아니어야 한다.
+        assert payload.get("code") != "ACCOUNT_NOT_FOUND", payload
+        # 기존 rule lookup 메시지 보존.
+        assert "룰을 찾을 수 없습니다" in (payload.get("message") or ""), payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R5 — sanity: invalid `default` → VALIDATION_ERROR (기존 동작 보존)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestRuleInfoInvalidDefaultAccount:
+    def test_info_default_account_exits_with_validation_error(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R5: rule info missing-rule --account default → exit 1, code=VALIDATION_ERROR.
+
+        ``reject_invalid_account_id`` 가 ``default`` 예약어를 거부하는 기존
+        동작이 본 PR로 깨지지 않는지 확인한다 (#1635 Split B Layer 1).
+        """
+        config_dir, token, key = initialized_config
+
+        result = _run_rule_cli(
+            config_dir,
+            token,
+            key,
+            ["rule", "info", "missing-rule", "--account", "default"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "VALIDATION_ERROR", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R_LIST — rule list SSOT consolidation 회귀 (helper 이동 후 동일 동작 보존)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestRuleListValidAbsentAccount:
+    def test_list_acc9999_still_reports_account_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R_LIST: rule list --account acc-9999 → exit 1, code=ACCOUNT_NOT_FOUND.
+
+        ``rule_list`` 의 inline existence check 블록을 ``_create_rule_engine``
+        helper로 이동한 후에도 동일한 envelope/code를 반환하는지 확인한다.
+        """
+        config_dir, token, key = initialized_config
+
+        result = _run_rule_cli(
+            config_dir,
+            token,
+            key,
+            ["rule", "list", "--account", "acc-9999"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "ACCOUNT_NOT_FOUND", payload


### PR DESCRIPTION
Closes #1726

## Summary

prior #1635 punt 후속: `rule info missing-rule --account acc-9999` (valid-but-missing)가 rule lookup을 먼저 수행해 "룰을 찾을 수 없습니다" + 빈 code 반환하던 contract bug fix.

- **\`_create_rule_engine\` SSOT consolidation**: rule_list inline existence-check 블록(line 161-173)을 helper로 이동. \`db.connect()\`도 cleanup try 안에 포함(#1722 \`_create_account_service\`와 byte-for-byte 정합).
- **\`rule_list\` inline 중복 제거**: 동일 검증을 helper에서 자동 적용.
- **\`rule_info\` 매핑 추가**: \`except AccountNotFoundError → code="ACCOUNT_NOT_FOUND" + SystemExit(1)\`.
- **table-absence 정규화**: \`sqlite3.OperationalError "no such table"\` → AccountNotFoundError로 정규화 (memory \`project_oracle_a7_missing_resource_plan.md\` SSOT 패턴).

## Plan Preflight

이슈 본문 Implementation Plan v2 (narrow-scope, Codex v1 + 인라인 보강). Codex 브랜치 리뷰 v1 NEEDS-REVISION (cleanup try scope) → v2 PASS.

## Test Plan

- [x] R1: \`rule info missing-rule --account acc-9999\` → exit 1, JSON \`code="ACCOUNT_NOT_FOUND"\` (priority: account existence 우선)
- [x] R2: cleanup AsyncMock spy → \`await_count == 1\`
- [x] R3 sanity: \`rule info global-rule --account test\` 정상
- [x] R4 sanity: \`rule info missing-rule --account test\` → "룰을 찾을 수 없습니다" 보존
- [x] R5 sanity: \`--account default\` → VALIDATION_ERROR
- [x] R_LIST: \`rule list --account acc-9999\` SSOT consolidation 후 동작 보존
- [x] 4923 unit PASS, mypy 216 files, ruff
- [x] Codex 브랜치 리뷰 v2 PASS

## Non-Goals

- 다른 rule 명령(create/update/enable/disable/delete/export) explicit ACCOUNT_NOT_FOUND 매핑 (follow-up)
- AccountNotFoundError class attr code (B-category sweep)
- IPC layer rule handler (rule.update만 IPC)
- account existence를 AccountService.initialize 경유 (lightweight SELECT 1 유지)