### PR TITLE
fix: #1773-#1782 CLI 에러코드 명명 규칙 sweep (10 commands)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -565,7 +565,8 @@ tests/
 │   ├── test_cli_treasury_read_account_not_found.py
 │   ├── test_bot_lifecycle_state_conflict.py
 │   ├── test_bot_create_signal_key_auto.py
-│   └── test_cli_bot_signal_key_rotate_external_gate.py
+│   ├── test_cli_bot_signal_key_rotate_external_gate.py
+│   └── test_cli_error_code_naming_sweep.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -789,7 +789,7 @@ def bot_logs(
 
     result = _run(_run_logs())
     if result.get("missing"):
-        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         raise SystemExit(1)
     if fmt.is_json:
         fmt.output(result)

--- a/src/ante/cli/commands/config.py
+++ b/src/ante/cli/commands/config.py
@@ -120,7 +120,10 @@ def config_get(ctx: click.Context, key: str | None) -> None:
 
     if isinstance(result, dict):
         if result["source"] == "not_found":
-            fmt.error(f"설정을 찾을 수 없습니다: {result['key']}")
+            fmt.error(
+                f"설정을 찾을 수 없습니다: {result['key']}",
+                code="CONFIG_KEY_NOT_FOUND",
+            )
             ctx.exit(1)
         _render_single(result, fmt)
     else:

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -578,7 +578,7 @@ def init(
             fmt,
             f"init이 이미 완료된 상태입니다: {config_path}\n"
             "  재설치를 원하면 디렉토리를 삭제한 뒤 다시 실행하세요.",
-            code="already_initialized",
+            code="CLI_ALREADY_INITIALIZED",
         )
 
     # 1. 디렉토리 생성 및 누락 파일 보충 (state 2/3/4/5 공통)

--- a/src/ante/cli/commands/instrument.py
+++ b/src/ante/cli/commands/instrument.py
@@ -327,7 +327,10 @@ def instrument_import(
     # 파일 형식 확인 (try 블록 밖에서 분기 — ctx.exit(1)이 같은 try의
     # except Exception에 잡혀 swallow되는 것을 방지)
     if ext not in (".csv", ".json"):
-        fmt.error(f"지원하지 않는 파일 형식: {ext} (csv 또는 json만 지원)")
+        fmt.error(
+            f"지원하지 않는 파일 형식: {ext} (csv 또는 json만 지원)",
+            code="INSTRUMENT_INVALID_FILE_FORMAT",
+        )
         ctx.exit(1)
 
     # 파일 읽기
@@ -346,11 +349,14 @@ def instrument_import(
         ctx.exit(1)
 
     if ext == ".json" and not isinstance(records, list):
-        fmt.error("JSON 파일은 배열 형태여야 합니다.")
+        fmt.error(
+            "JSON 파일은 배열 형태여야 합니다.",
+            code="INSTRUMENT_INVALID_JSON_SHAPE",
+        )
         ctx.exit(1)
 
     if not records:
-        fmt.error("파일에 데이터가 없습니다.")
+        fmt.error("파일에 데이터가 없습니다.", code="INSTRUMENT_EMPTY_FILE")
         ctx.exit(1)
 
     # 필수 컬럼 확인

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -228,7 +228,7 @@ def member_info(ctx: click.Context, member_id: str) -> None:
 
     result = _run(_run_info())
     if not result:
-        fmt.error(f"멤버를 찾을 수 없습니다: {member_id}")
+        fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         ctx.exit(1)
 
     if fmt.is_json:

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -434,7 +434,7 @@ def report_view(ctx: click.Context, report_id: str, db_path: str | None) -> None
     result = asyncio.run(_view())
 
     if not result:
-        fmt.error(f"리포트를 찾을 수 없습니다: {report_id}", code="report_not_found")
+        fmt.error(f"리포트를 찾을 수 없습니다: {report_id}", code="REPORT_NOT_FOUND")
         raise SystemExit(1)
 
     if fmt.is_json:

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -269,7 +269,7 @@ def rule_info(ctx: click.Context, rule_id: str, account_id: str) -> None:
         raise SystemExit(1) from e
 
     if not result:
-        fmt.error(f"룰을 찾을 수 없습니다: {rule_id}")
+        fmt.error(f"룰을 찾을 수 없습니다: {rule_id}", code="RULE_NOT_FOUND")
         raise SystemExit(1)
 
     if fmt.is_json:

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -566,7 +566,7 @@ def snapshot(
 
     if result is None:
         target = date_str or datetime.now(UTC).strftime("%Y-%m-%d")
-        fmt.error(f"{target} 날짜의 스냅샷이 없습니다.", code="snapshot_not_found")
+        fmt.error(f"{target} 날짜의 스냅샷이 없습니다.", code="SNAPSHOT_NOT_FOUND")
         raise SystemExit(1)
 
     if fmt.is_json:

--- a/tests/unit/test_cli_error_code_naming_sweep.py
+++ b/tests/unit/test_cli_error_code_naming_sweep.py
@@ -1,0 +1,460 @@
+"""CLI 에러코드 명명 규칙 sweep (#1773-#1782).
+
+10 개 oracle A7 이슈 동일 패턴 (CLI 에러코드 명명 위반) sweep을 잠근다.
+
+- 3 lower-case → SCREAMING_SNAKE (#1773 / #1774 / #1775)
+- 7 missing → 도메인 prefix SCREAMING_SNAKE 추가 (#1776-#1782)
+
+각 R-case는 subprocess로 ante CLI를 실행하고 ``--format json`` 출력에서
+``code`` 필드가 expected SCREAMING_SNAKE 값과 정확히 일치하는지 확인한다.
+
+R-case 매핑:
+  R1 #1773 ``ante init`` 2회 → ``CLI_ALREADY_INITIALIZED``
+  R2 #1774 ``ante report view <missing>`` → ``REPORT_NOT_FOUND``
+  R3 #1775 ``ante treasury snapshot --account test --date 1999-01-01``
+         → ``SNAPSHOT_NOT_FOUND``
+  R4 #1776 ``ante config get <missing-key>`` → ``CONFIG_KEY_NOT_FOUND``
+  R5 #1777 ``ante rule info <missing-rule> --account test``
+         → ``RULE_NOT_FOUND``
+  R6 #1778 ``ante member info <missing-member>`` → ``MEMBER_NOT_FOUND``
+  R7 #1779 ``ante bot logs <missing-bot>`` → ``BOT_NOT_FOUND``
+  R8 #1780 ``ante instrument import <file>.txt``
+         → ``INSTRUMENT_INVALID_FILE_FORMAT``
+  R9 #1781 ``ante instrument import <empty>.csv``
+         → ``INSTRUMENT_EMPTY_FILE``
+  R10 #1782 ``ante instrument import <object>.json``
+         → ``INSTRUMENT_INVALID_JSON_SHAPE``
+
+conftest 격리: ``_clean_env`` 헬퍼로 부모 프로세스의 환경변수가 새지 않도록
+``PATH`` / ``HOME`` / ``ANTE_CONFIG_DIR`` / ``PYTHONPATH`` 만 명시 전달한다
+(#1725 ``test_cli_treasury_account_not_found.py`` 동형).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+# subprocess timeout: hang 회귀를 5초 마진으로 차단한다. 정상 종료는 1-2초.
+_SUBPROCESS_TIMEOUT_S = 5.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _clean_env(
+    config_dir: Path,
+    *,
+    encryption_key: str | None = None,
+    token: str | None = None,
+) -> dict[str, str]:
+    """subprocess 환경 격리 헬퍼.
+
+    부모 프로세스의 ``ANTE_DB_ENCRYPTION_KEY`` / ``ANTE_MEMBER_TOKEN`` 등이
+    새는 것을 막기 위해 ``PATH`` / ``HOME`` / ``ANTE_CONFIG_DIR`` /
+    ``PYTHONPATH`` 만 명시 전달한다 (#1725 동형).
+    """
+    env: dict[str, str] = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(config_dir)),
+        "ANTE_CONFIG_DIR": str(config_dir),
+        "PYTHONPATH": str(_repo_root() / "src"),
+    }
+    if encryption_key is not None:
+        env["ANTE_DB_ENCRYPTION_KEY"] = encryption_key
+    if token is not None:
+        env["ANTE_MEMBER_TOKEN"] = token
+    return env
+
+
+def _parse_json_last(stdout: str) -> dict:
+    """JSON dict payload를 stdout에서 추출한다.
+
+    ``OutputFormatter.error`` 는 single-line JSON 한 줄로 dump하지만
+    ``OutputFormatter.output`` 은 indent=2로 multi-line dump한다.
+    우선 stdout 전체를 한 번에 ``json.loads`` 로 시도하고(success path),
+    실패하면 라인별 스캔으로 마지막 dict 라인을 찾는다 (error path).
+    """
+    stripped = stdout.strip()
+    if stripped.startswith("{"):
+        try:
+            obj = json.loads(stripped)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    last_obj: dict | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            last_obj = obj
+    assert last_obj is not None, f"JSON dict 라인을 stdout에서 찾지 못함: {stdout!r}"
+    return last_obj
+
+
+def _run_cli(
+    config_dir: Path,
+    args: list[str],
+    *,
+    token: str | None = None,
+    encryption_key: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """``ante --format json <args>`` 를 subprocess로 실행한다.
+
+    timeout=5로 hang 회귀를 차단한다.
+    """
+    env = _clean_env(config_dir, encryption_key=encryption_key, token=token)
+    return subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _run_init(config_dir: Path, encryption_key: str) -> tuple[str, str]:
+    """초기 ``ante init`` 을 호출하고 (token, encryption_key)를 반환한다.
+
+    init은 ``create_default_test_account()`` 경로로 ``account_id='test'``
+    시드 계좌를 자동 생성한다. token은 후속 subprocess 호출의
+    ``ANTE_MEMBER_TOKEN`` 으로 쓰인다.
+    """
+    init_env = _clean_env(config_dir, encryption_key=encryption_key)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ante",
+            "--format",
+            "json",
+            "init",
+            "--name",
+            "Sweep",
+        ],
+        env=init_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"init 실패: exit={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    token = payload.get("token")
+    assert token, f"init 출력에 token 없음: {payload}"
+    return token, encryption_key
+
+
+@pytest.fixture
+def initialized_config(tmp_path: Path) -> tuple[Path, str, str]:
+    """``ante init`` 을 완료한 (config_dir, token, encryption_key) 튜플."""
+    config_dir = tmp_path / "config"
+    key = Fernet.generate_key().decode()
+    token, _ = _run_init(config_dir, key)
+    return config_dir, token, key
+
+
+# ────────────────────────────────────────────────────────────────────
+# R1 #1773 — ante init 2회 → CLI_ALREADY_INITIALIZED
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestInitAlreadyInitializedCodeNaming:
+    def test_init_twice_emits_uppercase_already_initialized(
+        self, tmp_path: Path
+    ) -> None:
+        """R1: init 2번째 실행 → exit 1, code=CLI_ALREADY_INITIALIZED."""
+        config_dir = tmp_path / "config"
+        key = Fernet.generate_key().decode()
+        _run_init(config_dir, key)  # 1차 init (성공)
+
+        # 2차 init — already-initialized 상태에서 exit 1 + JSON 에러.
+        init_env = _clean_env(config_dir, encryption_key=key)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "ante",
+                "--format",
+                "json",
+                "init",
+                "--name",
+                "Sweep",
+            ],
+            env=init_env,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_S,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "CLI_ALREADY_INITIALIZED", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R2 #1774 — ante report view <missing> → REPORT_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestReportViewNotFoundCodeNaming:
+    def test_report_view_missing_id_emits_uppercase_report_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R2: report view <missing> → exit 1, code=REPORT_NOT_FOUND."""
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["report", "view", "rpt-does-not-exist"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "REPORT_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R3 #1775 — treasury snapshot --account test --date 1999-01-01
+#           → SNAPSHOT_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestTreasurySnapshotNotFoundCodeNaming:
+    def test_snapshot_missing_date_emits_uppercase_snapshot_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R3: snapshot --account test --date 1999-01-01 → SNAPSHOT_NOT_FOUND."""
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            [
+                "treasury",
+                "snapshot",
+                "--account",
+                "test",
+                "--date",
+                "1999-01-01",
+            ],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "SNAPSHOT_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R4 #1776 — config get <missing-key> → CONFIG_KEY_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestConfigGetMissingKeyCodeNaming:
+    def test_config_get_missing_key_emits_config_key_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R4: config get <missing> → exit 1, code=CONFIG_KEY_NOT_FOUND."""
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["config", "get", "does.not.exist.key"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "CONFIG_KEY_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R5 #1777 — rule info <missing> --account test → RULE_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestRuleInfoNotFoundCodeNaming:
+    def test_rule_info_missing_rule_emits_rule_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R5: rule info <missing> --account test → RULE_NOT_FOUND."""
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["rule", "info", "rule-does-not-exist", "--account", "test"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "RULE_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R6 #1778 — member info <missing> → MEMBER_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestMemberInfoNotFoundCodeNaming:
+    def test_member_info_missing_id_emits_member_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R6: member info <missing> → exit 1, code=MEMBER_NOT_FOUND."""
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["member", "info", "mbr-does-not-exist"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "MEMBER_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R7 #1779 — bot logs <missing> → BOT_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestBotLogsNotFoundCodeNaming:
+    def test_bot_logs_missing_bot_emits_bot_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        """R7: bot logs <missing> → exit 1, code=BOT_NOT_FOUND."""
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["bot", "logs", "bot-does-not-exist"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "BOT_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R8 #1780 — instrument import <file>.txt → INSTRUMENT_INVALID_FILE_FORMAT
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestInstrumentImportInvalidFormatCodeNaming:
+    def test_invalid_extension_emits_invalid_file_format(
+        self,
+        initialized_config: tuple[Path, str, str],
+        tmp_path: Path,
+    ) -> None:
+        """R8: import <file>.txt → exit 1, code=INSTRUMENT_INVALID_FILE_FORMAT."""
+        config_dir, token, key = initialized_config
+        bogus = tmp_path / "bogus.txt"
+        bogus.write_text("not a csv or json\n", encoding="utf-8")
+        result = _run_cli(
+            config_dir,
+            ["instrument", "import", str(bogus)],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "INSTRUMENT_INVALID_FILE_FORMAT", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R9 #1781 — instrument import <empty>.csv → INSTRUMENT_EMPTY_FILE
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestInstrumentImportEmptyFileCodeNaming:
+    def test_empty_json_emits_empty_file(
+        self,
+        initialized_config: tuple[Path, str, str],
+        tmp_path: Path,
+    ) -> None:
+        """R9: import <empty>.json (빈 array) → code=INSTRUMENT_EMPTY_FILE.
+
+        JSON 경로를 쓰면 ``ext == ".json"`` 분기를 통과해 ``records`` 가
+        빈 list가 되고, ``if not records`` 분기에서 INSTRUMENT_EMPTY_FILE
+        로 종료된다.
+        """
+        config_dir, token, key = initialized_config
+        empty = tmp_path / "empty.json"
+        empty.write_text("[]", encoding="utf-8")
+        result = _run_cli(
+            config_dir,
+            ["instrument", "import", str(empty)],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "INSTRUMENT_EMPTY_FILE", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R10 #1782 — instrument import <object>.json → INSTRUMENT_INVALID_JSON_SHAPE
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestInstrumentImportInvalidJsonShapeCodeNaming:
+    def test_json_object_root_emits_invalid_json_shape(
+        self,
+        initialized_config: tuple[Path, str, str],
+        tmp_path: Path,
+    ) -> None:
+        """R10: import <object>.json (object root) → INSTRUMENT_INVALID_JSON_SHAPE."""
+        config_dir, token, key = initialized_config
+        obj_json = tmp_path / "object.json"
+        obj_json.write_text('{"symbol": "AAPL"}', encoding="utf-8")
+        result = _run_cli(
+            config_dir,
+            ["instrument", "import", str(obj_json)],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "INSTRUMENT_INVALID_JSON_SHAPE", payload

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -778,7 +778,7 @@ class TestInitJsonErrorContract:
         data = self._parse_error_json(result.output)
         assert data["status"] == "error"
         assert "init이 이미 완료된 상태입니다" in data["message"]
-        assert data.get("code") == "already_initialized"
+        assert data.get("code") == "CLI_ALREADY_INITIALIZED"
 
     def test_init_bootstrap_failure_json_output(self, runner, tmp_path):
         """_bootstrap_master가 ValueError를 던지면 JSON 에러 + exit 1."""

--- a/tests/unit/test_cli_treasury_snapshot.py
+++ b/tests/unit/test_cli_treasury_snapshot.py
@@ -346,7 +346,7 @@ class TestSnapshotJson:
         assert result.exit_code == 1
         payload = json.loads(result.output)
         assert payload["status"] == "error"
-        assert payload["code"] == "snapshot_not_found"
+        assert payload["code"] == "SNAPSHOT_NOT_FOUND"
         assert "2026-01-01" in payload["message"]
 
 

--- a/tests/unit/test_report_draft.py
+++ b/tests/unit/test_report_draft.py
@@ -231,7 +231,7 @@ class TestReportViewCLI:
             assert result.exit_code == 1
             payload = json.loads(result.output)
             assert payload["status"] == "error"
-            assert payload["code"] == "report_not_found"
+            assert payload["code"] == "REPORT_NOT_FOUND"
             assert "찾을 수 없습니다" in payload["message"]
 
     def test_view_json_format(self, runner):


### PR DESCRIPTION
Closes #1773
Closes #1774
Closes #1775
Closes #1776
Closes #1777
Closes #1778
Closes #1779
Closes #1780
Closes #1781
Closes #1782

## Summary
10 oracle A7 이슈 동일 패턴 (CLI 에러코드 명명 위반) sweep.
- 3 lower-case → SCREAMING_SNAKE (init/report/treasury)
- 7 missing → 도메인 prefix SCREAMING_SNAKE 추가 (config/rule/member/bot + instrument 3종)

| 이슈 | 위치 | 기존 | 수정 후 |
|---|---|---|---|
| #1773 | src/ante/cli/commands/init.py:581 | code=\"already_initialized\" | code=\"CLI_ALREADY_INITIALIZED\" |
| #1774 | src/ante/cli/commands/report.py:437 | code=\"report_not_found\" | code=\"REPORT_NOT_FOUND\" |
| #1775 | src/ante/cli/commands/treasury.py:569 | code=\"snapshot_not_found\" | code=\"SNAPSHOT_NOT_FOUND\" |
| #1776 | src/ante/cli/commands/config.py:123 | (code 누락) | code=\"CONFIG_KEY_NOT_FOUND\" |
| #1777 | src/ante/cli/commands/rule.py:272 | (code 누락) | code=\"RULE_NOT_FOUND\" |
| #1778 | src/ante/cli/commands/member.py:231 | (code 누락) | code=\"MEMBER_NOT_FOUND\" |
| #1779 | src/ante/cli/commands/bot.py:792 | (code 누락) | code=\"BOT_NOT_FOUND\" |
| #1780 | src/ante/cli/commands/instrument.py:330 | (code 누락) | code=\"INSTRUMENT_INVALID_FILE_FORMAT\" |
| #1782 | src/ante/cli/commands/instrument.py:349 | (code 누락) | code=\"INSTRUMENT_INVALID_JSON_SHAPE\" |
| #1781 | src/ante/cli/commands/instrument.py:353 | (code 누락) | code=\"INSTRUMENT_EMPTY_FILE\" |

## Plan Preflight
이슈 #1773 본문 sweep 매트릭스 + Codex narrow-scope (1 must-fix CLI_* prefix 인라인).

## Test plan
- [x] 신규 sweep 회귀 10 R-cases (`tests/unit/test_cli_error_code_naming_sweep.py`) 모두 통과
- [x] 기존 assertion 3건 업데이트 (test_cli_init / test_report_draft / test_cli_treasury_snapshot)
- [x] 전체 unit 회귀 4988 passed, 2 skipped (168s)
- [x] ruff check / ruff format --check / mypy src/ 통과
- [x] project-structure.md 재생성 (신규 test 1개만 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)