### PR TITLE
refactor: #1840 ErrorSpec mapper + CLI/IPC error helper (helper-only, no callsite migration)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -286,7 +286,10 @@ src/ante/
 ├── __init__.py
 └── contracts/
     ├── __init__.py
-    └── vocab.py
+    ├── vocab.py
+    ├── error_registry.py
+    ├── errors.py
+    └── helpers.py
 ```
 
 ## tests/ — 테스트
@@ -582,7 +585,8 @@ tests/
 │   └── contracts/
 │       ├── __init__.py
 │       ├── helpers.py
-│       └── test_helpers.py
+│       ├── test_helpers.py
+│       └── test_error_helpers.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/__init__.py
+++ b/src/ante/contracts/__init__.py
@@ -3,8 +3,36 @@
 이 package는 CLI(#1815)/IPC(#1819) 계열 contract surface가
 공유할 vocabulary 등 공통 정의의 SSOT 위치다.
 
-본 패키지 초기 버전(#1822)은 vocabulary 정의(``ante.contracts.vocab``)만
-포함하며, package marker 역할만 한다. alias re-export는 의도적으로 하지
-않는다 -- 소비자는 `from ante.contracts.vocab import ...` 형태로
-명시 import하여, vocabulary 위치가 단일 SSOT로 고정되도록 한다.
+본 패키지에 등록된 SSOT:
+
+- ``ante.contracts.vocab`` — ``ContractKind`` / ``EnvelopeForm`` / ``AuthMode``
+  vocabulary (#1822). alias re-export 없음 — 소비자는 명시 import 한다.
+- ``ante.contracts.errors`` — ``ErrorCategory`` Literal + ``ErrorSpec`` dataclass
+  (#1839/#1840 normative).
+- ``ante.contracts.error_registry`` — 대표 fault lock mapping (#1840).
+  helper-internal — 외부 소비자는 ``error_spec_for_exception`` 을 호출한다.
+- ``ante.contracts.helpers`` — ``error_spec_for_exception`` / ``emit_cli_error`` /
+  ``ipc_error_payload`` CLI·IPC error helper (#1840).
+
+본 ``__init__`` 모듈은 ``error_*`` helper 의 alias re-export 만 수행한다
+(``ErrorSpec`` / ``ErrorCategory`` / 3 helper 함수). vocab module 은 의도적으로
+re-export 하지 않으며, vocabulary 위치가 단일 SSOT 로 고정되도록 ``from
+ante.contracts.vocab import ...`` 명시 import 형태를 유지한다.
 """
+
+from __future__ import annotations
+
+from ante.contracts.errors import ErrorCategory, ErrorSpec
+from ante.contracts.helpers import (
+    emit_cli_error,
+    error_spec_for_exception,
+    ipc_error_payload,
+)
+
+__all__ = [
+    "ErrorCategory",
+    "ErrorSpec",
+    "emit_cli_error",
+    "error_spec_for_exception",
+    "ipc_error_payload",
+]

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -1,0 +1,109 @@
+"""Domain exception → ErrorSpec mapping registry (#1840).
+
+본 모듈은 ``docs/specs/contracts/error-taxonomy.md`` 가 lock 한 **대표 fault
+lock** 4 건을 코드로 mapping 한다. helper
+(``ante.contracts.helpers.error_spec_for_exception``) 는 본 registry 를 MRO
+기반 lookup 하여 exception → ``ErrorSpec`` 을 resolve 한다.
+
+본 PR(#1840) 범위에서 등록되는 lock 4건:
+
+- ``InvalidAccountIdError`` → ``VALIDATION_ERROR`` / ``validation``
+- ``BotNotFoundError`` → ``BOT_NOT_FOUND`` / ``not_found``
+- ``ApprovalNotFoundError`` → ``APPROVAL_NOT_FOUND`` / ``not_found``
+- ``InvalidScopeError`` (member, code=``MEMBER_INVALID_SCOPE``) →
+  ``MEMBER_INVALID_SCOPE`` / ``permission``
+
+추가로 ``SERVICE_NOT_CONFIGURED`` 는 #1819 dispatch wrapper 가 도입할 예정인
+``ServiceNotConfiguredError`` 의 ErrorSpec value 를 module-level constant
+(``_SERVICE_NOT_CONFIGURED_SPEC``) 로 reserved 보존한다. 해당 exception class
+는 본 PR 에서 import 하지 않으며 (#1819 가 도입할 책임), 후속 PR 이 class 를
+추가하면 한 줄 entry 추가로 mapping 을 연결할 수 있다.
+
+본 모듈은 helper-internal 로 취급한다 — ``ante.contracts.__init__`` 에서
+re-export 하지 않으며, 외부 소비자는 ``error_spec_for_exception(exc)`` 를
+호출한다.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from ante.account.errors import InvalidAccountIdError
+from ante.approval.errors import ApprovalNotFoundError
+from ante.bot.exceptions import BotNotFoundError
+from ante.contracts.errors import ErrorSpec
+from ante.member.scopes import InvalidScopeError
+
+__all__ = [
+    "EXCEPTION_TO_SPEC",
+    "EXECUTION_ERROR_SPEC",
+]
+
+
+# ── 대표 lock 4건 (#1839 normative) ──────────────────────────────────────────
+
+_INVALID_ACCOUNT_ID_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="VALIDATION_ERROR",
+    category="validation",
+)
+
+_BOT_NOT_FOUND_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BOT_NOT_FOUND",
+    category="not_found",
+)
+
+_APPROVAL_NOT_FOUND_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="APPROVAL_NOT_FOUND",
+    category="not_found",
+)
+
+_MEMBER_INVALID_SCOPE_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="MEMBER_INVALID_SCOPE",
+    category="permission",
+)
+
+
+# ── reserved entry (#1819 후속 도입) ─────────────────────────────────────────
+#
+# ``SERVICE_NOT_CONFIGURED`` 는 taxonomy SSOT 가 ``service_unavailable`` 카테고리
+# 안정 코드로 lock 한 값이다. 해당 fault를 raise하는 도메인 exception class는
+# #1819 IPC CommandSpec metadata epic 이 ``ServiceNotConfiguredError`` 로 도입할
+# 예정이다. 본 PR 은 ErrorSpec value 만 module-level constant 로 reserved 보존
+# 하며, exception class 는 import 하지 않는다 — 후속 PR 이 class 를 추가하면
+# ``EXCEPTION_TO_SPEC`` 에 한 줄 entry 를 더하는 것으로 연결할 수 있다.
+_SERVICE_NOT_CONFIGURED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="SERVICE_NOT_CONFIGURED",
+    category="service_unavailable",
+)
+
+
+# ── fallback (registry miss + .code 도 없을 때) ──────────────────────────────
+
+EXECUTION_ERROR_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="EXECUTION_ERROR",
+    category="internal",
+)
+"""``error_spec_for_exception`` 의 최후 fallback ErrorSpec.
+
+taxonomy SSOT (#1839) ``EXECUTION_ERROR 허용 범위`` 절이 명시한 두 경우 —
+코드 버그 / unexpected programming error, 또는 외부 라이브러리 미분류 예외 —
+에 적용된다. domain exception 이 ``code`` 미부여로 본 fallback 에 접히는 것은
+taxonomy drift로 분류되며, drift test guard (#1841) 가 별도 책임으로 검출한다.
+"""
+
+
+# ── exception → spec mapping ─────────────────────────────────────────────────
+
+EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
+    InvalidAccountIdError: _INVALID_ACCOUNT_ID_SPEC,
+    BotNotFoundError: _BOT_NOT_FOUND_SPEC,
+    ApprovalNotFoundError: _APPROVAL_NOT_FOUND_SPEC,
+    InvalidScopeError: _MEMBER_INVALID_SCOPE_SPEC,
+}
+"""대표 fault lock registry (#1839 normative 4건).
+
+``error_spec_for_exception(exc)`` 는 ``type(exc).__mro__`` 순서로 본 dict를
+조회하여 첫 매치 ErrorSpec을 반환한다. registry miss 시 helper 는
+``getattr(exc, "code", None)`` 활용 → ``EXECUTION_ERROR`` fallback 순서로
+resolve 한다.
+"""

--- a/src/ante/contracts/errors.py
+++ b/src/ante/contracts/errors.py
@@ -1,0 +1,66 @@
+"""Stable error taxonomy mapper data model (#1840).
+
+이 모듈은 ``docs/specs/contracts/error-taxonomy.md`` 가 normative 로 lock 한
+``ErrorSpec`` shape 의 코드 SSOT 다. CLI (``--format json``) 와 IPC (Unix domain
+socket) 표면이 같은 안정 에러 코드 taxonomy 를 공유하도록 helper
+(``ante.contracts.helpers``) 가 본 모듈의 dataclass 를 소비한다.
+
+본 PR(#1840) 은 helper 모듈만 도입한다 — 기존 ``src/ante/cli/middleware.py``,
+``src/ante/cli/formatter.py``, ``src/ante/cli/commands/*``, ``src/ante/ipc/server.py``
+는 변경하지 않는다. callsite migration 은 후속 PR(#1842/#1843) 책임이다.
+
+본 모듈은 runtime behavior 를 가지지 않는다 — Literal alias + frozen dataclass
+만 제공한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = ["ErrorCategory", "ErrorSpec"]
+
+
+ErrorCategory = Literal[
+    "validation",
+    "auth",
+    "permission",
+    "not_found",
+    "state_conflict",
+    "service_unavailable",
+    "external",
+    "internal",
+]
+"""안정 에러 코드의 분류 vocabulary.
+
+``docs/specs/contracts/error-taxonomy.md`` (#1839 normative) 의 ``Category 의미``
+표가 lock한 8종 분류와 정확히 일치한다. 새 카테고리 도입은 taxonomy SSOT의
+선행 갱신이 필요하다.
+"""
+
+
+@dataclass(frozen=True)
+class ErrorSpec:
+    """안정 에러 코드 한 건의 normative spec (#1839/#1840).
+
+    Attributes:
+        code: SCREAMING_SNAKE_CASE 안정 코드. envelope의 ``code``/``error.code``에
+            그대로 직렬화된다. 도메인 prefix(``ACCOUNT_*``/``BOT_*``/``APPROVAL_*``/
+            ``MEMBER_*`` 등) 또는 공통 코드(``VALIDATION_ERROR``/``EXECUTION_ERROR``/
+            ``SERVICE_NOT_CONFIGURED`` 등)를 사용한다.
+        category: ``ErrorCategory`` 8종 중 하나.
+        exit_code: CLI 종료 코드. 기본 ``1``. click usage exit 2 전면 정렬은
+            taxonomy SSOT 범위 밖(별도 이슈).
+        retryable: reserved. 1.0 시점에서 소비자 미정 — envelope에 직렬화하지
+            않는다. 기본 ``False``.
+        default_message: helper가 사용할 optional fallback 메시지. envelope의
+            ``message`` slot은 호출자가 제공한 도메인 문구를 우선 사용하며,
+            본 fallback은 그 우선순위가 비어 있을 때만 사용된다 (envelope shape
+            변경 없음).
+    """
+
+    code: str
+    category: ErrorCategory
+    exit_code: int = 1
+    retryable: bool = False
+    default_message: str | None = None

--- a/src/ante/contracts/helpers.py
+++ b/src/ante/contracts/helpers.py
@@ -1,0 +1,160 @@
+"""CLI/IPC error helper functions (#1840).
+
+본 모듈은 ``docs/specs/contracts/error-taxonomy.md`` 가 normative 로 lock 한
+``ErrorSpec`` taxonomy 를 CLI direct path 와 IPC path 가 공통으로 사용할 수
+있도록 도입한 helper SSOT 다.
+
+API 3종:
+
+- ``error_spec_for_exception(exc)`` — exception → ``ErrorSpec`` resolver.
+- ``emit_cli_error(fmt, exc, ...)`` — CLI ``OutputFormatter.error`` callsite를
+  taxonomy-정렬된 형태로 호출하는 helper. ``NoReturn`` 으로 click ``Exit`` 를
+  raise 한다.
+- ``ipc_error_payload(exc)`` — IPC server.py:322 envelope ``{code, message}``
+  shape 의 payload helper.
+
+본 PR(#1840) 범위에서는 helper 만 도입한다 — 기존 callsite (CLI middleware /
+formatter / commands, IPC server.py) 는 변경하지 않는다. callsite migration
+은 후속 PR(#1842/#1843) 책임이다.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, NoReturn
+
+import click
+
+from ante.contracts.error_registry import EXCEPTION_TO_SPEC, EXECUTION_ERROR_SPEC
+from ante.contracts.errors import ErrorSpec
+
+if TYPE_CHECKING:
+    from ante.cli.formatter import OutputFormatter
+
+__all__ = [
+    "emit_cli_error",
+    "error_spec_for_exception",
+    "ipc_error_payload",
+]
+
+
+# ``code`` 속성이 SCREAMING_SNAKE 규약을 만족하는지 확인하는 패턴.
+# taxonomy SSOT (#1839) 의 명명 규칙 (SCREAMING_SNAKE_CASE only) 과 정렬.
+_SCREAMING_SNAKE_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+def error_spec_for_exception(exc: BaseException) -> ErrorSpec:
+    """Exception 인스턴스를 ``ErrorSpec`` 으로 resolve.
+
+    resolver 우선순위(plan #1840 — Codex Plan Review v2 흡수):
+
+    1. ``EXCEPTION_TO_SPEC`` registry 의 MRO lookup — ``type(exc).__mro__`` 를
+       따라 첫 매치를 반환한다 (subclass 도 base class registry entry로 매칭).
+    2. ``getattr(exc, "code", None)`` 이 SCREAMING_SNAKE_CASE 규약을 만족하면
+       해당 코드를 ``category="internal"`` 으로 보수적 ErrorSpec 으로 wrap한다.
+       기존 typed exception (예: ``AccountNotFoundError.code =
+       "ACCOUNT_NOT_FOUND"``) 가 본 fallback 으로 IPC envelope 의 안정 코드를
+       유지한다.
+    3. 위 둘 다 매치되지 않으면 ``EXECUTION_ERROR_SPEC`` (internal fallback).
+
+    Args:
+        exc: 분류할 exception 인스턴스.
+
+    Returns:
+        ``ErrorSpec`` — code/category 가 채워진 frozen dataclass.
+    """
+
+    # (1) Registry MRO lookup.
+    for klass in type(exc).__mro__:
+        spec = EXCEPTION_TO_SPEC.get(klass)
+        if spec is not None:
+            return spec
+
+    # (2) ``.code`` 속성 fallback (SCREAMING_SNAKE 규약 만족 시).
+    code_attr = getattr(exc, "code", None)
+    if isinstance(code_attr, str) and _SCREAMING_SNAKE_RE.match(code_attr):
+        return ErrorSpec(code=code_attr, category="internal")
+
+    # (3) 최후 fallback.
+    return EXECUTION_ERROR_SPEC
+
+
+def _resolve_message(
+    exc: BaseException,
+    spec: ErrorSpec,
+    *,
+    fallback_message: str | None,
+) -> str:
+    """``emit_cli_error`` / ``ipc_error_payload`` 가 공유하는 message resolution.
+
+    우선순위(plan #1840 Codex Plan Review v2 normative):
+
+    1. ``fallback_message`` 인자 (호출자가 명시 제공한 도메인 문구).
+    2. ``str(exc)`` (비어있지 않을 때).
+    3. ``spec.default_message`` (helper-internal fallback, optional).
+    4. 셋 다 없으면 빈 문자열 (envelope shape 호환 — ``message: ""``).
+    """
+
+    if fallback_message:
+        return fallback_message
+    exc_text = str(exc)
+    if exc_text:
+        return exc_text
+    if spec.default_message:
+        return spec.default_message
+    return ""
+
+
+def emit_cli_error(
+    fmt: OutputFormatter,
+    exc: BaseException,
+    *,
+    fallback_message: str | None = None,
+) -> NoReturn:
+    """``ErrorSpec`` 기반 CLI error envelope 출력 + click ``Exit`` raise.
+
+    호출자는 본 helper 를 CLI direct path 의 ``except`` 블록에서 사용해
+    taxonomy-정렬된 ``code`` 를 ``OutputFormatter.error`` 로 surface 한다.
+
+    동작:
+
+    - ``error_spec_for_exception(exc)`` 로 ``ErrorSpec`` 을 resolve.
+    - ``OutputFormatter.error(message, code=spec.code)`` 호출 — ``src/ante/cli/
+      formatter.py`` 의 ``error(message, code="")`` 시그니처와 정렬.
+    - ``click.exceptions.Exit(spec.exit_code)`` 를 raise — ``NoReturn``.
+
+    Args:
+        fmt: ``OutputFormatter`` 인스턴스 (CLI ctx 의 ``ctx.obj["formatter"]``).
+        exc: surface 할 exception.
+        fallback_message: 호출자가 명시 제공할 도메인 문구. ``None`` 이면
+            ``str(exc)`` → ``spec.default_message`` 순서로 fallback.
+
+    Raises:
+        click.exceptions.Exit: 항상 ``spec.exit_code`` (기본 1) 로 click
+            이 exit 하게 한다.
+    """
+
+    spec = error_spec_for_exception(exc)
+    message = _resolve_message(exc, spec, fallback_message=fallback_message)
+    fmt.error(message, code=spec.code)
+    raise click.exceptions.Exit(spec.exit_code)
+
+
+def ipc_error_payload(exc: BaseException) -> dict[str, str]:
+    """``{"code", "message"}`` IPC error payload helper.
+
+    IPC server.py:322 의 ``getattr(e, "code", "EXECUTION_ERROR")`` 패턴 대응
+    helper. 본 PR(#1840) 은 server.py callsite 를 변경하지 않으며, 본 helper 는
+    후속 #1842/#1843 callsite migration 에서 사용된다.
+
+    Args:
+        exc: 직렬화할 exception.
+
+    Returns:
+        ``{"code": <ErrorSpec.code>, "message": <resolved message>}``. 양쪽
+        모두 str 이다 — envelope shape (envelopes.md #1821) 와 정렬.
+    """
+
+    spec = error_spec_for_exception(exc)
+    message = _resolve_message(exc, spec, fallback_message=None)
+    return {"code": spec.code, "message": message}

--- a/tests/unit/contracts/test_error_helpers.py
+++ b/tests/unit/contracts/test_error_helpers.py
@@ -1,0 +1,358 @@
+"""``ante.contracts`` error helper unit tests (#1840).
+
+본 테스트 모듈은 helper 자체 동작만 검증한다. repository-wide drift assertion
+(예: 모든 ``*Error`` class 가 ``EXCEPTION_TO_SPEC`` 에 등록되어야 한다는
+검증) 은 의도적으로 추가하지 않는다 — drift test guard 는 #1841 책임이며
+본 PR 범위 밖이다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import click
+import pytest
+
+from ante.account.errors import InvalidAccountIdError
+from ante.approval.errors import ApprovalNotFoundError
+from ante.bot.exceptions import BotNotFoundError
+from ante.cli.formatter import OutputFormatter
+from ante.contracts import (
+    ErrorCategory,
+    ErrorSpec,
+    emit_cli_error,
+    error_spec_for_exception,
+    ipc_error_payload,
+)
+from ante.contracts.error_registry import EXCEPTION_TO_SPEC, EXECUTION_ERROR_SPEC
+from ante.member.scopes import InvalidScopeError
+
+# ── ErrorSpec dataclass shape ─────────────────────────────────────────────────
+
+
+class TestErrorSpecShape:
+    """``ErrorSpec`` dataclass 의 frozen + 기본값 shape."""
+
+    def test_construct_with_minimum_fields(self) -> None:
+        """``code`` + ``category`` 만으로 생성 가능 (나머지 default)."""
+        spec = ErrorSpec(code="FOO", category="internal")
+        assert spec.code == "FOO"
+        assert spec.category == "internal"
+        assert spec.exit_code == 1
+        assert spec.retryable is False
+        assert spec.default_message is None
+
+    def test_construct_with_all_fields(self) -> None:
+        spec = ErrorSpec(
+            code="BAR",
+            category="validation",
+            exit_code=2,
+            retryable=True,
+            default_message="hello",
+        )
+        assert spec.code == "BAR"
+        assert spec.category == "validation"
+        assert spec.exit_code == 2
+        assert spec.retryable is True
+        assert spec.default_message == "hello"
+
+    def test_is_frozen(self) -> None:
+        """frozen dataclass — 필드 재할당이 거부된다."""
+        from dataclasses import FrozenInstanceError
+
+        spec = ErrorSpec(code="FOO", category="internal")
+        with pytest.raises(FrozenInstanceError):
+            spec.code = "BAR"  # type: ignore[misc]
+
+
+# ── error_spec_for_exception ─────────────────────────────────────────────────
+
+
+class TestErrorSpecForException:
+    """대표 lock 4건 + .code fallback + EXECUTION_ERROR fallback resolver."""
+
+    def test_invalid_account_id_resolves_validation_error(self) -> None:
+        spec = error_spec_for_exception(InvalidAccountIdError("bad id"))
+        assert spec.code == "VALIDATION_ERROR"
+        assert spec.category == "validation"
+
+    def test_bot_not_found_resolves_typed_code(self) -> None:
+        spec = error_spec_for_exception(BotNotFoundError("bot-xyz"))
+        assert spec.code == "BOT_NOT_FOUND"
+        assert spec.category == "not_found"
+
+    def test_approval_not_found_resolves_typed_code(self) -> None:
+        spec = error_spec_for_exception(ApprovalNotFoundError("appr-1"))
+        assert spec.code == "APPROVAL_NOT_FOUND"
+        assert spec.category == "not_found"
+
+    def test_member_invalid_scope_resolves_permission(self) -> None:
+        spec = error_spec_for_exception(InvalidScopeError("oracle:bad"))
+        assert spec.code == "MEMBER_INVALID_SCOPE"
+        assert spec.category == "permission"
+
+    def test_unknown_exception_returns_execution_error_internal(self) -> None:
+        """registry miss + ``.code`` 없음 → ``EXECUTION_ERROR`` fallback."""
+
+        class _RandomError(Exception):
+            pass
+
+        spec = error_spec_for_exception(_RandomError("boom"))
+        assert spec.code == "EXECUTION_ERROR"
+        assert spec.category == "internal"
+        # ``EXECUTION_ERROR_SPEC`` constant 와 동일 객체.
+        assert spec is EXECUTION_ERROR_SPEC
+
+    def test_typed_exception_with_code_attribute_uses_typed_code(self) -> None:
+        """registry miss 지만 ``.code`` SCREAMING_SNAKE 속성이 있으면 사용."""
+
+        class _TypedError(Exception):
+            code: str = "X_FOO"
+
+        spec = error_spec_for_exception(_TypedError("typed boom"))
+        assert spec.code == "X_FOO"
+        assert spec.category == "internal"  # 보수적 default
+
+    def test_typed_exception_with_lowercase_code_falls_back_to_execution(
+        self,
+    ) -> None:
+        """``.code`` 가 SCREAMING_SNAKE 규약 미준수면 fallback."""
+
+        class _BadCodeError(Exception):
+            code: str = "lowercase_code"
+
+        spec = error_spec_for_exception(_BadCodeError("bad code"))
+        assert spec.code == "EXECUTION_ERROR"
+
+    def test_typed_exception_with_non_string_code_falls_back(self) -> None:
+        """``.code`` 가 str 이 아니면 fallback (방어적)."""
+
+        class _IntCodeError(Exception):
+            code = 42  # type: ignore[var-annotated]
+
+        spec = error_spec_for_exception(_IntCodeError("int code"))
+        assert spec.code == "EXECUTION_ERROR"
+
+    def test_subclass_resolves_via_mro(self) -> None:
+        """registry 에 등록된 base class subclass 도 MRO 매칭으로 resolve."""
+
+        class _CustomBotError(BotNotFoundError):
+            pass
+
+        spec = error_spec_for_exception(_CustomBotError("child"))
+        assert spec.code == "BOT_NOT_FOUND"
+
+    def test_account_not_found_uses_class_code_attribute_fallback(self) -> None:
+        """대표 lock 에 등록되지 않은 ``AccountNotFoundError`` (``.code`` 보유)
+        는 (2) 단계 ``.code`` fallback 으로 typed code 를 surface 한다.
+
+        이는 본 PR 범위인 4건 lock 외 기존 typed exception 의 IPC envelope
+        ``getattr(e, "code", "EXECUTION_ERROR")`` 패턴과 동등한 동작이다.
+        """
+        from ante.account.errors import AccountNotFoundError
+
+        spec = error_spec_for_exception(AccountNotFoundError("missing"))
+        assert spec.code == "ACCOUNT_NOT_FOUND"
+
+
+# ── ipc_error_payload ────────────────────────────────────────────────────────
+
+
+class TestIpcErrorPayload:
+    """IPC envelope ``{code, message}`` shape."""
+
+    def test_matches_shape(self) -> None:
+        payload = ipc_error_payload(BotNotFoundError("bot-xyz"))
+        assert set(payload.keys()) == {"code", "message"}
+        assert payload["code"] == "BOT_NOT_FOUND"
+        # ``BotNotFoundError`` 가 ``__init__`` 에서 만든 문구를 surface.
+        assert "bot-xyz" in payload["message"]
+
+    def test_unknown_exception_yields_execution_error_message(self) -> None:
+        payload = ipc_error_payload(RuntimeError("kaboom"))
+        assert payload["code"] == "EXECUTION_ERROR"
+        assert payload["message"] == "kaboom"
+
+    def test_empty_exception_message_uses_default(self) -> None:
+        """``str(exc)`` 가 비어있으면 ``spec.default_message`` 로 fallback.
+
+        대표 lock 4건은 모두 ``default_message`` 가 ``None`` 이므로 빈 문자열이
+        된다 — envelope shape 호환 (``message: ""``).
+        """
+
+        class _BareError(Exception):
+            pass
+
+        payload = ipc_error_payload(_BareError())
+        assert payload["code"] == "EXECUTION_ERROR"
+        assert payload["message"] == ""
+
+    def test_payload_is_json_serializable(self) -> None:
+        """envelope 직렬화 호환 확인 (CLI/IPC 양쪽 모두 JSON 직렬화)."""
+        payload = ipc_error_payload(InvalidAccountIdError("bad"))
+        serialized = json.dumps(payload)
+        decoded = json.loads(serialized)
+        assert decoded == payload
+
+
+# ── emit_cli_error ───────────────────────────────────────────────────────────
+
+
+class TestEmitCliError:
+    """``OutputFormatter`` 호출 + click ``Exit`` raise 동작."""
+
+    def test_calls_fmt_error_with_spec_code(self) -> None:
+        """대표 lock 에 대해 ``fmt.error(message, code=spec.code)`` 호출."""
+        mock_fmt = MagicMock(spec=OutputFormatter)
+        exc = BotNotFoundError("bot-1")
+
+        with pytest.raises(click.exceptions.Exit) as exit_info:
+            emit_cli_error(mock_fmt, exc)
+
+        assert exit_info.value.exit_code == 1
+        mock_fmt.error.assert_called_once()
+        args, kwargs = mock_fmt.error.call_args
+        # 첫 positional 은 message (str(exc)).
+        assert args == ("Bot not found: bot-1",)
+        assert kwargs == {"code": "BOT_NOT_FOUND"}
+
+    def test_message_priority_fallback_overrides_str_exc(self) -> None:
+        """``fallback_message`` 인자가 ``str(exc)`` 보다 우선."""
+        mock_fmt = MagicMock(spec=OutputFormatter)
+        exc = BotNotFoundError("bot-1")  # str(exc) == "Bot not found: bot-1"
+
+        with pytest.raises(click.exceptions.Exit):
+            emit_cli_error(mock_fmt, exc, fallback_message="explicit override")
+
+        args, _ = mock_fmt.error.call_args
+        assert args == ("explicit override",)
+
+    def test_message_priority_str_exc_used_when_no_fallback(self) -> None:
+        """``fallback_message`` 가 ``None`` 이면 ``str(exc)`` 가 두 번째 우선순위."""
+        mock_fmt = MagicMock(spec=OutputFormatter)
+        exc = BotNotFoundError("bot-2")
+
+        with pytest.raises(click.exceptions.Exit):
+            emit_cli_error(mock_fmt, exc, fallback_message=None)
+
+        args, _ = mock_fmt.error.call_args
+        assert args == ("Bot not found: bot-2",)
+
+    def test_message_priority_default_message_used_when_exc_empty(self) -> None:
+        """``str(exc)`` 가 비어있으면 ``spec.default_message`` 가 세 번째 우선순위."""
+        # default_message 가 있는 ErrorSpec 을 직접 lookup 하도록
+        # custom exception 을 만들고 임시 registry 에 등록한다.
+
+        class _SilentError(Exception):
+            pass
+
+        spec_with_default = ErrorSpec(
+            code="SILENT_X",
+            category="internal",
+            default_message="fell back to default",
+        )
+        EXCEPTION_TO_SPEC[_SilentError] = spec_with_default
+        try:
+            mock_fmt = MagicMock(spec=OutputFormatter)
+            with pytest.raises(click.exceptions.Exit):
+                emit_cli_error(mock_fmt, _SilentError())  # str(exc) == ""
+
+            args, kwargs = mock_fmt.error.call_args
+            assert args == ("fell back to default",)
+            assert kwargs == {"code": "SILENT_X"}
+        finally:
+            EXCEPTION_TO_SPEC.pop(_SilentError, None)
+
+    def test_message_falls_back_to_empty_string_when_nothing_resolves(
+        self,
+    ) -> None:
+        """``fallback_message`` None + ``str(exc)`` empty + ``default_message``
+        None 이면 빈 문자열을 ``fmt.error`` 에 넘긴다 (envelope shape 호환)."""
+
+        class _BareError(Exception):
+            pass
+
+        mock_fmt = MagicMock(spec=OutputFormatter)
+        with pytest.raises(click.exceptions.Exit):
+            emit_cli_error(mock_fmt, _BareError())
+
+        args, kwargs = mock_fmt.error.call_args
+        assert args == ("",)
+        assert kwargs == {"code": "EXECUTION_ERROR"}
+
+    def test_exit_code_from_spec(self) -> None:
+        """``ErrorSpec.exit_code`` 가 ``Exit`` 종료 코드로 전달된다."""
+
+        class _CustomExitError(Exception):
+            pass
+
+        custom_spec = ErrorSpec(code="X_CUSTOM_EXIT", category="internal", exit_code=42)
+        EXCEPTION_TO_SPEC[_CustomExitError] = custom_spec
+        try:
+            mock_fmt = MagicMock(spec=OutputFormatter)
+            with pytest.raises(click.exceptions.Exit) as exit_info:
+                emit_cli_error(mock_fmt, _CustomExitError("boom"))
+            assert exit_info.value.exit_code == 42
+        finally:
+            EXCEPTION_TO_SPEC.pop(_CustomExitError, None)
+
+    def test_integrates_with_real_output_formatter_json_mode(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """실제 ``OutputFormatter(json)`` 와 통합 — envelope shape 확인."""
+        fmt = OutputFormatter("json")
+        with pytest.raises(click.exceptions.Exit):
+            emit_cli_error(fmt, InvalidAccountIdError("bad-id"))
+
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out)
+        # envelope shape SSOT (envelopes.md #1821) — ``status``/``code``/
+        # ``message`` 3-key shape.
+        assert envelope["status"] == "error"
+        assert envelope["code"] == "VALIDATION_ERROR"
+        assert envelope["message"] == "bad-id"
+
+
+# ── ErrorCategory Literal sanity ──────────────────────────────────────────────
+
+
+def test_error_category_literal_covers_taxonomy_eight_values() -> None:
+    """``ErrorCategory`` 가 taxonomy SSOT 의 8 카테고리를 정확히 enumerate.
+
+    drift 가 발생하면 본 테스트가 즉시 깨진다 — taxonomy SSOT 갱신과 함께
+    본 테스트의 expected set 도 갱신되어야 한다.
+    """
+    from typing import get_args
+
+    expected = {
+        "validation",
+        "auth",
+        "permission",
+        "not_found",
+        "state_conflict",
+        "service_unavailable",
+        "external",
+        "internal",
+    }
+    assert set(get_args(ErrorCategory)) == expected
+
+
+# ── module public surface ─────────────────────────────────────────────────────
+
+
+def test_public_surface_importable() -> None:
+    """``ante.contracts`` 모듈의 public API alias re-export."""
+    from ante import contracts
+
+    expected = {
+        "ErrorCategory",
+        "ErrorSpec",
+        "emit_cli_error",
+        "error_spec_for_exception",
+        "ipc_error_payload",
+    }
+    assert expected.issubset(set(contracts.__all__))
+    for name in expected:
+        assert hasattr(contracts, name), name


### PR DESCRIPTION
Closes #1840

## Summary

- `src/ante/contracts/errors.py` 신규 — `ErrorCategory` Literal(8값) + `@dataclass(frozen=True) ErrorSpec(code, category, exit_code=1, retryable=False, default_message=None)`. #1839 normative shape 과 정확히 정렬.
- `src/ante/contracts/error_registry.py` 신규 — `EXCEPTION_TO_SPEC` registry (대표 fault lock 4건) + `EXECUTION_ERROR_SPEC` fallback. `SERVICE_NOT_CONFIGURED` 는 module-level constant 로 reserved 보존 (해당 exception class 는 #1819 가 도입할 예정이므로 import 하지 않음).
- `src/ante/contracts/helpers.py` 신규 — `error_spec_for_exception(exc)`, `emit_cli_error(fmt, exc, *, fallback_message=None)`, `ipc_error_payload(exc)` 3종 helper.
- `src/ante/contracts/__init__.py` — 공개 API alias re-export (`ErrorSpec` / `ErrorCategory` / 3 helper).
- `tests/unit/contracts/test_error_helpers.py` 신규 — 26 R-case.
- `docs/architecture/generated/project-structure.md` — 신규 모듈 4개 반영.

## Helper API

| Helper | Signature | Notes |
|---|---|---|
| `error_spec_for_exception(exc)` | `(BaseException) -> ErrorSpec` | (1) registry MRO lookup → (2) `.code` SCREAMING_SNAKE fallback (`category="internal"`) → (3) `EXECUTION_ERROR_SPEC`. |
| `emit_cli_error(fmt, exc, *, fallback_message=None)` | `(OutputFormatter, BaseException, *, str \| None) -> NoReturn` | `fmt.error(message, code=spec.code)` 호출 + `click.exceptions.Exit(spec.exit_code)` raise. message 우선순위: `fallback_message → str(exc) → spec.default_message → ""`. |
| `ipc_error_payload(exc)` | `(BaseException) -> {"code": str, "message": str}` | IPC server.py:322 envelope 대응 shape. |

## Registry

| Exception | Public code | Category |
|---|---|---|
| `InvalidAccountIdError` (account) | `VALIDATION_ERROR` | `validation` |
| `BotNotFoundError` (bot) | `BOT_NOT_FOUND` | `not_found` |
| `ApprovalNotFoundError` (approval) | `APPROVAL_NOT_FOUND` | `not_found` |
| `InvalidScopeError` (member, `code="MEMBER_INVALID_SCOPE"`) | `MEMBER_INVALID_SCOPE` | `permission` |
| `SERVICE_NOT_CONFIGURED` (#1819 reserved) | `SERVICE_NOT_CONFIGURED` | `service_unavailable` — module-level constant 만 보존, exception class 미 import |

## Non-Goals (별도 후속 PR)

- 기존 CLI middleware / CLI formatter / CLI command callsite migration → #1842 / #1843.
- IPC `server.py:322` envelope 정렬 → #1842 / #1843.
- exception class 대량 재작성 → #1842 / #1843.
- drift test guard (`fmt.error` code 누락 등) → #1841.
- error message 문구 표준화.

기존 production 코드 경로는 변경하지 않으며 helper 모듈만 추가한다.

## Test plan

- [x] `python -c "from ante.contracts import ErrorSpec, ErrorCategory, error_spec_for_exception, emit_cli_error, ipc_error_payload"` smoke OK
- [x] `pytest tests/unit/contracts/test_error_helpers.py -v` — 26 passed
- [x] `pytest tests/unit/` — 5112 passed, 2 skipped (회귀 없음)
- [x] `mypy src/ante` — Success: no issues found in 222 source files
- [x] `ruff check + format --check src/ante/contracts tests/unit/contracts` — clean
- [x] `python scripts/generate_project_structure.py` — 신규 모듈 반영 diff 적용

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>