### PR TITLE
docs: #1747 invalid-role runbook의 stale CLI path 정정

### DIFF
--- a/docs/runbooks/07-member-invalid-role-cleanup.md
+++ b/docs/runbooks/07-member-invalid-role-cleanup.md
@@ -60,7 +60,7 @@ JSON 출력 스키마:
 - `actionable`: `role` 이 invalid 이고 `status != revoked` 인 row. 운영자 cleanup 대상.
   `revoke_command` 는 즉시 실행 가능한 형태(`--yes` 포함, `member_id` 는
   `shlex.quote` 로 셸 안전 인용, 옵션/포지셔널 경계는 `--` separator 로 명시)로
-  노출된다. 또한 `ante list-invalid-roles` 호출에 `--config-dir <path>` 가
+  노출된다. 또한 `ante member list-invalid-roles` 호출에 `--config-dir <path>` 가
   지정되었다면 동일한 값을 `ante --config-dir <quoted-path> member revoke ...`
   형태로 **그대로 보존**해 운영자가 payload 를 복사·실행해도 같은 인스턴스(DB)
   대상으로 동작하도록 보장한다. default config_dir 일 때는 `--config-dir` 인자가


### PR DESCRIPTION
Closes #1747

## Summary
`docs/runbooks/07-member-invalid-role-cleanup.md:63`의 root-level `ante list-invalid-roles`를 `ante member list-invalid-roles`로 정정 (1 라인).

line 97의 `list-invalid-roles`는 line 96-97 멀티라인(`ante --config-dir ... member\nlist-invalid-roles`)으로 이미 정상 — Codex Plan Review file-verified.

## Plan Preflight
이슈 본문 v1 + Codex narrow-scope (scope 정정 → 1 라인만).

## Test Plan
- [x] grep `ante list-invalid-roles` 매치 0 (runbook + docs/ 전체)
- [x] 같은 문서 6 매치 모두 `member list-invalid-roles` 형태로 통일 (line 96-97 멀티라인 포함)
- [x] pytest tests/unit/ 4928 passed / 2 skipped