### PR TITLE
fix: #1758 treasury read 계열 valid-but-missing account_id ACCOUNT_NOT_FOUND 매핑

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -561,7 +561,8 @@ tests/
 │   ├── test_cli_ipc_click_exception_json_envelope.py
 │   ├── test_cli_report_approval_db_cleanup.py
 │   ├── test_cli_strategy_submit_meta_shape.py
-│   └── test_cli_system_start_json_stdout.py
+│   ├── test_cli_system_start_json_stdout.py
+│   └── test_cli_treasury_read_account_not_found.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -299,7 +299,20 @@ def budgets(ctx: click.Context, account_id: str | None) -> None:
         finally:
             await db.close()
 
-    result = _run(_run_budgets())
+    # valid-but-missing account_id(예: `acc-9999`)는 `_create_treasury` 내부의
+    # `account_service.get`에서 `AccountNotFoundError`로 raise된다. Click 기본
+    # 핸들러가 typed exception을 모르고 traceback/빈 stdout으로 새던
+    # contract-drift를 본 매핑이 닫는다 (#1758, status/snapshot #1725 동형).
+    # 에러코드는 `ACCOUNT_NOT_FOUND` SSOT.
+    try:
+        result = _run(_run_budgets())
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
+    except Exception as e:
+        fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
+        raise SystemExit(1) from e
+
     if fmt.is_json:
         fmt.output(result)
     else:
@@ -345,12 +358,17 @@ def set_balance(ctx: click.Context, amount: float, account_id: str) -> None:
         finally:
             await db.close()
 
+    # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다
+    # (#1758, #1725). Click/Exception fallback은 기존(#1722 IPC 분기)을 보존한다.
     try:
         result = _run(_run_set_balance())
     except click.ClickException as e:
         code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
         message = getattr(e, "ipc_error_message", None) or e.message
         fmt.error(message, code=code)
+        raise SystemExit(1) from e
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
         fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
@@ -657,7 +675,18 @@ def portfolio_value(ctx: click.Context, account_id: str | None) -> None:
         finally:
             await db.close()
 
-    result = _run(_run_value())
+    # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다
+    # (#1758, #1725). outer try는 `_create_treasury`(line ~612)와
+    # `_create_treasury_manager`(line ~615) 두 경로의 raise를 모두 cover한다.
+    try:
+        result = _run(_run_value())
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
+    except Exception as e:
+        fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
+        raise SystemExit(1) from e
+
     if fmt.is_json:
         fmt.output(result)
     else:
