### PR TITLE
fix: #1792 treasury allocate/deallocate에 bot 존재 검증 추가

### DIFF
--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -349,6 +349,7 @@ async def _handle_treasury_allocate(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
     from ante.account.scoping import require_account_id
+    from ante.bot.exceptions import BotNotFoundError
 
     # #1656 E bucket / #1633 finding: ``require_account_id``를 함수 **첫
     # 문장**으로(``args["bot_id"]``/``args["amount"]`` 이전) 둔다. raw
@@ -364,6 +365,15 @@ async def _handle_treasury_allocate(
     )
     bot_id = args["bot_id"]
     amount = args["amount"]
+    # #1792: missing bot id 로 호출해도 ``Treasury.allocate`` 가 cash 만 검증하고
+    # bot 존재 여부를 검사하지 않아 exit 0 + status=ok 가 반환되던 회귀를 차단.
+    # ``bot.start``/``bot.stop``/``bot.status``/``bot.update`` (registry.py:212/
+    # 256/297/326) 와 동일한 ``svc.bot_manager.get_bot`` + ``BotNotFoundError``
+    # (code="BOT_NOT_FOUND") 패턴을 사용한다. ``Treasury`` 서비스 자체는 단일
+    # 책임(현금/예산)을 유지하고 IPC handler 가 cross-module 존재 검증을 한다.
+    bot = svc.bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise BotNotFoundError(bot_id)
     treasury = svc.treasury_manager.get(account_id)
     result = await treasury.allocate(bot_id, amount)
     return {"account_id": account_id, "bot_id": bot_id, "success": result}
@@ -373,6 +383,7 @@ async def _handle_treasury_deallocate(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
     from ante.account.scoping import require_account_id
+    from ante.bot.exceptions import BotNotFoundError
 
     # #1656 E bucket / #1633 finding: ``_handle_treasury_allocate``와 동형 —
     # ``require_account_id``를 첫 문장으로(``args["bot_id"]``/``args["amount"]``
@@ -383,6 +394,12 @@ async def _handle_treasury_deallocate(
     )
     bot_id = args["bot_id"]
     amount = args["amount"]
+    # #1792: allocate 와 동형 — bot 존재 검증을 ``Treasury.deallocate`` 호출
+    # 이전에 둔다. ``BotNotFoundError`` (code="BOT_NOT_FOUND") 가 raise 되며
+    # IPC server.py 의 ``getattr(e, "code", ...)`` envelope 으로 surface 된다.
+    bot = svc.bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise BotNotFoundError(bot_id)
     treasury = svc.treasury_manager.get(account_id)
     result = await treasury.deallocate(bot_id, amount)
     return {"account_id": account_id, "bot_id": bot_id, "success": result}

--- a/tests/unit/test_ipc_treasury_allocate_missing_bot.py
+++ b/tests/unit/test_ipc_treasury_allocate_missing_bot.py
@@ -1,0 +1,222 @@
+"""``treasury.allocate``/``treasury.deallocate`` IPC missing-bot 회귀 (#1792).
+
+oracle A7 probe ``cli_treasury_allocate_missing_bot_error_code_contract`` /
+``cli_treasury_deallocate_missing_bot_error_code_contract`` 가 발견한
+회귀 모델: 두 표면이 missing bot id 로 호출되어도 ``Treasury.allocate``/
+``deallocate`` 가 cash 만 검증하고 bot 존재 여부를 검사하지 않아 exit 0
++ status="ok" 가 반환되어 budget automation 이 nonexistent bot 에 예산을
+할당/회수할 수 있었다.
+
+#1792 fix: IPC handler ``_handle_treasury_allocate``/``_handle_treasury_deallocate``
+(src/ante/ipc/registry.py:348/372) 에 ``bot.start``/``bot.stop``/``bot.status``/
+``bot.update`` (registry.py:212/256/297/326) 와 동형의 ``svc.bot_manager.get_bot``
++ ``BotNotFoundError`` (code="BOT_NOT_FOUND") 가드를 ``Treasury`` 호출 이전에
+배치한다.
+
+검증축:
+
+1. missing bot id → ``error.code == "BOT_NOT_FOUND"`` envelope
+2. account_id 검증과 bot 존재 검증이 모두 통과한 경우만 ``treasury_manager.get``
+   + ``Treasury.allocate``/``deallocate`` 도달 (회귀 0)
+3. ``Treasury`` 서비스 자체는 단일 책임 유지 — bot 검증을 service 가 아닌
+   handler 가 수행
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.core.registry import ServiceRegistry
+from ante.ipc.client import IPCClient
+from ante.ipc.registry import CommandRegistry, register_all_handlers
+from ante.ipc.server import IPCServer
+
+
+def _make_service_registry(*, bot_present: bool) -> ServiceRegistry:
+    """missing-bot vs present-bot 양 분기를 시뮬레이션할 mock ServiceRegistry."""
+    bot_manager = MagicMock()
+    if bot_present:
+        present_bot = MagicMock()
+        bot_manager.get_bot = MagicMock(return_value=present_bot)
+    else:
+        bot_manager.get_bot = MagicMock(return_value=None)
+
+    treasury = MagicMock()
+    treasury.allocate = AsyncMock(return_value=True)
+    treasury.deallocate = AsyncMock(return_value=True)
+    treasury_manager = MagicMock()
+    treasury_manager.get = MagicMock(return_value=treasury)
+
+    return ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=bot_manager,
+        treasury_manager=treasury_manager,
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=MagicMock(),
+    )
+
+
+@pytest.fixture
+def socket_path() -> str:
+    td = tempfile.mkdtemp(prefix="ipc_1792_", dir="/tmp")
+    return str(Path(td) / "t.sock")
+
+
+# ── 축 1: missing bot → BOT_NOT_FOUND envelope ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_treasury_allocate_missing_bot_returns_bot_not_found(
+    socket_path: str,
+) -> None:
+    """``treasury.allocate`` missing bot id → ``BOT_NOT_FOUND`` envelope (#1792)."""
+    svc = _make_service_registry(bot_present=False)
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+        response = await client.send(
+            "treasury.allocate",
+            {
+                "account_id": "domestic",
+                "bot_id": "oracle-missing-bot",
+                "amount": 1000.0,
+            },
+            actor="tester",
+        )
+        assert response["status"] == "error", response
+        assert response["error"]["code"] == "BOT_NOT_FOUND", response
+        # 회귀 핵심: status=ok success envelope 반환 금지.
+        assert response["status"] != "ok", response
+        # 회귀 핵심: missing bot 검증이 ``Treasury.allocate`` 도달을 차단.
+        svc.treasury_manager.get.return_value.allocate.assert_not_called()
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_treasury_deallocate_missing_bot_returns_bot_not_found(
+    socket_path: str,
+) -> None:
+    """``treasury.deallocate`` missing bot id → ``BOT_NOT_FOUND`` envelope (#1792)."""
+    svc = _make_service_registry(bot_present=False)
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+        response = await client.send(
+            "treasury.deallocate",
+            {
+                "account_id": "domestic",
+                "bot_id": "oracle-missing-bot",
+                "amount": 1000.0,
+            },
+            actor="tester",
+        )
+        assert response["status"] == "error", response
+        assert response["error"]["code"] == "BOT_NOT_FOUND", response
+        assert response["status"] != "ok", response
+        svc.treasury_manager.get.return_value.deallocate.assert_not_called()
+    finally:
+        await server.stop()
+
+
+# ── 축 2: present bot → 정상 통과 (회귀 0) ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_treasury_allocate_present_bot_reaches_service(
+    socket_path: str,
+) -> None:
+    """존재하는 bot id 는 가드를 통과해 ``Treasury.allocate`` 에 도달 (회귀 0)."""
+    svc = _make_service_registry(bot_present=True)
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+        response = await client.send(
+            "treasury.allocate",
+            {"account_id": "domestic", "bot_id": "bot-1", "amount": 1000.0},
+            actor="tester",
+        )
+        assert response["status"] == "ok", response
+        svc.treasury_manager.get.assert_called_once_with("domestic")
+        svc.treasury_manager.get.return_value.allocate.assert_awaited_once_with(
+            "bot-1", 1000.0
+        )
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_treasury_deallocate_present_bot_reaches_service(
+    socket_path: str,
+) -> None:
+    """존재하는 bot id 는 가드를 통과해 ``Treasury.deallocate`` 에 도달."""
+    svc = _make_service_registry(bot_present=True)
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+        response = await client.send(
+            "treasury.deallocate",
+            {"account_id": "domestic", "bot_id": "bot-1", "amount": 1000.0},
+            actor="tester",
+        )
+        assert response["status"] == "ok", response
+        svc.treasury_manager.get.return_value.deallocate.assert_awaited_once_with(
+            "bot-1", 1000.0
+        )
+    finally:
+        await server.stop()
+
+
+# ── 축 3: account_id 검증 vs bot 검증 우선순위 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_treasury_allocate_invalid_account_precedes_bot_check(
+    socket_path: str,
+) -> None:
+    """invalid account_id 는 ``BOT_NOT_FOUND`` 보다 먼저 ``VALIDATION_ERROR``.
+
+    handler 첫 문장의 ``require_account_id`` (#1656) 가 bot 가드보다 앞에 있어
+    invalid account_id 입력 시 bot 존재 검증에 도달하지 않는다.
+    """
+    svc = _make_service_registry(bot_present=False)
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+        response = await client.send(
+            "treasury.allocate",
+            {"account_id": "default", "bot_id": "oracle-missing-bot", "amount": 1000.0},
+            actor="tester",
+        )
+        assert response["status"] == "error", response
+        assert response["error"]["code"] == "VALIDATION_ERROR", response
+        # account 검증이 먼저이므로 bot_manager.get_bot 미호출.
+        svc.bot_manager.get_bot.assert_not_called()
+    finally:
+        await server.stop()


### PR DESCRIPTION
## Summary

- oracle A7 probe (`cli_treasury_allocate_missing_bot_error_code_contract` / `cli_treasury_deallocate_missing_bot_error_code_contract`) 가 발견한 회귀: `treasury allocate`/`deallocate` 가 nonexistent bot id 로 호출되어도 exit 0 + `status="ok"` 가 반환되어 budget automation 이 missing bot 에 예산을 할당/회수할 수 있던 contract 누락을 차단합니다.
- IPC handler `_handle_treasury_allocate`/`_handle_treasury_deallocate` 에 `bot.start`/`stop`/`status`/`update` (`registry.py:212/256/297/326`) 와 동형의 `svc.bot_manager.get_bot` + `BotNotFoundError` (code=`BOT_NOT_FOUND`) 가드를 `Treasury` 호출 이전에 추가합니다.

## Decision

- 검증 위치: **IPC handler** (`Treasury` 서비스는 단일 책임 — 현금/예산 — 을 유지하고 cross-module 존재 검증은 handler 가 담당).
- 검증 순서: `require_account_id` (#1656) → bot 검증 → `treasury_manager.get` / `Treasury.{allocate,deallocate}`. account 검증이 우선이므로 invalid account_id 입력 시 bot 검증에 도달하지 않습니다.
- 에러코드 SSOT: `BotNotFoundError.code = "BOT_NOT_FOUND"` (`src/ante/bot/exceptions.py:11/28`) 재사용 — `bot.start` 등 기존 코드 표면과 일관.

## Changes

- `src/ante/ipc/registry.py:348/372` — 두 handler 에 bot 가드 추가 (+ `BotNotFoundError` import).
- `tests/unit/test_ipc_treasury_allocate_missing_bot.py` 신규 — 5 cases:
  - missing bot → `BOT_NOT_FOUND` envelope (allocate/deallocate)
  - present bot → `Treasury` 서비스 도달 (회귀 0, allocate/deallocate)
  - invalid account_id → `VALIDATION_ERROR` 우선 (bot 가드 미도달)

## Verification

- [x] `pytest tests/unit/test_ipc_treasury_allocate_missing_bot.py` — 5/5 통과
- [x] `pytest tests/unit/ -k treasury` — 325/325 통과 (회귀 0)
- [x] `pytest tests/unit/test_ipc_error_code_mapping.py tests/unit/test_cli_e_bucket_mutating_ipc_account_id.py` — 28/28 통과
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/ante/ipc/registry.py` — clean

## Test plan

- [ ] CI 통과 확인
- [ ] Codex review 수신·반영
- [ ] oracle A7 probe 재실행으로 contract 회귀 차단 확인

Closes #1792

🤖 Generated with [Claude Code](https://claude.com/claude-code)