### PR TITLE
fix: #1812/#1813/#1814 Group Q state-conflict typed code sweep (3 issues)

### DIFF
--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -22,15 +22,26 @@ class AccountNotFoundError(AccountError):
 
 
 class AccountAlreadyExistsError(AccountError):
-    """동일 account_id가 이미 존재."""
+    """동일 account_id가 이미 존재.
 
-    pass
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"ACCOUNT_ALREADY_EXISTS"``를 노출하도록 한다 (#1812 Group Q sweep —
+    state-conflict / duplicate-resource typed code 정합).
+    """
+
+    code: str = "ACCOUNT_ALREADY_EXISTS"
 
 
 class InvalidBrokerTypeError(AccountError):
-    """등록되지 않은 broker_type."""
+    """등록되지 않은 broker_type.
 
-    pass
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"ACCOUNT_INVALID_BROKER_TYPE"``를 노출하도록 한다 (#1812 Group Q sweep).
+    """
+
+    code: str = "ACCOUNT_INVALID_BROKER_TYPE"
 
 
 class InvalidExchangeError(AccountError):
@@ -50,27 +61,56 @@ class InvalidExchangeError(AccountError):
 
 
 class MissingCredentialsError(AccountError):
-    """필수 credentials 키 누락."""
+    """필수 credentials 키 누락.
 
-    pass
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"ACCOUNT_MISSING_CREDENTIALS"``를 노출하도록 한다 (#1812 Group Q sweep).
+    """
+
+    code: str = "ACCOUNT_MISSING_CREDENTIALS"
 
 
 class AccountAlreadySuspendedError(AccountError):
-    """이미 정지 상태인 계좌에 대한 재정지 시도."""
+    """이미 정지 상태인 계좌에 대한 재정지 시도.
 
-    pass
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"ACCOUNT_ALREADY_SUSPENDED"``를 노출하도록 한다 (#1812 Group Q sweep —
+    state-conflict typed code 정합. CLI ``account suspend`` 가 IPC envelope
+    의 typed code 를 middleware ``ClickException`` fallback 으로 그대로
+    surface 한다).
+    """
+
+    code: str = "ACCOUNT_ALREADY_SUSPENDED"
 
 
 class AccountDeletedError(AccountError):
-    """DELETED 상태 계좌에 대한 수정/활성화 시도."""
+    """DELETED 상태 계좌에 대한 수정/활성화 시도.
 
-    pass
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"ACCOUNT_DELETED"``를 노출하도록 한다 (#1812 Group Q sweep —
+    state-conflict typed code 정합).
+
+    NOTE: CLI ``account delete`` 의 ``except AccountDeletedError`` 분기는
+    명시적으로 ``code="ACCOUNT_ALREADY_DELETED"`` 를 출력해 already-deleted
+    UX 의미를 보존한다 (CLI surface override). 본 클래스 레벨 ``code`` 는
+    IPC envelope 의 fallback 코드 (직접 catch 가 없는 표면)를 의미한다.
+    """
+
+    code: str = "ACCOUNT_DELETED"
 
 
 class AccountSuspendedError(AccountError):
-    """정지(SUSPENDED) 상태 계좌에 대한 작업 시도."""
+    """정지(SUSPENDED) 상태 계좌에 대한 작업 시도.
 
-    pass
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"ACCOUNT_SUSPENDED"``를 노출하도록 한다 (#1812 Group Q sweep).
+    """
+
+    code: str = "ACCOUNT_SUSPENDED"
 
 
 class InvalidAccountIdError(AccountError):
@@ -86,9 +126,14 @@ class InvalidAccountIdError(AccountError):
 
 
 class AccountImmutableFieldError(AccountError):
-    """불변 필드 수정 시도."""
+    """불변 필드 수정 시도.
 
-    pass
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"ACCOUNT_IMMUTABLE_FIELD"``를 노출하도록 한다 (#1812 Group Q sweep).
+    """
+
+    code: str = "ACCOUNT_IMMUTABLE_FIELD"
 
 
 class BrokerReconnectFailedError(AccountError):
@@ -96,9 +141,13 @@ class BrokerReconnectFailedError(AccountError):
 
     update() 자체는 DB에 반영되지만, 새 자격증명/설정으로 broker connect()가
     실패했을 때 발생한다. 운영자는 설정을 교정한 뒤 재시도해야 한다.
