### PR TITLE
feat: #1822 contract vocabulary SSOT module (ContractKind/EnvelopeForm/AuthMode)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-05-24 (KST)
+> 마지막 생성 시점: 2026-05-25 (KST)
 
 ## 최상위 구조
 
@@ -283,7 +283,10 @@ src/ante/
 │   ├── __init__.py
 │   ├── checker.py
 │   └── executor.py
-└── __init__.py
+├── __init__.py
+└── contracts/
+    ├── __init__.py
+    └── vocab.py
 ```
 
 ## tests/ — 테스트
@@ -568,7 +571,14 @@ tests/
 │   ├── test_bot_create_signal_key_auto.py
 │   ├── test_cli_bot_signal_key_rotate_external_gate.py
 │   ├── test_cli_error_code_naming_sweep.py
-│   └── test_cli_envelope_typed_codes_group_a_sweep.py
+│   ├── test_cli_envelope_typed_codes_group_a_sweep.py
+│   ├── test_cli_approval_args_key_alignment.py
+│   ├── test_cli_bot_create_active_account_cleanup.py
+│   ├── test_cli_group_p_missing_resource_sweep.py
+│   ├── test_cli_group_q_state_conflict_sweep.py
+│   ├── test_cli_group_r_member_duplicate_validation_sweep.py
+│   ├── test_cli_group_s_treasury_typed_reject.py
+│   └── test_ipc_treasury_allocate_missing_bot.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/__init__.py
+++ b/src/ante/contracts/__init__.py
@@ -1,0 +1,10 @@
+"""Contract SSOT 공통 인프라.
+
+이 package는 CLI(#1815)/IPC(#1819) 계열 contract surface가
+공유할 vocabulary 등 공통 정의의 SSOT 위치다.
+
+본 패키지 초기 버전(#1822)은 vocabulary 정의(``ante.contracts.vocab``)만
+포함하며, package marker 역할만 한다. alias re-export는 의도적으로 하지
+않는다 -- 소비자는 `from ante.contracts.vocab import ...` 형태로
+명시 import하여, vocabulary 위치가 단일 SSOT로 고정되도록 한다.
+"""

--- a/src/ante/contracts/vocab.py
+++ b/src/ante/contracts/vocab.py
@@ -1,0 +1,36 @@
+"""Contract vocabulary SSOT (#1822).
+
+CLI command registry(#1815)와 IPC CommandSpec metadata(#1819) 양쪽이
+공유하는 contract vocabulary의 단일 코드 SSOT.
+
+본 모듈은 다음 3개 Literal type alias만 정의한다.
+
+- ``ContractKind`` : contract가 노출하는 result shape 종류
+- ``EnvelopeForm`` : 응답 envelope 형태
+- ``AuthMode``     : 인증 요구 모드 vocabulary
+
+중요한 정렬:
+
+- ``raw_legacy``는 ``EnvelopeForm``에만 존재하며 ``ContractKind``에는
+  포함되지 않는다. legacy raw JSON 출력은 후속 #1815에서
+  ``kind="raw"`` + ``envelope="raw_legacy"`` 조합으로 표현한다.
+- ``AuthMode``는 후속 #1815/#1819가 인증 요구사항을 같은 단어로
+  표현하기 위한 vocabulary이며, 본 모듈은 auth enforcement를 바꾸지
+  않는다.
+
+본 모듈은 runtime behavior를 가지지 않는다. enum/dataclass/helper/
+validator 추가는 의도적으로 제외한다 -- 필요해지면 별도 이슈로 분리한다.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ContractKind = Literal["entity", "operation", "collection", "raw", "stream"]
+"""Contract가 노출하는 result shape 종류."""
+
+EnvelopeForm = Literal["standard", "raw_legacy"]
+"""응답 envelope 형태. ``raw_legacy``는 후방 호환용."""
+
+AuthMode = Literal["public", "authenticated", "scoped", "master"]
+"""인증 요구 모드 vocabulary."""


### PR DESCRIPTION
Closes #1822
Epic: #1820

## Implementation summary

본 PR은 #1820 (Meta-Epic: Contract SSOT 공통 인프라)의 첫 sub-issue
구현으로, CLI command registry (#1815)와 IPC CommandSpec metadata
(#1819) 양쪽이 공유할 vocabulary의 단일 코드 SSOT를 추가한다.

신규 파일:

- `src/ante/contracts/__init__.py` — package marker only. alias
  re-export는 의도적으로 하지 않는다. 소비자는
  `from ante.contracts.vocab import ...` 형태로 명시 import한다.
- `src/ante/contracts/vocab.py` — 정확히 3개 Literal type alias.

```python
ContractKind = Literal["entity", "operation", "collection", "raw", "stream"]
EnvelopeForm = Literal["standard", "raw_legacy"]
AuthMode     = Literal["public", "authenticated", "scoped", "master"]
```

핵심 invariant (parent #1820):

- `raw_legacy`는 `EnvelopeForm`에만 존재하며 `ContractKind`에는
  없다. legacy raw JSON 출력은 #1815에서 `kind="raw"` +
  `envelope="raw_legacy"`로 표현한다.
- `AuthMode`는 #1815/#1819가 인증 요구사항을 같은 단어로 표현하기
  위한 vocabulary이며, 본 PR은 auth enforcement를 바꾸지 않는다.

수정하지 않은 영역 (Plan Stop Condition):

- `src/ante/cli/**`, `src/ante/ipc/**`, `src/ante/__init__.py`
- 어떤 runtime/CLI/IPC 모듈에도 `ante.contracts` import 추가 없음.
- runtime behavior 변경 없음. enum/dataclass/helper/validator 없음.

Generated artifact:

- `docs/architecture/generated/project-structure.md`를
  `scripts/generate_project_structure.py`로 full regen.
- diff에는 새 `src/ante/contracts/*` 항목 외에, parent plan이 명시한
  `baseline-generated-drift` (현 main 기준 stale했던
  `tests/unit/` 신규 항목들)이 함께 포함된다.

Codex Plan Review verdict: `approve-implement` (이슈 본문 참조).

## Test plan

- [x] `PYTHONPATH=src python -c "from ante.contracts.vocab import AuthMode, ContractKind, EnvelopeForm"` → OK
- [x] vocabulary invariant assert: `raw_legacy ∉ ContractKind`,
      `raw_legacy ∈ EnvelopeForm`, 3개 alias 값 집합 일치
- [x] `mypy src/ante` → `Success: no issues found in 219 source files`
- [x] `ruff check src/ante/contracts` → clean
- [x] `ruff format --check src/ante/contracts` → clean
- [x] `rg -n "from ante\.contracts|import ante\.contracts" src/ante --glob '!src/ante/contracts/**'` → 결과 없음 (외부 import 없음)
- [x] `scripts/generate_project_structure.py --check` → up to date
- [x] `pytest tests/unit/` → 5058 passed, 2 skipped, 0 failed (165s)