### PR TITLE
feat: #1820 meta-epic contract SSOT 공통 인프라 (closes #1820/#1821/#1822/#1823/#1824)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -878,16 +878,18 @@ docs/
 │   │   ├── 08-daily-asset-snapshots.md
 │   │   ├── 09-virtual-asset-sync.md
 │   │   └── 11-cross-module-notes.md
-│   └── logging/
-│       ├── 01-overview.md
-│       ├── 02-design-decisions.md
-│       ├── 03-json-schema.md
-│       ├── 04-fingerprint.md
-│       ├── 05-handlers-and-rotation.md
-│       ├── 06-context-fields.md
-│       ├── 07-implementation.md
-│       ├── logging.md
-│       └── README.md
+│   ├── logging/
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-json-schema.md
+│   │   ├── 04-fingerprint.md
+│   │   ├── 05-handlers-and-rotation.md
+│   │   ├── 06-context-fields.md
+│   │   ├── 07-implementation.md
+│   │   ├── logging.md
+│   │   └── README.md
+│   └── contracts/
+│       └── envelopes.md
 ├── temp/                             # 임시 작업 문서
 │   └── 05-issue-processing-process-map.md
 └── superpowers/

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-05-24 (KST)
+> 마지막 생성 시점: 2026-05-25 (KST)
 
 ## 최상위 구조
 
@@ -283,7 +283,10 @@ src/ante/
 │   ├── __init__.py
 │   ├── checker.py
 │   └── executor.py
-└── __init__.py
+├── __init__.py
+└── contracts/
+    ├── __init__.py
+    └── vocab.py
 ```
 
 ## tests/ — 테스트
@@ -568,7 +571,14 @@ tests/
 │   ├── test_bot_create_signal_key_auto.py
 │   ├── test_cli_bot_signal_key_rotate_external_gate.py
 │   ├── test_cli_error_code_naming_sweep.py
-│   └── test_cli_envelope_typed_codes_group_a_sweep.py
+│   ├── test_cli_envelope_typed_codes_group_a_sweep.py
+│   ├── test_cli_approval_args_key_alignment.py
+│   ├── test_cli_bot_create_active_account_cleanup.py
+│   ├── test_cli_group_p_missing_resource_sweep.py
+│   ├── test_cli_group_q_state_conflict_sweep.py
+│   ├── test_cli_group_r_member_duplicate_validation_sweep.py
+│   ├── test_cli_group_s_treasury_typed_reject.py
+│   └── test_ipc_treasury_allocate_missing_bot.py
 └── __init__.py
 ```
 

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -578,7 +578,11 @@ tests/
 │   ├── test_cli_group_q_state_conflict_sweep.py
 │   ├── test_cli_group_r_member_duplicate_validation_sweep.py
 │   ├── test_cli_group_s_treasury_typed_reject.py
