### PR TITLE
fix: #1730 D-018 후 init/config의 [web] 섹션 제거 (web surface stale config sweep)

### DIFF
--- a/config/system.toml.example
+++ b/config/system.toml.example
@@ -11,11 +11,6 @@ path = "db/ante.db"
 [data]
 path = "data/"
 
-[web]
-enabled = false  # 대시보드 활성화 시 true
-host = "0.0.0.0"
-port = 3982
-
 [eventbus]
 history_size = 1000
 

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -554,7 +554,8 @@ tests/
 │   ├── test_cli_account_invalid_id_ingress.py
 │   ├── test_cli_treasury_account_not_found.py
 │   ├── test_cli_rule_account_not_found.py
-│   └── test_cli_broker_account_not_found.py
+│   ├── test_cli_broker_account_not_found.py
+│   └── test_cli_init_no_web_section.py
 └── __init__.py
 ```
 

--- a/docs/specs/config/03-design-decisions.md
+++ b/docs/specs/config/03-design-decisions.md
@@ -32,11 +32,6 @@ directory = "logs"
 [parquet]
 compression = "snappy"
 
-[web]
-host = "0.0.0.0"
-port = 3982
-cors_origins = ["http://localhost:3000"]
-
 # [broker] 섹션의 계좌성 값은 Account 모델로 이관됨.
 # broker.type → Account.broker_type
 # broker.commission_rate → Account.buy_commission_rate

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -50,10 +50,6 @@ path = "{db_path}"
 # docs/specs/config/03-design-decisions.md 200-202).
 pid_path = "run/ante.pid"
 socket_path = "run/ante.sock"
-
-[web]
-host = "0.0.0.0"
-port = 3982
 """
 
 _ENCRYPTION_KEY_NAME = "ANTE_DB_ENCRYPTION_KEY"

--- a/tests/unit/test_cli_init_no_web_section.py
+++ b/tests/unit/test_cli_init_no_web_section.py
@@ -1,0 +1,98 @@
+"""D-018 회귀: ante init 산출물 system.toml에 ``[web]`` 섹션 부재 검증.
+
+D-018(`docs/decisions/D-018-core-interface-cli-ipc.md`)은 Ante 1.0의 활성
+운영 인터페이스를 CLI와 Unix socket IPC로 제한하고 HTTP REST/Web UI를 코어
+런타임에서 제거한다. PR #1718/#1720이 코드 surface를 제거한 뒤에도
+``SYSTEM_TOML_TEMPLATE``에 ``[web] host/port = 3982`` 라인이 stale로 남아
+``ante init`` 산출물이 제거된 surface를 활성 설정처럼 노출했다(#1730).
+
+본 테스트는 ``ante init``으로 생성되는 ``system.toml``에 ``[web]`` 섹션과
+``port = 3982`` 라인이 다시 들어가지 않도록 회귀 락으로 고정한다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.commands.init import SYSTEM_TOML_TEMPLATE
+from ante.cli.main import cli
+
+_MOCK_MASTER_INFO = {
+    "member_id": "owner",
+    "name": "Owner",
+    "role": "master",
+    "emoji": "🦊",
+}
+_MOCK_TOKEN = "ante_hk_test_token_d018"
+_MOCK_RECOVERY_KEY = "ANTE-RK-XXXX-YYYY-ZZZZ-AAAA-BBBB-CCCC"
+_MOCK_TEST_ACCOUNT = {
+    "account_id": "test",
+    "broker_type": "test",
+    "exchange": "TEST",
+}
+
+
+def _mock_bootstrap(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+    return _MOCK_MASTER_INFO, _MOCK_TOKEN, _MOCK_RECOVERY_KEY
+
+
+def _mock_create_test_account(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+    return _MOCK_TEST_ACCOUNT
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_system_toml_template_omits_web_section() -> None:
+    """SYSTEM_TOML_TEMPLATE 자체에 ``[web]`` / ``port = 3982`` 부재."""
+    assert "[web]" not in SYSTEM_TOML_TEMPLATE
+    assert "port = 3982" not in SYSTEM_TOML_TEMPLATE
+    # D-018 active surface 섹션은 그대로 보존되어야 한다.
+    assert "[system]" in SYSTEM_TOML_TEMPLATE
+    assert "[db]" in SYSTEM_TOML_TEMPLATE
+    assert "[runtime]" in SYSTEM_TOML_TEMPLATE
+
+
+def test_init_creates_system_toml_without_web_section(
+    runner: CliRunner, tmp_path
+) -> None:
+    """``ante init`` 산출물 ``system.toml``에 ``[web]`` 섹션 부재."""
+    target = tmp_path / "config"
+
+    with (
+        patch(
+            "ante.cli.commands.init._bootstrap_master",
+            new=AsyncMock(side_effect=_mock_bootstrap),
+        ),
+        patch(
+            "ante.cli.commands.init._create_test_account",
+            new=AsyncMock(side_effect=_mock_create_test_account),
+        ),
+        patch(
+            "ante.cli.commands.init._master_exists_in_db",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "ante.cli.commands.init._test_account_state",
+            new=AsyncMock(return_value="missing"),
+        ),
+        patch("ante.cli.main.authenticate_member"),
+    ):
+        result = runner.invoke(cli, ["init", "--dir", str(target)])
+
+    assert result.exit_code == 0, result.output
+    system_toml_path = target / "system.toml"
+    assert system_toml_path.exists()
+
+    content = system_toml_path.read_text()
+    assert "[web]" not in content
+    assert "port = 3982" not in content
+    # active surface 섹션 보존 확인.
+    assert "[system]" in content
+    assert "[db]" in content
+    assert "[runtime]" in content


### PR DESCRIPTION
## Summary

D-018(`docs/decisions/D-018-core-interface-cli-ipc.md`)이 Ante 1.0의 활성 운영 인터페이스를 CLI와 Unix socket IPC로 제한하고 HTTP REST/Web UI를 제거한 뒤, 코드 surface 제거(PR #1718/#1720)에는 따라가지 않은 config seed/template를 정리한다.

- `src/ante/cli/commands/init.py`의 `SYSTEM_TOML_TEMPLATE`에서 `[web]\nhost = "0.0.0.0"\nport = 3982` 3 라인 + preceding blank 제거. `ante init`이 만드는 새 `system.toml`은 system/db/runtime 섹션만 보유.
- `docs/specs/config/03-design-decisions.md` spec 예시의 `[web]` 섹션 (host/port/cors_origins) 제거.
- `config/system.toml.example` sample config의 `[web]` 섹션 제거.
  - `config/system.toml`은 git untracked 운영 seed (이슈 plan 본 PR 범위에 포함되었으나 repo에 없음 → 사용자 책임).
- 회귀 test (`tests/unit/test_cli_init_no_web_section.py`):
  - `SYSTEM_TOML_TEMPLATE` 자체에 `[web]` / `port = 3982` 부재 단위 락.
  - 실제 `ante init` 실행 산출물 `system.toml`에 `[web]` 부재 E2E 락.
- `docs/architecture/generated/project-structure.md` 신규 test 파일 반영.

D-018 결정과 모순되는 stale config seed가 더 이상 사용자/Agent에게 제거된 surface를 활성처럼 노출하지 않도록 한다.

closes #1730

## Test plan

- [x] `pytest tests/unit/test_cli_init_no_web_section.py tests/unit/test_cli_init.py -q` (52 passed)
- [x] `pytest tests/unit/ -q` (4928 passed, 2 skipped)
- [x] `mypy src/` (no issues, 216 source files)
- [x] `ruff check src/ tests/` (all checks passed)
- [x] `ruff format --check src/ tests/` (477 files already formatted)
- [x] `python scripts/generate_project_structure.py && git diff --exit-code docs/architecture/generated/project-structure.md` (commit 후 clean)
- [x] grep `\[web\]|port = 3982` in target paths → 0 매치

## Non-Goals

- Web API/HTTP 코드 surface 추가 정리 (이미 #1718/#1720으로 완료)
- D-018 spec 본문 갱신 (현재 정확)
- historical `docs/superpowers/*`, `docs/temp/*` 정리 (Codex v1 분류 제외)
- 기존 init이 만든 system.toml의 retroactive 정리 (사용자 책임)

🤖 Generated with [Claude Code](https://claude.com/claude-code)