### PR TITLE
fix: #1759 BotManager start_bot/stop_bot strict state machine + BOT_STATE_CONFLICT

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -562,7 +562,8 @@ tests/
 │   ├── test_cli_report_approval_db_cleanup.py
 │   ├── test_cli_strategy_submit_meta_shape.py
 │   ├── test_cli_system_start_json_stdout.py
-│   └── test_cli_treasury_read_account_not_found.py
+│   ├── test_cli_treasury_read_account_not_found.py
+│   └── test_bot_lifecycle_state_conflict.py
 └── __init__.py
 ```
 

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -17,7 +17,7 @@ from ante.bot.config import (
     validate_interval,
     validate_runtime_controls,
 )
-from ante.bot.exceptions import BotError, BotNotFoundError
+from ante.bot.exceptions import BotError, BotNotFoundError, BotStateConflict
 
 if TYPE_CHECKING:
     from ante.account.service import AccountService
@@ -718,8 +718,20 @@ class BotManager:
         logger.info("봇 재개: %s", bot_id)
 
     async def start_bot(self, bot_id: str) -> None:
-        """봇 시작. 전략별 룰이 설정되어 있으면 RuleEngine에 로드."""
+        """봇 시작. 전략별 룰이 설정되어 있으면 RuleEngine에 로드.
+
+        Refs #1759: 이미 ``RUNNING`` 상태인 봇에 대한 중복 호출은
+        ``BotStateConflict`` 로 거부한다 (IPC envelope:
+        ``BOT_STATE_CONFLICT``). ``resume_bot`` 의 status 체크 + raise
+        패턴과 동형이며, ``BotStateConflict`` 는 ``BotError`` 서브클래스
+        이므로 기존 ``except BotError`` 호출자 (IPC handler) 는 자연스럽게
+        ``BOT_STATE_CONFLICT`` envelope 으로 매핑된다.
+        """
         bot = self._get_bot(bot_id)
+        if bot.status == BotStatus.RUNNING:
+            raise BotStateConflict(
+                f"이미 실행 중인 봇입니다: {bot_id} (상태: {bot.status.value})"
+            )
         self._load_strategy_rules(bot.config.strategy_id)
         await bot.start()
 
@@ -730,8 +742,19 @@ class BotManager:
 
         suppress_notification이 True이면 BotStoppedEvent에 의한
         NotificationEvent 발행을 1회 억제한다.
+
+        Refs #1759: ``RUNNING`` / ``ERROR`` 가 아닌 상태에서의 중복 호출은
+        ``BotStateConflict`` 로 거부한다. 허용 범위는 ``Bot.stop()`` 이
+        실제로 처리하는 상태 집합 (``RUNNING``/``ERROR``) 과 정합시킨다.
+        ``BotStateConflict`` 는 ``BotError`` 서브클래스이므로 기존
+        ``except BotError`` 호출자 (IPC handler) 는 자연스럽게
+        ``BOT_STATE_CONFLICT`` envelope 으로 매핑된다.
         """
         bot = self._get_bot(bot_id)
+        if bot.status not in (BotStatus.RUNNING, BotStatus.ERROR):
+            raise BotStateConflict(
+                f"중지할 수 없는 상태입니다: {bot_id} (현재: {bot.status.value})"
+            )
         if suppress_notification:
             self._suppress_notification_bot_ids.add(bot_id)
         await bot.stop()
@@ -940,13 +963,23 @@ class BotManager:
     # ── EventBus 핸들러 ──────────────────────────────
 
     async def _on_bot_stop_request(self, event: object) -> None:
-        """BotStopEvent 수신 시 해당 봇 중지."""
+        """BotStopEvent 수신 시 해당 봇 중지.
+
+        Refs #1759: ``BotManager.stop_bot`` 이 strict state machine 으로
+        전환된 이후에도 EventBus 경로의 ``BotStopEvent`` 핸들러는
+        idempotent 의미를 보존한다 (rule engine 이 한도 위반으로 발행한
+        이벤트가 중복 수신되거나 봇이 이미 중지되어 있을 수 있음).
+        state machine 거부는 silent ignore 한다.
+        """
         from ante.eventbus.events import BotStopEvent
 
         if not isinstance(event, BotStopEvent):
             return
         if event.bot_id in self._bots:
-            await self.stop_bot(event.bot_id)
+            try:
+                await self.stop_bot(event.bot_id)
+            except BotStateConflict:
+                return
 
     async def _on_account_suspended(self, event: object) -> None:
         """계좌 정지 시 해당 계좌의 봇만 중지."""

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1135,6 +1135,22 @@ async def _init_approval(s: Services) -> None:
             source_path=Path(record.filepath),
         )
 
+    async def _exec_bot_stop_idempotent(params: dict) -> None:
+        """approval ``bot_stop`` executor.
+
+        Refs #1759: ``BotManager.stop_bot`` 이 strict state machine 으로
+        전환된 이후에도 approval workflow 의 ``bot_stop`` action 은
+        idempotent 의미를 보존한다 (이미 중지된 봇에 대해 BotStoppedEvent
+        가 재처리되는 cold path 회귀 보호). state machine 거부는 silent
+        ignore 하고, 그 외 ``BotError`` 는 그대로 전파한다.
+        """
+        from ante.bot.exceptions import BotStateConflict
+
+        try:
+            await s.bot_manager.stop_bot(params["bot_id"])
+        except BotStateConflict:
+            return
+
     approval_executors: dict = {
         # 전략 관련
         "strategy_adopt": _exec_strategy_adopt,
@@ -1147,7 +1163,7 @@ async def _init_approval(s: Services) -> None:
         "bot_change_strategy": lambda params: s.bot_manager.change_strategy(
             params["bot_id"], params["strategy_id"]
         ),
-        "bot_stop": lambda params: s.bot_manager.stop_bot(params["bot_id"]),
+        "bot_stop": _exec_bot_stop_idempotent,
         "bot_resume": lambda params: s.bot_manager.resume_bot(params["bot_id"]),
         "bot_delete": lambda params: s.bot_manager.delete_bot(params["bot_id"]),
         # 자금·규칙

--- a/tests/unit/test_bot_lifecycle_state_conflict.py
+++ b/tests/unit/test_bot_lifecycle_state_conflict.py
@@ -1,0 +1,262 @@
+"""BotManager start_bot/stop_bot state machine 회귀 (#1759).
+
+Refs #1759: ante-oracle A7 ``cli_bot_lifecycle_state_conflict_contract`` 가
+재현한 silent-success 결함 잠금. ``BotManager.start_bot`` / ``stop_bot`` 는
+``Bot.start`` / ``Bot.stop`` 위에 strict state machine 을 적용해 중복
+호출을 ``BotStateConflict`` (code=``BOT_STATE_CONFLICT``) 로 거부한다.
+``resume_bot`` (manager.py:699-718) 의 status 체크 + raise 패턴과 동형.
+
+회귀 매트릭스:
+
+- R1: ``start_bot`` 두 번 → 두 번째 ``BotStateConflict`` raise + code.
+- R2: ``stop_bot`` 두 번 → 두 번째 ``BotStateConflict`` raise + code.
+- R5 (caller silent-ignore 회귀 보존):
+  - EventBus 경로 ``_on_bot_stop_request`` 가 비실행 봇에서도 raise 하지
+    않는다 (rule engine 의 중복 발행 / cold path 호환).
+  - approval ``bot_stop`` executor (``main.py`` lambda 대체) 가 비실행
+    봇에서도 raise 하지 않는다 (BotStoppedEvent 재처리 호환).
+
+R3/R4 (CLI/IPC envelope: BOT_STATE_CONFLICT) 는 기존
+``tests/unit/test_cli_bot_lifecycle.py`` / ``tests/unit/test_ipc_bot_lifecycle.py``
+가 envelope passthrough 를 잠그고 있다 (BotStateConflict 가 BotError
+서브클래스이므로 ipc handler 의 ``except BotError`` → ``BotStateConflict``
+매핑이 동일하게 동작).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import polars as pl
+import pytest
+
+from ante.bot import BotConfig, BotManager
+from ante.bot.config import BotStatus
+from ante.bot.exceptions import BOT_STATE_CONFLICT_CODE, BotStateConflict
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import BotStopEvent
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+
+
+class _FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):  # type: ignore[override]
+        return pl.DataFrame({"close": [100.0]})
+
+    async def get_current_price(self, symbol):  # type: ignore[override]
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):  # type: ignore[override]
+        return {}
+
+
+class _FakePortfolio(PortfolioView):
+    def get_positions(self, bot_id):  # type: ignore[override]
+        return {}
+
+    def get_balance(self, bot_id):  # type: ignore[override]
+        return {"total": 1.0, "available": 1.0}
+
+
+class _FakeOrders(OrderView):
+    def get_open_orders(self, bot_id):  # type: ignore[override]
+        return []
+
+
+class _NoopStrategy(Strategy):
+    meta = StrategyMeta(name="noop", version="1.0.0", description="state conflict test")
+
+    async def on_step(self, context):  # type: ignore[override]
+        return []
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def ctx() -> StrategyContext:
+    return StrategyContext(
+        bot_id="bot-1759",
+        data_provider=_FakeDataProvider(),
+        portfolio=_FakePortfolio(),
+        order_view=_FakeOrders(),
+    )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    try:
+        await asyncio.wait_for(database.close(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+async def manager(eventbus: EventBus, db: Database) -> BotManager:
+    m = BotManager(eventbus=eventbus, db=db)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+async def _create_bot(
+    manager: BotManager, ctx: StrategyContext, *, bot_id: str = "bot-1759"
+):
+    config = BotConfig(
+        bot_id=bot_id,
+        strategy_id=f"strat-{bot_id}",
+        account_id="acc-test",
+    )
+    return await manager.create_bot(config, _NoopStrategy, ctx)
+
+
+# ── R1: start_bot 두 번 → BotStateConflict ─────────────────────────────
+
+
+async def test_start_bot_twice_raises_state_conflict(
+    manager: BotManager, ctx: StrategyContext
+) -> None:
+    """이미 실행 중인 봇에 대한 두 번째 start_bot 은 BotStateConflict."""
+    bot = await _create_bot(manager, ctx)
+    await manager.start_bot(bot.bot_id)
+    try:
+        assert bot.status == BotStatus.RUNNING
+
+        with pytest.raises(BotStateConflict) as exc:
+            await manager.start_bot(bot.bot_id)
+
+        assert exc.value.code == BOT_STATE_CONFLICT_CODE
+        # 메시지에 bot_id 및 현재 상태가 노출된다 (운영 추적용).
+        assert bot.bot_id in str(exc.value)
+        assert BotStatus.RUNNING.value in str(exc.value)
+        # 봇 상태는 RUNNING 그대로 — 거부가 부수효과를 남기지 않는다.
+        assert bot.status == BotStatus.RUNNING
+    finally:
+        await manager.stop_bot(bot.bot_id)
+
+
+# ── R2: stop_bot 두 번 → BotStateConflict ──────────────────────────────
+
+
+async def test_stop_bot_twice_raises_state_conflict(
+    manager: BotManager, ctx: StrategyContext
+) -> None:
+    """이미 정지된 봇에 대한 두 번째 stop_bot 은 BotStateConflict."""
+    bot = await _create_bot(manager, ctx)
+    await manager.start_bot(bot.bot_id)
+    await manager.stop_bot(bot.bot_id)
+    assert bot.status == BotStatus.STOPPED
+
+    with pytest.raises(BotStateConflict) as exc:
+        await manager.stop_bot(bot.bot_id)
+
+    assert exc.value.code == BOT_STATE_CONFLICT_CODE
+    assert bot.bot_id in str(exc.value)
+    assert BotStatus.STOPPED.value in str(exc.value)
+    assert bot.status == BotStatus.STOPPED
+
+
+async def test_stop_bot_on_created_state_raises_state_conflict(
+    manager: BotManager, ctx: StrategyContext
+) -> None:
+    """``CREATED`` 상태(시작된 적 없는 봇) stop_bot 은 BotStateConflict.
+
+    ``Bot.stop()`` 이 ``RUNNING``/``ERROR`` 만 처리하므로 manager 도 동일
+    범위로 정합.
+    """
+    bot = await _create_bot(manager, ctx, bot_id="bot-1759-created")
+    assert bot.status == BotStatus.CREATED
+
+    with pytest.raises(BotStateConflict) as exc:
+        await manager.stop_bot(bot.bot_id)
+
+    assert exc.value.code == BOT_STATE_CONFLICT_CODE
+    assert BotStatus.CREATED.value in str(exc.value)
+
+
+# ── R5: caller silent-ignore 회귀 보존 ─────────────────────────────────
+
+
+async def test_on_bot_stop_request_silent_ignores_state_conflict(
+    manager: BotManager, ctx: StrategyContext, eventbus: EventBus
+) -> None:
+    """EventBus ``BotStopEvent`` 핸들러는 비실행 봇에서도 raise 하지 않는다.
+
+    rule engine 이 한도 위반으로 발행한 이벤트가 중복 수신되거나 봇이
+    이미 중지되어 있을 수 있다 — 이 cold path 는 idempotent 의미를
+    유지한다.
+    """
+    bot = await _create_bot(manager, ctx, bot_id="bot-1759-evt")
+    # 시작된 적 없는 봇 (status=CREATED) — stop_bot 직접 호출은 R2 에서
+    # BotStateConflict 가 발생함을 확인했다. 같은 봇에 BotStopEvent 를
+    # 발행하면 핸들러가 silent ignore 하여 raise 가 전파되지 않는다.
+    assert bot.status == BotStatus.CREATED
+
+    # 핸들러가 BotStateConflict 를 흡수하는지 직접 호출로 검증한다
+    # (eventbus.publish 는 핸들러 예외를 로깅만 하고 삼킬 수 있어 회귀
+    # 보장이 약하다 — 핸들러 함수를 직접 await 한다).
+    event = BotStopEvent(bot_id=bot.bot_id, reason="test-1759-cold-path")
+    # raise 가 전파되지 않으면 통과. 어떤 예외든 잡히면 회귀.
+    await manager._on_bot_stop_request(event)
+    # 상태는 CREATED 그대로 (silent ignore).
+    assert bot.status == BotStatus.CREATED
+
+
+async def test_approval_bot_stop_executor_silent_ignores_state_conflict(
+    manager: BotManager, ctx: StrategyContext
+) -> None:
+    """approval ``bot_stop`` executor (main.py) 는 비실행 봇에서도 raise 하지 않는다.
+
+    ``BotManager.stop_bot`` 이 strict state machine 으로 전환된 이후에도
+    approval workflow 의 ``bot_stop`` action 은 idempotent 의미를 보존
+    한다 (이미 중지된 봇에 대해 BotStoppedEvent 가 재처리되는 cold path
+    회귀 보호). state machine 거부 (``BotStateConflict``) 는 silent
+    ignore 하고, 그 외 예외는 전파한다.
+
+    main.py 의 ``_exec_bot_stop_idempotent`` 와 동형 inline 으로
+    회귀를 잠근다 (main.py 는 closure 라 직접 import 불가).
+    """
+    bot = await _create_bot(manager, ctx, bot_id="bot-1759-approval")
+    assert bot.status == BotStatus.CREATED  # 시작된 적 없음 → stop_bot 거부 대상
+
+    async def _exec_bot_stop_idempotent(params: dict) -> None:
+        try:
+            await manager.stop_bot(params["bot_id"])
+        except BotStateConflict:
+            return
+
+    # raise 가 전파되지 않으면 통과 — silent ignore 회귀 보존.
+    await _exec_bot_stop_idempotent({"bot_id": bot.bot_id})
+    assert bot.status == BotStatus.CREATED
+
+
+# ── 정상 흐름 sanity (회귀 보존) ──────────────────────────────────────
+
+
+async def test_start_then_stop_remains_legal(
+    manager: BotManager, ctx: StrategyContext
+) -> None:
+    """정상 start → stop 흐름은 state machine 도입 후에도 그대로 동작."""
+    bot = await _create_bot(manager, ctx, bot_id="bot-1759-happy")
+    await manager.start_bot(bot.bot_id)
+    assert bot.status == BotStatus.RUNNING
+    await manager.stop_bot(bot.bot_id)
+    assert bot.status == BotStatus.STOPPED


### PR DESCRIPTION
Closes #1759

## Summary
- `BotManager.start_bot` / `stop_bot` 에 strict state machine 적용. 중복 호출은 `BotStateConflict` (code=`BOT_STATE_CONFLICT`) 로 거부. `resume_bot` (manager.py:699-718) 패턴과 동형.
- IPC handler 의 `except BotError` → `BotStateConflict` 매핑이 envelope 으로 자동 정렬 (BotStateConflict 가 BotError 서브클래스).
- caller 회귀 보존: `_on_bot_stop_request` (EventBus) / approval `bot_stop` executor 는 `BotStateConflict` silent ignore.

## Root cause
`manager.py:720-738` 의 `start_bot` / `stop_bot` 가 status 체크 없이 `Bot.start()` / `Bot.stop()` 를 직접 호출했다. `Bot.stop()` 은 RUNNING/ERROR 외 상태에서 early return 하므로 두 번째 호출이 silent success 했고, 동일 결함이 `Bot.start()` 에도 존재했다. ante-oracle A7 host probe `cli_bot_lifecycle_state_conflict_contract` 가 `second_start_success=True, second_stop_success=True` 시그니처로 재현.

## Test plan
- [x] `pytest tests/unit/test_bot_lifecycle_state_conflict.py -q` (R1/R2/R2'/R5/sanity 6 passed).
- [x] `pytest tests/unit/test_ipc_bot_lifecycle.py tests/unit/test_cli_bot_lifecycle.py tests/unit/test_bot_manager_*.py tests/unit/test_bot_restart.py tests/unit/test_bot_stop_release.py -q` (145 passed).
- [x] `pytest tests/unit/ -q` (4964 passed, 2 skipped).
- [x] `ruff check` / `ruff format --check`.
- [x] `mypy src/ante/bot/manager.py src/ante/main.py`.
- [x] project-structure regen (drift 1줄 — neuer test file).

## Non-Goals
- `resume_bot` 변경 (기존 BotError 유지; typed exception 일관화는 별도 sweep).
- `delete_bot` state 체크.
- IPC server.py 코드 매핑 (자동: `getattr(e, "code", ...)`).
- 다른 manager 함수 state 일관화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)