### PR TITLE
fix: #1761 bot signal-key --rotate에 accepts_external_signals 게이트

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -563,7 +563,9 @@ tests/
 │   ├── test_cli_strategy_submit_meta_shape.py
 │   ├── test_cli_system_start_json_stdout.py
 │   ├── test_cli_treasury_read_account_not_found.py
-│   └── test_bot_lifecycle_state_conflict.py
+│   ├── test_bot_lifecycle_state_conflict.py
+│   ├── test_bot_create_signal_key_auto.py
+│   └── test_cli_bot_signal_key_rotate_external_gate.py
 └── __init__.py
 ```
 

--- a/src/ante/bot/exceptions.py
+++ b/src/ante/bot/exceptions.py
@@ -11,6 +11,7 @@ Refs #1712: ``bot.start``/``bot.stop`` IPC handler 가 stable coded exception을
 BOT_NOT_FOUND_CODE = "BOT_NOT_FOUND"
 BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE = "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED"
 BOT_STATE_CONFLICT_CODE = "BOT_STATE_CONFLICT"
+BOT_NOT_ACCEPTING_SIGNALS_CODE = "BOT_NOT_ACCEPTING_SIGNALS"
 
 
 class BotError(Exception):
@@ -50,3 +51,16 @@ class BotStateConflict(BotError):  # noqa: N818
     """
 
     code: str = BOT_STATE_CONFLICT_CODE
+
+
+class BotNotAcceptingSignals(BotError):  # noqa: N818
+    """봇의 전략이 외부 시그널을 받지 않음 (``accepts_external_signals=False``).
+
+    Refs #1761: ``bot signal-key --rotate`` 가 ``accepts_external_signals=False``
+    전략에도 키를 발급해 orphan credential 이 생기던 회귀를 막는다.
+    ``signal connect`` 가 동일 조건을 이미 ``BOT_NOT_ACCEPTING_SIGNALS`` 로
+    거부(``ante/cli/commands/signal.py:70-75``)하고 있어 같은 코드를 재사용해
+    IPC/CLI 표면 간 envelope 코드 일관성을 유지한다.
+    """
+
+    code: str = BOT_NOT_ACCEPTING_SIGNALS_CODE

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -17,7 +17,12 @@ from ante.bot.config import (
     validate_interval,
     validate_runtime_controls,
 )
-from ante.bot.exceptions import BotError, BotNotFoundError, BotStateConflict
+from ante.bot.exceptions import (
+    BotError,
+    BotNotAcceptingSignals,
+    BotNotFoundError,
+    BotStateConflict,
+)
 
 if TYPE_CHECKING:
     from ante.account.service import AccountService
@@ -1182,10 +1187,48 @@ class BotManager:
         return await self._signal_key_manager.get_key(bot_id)
 
     async def rotate_signal_key(self, bot_id: str) -> str:
-        """시그널 키 재발급."""
+        """시그널 키 재발급.
+
+        Refs #1761: ``accepts_external_signals=False`` 전략의 봇에 rotate 가
+        새 키를 발급해 orphan credential 이 생기던 회귀를 막는다.
+        ``create_bot`` 의 자동 발급 분기 (``manager.py`` 의
+        ``getattr(strategy_cls.meta, "accepts_external_signals", False)``)와
+        동일한 조건을 사용해 일관성을 유지한다.
+        """
         if not self._signal_key_manager:
             raise BotError("SignalKeyManager가 설정되지 않았습니다")
-        self._get_bot(bot_id)  # 존재 확인
+        bot = self._get_bot(bot_id)  # 존재 확인
+
+        # accepts_external_signals 게이트 (#1761).
+        # ``Bot.__init__`` 가 ``_strategy_cls`` 를 보관하므로 ``start()``
+        # 이전(``bot.strategy is None``)에도 메타를 조회할 수 있다. fallback
+        # 으로는 registry+loader 를 사용해 cold-path 호출자에서도 동작한다.
+        meta = None
+        strategy = getattr(bot, "strategy", None)
+        if strategy is not None:
+            meta = getattr(strategy, "meta", None)
+        if meta is None:
+            strategy_cls = getattr(bot, "_strategy_cls", None)
+            if strategy_cls is not None:
+                meta = getattr(strategy_cls, "meta", None)
+        if meta is None:
+            from ante.strategy.loader import StrategyLoader
+            from ante.strategy.registry import StrategyRegistry
+
+            registry = StrategyRegistry(self._db)
+            await registry.initialize()
+            record = await registry.get(bot.config.strategy_id)
+            if record is None:
+                raise BotError(f"전략 미발견: {bot.config.strategy_id}")
+            loaded_cls = StrategyLoader.load(Path(record.filepath))
+            meta = getattr(loaded_cls, "meta", None)
+
+        if not getattr(meta, "accepts_external_signals", False):
+            raise BotNotAcceptingSignals(
+                f"이 봇의 전략은 외부 시그널을 받지 않습니다: "
+                f"bot_id={bot_id}, strategy_id={bot.config.strategy_id}"
+            )
+
         return await self._signal_key_manager.rotate(bot_id)
 
     def get_restart_count(self, bot_id: str) -> int:

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -401,8 +401,13 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
             # 한다 (malformed db 같은 다른 ``OperationalError`` 까지
             # 삼키지 않도록 메시지로 좁힌다, #1558 동형).
             try:
+                # Refs #1761: ``--rotate`` 게이트가 ``strategy_id`` 를
+                # 필요로 하므로 존재 확인 쿼리에서 함께 SELECT 한다.
+                # row 의 truthiness 는 보존되어 기존 미존재/소프트삭제
+                # 거부 회귀(#1596)와 동일하게 동작한다.
                 bot_row = await db.fetch_one(
-                    "SELECT 1 FROM bots WHERE bot_id = ? AND status != 'deleted'",
+                    "SELECT strategy_id FROM bots "
+                    "WHERE bot_id = ? AND status != 'deleted'",
                     (bot_id,),
                 )
             except sqlite3.OperationalError as e:
@@ -414,6 +419,42 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
                 return {"bot_id": bot_id, "missing": True}
 
             if rotate:
+                # accepts_external_signals 게이트 (#1761).
+                # ``BotManager.rotate_signal_key`` 가 적용하는 동일 invariant
+                # 를 CLI cold-path 에도 적용해 defense-in-depth 를 유지한다
+                # (CLI 는 BotManager 를 우회해 ``SignalKeyManager`` 를 직접
+                # 호출하므로 manager 게이트가 cover 하지 않는다).
+                from ante.bot.exceptions import BOT_NOT_ACCEPTING_SIGNALS_CODE
+                from ante.strategy.loader import StrategyLoader
+                from ante.strategy.registry import StrategyRegistry
+
+                strategy_id = bot_row["strategy_id"]
+                registry = StrategyRegistry(db)
+                await registry.initialize()
+                record = await registry.get(strategy_id)
+                if record is None:
+                    return {
+                        "bot_id": bot_id,
+                        "error": f"전략 미발견: {strategy_id}",
+                        "code": "STRATEGY_NOT_FOUND",
+                        "external_signals_disabled": True,
+                    }
+                strategy_cls = StrategyLoader.load(Path(record.filepath))
+                if not getattr(
+                    getattr(strategy_cls, "meta", None),
+                    "accepts_external_signals",
+                    False,
+                ):
+                    return {
+                        "bot_id": bot_id,
+                        "error": (
+                            "이 봇의 전략은 외부 시그널을 받지 않습니다: "
+                            f"bot_id={bot_id}, strategy_id={strategy_id}"
+                        ),
+                        "code": BOT_NOT_ACCEPTING_SIGNALS_CODE,
+                        "external_signals_disabled": True,
+                    }
+
                 new_key = await skm.rotate(bot_id)
                 return {"bot_id": bot_id, "signal_key": new_key, "rotated": True}
 
@@ -443,6 +484,14 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
         # 않도록 한다.
         fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
         ctx.exit(1)
+
+    if result.get("external_signals_disabled"):
+        # Refs #1761: ``accepts_external_signals=False`` 전략 봇에 rotate
+        # 가 새 키를 발급해 orphan credential 이 생기던 회귀를 막는다.
+        # ``signal connect`` 의 동형 거부(``ante/cli/commands/signal.py:70-75``)
+        # 와 동일한 ``BOT_NOT_ACCEPTING_SIGNALS`` 코드를 stable 하게 노출한다.
+        fmt.error(result["error"], code=result.get("code", ""))
+        raise SystemExit(1)
 
     if result.get("signal_key") is None:
         fmt.error(f"시그널 키가 없습니다: {bot_id}")

--- a/tests/unit/test_cli_bot_signal_key_rotate_external_gate.py
+++ b/tests/unit/test_cli_bot_signal_key_rotate_external_gate.py
@@ -1,0 +1,398 @@
+"""Refs #1761 — ``bot signal-key --rotate`` accepts_external_signals 게이트.
+
+## 배경
+
+오라클 host probe ``cli_signal_key_rotate_accepts_external_contract`` (A7)
+는 ``accepts_external_signals=False`` 전략의 봇에 대해서도
+``bot signal-key --rotate`` 가 ``returncode=0`` 으로 새 키를 발급하고,
+이어지는 조회에서 ``after_key_present=true`` 가 관측되는 invariant 위반을
+보고했다. 외부 신호를 받지 않아야 할 봇에 인증 키가 생겨 운영자가 전략의
+외부 신호 허용 상태를 잘못 이해할 수 있다.
+
+Root cause (사실):
+1. ``ante/cli/commands/bot.py`` 의 ``bot_signal_key`` ``--rotate`` 분기가
+   ``skm.rotate(bot_id)`` 호출 전에 전략의 ``accepts_external_signals``
+   메타를 확인하지 않았다.
+2. ``BotManager.rotate_signal_key`` 도 동일 게이트를 적용하지 않아 IPC /
+   server-side 경로에서도 같은 회귀가 가능했다.
+3. 비교: ``BotManager.create_bot`` 의 자동 발급 분기는 정확히
+   ``getattr(strategy_cls.meta, "accepts_external_signals", False)`` 일 때만
+   ``signal_key_manager.generate(bot_id)`` 를 호출 — rotate 가 같은 invariant
+   를 따르지 않아 일관성이 깨졌다.
+
+## 회귀 lock
+
+- R1 (회귀 보존 — external strategy): ``accepts_external_signals=True`` 전략의
+  봇은 ``--rotate`` 가 exit 0 + ``rotated=True`` envelope, ``skm.rotate``
+  호출됨.
+- R2 (게이트 — non-external strategy): ``accepts_external_signals=False``
+  전략의 봇은 ``--rotate`` 가 exit 1 + ``code="BOT_NOT_ACCEPTING_SIGNALS"``
+  envelope.
+- R3 (orphan 차단): R2 조건에서 ``skm.rotate`` 가 **호출되지 않는다**
+  (게이트가 키 발급 자체를 차단해 orphan credential 미발급).
+- R4 (sanity): non-rotate get 경로는 게이트 적용 대상 아님 — 기존 키 조회는
+  정상 동작 (회귀 보존).
+- R5 (BotManager 게이트): ``BotManager.rotate_signal_key`` 가 동일 invariant
+  를 raise ``BotNotAcceptingSignals`` (code=``BOT_NOT_ACCEPTING_SIGNALS``) 로
+  적용 — IPC / server-side 경로의 defense-in-depth.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.bot.config import BotConfig
+from ante.bot.exceptions import (
+    BOT_NOT_ACCEPTING_SIGNALS_CODE,
+    BotNotAcceptingSignals,
+)
+from ante.bot.manager import BotManager
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """인증을 mock으로 우회한 CliRunner (test_cli_missing_resource_exit 동형)."""
+    r = CliRunner(mix_stderr=False)
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class _AcceptingStrategy(Strategy):
+    """accepts_external_signals=True 전략."""
+
+    meta = StrategyMeta(
+        name="accepting",
+        version="1.0.0",
+        description="accepts external signals",
+        accepts_external_signals=True,
+    )
+
+    async def on_step(self, context: dict) -> list[Signal]:  # type: ignore[override]
+        return []
+
+
+class _NormalStrategy(Strategy):
+    """accepts_external_signals=False 전략."""
+
+    meta = StrategyMeta(
+        name="normal",
+        version="1.0.0",
+        description="non-external strategy",
+    )
+
+    async def on_step(self, context: dict) -> list[Signal]:  # type: ignore[override]
+        return []
+
+
+def _make_strategy_patches(*, accepts_external_signals: bool) -> tuple:
+    """``StrategyRegistry`` + ``StrategyLoader.load`` patch tuple 을 생성한다.
+
+    rotate 게이트가 봇의 ``strategy_id`` 로 registry 조회 → ``StrategyLoader``
+    로 클래스 로드 → ``meta.accepts_external_signals`` 확인하는 경로를
+    단위 테스트에서 시뮬레이션한다.
+    """
+    mock_record = MagicMock()
+    mock_record.filepath = "/fake/path.py"
+    mock_registry = AsyncMock()
+    mock_registry.initialize = AsyncMock()
+    mock_registry.get = AsyncMock(return_value=mock_record)
+
+    mock_strategy_cls = MagicMock()
+    mock_strategy_cls.meta = StrategyMeta(
+        name="t",
+        version="1.0.0",
+        description="t",
+        accepts_external_signals=accepts_external_signals,
+    )
+
+    return (
+        patch(
+            "ante.strategy.registry.StrategyRegistry",
+            return_value=mock_registry,
+        ),
+        patch(
+            "ante.strategy.loader.StrategyLoader.load",
+            return_value=mock_strategy_cls,
+        ),
+    )
+
+
+# ── R1: 회귀 보존 ─────────────────────────────────────
+
+
+class TestRotateExternalStrategyAllowed:
+    """R1: ``accepts_external_signals=True`` 전략 봇은 rotate 정상."""
+
+    def test_rotate_external_strategy_exits_zero_with_key(
+        self, runner: CliRunner
+    ) -> None:
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "ext-1"})
+        mock_skm = AsyncMock()
+        mock_skm.initialize = AsyncMock()
+        mock_skm.rotate = AsyncMock(return_value="sk_external_rotated_42")
+
+        reg_patch, loader_patch = _make_strategy_patches(accepts_external_signals=True)
+        with (
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new_callable=AsyncMock,
+                return_value=(mock_db, None, None, None),
+            ),
+            patch(
+                "ante.bot.signal_key.SignalKeyManager",
+                return_value=mock_skm,
+            ),
+            reg_patch,
+            loader_patch,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "signal-key",
+                    "bot-ext-1",
+                    "--rotate",
+                ],
+            )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "ok"
+        assert payload["data"]["signal_key"] == "sk_external_rotated_42"
+        assert payload["data"]["rotated"] is True
+        mock_skm.rotate.assert_awaited_once_with("bot-ext-1")
+
+
+# ── R2 + R3: 게이트 + orphan 차단 ─────────────────────
+
+
+class TestRotateNonExternalStrategyRejected:
+    """R2/R3: non-external 전략 봇은 rotate 거부 + skm.rotate 미호출."""
+
+    def _gated_skm(self) -> AsyncMock:
+        """rotate 가 호출되면 즉시 실패하는 SignalKeyManager mock.
+
+        R3 검증의 핵심: 게이트가 ``skm.rotate`` **이전** 에 걸려야 한다.
+        ``assert_not_awaited`` 와 함께 이중으로 orphan 미발급을 lock 한다.
+        """
+        skm = AsyncMock()
+        skm.initialize = AsyncMock()
+        skm.rotate = AsyncMock(
+            side_effect=AssertionError(
+                "non-external 전략인데 rotate 가 호출됨 (orphan credential)"
+            )
+        )
+        skm.get_key = AsyncMock()
+        return skm
+
+    def test_rotate_non_external_strategy_exits_one_with_code_json(
+        self, runner: CliRunner
+    ) -> None:
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "normal-1"})
+        mock_skm = self._gated_skm()
+
+        reg_patch, loader_patch = _make_strategy_patches(accepts_external_signals=False)
+        with (
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new_callable=AsyncMock,
+                return_value=(mock_db, None, None, None),
+            ),
+            patch(
+                "ante.bot.signal_key.SignalKeyManager",
+                return_value=mock_skm,
+            ),
+            reg_patch,
+            loader_patch,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "signal-key",
+                    "bot-normal-1",
+                    "--rotate",
+                ],
+            )
+
+        # R2: exit 1 + JSON envelope 의 안정된 code.
+        assert result.exit_code == 1, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == BOT_NOT_ACCEPTING_SIGNALS_CODE
+        assert payload["code"] == "BOT_NOT_ACCEPTING_SIGNALS"
+        assert "외부 시그널을 받지 않습니다" in payload["message"]
+        # R3: 게이트가 키 발급을 차단 — skm.rotate 미호출 (orphan 미발급).
+        mock_skm.rotate.assert_not_awaited()
+
+    def test_rotate_non_external_strategy_exits_one_text(
+        self, runner: CliRunner
+    ) -> None:
+        """text 모드에서도 동일 거부 — exit 1 + stderr ``Error:``."""
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "normal-1"})
+        mock_skm = self._gated_skm()
+
+        reg_patch, loader_patch = _make_strategy_patches(accepts_external_signals=False)
+        with (
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new_callable=AsyncMock,
+                return_value=(mock_db, None, None, None),
+            ),
+            patch(
+                "ante.bot.signal_key.SignalKeyManager",
+                return_value=mock_skm,
+            ),
+            reg_patch,
+            loader_patch,
+        ):
+            result = runner.invoke(
+                cli, ["bot", "signal-key", "bot-normal-1", "--rotate"]
+            )
+
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert "Error:" in result.stderr
+        assert "외부 시그널을 받지 않습니다" in result.stderr
+        mock_skm.rotate.assert_not_awaited()
+
+
+# ── R4: sanity — non-rotate get 경로는 게이트 적용 대상 아님 ───
+
+
+class TestNonRotateGetUnaffectedByGate:
+    """R4: 게이트는 ``--rotate`` 분기 전용 — 키 조회 경로는 회귀 보존."""
+
+    def test_get_key_non_external_strategy_returns_existing_key(
+        self, runner: CliRunner
+    ) -> None:
+        """non-external 전략이라도 이미 발급된 키 조회는 정상 (#1761 비대상).
+
+        게이트는 발급 차단 invariant. 기존 키 조회는 운영상 의도된 동작이며,
+        게이트가 키 조회까지 막으면 회귀 (#1596과 동일 분리 원칙).
+        """
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "normal-1"})
+        mock_skm = AsyncMock()
+        mock_skm.initialize = AsyncMock()
+        mock_skm.get_key = AsyncMock(return_value="sk_already_present_99")
+
+        with (
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new_callable=AsyncMock,
+                return_value=(mock_db, None, None, None),
+            ),
+            patch(
+                "ante.bot.signal_key.SignalKeyManager",
+                return_value=mock_skm,
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "bot", "signal-key", "bot-normal-1"]
+            )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["signal_key"] == "sk_already_present_99"
+        mock_skm.get_key.assert_awaited_once_with("bot-normal-1")
+
+
+# ── R5: BotManager 게이트 (defense-in-depth) ────────
+
+
+def _make_bot_manager(signal_key_manager: MagicMock) -> BotManager:
+    """server-side BotManager 인스턴스 (test_bot_create_signal_key_auto 동형)."""
+    db = MagicMock()
+    db.execute = AsyncMock()
+    db.execute_script = AsyncMock()
+    eventbus = MagicMock()
+    eventbus.subscribe = MagicMock()
+    return BotManager(eventbus=eventbus, db=db, signal_key_manager=signal_key_manager)
+
+
+@pytest.mark.asyncio
+class TestBotManagerRotateSignalKeyGate:
+    """R5: ``BotManager.rotate_signal_key`` 도 동일 invariant 를 raise."""
+
+    async def test_rotate_non_external_strategy_raises_typed_exception(
+        self,
+    ) -> None:
+        """non-external 전략 봇 → ``BotNotAcceptingSignals`` raise, rotate
+        미호출."""
+        skm = MagicMock()
+        skm.rotate = AsyncMock(return_value="sk_should_not_be_called")
+
+        manager = _make_bot_manager(skm)
+        config = BotConfig(
+            bot_id="bot-mgr-normal",
+            strategy_id="normal",
+            account_id="acc-test",
+        )
+        await manager.create_bot(config, _NormalStrategy, ctx=MagicMock())
+
+        with pytest.raises(BotNotAcceptingSignals) as exc_info:
+            await manager.rotate_signal_key("bot-mgr-normal")
+
+        # IPC server.py envelope 정렬을 위한 안정된 code attribute.
+        assert exc_info.value.code == BOT_NOT_ACCEPTING_SIGNALS_CODE
+        # 게이트가 키 발급을 차단해 orphan credential 미발급.
+        skm.rotate.assert_not_called()
+
+    async def test_rotate_external_strategy_delegates_to_skm(self) -> None:
+        """sanity: external 전략은 회귀 보존 — ``skm.rotate(bot_id)`` 호출."""
+        skm = MagicMock()
+        skm.generate = AsyncMock(return_value="sk_auto")
+        skm.rotate = AsyncMock(return_value="sk_mgr_rotated")
+
+        manager = _make_bot_manager(skm)
+        config = BotConfig(
+            bot_id="bot-mgr-ext",
+            strategy_id="accepting",
+            account_id="acc-test",
+        )
+        await manager.create_bot(config, _AcceptingStrategy, ctx=MagicMock())
+
+        new_key = await manager.rotate_signal_key("bot-mgr-ext")
+
+        assert new_key == "sk_mgr_rotated"
+        skm.rotate.assert_awaited_once_with("bot-mgr-ext")

--- a/tests/unit/test_cli_missing_resource_exit.py
+++ b/tests/unit/test_cli_missing_resource_exit.py
@@ -407,13 +407,35 @@ class TestBotSignalKeyMissingExit:
         assert payload["signal_key"] == "sk_test123"
 
     def test_valid_rotate_exits_zero(self, runner: CliRunner) -> None:
-        """실재 bot --rotate 재발급은 exit 0 + rotated 회귀 보존."""
+        """실재 bot --rotate 재발급은 exit 0 + rotated 회귀 보존.
+
+        Refs #1761: rotate 분기가 ``strategy_id`` 를 함께 SELECT 하고
+        ``accepts_external_signals`` 게이트를 통과해야 ``skm.rotate`` 가
+        호출된다. ``StrategyRegistry``/``StrategyLoader`` 를 patch 해
+        external signals=True 전략을 시뮬레이션한다.
+        """
+        from ante.strategy.base import StrategyMeta
+
         mock_db = AsyncMock()
         mock_db.close = AsyncMock()
-        mock_db.fetch_one = AsyncMock(return_value={"1": 1})
+        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "s-1"})
         mock_skm = AsyncMock()
         mock_skm.initialize = AsyncMock()
         mock_skm.rotate = AsyncMock(return_value="sk_rotated999")
+
+        mock_record = MagicMock()
+        mock_record.filepath = "/fake/path.py"
+        mock_registry = AsyncMock()
+        mock_registry.initialize = AsyncMock()
+        mock_registry.get = AsyncMock(return_value=mock_record)
+
+        mock_strategy_cls = MagicMock()
+        mock_strategy_cls.meta = StrategyMeta(
+            name="ext",
+            version="1.0.0",
+            description="external",
+            accepts_external_signals=True,
+        )
 
         with (
             patch(
@@ -424,6 +446,14 @@ class TestBotSignalKeyMissingExit:
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
                 return_value=mock_skm,
+            ),
+            patch(
+                "ante.strategy.registry.StrategyRegistry",
+                return_value=mock_registry,
+            ),
+            patch(
+                "ante.strategy.loader.StrategyLoader.load",
+                return_value=mock_strategy_cls,
             ),
         ):
             result = runner.invoke(


### PR DESCRIPTION
## Summary
- Closes #1761. `bot signal-key --rotate` 가 `accepts_external_signals=False` 전략 봇에도 새 키를 발급해 orphan credential 이 생기던 회귀를 막는다.
- CLI rotate 분기와 `BotManager.rotate_signal_key` 양쪽에 게이트를 적용해 IPC/cold-path 모든 경로에서 defense-in-depth.
- `signal connect` 가 이미 사용 중인 안정 코드 `BOT_NOT_ACCEPTING_SIGNALS` 를 재사용해 envelope 일관성 보존 (신규 에러코드 신설 없음).

## 변경
- `src/ante/bot/exceptions.py`: `BotNotAcceptingSignals(BotError)` 추가 (code=`BOT_NOT_ACCEPTING_SIGNALS`).
- `src/ante/bot/manager.py`: `rotate_signal_key` 가 strategy 메타 확인 후 거부.
- `src/ante/cli/commands/bot.py`: `--rotate` 분기 직전에 strategy lookup + 게이트, 존재확인 쿼리는 `SELECT strategy_id` 로 확장.
- `tests/unit/test_cli_bot_signal_key_rotate_external_gate.py` (신규): R1-R5.
- `tests/unit/test_cli_missing_resource_exit.py`: `test_valid_rotate_exits_zero` 픽스처를 게이트 통과 형태로 갱신.

## Test plan
- [x] `pytest tests/unit/test_cli_bot_signal_key_rotate_external_gate.py` — 6 passed (R1/R2/R3/R4/R5)
- [x] `pytest tests/unit/test_cli_missing_resource_exit.py` — 33 passed (회귀)
- [x] `pytest tests/unit/` — 4978 passed, 2 skipped
- [x] `ruff check` + `ruff format --check`
- [x] `mypy src/` — Success: no issues found in 216 source files

## Non-Goals
- 기존 orphan key cleanup (별도 sweep)
- SignalKeyManager 자체 변경
- IPC rotate handler 추가 (별도 sweep)
- CLI 를 `BotManager.rotate_signal_key` 경유로 변경 (CLI self-contained 유지)

Refs Plan v2 narrow-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)