### PR TITLE
docs: #1746 EventBus 스펙 D-018 정합 publisher 정정

### DIFF
--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -144,13 +144,13 @@ D-005에서 정의한 EventBus 대상 이벤트. 모든 이벤트는 `Event`를 
 
 | 이벤트 타입 | 발행자 | 구독자 | 핵심 필드 |
 |------------|--------|--------|----------|
-| `ExternalSignalEvent` | REST API | Bot | `account_id`, `bot_id`, `signal_id`, `symbol`, `action` (`"buy"` / `"sell"`), `reason`, `confidence`, `metadata`, `exchange` |
+| `ExternalSignalEvent` | SignalChannel | Bot | `account_id`, `bot_id`, `signal_id`, `symbol`, `action` (`"buy"` / `"sell"`), `reason`, `confidence`, `metadata`, `exchange` |
 
 #### 설정 변경 (Config)
 
 | 이벤트 타입 | 발행자 | 구독자 | 핵심 필드 |
 |------------|--------|--------|----------|
-| `ConfigChangedEvent` | WebAPI / CLI | 각 모듈 | `category`, `key`, `old_value`, `new_value`, `changed_by` |
+| `ConfigChangedEvent` | DynamicConfigService | 각 모듈 | `category`, `key`, `old_value`, `new_value`, `changed_by` |
 
 #### 결재 (Approval)
 


### PR DESCRIPTION
Closes #1746

## Summary
D-018 후속 docs-only sweep: EventBus publisher 표 2 라인을 실제 코드 publisher 모듈명으로 정정.

- `ExternalSignalEvent`: REST API → SignalChannel (src/ante/bot/signal_channel.py:101-106)
- `ConfigChangedEvent`: WebAPI / CLI → DynamicConfigService (src/ante/config/dynamic.py:243)

## Plan Preflight
이슈 본문 v1, Codex approve-implement.

## Test Plan
- [x] `grep -n 'REST API\|WebAPI' docs/specs/eventbus/eventbus.md` → 0 매치
- [x] `grep -n 'SignalChannel\|DynamicConfigService' docs/specs/eventbus/eventbus.md` → 2 매치 (147, 153) + 기존 StopOrder 행 3건/본문 1건은 무관
- [x] sibling row 명명 패턴(BacktestEngine/PositionReconciler 등)과 일관
- [x] `pytest tests/unit/ -q` → 4928 passed, 2 skipped

## Non-Goals (follow-up sweep 후보)
- `docs/specs/config/03-design-decisions.md:163-165` 동형 WebAPI 흐름 stale
- `src/ante/eventbus/events.py:419-437` docstring stale