@@ -734,7 +763,18 @@ def portfolio_history(
         finally:
             await db.close()
 
-    result = _run(_run_history())
+    # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다
+    # (#1758, #1725). outer try는 `_create_treasury`(line ~699)와
+    # `_create_treasury_manager`(line ~702) 두 경로의 raise를 모두 cover한다.
+    try:
+        result = _run(_run_history())
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
+    except Exception as e:
+        fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
+        raise SystemExit(1) from e
+
     if fmt.is_json:
         fmt.output(result)
     else:

--- a/tests/unit/test_cli_treasury_read_account_not_found.py
+++ b/tests/unit/test_cli_treasury_read_account_not_found.py
@@ -1,0 +1,339 @@
+"""treasury read 계열 CLI valid-but-missing account_id 회귀 (#1758).
+
+#1725 follow-up sweep. status/snapshot이 #1725로 typed
+``except AccountNotFoundError → code="ACCOUNT_NOT_FOUND"`` 매핑을 받은 것과
+동형으로, 나머지 4개 명령(`budgets`, `portfolio value`, `portfolio history`,
+`set-balance`)에도 같은 매핑을 적용한다.
+
+ante-oracle host probe ``cli_treasury_valid_absent_read_followup_contract`` 가
+signature ``treasury_budgets_valid_absent`` /
+``treasury_portfolio_value_valid_absent`` /
+``treasury_portfolio_history_valid_absent`` 로 잡은 contract-drift를 잠근다.
+
+회귀:
+
+- R1 (budgets): ``ante treasury budgets --account acc-9999`` →
+  ``exit 1`` + JSON ``code="ACCOUNT_NOT_FOUND"``.
+- R2 (portfolio value): ``ante treasury portfolio value --account acc-9999`` →
+  동일.
+- R3 (portfolio history): ``ante treasury portfolio history --account acc-9999``
+  → 동일.
+- R4 (set-balance): ``ante treasury set-balance acc-9999 100`` → 동일.
+  (요청 본문 작업 #2, ``treasury.py:337-356`` 호출 표면이 이미 generic except
+  를 가지고 있어 typed ``AccountNotFoundError`` 를 분기에 추가했다.)
+- R5 sanity (valid existing `test` 계좌): 위 4개 명령 모두 ``exit 0`` +
+  정상 payload (#1725 와 동형 sanity 회귀 보존).
+
+conftest fixture 격리는 ``test_cli_treasury_account_not_found.py`` (#1725) 와
+동형이다 (명시 ``env`` allowlist, ``ANTE_DB_ENCRYPTION_KEY`` /
+``ANTE_MEMBER_TOKEN`` 누출 차단).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+# subprocess timeout: hang 회귀를 5초 마진으로 차단한다. 정상 종료는 1-2초.
+_SUBPROCESS_TIMEOUT_S = 5.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _clean_env(
+    config_dir: Path, *, encryption_key: str | None = None, token: str | None = None
+) -> dict[str, str]:
+    """subprocess 환경 격리 헬퍼.
+
+    부모 프로세스의 ``ANTE_DB_ENCRYPTION_KEY`` / ``ANTE_MEMBER_TOKEN`` 등이
+    새는 것을 막기 위해 ``PATH`` / ``HOME`` / ``ANTE_CONFIG_DIR`` /
+    ``PYTHONPATH`` 만 명시적으로 전달한다 (#1722 / #1725 동형).
+    """
+    env: dict[str, str] = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(config_dir)),
+        "ANTE_CONFIG_DIR": str(config_dir),
+        "PYTHONPATH": str(_repo_root() / "src"),
+    }
+    if encryption_key is not None:
+        env["ANTE_DB_ENCRYPTION_KEY"] = encryption_key
+    if token is not None:
+        env["ANTE_MEMBER_TOKEN"] = token
+    return env
+
+
+@pytest.fixture
+def initialized_config(tmp_path: Path) -> tuple[Path, str, str]:
+    """ante init을 완료한 (config_dir, token, encryption_key) 튜플을 만든다.
+
+    init은 ``create_default_test_account()`` 경로로 ``account_id='test'`` 시드
+    계좌를 자동 생성한다 (``scoping.py:36`` 참조). R5 sanity가 이 시드 계좌를
+    재사용한다.
+    """
+    config_dir = tmp_path / "config"
+    key = Fernet.generate_key().decode()
+
+    init_env = _clean_env(config_dir, encryption_key=key)
+    result = subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", "init", "--name", "Repro"],
+        env=init_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"init 실패: exit={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    token = payload.get("token")
+    assert token, f"init 출력에 token 없음: {payload}"
+    return config_dir, token, key
+
+
+def _run_treasury_cli(
+    config_dir: Path,
+    token: str,
+    encryption_key: str,
+    args: list[str],
+) -> subprocess.CompletedProcess[str]:
+    """treasury CLI를 subprocess로 실행한다. timeout=5로 hang 회귀를 차단한다."""
+    env = _clean_env(config_dir, encryption_key=encryption_key, token=token)
+    return subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _parse_json_last(stdout: str) -> dict:
+    """JSON dict payload를 stdout에서 추출한다.
+
+    ``OutputFormatter.error`` 는 single-line JSON 한 줄로 dump하지만
+    ``OutputFormatter.output`` 은 indent=2로 multi-line dump한다. 전체 stdout을
+    먼저 한 번에 ``json.loads`` 로 시도하고, 실패하면 라인별로 마지막 dict
+    라인을 찾는다 (#1725 동형).
+    """
+    stripped = stdout.strip()
+    if stripped.startswith("{"):
+        try:
+            obj = json.loads(stripped)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    last_obj: dict | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            last_obj = obj
+    assert last_obj is not None, f"JSON dict 라인을 stdout에서 찾지 못함: {stdout!r}"
+    return last_obj
+
+
+# ────────────────────────────────────────────────────────────────────
+# R1 — budgets valid-but-missing → ACCOUNT_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasuryBudgetsValidAbsentAccount:
+    def test_budgets_acc9999_exits_with_account_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R1: budgets --account acc-9999 → exit 1, code=ACCOUNT_NOT_FOUND."""
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "budgets", "--account", "acc-9999"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "ACCOUNT_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R2 — portfolio value valid-but-missing → ACCOUNT_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasuryPortfolioValueValidAbsentAccount:
+    def test_portfolio_value_acc9999_exits_with_account_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R2: portfolio value --account acc-9999 → exit 1, code=ACCOUNT_NOT_FOUND."""
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "portfolio", "value", "--account", "acc-9999"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "ACCOUNT_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R3 — portfolio history valid-but-missing → ACCOUNT_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasuryPortfolioHistoryValidAbsentAccount:
+    def test_portfolio_history_acc9999_exits_with_account_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R3: portfolio history --account acc-9999 → exit 1, code=ACCOUNT_NOT_FOUND."""
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "portfolio", "history", "--account", "acc-9999"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "ACCOUNT_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R4 — set-balance valid-but-missing → ACCOUNT_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasurySetBalanceValidAbsentAccount:
+    def test_set_balance_acc9999_exits_with_account_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R4: set-balance acc-9999 100 → exit 1, code=ACCOUNT_NOT_FOUND.
+
+        cold-path (``is_active_runtime() == False``) 분기에서
+        ``_create_treasury`` 가 ``AccountNotFoundError`` 를 raise한다. typed
+        매핑이 없으면 generic ``Exception`` fallback이 ``TREASURY_ERROR`` 로
+        새 contract-drift가 발생하므로 typed 분기를 친다.
+        """
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "set-balance", "100", "--account", "acc-9999"],
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "ACCOUNT_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R5 — sanity: valid existing `test` 계좌는 모든 4개 명령에서 정상 동작
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasuryReadValidExistingAccountSanity:
+    """valid 계좌(`test`) 회귀 보존 — 본 PR이 정상 경로를 깨지 않는지 확인.
+
+    ``test`` 계좌는 ``ante init`` 이 ``create_default_test_account()`` 로
+    자동 생성한다 (#1725 R4 동형).
+    """
+
+    def test_budgets_test_account_exits_ok(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "budgets", "--account", "test"],
+        )
+        assert result.returncode == 0, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert "budgets" in payload, payload
+
+    def test_portfolio_value_test_account_exits_ok(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "portfolio", "value", "--account", "test"],
+        )
+        assert result.returncode == 0, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert "total_value" in payload, payload
+
+    def test_portfolio_history_test_account_exits_ok(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "portfolio", "history", "--account", "test"],
+        )
+        assert result.returncode == 0, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert "data" in payload, payload
+
+    def test_set_balance_test_account_exits_ok(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+
+        result = _run_treasury_cli(
+            config_dir,
+            token,
+            key,
+            ["treasury", "set-balance", "100000", "--account", "test"],
+        )
+        assert result.returncode == 0, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("account_id") == "test", payload


### PR DESCRIPTION
Closes #1758. #1725 follow-up sweep.

## Summary
- `treasury budgets` / `treasury portfolio value` / `treasury portfolio history` / `treasury set-balance` 호출 표면에 typed `except AccountNotFoundError → fmt.error(code="ACCOUNT_NOT_FOUND") + SystemExit(1)` 매핑을 추가했다 (status/snapshot #1725와 동형).
- generic fallback은 `getattr(e, "code", "TREASURY_ERROR")`로 통일하고, `set-balance`의 기존 `ClickException` 분기(#1722 IPC 경로)는 보존했다.
- ante-oracle host probe `cli_treasury_valid_absent_read_followup_contract` 가 잡은 signature `treasury_budgets_valid_absent` / `treasury_portfolio_value_valid_absent` / `treasury_portfolio_history_valid_absent` 의 contract-drift(stderr traceback, JSON code 부재)를 모두 닫는다.

## Test plan
- [x] `pytest tests/unit/test_cli_treasury_read_account_not_found.py -q` (8 passed: R1 budgets, R2 portfolio value, R3 portfolio history, R4 set-balance, R5 sanity 4종)
- [x] `pytest tests/unit/ -q` (4958 passed, 2 skipped — 회귀 없음)
- [x] `ruff check` / `ruff format --check` 변경 파일 PASS
- [x] `mypy src/` (216 files, no issues)
- [x] `scripts/generate_project_structure.py` 재실행, 신규 test 1개만 반영

## Non-Goals
- `AccountNotFoundError` class attr `code` 추가 (B-category sweep).
- `status` / `snapshot` 매핑 (#1725로 이미 적용).
- IPC handler 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)