### PR TITLE
fix: #1805/#1808/#1810/#1811 Group P missing-resource typed code sweep (4 issues)

### DIFF
--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -573,11 +573,16 @@ class ApprovalService:
         result: str,
         detail: str = "",
     ) -> ApprovalRequest:
-        """검토 의견 추가."""
+        """검토 의견 추가.
+
+        not-found 는 ``ApprovalNotFoundError`` 로 raise 해 CLI ``approval
+        review`` 가 typed envelope code ``APPROVAL_NOT_FOUND`` 로 surface
+        할 수 있도록 한다 (#1811 — Group A ``cancel_invalid_type_request``
+        #1798 동형 패턴).
+        """
         request = await self.get(id)
         if not request:
-            msg = f"결재 요청을 찾을 수 없음: {id}"
-            raise ValueError(msg)
+            raise ApprovalNotFoundError(id)
 
         now = datetime.now(UTC).isoformat()
 

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -8,6 +8,7 @@ import logging
 
 import click
 
+from ante.approval.errors import ApprovalNotFoundError
 from ante.approval.models import ApprovalStatus, ApprovalType
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
@@ -278,6 +279,11 @@ def info(ctx: click.Context, id: str, db_path: str | None) -> None:
     try:
         result = asyncio.run(_info())
         fmt.output(result)
+    except ApprovalNotFoundError as e:
+        # #1811: missing approval 은 안정 코드 ``APPROVAL_NOT_FOUND`` 로
+        # surface 한다 (Group A ``ApprovalNotFoundError.code`` 와 동형).
+        fmt.error(str(e), code="APPROVAL_NOT_FOUND")
+        raise SystemExit(1) from e
     except Exception as e:
         fmt.error(str(e), code="APPROVAL_ERROR")
         raise SystemExit(1) from e
