### PR TITLE
docs: #1729 #1404 close 후 CLI 인증 설계 stale 진행 문구 정리

### DIFF
--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -264,18 +264,7 @@ CLI는 default-deny + allowlist (opt-out) 정책이다. 새 명령 추가 시 �
 1. **공개 명령 allowlist 검토**: 신설 명령이 인증 없이 접근 가능해야 하는지 판단한다.
    - 인증 필요(기본값) → 별도 조치 없음. default-deny가 자동 적용된다. scope가 필요하면 `@require_scope`를 명시한다.
    - 공개 필요 → 위 SSOT 표(`03-commands.md`)에 행을 추가하고, 같은 PR에서 코드 allowlist(`_AUTH_EXEMPT_COMMAND_PATHS`)도 함께 갱신한다.
-2. **검증 체크리스트**: PR 검증 단계에서 (1) 공개 명령 표와 코드 allowlist가 동기 상태인지, (2) 인증 필요 명령이 `authenticated_group` factory로 보호되는지, (3) scope가 필요하면 `@require_scope`가 부착되었는지를 확인한다.
-
-#### 8.1.1 게이트 구현 완료 전 임시 조항 (#1403/#1404 close까지)
-
-> 잔여 P2-B (D-015 ADR / #1402 PR #1420 review 잔재).
-
-epic [#1401](https://github.com/joshua-jingu-lee/ante/issues/1401)의 [#1404](https://github.com/joshua-jingu-lee/ante/issues/1404) (CLI `authenticated_group` factory)가 close되기 전까지는, 새 mutation 명령 추가 시 자동 default-deny에 의존하지 말고 명시적 가드를 부착한다.
-
-- Web 라우트: `Depends(require_master_caller)` / `Depends(require_audit_read)` / `Depends(require_config_write)` 등 기존 dependency 중 하나를 라우트 시그니처에 명시한다.
-- CLI 명령: `@require_auth` / `@require_scope` 데코레이터를 명령 함수에 명시한다.
-
-두 이슈가 모두 close되고 게이트가 런타임 동작으로 확인되면 [#1408](https://github.com/joshua-jingu-lee/ante/issues/1408) cleanup에서 본 임시 조항을 제거하고, dependency/decorator는 scope 검증 책임만 가진다(D-015 책임 매트릭스). 그 시점부터는 미들웨어/factory가 1차 차단을 보장하므로 누락이 자동 401/exit 1로 드러난다.
+2. **검증 체크리스트**: PR 검증 단계에서 (1) 공개 명령 표와 코드 allowlist가 동기 상태인지, (2) 인증 필요 명령이 `AuthenticatedGroup` factory로 보호되는지, (3) scope가 필요하면 `@require_scope`가 부착되었는지를 확인한다.
 
 ## 9. AGENTS.md 경량화 원칙
 

--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -224,15 +224,17 @@ CLI는 default-deny + allowlist (opt-out) 정책을 적용한다. 새 명령 추
 
 | 단계 | 책임 | 위치 |
 |------|------|------|
-| 1차 차단 (authentication) | `ANTE_MEMBER_TOKEN`이 없거나 검증 실패면 exit 1. allowlist 명령은 면제. | `authenticated_group` factory(#1404 구현 예정). 현재는 루트 그룹의 `authenticate_member(ctx)` + 명령 단의 `@require_auth`로 부분 적용. |
+| 1차 차단 (authentication) | `ANTE_MEMBER_TOKEN`이 없거나 검증 실패면 exit 1. allowlist 명령은 면제. | `AuthenticatedGroup` factory(#1404 closed). 적용 위치: `src/ante/cli/main.py:58`. |
 | 2차 차단 (authorization) | `@require_scope(...)` 데코레이터. agent에 대해서만 required scope를 검사하고 human은 bypass. | `src/ante/cli/middleware.py`의 `@require_scope`. |
 
 **현재 상태와 후속 전환**:
 
-- 1.0 현재 CLI는 opt-in 모델(`@require_auth` + `@require_scope` 명령별 부착)을 유지하고
-  있다. default-deny factory(`authenticated_group`) 도입은 #1404에서 구현한다.
-- 본 spec은 정책과 allowlist 결정만 확정한다. factory 시그니처, decorator shim,
-  마이그레이션 순서는 #1404가 SSOT다.
+- 1.0 현재 CLI는 default-deny 모델로 동작한다. default-deny factory
+  (`AuthenticatedGroup`)는 #1404로 적용 완료(`src/ante/cli/main.py:58`,
+  `src/ante/cli/middleware.py:353`).
+- 본 spec은 정책과 allowlist 결정을 확정한다. factory 시그니처와 decorator shim은
+  `src/ante/cli/middleware.py`의 `AuthenticatedGroup`가 SSOT다. 마이그레이션은
+  #1404로 완료되었고, 후속 명령 추가 시 default-deny가 자동 적용된다.
 - 공개 명령 allowlist의 SSOT는 [03-commands.md — 공개 명령 allowlist](03-commands.md#공개-명령-allowlist--인증-면제)다.
 
 **게이트-면제 메타 경로 (allowlist와 분리)**:
@@ -243,9 +245,9 @@ CLI는 default-deny + allowlist (opt-out) 정책을 적용한다. 새 명령 추
 | 게이트-면제 경로 | 사유 | 코드 cite |
 |-----------------|------|----------|
 | `ante --help` (root) | `click`은 root 그룹의 콜백 실행 **전에** root 레벨 `--help` 플래그를 처리해 도움말을 출력하고 종료한다. 인증 단계까지 진입하지 않는다. | `src/ante/cli/main.py:105`의 root `cli()` 콜백 안 `authenticate_member(ctx)`는 click이 root `--help`를 처리한 뒤에는 호출되지 않는다. |
-| `ante <cmd> --help`, `ante <cmd> <sub> --help` 등 nested `--help` | **주의**: click은 nested `--help`에서 **부모 그룹 콜백을 먼저 실행한 뒤** 서브커맨드 단의 도움말을 출력한다. 즉 `ante member --help`나 `ante member list --help`에서도 root `cli()` 콜백(과 #1404 도입 후 `authenticated_group` factory)이 실행된다. 토큰 없이 인증을 강제하면 보호 서브커맨드의 도움말 자체를 못 받게 되어 학습 경로가 막힌다. | nested help 처리 시 부모 group 콜백이 실행되는 시점의 `ctx.resilient_parsing` 값은 **click 내부 동작에 의존**하며 항상 `True`라고 보장되지 않는다. 따라서 본 spec은 invariant만 정의하고 구체 검사 시그니처는 #1404 plan-preflight에서 확정한다. invariant는 아래 "nested help 면제 invariant" 절을 따른다. raw `sys.argv` 검사(`"--help" in sys.argv[1:]`)는 어떤 경우에도 사용하지 않는다. `ante strategy submit -- --help`처럼 `--` 이후 위치 인자로 들어간 `--help`는 인증을 면제하지 않으며 default-deny 게이트가 정상 발화해야 한다. 도움말은 명령 사용법 그 자체이며 토큰 없이 받을 수 있어야 Agent와 사람이 명령을 학습할 수 있으므로 본 면제는 default-deny의 의도와 충돌하지 않는다(Codex review v4 Finding 2 — raw sys.argv 검사로 인한 우회 차단). |
+| `ante <cmd> --help`, `ante <cmd> <sub> --help` 등 nested `--help` | **주의**: click은 nested `--help`에서 **부모 그룹 콜백을 먼저 실행한 뒤** 서브커맨드 단의 도움말을 출력한다. 즉 `ante member --help`나 `ante member list --help`에서도 root `cli()` 콜백(과 `AuthenticatedGroup` factory, #1404 적용 후)이 실행된다. 토큰 없이 인증을 강제하면 보호 서브커맨드의 도움말 자체를 못 받게 되어 학습 경로가 막힌다. | nested help 처리 시 부모 group 콜백이 실행되는 시점의 `ctx.resilient_parsing` 값은 **click 내부 동작에 의존**하며 항상 `True`라고 보장되지 않는다. 따라서 본 spec은 invariant만 정의하고 구체 검사 시그니처는 #1404로 확정됨(`src/ante/cli/middleware.py`의 `AuthenticatedGroup`). invariant는 아래 "nested help 면제 invariant" 절을 따른다. raw `sys.argv` 검사(`"--help" in sys.argv[1:]`)는 어떤 경우에도 사용하지 않는다. `ante strategy submit -- --help`처럼 `--` 이후 위치 인자로 들어간 `--help`는 인증을 면제하지 않으며 default-deny 게이트가 정상 발화해야 한다. 도움말은 명령 사용법 그 자체이며 토큰 없이 받을 수 있어야 Agent와 사람이 명령을 학습할 수 있으므로 본 면제는 default-deny의 의도와 충돌하지 않는다(Codex review v4 Finding 2 — raw sys.argv 검사로 인한 우회 차단). |
 | `ante --version` | `@click.version_option`(`src/ante/cli/main.py:94`)이 root 콜백 진입 전 처리. 메타데이터 출력. | 동일. |
-| Click resilient parsing 경로 | `click`이 자동완성(shell completion) 등을 위해 명시적으로 `ctx.resilient_parsing=True`로 옵션 파싱을 시도할 때. 이 모드에서는 부작용을 일으키지 않아야 한다. **nested `--help`는 click 버전에 따라 부모 콜백 invoke 시점에 `resilient_parsing`이 `True`가 아닐 수 있으므로 위 nested help 행과 별도로 다룬다.** | `authenticate_member(ctx)`는 `ctx.resilient_parsing`이 True면 즉시 return하여 인증을 건너뛴다(`src/ante/cli/middleware.py:64-65`). #1404의 `authenticated_group` factory도 동일 가드를 갖는다. |
+| Click resilient parsing 경로 | `click`이 자동완성(shell completion) 등을 위해 명시적으로 `ctx.resilient_parsing=True`로 옵션 파싱을 시도할 때. 이 모드에서는 부작용을 일으키지 않아야 한다. **nested `--help`는 click 버전에 따라 부모 콜백 invoke 시점에 `resilient_parsing`이 `True`가 아닐 수 있으므로 위 nested help 행과 별도로 다룬다.** | `authenticate_member(ctx)`는 `ctx.resilient_parsing`이 True면 즉시 return하여 인증을 건너뛴다(`src/ante/cli/middleware.py:64-65`). `AuthenticatedGroup` factory(#1404 적용)도 동일 가드를 갖는다. |
 
 이 면제 경로는 4개 명령 allowlist와 다른 결로 운영된다.
 
@@ -265,8 +267,8 @@ CLI는 default-deny + allowlist (opt-out) 정책을 적용한다. 새 명령 추
 부모 group의 콜백을 먼저 invoke한 뒤 자식의 도움말을 렌더링하는 경로다. 이때
 부모 콜백이 호출되는 시점의 `ctx.resilient_parsing` 값은 click 내부 동작에
 의존하며 spec이 "항상 `True`"로 단언할 수 없다. 따라서 본 spec은 **invariant
-세 개만** 정의하고, 정확한 검사 시그니처(`ctx` 필드 조합)는 #1404 plan-preflight
-단계에서 click의 실제 동작을 확인한 뒤 확정한다.
+세 개만** 정의하고, 정확한 검사 시그니처(`ctx` 필드 조합)는 #1404로 확정됨
+(`src/ante/cli/middleware.py`의 `AuthenticatedGroup`).
 
 | invariant | 내용 |
 |-----------|------|
@@ -275,15 +277,15 @@ CLI는 default-deny + allowlist (opt-out) 정책을 적용한다. 새 명령 추
 | (H3) 검사 방식 | nested help 판정은 **Click context가 노출하는 상태만** 본다(예: `ctx.resilient_parsing`, `ctx.protected_args`, `ctx.invoked_subcommand`, `ctx.params`의 click 결과). raw `sys.argv` 검사(`"--help" in sys.argv`)는 어떤 경우에도 사용하지 않는다. (H2)를 만족시키기 위해 click이 이미 `--` 분리를 처리한 뒤의 context를 기준으로 한다. |
 
 대안 패턴(예: `group.no_args_is_help = True` 설정 후 root 콜백 진입 전에 click이
-help를 가로채도록 위임)도 본 invariant를 만족하면 허용된다. #1404 plan-preflight는
-click 버전(`click>=8.0` 등 본 프로젝트 pin)에서 실제 nested help 호출 시 어떤
+help를 가로채도록 위임)도 본 invariant를 만족하면 허용된다. #1404에서 click
+버전(`click>=8.0` 등 본 프로젝트 pin)의 실제 nested help 호출 시 어떤
 context 필드가 어떤 값으로 채워지는지 확인하고 (H1)(H2)(H3)을 동시에 만족하는
-검사 식을 확정한다.
+검사 식을 확정했다.
 
 **caveat**: 본 spec은 nested help 면제 검사의 정확한 함수 시그니처를 못박지
 않는다. click 내부 동작 의존 표면이라 spec과 코드를 같은 라운드에 정정하지
 않으면 회귀가 발생하기 쉽기 때문이다. 따라서 (H1)(H2)(H3) invariant 위반은
-#1404 PR에서 단위 테스트로 보증하고, spec은 invariant 정의에 한정한다.
+#1404 PR에서 단위 테스트로 보증되었고, spec은 invariant 정의에 한정한다.
 
 **`ante login` 후보 제거**: 본 이슈 검토 과정에서 거론되었으나 CLI는 `ANTE_MEMBER_TOKEN`
 환경변수 모델이며 별도 `login` 명령은 spec(`docs/specs/cli/03-commands.md`)과 코드

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -45,7 +45,7 @@ allowlist 후보에서 제거한다.
 
 | 메타 경로 | 적용 범위 | 사유 |
 |----------|----------|------|
-| `--help` | `ante --help`, `ante <cmd> --help`, `ante <cmd> <sub> --help` 등 모든 명령 단계 | root `--help`만 root 콜백 진입 전 처리되고, **nested `--help`는 부모 그룹 콜백이 먼저 실행된 뒤** 서브커맨드 단의 도움말이 출력된다(click 동작). 이 때문에 `authenticate_member(ctx)` 및 #1404 `authenticated_group` factory는 invocation에 `--help` 플래그가 있거나 `ctx.resilient_parsing == True`인 경우 인증 검사를 skip한다. 도움말은 명령 사용법 그 자체이며 인증 없이도 받을 수 있어야 Agent와 사람이 명령을 학습할 수 있다. 상세 정정 근거는 [02-design-decisions.md — `--help` 처리 시점](02-design-decisions.md#default-deny-cli-인증-게이트) 참조. |
+| `--help` | `ante --help`, `ante <cmd> --help`, `ante <cmd> <sub> --help` 등 모든 명령 단계 | root `--help`만 root 콜백 진입 전 처리되고, **nested `--help`는 부모 그룹 콜백이 먼저 실행된 뒤** 서브커맨드 단의 도움말이 출력된다(click 동작). 이 때문에 `authenticate_member(ctx)` 및 `AuthenticatedGroup` factory(#1404 적용)는 invocation에 `--help` 플래그가 있거나 `ctx.resilient_parsing == True`인 경우 인증 검사를 skip한다. 도움말은 명령 사용법 그 자체이며 인증 없이도 받을 수 있어야 Agent와 사람이 명령을 학습할 수 있다. 상세 정정 근거는 [02-design-decisions.md — `--help` 처리 시점](02-design-decisions.md#default-deny-cli-인증-게이트) 참조. |
 | `--version` | `ante --version` | `@click.version_option`이 root 콜백 진입 전 처리. 메타데이터 출력. |
 | resilient parsing | 자동완성 등 click이 `ctx.resilient_parsing=True`로 옵션을 시도 파싱하는 경로 | 부작용 없는 파싱이므로 인증 단계로 진입하지 않는다. `authenticate_member(ctx)`가 `ctx.resilient_parsing`을 확인해 즉시 return(`src/ante/cli/middleware.py:64-65`). |
 


### PR DESCRIPTION
## Summary

- closes #1729
- #1404 (CLI `AuthenticatedGroup` factory + default-deny 마이그레이션)이 CLOSED 상태인데, 문서들이 여전히 "#1404 구현 예정" / "1404에서 구현한다" / "#1403/#1404 close까지" 같은 stale 진행 문구를 그대로 두고 있었음. 3개 docs 파일을 sweep해서 applied/closed wording으로 정리.
- code 변경 없음 (docs-only).

## 변경

- `docs/specs/cli/02-design-decisions.md`: stale 표현 8 라인 갱신
  - line 227 책임 분리 표 1차 차단 행: ``AuthenticatedGroup` factory(#1404 closed). 적용 위치: `src/ante/cli/main.py:58`.``
  - line 233-237 "현재 상태와 후속 전환" 단락: default-deny 모델 적용 완료로 재기술 (`src/ante/cli/main.py:58`, `src/ante/cli/middleware.py:353` cite)
  - line 248 nested `--help` 행: `AuthenticatedGroup` factory (#1404 적용 후) wording
  - line 250 resilient parsing 행: `AuthenticatedGroup` factory(#1404 적용) wording
  - line 270 nested help invariant 단락: 검사 시그니처 #1404로 확정됨
  - line 280-281 대안 패턴 단락: #1404에서 확정했다 (과거형)
  - line 288 caveat 단락: #1404 PR에서 단위 테스트로 보증되었고 (과거형)
- `docs/specs/cli/03-commands.md:48`: 게이트-면제 메타 경로 표 `--help` 행 사유 칸의 `#1404 authenticated_group factory` → ``AuthenticatedGroup` factory(#1404 적용)``
- `docs/runbooks/01-development-process.md`: 8.1.1 "게이트 구현 완료 전 임시 조항 (#1403/#1404 close까지)" 섹션 완전 제거. line 267 `authenticated_group` → `AuthenticatedGroup` 갱신. #1403=CLOSED, #1404=CLOSED 확정.

## 검증

- `grep -rn "1404 구현 예정\|#1403/#1404 close까지\|1404에서 구현한다" docs/` → no match (stale 문구 0개)
- `grep -rn "#1404" docs/ --include="*.md" | grep -v "docs/temp/autopilot-report-"` → 9 매치 모두 historical/closed/적용 wording으로 정리됨 확인
- `PYTHONPATH=$PWD/src python scripts/generate_project_structure.py && git diff --exit-code docs/architecture/generated/project-structure.md` → no drift
- `ruff check src/ tests/` → All checks passed!
- `PYTHONPATH=$PWD/src pytest tests/unit/ -q --no-header -x` → 4926 passed, 2 skipped, 38 warnings in 146.31s (회귀 0)
- 메인 repo HEAD 불변: `f835f90 → f835f90`

## Test plan

- [x] grep stale 문구 absence
- [x] grep #1404 remaining matches는 historical/closed wording
- [x] project-structure.md regenerate drift 0
- [x] ruff check
- [x] unit pytest 회귀 0
- [x] 메인 repo HEAD 불변

🤖 Generated with [Claude Code](https://claude.com/claude-code)