-│   └── test_ipc_treasury_allocate_missing_bot.py
+│   ├── test_ipc_treasury_allocate_missing_bot.py
+│   └── contracts/
+│       ├── __init__.py
+│       ├── helpers.py
+│       └── test_helpers.py
 └── __init__.py
 ```
 

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -889,7 +889,8 @@ docs/
 │   │   ├── logging.md
 │   │   └── README.md
 │   └── contracts/
-│       └── envelopes.md
+│       ├── envelopes.md
+│       └── README.md
 ├── temp/                             # 임시 작업 문서
 │   └── 05-issue-processing-process-map.md
 └── superpowers/

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -20,6 +20,7 @@
 | `broker-adapter` | [README.md](broker-adapter/README.md) | 브로커 어댑터 인터페이스, KIS/Test Broker |
 | `cli` | [README.md](cli/README.md) | CLI 명령 체계와 서비스 진입점 |
 | `config` | [README.md](config/README.md) | 설정 계층, 동적 설정 관리 |
+| `contracts` | [contracts/envelopes.md](contracts/envelopes.md) | CLI/IPC envelope 형태 등 외부 표면 계약 SSOT (전체 인덱스는 #1824에서 추가) |
 | `core` | [core/core.md](core/core.md) | 공통 인프라와 Database 래퍼 |
 | `data-feed` | [README.md](data-feed/README.md) | 배치 데이터 수집과 공급 인터페이스 |
 | `data-pipeline` | [README.md](data-pipeline/README.md) | 저장소, 스키마, ETL 파이프라인 |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -20,7 +20,7 @@
 | `broker-adapter` | [README.md](broker-adapter/README.md) | 브로커 어댑터 인터페이스, KIS/Test Broker |
 | `cli` | [README.md](cli/README.md) | CLI 명령 체계와 서비스 진입점 |
 | `config` | [README.md](config/README.md) | 설정 계층, 동적 설정 관리 |
-| `contracts` | [contracts/envelopes.md](contracts/envelopes.md) | CLI/IPC envelope 형태 등 외부 표면 계약 SSOT (전체 인덱스는 #1824에서 추가) |
+| `contracts` | [README.md](contracts/README.md) | CLI/IPC envelope 형태, vocabulary, drift helper 등 외부 표면 계약 SSOT 인덱스 |
 | `core` | [core/core.md](core/core.md) | 공통 인프라와 Database 래퍼 |
 | `data-feed` | [README.md](data-feed/README.md) | 배치 데이터 수집과 공급 인터페이스 |
 | `data-pipeline` | [README.md](data-pipeline/README.md) | 저장소, 스키마, ETL 파이프라인 |

--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -80,7 +80,9 @@ CLI 코드에서 다음 API 사용을 금지한다.
 **누락 입력 처리**:
 
 필수 옵션·인자가 누락되면 prompt하지 않고 구조화된 에러로 즉시 종료한다(exit code 1).
-JSON 모드(`--format json`)에서는 `{status: "error", code: "...", message: "..."}` 형식으로 출력한다.
+JSON 모드(`--format json`)에서는 CLI error envelope
+`{status:"error", code, message}`으로 출력한다. envelope 형태의 normative
+SSOT는 [contracts/envelopes.md](../contracts/envelopes.md#cli-error-envelope)다.
 
 **에러 코드 명명 규칙 (SSOT)**:
 
@@ -158,13 +160,17 @@ secret을 기록하기 위한 입력 경로로 1.0 시점에 남아 있다. CLI 
 
 text/json 모드를 지원하는 CLI 출력 포맷터.
 
+JSON 모드의 envelope 형태(`success`/`error`)는 상위 SSOT
+[contracts/envelopes.md](../contracts/envelopes.md)가 lock 한다. 본 절은 해당
+SSOT의 CLI success/error envelope을 적용하는 표면 메서드 시그니처만 기술한다.
+
 | 프로퍼티/메서드 | 파라미터 | 반환값 | 설명 |
 |----------------|----------|--------|------|
 | `is_json` (property) | — | bool | JSON 모드 여부 |
-| `output` | data: dict \| list, text_template: str = "" | None | 데이터 출력 (json 모드: JSON dump, text 모드: 템플릿 포맷) |
+| `output` | data: dict \| list, text_template: str = "" | None | 데이터 출력 (json 모드: JSON dump, text 모드: 템플릿 포맷). raw payload 출력이며 standard envelope wrapping은 하지 않는다. |
 | `table` | rows: list[dict], columns: list[str] | None | 테이블 형태 출력 |
-| `error` | message: str, code: str = "" | None | 에러 출력 |
-| `success` | message: str, data: dict \| None = None | None | 성공 메시지 출력 (json 모드: `{status: "ok", message, data}`) |
+| `error` | message: str, code: str = "" | None | CLI error envelope `{status:"error", code, message}` 출력 (SSOT: [envelopes.md](../contracts/envelopes.md#cli-error-envelope)) |
+| `success` | message: str, data: dict \| None = None | None | CLI success envelope `{status:"ok", message, data}` 출력 (SSOT: [envelopes.md](../contracts/envelopes.md#cli-success-envelope)) |
 
 소스: `src/ante/cli/formatter.py`
 

--- a/docs/specs/contracts/README.md
+++ b/docs/specs/contracts/README.md
@@ -1,0 +1,204 @@
+# Contracts SSOT 인덱스
+
+> Parent decision: [#1820 Contract SSOT 공통 인프라](https://github.com/joshua-jingu-lee/ante/issues/1820)
+> Status: 1.0 normative index — CLI/IPC 외부 표면 계약을 정렬하는 공통 SSOT의 단일 진입점.
+> Scope: 본 인덱스는 vocabulary / envelope / drift helper / migration order를 한 곳에서
+> 인덱싱한다. 후속 에픽(#1815/#1816/#1818/#1819)이 같은 단어와 같은 helper를 반복
+> 정의하지 않도록 한다.
+
+## 목적
+
+`docs/specs/contracts/`는 Ante 외부 표면(CLI `--format json`, IPC Unix domain
+socket)이 사용자/Agent에게 노출하는 **wire-level 계약의 SSOT**를 모은다.
+
+- 본 인덱스는 4개의 SSOT 산출물(envelope shape, vocabulary code module, drift
+  helper skeleton, migration domain order)을 한 곳에서 가리키고, 4 후속 에픽이
+  같은 SSOT를 참조하는지 cross-check 결과를 기록한다.
+- 본 인덱스는 SSOT 본문을 재정의하지 않는다. 본문은 각 산출물 문서/모듈을
+  따른다.
+- 본 인덱스는 후속 에픽(#1815/#1816/#1818/#1819)의 normative 책임(actual
+  registry/taxonomy/factory/metadata 구현)을 정의하지 않는다. 그 책임은 각
+  에픽의 본문에 있다.
+
+## SSOT 산출물 인덱스
+
+| 축 | SSOT 위치 | 소유 이슈 | 비고 |
+|---|---|---|---|
+| Envelope shape | [docs/specs/contracts/envelopes.md](envelopes.md) | #1821 | CLI success/error, IPC success/error 4형태 lock |
+| Vocabulary code | [src/ante/contracts/vocab.py](../../../src/ante/contracts/vocab.py) | #1822 | `ContractKind`, `EnvelopeForm`, `AuthMode` Literal SSOT |
+| Drift helper skeleton | [tests/unit/contracts/helpers.py](../../../tests/unit/contracts/helpers.py) | #1823 | Click/IPC iterator, `*Error` class / `fmt.error` callsite helper |
+| Migration domain order | 본 문서 [Migration Domain Order](#migration-domain-order) | #1820 | `account → member → approval → bot → treasury → broker → strategy → 기타` |
+
+### Envelope shape (#1821)
+
+[`docs/specs/contracts/envelopes.md`](envelopes.md)가 CLI/IPC envelope 4형태의
+단일 SSOT다. 본 인덱스는 그 본문을 재정의하지 않는다. 후속 에픽이 새 envelope
+shape을 추가하거나 기존 4형태를 변경하려면 envelopes.md 자체를 갱신한다.
+
+핵심 lock:
+
+- CLI success: `{status:"ok", message, data}`
+- CLI error: `{status:"error", code, message}`
+- IPC success: `{id, status:"ok", result}`
+- IPC error: `{id, status:"error", error:{code, message}}`
+
+### Vocabulary code (#1822)
+
+[`src/ante/contracts/vocab.py`](../../../src/ante/contracts/vocab.py)가 3개
+Literal type alias의 단일 코드 SSOT다.
+
+- `ContractKind = Literal["entity", "operation", "collection", "raw", "stream"]`
+- `EnvelopeForm = Literal["standard", "raw_legacy"]`
+- `AuthMode = Literal["public", "authenticated", "scoped", "master"]`
+
+본 모듈은 runtime behavior를 가지지 않고 Literal type alias만 export한다.
+enum/dataclass/helper/validator는 의도적으로 제외되어 있다 — 후속 에픽이
+필요해지면 별도 이슈로 분리한다.
+
+#### `raw_legacy` 표현
+
+`raw_legacy`는 `ContractKind`가 **아니다**. `raw_legacy`는 `EnvelopeForm`에만
+존재한다. 기존 raw JSON 출력 예외는 다음처럼 표현한다.
+
+```python
+OutputContract(kind="raw", envelope="raw_legacy")
+```
+
+즉, `kind`(result shape 종류) 축과 `envelope`(응답 envelope 형태) 축은 독립이며,
+legacy raw JSON 출력은 `ContractKind="raw"` + `EnvelopeForm="raw_legacy"`
+조합이다. 본 정렬은 #1820/#1822에서 결정되었고 후속 #1815가 reference한다.
+
+### Drift helper skeleton (#1823)
+
+[`tests/unit/contracts/helpers.py`](../../../tests/unit/contracts/helpers.py)가
+4 후속 에픽이 반복해서 작성할 drift-test 유틸의 공통 skeleton이다. 본 SSOT는
+helper API skeleton만 제공하고 실제 drift policy/assertion은 각 후속 에픽의
+책임이다.
+
+Helper 분류:
+
+- **import 기반** — Click root group, IPC `CommandRegistry`는 module import만으로
+  leaf 식별이 가능하므로 introspection으로 다룬다.
+  - `iter_click_leaf_commands(root=None)` — Click root group의 public leaf
+    command를 yield. hidden subtree는 제외한다. 기본 root는 `ante.cli.main.cli`.
+  - `iter_ipc_command_specs(registry=None)` — `CommandRegistry`에서 등록된
+    `CommandSpec`을 yield. registry 미지정 시 새 빈 registry에
+    `register_all_handlers`를 적용한 default를 사용한다.
+- **AST/텍스트 기반** — exception class와 `fmt.error(...)` callsite sweep은
+  import side effect를 피하기 위해 file text를 `ast.parse`한다.
+  - `iter_exception_classes(root=Path("src/ante"))` — `*Error` class와 class-level
+    `code` 속성을 식별한다.
+  - `iter_fmt_error_calls(root=Path("src/ante/cli"))` — `fmt.error(...)`
+    callsite와 code argument classification 정보를 yield한다.
+
+helper 자체 unit test는 [`tests/unit/contracts/test_helpers.py`](../../../tests/unit/contracts/test_helpers.py)에
+있다.
+
+### Migration domain order
+
+후속 4 에픽(#1815/#1816/#1818/#1819)의 **1차 migration 순서는 다음으로 고정**된다.
+
+```text
+account → member → approval → bot → treasury → broker → strategy → 기타
+```
+
+규칙:
+
+- 각 후속 에픽의 첫 구현 PR은 가능한 한 `account` domain부터 시작한다.
+- 독립성이 큰 #1818도 본 순서를 기본값으로 삼되, cleanup 회귀 차단 가치
+  때문에 `member`/`approval`까지 같은 1차 PR에 포함할 수 있다. 본 예외는
+  #1818 본문에 lock되어 있다.
+- 4 에픽 본문, 본 인덱스, 후속 PR에서 본 순서를 다르게 표현하면 drift다.
+  drift를 발견하면 본 인덱스를 SSOT로 정렬한다.
+
+본 순서는 [#1820](https://github.com/joshua-jingu-lee/ante/issues/1820)에서
+결정되었다.
+
+## 후속 에픽 reference matrix
+
+후속 4 에픽이 본 인덱스의 어느 SSOT 축을 참조해야 하는지 정렬한 표다. 4 에픽
+본문 prelude가 본 인덱스와 일치함을 [4-epic cross-check](#4-epic-cross-check)
+절에서 확인한다.
+
+| 에픽 | Envelope (#1821) | Vocabulary (#1822) | Drift helper (#1823) | Migration order (#1820) | 추가 reference |
+|---|---|---|---|---|---|
+| #1815 CLI command contract | CLI success/error | `ContractKind`, `EnvelopeForm`, `AuthMode` | `iter_click_leaf_commands` | 1차: `account` | #1819 IPC registry (server-side SSOT 분리), #1816 error taxonomy |
+| #1816 Stable error contract | CLI error, IPC error | (선택) | `iter_exception_classes`, `iter_fmt_error_calls` | 1차: `account` | #1815 auth registry, #1819 `SERVICE_NOT_CONFIGURED` 소비 |
+| #1818 Offline service factory | (에러 발화 시) CLI error | (독립) | (해당 없음) | 1차: `account` + `member`/`approval` 예외 허용 | #1816 error taxonomy(에러 발화 시), generated artifact policy |
+| #1819 IPC CommandSpec metadata | IPC success/error | `ContractKind` | `iter_ipc_command_specs` | 1차: `account` | #1816 `SERVICE_NOT_CONFIGURED`, #1815 CLI ↔ IPC drift test |
+
+규칙:
+
+- 본 표는 4 에픽이 같은 SSOT를 가리키는지 추적한다. 4 에픽 본문 자체를
+  reference 표로 대체하지 않는다. 본 인덱스는 reference matrix를 제공하고, 4
+  에픽 본문은 각자의 normative 책임을 별도로 기술한다.
+- 4 에픽 본문이 본 표와 어긋나는 새 vocabulary/envelope/helper를 도입하려고
+  하면, 그 변경은 본 인덱스와 #1820 결정에 영향을 주므로 별도 SSOT 이슈로
+  분리한다.
+- "(선택)"/"(독립)"/"(해당 없음)"은 해당 축이 그 에픽의 1차 책임이 아님을
+  뜻한다. 향후 PR에서 필요해지면 본 표를 갱신한다.
+
+## 4-epic cross-check
+
+본 인덱스 작성 시점(#1824 구현 PR, 2026-05-25 KST) 기준으로, 4 에픽 본문이
+본 인덱스의 SSOT를 이미 참조하는지 cross-check한 결과다. 본 절은 4 에픽 본문을
+재작성하지 않는다 — 본 인덱스 등록 후의 reference 상태를 기록한다.
+
+| 검사 항목 | #1815 | #1816 | #1818 | #1819 |
+|---|---|---|---|---|
+| `#1820` parent reference (선행 의존) | OK | OK | OK | OK |
+| `ContractKind`/`EnvelopeForm`/`AuthMode` vocabulary reference | OK | (선택) | (독립) | OK (`ContractKind`) |
+| Envelope shape SSOT reference (`docs/specs/contracts/envelopes.md`) | OK | OK (CLI/IPC error) | OK (에러 발화 시) | OK (IPC success/error) |
+| Drift test 공통 helper reference (#1823) | OK | OK | (해당 없음) | OK |
+| Migration domain 순서 (`account → … → 기타`) lock | OK | OK | OK (cleanup 예외 명시) | OK |
+| `raw_legacy`를 `EnvelopeForm`으로 표현 | OK | (해당 없음) | (해당 없음) | (해당 없음) |
+| Generated artifact policy 명시 | OK | OK | OK | OK |
+
+해석:
+
+- 4 에픽 prelude는 본 인덱스가 등록되기 전부터 `#1820`/`ContractKind`/`EnvelopeForm`/`AuthMode`/envelope shape SSOT/drift
+  helper/migration order를 일관되게 reference한다. #1824 인덱스 등록 후 본
+  인덱스(`docs/specs/contracts/README.md`)를 별도 entry로 가리키도록 4 에픽
+  본문을 추가 수정할 필요는 없다.
+- 본 인덱스는 4 에픽 본문에 새 normative reference를 강제 삽입하지 않는다.
+  4 에픽의 Plan Preflight나 실제 구현 PR에서 본 인덱스를 reference하는 것은
+  허용/권장이며, 본 인덱스에서 강제하지 않는다.
+- `raw_legacy` 표현은 #1815 prelude와 본 인덱스에서 모두 `EnvelopeForm`으로
+  정렬되어 있다. #1816/#1818/#1819는 `raw_legacy`를 직접 다루지 않으므로 해당
+  축은 표에서 "(해당 없음)"이다.
+- generated artifact policy(`docs/architecture/generated/project-structure.md`
+  영향 여부, `guide/cli.md` 재생성 조건)는 4 에픽 본문에 각자 명시되어 있다.
+  본 인덱스 추가에 따른 project-structure 재생성은 본 PR이 수행한다.
+
+## 변경 정책
+
+- 본 인덱스가 가리키는 SSOT(envelopes.md, vocab.py, helpers.py)의 본문 변경은
+  각 산출물의 변경 정책을 따른다. 본 인덱스는 본문을 재정의하지 않는다.
+- 본 인덱스 자체의 변경(새 SSOT 축 추가, migration order 변경, reference matrix
+  열 추가)은 #1820 결정을 갱신하는 contract change다. 별도 SSOT 이슈로 다룬다.
+- 4 에픽 본문이 본 인덱스와 어긋나면 본 인덱스를 SSOT로 정렬한다. 4 에픽 본문
+  대규모 재작성은 본 PR의 범위 밖이며, 후속 별도 이슈로 분리한다.
+
+## Non-Goals
+
+본 인덱스가 다루지 **않는** 항목:
+
+- 4 에픽 본문의 대규모 재작성 — 본 PR은 prelude에 이미 있는 reference 상태를
+  cross-check 표로 기록할 뿐이다.
+- 실제 CLI command registry / error taxonomy / offline service factory / IPC
+  CommandSpec metadata 구현 — 각각 #1815/#1816/#1818/#1819의 책임이다.
+- vocabulary/envelope/helper 본문 변경 — 각 산출물 SSOT의 책임이다.
+- envelope builder helper(`build_cli_success(...)` 등) 도입 강제 — 본 인덱스
+  범위 밖이다.
+- production code 변경 — 본 PR은 docs index 전용이다.
+
+## 후속 진행
+
+본 인덱스가 등록된 시점 기준 후속 진행 순서:
+
+1. #1820 meta-epic close (본 #1824 close가 마지막 sub-issue다).
+2. #1816 → #1819/#1815 → #1818 순으로 후속 에픽 착수.
+   - #1819는 #1816 taxonomy의 `SERVICE_NOT_CONFIGURED`를 소비하므로 #1816 이후.
+   - #1818은 #1816 error 발화만 reference하므로 #1815/#1819와 병행 가능.
+3. 각 후속 에픽의 Plan Preflight는 본 인덱스를 reference하고, 필요 시 본 인덱스
+   reference matrix를 갱신할 후속 patch 이슈를 발행한다.

--- a/docs/specs/contracts/envelopes.md
+++ b/docs/specs/contracts/envelopes.md
@@ -1,0 +1,224 @@
+# CLI/IPC Envelope Shape SSOT
+
+> Parent decision: [#1820 Contract SSOT 공통 인프라](https://github.com/joshua-jingu-lee/ante/issues/1820)
+> Status: 1.0 normative — CLI와 IPC 외부 표면이 공유하는 envelope 형태의 단일 SSOT.
+> Implementation references (non-normative): `src/ante/cli/formatter.py`, `src/ante/ipc/server.py`.
+
+## 목적
+
+본 문서는 Ante의 외부 표면(CLI `--format json`, IPC Unix domain socket)이
+사용자/Agent에 노출하는 envelope 형태를 한 곳에 모은다. 기존 CLI/IPC 스펙과
+구현이 이미 같은 4형태를 사용하고 있으므로, 본 문서는 새 계약을 발명하지 않고
+기존 4형태를 상위 SSOT로 lock 한다.
+
+후속 에픽(#1815/#1816/#1819/#1818)과 도메인 스펙은 envelope 형태를 별도로
+재정의하지 않고 본 문서를 reference 한다.
+
+## Envelope 4형태
+
+Ante의 외부 표면 envelope은 다음 4형태만이 normative다.
+
+```json
+{"status": "ok",    "message": "...",  "data":   {...}}
+{"status": "error", "code":    "...",  "message": "..."}
+{"id": "uuid-v4",   "status":  "ok",   "result": {...}}
+{"id": "uuid-v4",   "status":  "error","error":  {"code": "...", "message": "..."}}
+```
+
+순서대로 CLI success / CLI error / IPC success / IPC error 다.
+
+## CLI success envelope
+
+CLI 커맨드가 `--format json` 모드에서 성공한 경우 `stdout`으로 출력하는 형태다.
+
+```json
+{
+  "status": "ok",
+  "message": "<사람이 읽는 단문 메시지>",
+  "data": { ... }
+}
+```
+
+| 필드 | 타입 | 필수 | 의미 |
+|------|------|------|------|
+| `status` | `"ok"` | 필수 | 성공 응답 식별자. 항상 문자열 `"ok"`. |
+| `message` | `string` | 필수 | 사람이 읽는 단문 결과 메시지. 빈 문자열도 허용한다. |
+| `data` | `object` | 필수 | 커맨드별 payload. 페이로드가 없으면 빈 객체 `{}`를 직렬화한다. |
+
+규칙:
+
+- 세 필드는 항상 동시에 직렬화된다. `data`가 누락된 envelope은 본 SSOT를
+  따르지 않는다. payload 없는 경우 `{}`로 명시한다.
+- `data` 안의 키/값은 도메인별 페이로드 계약이며 본 SSOT 범위 밖이다.
+- `--format text` 모드의 사람 친화 출력은 본 SSOT 범위가 아니다.
+- 구현 reference: `OutputFormatter.success()` (`src/ante/cli/formatter.py`).
+
+## CLI error envelope
+
+CLI 커맨드가 `--format json` 모드에서 실패한 경우 출력하는 형태다.
+
+```json
+{
+  "status": "error",
+  "code":   "<STABLE_ERROR_CODE>",
+  "message": "<사람이 읽는 에러 메시지>"
+}
+```
+
+| 필드 | 타입 | 필수 | 의미 |
+|------|------|------|------|
+| `status` | `"error"` | 필수 | 에러 응답 식별자. 항상 문자열 `"error"`. |
+| `code` | `string` | 필수 | 안정 에러 코드. 빈 문자열 `""`은 본 1.0 계약에서 허용되는 fallback(아직 typed code가 부여되지 않은 surface). |
+| `message` | `string` | 필수 | 사람이 읽는 에러 메시지. 안내 문구는 도메인 스펙이 정한다. |
+
+규칙:
+
+- 세 필드는 항상 동시에 직렬화된다.
+- exit code는 1 이상(non-zero)이어야 한다. exit 0 + error envelope는 본 SSOT 위반이다.
+- `--format text` 모드는 `Error: <message>`를 `stderr`로 출력한다. JSON 모드는
+  `stdout`으로 envelope 한 줄을 출력한다.
+- `code` 값의 vocabulary(taxonomy, 도메인 prefix 등)는 본 SSOT 범위가 아니다 →
+  [Non-Goals](#non-goals) 참조.
+- 구현 reference: `OutputFormatter.error()` (`src/ante/cli/formatter.py`).
+
+## IPC success envelope
+
+IPC 서버가 요청을 성공적으로 처리한 경우 응답으로 직렬화하는 형태다.
+
+```json
+{
+  "id": "uuid-v4",
+  "status": "ok",
+  "result": { ... }
+}
+```
+
+| 필드 | 타입 | 필수 | 의미 |
+|------|------|------|------|
+| `id` | `string` | 필수 | 요청의 `id`와 1:1 매칭되는 식별자. 클라이언트가 응답을 요청과 짝짓는 데 사용한다. |
+| `status` | `"ok"` | 필수 | 성공 응답 식별자. 항상 문자열 `"ok"`. |
+| `result` | `object` | 필수 | 핸들러가 반환한 payload. payload 없으면 빈 객체 `{}`를 직렬화한다. |
+
+규칙:
+
+- 세 필드는 항상 동시에 직렬화된다.
+- `result` 안의 키/값은 IPC 커맨드별 payload 계약이며 본 SSOT 범위 밖이다.
+  도메인별 envelope 예시(예: `{"bot": ...}`, `{"suspended_count": N}`)는
+  `result` payload의 일부이지 별도 envelope 형태가 아니다.
+- 구현 reference: `IPCServer._dispatch()` 성공 분기 (`src/ante/ipc/server.py`).
+
+## IPC error envelope
+
+IPC 서버가 요청 처리 중 실패한 경우 응답으로 직렬화하는 형태다.
+
+```json
+{
+  "id": "uuid-v4",
+  "status": "error",
+  "error": {
+    "code":    "<STABLE_ERROR_CODE>",
+    "message": "<사람이 읽는 에러 메시지>"
+  }
+}
+```
+
+| 필드 | 타입 | 필수 | 의미 |
+|------|------|------|------|
+| `id` | `string`\|`null` | 필수 | 요청의 `id`와 1:1 매칭. 요청 디코드 실패 등으로 `id`를 식별할 수 없는 경우 `null`을 직렬화한다. |
+| `status` | `"error"` | 필수 | 에러 응답 식별자. 항상 문자열 `"error"`. |
+| `error` | `object` | 필수 | `code`/`message` 두 필드를 갖는 중첩 객체. |
+| `error.code` | `string` | 필수 | 안정 에러 코드(예: `BOT_NOT_FOUND`, `SERVICE_UNAVAILABLE`, `UNKNOWN_COMMAND`, `EXECUTION_ERROR`). |
+| `error.message` | `string` | 필수 | 사람이 읽는 에러 메시지. |
+
+규칙:
+
+- 네 필드(`id`, `status`, `error.code`, `error.message`)는 항상 동시에 직렬화된다.
+- `error`는 평탄화하지 않고 항상 중첩 객체로 직렬화한다. CLI error envelope과
+  다른 점이다(아래 [Wrapping 경계](#wrapping-경계) 참조).
+- 1.0에서 IPC error에 추가 메타데이터(`details`, `retryable` 등) 필드를 두지
+  않는다. 도입은 #1819의 책임이며 본 SSOT 범위 밖이다 → [Non-Goals](#non-goals).
+- 구현 reference: `IPCServer._dispatch()` 에러 분기와 `_service_unavailable()`
+  (`src/ante/ipc/server.py`).
+
+## Wrapping 경계
+
+CLI envelope과 IPC envelope은 **표면별 1회만** wrapping 된다. 한 응답을 두 형태로
+이중 wrapping 하지 않는다.
+
+- **오프라인 CLI**: 직접 모듈 임포트로 실행되는 명령은 결과 dict을
+  `OutputFormatter`로 한 번 wrapping 해 CLI envelope으로 출력한다.
+- **IPC passthrough CLI**: 런타임 IPC 위임 명령은 IPC 응답의 `result`(또는
+  `error`)를 그대로 사용해 CLI envelope을 1회 구성한다. IPC `result`를 다시
+  IPC envelope으로 재감싸서 CLI에 넘기지 않는다.
+- **CLI IPC 헬퍼 계약**: `src/ante/cli/commands/ipc_helpers.py`의 `ipc_send`는
+  IPC 성공 응답의 `result`만 caller에 반환하고, IPC 에러 응답은
+  `ClickException`에 안정 코드/메시지를 부착해 raise 한다. CLI leaf는 이를
+  받아 `OutputFormatter.success(...)` 또는 `OutputFormatter.error(code, message)`로
+  CLI envelope 1회 wrapping 한다. 이 동형은 `ante bot start/stop/status`의 IPC
+  passthrough reference 패턴이다 (`src/ante/cli/commands/bot.py`).
+- **결론**: 어느 표면이든 사용자/Agent에게 보이는 envelope은 CLI envelope 4형태
+  중 하나(텍스트/JSON), IPC envelope 4형태 중 하나(서버 응답)다. CLI가 IPC
+  envelope 그대로를 출력하거나, IPC가 CLI envelope을 반환하는 시나리오는 본
+  SSOT가 정의하는 envelope 형태가 아니다.
+
+## 도메인 payload 예시와의 관계
+
+기존 CLI/IPC 도메인 스펙은 도메인 payload 예시를 풍부히 기록한다. 대표적으로:
+
+- IPC `bot.status` → `{"bot": <BotDetail>}` payload (IPC envelope의 `result`)
+- IPC `system.halt` → `{"suspended_count": N}` payload (IPC envelope의 `result`)
+- CLI `bot list` → `{"bots": [...]}` payload (CLI envelope의 `data`)
+
+위 `{...}` payload들은 본 SSOT가 정의하는 envelope이 **아니다**. envelope 4형태
+**안쪽** 페이로드 슬롯(`data`/`result`)의 도메인 계약이다. payload schema의
+계약 SSOT는 각 도메인 스펙(`docs/specs/<module>/...`)이며 본 SSOT 범위 밖이다.
+
+## Non-Goals
+
+본 SSOT가 정의하지 **않는** 항목은 다음과 같다.
+
+- **에러 코드 taxonomy**: `code` 값의 도메인 prefix 규칙, 공통 코드 SSOT,
+  exception → code 매핑은 #1816의 책임이다. CLI 일부 분야는
+  `docs/specs/cli/02-design-decisions.md`의 입력 계약 에러 코드 표를 SSOT로
+  유지한다.
+- **CLI success payload migration**: 기존 raw-dict CLI 출력 명령을 standard
+  CLI success envelope으로 옮기는 작업은 #1815의 책임이다. 본 SSOT는 standard
+  envelope이 `{status, message, data}` 임만 lock 한다.
+- **IPC CommandSpec metadata**: IPC 핸들러의 args/result schema, audit
+  metadata, service 의존성 선언은 #1819의 책임이다. 본 SSOT는 IPC
+  `result`/`error` 슬롯의 외형만 lock 한다.
+- **도메인 payload schema**: `data`/`result` 안의 도메인별 필드 계약(예:
+  `bot info`의 필드 목록)은 각 도메인 스펙이 SSOT다.
+- **Envelope builder helper 도입 강제**: `build_cli_success(...)` /
+  `build_ipc_error(...)` 같은 코드 helper의 도입은 본 SSOT가 강제하지 않는다.
+  현재 `OutputFormatter`와 `IPCServer._dispatch()`가 envelope을 직접 직렬화하는
+  방식이 normative behavior다. helper 도입이 필요하면 별도 이슈로 다룬다.
+- **기존 formatter/server behavior 변경**: 본 SSOT는 문서화 변경만이며
+  `OutputFormatter`/`IPCServer`의 런타임 동작을 바꾸지 않는다.
+- **CLI `--format text` 출력 형태**: 사람 친화 텍스트 출력은 본 SSOT 범위 밖이다.
+- **`docs/specs/contracts/README.md` 인덱스 작성**: contracts 디렉토리의 SSOT
+  인덱스 작성은 #1824의 책임이다. 본 PR은 `docs/specs/README.md`에 contracts
+  entry만 추가한다.
+
+## 호출자/소비자 reference
+
+본 envelope SSOT는 다음 표면이 직접 소비한다.
+
+- **CLI 호출자**: 모든 `OutputFormatter.success/error` 호출자(현재 ante CLI
+  명령 전반). 호출자별 payload 계약은 도메인 스펙을 따른다.
+- **IPC 호출자**: `IPCClient.send()`를 통해 IPC 서버 응답을 받는 모든 CLI 명령
+  및 향후 MCP/외부 클라이언트. `src/ante/cli/commands/ipc_helpers.py`의
+  `ipc_send`가 1차 IPC envelope 디코더 reference다.
+- **IPC 서버**: `IPCServer._dispatch()`가 본 envelope 4형태 중 IPC 2형태를
+  직렬화하는 단일 chokepoint다. 핸들러는 평면 dict을 반환하며 envelope wrapping은
+  `_dispatch()`가 일임한다.
+
+## 변경 정책
+
+- 본 SSOT는 1.0 normative이며 형태 변경은 contract change다. 새 필드 추가
+  (예: `request_id`, `details`, `retryable`)는 본 문서 normative 절을 수정하지
+  말고 **별도 SSOT 이슈**로 제안한 뒤 본 문서를 갱신한다.
+- 도메인 payload 신설/변경은 본 SSOT를 건드리지 않는다. 해당 도메인 스펙에서
+  처리한다.
+- 본 문서가 lock 한 envelope 4형태와 충돌하는 normative 재정의가 다른 스펙에서
+  발견되면 해당 스펙을 본 SSOT를 reference 하도록 정렬한다.

--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -292,6 +292,11 @@ CWD나 `db.path` parent에서 socket 위치를 파생하지 않는다.
 
 JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 
+IPC 응답 envelope(`status:"ok"` + `result` / `status:"error"` + `error`) 형태의
+normative SSOT는 [contracts/envelopes.md](../contracts/envelopes.md)다. 본 절은
+요청 envelope 형태와 응답 envelope 의 IPC 측 적용 예시만 기술한다. 새 필드
+추가/변경은 본 절이 아닌 SSOT 문서를 우선 갱신한다.
+
 **요청**:
 ```json
 {
@@ -311,7 +316,9 @@ JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 | `args` | `dict` | 커맨드 파라미터 |
 | `actor` | `string` | CLI에서 인증된 멤버 ID (감사 추적용). 인증 면제 recovery 커맨드는 `"unknown"` 또는 recovery 대상 member_id |
 
-**응답 (성공)**:
+**응답 (성공)** — IPC success envelope의 적용 예시. envelope 형태 SSOT는
+[contracts/envelopes.md — IPC success envelope](../contracts/envelopes.md#ipc-success-envelope):
+
 ```json
 {
   "id": "uuid-v4",
@@ -322,7 +329,12 @@ JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 }
 ```
 
-**응답 (실패)**:
+`result` payload(`{"suspended_count": N}`, `{"bot": ...}` 등)는 도메인 IPC
+커맨드별 계약이며 envelope 형태가 아니다.
+
+**응답 (실패)** — IPC error envelope의 적용 예시. envelope 형태 SSOT는
+[contracts/envelopes.md — IPC error envelope](../contracts/envelopes.md#ipc-error-envelope):
+
 ```json
 {
   "id": "uuid-v4",
@@ -334,13 +346,9 @@ JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 }
 ```
 
-| 필드 | 타입 | 설명 |
-|------|------|------|
-| `id` | `string` | 요청 `id`와 동일 |
-| `status` | `"ok" \| "error"` | 성공/실패 |
-| `result` | `dict` | 성공 시 반환 데이터 |
-| `error.code` | `string` | 에러 코드 (서비스 예외 클래스명 등) |
-| `error.message` | `string` | 에러 메시지 |
+`error.code` 값의 vocabulary(taxonomy, 도메인 prefix 규칙, 공통 코드 SSOT)는
+#1816의 책임이며 본 스펙 범위 밖이다. 현재 사용되는 공통 코드 일부는 아래
+[에러 처리](#에러-처리) 표에 예시로 기록한다.
 
 ### 프레이밍
 

--- a/src/ante/contracts/__init__.py
+++ b/src/ante/contracts/__init__.py
@@ -1,0 +1,10 @@
+"""Contract SSOT 공통 인프라.
+
+이 package는 CLI(#1815)/IPC(#1819) 계열 contract surface가
+공유할 vocabulary 등 공통 정의의 SSOT 위치다.
+
+본 패키지 초기 버전(#1822)은 vocabulary 정의(``ante.contracts.vocab``)만
+포함하며, package marker 역할만 한다. alias re-export는 의도적으로 하지
+않는다 -- 소비자는 `from ante.contracts.vocab import ...` 형태로
+명시 import하여, vocabulary 위치가 단일 SSOT로 고정되도록 한다.
+"""

--- a/src/ante/contracts/vocab.py
+++ b/src/ante/contracts/vocab.py
@@ -1,0 +1,36 @@
+"""Contract vocabulary SSOT (#1822).
+
+CLI command registry(#1815)와 IPC CommandSpec metadata(#1819) 양쪽이
+공유하는 contract vocabulary의 단일 코드 SSOT.
+
+본 모듈은 다음 3개 Literal type alias만 정의한다.
+
+- ``ContractKind`` : contract가 노출하는 result shape 종류
+- ``EnvelopeForm`` : 응답 envelope 형태
+- ``AuthMode``     : 인증 요구 모드 vocabulary
+
+중요한 정렬:
+
+- ``raw_legacy``는 ``EnvelopeForm``에만 존재하며 ``ContractKind``에는
+  포함되지 않는다. legacy raw JSON 출력은 후속 #1815에서
+  ``kind="raw"`` + ``envelope="raw_legacy"`` 조합으로 표현한다.
+- ``AuthMode``는 후속 #1815/#1819가 인증 요구사항을 같은 단어로
+  표현하기 위한 vocabulary이며, 본 모듈은 auth enforcement를 바꾸지
+  않는다.
+
+본 모듈은 runtime behavior를 가지지 않는다. enum/dataclass/helper/
+validator 추가는 의도적으로 제외한다 -- 필요해지면 별도 이슈로 분리한다.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ContractKind = Literal["entity", "operation", "collection", "raw", "stream"]
+"""Contract가 노출하는 result shape 종류."""
+
+EnvelopeForm = Literal["standard", "raw_legacy"]
+"""응답 envelope 형태. ``raw_legacy``는 후방 호환용."""
+
+AuthMode = Literal["public", "authenticated", "scoped", "master"]
+"""인증 요구 모드 vocabulary."""

--- a/tests/unit/contracts/__init__.py
+++ b/tests/unit/contracts/__init__.py
@@ -1,0 +1,15 @@
+"""Contract drift test helpers (Refs #1823).
+
+이 패키지는 #1815/#1816/#1818/#1819 후속 epic에서 사용할 공통 helper만
+제공한다. 본 패키지는 실제 drift policy/assertion 을 포함하지 않는다 —
+helper API skeleton 과 그 helper 자체 unit test만 둔다.
+
+Helper 분류:
+
+- import 기반: Click leaf command iterator, IPC ``CommandRegistry`` spec
+  iterator. live runtime service 초기화나 DB 접근 없이 module import 만으로
+  동작한다.
+- AST/텍스트 기반: ``*Error`` class iterator, ``fmt.error(...)`` callsite
+  iterator. production module import 를 피하기 위해 file text 를
+  ``ast.parse`` 한다.
+"""

--- a/tests/unit/contracts/helpers.py
+++ b/tests/unit/contracts/helpers.py
@@ -1,0 +1,448 @@
+"""Contract drift test helper skeleton (Refs #1823).
+
+#1815/#1816/#1818/#1819 후속 epic 이 반복해서 작성할 drift-test 유틸을
+공통 helper 로 추출한다. 본 모듈은 helper API 만 제공하고 실제 drift
+policy/assertion 은 후속 epic 의 책임이다.
+
+Helper 분류 (Refs #1820 결정 / #1823 plan):
+
+* **import 기반** — Click CLI 트리, IPC ``CommandRegistry`` 는 module
+  import 만으로 leaf 식별이 가능하므로 introspection 으로 다룬다.
+
+  - :func:`iter_click_leaf_commands` — Click root group 에서 hidden
+    subtree 를 제외한 leaf command 만 yield. 기본 root 는 ``ante.cli.main.cli``.
+  - :func:`iter_ipc_command_specs` — :class:`CommandRegistry` 에서 등록된
+    :class:`CommandSpec` 을 yield. registry 미지정 시 기본 registry 를
+    만들고 :func:`register_all_handlers` 를 호출한다.
+
+* **AST/텍스트 기반** — exception class 와 ``fmt.error(...)`` callsite
+  sweep 은 import side effect 를 피하기 위해 file text 를 :func:`ast.parse`
+  한다.
+
+  - :func:`iter_exception_classes` — ``src/ante/**/*.py`` 의
+    ``*Error`` class 와 class-level ``code`` 속성을 식별한다.
+  - :func:`iter_fmt_error_calls` — ``src/ante/cli/**/*.py`` 의
+    ``fmt.error(...)`` callsite 와 code argument classification 정보를
+    yield 한다.
+
+본 helper 는 default repository root 를 알지 못한다. 호출자가 :class:`Path`
+를 명시한다 (default 는 cwd 기준 ``Path("src/ante")``). 후속 enforcement
+test 가 repository root 를 고정하는 책임을 진다.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from ante.ipc.registry import CommandRegistry, CommandSpec
+
+
+# ── import 기반 helper ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CliLeafCommand:
+    """Click leaf command 식별자.
+
+    Attributes:
+        path: ``ante`` prefix 를 제외한 leaf 까지의 segment 튜플
+            (예: ``("bot", "start")``).
+        command: 해당 Click command 객체. 후속 enforcement 가
+            ``cmd.callback`` chain / scope decorator 를 들여다볼 수 있다.
+    """
+
+    path: tuple[str, ...]
+    command: click.Command
+
+
+def _registration_order(group: click.Group) -> list[str]:
+    """Click Group 의 등록 순서를 반환한다.
+
+    Click 8+ 의 ``group.commands`` dict 는 삽입 순서를 보존한다. 일부
+    custom Group 구현(MultiCommand) 에서는 dict 가 아닐 수 있으므로
+    fallback 으로 ``list_commands`` 를 사용한다.
+
+    (참고: scripts/generate_cli_reference.py:_registration_order 와 동일
+    의도 — helper 가 module import side effect 를 늘리지 않도록 inline.)
+    """
+    commands = getattr(group, "commands", None)
+    if isinstance(commands, dict):
+        return list(commands.keys())
+    ctx = click.Context(group, info_name=group.name or "ante")
+    return list(group.list_commands(ctx))
+
+
+def _walk_click(
+    group: click.Group,
+    prefix: tuple[str, ...],
+) -> Iterator[CliLeafCommand]:
+    """Click 트리를 DFS 로 순회하며 leaf 만 yield 한다.
+
+    hidden subtree (그룹/leaf 모두) 는 ``cmd.hidden`` 표식을 따라
+    완전히 제외한다. 그룹 자체는 leaf 가 아니므로 yield 하지 않는다.
+    """
+    ctx = click.Context(group, info_name=group.name or "ante")
+    for name in _registration_order(group):
+        cmd = group.get_command(ctx, name)
+        if cmd is None:
+            continue
+        if getattr(cmd, "hidden", False):
+            # generic·mechanism-agnostic: hidden 그룹은 하위 재귀까지 skip.
+            continue
+        path = (*prefix, name)
+        if isinstance(cmd, click.Group):
+            yield from _walk_click(cmd, path)
+        else:
+            yield CliLeafCommand(path=path, command=cmd)
+
+
+def iter_click_leaf_commands(
+    root: click.Group | None = None,
+) -> Iterator[CliLeafCommand]:
+    """Click root group 의 public leaf command 를 yield 한다.
+
+    Args:
+        root: 검사할 Click root. ``None`` 이면 ``ante.cli.main.cli`` 를
+            가져온다 — 후속 enforcement test 가 inline Click fixture root
+            를 주입할 수 있도록 keyword 가 아니라 positional default 로
+            둔다.
+
+    Yields:
+        :class:`CliLeafCommand`: hidden subtree 를 제외한 leaf command.
+        그룹 자체는 yield 하지 않는다.
+    """
+    if root is None:
+        from ante.cli.main import cli as _cli  # 지연 import — fixture 주입 우선
+
+        root = _cli
+    yield from _walk_click(root, ())
+
+
+def iter_ipc_command_specs(
+    registry: CommandRegistry | None = None,
+) -> Iterator[CommandSpec]:
+    """IPC ``CommandRegistry`` 의 등록된 ``CommandSpec`` 을 yield 한다.
+
+    Args:
+        registry: 검사할 registry. ``None`` 이면 새 빈 registry 를 만들고
+            :func:`ante.ipc.registry.register_all_handlers` 를 호출해 default
+            production registry 를 구성한다. 후속 enforcement test 가 작은
+            fixture registry 를 주입할 수 있다.
+
+    Yields:
+        :class:`CommandSpec`: ``registry.commands`` 순서대로 ``CommandSpec``
+        를 반환한다 (이름이 아니라 spec 자체).
+    """
+    from ante.ipc.registry import CommandRegistry, register_all_handlers
+
+    if registry is None:
+        registry = CommandRegistry()
+        register_all_handlers(registry)
+    for name in registry.commands:
+        spec = registry.get(name)
+        if spec is not None:
+            yield spec
+
+
+# ── AST/텍스트 기반 helper ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ExceptionClassInfo:
+    """``*Error`` class 의 정적 메타데이터.
+
+    Attributes:
+        path: 클래스가 정의된 ``.py`` 파일 경로.
+        name: 클래스 이름.
+        lineno: 클래스 정의 시작 줄.
+        has_code: class body 에 ``code`` 속성 할당이 존재하면 True.
+            ``code: str = "..."`` 또는 ``code = "..."`` 둘 다 포함한다.
+        code_value: class-level ``code`` 가 literal string 이면 그 값,
+            non-literal (모듈 상수 식별자 등) 이면 ``None``. ``has_code`` 가
+            False 면 ``None``.
+    """
+
+    path: Path
+    name: str
+    lineno: int
+    has_code: bool
+    code_value: str | None
+
+
+@dataclass(frozen=True)
+class FmtErrorCallsite:
+    """``fmt.error(...)`` 호출의 정적 메타데이터.
+
+    Attributes:
+        path: callsite 파일 경로.
+        lineno: callsite 줄.
+        has_code_keyword: ``code=`` keyword argument 가 존재하면 True.
+        has_positional_code: 2번째 positional argument 가 존재하면 True
+            (``fmt.error(message, "CODE")`` 패턴).
+        has_effective_code: ``code=`` keyword 또는 positional code 중 어느
+            하나라도 존재하면 True. False 면 callsite 가 code 인자를 전혀
+            전달하지 않는다 (#1816 대상 후보).
+        has_empty_code_fallback: code 인자가 빈 fallback 으로 떨어지는지
+            **휴리스틱** 판정. 다음 중 어느 하나라도 매치하면 True:
+
+            - 인자 값이 빈 문자열 literal ``""`` 또는 ``''``.
+            - ``getattr(..., ..., "")`` 호출 (3번째 default 가 빈 문자열).
+            - ``.get(..., "")`` 호출 (2번째 default 가 빈 문자열).
+
+            드물게 false positive/negative 가능 — 후속 #1816 이
+            classification 을 강화할 skeleton 으로 사용한다.
+        snippet: 원본 source 의 callsite 줄 raw 문자열 (디버깅용).
+    """
+
+    path: Path
+    lineno: int
+    has_code_keyword: bool
+    has_positional_code: bool
+    has_effective_code: bool
+    has_empty_code_fallback: bool
+    snippet: str
+
+
+def _iter_python_files(root: Path) -> Iterator[Path]:
+    """``root`` 하위 ``.py`` 파일을 정렬된 순서로 yield 한다.
+
+    ``__pycache__`` 같은 비-source 디렉토리는 ``.py`` 파일을 갖지 않으므로
+    별도 필터는 불필요하다. 호출자가 ``root`` scope 를 좁히는 책임을 진다.
+    """
+    if not root.exists():
+        return
+    yield from sorted(root.rglob("*.py"))
+
+
+def _parse_module(path: Path) -> ast.Module | None:
+    """파일을 ``ast.parse`` 하고 실패하면 ``None``.
+
+    helper 가 sweep 도중 ``SyntaxError`` 로 깨지지 않도록 try/except 한다.
+    파일 자체가 깨졌으면 후속 enforcement 가 별도로 표면화한다.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        return ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return None
+
+
+def _extract_class_code_attr(
+    node: ast.ClassDef,
+) -> tuple[bool, str | None]:
+    """``code`` class attribute 의 존재/literal 값을 반환한다.
+
+    ``code: str = "..."`` (:class:`ast.AnnAssign`) 와 ``code = "..."``
+    (:class:`ast.Assign`) 둘 다 인식한다. literal 이 아니면 ``code_value``
+    는 ``None`` 이다 (예: ``code = BOT_NOT_FOUND_CODE``).
+    """
+    for stmt in node.body:
+        # ``code: str = "..."`` (annotated assignment)
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            if stmt.target.id == "code" and stmt.value is not None:
+                value = stmt.value
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    return True, value.value
+                return True, None
+        # ``code = "..."`` (plain assignment); 다중 타깃은 첫 ``code`` 만.
+        elif isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name) and target.id == "code":
+                    if isinstance(stmt.value, ast.Constant) and isinstance(
+                        stmt.value.value, str
+                    ):
+                        return True, stmt.value.value
+                    return True, None
+    return False, None
+
+
+def _is_error_class(name: str) -> bool:
+    """``name`` 이 ``*Error`` 인지 (suffix 일치, 단독 ``Error`` 도 포함)."""
+    return name == "Error" or name.endswith("Error")
+
+
+def iter_exception_classes(
+    root: Path = Path("src/ante"),
+) -> Iterator[ExceptionClassInfo]:
+    """``root`` 하위 ``*Error`` class 정의를 yield 한다.
+
+    AST 기반이라 module import 를 유발하지 않는다. base 가 ``Exception`` /
+    다른 ``*Error`` / ``ValueError`` 등 어느 것이든 ``name`` 만으로 식별
+    한다 — production code 가 ``Error`` suffix convention 을 따른다는
+    가정을 따른다.
+
+    Args:
+        root: 검사할 루트 디렉토리. 기본 ``Path("src/ante")``. 후속
+            enforcement test 가 repository root 절대경로를 합성해 주입할
+            수 있다.
+
+    Yields:
+        :class:`ExceptionClassInfo`: 각 ``*Error`` class 의 정적 메타데이터.
+        ``code`` 가 ``ValueError`` 등 stdlib 상속만으로 자동 채워지는 경우는
+        ``has_code=False`` (class body 에 명시 할당이 없으므로).
+    """
+    for path in _iter_python_files(root):
+        module = _parse_module(path)
+        if module is None:
+            continue
+        for node in ast.walk(module):
+            if isinstance(node, ast.ClassDef) and _is_error_class(node.name):
+                has_code, code_value = _extract_class_code_attr(node)
+                yield ExceptionClassInfo(
+                    path=path,
+                    name=node.name,
+                    lineno=node.lineno,
+                    has_code=has_code,
+                    code_value=code_value,
+                )
+
+
+def _is_fmt_error_call(call: ast.Call) -> bool:
+    """``call`` 이 ``<anything>.error(...)`` attribute call 인지.
+
+    ``fmt.error(...)`` 뿐 아니라 ``self._fmt.error(...)`` /
+    ``formatter.error(...)`` 같은 alias 도 모두 매치한다. 모듈 이름은
+    아무거나 받고 attribute 가 정확히 ``error`` 인지로 식별한다.
+    """
+    func = call.func
+    return isinstance(func, ast.Attribute) and func.attr == "error"
+
+
+def _is_empty_string_literal(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value == ""
+
+
+def _is_empty_default_fallback(node: ast.expr) -> bool:
+    """``getattr(..., "")`` / ``.get(..., "")`` 형식의 빈 fallback 인지.
+
+    헛수고 false positive 를 줄이려고 함수 이름이 ``getattr`` 또는
+    attribute call ``.get(...)`` 일 때만 인정한다. 더 정확한 분류는 #1816
+    이 책임진다.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "getattr":
+        # ``getattr(obj, name, default)`` — default 가 3번째 인자.
+        if len(node.args) >= 3 and _is_empty_string_literal(node.args[2]):
+            return True
+    if isinstance(func, ast.Attribute) and func.attr == "get":
+        # ``mapping.get(key, default)`` — default 가 2번째 인자.
+        if len(node.args) >= 2 and _is_empty_string_literal(node.args[1]):
+            return True
+    return False
+
+
+def _classify_code_argument(call: ast.Call) -> tuple[bool, bool, bool, bool]:
+    """``fmt.error(...)`` call 에서 code argument 정보를 추출한다.
+
+    Returns:
+        ``(has_code_keyword, has_positional_code, has_effective_code,
+        has_empty_code_fallback)`` 튜플.
+    """
+    has_kw = False
+    code_value_node: ast.expr | None = None
+
+    for kw in call.keywords:
+        if kw.arg == "code":
+            has_kw = True
+            code_value_node = kw.value
+            break
+
+    # ``fmt.error(message, "CODE")`` → 2번째 positional argument.
+    # ``ast.Call.args`` 는 positional 만, ``**kwargs`` star unpack 은 제외한다.
+    has_positional = len(call.args) >= 2
+    if has_positional and code_value_node is None:
+        code_value_node = call.args[1]
+
+    has_effective = has_kw or has_positional
+
+    has_empty_fallback = False
+    if code_value_node is not None:
+        if _is_empty_string_literal(code_value_node):
+            has_empty_fallback = True
+        elif _is_empty_default_fallback(code_value_node):
+            has_empty_fallback = True
+
+    return has_kw, has_positional, has_effective, has_empty_fallback
+
+
+def _source_line(source_lines: list[str], lineno: int) -> str:
+    """1-based ``lineno`` 의 source line 을 안전하게 반환한다."""
+    if 1 <= lineno <= len(source_lines):
+        return source_lines[lineno - 1].rstrip("\n")
+    return ""
+
+
+def iter_fmt_error_calls(
+    root: Path = Path("src/ante/cli"),
+) -> Iterator[FmtErrorCallsite]:
+    """``root`` 하위 ``fmt.error(...)`` callsite 를 yield 한다.
+
+    AST 기반이라 module import 를 유발하지 않는다. attribute name 이 정확히
+    ``error`` 인 모든 attribute call 을 잡으므로 ``self._fmt.error(...)`` /
+    ``formatter.error(...)`` 같은 alias 도 자동으로 매치된다.
+
+    Args:
+        root: 검사할 루트. 기본 ``Path("src/ante/cli")``. CLI 표면 밖에서
+            ``fmt.error`` 호출이 사실상 없지만, 후속 enforcement 가 범위를
+            확장해야 하면 ``Path("src/ante")`` 등을 명시하면 된다.
+
+    Yields:
+        :class:`FmtErrorCallsite`: callsite 별 code argument classification
+        과 source snippet.
+    """
+    for path in _iter_python_files(root):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            module = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        source_lines = source.splitlines()
+        for node in ast.walk(module):
+            if not isinstance(node, ast.Call):
+                continue
+            if not _is_fmt_error_call(node):
+                continue
+            (
+                has_kw,
+                has_pos,
+                has_effective,
+                has_empty_fallback,
+            ) = _classify_code_argument(node)
+            yield FmtErrorCallsite(
+                path=path,
+                lineno=node.lineno,
+                has_code_keyword=has_kw,
+                has_positional_code=has_pos,
+                has_effective_code=has_effective,
+                has_empty_code_fallback=has_empty_fallback,
+                snippet=_source_line(source_lines, node.lineno),
+            )
+
+
+# ── public surface ────────────────────────────────────────────────────────
+
+
+__all__ = [
+    "CliLeafCommand",
+    "ExceptionClassInfo",
+    "FmtErrorCallsite",
+    "iter_click_leaf_commands",
+    "iter_exception_classes",
+    "iter_fmt_error_calls",
+    "iter_ipc_command_specs",
+]

--- a/tests/unit/contracts/test_helpers.py
+++ b/tests/unit/contracts/test_helpers.py
@@ -1,0 +1,527 @@
+"""Contract drift helper skeleton 자체 unit test (Refs #1823).
+
+이 테스트는 helper API 가 동작한다는 것만 검증한다 — repository-wide drift
+count exact assertion 은 추가하지 않는다 (그것은 #1815/#1816/#1818/#1819
+후속 epic 의 책임).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import click
+import pytest
+
+from tests.unit.contracts.helpers import (
+    CliLeafCommand,
+    ExceptionClassInfo,
+    FmtErrorCallsite,
+    iter_click_leaf_commands,
+    iter_exception_classes,
+    iter_fmt_error_calls,
+    iter_ipc_command_specs,
+)
+
+# ── iter_click_leaf_commands ──────────────────────────────────────────────
+
+
+class TestIterClickLeafCommands:
+    """Click leaf command iterator skeleton."""
+
+    def test_yields_leaf_only(self) -> None:
+        """그룹 자체는 yield 하지 않고 leaf 만 yield 한다."""
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command()
+        def alpha() -> None:
+            """alpha leaf."""
+
+        @root.group()
+        def grp() -> None:
+            """그룹."""
+
+        @grp.command()
+        def beta() -> None:
+            """nested leaf."""
+
+        results = list(iter_click_leaf_commands(root))
+        paths = [r.path for r in results]
+        assert ("alpha",) in paths
+        assert ("grp", "beta") in paths
+        # group "grp" 자체는 leaf 가 아니다.
+        assert ("grp",) not in paths
+
+    def test_excludes_hidden_subtree(self) -> None:
+        """hidden 그룹/leaf 는 모두 제외 (#1682 generic·mechanism-agnostic)."""
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command(hidden=True)
+        def secret() -> None:
+            """hidden leaf."""
+
+        @root.command()
+        def visible() -> None:
+            """visible leaf."""
+
+        @root.group(name="buried", hidden=True)
+        def buried() -> None:
+            """hidden group."""
+
+        @buried.command()
+        def underground() -> None:
+            """hidden subtree leaf."""
+
+        results = list(iter_click_leaf_commands(root))
+        paths = [r.path for r in results]
+        assert ("visible",) in paths
+        assert ("secret",) not in paths
+        assert ("buried", "underground") not in paths
+
+    def test_returns_dataclass_with_command_object(self) -> None:
+        """결과는 CliLeafCommand 이고 command 객체에 접근 가능하다."""
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command()
+        def leaf() -> None:
+            """leaf doc."""
+
+        results = list(iter_click_leaf_commands(root))
+        assert len(results) == 1
+        item = results[0]
+        assert isinstance(item, CliLeafCommand)
+        assert item.path == ("leaf",)
+        assert isinstance(item.command, click.Command)
+        assert item.command.help == "leaf doc."
+
+    def test_default_root_loads_ante_cli(self) -> None:
+        """root 미지정 시 ante.cli.main.cli 를 사용 (live smoke).
+
+        count exact assertion 은 두지 않는다 — helper 가 동작하는지만
+        확인. 후속 epic 이 exact count 를 lock 한다.
+        """
+        results = list(iter_click_leaf_commands())
+        assert len(results) > 0
+        # path 는 항상 비어있지 않은 튜플.
+        for item in results:
+            assert isinstance(item.path, tuple)
+            assert len(item.path) >= 1
+            assert isinstance(item.command, click.Command)
+
+
+# ── iter_ipc_command_specs ────────────────────────────────────────────────
+
+
+class TestIterIpcCommandSpecs:
+    """IPC registry spec iterator skeleton."""
+
+    def test_injected_registry_fixture(self) -> None:
+        """주입된 registry 의 등록 spec 만 yield."""
+        from ante.ipc.registry import CommandRegistry
+
+        registry = CommandRegistry()
+
+        async def dummy(svc, args, actor):  # type: ignore[no-untyped-def]
+            return {}
+
+        registry.register("alpha", dummy, is_mutating=True)
+        registry.register("beta", dummy, is_mutating=False)
+
+        specs = list(iter_ipc_command_specs(registry))
+        names = {s.name for s in specs}
+        assert names == {"alpha", "beta"}
+        # taxonomy 가 그대로 보존된다.
+        spec_by_name = {s.name: s for s in specs}
+        assert spec_by_name["alpha"].is_mutating is True
+        assert spec_by_name["beta"].is_mutating is False
+
+    def test_default_registry_smoke(self) -> None:
+        """registry 미지정 시 register_all_handlers 결과를 사용 (live smoke)."""
+        specs = list(iter_ipc_command_specs())
+        # count exact assertion 은 후속 epic. iterator 동작만 확인.
+        assert len(specs) > 0
+        # 각 항목은 name / is_mutating 을 가진 CommandSpec.
+        for spec in specs:
+            assert isinstance(spec.name, str) and spec.name
+            assert isinstance(spec.is_mutating, bool)
+
+    def test_empty_registry_yields_nothing(self) -> None:
+        """등록 없는 registry 는 빈 iterator."""
+        from ante.ipc.registry import CommandRegistry
+
+        registry = CommandRegistry()
+        assert list(iter_ipc_command_specs(registry)) == []
+
+
+# ── iter_exception_classes ────────────────────────────────────────────────
+
+
+class TestIterExceptionClasses:
+    """``*Error`` class AST iterator skeleton."""
+
+    def test_detects_class_with_literal_code(self, tmp_path: Path) -> None:
+        """class-level ``code: str = "FOO"`` literal 추출."""
+        src = textwrap.dedent(
+            """
+            class FooError(Exception):
+                code: str = "FOO_ERROR"
+            """
+        ).lstrip()
+        module = tmp_path / "errors.py"
+        module.write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        assert len(results) == 1
+        info = results[0]
+        assert isinstance(info, ExceptionClassInfo)
+        assert info.name == "FooError"
+        assert info.has_code is True
+        assert info.code_value == "FOO_ERROR"
+        assert info.path == module
+        assert info.lineno == 1
+
+    def test_detects_class_without_code(self, tmp_path: Path) -> None:
+        """class body 에 ``code`` 가 없으면 has_code=False."""
+        src = textwrap.dedent(
+            """
+            class BareError(Exception):
+                pass
+            """
+        ).lstrip()
+        (tmp_path / "bare.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        assert len(results) == 1
+        info = results[0]
+        assert info.name == "BareError"
+        assert info.has_code is False
+        assert info.code_value is None
+
+    def test_detects_non_literal_code(self, tmp_path: Path) -> None:
+        """``code = MODULE_CONST`` 면 has_code=True, code_value=None."""
+        src = textwrap.dedent(
+            """
+            MY_CODE = "BAR"
+
+            class BarError(Exception):
+                code = MY_CODE
+            """
+        ).lstrip()
+        (tmp_path / "non_literal.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        assert len(results) == 1
+        info = results[0]
+        assert info.name == "BarError"
+        assert info.has_code is True
+        assert info.code_value is None
+
+    def test_detects_plain_assignment_literal(self, tmp_path: Path) -> None:
+        """``code = "LITERAL"`` (annotation 없음) 도 인식한다."""
+        src = textwrap.dedent(
+            """
+            class PlainError(Exception):
+                code = "PLAIN_CODE"
+            """
+        ).lstrip()
+        (tmp_path / "plain.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        assert len(results) == 1
+        info = results[0]
+        assert info.has_code is True
+        assert info.code_value == "PLAIN_CODE"
+
+    def test_skips_non_error_classes(self, tmp_path: Path) -> None:
+        """``*Error`` suffix 가 아닌 class 는 yield 하지 않는다."""
+        src = textwrap.dedent(
+            """
+            class NotAnException:
+                code: str = "X"
+
+            class HelperClass:
+                pass
+
+            class RealError(Exception):
+                code: str = "REAL"
+            """
+        ).lstrip()
+        (tmp_path / "mixed.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        names = [r.name for r in results]
+        assert names == ["RealError"]
+
+    def test_walks_nested_subdirectories(self, tmp_path: Path) -> None:
+        """root 하위 모든 ``.py`` 를 재귀 sweep."""
+        (tmp_path / "a").mkdir()
+        (tmp_path / "a" / "x.py").write_text(
+            "class AError(Exception):\n    code: str = 'A'\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "b").mkdir()
+        (tmp_path / "b" / "y.py").write_text(
+            "class BError(Exception):\n    pass\n",
+            encoding="utf-8",
+        )
+
+        results = list(iter_exception_classes(tmp_path))
+        names = {r.name for r in results}
+        assert names == {"AError", "BError"}
+
+    def test_skips_syntax_error_files(self, tmp_path: Path) -> None:
+        """SyntaxError 파일은 helper 가 깨지지 않고 skip 한다."""
+        (tmp_path / "good.py").write_text(
+            "class GoodError(Exception):\n    code: str = 'G'\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "broken.py").write_text("def broken(\n", encoding="utf-8")
+
+        results = list(iter_exception_classes(tmp_path))
+        names = [r.name for r in results]
+        assert names == ["GoodError"]
+
+    def test_missing_root_returns_empty(self, tmp_path: Path) -> None:
+        """존재하지 않는 root 는 빈 iterator."""
+        ghost = tmp_path / "does_not_exist"
+        assert list(iter_exception_classes(ghost)) == []
+
+
+# ── iter_fmt_error_calls ──────────────────────────────────────────────────
+
+
+class TestIterFmtErrorCalls:
+    """``fmt.error(...)`` callsite iterator skeleton."""
+
+    def test_detects_code_keyword(self, tmp_path: Path) -> None:
+        """``fmt.error(msg, code="X")`` → has_code_keyword=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt):
+                fmt.error("boom", code="EXPLODED")
+            """
+        ).lstrip()
+        (tmp_path / "a.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert isinstance(c, FmtErrorCallsite)
+        assert c.has_code_keyword is True
+        assert c.has_positional_code is False
+        assert c.has_effective_code is True
+        assert c.has_empty_code_fallback is False
+        assert "EXPLODED" in c.snippet
+
+    def test_detects_positional_code(self, tmp_path: Path) -> None:
+        """``fmt.error("msg", "CODE")`` → has_positional_code=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt):
+                fmt.error("boom", "CODE_X")
+            """
+        ).lstrip()
+        (tmp_path / "b.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is False
+        assert c.has_positional_code is True
+        assert c.has_effective_code is True
+        assert c.has_empty_code_fallback is False
+
+    def test_detects_missing_code(self, tmp_path: Path) -> None:
+        """``fmt.error("msg")`` → has_effective_code=False (#1816 대상)."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt):
+                fmt.error("oops")
+            """
+        ).lstrip()
+        (tmp_path / "c.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is False
+        assert c.has_positional_code is False
+        assert c.has_effective_code is False
+        assert c.has_empty_code_fallback is False
+
+    def test_detects_empty_string_code(self, tmp_path: Path) -> None:
+        """``fmt.error(msg, code="")`` → has_empty_code_fallback=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt):
+                fmt.error("oops", code="")
+            """
+        ).lstrip()
+        (tmp_path / "d.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is True
+        assert c.has_effective_code is True
+        assert c.has_empty_code_fallback is True
+
+    def test_detects_getattr_empty_fallback(self, tmp_path: Path) -> None:
+        """``code=getattr(e, "code", "")`` → has_empty_code_fallback=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt, e):
+                fmt.error(str(e), code=getattr(e, "code", ""))
+            """
+        ).lstrip()
+        (tmp_path / "e.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is True
+        assert c.has_empty_code_fallback is True
+
+    def test_detects_dict_get_empty_fallback(self, tmp_path: Path) -> None:
+        """``code=result.get("code", "")`` → has_empty_code_fallback=True."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt, result):
+                fmt.error(result["error"], code=result.get("code", ""))
+            """
+        ).lstrip()
+        (tmp_path / "f.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is True
+        assert c.has_empty_code_fallback is True
+
+    def test_non_empty_getattr_default_not_flagged(self, tmp_path: Path) -> None:
+        """비-empty default 의 getattr 는 fallback flag 끄지 않는다."""
+        src = textwrap.dedent(
+            """
+            def fail(fmt, e):
+                fmt.error(str(e), code=getattr(e, "code", "DEFAULT"))
+            """
+        ).lstrip()
+        (tmp_path / "g.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.has_code_keyword is True
+        assert c.has_empty_code_fallback is False
+
+    def test_matches_alias_attribute_call(self, tmp_path: Path) -> None:
+        """``self._fmt.error(...)`` / ``formatter.error(...)`` 같은 alias 도 매치."""
+        src = textwrap.dedent(
+            """
+            def fail(self, formatter):
+                self._fmt.error("boom", code="A")
+                formatter.error("boom", code="B")
+            """
+        ).lstrip()
+        (tmp_path / "h.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 2
+        codes = sorted(c.snippet for c in results)
+        # snippet 은 줄 raw — code value 가 포함되어야 한다.
+        assert any('"A"' in s for s in codes)
+        assert any('"B"' in s for s in codes)
+
+    def test_snippet_captures_callsite_line(self, tmp_path: Path) -> None:
+        """snippet 은 callsite 시작 줄의 source line 을 담는다."""
+        src = textwrap.dedent(
+            """
+            # leading comment
+            def fail(fmt):
+                fmt.error("boom", code="LINE_LEVEL")
+            """
+        ).lstrip()
+        (tmp_path / "i.py").write_text(src, encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        c = results[0]
+        assert c.lineno == 3
+        assert "LINE_LEVEL" in c.snippet
+
+    def test_skips_syntax_error_files(self, tmp_path: Path) -> None:
+        """SyntaxError 파일은 helper 가 깨지지 않고 skip 한다."""
+        (tmp_path / "good.py").write_text(
+            'def f(fmt): fmt.error("ok", code="C")\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "broken.py").write_text("def broken(\n", encoding="utf-8")
+
+        results = list(iter_fmt_error_calls(tmp_path))
+        assert len(results) == 1
+        assert results[0].has_code_keyword is True
+
+    def test_missing_root_returns_empty(self, tmp_path: Path) -> None:
+        """존재하지 않는 root 는 빈 iterator."""
+        ghost = tmp_path / "nope"
+        assert list(iter_fmt_error_calls(ghost)) == []
+
+
+# ── module surface ─────────────────────────────────────────────────────────
+
+
+def test_public_surface_importable() -> None:
+    """helper 모듈의 public API 를 한 번에 import 가능."""
+    from tests.unit.contracts import helpers
+
+    expected = {
+        "CliLeafCommand",
+        "ExceptionClassInfo",
+        "FmtErrorCallsite",
+        "iter_click_leaf_commands",
+        "iter_exception_classes",
+        "iter_fmt_error_calls",
+        "iter_ipc_command_specs",
+    }
+    assert expected.issubset(set(helpers.__all__))
+    for name in expected:
+        assert hasattr(helpers, name), name
+
+
+# ── repository-wide sanity ────────────────────────────────────────────────
+
+
+def test_helpers_run_against_repo_without_exact_assert() -> None:
+    """helper 가 repository 전체 sweep 에 대해 깨지지 않는다.
+
+    repository-wide drift count exact assertion 은 #1815/#1816/#1818/#1819
+    후속 epic 의 책임이다. 여기서는 helper 가 실제 repo 에서도 깨지지
+    않고 iterator 가 비어있지 않다는 것만 확인한다.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    src_ante = repo_root / "src" / "ante"
+    cli_root = repo_root / "src" / "ante" / "cli"
+
+    if not src_ante.exists():
+        pytest.skip("src/ante not present in this layout")
+
+    error_classes = list(iter_exception_classes(src_ante))
+    assert error_classes, "expected at least one *Error class under src/ante"
+
+    fmt_calls = list(iter_fmt_error_calls(cli_root))
+    assert fmt_calls, "expected at least one fmt.error callsite under src/ante/cli"
+
+    # path 는 절대 경로로 받아오는지 확인 (#1816 enforcement 가 추적용).
+    for info in error_classes:
+        assert info.path.is_absolute() or info.path.exists()
+    for call in fmt_calls:
+        assert call.path.is_absolute() or call.path.exists()


### PR DESCRIPTION
Closes #1820
Closes #1821
Closes #1822
Closes #1823
Closes #1824

## Summary

Meta-epic #1820 통합 PR. 4 sub-issue를 epic 브랜치에서 차례로 merge한 후 main으로 squash 통합.

### 포함 변경
- **#1822** `feat`: `src/ante/contracts/{__init__,vocab}.py` 신규 — `ContractKind`/`EnvelopeForm`/`AuthMode` Literal SSOT (#1834)
- **#1823** `refactor`: `tests/unit/contracts/{helpers,test_helpers}.py` 신규 — Click leaf / IPC registry / exception / fmt.error iterator skeleton (#1835)
- **#1821** `docs`: `docs/specs/contracts/envelopes.md` 신규 — CLI/IPC envelope 4 normative shape SSOT (#1836)
- **#1824** `docs`: `docs/specs/contracts/README.md` 신규 — vocabulary/envelope/drift-helper/migration-order index + 4-epic cross-reference (#1837)

### Non-Goals (후속 epic 책임)
- #1815 CLI command registry 구현
- #1816 error taxonomy/mapper 구현
- #1818 offline service factory 구현
- #1819 IPC CommandSpec metadata 확장 구현
- 실제 drift enforcement test 추가
- envelope builder helper 강제 도입

후속 epic 착수 순서 (parent #1820 결정): `#1816 → #1819/#1815 → #1818`

## Test Plan
- 4 sub-PR 모두 individually ci pass + Codex 브랜치 리뷰 PASS + auto-merge (각 PR base=epic)
- 최종 `pytest tests/unit/` 5086 passed
- `mypy src/ante` clean
- `ruff check + format --check` clean
- `generate_project_structure.py --check` up to date