@@ -356,6 +362,12 @@ def review(
     try:
         result = asyncio.run(_review())
         fmt.success(f"검토 의견 추가: {reviewer} → {review_result}", result)
+    except ApprovalNotFoundError as e:
+        # #1811: missing approval 은 안정 코드 ``APPROVAL_NOT_FOUND`` 로
+        # surface 한다 (Group A ``ApprovalNotFoundError.code`` 와 동형,
+        # ``approval info`` 형제 패턴 미러).
+        fmt.error(str(e), code="APPROVAL_NOT_FOUND")
+        raise SystemExit(1) from e
     except Exception as e:
         fmt.error(str(e), code="APPROVAL_ERROR")
         raise SystemExit(1) from e
@@ -652,7 +664,16 @@ def reject(ctx: click.Context, id: str, reason: str) -> None:
 
 
 async def _find_request(service, id: str):  # type: ignore[no-untyped-def]
-    """ID 전체 또는 prefix로 결재 요청 검색."""
+    """ID 전체 또는 prefix로 결재 요청 검색.
+
+    not-found 는 ``ApprovalNotFoundError`` 로 raise 해 CLI ``approval info``
+    / ``approval review`` 가 typed envelope code ``APPROVAL_NOT_FOUND`` 로
+    surface 할 수 있도록 한다 (#1811). multi-match 는 ``ValueError`` 로
+    유지 — 별도 의미(``"여러 건이 일치"``)이며 기존 generic 핸들러가
+    ``APPROVAL_ERROR`` 로 surface 한다.
+    """
+    from ante.approval.errors import ApprovalNotFoundError
+
     req = await service.get(id)
     if req:
         return req
@@ -667,8 +688,7 @@ async def _find_request(service, id: str):  # type: ignore[no-untyped-def]
         msg = f"여러 건이 일치합니다: {ids}"
         raise ValueError(msg)
 
-    msg = f"결재 요청을 찾을 수 없음: {id}"
-    raise ValueError(msg)
+    raise ApprovalNotFoundError(id)
 
 
 def _parse_expires_in(expires_in: str) -> str:

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -516,7 +516,15 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
         raise SystemExit(1)
 
     if result.get("signal_key") is None:
-        fmt.error(f"시그널 키가 없습니다: {bot_id}")
+        # #1808: 시그널 키 미발급은 안정 코드 ``SIGNAL_KEY_NOT_SET`` 로
+        # surface 한다. 미존재 bot (``BOT_NOT_FOUND``) 분기보다 뒤에 둬서
+        # 두 의미를 envelope 코드로 분리한다. typed exception 신설 대신
+        # None gate + code 라벨로 단순화한다 (BOT_NOT_FOUND 동형 — 본
+        # surface 는 service exception 을 거치지 않는다).
+        fmt.error(
+            f"signal key가 설정되지 않았습니다: {bot_id}",
+            code="SIGNAL_KEY_NOT_SET",
+        )
         ctx.exit(1)
 
     if result.get("rotated"):
@@ -594,9 +602,11 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
     result = _run(_run_positions())
 
     if result is None:
-        # 미존재 bot: 형제 명령(`bot info`/`bot remove`)과 동일하게
-        # code 없는 에러 메시지 + exit 1 (#1558).
-        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+        # #1810: 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 한다
+        # (CLI/IPC 일관성: ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와
+        # 동형, ``bot info`` line 162 / ``bot remove`` line 814 형제 패턴
+        # 1:1 미러).
+        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         ctx.exit(1)
 
     if not result:

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -27,7 +27,7 @@ from ante.cli.middleware import (
     require_master,
     require_scope,
 )
-from ante.member.errors import PermissionDeniedError
+from ante.member.errors import MemberNotFoundError, PermissionDeniedError
 from ante.member.models import MemberRole
 from ante.member.scopes import InvalidScopeError
 
@@ -547,6 +547,12 @@ def member_set_emoji(ctx: click.Context, member_id: str, emoji: str) -> None:
 
     try:
         result = _run(_run_set_emoji())
+    except MemberNotFoundError:
+        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
+        # 한다 (CLI/IPC 일관성: ``MemberNotFoundError.code`` 와 동형, ``member
+        # info`` line 231 형제 패턴 1:1 미러).
+        fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
+        raise SystemExit(1) from None
     except ValueError as e:
         fmt.error(str(e))
         raise SystemExit(1) from e
@@ -643,6 +649,11 @@ def member_suspend(ctx: click.Context, member_id: str) -> None:
     except PermissionDeniedError:
         fmt.error(_MASTER_REQUIRED_MESSAGE)
         raise SystemExit(1) from None
+    except MemberNotFoundError:
+        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
+        # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
+        fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
+        raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
         fmt.error(str(e))
         raise SystemExit(1) from e
@@ -672,6 +683,11 @@ def member_reactivate(ctx: click.Context, member_id: str) -> None:
         result = _run(_run_reactivate())
     except PermissionDeniedError:
         fmt.error(_MASTER_REQUIRED_MESSAGE)
+        raise SystemExit(1) from None
+    except MemberNotFoundError:
+        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
+        # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
+        fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
         fmt.error(str(e))
@@ -721,6 +737,11 @@ def member_revoke(ctx: click.Context, member_id: str, yes: bool) -> None:
     except PermissionDeniedError:
         fmt.error(_MASTER_REQUIRED_MESSAGE)
         raise SystemExit(1) from None
+    except MemberNotFoundError:
+        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
+        # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
+        fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
+        raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
         fmt.error(str(e))
         raise SystemExit(1) from e
@@ -750,6 +771,11 @@ def member_rotate_token(ctx: click.Context, member_id: str) -> None:
         result, token = _run(_run_rotate())
     except PermissionDeniedError:
         fmt.error(_MASTER_REQUIRED_MESSAGE)
+        raise SystemExit(1) from None
+    except MemberNotFoundError:
+        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
+        # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
+        fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
         fmt.error(str(e))

--- a/src/ante/member/errors.py
+++ b/src/ante/member/errors.py
@@ -1,4 +1,11 @@
-"""Member 모듈 예외."""
+"""Member 모듈 예외.
+
+Refs #1805: ``MemberNotFoundError`` 를 신규 도입해 service 의 missing-member
+경로가 ``ValueError`` 대신 typed exception 을 raise 한다. CLI 6 mutation
+surface (set-emoji/suspend/reactivate/revoke/rotate-token, register 는 not-found
+경로 부재) 가 envelope 코드 ``"MEMBER_NOT_FOUND"`` 를 stable 하게 surface 한다.
+``ApprovalNotFoundError`` (#1798) 와 동형 패턴이다.
+"""
 
 
 class MemberError(Exception):
@@ -7,3 +14,26 @@ class MemberError(Exception):
 
 class PermissionDeniedError(MemberError):
     """권한 부족 — master만 수행 가능한 작업을 비-master가 시도."""
+
+
+class MemberNotFoundError(MemberError, ValueError):
+    """멤버를 찾을 수 없음 (#1805).
+
+    클래스 레벨 ``code`` 속성은 CLI/IPC envelope 이 안정 코드
+    ``"MEMBER_NOT_FOUND"`` 로 surface 하도록 한다.
+
+    ``MemberError`` 와 ``ValueError`` 의 다중상속으로 둔다 — ``_get_or_raise``
+    가 본 서비스 전체에서 공유되는 헬퍼이므로, ``except ValueError`` 로
+    missing-member 를 받아온 기존 caller (CLI ``update-scopes``/``reset-password``
+    /``regenerate-recovery-key`` 등 5+ 표면, ``test_member.py:582``,
+    ``test_cli_member_non_interactive.py`` mock 시나리오) 가 회귀 없이
+    동일하게 잡히도록 한다. ``except MemberNotFoundError`` 를 먼저 둔
+    caller (#1805 의 5 mutation surface) 는 typed 분기를 우선 매칭해 안정
+    코드 envelope 을 surface 한다 (Python MRO 가 보장).
+    """
+
+    code: str = "MEMBER_NOT_FOUND"
+
+    def __init__(self, member_id: str) -> None:
+        self.member_id = member_id
+        super().__init__(f"존재하지 않는 멤버: {member_id}")

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -766,11 +766,20 @@ class MemberService:
             )
 
     async def _get_or_raise(self, member_id: str) -> Member:
