### PR TITLE
docs: #1821 CLI/IPC envelope shape SSOT (4 normative forms)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -878,16 +878,18 @@ docs/
 │   │   ├── 08-daily-asset-snapshots.md
 │   │   ├── 09-virtual-asset-sync.md
 │   │   └── 11-cross-module-notes.md
-│   └── logging/
-│       ├── 01-overview.md
-│       ├── 02-design-decisions.md
-│       ├── 03-json-schema.md
-│       ├── 04-fingerprint.md
-│       ├── 05-handlers-and-rotation.md
-│       ├── 06-context-fields.md
-│       ├── 07-implementation.md
-│       ├── logging.md
-│       └── README.md
+│   ├── logging/
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-json-schema.md
+│   │   ├── 04-fingerprint.md
+│   │   ├── 05-handlers-and-rotation.md
+│   │   ├── 06-context-fields.md
+│   │   ├── 07-implementation.md
+│   │   ├── logging.md
+│   │   └── README.md
+│   └── contracts/
+│       └── envelopes.md
 ├── temp/                             # 임시 작업 문서
 │   └── 05-issue-processing-process-map.md
 └── superpowers/

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -20,6 +20,7 @@
 | `broker-adapter` | [README.md](broker-adapter/README.md) | 브로커 어댑터 인터페이스, KIS/Test Broker |
 | `cli` | [README.md](cli/README.md) | CLI 명령 체계와 서비스 진입점 |
 | `config` | [README.md](config/README.md) | 설정 계층, 동적 설정 관리 |
