### PR TITLE
fix: #1794 approval CLI args key mismatch (approval_id → id)

### DIFF
--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -409,7 +409,12 @@ def reopen(
     async def _reopen() -> dict:
         from ante.cli.commands.ipc_helpers import ipc_send
 
-        args: dict = {"approval_id": id}
+        # IPC handler ``_handle_approval_reopen`` 가 ``args["id"]`` 를 기대한다
+        # (src/ante/ipc/registry.py). 과거 ``"approval_id"`` 키는 handler 미스매치
+        # 로 ``KeyError`` 를 일으켰다 — Web API/IPC 계약과 동일한 ``"id"`` 로 정렬
+        # (#1794). ``approval.cancel_invalid`` 만 별도 계약으로 ``approval_id``
+        # 사용을 유지한다.
+        args: dict = {"id": id}
         if body is not None:
             args["body"] = body
         if params is not None:
@@ -570,7 +575,10 @@ def cancel(ctx: click.Context, id: str) -> None:
     async def _cancel() -> dict:
         from ante.cli.commands.ipc_helpers import ipc_send
 
-        return await ipc_send("approval.cancel", {"approval_id": id}, actor=requester)
+        # IPC handler ``_handle_approval_cancel`` 가 ``args["id"]`` 를 기대한다
+        # (#1794, registry.py:533 참조). cancel-invalid 와 키 계약이 다르므로
+        # 혼동에 주의.
+        return await ipc_send("approval.cancel", {"id": id}, actor=requester)
 
     try:
         result = asyncio.run(_cancel())
@@ -596,7 +604,9 @@ def approve(ctx: click.Context, id: str) -> None:
     async def _approve() -> dict:
         from ante.cli.commands.ipc_helpers import ipc_send
 
-        return await ipc_send("approval.approve", {"approval_id": id}, actor=actor)
+        # IPC handler ``_handle_approval_approve`` 가 ``args["id"]`` 를 기대한다
+        # (#1794, registry.py:515 참조).
+        return await ipc_send("approval.approve", {"id": id}, actor=actor)
 
     try:
         result = asyncio.run(_approve())
@@ -623,9 +633,11 @@ def reject(ctx: click.Context, id: str, reason: str) -> None:
     async def _reject() -> dict:
         from ante.cli.commands.ipc_helpers import ipc_send
 
+        # IPC handler ``_handle_approval_reject`` 가 ``args["id"]`` 를 기대한다
+        # (#1794, registry.py:523 참조).
         return await ipc_send(
             "approval.reject",
-            {"approval_id": id, "reason": reason},
+            {"id": id, "reason": reason},
             actor=actor,
         )
 

--- a/tests/unit/test_cli_approval_args_key_alignment.py
+++ b/tests/unit/test_cli_approval_args_key_alignment.py
@@ -1,0 +1,179 @@
+"""``ante approval`` CLI ↔ IPC handler args 키 정렬 회귀 (#1794).
+
+CLI 표면 ``approval approve``/``reject``/``cancel``/``reopen`` 4 명령은
+IPC handler ``_handle_approval_approve``/``_handle_approval_reject``/
+``_handle_approval_cancel``/``_handle_approval_reopen``
+(src/ante/ipc/registry.py:515/523/533/569) 가 모두 ``args["id"]`` 를 기대
+하지만, CLI 가 과거에 ``{"approval_id": id}`` 를 전송하여 handler 에서
+``KeyError: 'id'`` 가 발생하던 contract drift 가 있었다. 이 테스트는
+``ipc_send`` 를 spy 로 패치하여 CLI 가 보내는 ``args`` dict 에 ``"id"`` 키
+가 포함되고 ``"approval_id"`` 키가 사용되지 않음을 락한다.
+
+``approval cancel-invalid`` 는 별도 계약 (``args["approval_id"]``,
+registry.py:548) 이므로 이 테스트의 sweep 대상이 아니며 회귀에서 제외한다
+(별도 contract).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _patch_ipc_send() -> tuple[object, AsyncMock]:
+    """``ipc_send`` spy AsyncMock. 모든 명령은 모듈 내부에서 import 하므로
+    원본 심볼을 패치한다."""
+    spy = AsyncMock(
+        return_value={"id": "appr-1", "status": "approved"},
+    )
+    return patch("ante.cli.commands.ipc_helpers.ipc_send", new=spy), spy
+
+
+def _extract_args(spy: AsyncMock) -> dict:
+    """spy 가 호출된 첫 번째 ``ipc_send(command, args, actor=...)`` 의 args."""
+    assert spy.await_count == 1, spy.await_args_list
+    call = spy.await_args_list[0]
+    # ipc_send(command, args, actor=...) — 위치 인자 1번이 args.
+    return call.args[1]
+
+
+class TestApprovalCliArgsKeyAlignment:
+    """4 명령 모두 ``args["id"]`` 사용 (handler 정렬)."""
+
+    def test_approve_sends_id_key(self, runner: CliRunner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "approval", "approve", "appr-1"],
+            )
+        assert result.exit_code == 0, result.output
+        args = _extract_args(spy)
+        assert "id" in args, args
+        assert args["id"] == "appr-1"
+        assert "approval_id" not in args, args
+        # 정상 envelope passthrough (fmt.success → status="ok" envelope).
+        payload = json.loads(result.output.strip())
+        assert payload["status"] == "ok", payload
+
+    def test_reject_sends_id_key(self, runner: CliRunner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "reject",
+                    "appr-1",
+                    "--reason",
+                    "test",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        args = _extract_args(spy)
+        assert args.get("id") == "appr-1", args
+        assert args.get("reason") == "test", args
+        assert "approval_id" not in args, args
+
+    def test_cancel_sends_id_key(self, runner: CliRunner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "approval", "cancel", "appr-1"],
+            )
+        assert result.exit_code == 0, result.output
+        args = _extract_args(spy)
+        assert args.get("id") == "appr-1", args
+        assert "approval_id" not in args, args
+
+    def test_reopen_sends_id_key(self, runner: CliRunner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "approval", "reopen", "appr-1"],
+            )
+        assert result.exit_code == 0, result.output
+        args = _extract_args(spy)
+        assert args.get("id") == "appr-1", args
+        assert "approval_id" not in args, args
+
+    def test_reopen_with_body_and_params_sends_id_key(self, runner: CliRunner) -> None:
+        """body/params 있는 reopen 경로에서도 ``id`` 키 유지."""
+        ipc_patch, spy = _patch_ipc_send()
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "reopen",
+                    "appr-1",
+                    "--body",
+                    "updated body",
+                    "--params",
+                    '{"k": "v"}',
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        args = _extract_args(spy)
+        assert args.get("id") == "appr-1", args
+        assert args.get("body") == "updated body", args
+        assert args.get("params") == {"k": "v"}, args
+        assert "approval_id" not in args, args
+
+
+class TestApprovalCancelInvalidKeptApprovalIdContract:
+    """``cancel-invalid`` 만 별도 계약 — ``args["approval_id"]`` 유지 (#1472)."""
+
+    def test_cancel_invalid_uses_approval_id_key(self, runner: CliRunner) -> None:
+        ipc_patch, spy = _patch_ipc_send()
+        with ipc_patch:
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "approval", "cancel-invalid", "appr-1"],
+            )
+        assert result.exit_code == 0, result.output
+        args = _extract_args(spy)
+        # cancel-invalid 는 registry.py:548 의 ``args["approval_id"]`` 계약.
+        assert args.get("approval_id") == "appr-1", args
+        assert "id" not in args, args