-        """멤버 조회. 없으면 ValueError."""
+        """멤버 조회. 없으면 ``MemberNotFoundError`` (#1805).
+
+        이전에는 ``ValueError("존재하지 않는 멤버: ...")`` 를 raise 했으나,
+        CLI/IPC envelope 이 안정 코드 ``"MEMBER_NOT_FOUND"`` 를 surface
+        하도록 typed exception (``MemberError`` 서브) 으로 변경한다. 메시지
+        시그니처와 회귀 케이스(``test_member.py:582`` 등) 호환을 위해
+        문자열은 동일하게 유지한다. ``ApprovalNotFoundError`` (#1798) 와
+        동형 패턴.
+        """
+        from ante.member.errors import MemberNotFoundError
+
         member = await self.get(member_id)
         if not member:
-            msg = f"존재하지 않는 멤버: {member_id}"
-            raise ValueError(msg)
+            raise MemberNotFoundError(member_id)
         return member
 
     @staticmethod

--- a/tests/unit/cli/test_bot_create_exit_code.py
+++ b/tests/unit/cli/test_bot_create_exit_code.py
@@ -34,10 +34,10 @@ Coverage map:
     0 포지션은 기존 계약(exit 0 + "보유 포지션 없음")을 그대로 유지**함을
     회귀 보장한다 (contract-drift 가드).
 