+| `contracts` | [contracts/envelopes.md](contracts/envelopes.md) | CLI/IPC envelope 형태 등 외부 표면 계약 SSOT (전체 인덱스는 #1824에서 추가) |
 | `core` | [core/core.md](core/core.md) | 공통 인프라와 Database 래퍼 |
 | `data-feed` | [README.md](data-feed/README.md) | 배치 데이터 수집과 공급 인터페이스 |
 | `data-pipeline` | [README.md](data-pipeline/README.md) | 저장소, 스키마, ETL 파이프라인 |

--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -80,7 +80,9 @@ CLI 코드에서 다음 API 사용을 금지한다.
 **누락 입력 처리**:
 
 필수 옵션·인자가 누락되면 prompt하지 않고 구조화된 에러로 즉시 종료한다(exit code 1).
-JSON 모드(`--format json`)에서는 `{status: "error", code: "...", message: "..."}` 형식으로 출력한다.
+JSON 모드(`--format json`)에서는 CLI error envelope
+`{status:"error", code, message}`으로 출력한다. envelope 형태의 normative
+SSOT는 [contracts/envelopes.md](../contracts/envelopes.md#cli-error-envelope)다.
 
 **에러 코드 명명 규칙 (SSOT)**:
 
@@ -158,13 +160,17 @@ secret을 기록하기 위한 입력 경로로 1.0 시점에 남아 있다. CLI 
 
 text/json 모드를 지원하는 CLI 출력 포맷터.
 
+JSON 모드의 envelope 형태(`success`/`error`)는 상위 SSOT
+[contracts/envelopes.md](../contracts/envelopes.md)가 lock 한다. 본 절은 해당
+SSOT의 CLI success/error envelope을 적용하는 표면 메서드 시그니처만 기술한다.
+
 | 프로퍼티/메서드 | 파라미터 | 반환값 | 설명 |
 |----------------|----------|--------|------|
 | `is_json` (property) | — | bool | JSON 모드 여부 |
-| `output` | data: dict \| list, text_template: str = "" | None | 데이터 출력 (json 모드: JSON dump, text 모드: 템플릿 포맷) |
+| `output` | data: dict \| list, text_template: str = "" | None | 데이터 출력 (json 모드: JSON dump, text 모드: 템플릿 포맷). raw payload 출력이며 standard envelope wrapping은 하지 않는다. |
 | `table` | rows: list[dict], columns: list[str] | None | 테이블 형태 출력 |
-| `error` | message: str, code: str = "" | None | 에러 출력 |
-| `success` | message: str, data: dict \| None = None | None | 성공 메시지 출력 (json 모드: `{status: "ok", message, data}`) |
+| `error` | message: str, code: str = "" | None | CLI error envelope `{status:"error", code, message}` 출력 (SSOT: [envelopes.md](../contracts/envelopes.md#cli-error-envelope)) |
+| `success` | message: str, data: dict \| None = None | None | CLI success envelope `{status:"ok", message, data}` 출력 (SSOT: [envelopes.md](../contracts/envelopes.md#cli-success-envelope)) |
 
 소스: `src/ante/cli/formatter.py`
 

--- a/docs/specs/contracts/envelopes.md
+++ b/docs/specs/contracts/envelopes.md
@@ -1,0 +1,224 @@
+# CLI/IPC Envelope Shape SSOT
+
+> Parent decision: [#1820 Contract SSOT 공통 인프라](https://github.com/joshua-jingu-lee/ante/issues/1820)
+> Status: 1.0 normative — CLI와 IPC 외부 표면이 공유하는 envelope 형태의 단일 SSOT.
+> Implementation references (non-normative): `src/ante/cli/formatter.py`, `src/ante/ipc/server.py`.
+
+## 목적
+
+본 문서는 Ante의 외부 표면(CLI `--format json`, IPC Unix domain socket)이
+사용자/Agent에 노출하는 envelope 형태를 한 곳에 모은다. 기존 CLI/IPC 스펙과
+구현이 이미 같은 4형태를 사용하고 있으므로, 본 문서는 새 계약을 발명하지 않고
+기존 4형태를 상위 SSOT로 lock 한다.
+
+후속 에픽(#1815/#1816/#1819/#1818)과 도메인 스펙은 envelope 형태를 별도로
+재정의하지 않고 본 문서를 reference 한다.
+
+## Envelope 4형태
+
+Ante의 외부 표면 envelope은 다음 4형태만이 normative다.
+
+```json
+{"status": "ok",    "message": "...",  "data":   {...}}
+{"status": "error", "code":    "...",  "message": "..."}
+{"id": "uuid-v4",   "status":  "ok",   "result": {...}}
+{"id": "uuid-v4",   "status":  "error","error":  {"code": "...", "message": "..."}}
+```
+
+순서대로 CLI success / CLI error / IPC success / IPC error 다.
+
+## CLI success envelope
+
+CLI 커맨드가 `--format json` 모드에서 성공한 경우 `stdout`으로 출력하는 형태다.
+
+```json
+{
+  "status": "ok",
+  "message": "<사람이 읽는 단문 메시지>",
+  "data": { ... }
+}
+```
+
+| 필드 | 타입 | 필수 | 의미 |
+|------|------|------|------|
+| `status` | `"ok"` | 필수 | 성공 응답 식별자. 항상 문자열 `"ok"`. |
+| `message` | `string` | 필수 | 사람이 읽는 단문 결과 메시지. 빈 문자열도 허용한다. |
+| `data` | `object` | 필수 | 커맨드별 payload. 페이로드가 없으면 빈 객체 `{}`를 직렬화한다. |
+
+규칙:
+
+- 세 필드는 항상 동시에 직렬화된다. `data`가 누락된 envelope은 본 SSOT를
+  따르지 않는다. payload 없는 경우 `{}`로 명시한다.
+- `data` 안의 키/값은 도메인별 페이로드 계약이며 본 SSOT 범위 밖이다.
+- `--format text` 모드의 사람 친화 출력은 본 SSOT 범위가 아니다.
+- 구현 reference: `OutputFormatter.success()` (`src/ante/cli/formatter.py`).
+
+## CLI error envelope
+
+CLI 커맨드가 `--format json` 모드에서 실패한 경우 출력하는 형태다.
+
+```json
+{
+  "status": "error",
+  "code":   "<STABLE_ERROR_CODE>",
+  "message": "<사람이 읽는 에러 메시지>"
+}
+```
+
+| 필드 | 타입 | 필수 | 의미 |
+|------|------|------|------|
+| `status` | `"error"` | 필수 | 에러 응답 식별자. 항상 문자열 `"error"`. |
+| `code` | `string` | 필수 | 안정 에러 코드. 빈 문자열 `""`은 본 1.0 계약에서 허용되는 fallback(아직 typed code가 부여되지 않은 surface). |
+| `message` | `string` | 필수 | 사람이 읽는 에러 메시지. 안내 문구는 도메인 스펙이 정한다. |
+
+규칙:
+
+- 세 필드는 항상 동시에 직렬화된다.
+- exit code는 1 이상(non-zero)이어야 한다. exit 0 + error envelope는 본 SSOT 위반이다.
+- `--format text` 모드는 `Error: <message>`를 `stderr`로 출력한다. JSON 모드는
+  `stdout`으로 envelope 한 줄을 출력한다.
+- `code` 값의 vocabulary(taxonomy, 도메인 prefix 등)는 본 SSOT 범위가 아니다 →
+  [Non-Goals](#non-goals) 참조.
+- 구현 reference: `OutputFormatter.error()` (`src/ante/cli/formatter.py`).
+
+## IPC success envelope
+
+IPC 서버가 요청을 성공적으로 처리한 경우 응답으로 직렬화하는 형태다.
+
+```json
+{
+  "id": "uuid-v4",
+  "status": "ok",
+  "result": { ... }
+}
+```
+
+| 필드 | 타입 | 필수 | 의미 |
+|------|------|------|------|
+| `id` | `string` | 필수 | 요청의 `id`와 1:1 매칭되는 식별자. 클라이언트가 응답을 요청과 짝짓는 데 사용한다. |
+| `status` | `"ok"` | 필수 | 성공 응답 식별자. 항상 문자열 `"ok"`. |
+| `result` | `object` | 필수 | 핸들러가 반환한 payload. payload 없으면 빈 객체 `{}`를 직렬화한다. |
+
+규칙:
+
+- 세 필드는 항상 동시에 직렬화된다.
+- `result` 안의 키/값은 IPC 커맨드별 payload 계약이며 본 SSOT 범위 밖이다.
+  도메인별 envelope 예시(예: `{"bot": ...}`, `{"suspended_count": N}`)는
+  `result` payload의 일부이지 별도 envelope 형태가 아니다.
+- 구현 reference: `IPCServer._dispatch()` 성공 분기 (`src/ante/ipc/server.py`).
+
+## IPC error envelope
+
+IPC 서버가 요청 처리 중 실패한 경우 응답으로 직렬화하는 형태다.
+
+```json
+{
+  "id": "uuid-v4",
+  "status": "error",
+  "error": {
+    "code":    "<STABLE_ERROR_CODE>",
+    "message": "<사람이 읽는 에러 메시지>"
+  }
+}
+```
+
+| 필드 | 타입 | 필수 | 의미 |
+|------|------|------|------|
+| `id` | `string`\|`null` | 필수 | 요청의 `id`와 1:1 매칭. 요청 디코드 실패 등으로 `id`를 식별할 수 없는 경우 `null`을 직렬화한다. |
+| `status` | `"error"` | 필수 | 에러 응답 식별자. 항상 문자열 `"error"`. |
+| `error` | `object` | 필수 | `code`/`message` 두 필드를 갖는 중첩 객체. |
+| `error.code` | `string` | 필수 | 안정 에러 코드(예: `BOT_NOT_FOUND`, `SERVICE_UNAVAILABLE`, `UNKNOWN_COMMAND`, `EXECUTION_ERROR`). |
+| `error.message` | `string` | 필수 | 사람이 읽는 에러 메시지. |
+
+규칙:
+
+- 네 필드(`id`, `status`, `error.code`, `error.message`)는 항상 동시에 직렬화된다.
+- `error`는 평탄화하지 않고 항상 중첩 객체로 직렬화한다. CLI error envelope과
+  다른 점이다(아래 [Wrapping 경계](#wrapping-경계) 참조).
+- 1.0에서 IPC error에 추가 메타데이터(`details`, `retryable` 등) 필드를 두지
+  않는다. 도입은 #1819의 책임이며 본 SSOT 범위 밖이다 → [Non-Goals](#non-goals).
+- 구현 reference: `IPCServer._dispatch()` 에러 분기와 `_service_unavailable()`
+  (`src/ante/ipc/server.py`).
+
+## Wrapping 경계
+
+CLI envelope과 IPC envelope은 **표면별 1회만** wrapping 된다. 한 응답을 두 형태로
+이중 wrapping 하지 않는다.
+
+- **오프라인 CLI**: 직접 모듈 임포트로 실행되는 명령은 결과 dict을
+  `OutputFormatter`로 한 번 wrapping 해 CLI envelope으로 출력한다.
+- **IPC passthrough CLI**: 런타임 IPC 위임 명령은 IPC 응답의 `result`(또는
+  `error`)를 그대로 사용해 CLI envelope을 1회 구성한다. IPC `result`를 다시
+  IPC envelope으로 재감싸서 CLI에 넘기지 않는다.
+- **CLI IPC 헬퍼 계약**: `src/ante/cli/commands/ipc_helpers.py`의 `ipc_send`는
+  IPC 성공 응답의 `result`만 caller에 반환하고, IPC 에러 응답은
+  `ClickException`에 안정 코드/메시지를 부착해 raise 한다. CLI leaf는 이를
+  받아 `OutputFormatter.success(...)` 또는 `OutputFormatter.error(code, message)`로
+  CLI envelope 1회 wrapping 한다. 이 동형은 `ante bot start/stop/status`의 IPC
+  passthrough reference 패턴이다 (`src/ante/cli/commands/bot.py`).
+- **결론**: 어느 표면이든 사용자/Agent에게 보이는 envelope은 CLI envelope 4형태
+  중 하나(텍스트/JSON), IPC envelope 4형태 중 하나(서버 응답)다. CLI가 IPC
+  envelope 그대로를 출력하거나, IPC가 CLI envelope을 반환하는 시나리오는 본
+  SSOT가 정의하는 envelope 형태가 아니다.
+
+## 도메인 payload 예시와의 관계
+
+기존 CLI/IPC 도메인 스펙은 도메인 payload 예시를 풍부히 기록한다. 대표적으로:
+
+- IPC `bot.status` → `{"bot": <BotDetail>}` payload (IPC envelope의 `result`)
+- IPC `system.halt` → `{"suspended_count": N}` payload (IPC envelope의 `result`)
+- CLI `bot list` → `{"bots": [...]}` payload (CLI envelope의 `data`)
+
+위 `{...}` payload들은 본 SSOT가 정의하는 envelope이 **아니다**. envelope 4형태
+**안쪽** 페이로드 슬롯(`data`/`result`)의 도메인 계약이다. payload schema의
+계약 SSOT는 각 도메인 스펙(`docs/specs/<module>/...`)이며 본 SSOT 범위 밖이다.
+
+## Non-Goals
+
+본 SSOT가 정의하지 **않는** 항목은 다음과 같다.
+
+- **에러 코드 taxonomy**: `code` 값의 도메인 prefix 규칙, 공통 코드 SSOT,
+  exception → code 매핑은 #1816의 책임이다. CLI 일부 분야는
+  `docs/specs/cli/02-design-decisions.md`의 입력 계약 에러 코드 표를 SSOT로
+  유지한다.
+- **CLI success payload migration**: 기존 raw-dict CLI 출력 명령을 standard
+  CLI success envelope으로 옮기는 작업은 #1815의 책임이다. 본 SSOT는 standard
+  envelope이 `{status, message, data}` 임만 lock 한다.
+- **IPC CommandSpec metadata**: IPC 핸들러의 args/result schema, audit
+  metadata, service 의존성 선언은 #1819의 책임이다. 본 SSOT는 IPC
+  `result`/`error` 슬롯의 외형만 lock 한다.
+- **도메인 payload schema**: `data`/`result` 안의 도메인별 필드 계약(예:
+  `bot info`의 필드 목록)은 각 도메인 스펙이 SSOT다.
+- **Envelope builder helper 도입 강제**: `build_cli_success(...)` /
+  `build_ipc_error(...)` 같은 코드 helper의 도입은 본 SSOT가 강제하지 않는다.
+  현재 `OutputFormatter`와 `IPCServer._dispatch()`가 envelope을 직접 직렬화하는
+  방식이 normative behavior다. helper 도입이 필요하면 별도 이슈로 다룬다.
+- **기존 formatter/server behavior 변경**: 본 SSOT는 문서화 변경만이며
+  `OutputFormatter`/`IPCServer`의 런타임 동작을 바꾸지 않는다.
+- **CLI `--format text` 출력 형태**: 사람 친화 텍스트 출력은 본 SSOT 범위 밖이다.
+- **`docs/specs/contracts/README.md` 인덱스 작성**: contracts 디렉토리의 SSOT
+  인덱스 작성은 #1824의 책임이다. 본 PR은 `docs/specs/README.md`에 contracts
+  entry만 추가한다.
+
+## 호출자/소비자 reference
+
+본 envelope SSOT는 다음 표면이 직접 소비한다.
+
+- **CLI 호출자**: 모든 `OutputFormatter.success/error` 호출자(현재 ante CLI
+  명령 전반). 호출자별 payload 계약은 도메인 스펙을 따른다.
+- **IPC 호출자**: `IPCClient.send()`를 통해 IPC 서버 응답을 받는 모든 CLI 명령
+  및 향후 MCP/외부 클라이언트. `src/ante/cli/commands/ipc_helpers.py`의
+  `ipc_send`가 1차 IPC envelope 디코더 reference다.
+- **IPC 서버**: `IPCServer._dispatch()`가 본 envelope 4형태 중 IPC 2형태를
+  직렬화하는 단일 chokepoint다. 핸들러는 평면 dict을 반환하며 envelope wrapping은
+  `_dispatch()`가 일임한다.
+
+## 변경 정책
+
+- 본 SSOT는 1.0 normative이며 형태 변경은 contract change다. 새 필드 추가
+  (예: `request_id`, `details`, `retryable`)는 본 문서 normative 절을 수정하지
+  말고 **별도 SSOT 이슈**로 제안한 뒤 본 문서를 갱신한다.
+- 도메인 payload 신설/변경은 본 SSOT를 건드리지 않는다. 해당 도메인 스펙에서
+  처리한다.
+- 본 문서가 lock 한 envelope 4형태와 충돌하는 normative 재정의가 다른 스펙에서
+  발견되면 해당 스펙을 본 SSOT를 reference 하도록 정렬한다.

--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -292,6 +292,11 @@ CWD나 `db.path` parent에서 socket 위치를 파생하지 않는다.
 
 JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 
+IPC 응답 envelope(`status:"ok"` + `result` / `status:"error"` + `error`) 형태의
+normative SSOT는 [contracts/envelopes.md](../contracts/envelopes.md)다. 본 절은
+요청 envelope 형태와 응답 envelope 의 IPC 측 적용 예시만 기술한다. 새 필드
+추가/변경은 본 절이 아닌 SSOT 문서를 우선 갱신한다.
+
 **요청**:
 ```json
 {
@@ -311,7 +316,9 @@ JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 | `args` | `dict` | 커맨드 파라미터 |
 | `actor` | `string` | CLI에서 인증된 멤버 ID (감사 추적용). 인증 면제 recovery 커맨드는 `"unknown"` 또는 recovery 대상 member_id |
 
-**응답 (성공)**:
+**응답 (성공)** — IPC success envelope의 적용 예시. envelope 형태 SSOT는
+[contracts/envelopes.md — IPC success envelope](../contracts/envelopes.md#ipc-success-envelope):
+
 ```json
 {
   "id": "uuid-v4",
@@ -322,7 +329,12 @@ JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 }
 ```
 
-**응답 (실패)**:
+`result` payload(`{"suspended_count": N}`, `{"bot": ...}` 등)는 도메인 IPC
+커맨드별 계약이며 envelope 형태가 아니다.
+
+**응답 (실패)** — IPC error envelope의 적용 예시. envelope 형태 SSOT는
+[contracts/envelopes.md — IPC error envelope](../contracts/envelopes.md#ipc-error-envelope):
+
 ```json
 {
   "id": "uuid-v4",
@@ -334,13 +346,9 @@ JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 }
 ```
 
-| 필드 | 타입 | 설명 |
-|------|------|------|
-| `id` | `string` | 요청 `id`와 동일 |
-| `status` | `"ok" \| "error"` | 성공/실패 |
-| `result` | `dict` | 성공 시 반환 데이터 |
-| `error.code` | `string` | 에러 코드 (서비스 예외 클래스명 등) |
-| `error.message` | `string` | 에러 메시지 |
+`error.code` 값의 vocabulary(taxonomy, 도메인 prefix 규칙, 공통 코드 SSOT)는
+#1816의 책임이며 본 스펙 범위 밖이다. 현재 사용되는 공통 코드 일부는 아래
+[에러 처리](#에러-처리) 표에 예시로 기록한다.
 
 ### 프레이밍
 


### PR DESCRIPTION
Closes #1821 (epic #1820 sub-issue).

## Summary

기존 CLI/IPC 구현과 스펙에 흩어진 envelope 설명을 `docs/specs/contracts/envelopes.md`로 모아 normative SSOT를 lock 한다. 새 계약을 발명하지 않고 기존 4형태를 상위 SSOT 로 정렬한다.

### Envelope 4형태 (normative)

| 표면 | shape |
|------|-------|
| CLI success | `{status:"ok", message, data}` |
| CLI error | `{status:"error", code, message}` |
| IPC success | `{id, status:"ok", result}` |
| IPC error | `{id, status:"error", error:{code, message}}` |

각 형태의 필드 의미, wrapping 경계(CLI ↔ IPC passthrough 이중 wrapping 금지), 도메인 payload(`{bot: ...}` 등)와의 관계는 `docs/specs/contracts/envelopes.md`에서 SSOT 로 명시한다.

## Reference alignment

- `docs/specs/README.md`: `contracts/envelopes.md` 발견 경로 추가. `contracts/README.md` 인덱스는 #1824 에서 추가.
- `docs/specs/cli/02-design-decisions.md`:
  - 누락 입력 처리 절 (line 83-85) → CLI error envelope SSOT reference.
  - OutputFormatter 절 (line 157-) → success/error 메서드가 envelope SSOT 의 표면 적용임을 명시. method 시그니처/source 는 보존.
- `docs/specs/ipc/ipc.md`: 메시지 형식 절 (line 291-) → IPC success/error envelope SSOT reference. 요청 envelope, IPC 측 적용 예시, error code taxonomy 가 #1816 책임임을 명시.

## Non-goals (별도 이슈 책임)

- error code taxonomy → #1816
- CLI success output migration → #1815
- IPC CommandSpec metadata → #1819
- 도메인 payload schema → 각 도메인 스펙
- envelope builder helper 강제 도입 → 본 PR 강제 없음
- 기존 `OutputFormatter` / `IPCServer` runtime behavior → 변경 없음 (docs-only PR)

## Generated artifact

- `docs/architecture/generated/project-structure.md`: 신규 `docs/specs/contracts/envelopes.md` 디렉토리 반영 위해 `scripts/generate_project_structure.py` full regen. epic 브랜치 baseline 은 이미 clean 했으므로 diff 는 신규 디렉토리 entry 만 포함 (~12 라인). hand edit 없음.

## Test plan

- [x] `rg -n 'status.*ok|status.*error|envelope|OutputFormatter|IPC' docs/specs` — 새 SSOT 와 충돌하는 normative 재정의 없음 확인.
- [x] `rg -n 'docs/specs/contracts/envelopes|contracts/envelopes|envelopes.md' docs/specs` — README / cli / ipc 4 곳에서 SSOT cross-link 발견.
- [x] `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check` → up to date.
- [x] `pytest tests/unit/` → 5086 passed, 2 skipped, 회귀 없음 (docs-only PR, code behavior 변경 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)