### PR TITLE
fix: #1752 backtest run --format json 단일 JSON document 출력

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-05-23 (KST)
+> 마지막 생성 시점: 2026-05-24 (KST)
 
 ## 최상위 구조
 
@@ -555,7 +555,8 @@ tests/
 │   ├── test_cli_treasury_account_not_found.py
 │   ├── test_cli_rule_account_not_found.py
 │   ├── test_cli_broker_account_not_found.py
-│   └── test_cli_init_no_web_section.py
+│   ├── test_cli_init_no_web_section.py
+│   └── test_cli_backtest_run_json_single_document.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -180,7 +180,11 @@ def run(
             "Final Balance: {final_balance:,.0f}",
         )
 
-        if metrics:
+        if metrics and not fmt.is_json:
+            # JSON 모드에서는 위 fmt.output(result_dict)의 result_dict["metrics"]에
+            # 이미 동일 지표가 포함되어 있으므로 별도 metric 테이블을 추가 출력하면
+            # stdout에 두 번째 JSON document(배열)가 붙어 single-document parser가
+            # `Extra data`로 실패한다. text 모드에서만 사람용 테이블을 추가 출력한다.
             metric_rows = _format_metrics(metrics)
             fmt.table(metric_rows, ["지표", "값"])
 

--- a/tests/unit/test_cli_backtest_run_json_single_document.py
+++ b/tests/unit/test_cli_backtest_run_json_single_document.py
@@ -1,0 +1,180 @@
+"""CLI `backtest run --format json` 회귀 — stdout이 단일 JSON document인지 검증 (#1752).
+
+버그:
+- 기존에는 결과 페이로드(`fmt.output(result_dict)`)와 metric 테이블(`fmt.table(...)`)이
+  JSON 모드에서도 모두 출력되어 stdout에 두 개의 독립된 JSON document가 붙었다.
+- `json.loads`/`jq` 같은 single-document parser가 `Extra data` 오류로 실패했다.
+
+회귀 검증 축:
+- R1: `--format json` 호출 → stdout이 `json.loads`로 한 번에 파싱된다.
+- R2: 파싱된 payload에 `metrics` 필드가 보존된다 (정보 손실 없음).
+- R3: text 모드는 기존대로 metric 테이블을 출력한다 (회귀 보존).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from ante.backtest.result import BacktestResult
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+def _make_runner() -> CliRunner:
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _make_result_with_metrics() -> BacktestResult:
+    """metrics가 비어있지 않은 BacktestResult를 만든다.
+
+    `if metrics and not fmt.is_json:` 분기를 타려면 metrics가 truthy해야 한다.
+    """
+    return BacktestResult(
+        strategy_name="momentum",
+        strategy_version="1.0.0",
+        start_date="2026-01-01",
+        end_date="2026-01-31",
+        initial_balance=10_000_000.0,
+        final_balance=11_000_000.0,
+        total_return=10.0,
+        trades=[],
+        equity_curve=[],
+        metrics={
+            "total_return": 10.0,
+            "sharpe_ratio": 1.5,
+            "max_drawdown": -3.2,
+            "win_rate": 0.6,
+            "total_trades": 5,
+        },
+    )
+
+
+class _SpyService:
+    """BacktestService를 흉내내고 미리 만들어진 BacktestResult를 돌려주는 spy."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    async def run(self, config: dict, progress_callback=None) -> BacktestResult:  # noqa: ARG002
+        return _make_result_with_metrics()
+
+
+def _invoke_run(runner: CliRunner, tmp_path, *extra_args: str):
+    """`backtest run`을 호출하되 BacktestService/_save_backtest_run을 stub."""
+    strategy = tmp_path / "test_strategy.py"
+    strategy.write_text("# dummy")
+
+    with (
+        patch("ante.backtest.service.BacktestService", _SpyService),
+        patch(
+            "ante.cli.commands.backtest._save_backtest_run",
+            new=_fake_save_backtest_run,
+        ),
+    ):
+        return runner.invoke(
+            cli,
+            [
+                *extra_args,
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-01-01",
+                "--end",
+                "2026-01-31",
+            ],
+        )
+
+
+async def _fake_save_backtest_run(
+    db_path: str,  # noqa: ARG001
+    result,  # noqa: ARG001
+    config: dict,  # noqa: ARG001
+    metrics: dict,  # noqa: ARG001
+) -> str:
+    """DB 접근 없이 결정적 run_id를 반환."""
+    return "run-test-1752"
+
+
+class TestBacktestRunJsonSingleDocument:
+    """`backtest run --format json` stdout이 단일 JSON document인지 (R1, R2)."""
+
+    def test_json_mode_stdout_is_single_parseable_document(self, tmp_path):
+        """R1: stdout 전체를 `json.loads`로 한 번에 파싱할 수 있어야 한다.
+
+        분기 추가 전에는 metric 테이블이 두 번째 JSON document(배열)로 추가 출력되어
+        `json.JSONDecodeError: Extra data`가 발생했다.
+        """
+        runner = _make_runner()
+        result = _invoke_run(runner, tmp_path, "--format", "json")
+
+        assert result.exit_code == 0, result.output
+        # 한 번의 json.loads로 stdout 전체가 파싱되어야 한다.
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, dict)
+
+    def test_json_mode_payload_preserves_metrics(self, tmp_path):
+        """R2: JSON payload의 `metrics`가 보존되어 정보 손실이 없다.
+
+        `if metrics and not fmt.is_json:` 분기는 표면 출력을 잘라낼 뿐,
+        result_dict["metrics"]는 그대로 노출되어야 한다.
+        """
+        runner = _make_runner()
+        result = _invoke_run(runner, tmp_path, "--format", "json")
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert "metrics" in payload
+        # 핵심 지표가 그대로 보존되는지 확인.
+        assert payload["metrics"]["sharpe_ratio"] == 1.5
+        assert payload["metrics"]["win_rate"] == 0.6
+        assert payload["metrics"]["max_drawdown"] == -3.2
+        # 결과 페이로드 본문도 함께 보존되는지 확인.
+        assert payload["run_id"] == "run-test-1752"
+        assert payload["strategy"] == "momentum_v1.0.0"
+
+
+class TestBacktestRunTextModeMetricTableRegression:
+    """R3: text 모드는 기존대로 metric 테이블을 출력해 회귀가 없어야 한다."""
+
+    def test_text_mode_still_renders_metric_table(self, tmp_path):
+        """text 모드: `_format_metrics` 라벨(`Sharpe Ratio` 등)이 stdout에 나타난다."""
+        runner = _make_runner()
+        # --format 미지정 = text 모드 (default).
+        result = _invoke_run(runner, tmp_path)
+
+        assert result.exit_code == 0, result.output
+        # _format_metrics가 만드는 한국어/영문 라벨 중 대표 토큰이 보여야 한다.
+        # (테이블 헤더 "지표 | 값" + 라벨 행 둘 다 검증한다.)
+        assert "지표" in result.output
+        assert "값" in result.output
+        assert "Sharpe Ratio" in result.output
+        # 결과 페이로드 텍스트 템플릿도 같이 출력된다 (기존 회귀 보존).
+        assert "Run ID: run-test-1752" in result.output