+
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"BROKER_RECONNECT_FAILED"``를 노출하도록 한다 (#1812 Group Q sweep).
     """
 
-    pass
+    code: str = "BROKER_RECONNECT_FAILED"
 
 
 class AccountStructuralChangeRequiresStoppedServerError(AccountError):
@@ -134,7 +183,15 @@ class AccountHasActiveBotsError(AccountError):
     봇은 ``ante bot remove``로 먼저 제거해야 한다. ``bot remove``는 서버 실행
     중에는 IPC, 서버 정지 상태에서는 cold-path cleanup으로 동작하므로 계좌
     삭제 복구 흐름에서 별도의 server start/stop 왕복이 필요하지 않다.
+
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"ACCOUNT_HAS_ACTIVE_BOTS"``를 노출하도록 한다 (#1812 Group Q sweep).
+    CLI ``account delete`` 의 명시적 ``except AccountHasActiveBotsError``
+    분기도 동일 코드를 surface 한다 (commands/account.py:874).
     """
+
+    code: str = "ACCOUNT_HAS_ACTIVE_BOTS"
 
     def __init__(self, account_id: str, bot_count: int) -> None:
         self.account_id = account_id

--- a/src/ante/approval/errors.py
+++ b/src/ante/approval/errors.py
@@ -6,9 +6,16 @@ approval 을 ``ValueError`` 대신 typed exception 으로 raise 한다. IPC
 ``APPROVAL_NOT_FOUND`` 로 변환한다. CLI ``approval cancel-invalid`` 도
 ``getattr(e, "code", ...)`` 패턴으로 typed code 를 surface 한다.
 
+Refs #1813 (Group Q sweep): ``ApprovalStatusConflictError`` 를 신규 도입해
+``approve``/``reject`` 표면의 status flow violation (rejected → 재reject,
+approved → 재approve 등) 을 ``ValueError`` 대신 typed exception 으로
+raise 한다. IPC envelope 이 ``APPROVAL_STATUS_CONFLICT`` 안정 코드를
+surface 한다. ``ValueError`` 다중상속으로 기존 ``except ValueError`` caller
+(CLI ``approval approve`` line 629 fallback 등) 회귀를 방지한다.
+
 ``ApprovalValidationError`` 는 호환을 위해 ``ante.approval.models`` 에
-계속 존재하며, 본 모듈은 cleanup/cancel 표면의 typed not-found 만 추가
-한다.
+계속 존재하며, 본 모듈은 cleanup/cancel 표면의 typed not-found + Group Q
+state-conflict 만 추가한다.
 """
 
 
@@ -32,3 +39,41 @@ class ApprovalNotFoundError(ApprovalError):
     def __init__(self, approval_id: str) -> None:
         self.approval_id = approval_id
         super().__init__(f"결재 요청을 찾을 수 없음: {approval_id}")
+
+
+class ApprovalStatusConflictError(ApprovalError, ValueError):
+    """결재 status flow 위반 (#1813 Group Q sweep).
+
+    ``approve``/``reject`` 메서드가 현재 status 가 허용 전이 집합에 포함되지
+    않을 때 raise 한다. 예시:
+
+    - ``rejected`` 상태에서 ``reject`` 재시도 (이미 거절됨)
+    - ``approved`` 상태에서 ``approve`` 재시도 (이미 승인됨)
+    - ``cancelled`` 상태에서 ``approve``/``reject`` 시도
+
+    ``ApprovalError`` 와 ``ValueError`` 다중상속으로 둔다 — ``approve``/
+    ``reject`` 메서드 이전에 기존 ``except ValueError`` 로 status conflict
+    를 받아온 caller (CLI ``approval approve`` line 629 generic fallback,
+    test mock 시나리오) 가 회귀 없이 동일하게 잡히도록 한다.
+    ``except ApprovalStatusConflictError`` 를 먼저 둔 caller 는 typed 분기
+    를 우선 매칭해 안정 코드 envelope 을 surface 한다 (Python MRO 보장).
+
+    IPC envelope 은 ``getattr(e, "code", "EXECUTION_ERROR")`` 로
+    ``"APPROVAL_STATUS_CONFLICT"`` 코드를 자동 노출한다.
+    """
+
+    code: str = "APPROVAL_STATUS_CONFLICT"
+
+    def __init__(
+        self,
+        approval_id: str,
+        current_status: str,
+        requested_action: str,
+    ) -> None:
+        self.approval_id = approval_id
+        self.current_status = current_status
+        self.requested_action = requested_action
+        super().__init__(
+            f"결재 '{approval_id}' 상태 '{current_status}' 에서 "
+            f"'{requested_action}' 작업을 수행할 수 없습니다."
+        )

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from ante.account.scoping import require_account_id
 from ante.approval.auto_approve import AutoApproveEvaluator
-from ante.approval.errors import ApprovalNotFoundError
+from ante.approval.errors import ApprovalNotFoundError, ApprovalStatusConflictError
 from ante.approval.models import (
     ApprovalRequest,
     ApprovalStatus,
@@ -222,11 +222,16 @@ class ApprovalService:
 
         approvable = (ApprovalStatus.PENDING, ApprovalStatus.EXECUTION_FAILED)
         if request.status not in approvable:
-            msg = (
-                "pending/execution_failed 상태에서만 승인 가능"
-                f" (현재: {request.status})"
+            # #1813 Group Q sweep: status flow 위반은 typed
+            # ``ApprovalStatusConflictError`` 로 raise 해 IPC envelope 이
+            # ``APPROVAL_STATUS_CONFLICT`` 안정 코드를 surface 한다.
+            # ``ValueError`` 다중상속이라 기존 ``except ValueError`` caller
+            # (CLI ``approval approve`` line 629 generic fallback) 회귀 없음.
+            raise ApprovalStatusConflictError(
+                id,
+                current_status=str(request.status),
+                requested_action="approve",
             )
-            raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()
         request.history.append(
@@ -275,11 +280,16 @@ class ApprovalService:
 
         rejectable = (ApprovalStatus.PENDING, ApprovalStatus.EXECUTION_FAILED)
         if request.status not in rejectable:
-            msg = (
-                "pending/execution_failed 상태에서만 거절 가능"
-                f" (현재: {request.status})"
+            # #1813 Group Q sweep: status flow 위반은 typed
+            # ``ApprovalStatusConflictError`` 로 raise 해 IPC envelope 이
+            # ``APPROVAL_STATUS_CONFLICT`` 안정 코드를 surface 한다.
+            # ``ValueError`` 다중상속이라 기존 ``except ValueError`` caller
+            # (CLI ``approval reject`` line 662 generic fallback) 회귀 없음.
+            raise ApprovalStatusConflictError(
+                id,
+                current_status=str(request.status),
+                requested_action="reject",
             )
-            raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()
         request.history.append(

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -27,7 +27,11 @@ from ante.cli.middleware import (
     require_master,
     require_scope,
 )
-from ante.member.errors import MemberNotFoundError, PermissionDeniedError
+from ante.member.errors import (
+    MemberNotFoundError,
+    MemberStateConflictError,
+    PermissionDeniedError,
+)
 from ante.member.models import MemberRole
 from ante.member.scopes import InvalidScopeError
 
@@ -654,6 +658,13 @@ def member_suspend(ctx: click.Context, member_id: str) -> None:
         # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
+    except MemberStateConflictError as e:
+        # #1814 Group Q sweep: state-conflict (이미 SUSPENDED 등) 는 안정 코드
+        # ``MEMBER_STATE_CONFLICT`` 로 surface 한다. ``ValueError`` 다중상속
+        # 이라 아래 ``except (ValueError, PermissionError)`` generic fallback
+        # 보다 typed 분기를 먼저 매칭한다 (Python MRO 보장).
+        fmt.error(str(e), code="MEMBER_STATE_CONFLICT")
+        raise SystemExit(1) from e
     except (ValueError, PermissionError) as e:
         fmt.error(str(e))
         raise SystemExit(1) from e
@@ -689,6 +700,13 @@ def member_reactivate(ctx: click.Context, member_id: str) -> None:
         # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
+    except MemberStateConflictError as e:
+        # #1814 Group Q sweep: state-conflict (이미 ACTIVE 등) 는 안정 코드
+        # ``MEMBER_STATE_CONFLICT`` 로 surface 한다 (``member suspend`` 1:1
+        # 미러). ``ValueError`` 다중상속이라 아래 generic fallback 보다
+        # typed 분기를 먼저 매칭한다.
+        fmt.error(str(e), code="MEMBER_STATE_CONFLICT")
+        raise SystemExit(1) from e
     except (ValueError, PermissionError) as e:
         fmt.error(str(e))
         raise SystemExit(1) from e

--- a/src/ante/member/errors.py
+++ b/src/ante/member/errors.py
@@ -5,6 +5,13 @@ Refs #1805: ``MemberNotFoundError`` 를 신규 도입해 service 의 missing-mem
 surface (set-emoji/suspend/reactivate/revoke/rotate-token, register 는 not-found
 경로 부재) 가 envelope 코드 ``"MEMBER_NOT_FOUND"`` 를 stable 하게 surface 한다.
 ``ApprovalNotFoundError`` (#1798) 와 동형 패턴이다.
+
+Refs #1814 (Group Q sweep): ``MemberStateConflictError`` 를 신규 도입해
+``suspend``/``reactivate`` 표면의 state 위반 (이미 SUSPENDED 인 멤버
+재정지, 이미 ACTIVE 인 멤버 재활성화) 을 ``PermissionError`` 대신 typed
+exception 으로 raise 한다. CLI envelope 이 ``"MEMBER_STATE_CONFLICT"``
+안정 코드를 surface 한다. ``ValueError`` 다중상속으로 #1805
+``MemberNotFoundError`` 패턴을 따른다.
 """
 
 
@@ -37,3 +44,45 @@ class MemberNotFoundError(MemberError, ValueError):
     def __init__(self, member_id: str) -> None:
         self.member_id = member_id
         super().__init__(f"존재하지 않는 멤버: {member_id}")
+
+
+class MemberStateConflictError(MemberError, ValueError):
+    """멤버 state flow 위반 (#1814 Group Q sweep).
+
+    ``suspend`` 메서드가 이미 SUSPENDED 인 멤버 (혹은 ACTIVE 가 아닌 상태)
+    를 재정지하려 할 때, ``reactivate`` 메서드가 이미 ACTIVE 인 멤버 (혹은
+    SUSPENDED 가 아닌 상태) 를 재활성화하려 할 때 raise 한다.
+
+    ``MemberError`` 와 ``ValueError`` 다중상속으로 둔다 — #1805
+    ``MemberNotFoundError`` 패턴 1:1 미러. 기존 caller (CLI ``suspend``
+    /``reactivate`` 의 ``except (ValueError, PermissionError)`` generic
+    fallback line 657/692, ``test_member_service.py:98`` 등) 가 회귀 없이
+    동일하게 잡히도록 한다. ``except MemberStateConflictError`` 를 먼저 둔
+    caller (#1814 의 2 mutation surface) 는 typed 분기를 우선 매칭해 안정
+    코드 envelope 을 surface 한다 (Python MRO 보장).
+
+    이전 (#1814 이전): ``_assert_status`` helper 가 ``PermissionError`` 를
+    raise 했으나, state-conflict 는 권한 부족이 아닌 상태 흐름 위반이라
+    의미가 모호했다. Group Q sweep 은 ``suspend``/``reactivate`` 의 state
+    체크를 인라인 typed raise 로 좁히고, ``revoke`` (plan scope 외, 다중
+    상태 허용) 는 기존 ``_assert_status`` helper 를 그대로 사용한다.
+
+    클래스 레벨 ``code`` 속성은 CLI/IPC envelope 이 안정 코드
+    ``"MEMBER_STATE_CONFLICT"`` 로 surface 하도록 한다.
+    """
+
+    code: str = "MEMBER_STATE_CONFLICT"
+
+    def __init__(
+        self,
+        member_id: str,
+        current_status: str,
+        requested_action: str,
+    ) -> None:
+        self.member_id = member_id
+        self.current_status = current_status
+        self.requested_action = requested_action
+        super().__init__(
+            f"멤버 '{member_id}' 상태 '{current_status}' 에서 "
+            f"'{requested_action}' 작업을 수행할 수 없습니다."
+        )

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -585,11 +585,25 @@ class MemberService:
         ``suspended_by``는 master 권한 caller여야 한다(#1351 — 보안 회귀
         잠금). 빈 문자열을 포함한 non-master는 ``PermissionDeniedError``로
         거부된다. 라우트 인증 가드와 무관하게 service-layer 자체 invariant.
+
+        state 위반 (이미 SUSPENDED 등) 은 #1814 Group Q sweep 에 따라
+        typed ``MemberStateConflictError`` 로 raise 한다 (이전 ``PermissionError``
+        의미를 좁힘). ``ValueError`` 다중상속이므로 기존 ``except (ValueError,
+        PermissionError)`` caller (CLI member suspend line 657 generic
+        fallback) 가 회귀 없이 동일하게 잡힌다. ``revoke`` 는 plan scope 외
+        라 기존 ``_assert_status`` ``PermissionError`` 경로를 유지한다.
         """
+        from ante.member.errors import MemberStateConflictError
+
         await self._assert_master(suspended_by, "suspend")
         member = await self._get_or_raise(member_id)
         self._assert_not_master(member, "suspend")
-        self._assert_status(member, MemberStatus.ACTIVE, "suspend")
+        if member.status != MemberStatus.ACTIVE:
+            raise MemberStateConflictError(
+                member_id,
+                current_status=str(member.status),
+                requested_action="suspend",
+            )
 
         now = _now()
         await self._db.execute(
@@ -615,10 +629,20 @@ class MemberService:
         """멤버 재활성화.
 
         ``reactivated_by``는 master 권한 caller여야 한다(#1351).
+
+        state 위반 (이미 ACTIVE 등) 은 #1814 Group Q sweep 에 따라 typed
+        ``MemberStateConflictError`` 로 raise 한다 (``suspend`` 1:1 미러).
         """
+        from ante.member.errors import MemberStateConflictError
+
         await self._assert_master(reactivated_by, "reactivate")
         member = await self._get_or_raise(member_id)
-        self._assert_status(member, MemberStatus.SUSPENDED, "reactivate")
+        if member.status != MemberStatus.SUSPENDED:
+            raise MemberStateConflictError(
+                member_id,
+                current_status=str(member.status),
+                requested_action="reactivate",
+            )
 
         await self._db.execute(
             "UPDATE members SET status = ? WHERE member_id = ?",

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -339,10 +339,22 @@ class TestResolve:
         )
         await service.approve(req.id)
 
-        with pytest.raises(
-            ValueError, match="pending/execution_failed 상태에서만 승인 가능"
-        ):
+        # #1813 Group Q sweep: status flow 위반은 typed
+        # ``ApprovalStatusConflictError`` (``ApprovalError`` + ``ValueError``
+        # 다중상속) 로 raise 된다. 이전 동작은 일반 ``ValueError`` 였다 —
+        # state 위반 의미가 generic validation 과 모호하게 섞여 있어 typed
+        # 로 좁힘. ``ValueError`` 다중상속이라 기존 ``except ValueError``
+        # caller (CLI generic fallback) 회귀는 없다.
+        from ante.approval.errors import ApprovalStatusConflictError
+
+        with pytest.raises(ApprovalStatusConflictError) as excinfo:
             await service.approve(req.id)
+        assert excinfo.value.code == "APPROVAL_STATUS_CONFLICT"
+        assert excinfo.value.approval_id == req.id
+        assert excinfo.value.requested_action == "approve"
+        # ``ValueError`` 회귀 보호: 다중상속이 유지되어 기존 caller 가
+        # ``except ValueError`` 로도 잡을 수 있어야 한다.
+        assert isinstance(excinfo.value, ValueError)
 
     async def test_reject(self, service):
         """결재 거절."""
@@ -368,10 +380,17 @@ class TestResolve:
         )
         await service.reject(req.id)
 
-        with pytest.raises(
-            ValueError, match="pending/execution_failed 상태에서만 거절 가능"
-        ):
+        # #1813 Group Q sweep: status flow 위반은 typed
+        # ``ApprovalStatusConflictError`` 로 raise (위 ``approve`` 분기 1:1
+        # 미러). ``ValueError`` 다중상속이라 기존 caller 회귀 없음.
+        from ante.approval.errors import ApprovalStatusConflictError
+
+        with pytest.raises(ApprovalStatusConflictError) as excinfo:
             await service.reject(req.id)
+        assert excinfo.value.code == "APPROVAL_STATUS_CONFLICT"
+        assert excinfo.value.approval_id == req.id
+        assert excinfo.value.requested_action == "reject"
+        assert isinstance(excinfo.value, ValueError)
 
     async def test_hold_and_resume(self, service):
         """보류 및 재개."""

--- a/tests/unit/test_cli_group_q_state_conflict_sweep.py
+++ b/tests/unit/test_cli_group_q_state_conflict_sweep.py
@@ -1,0 +1,632 @@
+"""Group Q state-conflict typed code sweep (#1812 / #1813 / #1814).
+
+3 oracle A7 state-conflict issue sweep — 각 CLI/IPC 표면이 안정 typed code
+envelope 을 surface 함을 verify 한다 (Group P #1805 missing-resource sweep
+동형 패턴).
+
+R-case 매트릭스:
+  R1 #1812 ``ante account suspend <SUSPENDED-account> --format json``
+         → exit 1, code=``ACCOUNT_ALREADY_SUSPENDED``
+         (IPC-only — server fixture 없이 subprocess 재현이 불가하므로
+         Group A #1795 ``AccountNotFoundError`` 패턴을 따라 typed exception
+         class ``code`` 속성 + IPC envelope 매핑 invariant 를 직접 verify
+         한다. ``test_ipc_error_code_mapping.py
+         ::test_ipc_server_surfaces_typed_code_for_account_already_suspended``
+         가 추가 회귀로 envelope 매핑을 lock 한다)
+  R2 #1813 ``ante approval reject <REJECTED-approval> --format json``
+         → exit 1, code=``APPROVAL_STATUS_CONFLICT``
+         (IPC-only — R1 과 동일 분류. 직접 service ``reject(rejected_id)``
+         호출이 ``ApprovalStatusConflictError`` 를 raise 함을 verify)
+  R3 #1814 ``ante member suspend <SUSPENDED-member> --format json``
+         → exit 1, code=``MEMBER_STATE_CONFLICT``
+         (member CLI 는 ``_create_service()`` 직접 호출 경로라 subprocess
+         E2E 가능. ``ante init`` → ``member register`` → ``member suspend``
+         × 2 로 재현)
+
+이전 (#1812 이전): 3 표면 모두 generic exception (``ValueError`` /
+``PermissionError``) 으로 raise 되어 IPC envelope 이 ``EXECUTION_ERROR``
+또는 미상수 코드로 떨어졌다. Group Q sweep 은 state-conflict 표면에
+typed exception class (``.code = "ACCOUNT_ALREADY_SUSPENDED"`` 등) 를
+도입하고 service-layer raise 를 typed 로 좁혀, IPC ``getattr(e, "code",
+"EXECUTION_ERROR")`` envelope 이 자동으로 안정 코드를 surface 하도록 한다.
+
+회귀 보호 매트릭스:
+- ``ValueError`` 다중상속 보존: ``ApprovalStatusConflictError`` /
+  ``MemberStateConflictError`` 가 ``ValueError`` 다중상속을 유지해 기존
+  ``except ValueError`` caller (#1805 ``MemberNotFoundError`` 패턴 1:1
+  미러) 회귀 없음.
+- ``.code`` 누락 폴백 lock: typed exception class 가 인스턴스에서도
+  ``getattr(exc, "code", None)`` 이 안정 코드를 반환해야 한다 (IPC
+  envelope ``getattr(e, "code", "EXECUTION_ERROR")`` 폴백 회귀 차단).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+# subprocess timeout: hang 회귀를 5초 마진으로 차단한다.
+_SUBPROCESS_TIMEOUT_S = 10.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _clean_env(
+    config_dir: Path,
+    *,
+    encryption_key: str | None = None,
+    token: str | None = None,
+) -> dict[str, str]:
+    """subprocess 환경 격리 — 부모 ANTE_* 변수가 새지 않도록 명시 전달."""
+    env: dict[str, str] = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", str(config_dir)),
+        "ANTE_CONFIG_DIR": str(config_dir),
+        "PYTHONPATH": str(_repo_root() / "src"),
+    }
+    if encryption_key is not None:
+        env["ANTE_DB_ENCRYPTION_KEY"] = encryption_key
+    if token is not None:
+        env["ANTE_MEMBER_TOKEN"] = token
+    return env
+
+
+def _parse_json_last(stdout: str) -> dict:
+    """stdout 에서 JSON dict payload 를 추출 (error 한 줄 또는 indent 멀티라인)."""
+    stripped = stdout.strip()
+    if stripped.startswith("{"):
+        try:
+            obj = json.loads(stripped)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    last_obj: dict | None = None
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            last_obj = obj
+    assert last_obj is not None, f"JSON dict 라인을 stdout 에서 찾지 못함: {stdout!r}"
+    return last_obj
+
+
+def _run_cli(
+    config_dir: Path,
+    args: list[str],
+    *,
+    token: str | None = None,
+    encryption_key: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """``ante --format json <args>`` 를 subprocess 로 실행."""
+    env = _clean_env(config_dir, encryption_key=encryption_key, token=token)
+    return subprocess.run(
+        [sys.executable, "-m", "ante", "--format", "json", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _run_init(config_dir: Path, encryption_key: str) -> tuple[str, str]:
+    """``ante init`` 후 (token, encryption_key) 반환."""
+    init_env = _clean_env(config_dir, encryption_key=encryption_key)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ante",
+            "--format",
+            "json",
+            "init",
+            "--name",
+            "GroupQ",
+        ],
+        env=init_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"init 실패: exit={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    token = payload.get("token")
+    assert token, f"init 출력에 token 없음: {payload}"
+    return token, encryption_key
+
+
+@pytest.fixture
+def initialized_config(tmp_path: Path) -> tuple[Path, str, str]:
+    """``ante init`` 을 완료한 (config_dir, token, encryption_key) 튜플."""
+    config_dir = tmp_path / "config"
+    key = Fernet.generate_key().decode()
+    token, _ = _run_init(config_dir, key)
+    return config_dir, token, key
+
+
+# ════════════════════════════════════════════════════════════════════
+# 카테고리 1 — typed exception class ``code`` 속성 lock (IPC envelope
+# 매핑 invariant). #1812 / #1813 / #1814 의 state-conflict typed exception
+# 이 SCREAMING_SNAKE_CASE 안정 코드를 ``.code`` 클래스 속성으로 보유함
+# 을 직접 verify 한다. IPC ``server.py:_dispatch`` 가 ``getattr(e,
+# "code", "EXECUTION_ERROR")`` 로 envelope 코드를 매핑하므로, 핸들러가
+# 이 typed exception 을 raise 하기만 하면 envelope 에 자동 surface 된다.
+# ════════════════════════════════════════════════════════════════════
+
+
+class TestTypedExceptionCodeAttributes:
+    """R1-R3 lock: typed exception class ``code`` 속성 매핑."""
+
+    # ─── #1812 Account state-conflict typed codes ──────────────────
+
+    def test_r1a_account_already_suspended_error_code(self) -> None:
+        """#1812: ``AccountAlreadySuspendedError.code ==
+        "ACCOUNT_ALREADY_SUSPENDED"``.
+        """
+        from ante.account.errors import AccountAlreadySuspendedError, AccountError
+
+        assert AccountAlreadySuspendedError.code == "ACCOUNT_ALREADY_SUSPENDED"
+        assert issubclass(AccountAlreadySuspendedError, AccountError)
+        # 인스턴스에서도 동일 코드가 surface 되어 IPC envelope 의
+        # ``getattr(e, "code", ...)`` 폴백이 안정 코드를 노출한다.
+        exc = AccountAlreadySuspendedError("이미 정지됨")
+        assert getattr(exc, "code", None) == "ACCOUNT_ALREADY_SUSPENDED"
+
+    def test_r1b_account_suspended_error_code(self) -> None:
+        """#1812: ``AccountSuspendedError.code == "ACCOUNT_SUSPENDED"``."""
+        from ante.account.errors import AccountError, AccountSuspendedError
+
+        assert AccountSuspendedError.code == "ACCOUNT_SUSPENDED"
+        assert issubclass(AccountSuspendedError, AccountError)
+        exc = AccountSuspendedError("정지된 계좌")
+        assert getattr(exc, "code", None) == "ACCOUNT_SUSPENDED"
+
+    def test_r1c_account_deleted_error_code(self) -> None:
+        """#1812: ``AccountDeletedError.code == "ACCOUNT_DELETED"`` (IPC
+        envelope 의 fallback 코드. CLI ``account delete`` 의 명시 except 는
+        UX 의미 보존을 위해 ``ACCOUNT_ALREADY_DELETED`` 를 override).
+        """
+        from ante.account.errors import AccountDeletedError, AccountError
+
+        assert AccountDeletedError.code == "ACCOUNT_DELETED"
+        assert issubclass(AccountDeletedError, AccountError)
+        exc = AccountDeletedError("삭제됨")
+        assert getattr(exc, "code", None) == "ACCOUNT_DELETED"
+
+    def test_r1d_account_has_active_bots_error_code(self) -> None:
+        """#1812: ``AccountHasActiveBotsError.code == "ACCOUNT_HAS_ACTIVE_BOTS"``."""
+        from ante.account.errors import AccountError, AccountHasActiveBotsError
+
+        assert AccountHasActiveBotsError.code == "ACCOUNT_HAS_ACTIVE_BOTS"
+        assert issubclass(AccountHasActiveBotsError, AccountError)
+        exc = AccountHasActiveBotsError("acc-1", 2)
+        assert getattr(exc, "code", None) == "ACCOUNT_HAS_ACTIVE_BOTS"
+
+    def test_r1e_account_already_exists_error_code(self) -> None:
+        """#1812: ``AccountAlreadyExistsError.code == "ACCOUNT_ALREADY_EXISTS"``."""
+        from ante.account.errors import AccountAlreadyExistsError, AccountError
+
+        assert AccountAlreadyExistsError.code == "ACCOUNT_ALREADY_EXISTS"
+        assert issubclass(AccountAlreadyExistsError, AccountError)
+        exc = AccountAlreadyExistsError("중복")
+        assert getattr(exc, "code", None) == "ACCOUNT_ALREADY_EXISTS"
+
+    def test_r1f_account_immutable_field_error_code(self) -> None:
+        """#1812: ``AccountImmutableFieldError.code == "ACCOUNT_IMMUTABLE_FIELD"``."""
+        from ante.account.errors import AccountError, AccountImmutableFieldError
+
+        assert AccountImmutableFieldError.code == "ACCOUNT_IMMUTABLE_FIELD"
+        assert issubclass(AccountImmutableFieldError, AccountError)
+        exc = AccountImmutableFieldError("exchange 변경 불가")
+        assert getattr(exc, "code", None) == "ACCOUNT_IMMUTABLE_FIELD"
+
+    def test_r1g_broker_reconnect_failed_error_code(self) -> None:
+        """#1812: ``BrokerReconnectFailedError.code == "BROKER_RECONNECT_FAILED"``."""
+        from ante.account.errors import AccountError, BrokerReconnectFailedError
+
+        assert BrokerReconnectFailedError.code == "BROKER_RECONNECT_FAILED"
+        assert issubclass(BrokerReconnectFailedError, AccountError)
+        exc = BrokerReconnectFailedError("connect 실패")
+        assert getattr(exc, "code", None) == "BROKER_RECONNECT_FAILED"
+
+    def test_r1h_missing_credentials_error_code(self) -> None:
+        """#1812: ``MissingCredentialsError.code == "ACCOUNT_MISSING_CREDENTIALS"``."""
+        from ante.account.errors import AccountError, MissingCredentialsError
+
+        assert MissingCredentialsError.code == "ACCOUNT_MISSING_CREDENTIALS"
+        assert issubclass(MissingCredentialsError, AccountError)
+        exc = MissingCredentialsError("app_key 누락")
+        assert getattr(exc, "code", None) == "ACCOUNT_MISSING_CREDENTIALS"
+
+    def test_r1i_invalid_broker_type_error_code(self) -> None:
+        """#1812: ``InvalidBrokerTypeError.code == "ACCOUNT_INVALID_BROKER_TYPE"``."""
+        from ante.account.errors import AccountError, InvalidBrokerTypeError
+
+        assert InvalidBrokerTypeError.code == "ACCOUNT_INVALID_BROKER_TYPE"
+        assert issubclass(InvalidBrokerTypeError, AccountError)
+        exc = InvalidBrokerTypeError("unknown broker")
+        assert getattr(exc, "code", None) == "ACCOUNT_INVALID_BROKER_TYPE"
+
+    # ─── #1813 Approval status-conflict typed code ─────────────────
+
+    def test_r2_approval_status_conflict_error_code(self) -> None:
+        """#1813: ``ApprovalStatusConflictError.code == "APPROVAL_STATUS_CONFLICT"``.
+
+        ``ApprovalError`` + ``ValueError`` 다중상속 보존 — 기존
+        ``except ValueError`` caller (CLI ``approval approve`` line 629
+        generic fallback) 회귀 없음.
+        """
+        from ante.approval.errors import ApprovalError, ApprovalStatusConflictError
+
+        assert ApprovalStatusConflictError.code == "APPROVAL_STATUS_CONFLICT"
+        assert issubclass(ApprovalStatusConflictError, ApprovalError)
+        assert issubclass(ApprovalStatusConflictError, ValueError)
+        exc = ApprovalStatusConflictError(
+            "appr-1",
+            current_status="rejected",
+            requested_action="reject",
+        )
+        assert getattr(exc, "code", None) == "APPROVAL_STATUS_CONFLICT"
+        assert exc.approval_id == "appr-1"
+        assert exc.current_status == "rejected"
+        assert exc.requested_action == "reject"
+
+    # ─── #1814 Member state-conflict typed code ────────────────────
+
+    def test_r3_member_state_conflict_error_code(self) -> None:
+        """#1814: ``MemberStateConflictError.code == "MEMBER_STATE_CONFLICT"``.
+
+        ``MemberError`` + ``ValueError`` 다중상속 보존 — #1805
+        ``MemberNotFoundError`` 패턴 1:1 미러. 기존 ``except (ValueError,
+        PermissionError)`` caller (CLI member suspend/reactivate line
+        657/692 generic fallback) 회귀 없음.
+        """
+        from ante.member.errors import MemberError, MemberStateConflictError
+
+        assert MemberStateConflictError.code == "MEMBER_STATE_CONFLICT"
+        assert issubclass(MemberStateConflictError, MemberError)
+        assert issubclass(MemberStateConflictError, ValueError)
+        exc = MemberStateConflictError(
+            "mbr-1",
+            current_status="suspended",
+            requested_action="suspend",
+        )
+        assert getattr(exc, "code", None) == "MEMBER_STATE_CONFLICT"
+        assert exc.member_id == "mbr-1"
+        assert exc.current_status == "suspended"
+        assert exc.requested_action == "suspend"
+
+
+# ════════════════════════════════════════════════════════════════════
+# 카테고리 2 — service-layer typed raise 검증. CLI/IPC 표면이 typed
+# 코드를 surface 하려면 service 가 typed exception 을 raise 해야 한다.
+# fixture-light 단위 테스트로 service 를 직접 호출해 raise type 회귀를
+# 막는다 (Group A ``TestServiceLayerTypedRaise`` 동형 패턴).
+# ════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+class TestServiceLayerTypedRaise:
+    """service-layer 가 state-conflict 를 typed exception 으로 raise."""
+
+    # ─── R1 #1812 account.suspend(SUSPENDED) → AccountAlreadySuspendedError ─
+
+    async def test_r1_account_service_suspend_already_suspended_raises_typed(
+        self, tmp_path: Path
+    ) -> None:
+        """#1812: ``AccountService.suspend(<SUSPENDED-account>)`` →
+        ``AccountAlreadySuspendedError`` (code ``"ACCOUNT_ALREADY_SUSPENDED"``).
+
+        IPC envelope 이 ``getattr(e, "code", ...)`` 로 안정 코드를 surface
+        하려면 service-layer 가 typed exception 을 raise 해야 한다. 본
+        테스트는 service 의 typed raise 자체를 lock 해 #1813 ``approve``
+        / #1814 ``suspend`` 와 형제 invariant 를 보장한다.
+        """
+        from decimal import Decimal
+
+        from ante.account.errors import AccountAlreadySuspendedError
+        from ante.account.models import (
+            Account,
+            AccountStatus,
+            TradingMode,
+        )
+        from ante.account.service import AccountService
+        from ante.core.database import Database
+        from ante.eventbus import EventBus
+
+        db_path = tmp_path / "test.db"
+        db = Database(str(db_path))
+        await db.connect()
+        try:
+            eventbus = EventBus()
+            service = AccountService(db, eventbus=eventbus)
+            await service.initialize()
+
+            # ACTIVE 계좌 생성 → suspend × 2 시 typed raise.
+            acct = Account(
+                account_id="acc-grp-q",
+                name="Group Q Test",
+                exchange="TEST",
+                currency="KRW",
+                timezone="Asia/Seoul",
+                trading_hours_start="00:00",
+                trading_hours_end="23:59",
+                trading_mode=TradingMode.VIRTUAL,
+                broker_type="test",
+                credentials={"app_key": "x", "app_secret": "y"},
+                broker_config={},
+                buy_commission_rate=Decimal("0"),
+                sell_commission_rate=Decimal("0"),
+                market_order_reserve_buffer_rate=Decimal("0"),
+            )
+            await service.create(acct)
+            await service.suspend(
+                "acc-grp-q",
+                reason="첫 정지",
+                suspended_by="system",
+            )
+            refreshed = await service.get("acc-grp-q")
+            assert refreshed.status == AccountStatus.SUSPENDED
+
+            with pytest.raises(AccountAlreadySuspendedError) as excinfo:
+                await service.suspend(
+                    "acc-grp-q",
+                    reason="재정지 시도",
+                    suspended_by="system",
+                )
+            assert getattr(excinfo.value, "code", None) == "ACCOUNT_ALREADY_SUSPENDED"
+        finally:
+            await db.close()
+
+    # ─── R2 #1813 approval.reject(REJECTED) → ApprovalStatusConflictError ──
+
+    async def test_r2_approval_service_reject_already_rejected_raises_typed(
+        self, tmp_path: Path
+    ) -> None:
+        """#1813: ``ApprovalService.reject(<REJECTED-approval>)`` →
+        ``ApprovalStatusConflictError`` (code ``"APPROVAL_STATUS_CONFLICT"``).
+
+        IPC envelope 이 typed code 를 surface 하려면 service-layer 가 typed
+        exception 을 raise 해야 한다. Group A #1798
+        ``cancel_invalid_type_request`` 동형 패턴.
+        """
+        from ante.approval.errors import ApprovalStatusConflictError
+        from ante.approval.models import ApprovalType
+        from ante.approval.service import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus import EventBus
+
+        async def _noop_executor(params: dict) -> None:
+            return None
+
+        db_path = tmp_path / "test.db"
+        db = Database(str(db_path))
+        await db.connect()
+        try:
+            eventbus = EventBus()
+            executors = {t.value: _noop_executor for t in ApprovalType}
+            service = ApprovalService(db, eventbus=eventbus, executors=executors)
+            await service.initialize()
+
+            req = await service.create(
+                type="budget_change",
+                requester="agent",
+                title="Group Q 테스트",
+                params={"account_id": "acc-grp-q"},
+            )
+            await service.reject(req.id, reject_reason="첫 거절")
+
+            with pytest.raises(ApprovalStatusConflictError) as excinfo:
+                await service.reject(req.id, reject_reason="재거절 시도")
+            assert getattr(excinfo.value, "code", None) == "APPROVAL_STATUS_CONFLICT"
+            assert excinfo.value.approval_id == req.id
+            assert excinfo.value.requested_action == "reject"
+            # ``ValueError`` 다중상속 회귀 보호 — 기존 ``except ValueError``
+            # caller 가 동일하게 잡을 수 있어야 한다.
+            assert isinstance(excinfo.value, ValueError)
+        finally:
+            await db.close()
+
+    async def test_r2b_approval_service_approve_already_approved_raises_typed(
+        self, tmp_path: Path
+    ) -> None:
+        """#1813: ``ApprovalService.approve(<APPROVED-approval>)`` →
+        ``ApprovalStatusConflictError`` (대칭 분기 — ``reject`` 1:1 미러).
+        """
+        from ante.approval.errors import ApprovalStatusConflictError
+        from ante.approval.models import ApprovalType
+        from ante.approval.service import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus import EventBus
+
+        async def _noop_executor(params: dict) -> None:
+            return None
+
+        db_path = tmp_path / "test.db"
+        db = Database(str(db_path))
+        await db.connect()
+        try:
+            eventbus = EventBus()
+            executors = {t.value: _noop_executor for t in ApprovalType}
+            service = ApprovalService(db, eventbus=eventbus, executors=executors)
+            await service.initialize()
+
+            req = await service.create(
+                type="budget_change",
+                requester="agent",
+                title="Group Q approve 테스트",
+                params={"account_id": "acc-grp-q"},
+            )
+            await service.approve(req.id)
+
+            with pytest.raises(ApprovalStatusConflictError) as excinfo:
+                await service.approve(req.id)
+            assert getattr(excinfo.value, "code", None) == "APPROVAL_STATUS_CONFLICT"
+            assert excinfo.value.requested_action == "approve"
+        finally:
+            await db.close()
+
+    # ─── R3 #1814 member.suspend(SUSPENDED) → MemberStateConflictError ─────
+
+    async def test_r3_member_service_suspend_already_suspended_raises_typed(
+        self, tmp_path: Path
+    ) -> None:
+        """#1814: ``MemberService.suspend(<SUSPENDED-member>)`` →
+        ``MemberStateConflictError`` (code ``"MEMBER_STATE_CONFLICT"``).
+
+        이전 (#1814 이전): ``_assert_status`` 가 ``PermissionError`` 를 raise
+        해 IPC envelope 이 ``EXECUTION_ERROR`` 폴백 (or unmapped) 로 떨어졌다.
+        Group Q sweep 은 ``suspend``/``reactivate`` state 체크를 typed
+        ``MemberStateConflictError`` 로 좁힌다.
+        """
+        from ante.core.database import Database
+        from ante.eventbus import EventBus
+        from ante.member.errors import MemberStateConflictError
+        from ante.member.models import MemberType
+        from ante.member.service import MemberService
+
+        db_path = tmp_path / "test.db"
+        db = Database(str(db_path))
+        await db.connect()
+        try:
+            eventbus = EventBus()
+            service = MemberService(db, eventbus=eventbus)
+            await service.initialize()
+
+            # master + ACTIVE agent 생성 → suspend 1회 후 재정지 시 typed.
+            await service.bootstrap_master("owner", "pass1234")
+            await service.register("agent-grp-q", MemberType.AGENT)
+            await service.suspend("agent-grp-q", suspended_by="owner")
+
+            with pytest.raises(MemberStateConflictError) as excinfo:
+                await service.suspend("agent-grp-q", suspended_by="owner")
+            assert getattr(excinfo.value, "code", None) == "MEMBER_STATE_CONFLICT"
+            assert excinfo.value.member_id == "agent-grp-q"
+            assert excinfo.value.requested_action == "suspend"
+            # ``ValueError`` 다중상속 회귀 보호.
+            assert isinstance(excinfo.value, ValueError)
+        finally:
+            await db.close()
+
+
+# ════════════════════════════════════════════════════════════════════
+# 카테고리 3 — subprocess CLI E2E. member CLI 는 ``_create_service()``
+# 직접 호출 경로라 server fixture 없이 ``ante init`` → ``member
+# register`` → ``member suspend`` × 2 로 R3 envelope 을 직접 검증할 수
+# 있다 (R1/R2 는 IPC-only 라 카테고리 2 service-layer 검증으로 대체).
+# ════════════════════════════════════════════════════════════════════
+
+
+class TestMemberSuspendStateConflictTypedCode:
+    """R3 subprocess E2E — ``ante member suspend <SUSPENDED> --format
+    json`` → exit 1, code=``MEMBER_STATE_CONFLICT``.
+
+    Group P #1805 ``member suspend <missing>`` → ``MEMBER_NOT_FOUND`` 와
+    형제 패턴이지만 envelope code 로 의미를 구분 (missing vs state-conflict).
+    """
+
+    def test_suspend_already_suspended_emits_typed_state_conflict(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+
+        # 1) member register — master 가 agent 를 등록 (text 출력 OK).
+        register_result = _run_cli(
+            config_dir,
+            ["member", "register", "--id", "agent-grp-q", "--type", "agent"],
+            token=token,
+            encryption_key=key,
+        )
+        assert register_result.returncode == 0, (
+            f"register 실패: exit={register_result.returncode}\n"
+            f"stdout={register_result.stdout}\nstderr={register_result.stderr}"
+        )
+
+        # 2) 첫 suspend — 정상 종료.
+        first_suspend = _run_cli(
+            config_dir,
+            ["member", "suspend", "agent-grp-q"],
+            token=token,
+            encryption_key=key,
+        )
+        assert first_suspend.returncode == 0, (
+            f"첫 suspend 실패: exit={first_suspend.returncode}\n"
+            f"stdout={first_suspend.stdout}\nstderr={first_suspend.stderr}"
+        )
+
+        # 3) 재정지 시도 — typed envelope code 검증.
+        second_suspend = _run_cli(
+            config_dir,
+            ["member", "suspend", "agent-grp-q"],
+            token=token,
+            encryption_key=key,
+        )
+        assert second_suspend.returncode == 1, (
+            f"exit={second_suspend.returncode}\n"
+            f"stdout={second_suspend.stdout}\nstderr={second_suspend.stderr}"
+        )
+        assert "Traceback" not in second_suspend.stderr, (
+            f"stderr 에 traceback 노출: {second_suspend.stderr!r}"
+        )
+        payload = _parse_json_last(second_suspend.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "MEMBER_STATE_CONFLICT", payload
+
+
+class TestMemberReactivateStateConflictTypedCode:
+    """R3 보조 — ``ante member reactivate <ACTIVE> --format json`` →
+    exit 1, code=``MEMBER_STATE_CONFLICT`` (대칭 분기, ``suspend`` 1:1
+    미러).
+    """
+
+    def test_reactivate_already_active_emits_typed_state_conflict(
+        self, initialized_config: tuple[Path, str, str]
+    ) -> None:
+        config_dir, token, key = initialized_config
+
+        # 1) member register — ACTIVE 상태로 등록.
+        register_result = _run_cli(
+            config_dir,
+            ["member", "register", "--id", "agent-grp-q-2", "--type", "agent"],
+            token=token,
+            encryption_key=key,
+        )
+        assert register_result.returncode == 0, (
+            f"register 실패: exit={register_result.returncode}\n"
+            f"stdout={register_result.stdout}\nstderr={register_result.stderr}"
+        )
+
+        # 2) reactivate 시도 — ACTIVE 상태에서 typed envelope code 검증.
+        reactivate_result = _run_cli(
+            config_dir,
+            ["member", "reactivate", "agent-grp-q-2"],
+            token=token,
+            encryption_key=key,
+        )
+        assert reactivate_result.returncode == 1, (
+            f"exit={reactivate_result.returncode}\n"
+            f"stdout={reactivate_result.stdout}\nstderr={reactivate_result.stderr}"
+        )
+        assert "Traceback" not in reactivate_result.stderr, (
+            f"stderr 에 traceback 노출: {reactivate_result.stderr!r}"
+        )
+        payload = _parse_json_last(reactivate_result.stdout)
+        assert payload.get("status") == "error", payload
+        assert payload.get("code") == "MEMBER_STATE_CONFLICT", payload

--- a/tests/unit/test_ipc_error_code_mapping.py
+++ b/tests/unit/test_ipc_error_code_mapping.py
@@ -119,12 +119,17 @@ async def test_ipc_server_falls_back_to_execution_error_when_no_code(
 
 
 @pytest.mark.asyncio
-async def test_ipc_server_falls_back_for_account_error_without_code(
+async def test_ipc_server_surfaces_typed_code_for_account_already_suspended(
     socket_path: str, service_registry: ServiceRegistry
 ) -> None:
-    """기존 AccountError 계층(``AccountAlreadySuspendedError`` 등)은 ``code`` 속성이
-    없으므로 ``EXECUTION_ERROR``로 폴백 — ``account.suspend`` 등 IPC 핸들러
-    응답 코드가 변경되지 않음을 보장 (회귀 보호).
+    """``AccountAlreadySuspendedError`` 는 typed ``code`` 속성을 보유하므로
+    IPC envelope 이 ``"ACCOUNT_ALREADY_SUSPENDED"`` 안정 코드를 surface 한다
+    (#1812 Group Q state-conflict typed code sweep).
+
+    이전 (#1812 이전): ``code`` 속성 부재 → ``EXECUTION_ERROR`` 폴백. 본 테스트
+    의 이전 단언은 회귀 보호용으로 폴백 동작을 lock 했으나, Group Q sweep 이
+    state-conflict 표면에 typed code 를 도입하면서 envelope 코드가 정정되었다.
+    typed code 회귀 (속성 누락 → ``EXECUTION_ERROR`` 폴백 재발) 차단 lock.
     """
     from ante.account.errors import AccountAlreadySuspendedError
 
@@ -145,8 +150,9 @@ async def test_ipc_server_falls_back_for_account_error_without_code(
         client = IPCClient(socket_path, timeout=5.0)
         response = await client.send("test.already_suspended", {})
         assert response["status"] == "error"
-        # 기존 동작 그대로
-        assert response["error"]["code"] == "EXECUTION_ERROR"
+        # #1812 Group Q: typed code 가 envelope 에 surface 된다
+        # (이전 ``EXECUTION_ERROR`` 폴백을 typed 코드로 정정).
+        assert response["error"]["code"] == "ACCOUNT_ALREADY_SUSPENDED"
         assert "이미 정지됨" in response["error"]["message"]
     finally:
         await server.stop()

--- a/tests/unit/test_member.py
+++ b/tests/unit/test_member.py
@@ -318,10 +318,24 @@ class TestSuspendReactivateRevoke:
             await service.revoke("owner", revoked_by="owner")
 
     async def test_reactivate_active_fails(self, service):
+        # #1814 Group Q sweep: state-conflict 는 ``MemberStateConflictError``
+        # (``MemberError`` + ``ValueError`` 다중상속) 로 raise 된다. 이전
+        # 동작은 ``PermissionError, match="suspended 상태에서만"`` 였다 —
+        # state 위반 의미가 권한 부족과 모호하게 섞여 있어 typed 로 좁힘.
+        # ``ValueError`` 다중상속이라 기존 ``except (ValueError, PermissionError)``
+        # caller (CLI generic fallback) 회귀는 없다.
+        from ante.member.errors import MemberStateConflictError
+
         await service.bootstrap_master("owner", "pass123")
         await service.register("agent-01", MemberType.AGENT)
-        with pytest.raises(PermissionError, match="suspended 상태에서만"):
+        with pytest.raises(MemberStateConflictError) as excinfo:
             await service.reactivate("agent-01", reactivated_by="owner")
+        assert excinfo.value.code == "MEMBER_STATE_CONFLICT"
+        assert excinfo.value.member_id == "agent-01"
+        assert excinfo.value.requested_action == "reactivate"
+        # ``ValueError`` 회귀 보호: 다중상속이 유지되어 기존 caller 가
+        # ``except ValueError`` 로도 잡을 수 있어야 한다.
+        assert isinstance(excinfo.value, ValueError)
 
     async def test_suspend_publishes_event(self, service, eventbus):
         events = []


### PR DESCRIPTION
## Summary

oracle A7 state-conflict sweep — 3 모듈 (account / approval / member) 의 state flow 위반 표면에 typed exception `.code` 속성을 도입해 IPC envelope 이 안정 SCREAMING_SNAKE_CASE 코드를 surface 하도록 한다. Group P #1805 missing-resource sweep 동형 패턴.

Closes #1812
Closes #1813
Closes #1814

## Root causes

- **#1812** account 모듈 `AccountAlreadySuspendedError` 외 9 typed exception 에 `.code` 속성이 없어 IPC envelope 이 `EXECUTION_ERROR` 로 폴백. state-conflict 의미가 일반 실행 오류와 분리되지 않음.
- **#1813** `ApprovalService.approve` / `reject` 의 status flow 위반 (rejected → 재reject 등) 이 generic `ValueError` 로 raise → IPC envelope 이 `EXECUTION_ERROR` 폴백. 호출자가 status flow 위반 의미를 코드로 식별할 수 없음.
- **#1814** `MemberService.suspend` / `reactivate` 의 state 체크가 `_assert_status` 의 `PermissionError` 로 raise → state 위반 의미가 권한 부족과 모호하게 섞임. CLI envelope 도 안정 코드를 surface 하지 못함.

## Changes

### #1812 account/errors.py — typed `.code` 추가
```
AccountAlreadySuspendedError.code = "ACCOUNT_ALREADY_SUSPENDED"
AccountSuspendedError.code         = "ACCOUNT_SUSPENDED"
AccountDeletedError.code           = "ACCOUNT_DELETED"
AccountHasActiveBotsError.code     = "ACCOUNT_HAS_ACTIVE_BOTS"
AccountAlreadyExistsError.code     = "ACCOUNT_ALREADY_EXISTS"
AccountImmutableFieldError.code    = "ACCOUNT_IMMUTABLE_FIELD"
BrokerReconnectFailedError.code    = "BROKER_RECONNECT_FAILED"
MissingCredentialsError.code       = "ACCOUNT_MISSING_CREDENTIALS"
InvalidBrokerTypeError.code        = "ACCOUNT_INVALID_BROKER_TYPE"
```
- IPC server `getattr(e, "code", "EXECUTION_ERROR")` 자동 매핑. CLI account suspend/activate 가 `ipc_send` + middleware `ClickException` fallback 으로 typed code 그대로 surface (CLI 매핑 추가 불요).
- `AccountDeletedError`: 클래스 레벨 `.code = "ACCOUNT_DELETED"`. CLI `account delete` 의 명시 except 분기는 UX 의미 보존을 위해 `ACCOUNT_ALREADY_DELETED` override 유지 (CLI surface override).

### #1813 approval — `ApprovalStatusConflictError` 신규
- `ApprovalStatusConflictError(ApprovalError, ValueError)`, `code = "APPROVAL_STATUS_CONFLICT"`, `approval_id` / `current_status` / `requested_action` 인자.
- `ApprovalService.approve` / `reject` 의 status flow 체크가 typed raise 로 좁혀짐 (이전 `ValueError`).
- `ValueError` 다중상속 — 기존 `except ValueError` caller (CLI approve/reject line 629/662 generic fallback) 회귀 없음. Python MRO 가 `except ApprovalStatusConflictError` 우선 매칭 보장.
- CLI approve/reject 는 `ipc_send` + middleware 경로라 별도 typed except 추가 불요.

### #1814 member — `MemberStateConflictError` 신규
- `MemberStateConflictError(MemberError, ValueError)`, `code = "MEMBER_STATE_CONFLICT"`. #1805 `MemberNotFoundError` 패턴 1:1 미러.
- `MemberService.suspend` (already SUSPENDED) / `reactivate` (already ACTIVE) 의 state 체크가 `_assert_status` `PermissionError` 대신 인라인 typed raise 로 좁힘. `revoke` 는 plan scope 외라 기존 helper 유지.
- `ValueError` 다중상속 — 기존 `except (ValueError, PermissionError)` caller (CLI member suspend/reactivate line 657/692 generic fallback) 회귀 없음.
- CLI member suspend/reactivate 에 typed except 분기 추가 (generic fallback 앞).

### 회귀 fix
- `test_ipc_error_code_mapping.py::test_ipc_server_falls_back_for_account_error_without_code` → `test_ipc_server_surfaces_typed_code_for_account_already_suspended` 로 정정 (EXECUTION_ERROR 폴백 → ACCOUNT_ALREADY_SUSPENDED typed code).
- `test_member.py::test_reactivate_active_fails` 가 `PermissionError` → `MemberStateConflictError` 로 정정. `ValueError` 다중상속 회귀 보호 단언 추가.
- `test_approval.py::test_approve_non_pending_fails` / `test_reject_non_pending_fails` 가 `ValueError` → `ApprovalStatusConflictError` 로 정정.

### 신규 sweep test
`tests/unit/test_cli_group_q_state_conflict_sweep.py` (17 시나리오):
- **카테고리 1** typed exception class `.code` 속성 lock × 11 (account 9 + approval 1 + member 1).
- **카테고리 2** service-layer typed raise 검증 × 4 (account.suspend / approval.reject / approval.approve / member.suspend).
- **카테고리 3** subprocess CLI E2E × 2 (member suspend / reactivate). member CLI 는 `_create_service()` 직접 호출 경로라 server fixture 불요. account/approval 은 IPC-only 라 카테고리 2 service-layer 검증으로 대체 (Group A #1795 동형 패턴).

## R-case 매트릭스

| R | Issue | 표면 | typed code |
|---|---|---|---|
| R1 | #1812 | `ante account suspend <SUSPENDED-account>` | `ACCOUNT_ALREADY_SUSPENDED` |
| R2 | #1813 | `ante approval reject <REJECTED-approval>` | `APPROVAL_STATUS_CONFLICT` |
| R3 | #1814 | `ante member suspend <SUSPENDED-member>` | `MEMBER_STATE_CONFLICT` |

## Test plan

- [x] `pytest tests/unit/test_cli_group_q_state_conflict_sweep.py` — 17/17 통과
- [x] `pytest tests/unit/` 전체 — 5038 passed / 2 skipped / 0 failed
- [x] `ruff check` clean
- [x] `ruff format --check` clean (1 file reformat)
- [x] `mypy src/ante` clean (217 source files)
- [x] EXECUTION_ERROR 회귀 verify — 5건 잔존 단언 모두 우리 변경과 무관 (`KeyError` / 무속성 `ValueError` 폴백 보호용)
- [x] main HEAD `cb48603` 불변 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)