### PR TITLE
fix: #1754 IPC ClickException 경로를 --format json envelope으로 변환

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -557,7 +557,8 @@ tests/
 │   ├── test_cli_broker_account_not_found.py
 │   ├── test_cli_init_no_web_section.py
 │   ├── test_cli_backtest_run_json_single_document.py
-│   └── test_cli_fresh_init_read_contract.py
+│   ├── test_cli_fresh_init_read_contract.py
+│   └── test_cli_ipc_click_exception_json_envelope.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/ipc_helpers.py
+++ b/src/ante/cli/commands/ipc_helpers.py
@@ -71,11 +71,23 @@ async def ipc_send(
         client = IPCClient(socket_path=get_socket_path(config_dir=config_dir))
         response = await client.send(command, args, actor)
     except ServerNotRunningError:
-        raise click.ClickException(
+        # #1754: middleware ClickException fallback 이 IPC 미기동/타임아웃
+        # 케이스를 stable code 로 매핑할 수 있도록 ``ipc_error_code`` /
+        # ``ipc_error_message`` 속성을 부착한다. ``raise`` 시그니처와 메시지
+        # 본문은 기존 호출자(__str__ 가 그대로 사용자 메시지를 반환)와의
+        # 호환을 위해 변경하지 않는다 (서버 error envelope 경로의 attrs
+        # 부착 #1673 과 동형 패턴).
+        exc = click.ClickException(
             "서버가 실행 중이 아닙니다. 'ante system start'로 시작하세요."
         )
+        exc.ipc_error_code = "IPC_SERVER_NOT_RUNNING"  # type: ignore[attr-defined]
+        exc.ipc_error_message = exc.message  # type: ignore[attr-defined]
+        raise exc
     except IPCTimeoutError:
-        raise click.ClickException("서버 응답 시간 초과")
+        exc = click.ClickException("서버 응답 시간 초과")
+        exc.ipc_error_code = "IPC_TIMEOUT"  # type: ignore[attr-defined]
+        exc.ipc_error_message = exc.message  # type: ignore[attr-defined]
+        raise exc
 
     # 서버 응답에서 에러 상태 처리
     if response.get("status") == "error":

--- a/src/ante/cli/middleware.py
+++ b/src/ante/cli/middleware.py
@@ -582,6 +582,35 @@ class AuthenticatedGroup(_LeafPathMixin):
             import sys as _sys
 
             _sys.exit(1)
+        except click.ClickException as e:
+            # #1754: IPC 미기동/타임아웃 등 비-``UsageError`` ``ClickException``
+            # 도 JSON 모드 구조화 에러 계약 (``{status, code, message}``
+            # envelope + exit non-zero, ``docs/specs/cli/02-design-decisions.md
+            # :78-81``) 을 만족해야 한다.
+            #
+            # ``UsageError`` 가 ``ClickException`` 의 subclass 이므로 Python
+            # ``except`` 순서 매칭상 본 분기는 ``UsageError`` 가 아닌 일반
+            # ``ClickException`` (예: ``ipc_send`` 가 raise 하는
+            # ``ServerNotRunningError`` / ``IPCTimeoutError`` 변환 + 서버 error
+            # envelope) 만 처리한다.
+            #
+            # ``ipc_send`` (``ante.cli.commands.ipc_helpers``) 는
+            # ``ClickException`` 인스턴스에 ``ipc_error_code`` /
+            # ``ipc_error_message`` 속성을 부착하므로 그 stable code 를 우선
+            # 사용하고, 없으면 ``IPC_ERROR`` fallback 으로 envelope 을 출력한다
+            # (``commands/bot.py``, ``commands/treasury.py``, ``commands/
+            # strategy.py``, ``commands/rule.py``, ``commands/member.py`` 의 호출
+            # 표면 try/except 매핑과 동형 fallback code).
+            from ante.cli.formatter import OutputFormatter
+
+            fmt = OutputFormatter("json")
+            code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+            message = getattr(e, "ipc_error_message", None) or e.message
+            fmt.error(message, code=code)
+            import sys as _sys
+
+            exit_code = e.exit_code if isinstance(e.exit_code, int) else 1
+            _sys.exit(exit_code if exit_code != 0 else 1)
         except click.exceptions.Abort:
             # ``standalone_mode=True`` 호출자 호환을 위해 click 기본 Abort 동작
             # (``Aborted!`` stderr + exit 1) 을 그대로 보존한다.

--- a/tests/unit/test_cli_ipc_click_exception_json_envelope.py
+++ b/tests/unit/test_cli_ipc_click_exception_json_envelope.py
@@ -1,0 +1,302 @@
+"""IPC ``ClickException`` 경로의 ``--format json`` envelope 회귀 (#1754).
+
+IPC 런타임이 없는 상태에서 다음 명령들이 ``--format json`` 모드에서
+구조화 에러 envelope (``{status: "error", code, message}``) 을 stdout 으로
+방출하고 stderr 에는 Python traceback 을 노출하지 않아야 한다.
+
+회귀 매트릭스:
+
+- R1: ``system halt --reason test --format json`` (IPC 미기동) → exit 1,
+  stdout JSON ``code="IPC_SERVER_NOT_RUNNING"``, stderr 에 ``Traceback`` 없음.
+- R2: ``treasury allocate <bot> <amount> --account <id> --format json``
+  (IPC 미기동) → exit 1, stdout JSON ``code="IPC_SERVER_NOT_RUNNING"``,
+  stderr 에 ``Traceback`` 없음.
+- R3: ``approval cancel <id> --format json`` (IPC 미기동) → exit 1, stdout
+  JSON ``code="IPC_SERVER_NOT_RUNNING"``, stderr 에 ``Traceback`` 없음.
+- R4 (sanity, text mode): 동일 명령 + ``--format text`` → exit 1, stderr
+  에 기존 사용자 메시지 ("서버가 실행 중이 아닙니다") 보존, JSON envelope
+  로 변환되지 않음 (text 모드 회귀 락).
+
+``_clean_env`` + ``subprocess.run`` 패턴은
+``tests/unit/test_cli_fresh_init_read_contract.py`` (#1753) 및
+``tests/unit/test_cli_account_crypto_error.py`` (#1722) 와 동형이다.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+# subprocess timeout: hang 회귀를 10초 마진으로 차단한다. 정상 종료는 1-2초.
+_SUBPROCESS_TIMEOUT_S = 10.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _clean_env(
+    config_dir: Path, *, encryption_key: str, token: str | None = None
+) -> dict[str, str]:
+    """subprocess 환경 격리 헬퍼.
+
+    부모 프로세스의 ``ANTE_DB_ENCRYPTION_KEY`` / ``ANTE_MEMBER_TOKEN`` 등이
+    새는 것을 막기 위해 ``PATH`` / ``HOME`` / ``ANTE_CONFIG_DIR`` /
+    ``ANTE_DB_ENCRYPTION_KEY`` / ``PYTHONPATH`` 만 명시 전달한다
+    (``test_cli_fresh_init_read_contract.py`` _clean_env 동형).
+    """
+    env: dict[str, str] = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(config_dir)),
+        "ANTE_CONFIG_DIR": str(config_dir),
+        "PYTHONPATH": str(_repo_root() / "src"),
+        "ANTE_DB_ENCRYPTION_KEY": encryption_key,
+    }
+    if token is not None:
+        env["ANTE_MEMBER_TOKEN"] = token
+    return env
+
+
+@pytest.fixture
+def fresh_init(tmp_path: Path) -> tuple[Path, str, str]:
+    """``ante init`` 만 수행한 fresh config dir + member token + key 페어.
+
+    IPC 서버는 시작하지 않는다. ``ipc_send`` 호출 시 ``ServerNotRunningError``
+    가 즉시 발생해 ``ClickException`` 으로 raise 되는 시나리오를 재현한다.
+    """
+    config_dir = tmp_path / "config"
+    key = Fernet.generate_key().decode()
+
+    init_env = _clean_env(config_dir, encryption_key=key)
+    result = subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", "init", "--name", "Repro"],
+        env=init_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"init 실패: exit={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    token = payload.get("token")
+    assert token, f"init 출력에 token 없음: {payload}"
+    return config_dir, token, key
+
+
+def _run_cli(
+    config_dir: Path,
+    token: str,
+    key: str,
+    args: list[str],
+) -> subprocess.CompletedProcess[str]:
+    """``ante <args>`` 를 subprocess 로 실행한다."""
+    env = _clean_env(config_dir, encryption_key=key, token=token)
+    return subprocess.run(
+        [sys.executable, "-m", "ante", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _parse_last_json_dict(stdout: str) -> dict:
+    """stdout 의 (마지막) JSON dict 라인을 추출한다.
+
+    ``OutputFormatter.error`` 는 JSON 모드에서 한 줄로 dump 한다. 전체가 단일
+    객체인 경우는 ``json.loads(stdout)`` 가 가장 robust 하므로 먼저 시도한다.
+    """
+    stripped = stdout.strip()
+    if stripped:
+        try:
+            obj = json.loads(stripped)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    last_obj: dict | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            last_obj = obj
+    assert last_obj is not None, f"JSON dict 라인을 stdout 에서 찾지 못함: {stdout!r}"
+    return last_obj
+
+
+def _assert_no_traceback(stderr: str) -> None:
+    """stderr 에 Python traceback 흔적이 없는지 검증.
+
+    ``Traceback (most recent call last)`` 헤더, ``click.exceptions`` 모듈
+    경로, ``ipc_helpers`` 경로 등 #1754 재현 시 새던 흔적을 차단한다.
+    """
+    assert "Traceback" not in stderr, f"stderr 에 traceback 노출: {stderr!r}"
+    assert "ipc_helpers" not in stderr, (
+        f"stderr 에 ipc_helpers 모듈 경로 노출: {stderr!r}"
+    )
+    assert "click.exceptions" not in stderr, (
+        f"stderr 에 click.exceptions 노출: {stderr!r}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────
+# R1 — system halt (IPC 미기동, JSON mode)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestSystemHaltJsonEnvelope:
+    def test_system_halt_no_runtime_returns_ipc_envelope(
+        self, fresh_init: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = fresh_init
+        result = _run_cli(
+            config_dir,
+            token,
+            key,
+            ["--format", "json", "system", "halt", "--reason", "test"],
+        )
+
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        _assert_no_traceback(result.stderr)
+
+        payload = _parse_last_json_dict(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "IPC_SERVER_NOT_RUNNING", payload
+        # 사용자 친화 메시지가 그대로 envelope ``message`` 로 노출되어야 한다.
+        assert "서버가 실행 중이 아닙니다" in payload.get("message", ""), payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R2 — treasury allocate (IPC 미기동, JSON mode)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasuryAllocateJsonEnvelope:
+    def test_treasury_allocate_no_runtime_returns_ipc_envelope(
+        self, fresh_init: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = fresh_init
+        # account_id 는 ``ACCOUNT_ID_PATTERN``(^[a-zA-Z0-9\-]{3,30}$) 을 통과
+        # 하는 합법 값을 사용해 ingress validation(``reject_invalid_account_id``)
+        # 을 통과시켜야 ``ipc_send`` 로 진입한다(#1754 회귀 표적).
+        result = _run_cli(
+            config_dir,
+            token,
+            key,
+            [
+                "--format",
+                "json",
+                "treasury",
+                "allocate",
+                "bot-1",
+                "1000",
+                "--account",
+                "acct-test-1",
+            ],
+        )
+
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        _assert_no_traceback(result.stderr)
+
+        payload = _parse_last_json_dict(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "IPC_SERVER_NOT_RUNNING", payload
+        assert "서버가 실행 중이 아닙니다" in payload.get("message", ""), payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R3 — approval cancel (IPC 미기동, JSON mode)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestApprovalCancelJsonEnvelope:
+    def test_approval_cancel_no_runtime_returns_ipc_envelope(
+        self, fresh_init: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = fresh_init
+        result = _run_cli(
+            config_dir,
+            token,
+            key,
+            ["--format", "json", "approval", "cancel", "missing-approval-id"],
+        )
+
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        _assert_no_traceback(result.stderr)
+
+        payload = _parse_last_json_dict(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "IPC_SERVER_NOT_RUNNING", payload
+        assert "서버가 실행 중이 아닙니다" in payload.get("message", ""), payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R4 — text mode sanity (회귀 보존)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTextModeRegressionPreservation:
+    """text 모드에서는 기존 click 동작 (stderr 한국어 메시지) 을 그대로 보존.
+
+    middleware 의 ``ClickException`` catch 분기는 ``--format json`` 모드에서만
+    발화한다 (``_sniff_output_format`` 가 json 이 아니면 ``super().main()`` 으로
+    바로 위임). 본 테스트가 text 모드 출력 회귀를 잠근다.
+    """
+
+    def test_system_halt_no_runtime_text_mode_preserves_stderr(
+        self, fresh_init: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = fresh_init
+        result = _run_cli(
+            config_dir,
+            token,
+            key,
+            ["--format", "text", "system", "halt", "--reason", "test"],
+        )
+
+        # text 모드의 click 기본 ClickException 동작: exit 1 + stderr 메시지.
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        # 기존 사용자 메시지가 stderr 또는 stdout 어느 한쪽에는 그대로 노출되어야
+        # 한다 (click 기본은 stderr; 회귀 보존 락).
+        combined = result.stderr + result.stdout
+        assert "서버가 실행 중이 아닙니다" in combined, (
+            f"기존 사용자 메시지 누락: stderr={result.stderr!r}, "
+            f"stdout={result.stdout!r}"
+        )
+        # text 모드 stdout 은 JSON envelope 으로 변환되지 **않아야** 한다.
+        stdout_stripped = result.stdout.strip()
+        if stdout_stripped.startswith("{"):
+            try:
+                obj = json.loads(stdout_stripped)
+                # JSON 객체가 파싱된다면 ``status: error`` envelope 형태여서는 안
+                # 된다 — text 모드 회귀.
+                assert obj.get("status") != "error" or obj.get("code") != (
+                    "IPC_SERVER_NOT_RUNNING"
+                ), (
+                    f"text 모드 stdout 이 JSON envelope 으로 변환되었습니다: "
+                    f"{stdout_stripped!r}"
+                )
+            except json.JSONDecodeError:
+                pass


### PR DESCRIPTION
## Summary

`AuthenticatedGroup.main`이 `UsageError`만 catch해 `ipc_send`가 raise하는
`ServerNotRunningError`/`IPCTimeoutError`(→ `ClickException`)가 `--format json`
모드에서도 stderr traceback으로 누출되던 #1754 회귀를 닫는다.

- **`src/ante/cli/middleware.py`**: `UsageError` 분기 직후에
  `except click.ClickException` base catch 추가. `ipc_send`가 부착한
  `ipc_error_code`/`ipc_error_message` 속성을 우선 사용하고, 없으면
  `IPC_ERROR` fallback으로 `{status: "error", code, message}` envelope을
  stdout으로 출력 + non-zero exit. `_sniff_output_format` 분기로 text 모드는
  click 기본 동작(stderr 메시지) 유지.
- **`src/ante/cli/commands/ipc_helpers.py`**:
  `ServerNotRunningError`/`IPCTimeoutError` raise 사이트에 `ipc_error_code`
  (`IPC_SERVER_NOT_RUNNING`/`IPC_TIMEOUT`) + `ipc_error_message` 속성을 부착해
  middleware fallback이 stable code로 매핑되도록 한다. raise 시그니처와
  메시지 본문은 기존 호출자(`__str__`) 호환을 위해 불변 (#1673 동형 패턴).
- **`tests/unit/test_cli_ipc_click_exception_json_envelope.py`**: R1
  `system halt`, R2 `treasury allocate`, R3 `approval cancel` 모두 IPC 미기동
  시 stdout JSON envelope + `code="IPC_SERVER_NOT_RUNNING"`, stderr traceback
  없음 검증. R4 text 모드 sanity로 기존 stderr 메시지 회귀 보존.

## Codex Plan Review

- v2 verdict: `narrow-scope` — middleware 단일 chokepoint 확장 + `ipc_helpers`
  attrs 부착.
- **Non-goals**: `ipc_send` 자체 시그니처/raise 변경, 각 명령 호출 표면
  try/except 추가, text 모드 출력 형식 변경.

## Test plan

- [x] `pytest tests/unit/test_cli_ipc_click_exception_json_envelope.py -q`
  → 4 passed (R1/R2/R3/R4). 패치 stash 후 baseline 재실행 → R1/R2/R3 모두
  Traceback assertion failure로 회귀 재현 확인.
- [x] `pytest tests/unit/ -q` → 4940 passed, 2 skipped (변경 무관 회귀 없음).
- [x] `mypy src/` → no issues found in 216 source files.
- [x] `ruff check src/ tests/` → All checks passed.
- [x] `ruff format --check src/ tests/` → 480 files already formatted.
- [x] `python scripts/generate_project_structure.py` → 신규 test 1개만 정합
  추가, 다른 drift 없음.

Closes #1754

🤖 Generated with [Claude Code](https://claude.com/claude-code)