### PR DESCRIPTION
Closes #1752

## Summary
- `backtest run --format json`이 stdout에 두 개의 JSON document를 출력해 `json.loads` 등 single-document parser가 `Extra data`로 실패하던 버그 수정
- `src/ante/cli/commands/backtest.py:183` `if metrics:` 조건에 `and not fmt.is_json` 추가
- JSON 모드: `line 173 fmt.output(result_dict)`의 `result_dict["metrics"]`가 이미 동일 지표를 포함 → 정보 손실 없음
- text 모드: metric 테이블은 기존대로 출력 (회귀 보존)

## Plan Preflight
이슈 본문 v1, Codex Plan Review `approve-implement`. 단일 명령 분기 추가 + CliRunner 회귀 테스트 1개의 좁은 범위.

## Test Plan
- [x] R1: `--format json` stdout이 `json.loads`로 한 번에 파싱됨 (fix 전: `JSONDecodeError: Extra data`로 실패 확인)
- [x] R2: JSON payload의 `metrics` 필드 보존 (sharpe_ratio, win_rate, max_drawdown 값 동일)
- [x] R3: text 모드는 metric 테이블 그대로 출력 (회귀 보존)
- [x] 인접 CLI backtest 테스트 47개 모두 통과
- [x] 전체 단위 테스트 4931 passed / 2 skipped
- [x] `mypy src/` no issues (216 source files)
- [x] `ruff check src/ tests/` All checks passed
- [x] `ruff format --check` 2 files already formatted