### PR TITLE
docs: #1748 rule-engine 인덱스의 stale 11-rest-api.md 링크 제거

### DIFF
--- a/docs/specs/rule-engine/README.md
+++ b/docs/specs/rule-engine/README.md
@@ -23,6 +23,5 @@
 | [08-notification-events.md](08-notification-events.md) | 알림 이벤트 정의 (Notification Events) |
 | [09-rule-management.md](09-rule-management.md) | 룰 정의 및 관리 |
 | [10-rule-engine-manager.md](10-rule-engine-manager.md) | RuleEngineManager |
-| [11-rest-api.md](11-rest-api.md) | REST API |
 | [12-cli.md](12-cli.md) | CLI 인터페이스 |
 | [14-cross-module-notes.md](14-cross-module-notes.md) | 타 모듈 설계 시 참고 |

--- a/docs/specs/rule-engine/rule-engine.md
+++ b/docs/specs/rule-engine/rule-engine.md
@@ -22,7 +22,6 @@
 | [08-notification-events.md](08-notification-events.md) | 알림 이벤트 정의 (Notification Events) |
 | [09-rule-management.md](09-rule-management.md) | 룰 정의 및 관리 |
 | [10-rule-engine-manager.md](10-rule-engine-manager.md) | RuleEngineManager |
-| [11-rest-api.md](11-rest-api.md) | REST API |
 | [12-cli.md](12-cli.md) | CLI 인터페이스 |
 | [14-cross-module-notes.md](14-cross-module-notes.md) | 타 모듈 설계 시 참고 |
 


### PR DESCRIPTION
Closes #1748

## Summary
`docs/specs/rule-engine/{README,rule-engine}.md`에서 존재하지 않는 `11-rest-api.md` 링크 2 라인 제거. D-018으로 HTTP REST 제거 후 인덱스 정합.

## Plan Preflight
이슈 본문 v1 + Codex approve-implement.

## Test Plan
- [x] grep "11-rest-api" 매치 0
- [x] 디렉토리에 11-rest-api.md 부재 (10→12 점프 의도된 상태)
- [x] pytest tests/unit/ -q: 4928 passed, 2 skipped
- [x] generate_project_structure.py 트리 변동 없음 (timestamp drift만 발생, PR 범위 외)

## Non-Goals (follow-up)
- `docs/specs/rule-engine/09-rule-management.md:19` rule REST API 표현 정합 (Codex Plan Review should-fix 1)