-Coverage map (#1558):
+Coverage map (#1558 → #1810 typed code sweep):
     - 미존재 bot ``bot positions oracle-missing-bot``
-      - JSON 모드: stdout ``{"status":"error","code":"","message":
-        "봇을 찾을 수 없습니다: oracle-missing-bot"}`` + exit 1.
+      - JSON 모드: stdout ``{"status":"error","code":"BOT_NOT_FOUND",
+        "message":"봇을 찾을 수 없습니다: oracle-missing-bot"}`` + exit 1.
       - text 모드: stderr ``Error: 봇을 찾을 수 없습니다: ...`` + exit 1.
     - 실재 bot, 0 포지션: exit 0 + ``{"message":"보유 포지션 없음",
       "positions":[]}`` 유지 (regression guard).
@@ -391,8 +391,11 @@ class TestBotPositionsMissingBotExitCode:
         )
         payload = _parse_json_line(result.stdout)
         assert payload["status"] == "error", payload
-        # CLI 형제 명령 일관: 미존재 bot 에 code 미부여.
-        assert payload["code"] == "", payload
+        # #1810: 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 한다
+        # (이전 #1558 의 "code 없음" 계약은 자동화 분류 불가 결함으로
+        # 보고되어 본 sweep 에서 폐기, ``bot info``/``bot remove`` 형제
+        # 패턴과 정렬).
+        assert payload["code"] == "BOT_NOT_FOUND", payload
         assert _BOT_NOT_FOUND_MESSAGE in str(payload["message"]), payload
         # 결함 시점의 success envelope 가 더는 새지 않아야 한다.
         assert "보유 포지션 없음" not in result.stdout, result.stdout
@@ -498,7 +501,9 @@ class TestBotPositionsNoBotsTableNormalized:
         assert "no such table" not in result.stdout, result.stdout
         payload = _parse_json_line(result.stdout)
         assert payload["status"] == "error", payload
-        assert payload["code"] == "", payload
+        # #1810: 미존재 bot (bots 테이블 부재 정규화 포함) 은 안정 코드
+        # ``BOT_NOT_FOUND`` 로 surface 한다.
+        assert payload["code"] == "BOT_NOT_FOUND", payload
         assert _BOT_NOT_FOUND_MESSAGE in str(payload["message"]), payload
 
     def test_no_bots_table_text_mode_emits_stderr_and_exits_1(

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -540,9 +540,13 @@ class TestReview:
         assert len(reviewed.reviews) == 2
 
     async def test_review_nonexistent_fails(self, service):
-        """존재하지 않는 요청에 검토 시 에러."""
-        with pytest.raises(ValueError, match="결재 요청을 찾을 수 없음"):
+        """존재하지 않는 요청에 검토 시 ``ApprovalNotFoundError`` (#1811)."""
+        from ante.approval.errors import ApprovalNotFoundError
+
+        with pytest.raises(ApprovalNotFoundError) as excinfo:
             await service.add_review("nonexistent", "treasury", "pass")
+        assert getattr(excinfo.value, "code", None) == "APPROVAL_NOT_FOUND"
+        assert "결재 요청을 찾을 수 없음" in str(excinfo.value)
 
 
 # ── 감사 이력 (US-5) ────────────────────────────────

--- a/tests/unit/test_cli_group_p_missing_resource_sweep.py
+++ b/tests/unit/test_cli_group_p_missing_resource_sweep.py
@@ -1,0 +1,326 @@
+"""Group P missing-resource typed code sweep (#1805 / #1808 / #1810 / #1811).
+
+4 oracle A7 missing-resource issue sweep — 각 CLI 표면이 안정 typed code
+envelope 를 surface 함을 subprocess 로 verify 한다 (Group A #1784/#1798
+sweep 동형 패턴).
+
+R-case 매트릭스:
+  R1 #1805 ``ante member suspend <missing-member> --format json``
+         → exit 1, code=``MEMBER_NOT_FOUND``
+  R2 #1808 ``ante bot signal-key <bot-without-key> --format json``
+         → exit 1, code=``SIGNAL_KEY_NOT_SET`` (in-process CliRunner;
+         signal_key 미발급 분기는 실재 bot 시드를 요구하므로 mock 으로
+         정확히 재현. subprocess 변형은 ``test_cli_missing_resource_exit.py
+         ::TestBotSignalKeyMissingExit`` 가 추가 회귀로 보장)
+  R3 #1810 ``ante bot positions <missing-bot> --format json``
+         → exit 1, code=``BOT_NOT_FOUND``
+  R4 #1811 ``ante approval info <missing-approval> --format json``
+         → exit 1, code=``APPROVAL_NOT_FOUND``
+
+R1/R3/R4 는 ``ante init`` 만 완료된 깨끗한 config 에서 missing-id 를
+바로 호출하면 typed not-found 가 즉시 발화하므로 subprocess 로 검증한다.
+``_clean_env`` / ``initialized_config`` 헬퍼는 ``test_cli_error_code_naming_sweep.py``
+패턴 1:1 미러로 부모 환경 누설을 차단한다.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+from cryptography.fernet import Fernet
+
+# subprocess timeout: hang 회귀를 5초 마진으로 차단한다.
+_SUBPROCESS_TIMEOUT_S = 10.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _clean_env(
+    config_dir: Path,
+    *,
+    encryption_key: str | None = None,
+    token: str | None = None,
+) -> dict[str, str]:
+    """subprocess 환경 격리 — 부모 ANTE_* 변수가 새지 않도록 명시 전달."""
+    env: dict[str, str] = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(config_dir)),
+        "ANTE_CONFIG_DIR": str(config_dir),
+        "PYTHONPATH": str(_repo_root() / "src"),
+    }
+    if encryption_key is not None:
+        env["ANTE_DB_ENCRYPTION_KEY"] = encryption_key
+    if token is not None:
+        env["ANTE_MEMBER_TOKEN"] = token
+    return env
+
+
+def _parse_json_last(stdout: str) -> dict:
+    """stdout 에서 JSON dict payload 를 추출 (error 한 줄 또는 indent 멀티라인)."""
+    stripped = stdout.strip()
+    if stripped.startswith("{"):
+        try:
+            obj = json.loads(stripped)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    last_obj: dict | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            last_obj = obj
+    assert last_obj is not None, f"JSON dict 라인을 stdout 에서 찾지 못함: {stdout!r}"
+    return last_obj
+
+
+def _run_cli(
+    config_dir: Path,
+    args: list[str],
+    *,
+    token: str | None = None,
+    encryption_key: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """``ante --format json <args>`` 를 subprocess 로 실행."""
+    env = _clean_env(config_dir, encryption_key=encryption_key, token=token)
+    return subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _run_init(config_dir: Path, encryption_key: str) -> tuple[str, str]:
+    """``ante init`` 후 (token, encryption_key) 반환."""
+    init_env = _clean_env(config_dir, encryption_key=encryption_key)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ante",
+            "--format",
+            "json",
+            "init",
+            "--name",
+            "GroupP",
+        ],
+        env=init_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"init 실패: exit={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    token = payload.get("token")
+    assert token, f"init 출력에 token 없음: {payload}"
+    return token, encryption_key
+
+
+@pytest.fixture
+def initialized_config(tmp_path: Path) -> tuple[Path, str, str]:
+    """``ante init`` 을 완료한 (config_dir, token, encryption_key) 튜플."""
+    config_dir = tmp_path / "config"
+    key = Fernet.generate_key().decode()
+    token, _ = _run_init(config_dir, key)
+    return config_dir, token, key
+
+
+# ────────────────────────────────────────────────────────────────────
+# R1 #1805 — member suspend <missing-member> → MEMBER_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestMemberSuspendMissingMemberTypedCode:
+    """``ante member suspend <missing> --format json`` →
+    exit 1, code=``MEMBER_NOT_FOUND``.
+
+    service ``_get_or_raise`` 가 ``MemberNotFoundError`` 를 raise 하고 CLI
+    ``member suspend`` 의 typed catch 분기가 안정 코드 envelope 으로
+    surface 한다.
+    """
+
+    def test_suspend_missing_member_emits_typed_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["member", "suspend", "mbr-does-not-exist"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        assert "Traceback" not in result.stderr, (
+            f"stderr 에 traceback 노출: {result.stderr!r}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "MEMBER_NOT_FOUND", payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R2 #1808 — bot signal-key <bot-without-key> → SIGNAL_KEY_NOT_SET
+# (in-process CliRunner — 실재 bot 시드 + signal_key None 분기 mock 재현)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestBotSignalKeyNotSetTypedCode:
+    """``ante bot signal-key <bot-without-key> --format json`` →
+    exit 1, code=``SIGNAL_KEY_NOT_SET``.
+
+    실재 bot 인데 ``signal key`` 가 발급되지 않은 분기 (#1808). 미존재 bot
+    (#1810 ``BOT_NOT_FOUND``) 과 envelope code 로 의미를 구분한다.
+    """
+
+    def test_signal_key_not_set_emits_typed_code(self) -> None:
+        from ante.cli.main import cli
+        from ante.member.models import Member, MemberRole, MemberType
+
+        master = Member(
+            member_id="grp-p-master",
+            type=MemberType.HUMAN,
+            role=MemberRole.MASTER,
+            org="default",
+            name="Group P Master",
+            status="active",
+            scopes=[],
+        )
+
+        runner = CliRunner(mix_stderr=False)
+
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        # 실재 bot row (status != deleted) — bots row 존재.
+        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "stg-1"})
+        mock_skm = AsyncMock()
+        mock_skm.initialize = AsyncMock()
+        mock_skm.get_key = AsyncMock(return_value=None)
+
+        def _auth_set(ctx):  # noqa: ANN001, ANN202
+            ctx.obj = ctx.obj or {}
+            ctx.obj["member"] = master
+
+        with (
+            patch("ante.cli.main.authenticate_member", side_effect=_auth_set),
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new_callable=AsyncMock,
+                return_value=(mock_db, None, None, None),
+            ),
+            patch(
+                "ante.bot.signal_key.SignalKeyManager",
+                return_value=mock_skm,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "signal-key",
+                    "bot-without-key",
+                ],
+            )
+
+        assert result.exit_code == 1, (
+            f"exit={result.exit_code}\nstdout={result.stdout!r}\n"
+            f"stderr={result.stderr!r}"
+        )
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "SIGNAL_KEY_NOT_SET", payload
+        assert "bot-without-key" in payload["message"], payload
+
+
+# ────────────────────────────────────────────────────────────────────
+# R3 #1810 — bot positions <missing-bot> → BOT_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestBotPositionsMissingBotTypedCode:
+    """``ante bot positions <missing> --format json`` →
+    exit 1, code=``BOT_NOT_FOUND``.
+
+    형제 명령 ``bot info`` / ``bot remove`` 와 envelope code 정렬 (#1810).
+    """
+
+    def test_positions_missing_bot_emits_typed_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["bot", "positions", "bot-does-not-exist"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        assert "Traceback" not in result.stderr, (
+            f"stderr 에 traceback 노출: {result.stderr!r}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "BOT_NOT_FOUND", payload
+        # 결함 시점의 success envelope 가 더는 새지 않아야 한다.
+        assert "보유 포지션 없음" not in result.stdout, result.stdout
+
+
+# ────────────────────────────────────────────────────────────────────
+# R4 #1811 — approval info <missing-approval> → APPROVAL_NOT_FOUND
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestApprovalInfoMissingTypedCode:
+    """``ante approval info <missing> --format json`` →
+    exit 1, code=``APPROVAL_NOT_FOUND``.
+
+    ``_find_request`` 가 ``ApprovalNotFoundError`` 를 raise 하고 CLI
+    ``approval info`` 의 typed catch 분기가 안정 코드 envelope 으로
+    surface 한다 (Group A #1798 ``cancel_invalid_type_request`` 동형 패턴).
+    """
+
+    def test_info_missing_approval_emits_typed_not_found(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+        result = _run_cli(
+            config_dir,
+            ["approval", "info", "appr-does-not-exist"],
+            token=token,
+            encryption_key=key,
+        )
+        assert result.returncode == 1, (
+            f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        assert "Traceback" not in result.stderr, (
+            f"stderr 에 traceback 노출: {result.stderr!r}"
+        )
+        payload = _parse_json_last(result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "APPROVAL_NOT_FOUND", payload

--- a/tests/unit/test_cli_missing_resource_exit.py
+++ b/tests/unit/test_cli_missing_resource_exit.py
@@ -350,8 +350,12 @@ class TestBotSignalKeyMissingExit:
         payload = json.loads(result.stdout)
         assert payload["status"] == "error"
         assert "bot-without-key" in payload["message"]
-        # 실재 bot 의 키 없음 → "시그널 키가 없습니다" (불변, #1596 비대상).
-        assert "시그널 키가 없습니다" in payload["message"]
+        # #1808: 실재 bot 의 키 없음 → typed code ``SIGNAL_KEY_NOT_SET`` +
+        # "signal key가 설정되지 않았습니다" (이전 "시그널 키가 없습니다").
+        # 미존재 bot 거부(#1596 → BOT_NOT_FOUND)와 envelope code 로 의미
+        # 구분된다.
+        assert "signal key가 설정되지 않았습니다" in payload["message"]
+        assert payload.get("code") == "SIGNAL_KEY_NOT_SET"
 
     def test_missing_key_exits_nonzero_text(self, runner: CliRunner) -> None:
         mock_db = AsyncMock()
@@ -376,7 +380,8 @@ class TestBotSignalKeyMissingExit:
 
         assert result.exit_code == 1
         assert "Error:" in result.stderr
-        assert "시그널 키가 없습니다" in result.stderr
+        # #1808: text 모드는 envelope code 없이 메시지만 — 새 wording 정렬.
+        assert "signal key가 설정되지 않았습니다" in result.stderr
 
     def test_valid_exits_zero(self, runner: CliRunner) -> None:
         """signal_key 존재 시 exit 0 회귀 보존."""

--- a/tests/unit/test_cli_report_approval_db_cleanup.py
+++ b/tests/unit/test_cli_report_approval_db_cleanup.py
@@ -194,7 +194,10 @@ class TestApprovalInfoMissingNoHang:
         payload = _parse_json_payload(result.stdout)
         assert isinstance(payload, dict)
         assert payload.get("status") == "error"
-        assert payload.get("code") == "APPROVAL_ERROR"
+        # #1811: missing approval 은 typed code ``APPROVAL_NOT_FOUND`` 로
+        # surface 한다 (이전: generic ``APPROVAL_ERROR``). cleanup invariant
+        # (db.close + no Traceback) 는 본 테스트가 그대로 보장한다.
+        assert payload.get("code") == "APPROVAL_NOT_FOUND"
 
 
 # ────────────────────────────────────────────────────────────────────
@@ -236,7 +239,10 @@ class TestApprovalReviewMissingNoHang:
         payload = _parse_json_payload(result.stdout)
         assert isinstance(payload, dict)
         assert payload.get("status") == "error"
-        assert payload.get("code") == "APPROVAL_ERROR"
+        # #1811: missing approval 은 typed code ``APPROVAL_NOT_FOUND`` 로
+        # surface 한다 (이전: generic ``APPROVAL_ERROR``). cleanup invariant
+        # (db.close + no Traceback) 는 본 테스트가 그대로 보장한다.
+        assert payload.get("code") == "APPROVAL_NOT_FOUND"
 
 
 # ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

oracle A7 missing-resource sweep — 4 CLI 표면이 안정 typed code envelope 을 surface 하도록 정렬한다 (Group A #1784/#1798 sweep 동형 패턴).

Closes #1805
Closes #1808
Closes #1810
Closes #1811

## Root cause (per issue)

- **#1805** `ante member <admin-mutation> <missing-member>` 6 표면이 missing-member 를 generic `ValueError` 로 raise 해 envelope code 가 빈 문자열(또는 generic) 로 surface. 자동화/오라클이 메시지 파싱 없이 분류 불가.
- **#1808** `ante bot signal-key <bot-without-key>` 가 "시그널 키가 없습니다" 만 출력하고 envelope code 미부착. 미존재 bot (`BOT_NOT_FOUND`) 과 의미 구분 불가.
- **#1810** `ante bot positions <missing-bot>` 의 sentinel `None` 분기에 `BOT_NOT_FOUND` code 미부착. 형제 `bot info`/`bot remove` 와 envelope 일관성 미달.
- **#1811** `ante approval info/review <missing-approval>` 가 generic `APPROVAL_ERROR` 로 wrap. Group A `cancel_invalid_type_request` 가 이미 `APPROVAL_NOT_FOUND` 로 분리했는데 형제 surface 미정렬.

## R-case 매트릭스

| R | 이슈 | Surface | 결과 envelope |
|---|------|---------|----------------|
| R1 | #1805 | `member suspend <missing>` | exit 1, `code=MEMBER_NOT_FOUND` |
| R2 | #1808 | `bot signal-key <bot-without-key>` | exit 1, `code=SIGNAL_KEY_NOT_SET` |
| R3 | #1810 | `bot positions <missing>` | exit 1, `code=BOT_NOT_FOUND` |
| R4 | #1811 | `approval info <missing>` | exit 1, `code=APPROVAL_NOT_FOUND` |

## 구현 노트

### #1805 member
- `MemberNotFoundError(MemberError, ValueError)` 신규. 다중상속 — `_get_or_raise` 가 공유 헬퍼이므로 `except ValueError` 로 받는 기존 5+ caller (CLI update-scopes/reset-password/regenerate-recovery-key) 가 회귀 없이 같은 분기로 잡힌다. typed catch 가 먼저 매칭되도록 MRO 순서 의존.
- `MemberService._get_or_raise` 가 typed exception raise.
- CLI 5 mutation surface 에 typed catch 분기 (set-emoji/suspend/reactivate/revoke/rotate-token). `register` 는 not-found 경로 부재로 제외.

### #1808 bot signal-key
- typed exception 신설 없이 `signal_key is None` 분기에 `code="SIGNAL_KEY_NOT_SET"` + 메시지 wording 변경 (`"signal key가 설정되지 않았습니다: {bot_id}"`).
- 미존재 bot (`BOT_NOT_FOUND`) 분기보다 뒤에 둬 두 의미를 envelope 코드로 분리.

### #1810 bot positions
- sentinel `None` 분기에 `code="BOT_NOT_FOUND"` 부착. `bot info`/`bot remove` 형제 패턴 미러.
- `BotNotFoundError.code = "BOT_NOT_FOUND"` 이미 존재 (Group A).

### #1811 approval info/review
- `ApprovalService.add_review` 가 missing 시 `ApprovalNotFoundError` raise (Group A `cancel_invalid_type_request` 동형).
- CLI `_find_request` 도 typed exception raise. multi-match 는 `ValueError` 유지 → generic `APPROVAL_ERROR`.
- `info`/`review` 핸들러에 typed catch 분기를 generic `except Exception → APPROVAL_ERROR` 앞에 추가.

## Test plan

- [x] 신규 `tests/unit/test_cli_group_p_missing_resource_sweep.py` 4 시나리오 (subprocess R1/R3/R4 + in-process CliRunner R2) — **4 passed**
- [x] 회귀 정합화 (의미 보존, 코드 라벨만 갱신):
  - `test_cli_report_approval_db_cleanup.py` info/review missing `APPROVAL_ERROR` → `APPROVAL_NOT_FOUND` (cleanup invariant + no Traceback 그대로)
  - `test_cli_missing_resource_exit.py` signal-key 키 없음 새 wording + `SIGNAL_KEY_NOT_SET` code
  - `cli/test_bot_create_exit_code.py` positions missing code `""` → `BOT_NOT_FOUND` (table-absence 정규화 포함)
  - `test_approval.py` add_review nonexistent → `ApprovalNotFoundError`
- [x] pytest unit suite: **5021 passed / 2 skipped**
- [x] `ruff check` / `ruff format --check`: clean
- [x] `mypy src/`: **Success: no issues found in 217 source files**
- [x] main HEAD (a5d8edf) 불변

🤖 Generated with [Claude Code](https://claude.com/claude-code)