--- a/tests/unit/test_cli_config_approval_broker_ipc.py
+++ b/tests/unit/test_cli_config_approval_broker_ipc.py
@@ -220,8 +220,10 @@ class TestApprovalApproveIPC:
 
         assert result.exit_code == 0, result.output
         assert "결재 승인" in result.output
+        # #1794: IPC handler ``_handle_approval_approve`` (registry.py:515) 가
+        # ``args["id"]`` 를 기대 — CLI 가 동일 키로 정렬.
         mock_client.send.assert_called_once_with(
-            "approval.approve", {"approval_id": "apr-abc"}, "test-master"
+            "approval.approve", {"id": "apr-abc"}, "test-master"
         )
 
 
@@ -243,9 +245,11 @@ class TestApprovalRejectIPC:
 
         assert result.exit_code == 0, result.output
         assert "결재 거절" in result.output
+        # #1794: handler ``_handle_approval_reject`` (registry.py:523) 가
+        # ``args["id"]`` 를 기대.
         mock_client.send.assert_called_once_with(
             "approval.reject",
-            {"approval_id": "apr-abc", "reason": "부적절"},
+            {"id": "apr-abc", "reason": "부적절"},
             "test-master",
         )
 
@@ -265,8 +269,10 @@ class TestApprovalCancelIPC:
 
         assert result.exit_code == 0, result.output
         assert "결재 철회" in result.output
+        # #1794: handler ``_handle_approval_cancel`` (registry.py:533) 가
+        # ``args["id"]`` 를 기대. ``cancel-invalid`` 만 별도 계약(approval_id).
         mock_client.send.assert_called_once_with(
-            "approval.cancel", {"approval_id": "apr-abc"}, "test-master"
+            "approval.cancel", {"id": "apr-abc"}, "test-master"
         )
 
 
@@ -290,8 +296,10 @@ class TestApprovalReopenIPC:
 
         assert result.exit_code == 0, result.output
         assert "결재 재상신" in result.output
+        # #1794: handler ``_handle_approval_reopen`` (registry.py:569) 가
+        # ``args["id"]`` 를 기대 (body/params optional).
         mock_client.send.assert_called_once_with(
-            "approval.reopen", {"approval_id": "apr-abc"}, "test-master"
+            "approval.reopen", {"id": "apr-abc"}, "test-master"
         )
 
 


### PR DESCRIPTION
## Summary

- `ante approval approve`/`reject`/`cancel`/`reopen` CLI 4 명령이 IPC handler (`_handle_approval_approve`/`reject`/`cancel`/`reopen`, `src/ante/ipc/registry.py:515/523/533/569`) 가 기대하는 `args["id"]` 대신 `args["approval_id"]` 를 보내고 있어 handler 에서 `KeyError: 'id'` 가 발생하던 contract drift 를 정정합니다.
- `approval cancel-invalid` 는 별도 계약 (`args["approval_id"]`, `registry.py:548`) 이므로 본 변경 범위에서 의도적으로 제외했습니다.

## Changes

- `src/ante/cli/commands/approval.py`
  - line 412 (reopen): `{"approval_id": id}` → `{"id": id}` (+ `id` 키 정렬 근거 주석)
  - line 573 (cancel): 동일
  - line 599 (approve): 동일
  - line 626 (reject): 동일
- `tests/unit/test_cli_approval_args_key_alignment.py` 신규 — 4 명령 + reopen+body/params + `cancel-invalid` 별도 계약 회귀 락 (6 cases)
- `tests/unit/test_cli_config_approval_broker_ipc.py` — 기존 4 단언을 handler 정렬 (`id`) 로 정정

## Verification

- [x] `pytest tests/unit/test_cli_approval_args_key_alignment.py` — 6/6 통과
- [x] `pytest tests/unit/ -k approval` — 305/305 통과 (회귀 0)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/ante/cli/commands/approval.py` — clean

## Test plan

- [ ] CI 통과 확인
- [ ] Codex review 수신·반영

Closes #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)