### PR TITLE
fix: #1784,#1789,#1795-#1798,#1800 Group A typed code + envelope sweep (7 issues)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -69,7 +69,8 @@ src/ante/
 │   ├── models.py                     # ApprovalRequest, ApprovalStatus, ApprovalType
 │   ├── service.py                    # ApprovalService — 결재 요청 관리 + 자동 실행
 │   ├── __init__.py
-│   └── auto_approve.py
+│   ├── auto_approve.py
+│   └── errors.py
 ├── instrument/
 │   ├── models.py                     # Instrument — 종목 메타데이터 (frozen dataclass)
 │   ├── service.py                    # InstrumentService — 전체 메모리 캐시 + SQLite
@@ -566,7 +567,8 @@ tests/
 │   ├── test_bot_lifecycle_state_conflict.py
 │   ├── test_bot_create_signal_key_auto.py
 │   ├── test_cli_bot_signal_key_rotate_external_gate.py
-│   └── test_cli_error_code_naming_sweep.py
+│   ├── test_cli_error_code_naming_sweep.py
+│   └── test_cli_envelope_typed_codes_group_a_sweep.py
 └── __init__.py
 ```
 

--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -8,9 +8,17 @@ class AccountError(Exception):
 
 
 class AccountNotFoundError(AccountError):
-    """계좌를 찾을 수 없음."""
+    """계좌를 찾을 수 없음.
 
-    pass
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"ACCOUNT_NOT_FOUND"``를 노출하도록 한다 (#1795). CLI
+    ``account suspend``/``account activate`` 등이 IPC error envelope 의
+    typed code 를 그대로 surface 해 not-found 의미가 일반
+    ``EXECUTION_ERROR`` 로 분실되지 않게 한다.
+    """
+
+    code: str = "ACCOUNT_NOT_FOUND"
 
 
 class AccountAlreadyExistsError(AccountError):

--- a/src/ante/approval/__init__.py
+++ b/src/ante/approval/__init__.py
@@ -1,6 +1,7 @@
 """Approval — AI Agent 결재 체계."""
 
 from ante.approval.auto_approve import AutoApproveConfig, AutoApproveEvaluator
+from ante.approval.errors import ApprovalError, ApprovalNotFoundError
 from ante.approval.models import (
     ApprovalRequest,
     ApprovalStatus,
@@ -11,6 +12,8 @@ from ante.approval.models import (
 from ante.approval.service import ApprovalService
 
 __all__ = [
+    "ApprovalError",
+    "ApprovalNotFoundError",
     "ApprovalRequest",
     "ApprovalService",
     "ApprovalStatus",

--- a/src/ante/approval/errors.py
+++ b/src/ante/approval/errors.py
@@ -1,0 +1,34 @@
+"""Approval 모듈 예외.
+
+Refs #1798: ``ApprovalNotFoundError`` 를 신규 도입해 service 가 missing
+approval 을 ``ValueError`` 대신 typed exception 으로 raise 한다. IPC
+``server.py`` 의 ``getattr(e, "code", "EXECUTION_ERROR")`` envelope 이
+``APPROVAL_NOT_FOUND`` 로 변환한다. CLI ``approval cancel-invalid`` 도
+``getattr(e, "code", ...)`` 패턴으로 typed code 를 surface 한다.
+
+``ApprovalValidationError`` 는 호환을 위해 ``ante.approval.models`` 에
+계속 존재하며, 본 모듈은 cleanup/cancel 표면의 typed not-found 만 추가
+한다.
+"""
+
+
+class ApprovalError(Exception):
+    """Approval 기본 예외."""
+
+    pass
+
+
+class ApprovalNotFoundError(ApprovalError):
+    """결재 요청을 찾을 수 없음 (#1798).
+
+    클래스 레벨 ``code`` 속성은 IPC 서버 envelope 이 안정 코드
+    ``"APPROVAL_NOT_FOUND"`` 로 surface 하도록 한다. ``ValueError`` 와
+    분리해 호출자가 vocabulary/state 검증 오류와 not-found 의미를
+    명확히 구분할 수 있게 한다.
+    """
+
+    code: str = "APPROVAL_NOT_FOUND"
+
+    def __init__(self, approval_id: str) -> None:
+        self.approval_id = approval_id
+        super().__init__(f"결재 요청을 찾을 수 없음: {approval_id}")

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 from ante.account.scoping import require_account_id
 from ante.approval.auto_approve import AutoApproveEvaluator
+from ante.approval.errors import ApprovalNotFoundError
 from ante.approval.models import (
     ApprovalRequest,
     ApprovalStatus,
@@ -789,8 +790,13 @@ class ApprovalService:
         """
         request = await self.get(id)
         if not request:
-            msg = f"결재 요청을 찾을 수 없음: {id}"
-            raise ValueError(msg)
+            # #1798: missing approval 은 typed ``ApprovalNotFoundError`` 로
+            # raise 해 IPC envelope 이 ``APPROVAL_NOT_FOUND`` typed code 를
+            # 보존하게 한다. 기존 ``except ValueError`` 핸들러가 있던 호출자
+            # (``cancel_invalid`` CLI 등) 는 ``ApprovalNotFoundError`` 가
+            # ``ApprovalError`` 의 sub 이지만 ``Exception`` 으로도 잡히므로
+            # 메시지 시그니처와 exit code 는 동일하게 유지된다.
+            raise ApprovalNotFoundError(id)
 
         if request.type in _VALID_APPROVAL_TYPES:
             msg = (

--- a/src/ante/bot/exceptions.py
+++ b/src/ante/bot/exceptions.py
@@ -12,6 +12,8 @@ BOT_NOT_FOUND_CODE = "BOT_NOT_FOUND"
 BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE = "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED"
 BOT_STATE_CONFLICT_CODE = "BOT_STATE_CONFLICT"
 BOT_NOT_ACCEPTING_SIGNALS_CODE = "BOT_NOT_ACCEPTING_SIGNALS"
+BOT_ALREADY_EXISTS_CODE = "BOT_ALREADY_EXISTS"
+BOT_STRATEGY_ALREADY_RUNNING_CODE = "BOT_STRATEGY_ALREADY_RUNNING"
 
 
 class BotError(Exception):
@@ -64,3 +66,26 @@ class BotNotAcceptingSignals(BotError):  # noqa: N818
     """
 
     code: str = BOT_NOT_ACCEPTING_SIGNALS_CODE
+
+
+class BotAlreadyExistsError(BotError):
+    """동일 ``bot_id`` 가 이미 존재함 (#1800).
+
+    ``BotManager.create_bot`` 가 동일 bot_id 중복 등록을 거부할 때 raise
+    한다. IPC ``server.py`` 의 ``getattr(e, "code", ...)`` envelope 이
+    ``BOT_ALREADY_EXISTS`` 로 변환한다. CLI ``bot create`` 는 동 코드를
+    surface 해 자동화가 중복 회피 처리할 수 있게 한다.
+    """
+
+    code: str = BOT_ALREADY_EXISTS_CODE
+
+
+class BotStrategyAlreadyRunningError(BotError):
+    """동일 ``strategy_id`` 가 이미 실행 중인 다른 봇에 의해 사용 중 (#1800).
+
+    "1전략 1봇" 정책에 따른 거부. IPC envelope 이
+    ``BOT_STRATEGY_ALREADY_RUNNING`` 으로 변환되어 자동화/사용자가 동일
+    전략의 다중 실행 시도를 명확히 식별할 수 있다.
+    """
+
+    code: str = BOT_STRATEGY_ALREADY_RUNNING_CODE

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -18,10 +18,12 @@ from ante.bot.config import (
     validate_runtime_controls,
 )
 from ante.bot.exceptions import (
+    BotAlreadyExistsError,
     BotError,
     BotNotAcceptingSignals,
     BotNotFoundError,
     BotStateConflict,
+    BotStrategyAlreadyRunningError,
 )
 
 if TYPE_CHECKING:
@@ -347,7 +349,10 @@ class BotManager:
         )
 
         if config.bot_id in self._bots:
-            raise BotError(f"Bot already exists: {config.bot_id}")
+            # #1800: 동일 bot_id 중복 등록은 ``BotAlreadyExistsError``
+            # (code=``"BOT_ALREADY_EXISTS"``) 로 typed raise — IPC envelope
+            # 이 일반 ``EXECUTION_ERROR`` 가 아닌 안정 코드를 surface 한다.
+            raise BotAlreadyExistsError(f"Bot already exists: {config.bot_id}")
 
         # 1전략 1봇 정책: 실행 중인 봇이 사용 중인 전략 중복 차단
         active_statuses = {BotStatus.RUNNING, BotStatus.STOPPING}
@@ -356,7 +361,10 @@ class BotManager:
                 existing_bot.config.strategy_id == config.strategy_id
                 and existing_bot.status in active_statuses
             ):
-                raise BotError(
+                # #1800: 1전략 1봇 정책 위반은
+                # ``BotStrategyAlreadyRunningError`` (code=
+                # ``"BOT_STRATEGY_ALREADY_RUNNING"``) 로 typed raise.
+                raise BotStrategyAlreadyRunningError(
                     f"전략 '{config.strategy_id}'은(는) 이미 봇 "
                     f"'{existing_bot.bot_id}'에서 사용 중입니다. "
                     f"파라미터가 다른 전략은 별도 파일로 작성하세요."

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -156,7 +156,10 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
     result = _run(_run_info())
 
     if not result:
-        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+        # #1784: missing bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 해
+        # 자동화가 메시지 파싱 없이 분류할 수 있도록 한다 (CLI/IPC
+        # 일관성: ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와 동형).
+        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         ctx.exit(1)
 
     if fmt.is_json:
@@ -255,7 +258,10 @@ def bot_create(
             key, value = _parse_param(p)
             param_dict[key] = value
         except click.BadParameter as e:
-            fmt.error(str(e))
+            # #1784: invalid --param 입력은 안정 코드
+            # ``BOT_INVALID_PARAM`` 으로 surface 한다. 자동화/오라클이
+            # 메시지 텍스트 파싱 없이 invalid-input 분류를 할 수 있게 한다.
+            fmt.error(str(e), code="BOT_INVALID_PARAM")
             raise SystemExit(1) from e
 
     # #1656 E bucket defense-in-depth: provided invalid account_id
@@ -305,7 +311,10 @@ def bot_create(
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e))
+        # #1800: typed exception 의 class-level ``code`` 속성을 우선 surface
+        # 한다 (예: ``BotAlreadyExistsError.code = "BOT_ALREADY_EXISTS"``).
+        # 속성이 없는 일반 ``BotError`` 는 빈 code 로 종전 동작을 보존한다.
+        fmt.error(str(e), code=getattr(e, "code", ""))
         raise SystemExit(1) from e
 
     fmt.success(f"봇 생성 완료: {result.get('bot_id', '')}", result)
@@ -478,11 +487,11 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
         raise SystemExit(1) from e
 
     if result.get("missing"):
-        # 미존재 bot: 형제 명령(`bot info`/`bot remove`/`bot positions`)과
-        # 동일하게 code 없는 에러 메시지 + exit 1 (#1596). signal_key None
-        # 분기보다 먼저 처리하여 미존재 bot 이 "키 없음" 으로 잘못 빠지지
-        # 않도록 한다.
-        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+        # #1784: 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 한다
+        # (CLI/IPC 일관성: ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와
+        # 동형). signal_key None 분기보다 먼저 처리하여 미존재 bot 이 "키
+        # 없음" 으로 잘못 빠지지 않도록 한다.
+        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         ctx.exit(1)
 
     if result.get("external_signals_disabled"):

--- a/src/ante/cli/commands/instrument.py
+++ b/src/ante/cli/commands/instrument.py
@@ -345,7 +345,10 @@ def instrument_import(
             with open(path, encoding="utf-8") as f:
                 records = json.load(f)
     except Exception as e:
-        fmt.error(f"파일 읽기 실패: {e}")
+        # #1784: 파일 읽기 I/O 실패(directory-with-csv-suffix, 권한 등)는
+        # 안정 코드 ``INSTRUMENT_IO_ERROR`` 로 surface 한다. 자동화/오라클이
+        # 메시지 텍스트 파싱 없이 I/O 실패를 분류할 수 있게 한다.
+        fmt.error(f"파일 읽기 실패: {e}", code="INSTRUMENT_IO_ERROR")
         ctx.exit(1)
 
     if ext == ".json" and not isinstance(records, list):
@@ -362,7 +365,14 @@ def instrument_import(
     # 필수 컬럼 확인
     first = records[0]
     if "symbol" not in first or "exchange" not in first:
-        fmt.error("필수 컬럼 누락: symbol, exchange가 필요합니다.")
+        # #1784: 필수 컬럼 누락은 안정 코드
+        # ``INSTRUMENT_MISSING_COLUMNS`` 로 surface 한다. 형제 코드
+        # ``INSTRUMENT_INVALID_JSON_SHAPE`` / ``INSTRUMENT_EMPTY_FILE`` /
+        # ``INSTRUMENT_INVALID_FILE_FORMAT`` 와 동형 envelope 일관성.
+        fmt.error(
+            "필수 컬럼 누락: symbol, exchange가 필요합니다.",
+            code="INSTRUMENT_MISSING_COLUMNS",
+        )
         ctx.exit(1)
 
     # Axis 2 — import 행별 검증: dry-run preview/실저장 전, 각 행

--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -133,10 +133,15 @@ def submit(ctx: click.Context, path: str) -> None:
 
     if not validation.valid:
         if fmt.is_json:
+            # #1789: 기존 ad-hoc envelope (``submitted``/``stage``/``errors``)
+            # 은 자동화 의존성 보호를 위해 유지하되, 안정 ``code`` 필드를
+            # 추가해 표준 JSON 에러 envelope 의 분류 의미를 보존한다 (현존
+            # ``meta_validation`` 분기와 동형).
             fmt.output(
                 {
                     "submitted": False,
                     "stage": "validate",
+                    "code": "STRATEGY_VALIDATION_ERROR",
                     "errors": validation.errors,
                 }
             )
@@ -155,10 +160,12 @@ def submit(ctx: click.Context, path: str) -> None:
         strategy_cls = StrategyLoader.load(filepath)
     except StrategyLoadError as e:
         if fmt.is_json:
+            # #1789: load 실패에도 안정 ``code`` 를 envelope 에 포함한다.
             fmt.output(
                 {
                     "submitted": False,
                     "stage": "load",
+                    "code": "STRATEGY_LOAD_ERROR",
                     "error": str(e),
                 }
             )
@@ -235,10 +242,15 @@ def submit(ctx: click.Context, path: str) -> None:
         result = _run(_register())
     except StrategyError as e:
         if fmt.is_json:
+            # #1789: register 실패 (duplicate id 등) envelope 에 typed
+            # ``code`` 를 포함한다. 예외 인스턴스가 class-level ``code`` 를
+            # 가지면 우선 사용하고, 없으면 generic ``STRATEGY_ERROR``
+            # fallback 으로 envelope 일관성을 유지한다.
             fmt.output(
                 {
                     "submitted": False,
                     "stage": "register",
+                    "code": getattr(e, "code", "STRATEGY_ERROR"),
                     "error": str(e),
                 }
             )
@@ -388,7 +400,11 @@ def strategy_set_status(ctx: click.Context, strategy_id: str, status: str) -> No
         fmt.error(str(e), code="STRATEGY_INVALID_STATUS_TRANSITION")
         raise SystemExit(1) from e
     except Exception as e:
-        fmt.error(str(e), code="STRATEGY_ERROR")
+        # #1796: typed exception 의 class-level ``code`` 속성을 우선 surface
+        # 한다 (예: ``StrategyNotFoundError.code = "STRATEGY_NOT_FOUND"``).
+        # 속성이 없는 일반 ``StrategyError`` 는 기존 ``STRATEGY_ERROR``
+        # fallback 으로 유지된다 (회귀 없음).
+        fmt.error(str(e), code=getattr(e, "code", "STRATEGY_ERROR"))
         raise SystemExit(1) from e
 
     if fmt.is_json:

--- a/src/ante/member/scopes.py
+++ b/src/ante/member/scopes.py
@@ -102,7 +102,15 @@ class InvalidScopeError(ValueError):
     ``ValueError`` 의 서브클래스로 두어 기존 ``except ValueError`` 핸들러가
     그대로 동작하지만, 호출자가 vocabulary 위반과 다른 도메인 오류
     (예: 존재하지 않는 멤버) 를 구분하려면 본 클래스로 좁혀 catch 한다.
+
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"MEMBER_INVALID_SCOPE"`` 를 노출하도록 한다 (#1797). CLI 표면은 이미
+    ``code="MEMBER_INVALID_SCOPE"`` 로 명시 매핑하고 있어 envelope 일관성
+    회귀가 없다.
     """
+
+    code: str = "MEMBER_INVALID_SCOPE"
 
     def __init__(self, scope: str) -> None:
         self.scope = scope

--- a/src/ante/strategy/exceptions.py
+++ b/src/ante/strategy/exceptions.py
@@ -7,6 +7,19 @@ class StrategyError(Exception):
     pass
 
 
+class StrategyNotFoundError(StrategyError):
+    """전략을 찾을 수 없음 (#1796).
+
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"STRATEGY_NOT_FOUND"`` 를 노출하도록 한다. ``StrategyRegistry.update_status``
+    가 missing strategy 에 대해 raise 하면 CLI ``strategy set-status`` 가
+    typed code envelope 으로 종료한다.
+    """
+
+    code: str = "STRATEGY_NOT_FOUND"
+
+
 class StrategyLoadError(StrategyError):
     """전략 파일 로드 실패."""
 

--- a/src/ante/strategy/registry.py
+++ b/src/ante/strategy/registry.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ante.strategy.base import StrategyMeta
-from ante.strategy.exceptions import StrategyError
+from ante.strategy.exceptions import StrategyError, StrategyNotFoundError
 
 if TYPE_CHECKING:
     from ante.core.database import Database
@@ -213,10 +213,15 @@ class StrategyRegistry:
         strategy_id: str,
         status: StrategyStatus,
     ) -> None:
-        """전략 상태 변경. 허용된 전환만 수행한다."""
+        """전략 상태 변경. 허용된 전환만 수행한다.
+
+        Missing strategy 는 ``StrategyNotFoundError`` (code=
+        ``"STRATEGY_NOT_FOUND"``) 로 raise 해 CLI/IPC 표면이 typed code 를
+        보존하게 한다 (#1796).
+        """
         record = await self.get(strategy_id)
         if record is None:
-            raise StrategyError(f"Strategy not found: {strategy_id}")
+            raise StrategyNotFoundError(f"Strategy not found: {strategy_id}")
 
         allowed = _ALLOWED_TRANSITIONS.get(record.status, set())
         if status not in allowed:

--- a/tests/unit/cli/test_bot_create_exit_code.py
+++ b/tests/unit/cli/test_bot_create_exit_code.py
@@ -162,7 +162,10 @@ class TestBotCreateBadParamExitCode:
         )
         payload = _parse_json_line(result.stdout)
         assert payload["status"] == "error", payload
-        assert payload["code"] == "", payload
+        # #1784 Group A sweep: invalid --param 입력은 안정 코드
+        # ``BOT_INVALID_PARAM`` 으로 surface 한다 (이전: empty ``code``).
+        # 자동화/오라클이 메시지 텍스트 파싱 없이 invalid-input 분류 가능.
+        assert payload["code"] == "BOT_INVALID_PARAM", payload
         assert "잘못된 파라미터 형식" in str(payload["message"]), payload
         # text 메시지가 stderr 로 동시에 새지 않아야 한다.
         assert "잘못된 파라미터 형식" not in result.stderr, result.stderr

--- a/tests/unit/test_approval_invalid_type_cleanup.py
+++ b/tests/unit/test_approval_invalid_type_cleanup.py
@@ -292,11 +292,20 @@ class TestCancelInvalidTypeRequestRejection:
         self,
         service: ApprovalService,
     ) -> None:
-        """미존재 id 는 ``ValueError``."""
-        with pytest.raises(ValueError, match="찾을 수 없음"):
+        """미존재 id 는 ``ApprovalNotFoundError`` (code=APPROVAL_NOT_FOUND).
+
+        #1798 Group A sweep: 이전 ``ValueError`` 에서 typed
+        ``ApprovalNotFoundError`` 로 전환되어 IPC envelope 이 안정
+        코드 ``APPROVAL_NOT_FOUND`` 를 surface 한다. type/status 검증의
+        ``ValueError`` 는 그대로 유지된다 (sibling tests 회귀 없음).
+        """
+        from ante.approval.errors import ApprovalNotFoundError
+
+        with pytest.raises(ApprovalNotFoundError, match="찾을 수 없음") as excinfo:
             await service.cancel_invalid_type_request(
                 "no-such-id", resolved_by="admin-1"
             )
+        assert getattr(excinfo.value, "code", None) == "APPROVAL_NOT_FOUND"
 
 
 # ── cancel_invalid_type_request 성공 케이스 ───────────────────────

--- a/tests/unit/test_cli_envelope_typed_codes_group_a_sweep.py
+++ b/tests/unit/test_cli_envelope_typed_codes_group_a_sweep.py
@@ -1,0 +1,479 @@
+"""CLI/IPC envelope typed-code Group A sweep (#1784, #1789, #1795-#1798, #1800).
+
+7 oracle A7 이슈 sweep — typed exception code 보존 + CLI ``fmt.error`` code
+명시 + strategy submit envelope 정합. CLI 표면이 다음 카테고리로 갈린다:
+
+- **cold-path subprocess 검증 가능**: bot info / bot signal-key (cold-path),
+  instrument import (no DB), strategy submit (no DB) — ``ante`` CLI 를
+  실제 subprocess 로 실행해 ``--format json`` 출력의 ``code`` 필드를
+  검증한다.
+- **IPC 전용 (server 필요)**: account suspend/activate, bot create,
+  approval cancel-invalid, strategy set-status (active runtime branch),
+  member update-scopes (active runtime branch) — server fixture 없이는
+  ``IPC_SERVER_NOT_RUNNING`` 만 받기 때문에, 본 sweep 은 typed exception
+  class 의 ``code`` 속성을 직접 verify 하고 IPC server.py 의
+  ``getattr(e, "code", "EXECUTION_ERROR")`` envelope 매핑 invariant 가
+  보존되는지 확인한다 (registry handler 가 typed exception 을 raise
+  하면 envelope 코드가 자동으로 surface 된다).
+
+R-case 매핑:
+  R1 #1795 ``AccountNotFoundError.code = "ACCOUNT_NOT_FOUND"`` 보존
+  R2 #1796 ``StrategyNotFoundError.code = "STRATEGY_NOT_FOUND"`` +
+         ``StrategyRegistry.update_status`` 가 typed exception raise
+  R3 #1797 ``InvalidScopeError.code = "MEMBER_INVALID_SCOPE"`` 보존
+  R4 #1798 ``ApprovalNotFoundError.code = "APPROVAL_NOT_FOUND"`` +
+         ``ApprovalService.cancel_invalid_type_request`` typed raise
+  R5 #1800 ``BotAlreadyExistsError.code = "BOT_ALREADY_EXISTS"`` +
+         ``BotManager.create_bot`` 가 duplicate id 시 typed raise
+  R6 #1784 ``bot info <missing>`` → ``code="BOT_NOT_FOUND"`` (subprocess)
+  R7 #1784 ``bot signal-key <missing>`` → ``code="BOT_NOT_FOUND"`` (subprocess)
+  R8 #1784 ``bot create --param invalid`` → ``code="BOT_INVALID_PARAM"``
+         (subprocess, param 파싱은 IPC 이전 단계)
+  R9 #1784 ``instrument import <csv_missing_cols>`` →
+         ``code="INSTRUMENT_MISSING_COLUMNS"`` (subprocess)
+  R10 #1784 ``instrument import <directory>`` →
+         ``code="INSTRUMENT_IO_ERROR"`` (subprocess)
+  R11 #1789 ``strategy submit <invalid>`` envelope 에 ``code`` 필드 추가
+         (subprocess)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+_SUBPROCESS_TIMEOUT_S = 10.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _clean_env(
+    config_dir: Path,
+    *,
+    encryption_key: str | None = None,
+    token: str | None = None,
+) -> dict[str, str]:
+    env: dict[str, str] = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(config_dir)),
+        "ANTE_CONFIG_DIR": str(config_dir),
+        "PYTHONPATH": str(_repo_root() / "src"),
+    }
+    if encryption_key is not None:
+        env["ANTE_DB_ENCRYPTION_KEY"] = encryption_key
+    if token is not None:
+        env["ANTE_MEMBER_TOKEN"] = token
+    return env
+
+
+def _parse_json_last(stdout: str) -> dict:
+    stripped = stdout.strip()
+    if stripped.startswith("{"):
+        try:
+            obj = json.loads(stripped)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    last_obj: dict | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            last_obj = obj
+    assert last_obj is not None, f"JSON dict 라인을 stdout에서 찾지 못함: {stdout!r}"
+    return last_obj
+
+
+def _run_cli(
+    config_dir: Path,
+    args: list[str],
+    *,
+    token: str | None = None,
+    encryption_key: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = _clean_env(config_dir, encryption_key=encryption_key, token=token)
+    return subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _run_init(config_dir: Path, encryption_key: str) -> tuple[str, str]:
+    init_env = _clean_env(config_dir, encryption_key=encryption_key)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ante",
+            "--format",
+            "json",
+            "init",
+            "--name",
+            "GroupASweep",
+        ],
+        env=init_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"init 실패: exit={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    token = payload.get("token")
+    assert token, f"init 출력에 token 없음: {payload}"
+    return token, encryption_key
+
+
+@pytest.fixture
+def initialized_config(tmp_path: Path) -> tuple[Path, str, str]:
+    """``ante init`` 완료 (config_dir, token, encryption_key)."""
+    config_dir = tmp_path / "config"
+    key = Fernet.generate_key().decode()
+    token, _ = _run_init(config_dir, key)
+    return config_dir, token, key
+
+
+# ════════════════════════════════════════════════════════════════════
+# 카테고리 1 — typed exception class ``code`` 속성 보존 (IPC envelope
+# 매핑 invariant). IPC 전용 표면은 server fixture 없이 envelope 을
+# subprocess 로 재현할 수 없으므로 typed exception 의 class-level
+# ``code`` 가 SCREAMING_SNAKE_CASE 안정 값을 갖는지 직접 verify 한다.
+# IPC ``server.py:_dispatch`` 가 ``getattr(e, "code", "EXECUTION_ERROR")``
+# 로 envelope 코드를 매핑하므로 (registry handler 가 해당 typed
+# exception 을 raise 하기만 하면) envelope 에 자동 surface 된다.
+# ════════════════════════════════════════════════════════════════════
+
+
+class TestTypedExceptionCodeAttributes:
+    """R1-R5: typed exception class ``code`` 속성 매핑 lock."""
+
+    def test_r1_account_not_found_error_code_is_account_not_found(self) -> None:
+        """#1795: ``AccountNotFoundError.code = "ACCOUNT_NOT_FOUND"``."""
+        from ante.account.errors import AccountNotFoundError
+
+        assert AccountNotFoundError.code == "ACCOUNT_NOT_FOUND"
+        # 인스턴스에서도 동일 코드가 surface 되어 IPC envelope 의
+        # ``getattr(e, "code", ...)`` 가 안정적으로 작동한다.
+        exc = AccountNotFoundError("계좌 없음: foo")
+        assert getattr(exc, "code", None) == "ACCOUNT_NOT_FOUND"
+
+    def test_r2_strategy_not_found_error_code_is_strategy_not_found(self) -> None:
+        """#1796: ``StrategyNotFoundError.code = "STRATEGY_NOT_FOUND"``."""
+        from ante.strategy.exceptions import StrategyError, StrategyNotFoundError
+
+        assert StrategyNotFoundError.code == "STRATEGY_NOT_FOUND"
+        # StrategyError 상속 보존 — 기존 ``except StrategyError`` 핸들러
+        # 회귀 없음.
+        assert issubclass(StrategyNotFoundError, StrategyError)
+        exc = StrategyNotFoundError("Strategy not found: foo")
+        assert getattr(exc, "code", None) == "STRATEGY_NOT_FOUND"
+
+    def test_r3_invalid_scope_error_code_is_member_invalid_scope(self) -> None:
+        """#1797: ``InvalidScopeError.code = "MEMBER_INVALID_SCOPE"``."""
+        from ante.member.scopes import InvalidScopeError
+
+        assert InvalidScopeError.code == "MEMBER_INVALID_SCOPE"
+        # ``ValueError`` 상속 보존 — 기존 ``except ValueError`` 핸들러 회귀
+        # 없음.
+        assert issubclass(InvalidScopeError, ValueError)
+        exc = InvalidScopeError("invalid:scope")
+        assert getattr(exc, "code", None) == "MEMBER_INVALID_SCOPE"
+
+    def test_r4_approval_not_found_error_code_is_approval_not_found(self) -> None:
+        """#1798: ``ApprovalNotFoundError.code = "APPROVAL_NOT_FOUND"``."""
+        from ante.approval.errors import ApprovalError, ApprovalNotFoundError
+
+        assert ApprovalNotFoundError.code == "APPROVAL_NOT_FOUND"
+        assert issubclass(ApprovalNotFoundError, ApprovalError)
+        exc = ApprovalNotFoundError("appr-missing")
+        assert getattr(exc, "code", None) == "APPROVAL_NOT_FOUND"
+
+    def test_r5a_bot_already_exists_error_code(self) -> None:
+        """#1800: ``BotAlreadyExistsError.code = "BOT_ALREADY_EXISTS"``."""
+        from ante.bot.exceptions import (
+            BOT_ALREADY_EXISTS_CODE,
+            BotAlreadyExistsError,
+            BotError,
+        )
+
+        assert BOT_ALREADY_EXISTS_CODE == "BOT_ALREADY_EXISTS"
+        assert BotAlreadyExistsError.code == "BOT_ALREADY_EXISTS"
+        assert issubclass(BotAlreadyExistsError, BotError)
+        exc = BotAlreadyExistsError("Bot already exists: foo")
+        assert getattr(exc, "code", None) == "BOT_ALREADY_EXISTS"
+
+    def test_r5b_bot_strategy_already_running_error_code(self) -> None:
+        """#1800: ``BotStrategyAlreadyRunningError`` code ==
+        ``"BOT_STRATEGY_ALREADY_RUNNING"``.
+        """
+        from ante.bot.exceptions import (
+            BOT_STRATEGY_ALREADY_RUNNING_CODE,
+            BotError,
+            BotStrategyAlreadyRunningError,
+        )
+
+        assert BOT_STRATEGY_ALREADY_RUNNING_CODE == "BOT_STRATEGY_ALREADY_RUNNING"
+        assert BotStrategyAlreadyRunningError.code == "BOT_STRATEGY_ALREADY_RUNNING"
+        assert issubclass(BotStrategyAlreadyRunningError, BotError)
+
+
+# ════════════════════════════════════════════════════════════════════
+# 카테고리 2 — service-layer typed raise 검증. CLI/IPC 표면이 typed
+# 코드를 surface 하려면 service 가 typed exception 을 raise 해야 한다.
+# 본 fixture-light 단위 테스트는 직접 service 를 호출해 raise type
+# 회귀를 막는다.
+# ════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+class TestServiceLayerTypedRaise:
+    """service-layer 가 missing resource 를 typed exception 으로 raise."""
+
+    async def test_r2_strategy_registry_update_status_raises_typed_not_found(
+        self, tmp_path: Path
+    ) -> None:
+        """#1796: ``StrategyRegistry.update_status(missing)`` →
+        ``StrategyNotFoundError`` (code ``"STRATEGY_NOT_FOUND"``).
+        """
+        from ante.core.database import Database
+        from ante.strategy.exceptions import StrategyNotFoundError
+        from ante.strategy.registry import StrategyRegistry, StrategyStatus
+
+        db_path = tmp_path / "test.db"
+        db = Database(db_path)
+        await db.connect()
+        try:
+            registry = StrategyRegistry(db)
+            await registry.initialize()
+
+            with pytest.raises(StrategyNotFoundError) as excinfo:
+                await registry.update_status(
+                    "missing-strategy-id", StrategyStatus.ADOPTED
+                )
+            assert getattr(excinfo.value, "code", None) == "STRATEGY_NOT_FOUND"
+        finally:
+            await db.close()
+
+    async def test_r4_approval_service_cancel_invalid_raises_typed_not_found(
+        self, tmp_path: Path
+    ) -> None:
+        """#1798: ``ApprovalService.cancel_invalid_type_request(missing)`` →
+        ``ApprovalNotFoundError`` (code ``"APPROVAL_NOT_FOUND"``).
+        """
+        from ante.approval.errors import ApprovalNotFoundError
+        from ante.approval.service import ApprovalService
+        from ante.core.database import Database
+
+        db_path = tmp_path / "test.db"
+        db = Database(db_path)
+        await db.connect()
+        try:
+            service = ApprovalService(db, eventbus=None)
+            await service.initialize()
+
+            with pytest.raises(ApprovalNotFoundError) as excinfo:
+                await service.cancel_invalid_type_request(
+                    "appr-missing",
+                    resolved_by="admin",
+                )
+            assert getattr(excinfo.value, "code", None) == "APPROVAL_NOT_FOUND"
+        finally:
+            await db.close()
+
+
+# ════════════════════════════════════════════════════════════════════
+# 카테고리 3 — subprocess CLI envelope 검증 (#1784 + #1789).
+# ════════════════════════════════════════════════════════════════════
+
+
+class TestBotInfoMissingCodeContract:
+    """R6 #1784: ``bot info <missing>`` → exit 1, code=BOT_NOT_FOUND."""
+
+    def test_bot_info_missing_emits_bot_not_found_code(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["bot", "info", "oracle-missing-bot"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "BOT_NOT_FOUND", payload
+
+
+class TestBotSignalKeyMissingCodeContract:
+    """R7 #1784: ``bot signal-key <missing>`` → exit 1, code=BOT_NOT_FOUND."""
+
+    def test_bot_signal_key_missing_emits_bot_not_found_code(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["bot", "signal-key", "oracle-missing-bot"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "BOT_NOT_FOUND", payload
+
+
+class TestBotCreateInvalidParamCodeContract:
+    """R8 #1784: ``bot create --param invalid`` → exit 1, code=BOT_INVALID_PARAM.
+
+    param 파싱은 IPC 이전 단계라 server 없이도 reproducer 가 된다.
+    """
+
+    def test_bot_create_invalid_param_emits_bot_invalid_param_code(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            [
+                "bot",
+                "create",
+                "--strategy",
+                "any-strategy",
+                "--name",
+                "oracle-test",
+                "--param",
+                "not_key_value",  # = 미포함 → BadParameter
+            ],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "BOT_INVALID_PARAM", payload
+
+
+class TestInstrumentImportMissingColumnsCodeContract:
+    """R9 #1784: ``instrument import <csv_missing_symbol_exchange>`` →
+    exit 1, code=INSTRUMENT_MISSING_COLUMNS.
+    """
+
+    def test_instrument_import_missing_columns_emits_missing_columns_code(
+        self,
+        initialized_config: tuple[Path, str, str],
+        tmp_path: Path,
+    ) -> None:
+        config_dir, token, key = initialized_config
+        bad_csv = tmp_path / "missing-cols.csv"
+        bad_csv.write_text(
+            "ticker,price\nFOO,100\nBAR,200\n",
+            encoding="utf-8",
+        )
+        result = _run_cli(
+            config_dir,
+            ["instrument", "import", str(bad_csv), "--dry-run"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "INSTRUMENT_MISSING_COLUMNS", payload
+
+
+class TestInstrumentImportDirectoryCodeContract:
+    """R10 #1784: ``instrument import <directory_with_csv_suffix>`` →
+    exit 1, code=INSTRUMENT_IO_ERROR.
+    """
+
+    def test_instrument_import_directory_emits_io_error_code(
+        self,
+        initialized_config: tuple[Path, str, str],
+        tmp_path: Path,
+    ) -> None:
+        config_dir, token, key = initialized_config
+        # ``.csv`` suffix 를 가진 디렉토리: 파일 형식 분기는 통과하지만
+        # ``open(...)`` 에서 IsADirectoryError raise → ``INSTRUMENT_IO_ERROR``.
+        bad_dir = tmp_path / "instrument-dir.csv"
+        bad_dir.mkdir()
+        result = _run_cli(
+            config_dir,
+            ["instrument", "import", str(bad_dir), "--dry-run"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "INSTRUMENT_IO_ERROR", payload
+
+
+class TestStrategySubmitEnvelopeCodeField:
+    """R11 #1789: ``strategy submit`` validation/load failure envelope 에
+    ``code`` 필드가 추가되어 자동화가 분류할 수 있다.
+    """
+
+    def test_strategy_submit_validation_failure_envelope_has_code(
+        self,
+        initialized_config: tuple[Path, str, str],
+        tmp_path: Path,
+    ) -> None:
+        config_dir, token, key = initialized_config
+        # 정적 검증 실패: 전략 파일이 ``Strategy`` 클래스를 정의하지 않음.
+        bad_py = tmp_path / "invalid_strategy.py"
+        bad_py.write_text(
+            "# 전략 클래스가 없는 빈 파이썬 파일\n",
+            encoding="utf-8",
+        )
+        result = _run_cli(
+            config_dir,
+            ["strategy", "submit", str(bad_py)],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = _parse_json_last(result.stdout)
+        # validate 또는 load 단계에서 실패할 수 있으므로 둘 다 허용.
+        assert payload.get("submitted") is False, payload
+        stage = payload.get("stage")
+        assert stage in {"validate", "load"}, payload
+        # #1789 invariant: envelope 에 typed ``code`` 가 존재해야 함.
+        code = payload.get("code")
+        assert code in {
+            "STRATEGY_VALIDATION_ERROR",
+            "STRATEGY_LOAD_ERROR",
+        }, payload

--- a/tests/unit/test_cli_missing_resource_exit.py
+++ b/tests/unit/test_cli_missing_resource_exit.py
@@ -532,9 +532,11 @@ class TestBotSignalKeyMissingBotExit:
         payload = json.loads(result.stdout)
         assert payload["status"] == "error"
         assert "봇을 찾을 수 없습니다: oracle-missing-bot" in payload["message"]
-        # code 없는 형제 계약(#1558): error envelope 의 code 는 빈 문자열
-        # (신규 에러코드 신설 금지 — Non-Goal).
-        assert payload["code"] == ""
+        # #1784 Group A sweep: 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로
+        # surface 한다 (CLI/IPC 일관성: ``BotNotFoundError.code`` 와 동형).
+        # 이전 #1558 의 "code 없음" 계약은 #1784 oracle A7 evidence 에서
+        # 자동화 분류 불가 결함으로 보고되어 본 sweep 에서 폐기.
+        assert payload["code"] == "BOT_NOT_FOUND"
         # orphan credential 미발급: rotate 가 호출되지 않았어야 한다.
         mock_skm.rotate.assert_not_awaited()
         mock_skm.get_key.assert_not_awaited()
@@ -594,7 +596,8 @@ class TestBotSignalKeyMissingBotExit:
         assert "봇을 찾을 수 없습니다: oracle-missing-bot" in payload["message"]
         # 미존재 bot 이 "시그널 키가 없습니다" 로 잘못 빠지지 않아야 한다.
         assert "시그널 키가 없습니다" not in payload["message"]
-        assert payload["code"] == ""
+        # #1784 Group A sweep: 안정 코드 ``BOT_NOT_FOUND`` 로 surface.
+        assert payload["code"] == "BOT_NOT_FOUND"
         mock_skm.get_key.assert_not_awaited()
 
     def test_missing_bot_lookup_exits_nonzero_text(self, runner: CliRunner) -> None:
@@ -867,8 +870,9 @@ class TestBotSignalKeySoftDeletedBotExit:
         payload = json.loads(result.stdout)
         assert payload["status"] == "error"
         assert "봇을 찾을 수 없습니다: soft-deleted-bot" in payload["message"]
-        # 미존재 bot 과 동일 형제 계약(#1558): code 없음 (Non-Goal).
-        assert payload["code"] == ""
+        # #1784 Group A sweep: 미존재 bot 과 동일 형제 계약 — 안정 코드
+        # ``BOT_NOT_FOUND`` 로 surface (이전 #1558 의 "code 없음" 폐기).
+        assert payload["code"] == "BOT_NOT_FOUND"
         # orphan credential 미발급: rotate 가 호출되지 않았어야 한다.
         mock_skm.rotate.assert_not_awaited()
         mock_skm.get_key.assert_not_awaited()
@@ -928,7 +932,8 @@ class TestBotSignalKeySoftDeletedBotExit:
         assert "봇을 찾을 수 없습니다: soft-deleted-bot" in payload["message"]
         # soft-deleted bot 이 "시그널 키가 없습니다" 로 잘못 빠지지 않아야 한다.
         assert "시그널 키가 없습니다" not in payload["message"]
-        assert payload["code"] == ""
+        # #1784 Group A sweep: 안정 코드 ``BOT_NOT_FOUND`` 로 surface.
+        assert payload["code"] == "BOT_NOT_FOUND"
         mock_skm.get_key.assert_not_awaited()
 
     def test_soft_deleted_bot_lookup_exits_nonzero_text(


### PR DESCRIPTION
## Summary

7개의 oracle A7 이슈를 한 PR 로 sweep — typed exception `code` 속성 추가 + CLI `fmt.error` code 매핑 + strategy submit envelope 정합. **Codex Plan Review v1 split-recommended verdict** 에 따라 행위 변경(#1792 / #1794 / #1799) 은 별도 Group B PR 로 분리.

Closes #1784
Closes #1789
Closes #1795
Closes #1796
Closes #1797
Closes #1798
Closes #1800

## Plan

### 카테고리 A — typed exception `code` 속성 (5건)

| 이슈 | 클래스 | code 값 | service-layer raise site |
|---|---|---|---|
| #1795 | `AccountNotFoundError` | `ACCOUNT_NOT_FOUND` | (기존 호출자가 raise) |
| #1796 | `StrategyNotFoundError` (신규, `StrategyError` subclass) | `STRATEGY_NOT_FOUND` | `StrategyRegistry.update_status` typed raise |
| #1797 | `InvalidScopeError` | `MEMBER_INVALID_SCOPE` | (기존 호출자가 raise) |
| #1798 | `ApprovalNotFoundError` (신규, `ApprovalError` subclass in new `src/ante/approval/errors.py`) | `APPROVAL_NOT_FOUND` | `ApprovalService.cancel_invalid_type_request` typed raise |
| #1800 | `BotAlreadyExistsError` / `BotStrategyAlreadyRunningError` (신규, `BotError` subclass) | `BOT_ALREADY_EXISTS` / `BOT_STRATEGY_ALREADY_RUNNING` | `BotManager.create_bot` typed raise |

IPC `server.py` 의 `getattr(e, "code", "EXECUTION_ERROR")` envelope 매핑 invariant 가 typed code 를 자동 surface.

### 카테고리 B — CLI `fmt.error` code 매핑 (#1784, 5 surface)

- `bot info <missing>` → `code="BOT_NOT_FOUND"`
- `bot signal-key <missing>` → `code="BOT_NOT_FOUND"`
- `bot create --param invalid` → `code="BOT_INVALID_PARAM"`
- `instrument import <missing columns>` → `code="INSTRUMENT_MISSING_COLUMNS"`
- `instrument import <directory>` → `code="INSTRUMENT_IO_ERROR"`

CLI `strategy set-status` / `bot create` / `approval cancel-invalid` exception 핸들러를 `getattr(e, "code", <fallback>)` 패턴으로 정렬해 typed code passthrough 보장.

### 카테고리 C — strategy submit envelope `code` 필드 (#1789, 3 path)

기존 ad-hoc envelope (`submitted`/`stage`/`errors`) 은 자동화 의존성 보호를 위해 유지하고 안정 `code` 필드만 추가 — passthrough 일관성 보존.

- validate 실패 → `code="STRATEGY_VALIDATION_ERROR"`
- load 실패 → `code="STRATEGY_LOAD_ERROR"`
- register 실패 → `code=getattr(e, "code", "STRATEGY_ERROR")`

## Codex Plan Review (요약)

- v1 verdict: **split-recommended** — 10 이슈 → 2 그룹으로 분할
- Group A (본 PR, 7건): typed code + CLI fmt.error + strategy envelope
- Group B (별도 PR, 3건): #1792 / #1794 / #1799 행위 변경

## Test plan

- [x] 신규 sweep test `tests/unit/test_cli_envelope_typed_codes_group_a_sweep.py` (14 cases)
- [x] 기존 회귀 test 4건 갱신
  - `test_cli_missing_resource_exit.py`: bot signal-key missing/soft-deleted 4 case `code == ""` → `"BOT_NOT_FOUND"`
  - `test_bot_create_exit_code.py`: bad_param json mode `code == ""` → `"BOT_INVALID_PARAM"`
  - `test_approval_invalid_type_cleanup.py`: `test_rejects_nonexistent_row` `ValueError` → `ApprovalNotFoundError`
- [x] `pytest tests/unit/` → 5002 passed, 0 failed, 2 skipped (2:36)
- [x] `ruff check src/ tests/` / `ruff format --check` → clean
- [x] `mypy src/` → Success (217 files)
- [x] `scripts/generate_project_structure.py` → expected drift only (approval/errors.py + sweep test)

## Non-Goals (별도 PR)
- #1792 treasury allocate/deallocate bot 존재 검증 (Group B)
- #1794 approval CLI/IPC args key 정합 (Group B)
- #1799 bot create active account 0/2+ cleanup (Group B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)