### PR TITLE
refactor: #1823 contract drift test helper skeleton (Click leaf / IPC registry / exception / fmt.error iterators)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -578,7 +578,11 @@ tests/
 │   ├── test_cli_group_q_state_conflict_sweep.py
 │   ├── test_cli_group_r_member_duplicate_validation_sweep.py
 │   ├── test_cli_group_s_treasury_typed_reject.py
-│   └── test_ipc_treasury_allocate_missing_bot.py
+│   ├── test_ipc_treasury_allocate_missing_bot.py
+│   └── contracts/
+│       ├── __init__.py
+│       ├── helpers.py
+│       └── test_helpers.py
 └── __init__.py
 ```
 

--- a/tests/unit/contracts/__init__.py
+++ b/tests/unit/contracts/__init__.py
@@ -1,0 +1,15 @@
+"""Contract drift test helpers (Refs #1823).
+
+이 패키지는 #1815/#1816/#1818/#1819 후속 epic에서 사용할 공통 helper만
+제공한다. 본 패키지는 실제 drift policy/assertion 을 포함하지 않는다 —
+helper API skeleton 과 그 helper 자체 unit test만 둔다.
+
+Helper 분류:
+
+- import 기반: Click leaf command iterator, IPC ``CommandRegistry`` spec
+  iterator. live runtime service 초기화나 DB 접근 없이 module import 만으로
+  동작한다.
+- AST/텍스트 기반: ``*Error`` class iterator, ``fmt.error(...)`` callsite
+  iterator. production module import 를 피하기 위해 file text 를
+  ``ast.parse`` 한다.
+"""

--- a/tests/unit/contracts/helpers.py
+++ b/tests/unit/contracts/helpers.py
@@ -1,0 +1,448 @@
+"""Contract drift test helper skeleton (Refs #1823).
+
+#1815/#1816/#1818/#1819 후속 epic 이 반복해서 작성할 drift-test 유틸을
+공통 helper 로 추출한다. 본 모듈은 helper API 만 제공하고 실제 drift
+policy/assertion 은 후속 epic 의 책임이다.
+
+Helper 분류 (Refs #1820 결정 / #1823 plan):
+
+* **import 기반** — Click CLI 트리, IPC ``CommandRegistry`` 는 module
+  import 만으로 leaf 식별이 가능하므로 introspection 으로 다룬다.
+
+  - :func:`iter_click_leaf_commands` — Click root group 에서 hidden
+    subtree 를 제외한 leaf command 만 yield. 기본 root 는 ``ante.cli.main.cli``.
+  - :func:`iter_ipc_command_specs` — :class:`CommandRegistry` 에서 등록된
+    :class:`CommandSpec` 을 yield. registry 미지정 시 기본 registry 를
+    만들고 :func:`register_all_handlers` 를 호출한다.
+
+* **AST/텍스트 기반** — exception class 와 ``fmt.error(...)`` callsite
+  sweep 은 import side effect 를 피하기 위해 file text 를 :func:`ast.parse`
+  한다.
+
+  - :func:`iter_exception_classes` — ``src/ante/**/*.py`` 의
+    ``*Error`` class 와 class-level ``code`` 속성을 식별한다.
+  - :func:`iter_fmt_error_calls` — ``src/ante/cli/**/*.py`` 의
+    ``fmt.error(...)`` callsite 와 code argument classification 정보를
+    yield 한다.
+
+본 helper 는 default repository root 를 알지 못한다. 호출자가 :class:`Path`
+를 명시한다 (default 는 cwd 기준 ``Path("src/ante")``). 후속 enforcement
+test 가 repository root 를 고정하는 책임을 진다.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from ante.ipc.registry import CommandRegistry, CommandSpec
+
+
+# ── import 기반 helper ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CliLeafCommand:
+    """Click leaf command 식별자.
+
+    Attributes:
+        path: ``ante`` prefix 를 제외한 leaf 까지의 segment 튜플
+            (예: ``("bot", "start")``).
+        command: 해당 Click command 객체. 후속 enforcement 가
+            ``cmd.callback`` chain / scope decorator 를 들여다볼 수 있다.
+    """
+
+    path: tuple[str, ...]
+    command: click.Command
+
+
+def _registration_order(group: click.Group) -> list[str]:
+    """Click Group 의 등록 순서를 반환한다.
+
+    Click 8+ 의 ``group.commands`` dict 는 삽입 순서를 보존한다. 일부
+    custom Group 구현(MultiCommand) 에서는 dict 가 아닐 수 있으므로
+    fallback 으로 ``list_commands`` 를 사용한다.
+
+    (참고: scripts/generate_cli_reference.py:_registration_order 와 동일
+    의도 — helper 가 module import side effect 를 늘리지 않도록 inline.)
+    """
+    commands = getattr(group, "commands", None)
+    if isinstance(commands, dict):
+        return list(commands.keys())
+    ctx = click.Context(group, info_name=group.name or "ante")
+    return list(group.list_commands(ctx))
+
+
+def _walk_click(
+    group: click.Group,
+    prefix: tuple[str, ...],
+) -> Iterator[CliLeafCommand]:
+    """Click 트리를 DFS 로 순회하며 leaf 만 yield 한다.
+
+    hidden subtree (그룹/leaf 모두) 는 ``cmd.hidden`` 표식을 따라
+    완전히 제외한다. 그룹 자체는 leaf 가 아니므로 yield 하지 않는다.
+    """
+    ctx = click.Context(group, info_name=group.name or "ante")
+    for name in _registration_order(group):
+        cmd = group.get_command(ctx, name)
+        if cmd is None:
+            continue
+        if getattr(cmd, "hidden", False):
+            # generic·mechanism-agnostic: hidden 그룹은 하위 재귀까지 skip.
+            continue
+        path = (*prefix, name)
+        if isinstance(cmd, click.Group):
+            yield from _walk_click(cmd, path)
+        else:
+            yield CliLeafCommand(path=path, command=cmd)
+
+
+def iter_click_leaf_commands(
+    root: click.Group | None = None,
+) -> Iterator[CliLeafCommand]:
+    """Click root group 의 public leaf command 를 yield 한다.
+
+    Args:
+        root: 검사할 Click root. ``None`` 이면 ``ante.cli.main.cli`` 를
+            가져온다 — 후속 enforcement test 가 inline Click fixture root
+            를 주입할 수 있도록 keyword 가 아니라 positional default 로
+            둔다.
+
+    Yields:
+        :class:`CliLeafCommand`: hidden subtree 를 제외한 leaf command.
+        그룹 자체는 yield 하지 않는다.
+    """
+    if root is None:
+        from ante.cli.main import cli as _cli  # 지연 import — fixture 주입 우선
+
+        root = _cli
+    yield from _walk_click(root, ())
+
+
+def iter_ipc_command_specs(
+    registry: CommandRegistry | None = None,
+) -> Iterator[CommandSpec]:
+    """IPC ``CommandRegistry`` 의 등록된 ``CommandSpec`` 을 yield 한다.
+
+    Args:
+        registry: 검사할 registry. ``None`` 이면 새 빈 registry 를 만들고
+            :func:`ante.ipc.registry.register_all_handlers` 를 호출해 default
+            production registry 를 구성한다. 후속 enforcement test 가 작은
+            fixture registry 를 주입할 수 있다.
+
+    Yields:
+        :class:`CommandSpec`: ``registry.commands`` 순서대로 ``CommandSpec``
+        를 반환한다 (이름이 아니라 spec 자체).
+    """
+    from ante.ipc.registry import CommandRegistry, register_all_handlers
+
+    if registry is None:
+        registry = CommandRegistry()
+        register_all_handlers(registry)
+    for name in registry.commands:
+        spec = registry.get(name)
+        if spec is not None:
+            yield spec
+
+
+# ── AST/텍스트 기반 helper ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ExceptionClassInfo:
+    """``*Error`` class 의 정적 메타데이터.
+
+    Attributes:
+        path: 클래스가 정의된 ``.py`` 파일 경로.
+        name: 클래스 이름.
+        lineno: 클래스 정의 시작 줄.
+        has_code: class body 에 ``code`` 속성 할당이 존재하면 True.
+            ``code: str = "..."`` 또는 ``code = "..."`` 둘 다 포함한다.
+        code_value: class-level ``code`` 가 literal string 이면 그 값,
+            non-literal (모듈 상수 식별자 등) 이면 ``None``. ``has_code`` 가
+            False 면 ``None``.
+    """
+
+    path: Path
+    name: str
+    lineno: int
+    has_code: bool
+    code_value: str | None
+
+
+@dataclass(frozen=True)
+class FmtErrorCallsite:
+    """``fmt.error(...)`` 호출의 정적 메타데이터.
+
+    Attributes:
+        path: callsite 파일 경로.
+        lineno: callsite 줄.
+        has_code_keyword: ``code=`` keyword argument 가 존재하면 True.
+        has_positional_code: 2번째 positional argument 가 존재하면 True
+            (``fmt.error(message, "CODE")`` 패턴).
+        has_effective_code: ``code=`` keyword 또는 positional code 중 어느
+            하나라도 존재하면 True. False 면 callsite 가 code 인자를 전혀
+            전달하지 않는다 (#1816 대상 후보).
+        has_empty_code_fallback: code 인자가 빈 fallback 으로 떨어지는지
+            **휴리스틱** 판정. 다음 중 어느 하나라도 매치하면 True:
+
+            - 인자 값이 빈 문자열 literal ``""`` 또는 ``''``.
+            - ``getattr(..., ..., "")`` 호출 (3번째 default 가 빈 문자열).
+            - ``.get(..., "")`` 호출 (2번째 default 가 빈 문자열).
+
+            드물게 false positive/negative 가능 — 후속 #1816 이
+            classification 을 강화할 skeleton 으로 사용한다.
+        snippet: 원본 source 의 callsite 줄 raw 문자열 (디버깅용).
+    """
+
+    path: Path
+    lineno: int
+    has_code_keyword: bool
+    has_positional_code: bool
+    has_effective_code: bool
+    has_empty_code_fallback: bool
+    snippet: str
+
+
+def _iter_python_files(root: Path) -> Iterator[Path]:
+    """``root`` 하위 ``.py`` 파일을 정렬된 순서로 yield 한다.
+
+    ``__pycache__`` 같은 비-source 디렉토리는 ``.py`` 파일을 갖지 않으므로
+    별도 필터는 불필요하다. 호출자가 ``root`` scope 를 좁히는 책임을 진다.
+    """
+    if not root.exists():
+        return
+    yield from sorted(root.rglob("*.py"))
+
+
+def _parse_module(path: Path) -> ast.Module | None:
+    """파일을 ``ast.parse`` 하고 실패하면 ``None``.
+
+    helper 가 sweep 도중 ``SyntaxError`` 로 깨지지 않도록 try/except 한다.
+    파일 자체가 깨졌으면 후속 enforcement 가 별도로 표면화한다.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        return ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return None
+
+
+def _extract_class_code_attr(
+    node: ast.ClassDef,
+) -> tuple[bool, str | None]:
+    """``code`` class attribute 의 존재/literal 값을 반환한다.
+
+    ``code: str = "..."`` (:class:`ast.AnnAssign`) 와 ``code = "..."``
+    (:class:`ast.Assign`) 둘 다 인식한다. literal 이 아니면 ``code_value``
+    는 ``None`` 이다 (예: ``code = BOT_NOT_FOUND_CODE``).
+    """
+    for stmt in node.body:
+        # ``code: str = "..."`` (annotated assignment)
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            if stmt.target.id == "code" and stmt.value is not None:
+                value = stmt.value
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    return True, value.value
+                return True, None
+        # ``code = "..."`` (plain assignment); 다중 타깃은 첫 ``code`` 만.
+        elif isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name) and target.id == "code":
+                    if isinstance(stmt.value, ast.Constant) and isinstance(
+                        stmt.value.value, str
+                    ):
+                        return True, stmt.value.value
+                    return True, None
+    return False, None
+
+
+def _is_error_class(name: str) -> bool:
+    """``name`` 이 ``*Error`` 인지 (suffix 일치, 단독 ``Error`` 도 포함)."""
+    return name == "Error" or name.endswith("Error")
+
+
+def iter_exception_classes(
+    root: Path = Path("src/ante"),
+) -> Iterator[ExceptionClassInfo]:
+    """``root`` 하위 ``*Error`` class 정의를 yield 한다.
+
+    AST 기반이라 module import 를 유발하지 않는다. base 가 ``Exception`` /
+    다른 ``*Error`` / ``ValueError`` 등 어느 것이든 ``name`` 만으로 식별
+    한다 — production code 가 ``Error`` suffix convention 을 따른다는
+    가정을 따른다.
+
+    Args:
+        root: 검사할 루트 디렉토리. 기본 ``Path("src/ante")``. 후속
+            enforcement test 가 repository root 절대경로를 합성해 주입할
+            수 있다.
+
+    Yields:
+        :class:`ExceptionClassInfo`: 각 ``*Error`` class 의 정적 메타데이터.
+        ``code`` 가 ``ValueError`` 등 stdlib 상속만으로 자동 채워지는 경우는
+        ``has_code=False`` (class body 에 명시 할당이 없으므로).
+    """
+    for path in _iter_python_files(root):
+        module = _parse_module(path)
+        if module is None:
+            continue
+        for node in ast.walk(module):
+            if isinstance(node, ast.ClassDef) and _is_error_class(node.name):
+                has_code, code_value = _extract_class_code_attr(node)
+                yield ExceptionClassInfo(
+                    path=path,
+                    name=node.name,
+                    lineno=node.lineno,
+                    has_code=has_code,
+                    code_value=code_value,
+                )
+
+
+def _is_fmt_error_call(call: ast.Call) -> bool:
+    """``call`` 이 ``<anything>.error(...)`` attribute call 인지.
+
+    ``fmt.error(...)`` 뿐 아니라 ``self._fmt.error(...)`` /
+    ``formatter.error(...)`` 같은 alias 도 모두 매치한다. 모듈 이름은
+    아무거나 받고 attribute 가 정확히 ``error`` 인지로 식별한다.
+    """
+    func = call.func
+    return isinstance(func, ast.Attribute) and func.attr == "error"
+
+
+def _is_empty_string_literal(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value == ""
+
+
+def _is_empty_default_fallback(node: ast.expr) -> bool:
+    """``getattr(..., "")`` / ``.get(..., "")`` 형식의 빈 fallback 인지.
+
+    헛수고 false positive 를 줄이려고 함수 이름이 ``getattr`` 또는
+    attribute call ``.get(...)`` 일 때만 인정한다. 더 정확한 분류는 #1816
+    이 책임진다.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "getattr":
+        # ``getattr(obj, name, default)`` — default 가 3번째 인자.
+        if len(node.args) >= 3 and _is_empty_string_literal(node.args[2]):
+            return True
+    if isinstance(func, ast.Attribute) and func.attr == "get":
+        # ``mapping.get(key, default)`` — default 가 2번째 인자.
+        if len(node.args) >= 2 and _is_empty_string_literal(node.args[1]):
+            return True
+    return False
+
+
+def _classify_code_argument(call: ast.Call) -> tuple[bool, bool, bool, bool]:
+    """``fmt.error(...)`` call 에서 code argument 정보를 추출한다.
+
+    Returns:
+        ``(has_code_keyword, has_positional_code, has_effective_code,
+        has_empty_code_fallback)`` 튜플.
+    """
+    has_kw = False
+    code_value_node: ast.expr | None = None
+
+    for kw in call.keywords:
+        if kw.arg == "code":
+            has_kw = True
+            code_value_node = kw.value
+            break
+
+    # ``fmt.error(message, "CODE")`` → 2번째 positional argument.
+    # ``ast.Call.args`` 는 positional 만, ``**kwargs`` star unpack 은 제외한다.
+    has_positional = len(call.args) >= 2
+    if has_positional and code_value_node is None:
+        code_value_node = call.args[1]
+
+    has_effective = has_kw or has_positional
+
+    has_empty_fallback = False
+    if code_value_node is not None:
+        if _is_empty_string_literal(code_value_node):
+            has_empty_fallback = True
+        elif _is_empty_default_fallback(code_value_node):
+            has_empty_fallback = True
+
+    return has_kw, has_positional, has_effective, has_empty_fallback
+
+
+def _source_line(source_lines: list[str], lineno: int) -> str:
+    """1-based ``lineno`` 의 source line 을 안전하게 반환한다."""
+    if 1 <= lineno <= len(source_lines):
+        return source_lines[lineno - 1].rstrip("\n")
+    return ""
+
+
+def iter_fmt_error_calls(
+    root: Path = Path("src/ante/cli"),
+) -> Iterator[FmtErrorCallsite]:
+    """``root`` 하위 ``fmt.error(...)`` callsite 를 yield 한다.
+
+    AST 기반이라 module import 를 유발하지 않는다. attribute name 이 정확히
+    ``error`` 인 모든 attribute call 을 잡으므로 ``self._fmt.error(...)`` /
+    ``formatter.error(...)`` 같은 alias 도 자동으로 매치된다.
+
+    Args:
+        root: 검사할 루트. 기본 ``Path("src/ante/cli")``. CLI 표면 밖에서
+            ``fmt.error`` 호출이 사실상 없지만, 후속 enforcement 가 범위를
+            확장해야 하면 ``Path("src/ante")`` 등을 명시하면 된다.
+
+    Yields:
+        :class:`FmtErrorCallsite`: callsite 별 code argument classification
+        과 source snippet.
+    """
+    for path in _iter_python_files(root):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            module = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        source_lines = source.splitlines()
+        for node in ast.walk(module):
+            if not isinstance(node, ast.Call):
+                continue
+            if not _is_fmt_error_call(node):
+                continue
+            (
+                has_kw,
+                has_pos,
+                has_effective,
+                has_empty_fallback,
+            ) = _classify_code_argument(node)
+            yield FmtErrorCallsite(
+                path=path,
+                lineno=node.lineno,
+                has_code_keyword=has_kw,
+                has_positional_code=has_pos,
+                has_effective_code=has_effective,
+                has_empty_code_fallback=has_empty_fallback,
+                snippet=_source_line(source_lines, node.lineno),
+            )
+
+
+# ── public surface ────────────────────────────────────────────────────────
+
+
+__all__ = [
+    "CliLeafCommand",
+    "ExceptionClassInfo",
+    "FmtErrorCallsite",
+    "iter_click_leaf_commands",
+    "iter_exception_classes",
+    "iter_fmt_error_calls",
+    "iter_ipc_command_specs",
+]

--- a/tests/unit/contracts/test_helpers.py
+++ b/tests/unit/contracts/test_helpers.py
@@ -1,0 +1,527 @@
+"""Contract drift helper skeleton 자체 unit test (Refs #1823).
+
+이 테스트는 helper API 가 동작한다는 것만 검증한다 — repository-wide drift
+count exact assertion 은 추가하지 않는다 (그것은 #1815/#1816/#1818/#1819
+후속 epic 의 책임).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import click
+import pytest
+
+from tests.unit.contracts.helpers import (
+    CliLeafCommand,
+    ExceptionClassInfo,
+    FmtErrorCallsite,
+    iter_click_leaf_commands,
+    iter_exception_classes,
+    iter_fmt_error_calls,
+    iter_ipc_command_specs,
+)
+
+# ── iter_click_leaf_commands ──────────────────────────────────────────────
+
+
+class TestIterClickLeafCommands:
+    """Click leaf command iterator skeleton."""
+
+    def test_yields_leaf_only(self) -> None:
+        """그룹 자체는 yield 하지 않고 leaf 만 yield 한다."""
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command()
+        def alpha() -> None:
+            """alpha leaf."""
+
+        @root.group()
+        def grp() -> None:
+            """그룹."""
+
+        @grp.command()
+        def beta() -> None:
+            """nested leaf."""
+
+        results = list(iter_click_leaf_commands(root))
+        paths = [r.path for r in results]
+        assert ("alpha",) in paths
+        assert ("grp", "beta") in paths
+        # group "grp" 자체는 leaf 가 아니다.
+        assert ("grp",) not in paths
+
+    def test_excludes_hidden_subtree(self) -> None:
+        """hidden 그룹/leaf 는 모두 제외 (#1682 generic·mechanism-agnostic)."""
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command(hidden=True)
+        def secret() -> None:
+            """hidden leaf."""
+
+        @root.command()
+        def visible() -> None:
+            """visible leaf."""
+
+        @root.group(name="buried", hidden=True)
+        def buried() -> None:
+            """hidden group."""
+
+        @buried.command()
+        def underground() -> None:
+            """hidden subtree leaf."""
+
+        results = list(iter_click_leaf_commands(root))
+        paths = [r.path for r in results]
+        assert ("visible",) in paths
+        assert ("secret",) not in paths
+        assert ("buried", "underground") not in paths
+
+    def test_returns_dataclass_with_command_object(self) -> None:
+        """결과는 CliLeafCommand 이고 command 객체에 접근 가능하다."""
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command()
+        def leaf() -> None:
+            """leaf doc."""
+
+        results = list(iter_click_leaf_commands(root))
+        assert len(results) == 1
+        item = results[0]
+        assert isinstance(item, CliLeafCommand)
+        assert item.path == ("leaf",)
+        assert isinstance(item.command, click.Command)
+        assert item.command.help == "leaf doc."
+
+    def test_default_root_loads_ante_cli(self) -> None:
+        """root 미지정 시 ante.cli.main.cli 를 사용 (live smoke).
+
+        count exact assertion 은 두지 않는다 — helper 가 동작하는지만
+        확인. 후속 epic 이 exact count 를 lock 한다.
+        """
+        results = list(iter_click_leaf_commands())
+        assert len(results) > 0
+        # path 는 항상 비어있지 않은 튜플.
+        for item in results:
+            assert isinstance(item.path, tuple)
+            assert len(item.path) >= 1
+            assert isinstance(item.command, click.Command)
+
+
+# ── iter_ipc_command_specs ────────────────────────────────────────────────
+
+
+class TestIterIpcCommandSpecs:
+    """IPC registry spec iterator skeleton."""
+
+    def test_injected_registry_fixture(self) -> None:
+        """주입된 registry 의 등록 spec 만 yield."""
+        from ante.ipc.registry import CommandRegistry
+
+        registry = CommandRegistry()
+
+        async def dummy(svc, args, actor):  # type: ignore[no-untyped-def]
+            return {}
+
+        registry.register("alpha", dummy, is_mutating=True)
+        registry.register("beta", dummy, is_mutating=False)
+
+        specs = list(iter_ipc_command_specs(registry))
+        names = {s.name for s in specs}
+        assert names == {"alpha", "beta"}
+        # taxonomy 가 그대로 보존된다.
+        spec_by_name = {s.name: s for s in specs}
+        assert spec_by_name["alpha"].is_mutating is True
+        assert spec_by_name["beta"].is_mutating is False
+
+    def test_default_registry_smoke(self) -> None:
+        """registry 미지정 시 register_all_handlers 결과를 사용 (live smoke)."""
+        specs = list(iter_ipc_command_specs())
+        # count exact assertion 은 후속 epic. iterator 동작만 확인.
+        assert len(specs) > 0
+        # 각 항목은 name / is_mutating 을 가진 CommandSpec.
+        for spec in specs:
+            assert isinstance(spec.name, str) and spec.name
+            assert isinstance(spec.is_mutating, bool)
+
+    def test_empty_registry_yields_nothing(self) -> None:
+        """등록 없는 registry 는 빈 iterator."""
+        from ante.ipc.registry import CommandRegistry
+
+        registry = CommandRegistry()
+        assert list(iter_ipc_command_specs(registry)) == []
+
+
+# ── iter_exception_classes ────────────────────────────────────────────────
+
+
+class TestIterExceptionClasses:
+    """``*Error`` class AST iterator skeleton."""
+
+    def test_detects_class_with_literal_code(self, tmp_path: Path) -> None:
+        """class-level ``code: str = "FOO"`` literal 추출."""
+        src = textwrap.dedent(
+            """
+            class FooError(Exception):
+                code: str = "FOO_ERROR"
+            """
+        ).lstrip()
+        module = tmp_path / "errors.py"
+        module.write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        assert len(results) == 1
+        info = results[0]
+        assert isinstance(info, ExceptionClassInfo)
+        assert info.name == "FooError"
+        assert info.has_code is True
+        assert info.code_value == "FOO_ERROR"
+        assert info.path == module
+        assert info.lineno == 1
+
+    def test_detects_class_without_code(self, tmp_path: Path) -> None:
+        """class body 에 ``code`` 가 없으면 has_code=False."""
+        src = textwrap.dedent(
+            """
+            class BareError(Exception):
+                pass
+            """
+        ).lstrip()
+        (tmp_path / "bare.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        assert len(results) == 1
+        info = results[0]
+        assert info.name == "BareError"
+        assert info.has_code is False
+        assert info.code_value is None
+
+    def test_detects_non_literal_code(self, tmp_path: Path) -> None:
+        """``code = MODULE_CONST`` 면 has_code=True, code_value=None."""
+        src = textwrap.dedent(
+            """
+            MY_CODE = "BAR"
+
+            class BarError(Exception):
+                code = MY_CODE
+            """
+        ).lstrip()
+        (tmp_path / "non_literal.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        assert len(results) == 1
+        info = results[0]
+        assert info.name == "BarError"
+        assert info.has_code is True
+        assert info.code_value is None
+
+    def test_detects_plain_assignment_literal(self, tmp_path: Path) -> None:
+        """``code = "LITERAL"`` (annotation 없음) 도 인식한다."""
+        src = textwrap.dedent(
+            """
+            class PlainError(Exception):
+                code = "PLAIN_CODE"
+            """
+        ).lstrip()
+        (tmp_path / "plain.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        assert len(results) == 1
+        info = results[0]
+        assert info.has_code is True
+        assert info.code_value == "PLAIN_CODE"
+
+    def test_skips_non_error_classes(self, tmp_path: Path) -> None:
+        """``*Error`` suffix 가 아닌 class 는 yield 하지 않는다."""
+        src = textwrap.dedent(
+            """
+            class NotAnException:
+                code: str = "X"
+
+            class HelperClass:
+                pass
+
+            class RealError(Exception):
+                code: str = "REAL"
+            """
+        ).lstrip()
+        (tmp_path / "mixed.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        names = [r.name for r in results]
+        assert names == ["RealError"]
+
+    def test_walks_nested_subdirectories(self, tmp_path: Path) -> None:
+        """root 하위 모든 ``.py`` 를 재귀 sweep."""
+        (tmp_path / "a").mkdir()
+        (tmp_path / "a" / "x.py").write_text(
+            "class AError(Exception):\n    code: str = 'A'\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "b").mkdir()
+        (tmp_path / "b" / "y.py").write_text(
+            "class BError(Exception):\n    pass\n",
+            encoding="utf-8",
+        )
+
+        results = list(iter_exception_classes(tmp_path))
+        names = {r.name for r in results}
+        assert names == {"AError", "BError"}
+
+    def test_skips_syntax_error_files(self, tmp_path: Path) -> None:
+        """SyntaxError 파일은 helper 가 깨지지 않고 skip 한다."""
+        (tmp_path / "good.py").write_text(
+            "class GoodError(Exception):\n    code: str = 'G'\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "broken.py").write_text("def broken(\n", encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        names = [r.name for r in results]
+        assert names == ["GoodError"]
+
+    def test_missing_root_returns_empty(self, tmp_path: Path) -> None:
+        """존재하지 않는 root 는 빈 iterator."""
+        ghost = tmp_path / "does_not_exist"
+        assert list(iter_exception_classes(ghost)) == []
+
+
+# ── iter_fmt_error_calls ──────────────────────────────────────────────────
+
+
+class TestIterFmtErrorCalls:
+    """``fmt.error(...)`` callsite iterator skeleton."""
+
+    def test_detects_code_keyword(self, tmp_path: Path) -> None:
+        """``fmt.error(msg, code="X")`` → has_code_keyword=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt):
+                fmt.error("boom", code="EXPLODED")
+            """
+        ).lstrip()
+        (tmp_path / "a.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert isinstance(c, FmtErrorCallsite)
+        assert c.has_code_keyword is True
+        assert c.has_positional_code is False
+        assert c.has_effective_code is True
+        assert c.has_empty_code_fallback is False
+        assert "EXPLODED" in c.snippet
+
+    def test_detects_positional_code(self, tmp_path: Path) -> None:
+        """``fmt.error("msg", "CODE")`` → has_positional_code=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt):
+                fmt.error("boom", "CODE_X")
+            """
+        ).lstrip()
+        (tmp_path / "b.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is False
+        assert c.has_positional_code is True
+        assert c.has_effective_code is True
+        assert c.has_empty_code_fallback is False
+
+    def test_detects_missing_code(self, tmp_path: Path) -> None:
+        """``fmt.error("msg")`` → has_effective_code=False (#1816 대상)."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt):
+                fmt.error("oops")
+            """
+        ).lstrip()
+        (tmp_path / "c.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is False
+        assert c.has_positional_code is False
+        assert c.has_effective_code is False
+        assert c.has_empty_code_fallback is False
+
+    def test_detects_empty_string_code(self, tmp_path: Path) -> None:
+        """``fmt.error(msg, code="")`` → has_empty_code_fallback=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt):
+                fmt.error("oops", code="")
+            """
+        ).lstrip()
+        (tmp_path / "d.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is True
+        assert c.has_effective_code is True
+        assert c.has_empty_code_fallback is True
+
+    def test_detects_getattr_empty_fallback(self, tmp_path: Path) -> None:
+        """``code=getattr(e, "code", "")`` → has_empty_code_fallback=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt, e):
+                fmt.error(str(e), code=getattr(e, "code", ""))
+            """
+        ).lstrip()
+        (tmp_path / "e.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is True
+        assert c.has_empty_code_fallback is True
+
+    def test_detects_dict_get_empty_fallback(self, tmp_path: Path) -> None:
+        """``code=result.get("code", "")`` → has_empty_code_fallback=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt, result):
+                fmt.error(result["error"], code=result.get("code", ""))
+            """
+        ).lstrip()
+        (tmp_path / "f.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is True
+        assert c.has_empty_code_fallback is True
+
+    def test_non_empty_getattr_default_not_flagged(self, tmp_path: Path) -> None:
+        """비-empty default 의 getattr 는 fallback flag 끄지 않는다."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt, e):
+                fmt.error(str(e), code=getattr(e, "code", "DEFAULT"))
+            """
+        ).lstrip()
+        (tmp_path / "g.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is True
+        assert c.has_empty_code_fallback is False
+
+    def test_matches_alias_attribute_call(self, tmp_path: Path) -> None:
+        """``self._fmt.error(...)`` / ``formatter.error(...)`` 같은 alias 도 매치."""
+        src = textwrap.dedent(
+            """
+            def fail(self, formatter):
+                self._fmt.error("boom", code="A")
+                formatter.error("boom", code="B")
+            """
+        ).lstrip()
+        (tmp_path / "h.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 2
+        codes = sorted(c.snippet for c in results)
+        # snippet 은 줄 raw — code value 가 포함되어야 한다.
+        assert any('"A"' in s for s in codes)
+        assert any('"B"' in s for s in codes)
+
+    def test_snippet_captures_callsite_line(self, tmp_path: Path) -> None:
+        """snippet 은 callsite 시작 줄의 source line 을 담는다."""
+        src = textwrap.dedent(
+            """
+            # leading comment
+            def fail(fmt):
+                fmt.error("boom", code="LINE_LEVEL")
+            """
+        ).lstrip()
+        (tmp_path / "i.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.lineno == 3
+        assert "LINE_LEVEL" in c.snippet
+
+    def test_skips_syntax_error_files(self, tmp_path: Path) -> None:
+        """SyntaxError 파일은 helper 가 깨지지 않고 skip 한다."""
+        (tmp_path / "good.py").write_text(
+            'def f(fmt): fmt.error("ok", code="C")\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "broken.py").write_text("def broken(\n", encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        assert results[0].has_code_keyword is True
+
+    def test_missing_root_returns_empty(self, tmp_path: Path) -> None:
+        """존재하지 않는 root 는 빈 iterator."""
+        ghost = tmp_path / "nope"
+        assert list(iter_fmt_error_calls(ghost)) == []
+
+
+# ── module surface ─────────────────────────────────────────────────────────
+
+
+def test_public_surface_importable() -> None:
+    """helper 모듈의 public API 를 한 번에 import 가능."""
+    from tests.unit.contracts import helpers
+
+    expected = {
+        "CliLeafCommand",
+        "ExceptionClassInfo",
+        "FmtErrorCallsite",
+        "iter_click_leaf_commands",
+        "iter_exception_classes",
+        "iter_fmt_error_calls",
+        "iter_ipc_command_specs",
+    }
+    assert expected.issubset(set(helpers.__all__))
+    for name in expected:
+        assert hasattr(helpers, name), name
+
+
+# ── repository-wide sanity ────────────────────────────────────────────────
+
+
+def test_helpers_run_against_repo_without_exact_assert() -> None:
+    """helper 가 repository 전체 sweep 에 대해 깨지지 않는다.
+
+    repository-wide drift count exact assertion 은 #1815/#1816/#1818/#1819
+    후속 epic 의 책임이다. 여기서는 helper 가 실제 repo 에서도 깨지지
+    않고 iterator 가 비어있지 않다는 것만 확인한다.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    src_ante = repo_root / "src" / "ante"
+    cli_root = repo_root / "src" / "ante" / "cli"
+
+    if not src_ante.exists():
+        pytest.skip("src/ante not present in this layout")
+
+    error_classes = list(iter_exception_classes(src_ante))
+    assert error_classes, "expected at least one *Error class under src/ante"
+
+    fmt_calls = list(iter_fmt_error_calls(cli_root))
+    assert fmt_calls, "expected at least one fmt.error callsite under src/ante/cli"
+
+    # path 는 절대 경로로 받아오는지 확인 (#1816 enforcement 가 추적용).
+    for info in error_classes:
+        assert info.path.is_absolute() or info.path.exists()
+    for call in fmt_calls:
+        assert call.path.is_absolute() or call.path.exists()


### PR DESCRIPTION
Closes #1823
Refs #1820 (Meta-Epic: Contract SSOT 공통 인프라)

## Summary

#1815/#1816/#1818/#1819 후속 epic 이 공유할 drift-test 유틸을
`tests/unit/contracts/` 공통 helper 로 추출한다. 본 PR 은 helper API
skeleton 과 helper 자체 unit test 만 제공한다 — 실제 drift
policy/assertion 은 후속 epic 의 책임이다.

## Helper API

import 기반 (live introspection):
- `CliLeafCommand(path, command)` + `iter_click_leaf_commands(root=None)`
  - hidden subtree 제외, leaf-only, `ante.cli.main.cli` 기본 root.
  - test 가 inline Click fixture root 를 주입할 수 있다.
- `iter_ipc_command_specs(registry=None)`
  - `CommandRegistry` 미지정 시 `register_all_handlers` 호출 (default
    production registry).
  - test 가 작은 fixture registry 를 주입할 수 있다.

AST/텍스트 기반 (import side effect 없음):
- `ExceptionClassInfo(path, name, lineno, has_code, code_value)`
  + `iter_exception_classes(root=Path("src/ante"))`
  - `*Error` suffix 식별. class-level `code` (annotated/plain assignment)
    의 literal/non-literal 모두 캐치.
- `FmtErrorCallsite(path, lineno, has_code_keyword, has_positional_code,
  has_effective_code, has_empty_code_fallback, snippet)`
  + `iter_fmt_error_calls(root=Path("src/ante/cli"))`
  - `code=` keyword / 2번째 positional / `getattr(..., "")` /
    `.get(..., "")` 빈 fallback 분류 (#1816 enforcement 용 skeleton).
  - `<anything>.error(...)` attribute call 매치 (alias `self._fmt.error` /
    `formatter.error` 도 자동).

## Non-goals (#1820 / 이슈 본문)

- 모든 Click leaf command 가 registry 에 등록됐는지 검증 (#1815)
- `fmt.error` code 누락을 실패시키는 actual drift test (#1816)
- CLI offline factory direct DB construction drift test (#1818)
- 모든 IPC command metadata 가 채워졌는지 검증 (#1819)
- production code (`src/ante/**`) 변경
- repository-wide exact count assertion (이슈 본문 measurements 는 reference 전용)

## Generated artifact

- `docs/architecture/generated/project-structure.md` — 신규
  `tests/unit/contracts/` 노드만 추가 (project-structure 생성기 full
  regen, hand edit 없음).

## Test plan

- [x] `pytest tests/unit/contracts -q` — 28 passed (helper unit test only).
- [x] `pytest tests/unit/ipc/test_registry.py -q` — 16 passed (registry
  smoke 회귀 없음).
- [x] `pytest tests/unit -q` — 5086 passed, 2 skipped (전체 회귀 없음).
- [x] `ruff check tests/unit/contracts` — clean.
- [x] `ruff format --check tests/unit/contracts` — clean.
- [x] `mypy tests/unit/contracts src/ante` — Success: no issues found in 222 source files.
- [x] `python scripts/generate_project_structure.py --check` — up to date.

## Worktree / main safety

- Branch: `refactor/1823-contract-drift-helpers` (base
  `epic/1820-contract-ssot-common-infra`).
- main HEAD `eb15e6a` 불변 (별도 worktree 에서 작업).