### PR TITLE
[codex] docs: raise autopilot issue limit to 25

### DIFF
--- a/.agent/commands/autopilot.md
+++ b/.agent/commands/autopilot.md
@@ -6,7 +6,7 @@
 
 $ARGUMENTS — 옵션 (생략 가능)
 - 없음: 기본 autopilot 큐 (`--limit 10`)
-- `--limit {N}`: 이번 배치에서 처리할 최대 이슈 수 (기본 10, 최대 10)
+- `--limit {N}`: 이번 배치에서 처리할 최대 이슈 수 (기본 10, 최대 25)
 - `--time-budget {예: 4h, 90m}`: 시간 예산이 소진되면 다음 이슈로 넘어가지 않고 종료
 - `--label {라벨}`: 특정 라벨만 대상으로 제한
 - `--handoff-only`: 예외적으로 PR 생성 후 기존 게이트 인계까지만 처리하고 merge/post-merge 확인은 생략
@@ -137,7 +137,7 @@ GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따
 
 - 기본 처리 한도는 `10`개다.
 - `--limit`이 생략되면 `10`으로 간주한다.
-- `--limit`에 `10`보다 큰 값이 들어오면 `10`으로 고정하고, 그 사실을 리포트에 기록한다.
+- `--limit`에 `25`보다 큰 값이 들어오면 `25`로 고정하고, 그 사실을 리포트에 기록한다.
 - 현재 활성 이슈가 merge/post-merge까지 정리되지 않으면, 남은 한도와 무관하게 다음 이슈로 넘어가지 않는다.
 
 ## Plan Preflight 규칙
@@ -195,7 +195,7 @@ done
 - `needs-triage`와 기본 제외 라벨은 **수집 단계에서 server-side search filter로 먼저 제외**한다.
 - snapshot은 100건 단일 조회가 아니라 **pagination으로 끝까지 수집한 전체 open issue 후보 집합**으로 고정한다.
 - 위 전체 snapshot에 대해서만 open PR 존재, 선행 의존 이슈 close 여부, `--label` 좁히기처럼 server-side로 표현하기 어려운 후행 검사를 적용한다.
-- snapshot 후 실제 처리 대상은 정렬 결과 상위 `min(limit, 10)`건으로 자른다.
+- snapshot 후 실제 처리 대상은 정렬 결과 상위 `min(limit, 25)`건으로 자른다.
 - 이번 배치 큐가 1건 이상이면 실행 모드와 관계없이 `docs/temp/autopilot-report-<YYYYMMDD-HHMM>.md` 리포트를 반드시 생성한다.
 - `--dry-run`이면 이 단계 결과를 리포트에 남기고 종료한다.
 

--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -121,7 +121,7 @@ Claude 오케스트레이터
 |--------|------|------|
 | `/plan-preflight` | GitHub 이슈 본문 구현계획 작성/정비 → Codex Plan Review → `plan-preflight:done` 확정 | `.agent/commands/plan-preflight.md` |
 | `/implement-issue` | 이슈 구현 전체 흐름 (분석 → Plan Preflight 확인 → Codex Plan Review → 구현 → Codex 브랜치 리뷰 → PR 생성) | `.agent/commands/implement-issue.md` |
-| `/autopilot` | 오픈 이슈 큐 순차 처리 (선별 → Plan Preflight → `/implement-issue` → merge/post-merge 모니터링, 기본 `limit=10`) | `.agent/commands/autopilot.md` |
+| `/autopilot` | 오픈 이슈 큐 순차 처리 (선별 → Plan Preflight → `/implement-issue` → merge/post-merge 모니터링, 기본 `limit=10`, 최대 `limit=25`) | `.agent/commands/autopilot.md` |
 | `/release` | prepare: release PR 생성 / publish: GitHub Release + PyPI + Docker image 배포 | `.agent/commands/release.md` |
 | `/api-docs` | OpenAPI 스키마 조회 | `.agent/commands/api-docs.md` |
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -25,6 +25,6 @@
 |--------|------|
 | `/plan-preflight` | `superpowers:writing-plans` 원칙으로 이슈 본문 구현계획 작성/정비, Codex Plan Review, `plan-preflight:done` 라벨 확정 |
 | `/implement-issue` | 이슈 구현 전체 흐름 (분석 → Plan Preflight 확인 → Codex Plan Review → 구현 → Codex 브랜치 리뷰 → PR 생성) |
-| `/autopilot` | 오픈 이슈 큐 순차 처리 (필요 시 Plan Preflight 후 `/implement-issue`와 merge/post-merge까지 순차 모니터링, 기본 `limit=10`) |
+| `/autopilot` | 오픈 이슈 큐 순차 처리 (필요 시 Plan Preflight 후 `/implement-issue`와 merge/post-merge까지 순차 모니터링, 기본 `limit=10`, 최대 `limit=25`) |
 | `/release` | prepare로 release PR 생성, publish로 GitHub Release/PyPI/Docker image 배포 |
 | `/api-docs` | OpenAPI 스키마 조회 |


### PR DESCRIPTION
## Summary

- Raise `/autopilot --limit` maximum from 10 to 25 while keeping the default at 10.
- Update the queue truncation rule from `min(limit, 10)` to `min(limit, 25)`.
- Align runbook summaries with the new maximum.

## Validation

- `git diff --check`
- Obsolete-limit grep: no matches for `기본 10, 최대 10`, `10보다 큰`, `min(limit, 10)`, or `최대 10` in the edited docs.
- New-limit grep: confirmed `기본 10, 최대 25`, `25보다 큰`, `min(limit, 25)`, and `최대 limit=25` references.