### PR TITLE
docs: #1728 #1698 epic 완료 후 stale 진행 문구 제거 (bot CLI usage + cli commands)

### DIFF
--- a/docs/specs/bot/06-cli-usage.md
+++ b/docs/specs/bot/06-cli-usage.md
@@ -19,12 +19,6 @@ DB의 persisted state를 직접 정리한다. 서버 실행 중 조회는 IPC로
 실행 중일 때만 동작하며, cold-path fallback은 없다. 정렬 계약은
 [cli/03-commands.md](../cli/03-commands.md#ante-bot--봇-관리)에 있다.
 
-> **구현 진행 상황 (#1698 epic)**: 본 절은 그 계약을 사전에 확정하는 SSOT다. 현재
-> main(`8479e53`)의 `ante bot --help`에는 `start/stop/status`가 아직 노출되지 않으며,
-> 실행 시 `No such command`로 실패한다. IPC handler 등록은 #1712, Click command
-> 등록과 `guide/cli.md` 재생성은 #1713에서 수행한다. 아래 사용 예시는 #1712 + #1713
-> merge 후 실행 가능한 형태다.
-
 ```bash
 # 전략 등록 후 봇 생성 — --account 필수 옵션 (active 계좌가 정확히 1개일 때만 생략 가능, 자동 선택)
 # active 계좌가 0개 또는 2개 이상이면 prompt 없이 BOT_MISSING_REQUIRED_ACCOUNT로 실패한다.

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -328,8 +328,6 @@ JSON 출력이 필요하면 root 전역 옵션을 사용한다:
 
 ### `ante bot` — 봇 관리
 
-> **구현 진행 상황 (#1698 epic)**: `start/stop/status`의 IPC handler 등록은 #1712, Click command 등록과 `guide/cli.md` 재생성은 #1713에서 수행한다. 본 절은 그 계약을 사전에 확정하는 SSOT다. 현재 main(`8479e53`)의 `ante bot --help`에는 `start/stop/status`가 아직 노출되지 않는다 — 사용자/Agent는 #1712 + #1713 merge 후 실행 가능하다.
-
 ```bash
 ante bot list [--account <account_id>]  # 봇 목록 (계좌별 필터링)
 ante bot create --name <name> --strategy <strategy_id> [--account <account_id>] [--id <bot_id>] [--interval <초>] [--param key=value ...]


### PR DESCRIPTION
Closes #1728

## Summary

PR #1717이 #1698 epic / #1712 / #1713을 모두 완료해 `ante bot start/stop/status`가 정상 노출 (`--help` exit 0). 그러나 다음 두 파일에 stale 진행 문구가 남아 있어 제거:

- `docs/specs/bot/06-cli-usage.md:22-26` (5라인 blockquote)
- `docs/specs/cli/03-commands.md:331` (1라인 blockquote)

## Plan Preflight

이슈 본문 v2 narrow-scope (Codex v1 revise-plan → 인라인 흡수 후 final orchestrator-attested). docs-only fix.

## Test Plan

- [x] `grep -rn "구현 진행 상황 (#1698 epic)" docs/` → 0 matches
- [x] `grep -rn "8479e53\|No such command" docs/` → 0 matches
- [x] project-structure.md no diff (파일 추가/삭제 없음)
- [x] Codex 브랜치 리뷰 PASS

## Non-Goals

- 코드 변경 (이미 #1717로 완료)
- bot CLI 사용 예시 내용 변경 (현재 정확)
- 다른 unrelated stale (별도 sweep)