### PR TITLE
test: #1841 error taxonomy drift guard + fmt.error code missing allowlist (3 families)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-05-25 (KST)
+> 마지막 생성 시점: 2026-05-26 (KST)
 
 ## 최상위 구조
 
@@ -586,7 +586,10 @@ tests/
 │       ├── __init__.py
 │       ├── helpers.py
 │       ├── test_helpers.py
-│       └── test_error_helpers.py
+│       ├── test_error_helpers.py
+│       ├── error_drift_allowlist.yaml
+│       ├── test_auth_middleware_code_policy.py
+│       └── test_error_drift.py
 └── __init__.py
 ```
 

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -1,0 +1,280 @@
+# Error taxonomy drift allowlist (#1841)
+#
+# 본 파일은 fmt.error code 누락 callsite (Family A) 와 ErrorSpec 등록되지
+# 않은 domain exception class (Family B) 의 baseline 을 구조화 보관한다.
+# 신규/수정 drift 는 enforcement test (`test_error_drift.py`) 가 차단하며,
+# 본 파일에 entry 가 등록된 callsite/class 만 baseline 으로 면제된다.
+#
+# 3 section:
+#
+#   intended_no_code
+#     code 인자를 영구적으로 갖지 않는 의도된 callsite.
+#     예: click usage exit 처럼 envelope 변환 책임이 다른 layer 에 있음.
+#
+#   known_drift_fmt_error_no_code
+#     baseline 시점에 code 가 부여되지 않은 fmt.error callsite.
+#     #1843 이 단계적으로 제거한다.
+#
+#   pending_migration
+#     baseline 시점에 class-level code 도 없고 EXCEPTION_TO_SPEC 등록도
+#     안 된 *Error class. #1842/#1843 이 단계적으로 등록한다.
+#
+# Anchor 정책 (#1841 plan):
+#   - fmt entry: (path, line, snippet_sha1) 3중 anchor.
+#       snippet_sha1 = SHA-1(snippet)[:12]. snippet 가 바뀌면 anchor 갱신
+#       필요. line 만 재사용되는 false negative 차단.
+#   - exception entry: (module, class_anchor) 2중 anchor.
+#       module = dotted module path (예: ante.account.errors).
+#       class_anchor = class 이름.
+
+intended_no_code: []
+
+known_drift_fmt_error_no_code:
+  - path: src/ante/cli/commands/account.py
+    line: 762
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/account.py
+    line: 804
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/bot.py
+    line: 384
+    snippet_sha1: "826b5811c10c"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/bot.py
+    line: 499
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/bot.py
+    line: 872
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/bot.py
+    line: 908
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/bot.py
+    line: 942
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/broker.py
+    line: 211
+    snippet_sha1: "f65e1080d3f2"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/broker.py
+    line: 266
+    snippet_sha1: "f65e1080d3f2"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/broker.py
+    line: 318
+    snippet_sha1: "f65e1080d3f2"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/config.py
+    line: 176
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/config.py
+    line: 179
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 514
+    snippet_sha1: "5d87cae098dd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 531
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 570
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 627
+    snippet_sha1: "5d87cae098dd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 633
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 663
+    snippet_sha1: "5d87cae098dd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 678
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 705
+    snippet_sha1: "5d87cae098dd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 720
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 765
+    snippet_sha1: "5d87cae098dd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 773
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 800
+    snippet_sha1: "5d87cae098dd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 808
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 878
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/member.py
+    line: 941
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/strategy.py
+    line: 149
+    snippet_sha1: "439fab766435"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/strategy.py
+    line: 173
+    snippet_sha1: "653a1306dd44"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/strategy.py
+    line: 258
+    snippet_sha1: "f65e1080d3f2"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/update.py
+    line: 135
+    snippet_sha1: "988007ecd452"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/update.py
+    line: 196
+    snippet_sha1: "e6c835b3f5c4"
+    reason: "baseline (#1841); migrate in #1843"
+  - path: src/ante/cli/commands/update.py
+    line: 256
+    snippet_sha1: "0aa58cc91ade"
+    reason: "baseline (#1841); migrate in #1843"
+
+pending_migration:
+  - module: ante.account.errors
+    class_anchor: AccountError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.approval.errors
+    class_anchor: ApprovalError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.approval.models
+    class_anchor: ApprovalValidationError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.backtest.exceptions
+    class_anchor: BacktestConfigError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.backtest.exceptions
+    class_anchor: BacktestDataError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.backtest.exceptions
+    class_anchor: BacktestError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.bot.exceptions
+    class_anchor: BotError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.broker.exceptions
+    class_anchor: APIError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.broker.exceptions
+    class_anchor: AuthenticationError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.broker.exceptions
+    class_anchor: BrokerError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.broker.exceptions
+    class_anchor: CircuitOpenError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.broker.exceptions
+    class_anchor: OrderNotFoundError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.broker.exceptions
+    class_anchor: RateLimitError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.broker.registry
+    class_anchor: InvalidBrokerTypeError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.config.exceptions
+    class_anchor: ConfigError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.feed.sources.dart
+    class_anchor: CriticalApiError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.feed.sources.dart
+    class_anchor: DARTError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.feed.sources.dart
+    class_anchor: DailyLimitExceededError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.feed.sources.data_go_kr
+    class_anchor: CriticalApiError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.feed.sources.data_go_kr
+    class_anchor: DailyLimitExceededError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.feed.sources.data_go_kr
+    class_anchor: DataGoKrError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.ipc.exceptions
+    class_anchor: IPCError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.ipc.exceptions
+    class_anchor: IPCTimeoutError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.ipc.exceptions
+    class_anchor: MessageTooLargeError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.ipc.exceptions
+    class_anchor: ServerNotRunningError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.member.errors
+    class_anchor: MemberError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.member.errors
+    class_anchor: PermissionDeniedError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.rule.exceptions
+    class_anchor: RuleConfigError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.rule.exceptions
+    class_anchor: RuleError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.strategy.exceptions
+    class_anchor: IncompatibleExchangeError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.strategy.exceptions
+    class_anchor: StrategyError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.strategy.exceptions
+    class_anchor: StrategyFileAccessError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.strategy.exceptions
+    class_anchor: StrategyLoadError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.strategy.exceptions
+    class_anchor: StrategyValidationError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.treasury.exceptions
+    class_anchor: BotNotStoppedError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.treasury.exceptions
+    class_anchor: InsufficientFundsError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.treasury.exceptions
+    class_anchor: TreasuryError
+    reason: "baseline (#1841); register in #1842/#1843"
+  - module: ante.treasury.exceptions
+    class_anchor: TreasuryNotConfiguredError
+    reason: "baseline (#1841); register in #1842/#1843"

--- a/tests/unit/contracts/helpers.py
+++ b/tests/unit/contracts/helpers.py
@@ -25,6 +25,13 @@ Helper 분류 (Refs #1820 결정 / #1823 plan):
     ``fmt.error(...)`` callsite 와 code argument classification 정보를
     yield 한다.
 
+* **YAML 기반** — error taxonomy drift allowlist (#1841) 는 baseline
+  callsite/class 를 구조화 보관한다.
+
+  - :func:`load_drift_allowlist` — ``error_drift_allowlist.yaml`` 을
+    파싱해 3 section (`intended_no_code`, `known_drift_fmt_error_no_code`,
+    `pending_migration`) 의 :class:`DriftAllowlist` 를 반환한다.
+
 본 helper 는 default repository root 를 알지 못한다. 호출자가 :class:`Path`
 를 명시한다 (default 는 cwd 기준 ``Path("src/ante")``). 후속 enforcement
 test 가 repository root 를 고정하는 책임을 진다.
@@ -34,11 +41,12 @@ from __future__ import annotations
 
 import ast
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import click
+import yaml
 
 if TYPE_CHECKING:
     from ante.ipc.registry import CommandRegistry, CommandSpec
@@ -434,15 +442,124 @@ def iter_fmt_error_calls(
             )
 
 
+# ── YAML allowlist loader (#1841) ─────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class FmtErrorAllowlistEntry:
+    """``fmt.error`` code 누락 callsite allowlist entry.
+
+    Attributes:
+        path: callsite 파일 경로 (repo root 기준 상대 경로 문자열).
+        line: callsite 줄 (1-based).
+        snippet_sha1: ``FmtErrorCallsite.snippet`` 의 SHA-1 12-char prefix.
+        reason: baseline 등록 사유.
+    """
+
+    path: str
+    line: int
+    snippet_sha1: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ExceptionAllowlistEntry:
+    """``*Error`` class code/registry 미부여 allowlist entry.
+
+    Attributes:
+        module: dotted module path (예: ``ante.account.errors``).
+        class_anchor: class 이름 (예: ``AccountError``).
+        reason: baseline 등록 사유.
+    """
+
+    module: str
+    class_anchor: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class DriftAllowlist:
+    """3 section 으로 분리된 error taxonomy drift allowlist.
+
+    Attributes:
+        intended_no_code: code 인자를 영구적으로 갖지 않는 의도된 callsite.
+        known_drift_fmt_error_no_code: baseline 시점에 code 가 부여되지
+            않은 fmt.error callsite. #1843 이 단계적으로 제거.
+        pending_migration: baseline 시점에 class-level code 도 없고
+            ``EXCEPTION_TO_SPEC`` 등록도 안 된 ``*Error`` class.
+            #1842/#1843 이 단계적으로 등록.
+    """
+
+    intended_no_code: tuple[FmtErrorAllowlistEntry, ...] = field(default_factory=tuple)
+    known_drift_fmt_error_no_code: tuple[FmtErrorAllowlistEntry, ...] = field(
+        default_factory=tuple
+    )
+    pending_migration: tuple[ExceptionAllowlistEntry, ...] = field(
+        default_factory=tuple,
+    )
+
+
+def _default_allowlist_path() -> Path:
+    """default YAML 위치 (본 helper 와 동일 디렉토리)."""
+    return Path(__file__).parent / "error_drift_allowlist.yaml"
+
+
+def load_drift_allowlist(path: Path | None = None) -> DriftAllowlist:
+    """``error_drift_allowlist.yaml`` 을 파싱해 :class:`DriftAllowlist` 반환.
+
+    Args:
+        path: 로드할 YAML 경로. ``None`` 이면 helper 와 동일 디렉토리의
+            ``error_drift_allowlist.yaml`` 사용. 후속 enforcement test 가
+            fixture YAML 을 주입할 수 있다.
+
+    Returns:
+        :class:`DriftAllowlist`: 3 section 의 frozen dataclass tuple.
+    """
+    yaml_path = path if path is not None else _default_allowlist_path()
+    data = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+
+    def _fmt_entries(key: str) -> tuple[FmtErrorAllowlistEntry, ...]:
+        raw = data.get(key) or []
+        return tuple(
+            FmtErrorAllowlistEntry(
+                path=str(item["path"]),
+                line=int(item["line"]),
+                snippet_sha1=str(item["snippet_sha1"]),
+                reason=str(item.get("reason", "")),
+            )
+            for item in raw
+        )
+
+    raw_exc = data.get("pending_migration") or []
+    exc_entries = tuple(
+        ExceptionAllowlistEntry(
+            module=str(item["module"]),
+            class_anchor=str(item["class_anchor"]),
+            reason=str(item.get("reason", "")),
+        )
+        for item in raw_exc
+    )
+
+    return DriftAllowlist(
+        intended_no_code=_fmt_entries("intended_no_code"),
+        known_drift_fmt_error_no_code=_fmt_entries("known_drift_fmt_error_no_code"),
+        pending_migration=exc_entries,
+    )
+
+
 # ── public surface ────────────────────────────────────────────────────────
 
 
 __all__ = [
     "CliLeafCommand",
+    "DriftAllowlist",
+    "ExceptionAllowlistEntry",
     "ExceptionClassInfo",
+    "FmtErrorAllowlistEntry",
     "FmtErrorCallsite",
     "iter_click_leaf_commands",
     "iter_exception_classes",
     "iter_fmt_error_calls",
     "iter_ipc_command_specs",
+    "load_drift_allowlist",
 ]

--- a/tests/unit/contracts/test_auth_middleware_code_policy.py
+++ b/tests/unit/contracts/test_auth_middleware_code_policy.py
@@ -1,0 +1,75 @@
+"""Auth middleware error code 정책 회귀 lock (#1841 Family C).
+
+``src/ante/cli/middleware.py`` 는 인증/권한 실패 시 ``_emit_auth_error`` 에
+전달하는 envelope ``code`` 값으로 lowercase 토큰 3 종 (``auth_required``,
+``auth_failed``, ``permission_denied``) 을 사용한다.
+
+Taxonomy SSOT (``docs/specs/contracts/error-taxonomy.md``, #1839) 는
+SCREAMING_SNAKE 를 normative 로 명시했지만, auth middleware 의 lowercase
+값은 #1815 migration 시점까지 의도적으로 유지된다 (#1839 결정).
+
+본 test 는 다음 두 가지를 회귀 lock 한다:
+
+* lowercase 토큰 3 종이 source 에 그대로 존재한다.
+* SCREAMING_SNAKE 변형 (``AUTH_REQUIRED`` 등) 이 ``_emit_auth_error``
+  호출 인자로 도입되지 않았다 (=의도 없는 migration 회피).
+
+migration 은 #1815 가 책임지며, 그 시점에 본 test 도 함께 갱신된다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIDDLEWARE = _REPO_ROOT / "src" / "ante" / "cli" / "middleware.py"
+
+_LOWERCASE_CODES = ("auth_required", "auth_failed", "permission_denied")
+_SCREAMING_VARIANTS = ("AUTH_REQUIRED", "AUTH_FAILED", "PERMISSION_DENIED")
+
+
+@pytest.fixture(scope="module")
+def middleware_source() -> str:
+    """``middleware.py`` raw source 를 반환한다.
+
+    AST 도 가능하지만 본 lock 은 literal 매치로 충분하다.
+    """
+    return _MIDDLEWARE.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("code", _LOWERCASE_CODES)
+def test_auth_middleware_lowercase_codes_preserved(
+    middleware_source: str,
+    code: str,
+) -> None:
+    """auth middleware lowercase 토큰이 source 에 그대로 존재해야 한다.
+
+    실패 시 #1815 migration 이 의도와 다르게 본 epic (#1841) 범위에서
+    선반영되었거나, 코드가 잘못 삭제되었음을 의미한다. #1815 가 정식으로
+    SCREAMING_SNAKE 로 migration 할 때 본 test 도 함께 갱신해야 한다.
+    """
+    literal = f'"{code}"'
+    assert literal in middleware_source, (
+        f"middleware.py 에서 {literal} 회귀 — auth lowercase 토큰은 #1815 "
+        "migration 시점까지 의도적으로 유지된다 (#1839 결정)."
+    )
+
+
+@pytest.mark.parametrize("variant", _SCREAMING_VARIANTS)
+def test_auth_middleware_no_screaming_snake_variant(
+    middleware_source: str,
+    variant: str,
+) -> None:
+    """SCREAMING_SNAKE 변형이 의도 없이 도입되지 않아야 한다.
+
+    #1815 가 migration 을 책임지므로 본 epic (#1841) 범위에서는 변형이
+    source 에 등장해선 안 된다. 등장 시 #1815 와 본 test 갱신을 동기화해야
+    한다.
+    """
+    literal = f'"{variant}"'
+    assert literal not in middleware_source, (
+        f"middleware.py 에 {literal} 도입 감지 — #1815 migration 이 본 epic "
+        "(#1841) 보다 먼저 들어왔다면 본 test 도 함께 갱신해야 한다."
+    )

--- a/tests/unit/contracts/test_error_drift.py
+++ b/tests/unit/contracts/test_error_drift.py
@@ -1,0 +1,231 @@
+"""Error taxonomy drift guard tests (#1841).
+
+세 Family 의 drift 를 정적 sweep 으로 차단한다:
+
+* Family A — ``fmt.error(...)`` callsite 에 code 인자 누락.
+* Family B — ``*Error`` class 가 class-level ``code`` 도 없고
+  ``EXCEPTION_TO_SPEC`` 에도 등록 안 됨 (=``EXECUTION_ERROR`` 로 접힘).
+* Staleness — allowlist entry 가 더 이상 존재하지 않는 path/line/snippet
+  또는 class 를 가리키면 검출.
+
+baseline 은 ``error_drift_allowlist.yaml`` 에 구조화 보관되며, 신규/수정
+drift 만 본 test 가 차단한다 (#1843/#1842 가 단계적으로 baseline 을
+제거한다).
+
+Anchor 정책 (#1841 plan):
+
+* fmt entry: ``(path, line, snippet_sha1)`` 3중 anchor.
+* exception entry: ``(module, class_anchor)`` 2중 anchor.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from ante.contracts.error_registry import EXCEPTION_TO_SPEC
+from tests.unit.contracts.helpers import (
+    iter_exception_classes,
+    iter_fmt_error_calls,
+    load_drift_allowlist,
+)
+
+# ── 공통 경로 ─────────────────────────────────────────────────────────────────
+
+# tests/unit/contracts/test_error_drift.py → parents[3] == repository root.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CLI_ROOT = _REPO_ROOT / "src" / "ante" / "cli"
+_SRC_ROOT = _REPO_ROOT / "src" / "ante"
+
+
+def _snippet_sha1(snippet: str) -> str:
+    """allowlist 와 동일한 anchor 산출식 (SHA-1 12-char prefix)."""
+    return hashlib.sha1(snippet.encode("utf-8")).hexdigest()[:12]
+
+
+def _module_dotted(path: Path) -> str:
+    """``src/ante/foo/bar.py`` → ``ante.foo.bar`` (allowlist module key 형식)."""
+    rel = path.resolve().relative_to(_REPO_ROOT / "src")
+    return str(rel.with_suffix("")).replace("/", ".")
+
+
+def _rel_str(path: Path) -> str:
+    """allowlist path 키와 비교 가능한 repo-relative POSIX 문자열."""
+    return path.resolve().relative_to(_REPO_ROOT).as_posix()
+
+
+# ── Family A — fmt.error code 누락 drift ────────────────────────────────────
+
+
+def test_fmt_error_callsites_have_code_or_are_allowlisted() -> None:
+    """모든 ``fmt.error`` callsite 는 code 가 있거나 allowlist 등록되어야 한다.
+
+    baseline (#1841): allowlist YAML 의 ``known_drift_fmt_error_no_code`` +
+    ``intended_no_code`` 두 section 에 등록된 callsite 만 면제.
+
+    실패 시 후속 작업 가이드:
+
+    * 신규 callsite 라면 code 인자를 추가하라
+      (``fmt.error(message, code="...")``).
+    * 의도된 code-less 케이스라면 ``intended_no_code`` 에 추가.
+    * baseline 이라면 ``known_drift_fmt_error_no_code`` 에 추가하고
+      #1843 follow-up 으로 단계적으로 제거.
+    """
+    allowlist = load_drift_allowlist()
+    allowed: set[tuple[str, int, str]] = set()
+    for entry in allowlist.intended_no_code:
+        allowed.add((entry.path, entry.line, entry.snippet_sha1))
+    for entry in allowlist.known_drift_fmt_error_no_code:
+        allowed.add((entry.path, entry.line, entry.snippet_sha1))
+
+    drift: list[str] = []
+    for call in iter_fmt_error_calls(_CLI_ROOT):
+        if call.has_effective_code:
+            continue
+        key = (_rel_str(call.path), call.lineno, _snippet_sha1(call.snippet))
+        if key in allowed:
+            continue
+        drift.append(
+            f"{key[0]}:{key[1]} (snippet_sha1={key[2]}) -> {call.snippet.strip()}"
+        )
+
+    assert not drift, (
+        "fmt.error code 인자 누락 신규/수정 callsite 감지. code 인자를 "
+        "추가하거나 tests/unit/contracts/error_drift_allowlist.yaml 의 "
+        "intended_no_code/known_drift_fmt_error_no_code 에 등록하라.\n"
+        + "\n".join(drift)
+    )
+
+
+# ── Family B — domain exception EXECUTION_ERROR 접힘 drift ──────────────────
+
+
+def test_exception_classes_have_code_or_registry_or_allowlisted() -> None:
+    """모든 ``*Error`` class 는 다음 중 하나여야 한다.
+
+    1. class-level ``code`` 속성 보유 (``has_code == True``).
+    2. ``EXCEPTION_TO_SPEC`` 에 등록되어 helper 가 ErrorSpec 을 resolve.
+    3. ``pending_migration`` allowlist 에 등록 (baseline, #1842/#1843
+       후속 작업으로 단계 제거).
+
+    셋 모두에 해당하지 않는 class 는 ``EXECUTION_ERROR`` 로 fallback 되어
+    taxonomy drift 가 발생한다.
+    """
+    registry_names = {cls.__name__ for cls in EXCEPTION_TO_SPEC.keys()}
+    allowlist = load_drift_allowlist()
+    allowed: set[tuple[str, str]] = {
+        (entry.module, entry.class_anchor) for entry in allowlist.pending_migration
+    }
+
+    drift: list[str] = []
+    for exc in iter_exception_classes(_SRC_ROOT):
+        if exc.has_code:
+            continue
+        if exc.name in registry_names:
+            continue
+        module = _module_dotted(exc.path)
+        if (module, exc.name) in allowed:
+            continue
+        drift.append(f"{module}::{exc.name} (L{exc.lineno})")
+
+    assert not drift, (
+        "*Error class 가 class-level code 도 없고 EXCEPTION_TO_SPEC 에도 "
+        "등록되지 않았다. class 에 code 속성을 추가하거나 registry 에 "
+        "등록하거나 tests/unit/contracts/error_drift_allowlist.yaml 의 "
+        "pending_migration 에 추가하라.\n" + "\n".join(drift)
+    )
+
+
+# ── Staleness — allowlist entry 의 anchor 가 실존하는지 검증 ─────────────────
+
+
+def _scan_fmt_anchors() -> set[tuple[str, int, str]]:
+    """현재 source 에서 검출되는 모든 code-less fmt callsite anchor 의 집합."""
+    anchors: set[tuple[str, int, str]] = set()
+    for call in iter_fmt_error_calls(_CLI_ROOT):
+        if call.has_effective_code:
+            continue
+        anchors.add(
+            (_rel_str(call.path), call.lineno, _snippet_sha1(call.snippet)),
+        )
+    return anchors
+
+
+def _scan_exception_anchors() -> set[tuple[str, str]]:
+    """현재 source 에서 검출되는 모든 code-less, registry-미등록 ``*Error`` anchor."""
+    registry_names = {cls.__name__ for cls in EXCEPTION_TO_SPEC.keys()}
+    anchors: set[tuple[str, str]] = set()
+    for exc in iter_exception_classes(_SRC_ROOT):
+        if exc.has_code:
+            continue
+        if exc.name in registry_names:
+            continue
+        anchors.add((_module_dotted(exc.path), exc.name))
+    return anchors
+
+
+def test_drift_allowlist_no_stale_fmt_entries() -> None:
+    """allowlist 의 fmt entry 는 현재 source 에 anchor 가 그대로 존재해야 한다.
+
+    callsite 가 fix 되어 code 인자를 받게 되었거나, file/line 이 옮겨졌거나,
+    snippet 가 변경되면 anchor 가 더 이상 매치하지 않는다. 이런 stale entry
+    는 즉시 allowlist 에서 제거해 drift guard 의 보호 면적을 유지한다.
+    """
+    allowlist = load_drift_allowlist()
+    actual = _scan_fmt_anchors()
+
+    stale: list[str] = []
+    for section_name, entries in (
+        ("intended_no_code", allowlist.intended_no_code),
+        ("known_drift_fmt_error_no_code", allowlist.known_drift_fmt_error_no_code),
+    ):
+        for entry in entries:
+            key = (entry.path, entry.line, entry.snippet_sha1)
+            if key not in actual:
+                stale.append(
+                    f"[{section_name}] {entry.path}:{entry.line} "
+                    f"(snippet_sha1={entry.snippet_sha1})"
+                )
+
+    assert not stale, (
+        "drift allowlist 의 fmt entry 가 더 이상 source 에 매치하지 않는다. "
+        "callsite 가 fix 되었거나 옮겨졌으면 allowlist 에서 제거하라.\n"
+        + "\n".join(stale)
+    )
+
+
+def test_drift_allowlist_no_stale_exception_entries() -> None:
+    """allowlist 의 exception entry 는 현재 source 에 anchor 가 존재해야 한다.
+
+    class 가 EXCEPTION_TO_SPEC 에 등록되었거나, class-level code 속성을
+    부여받았거나, class 가 삭제/이동되면 stale entry 가 된다.
+    """
+    allowlist = load_drift_allowlist()
+    actual = _scan_exception_anchors()
+
+    stale = [
+        f"{entry.module}::{entry.class_anchor}"
+        for entry in allowlist.pending_migration
+        if (entry.module, entry.class_anchor) not in actual
+    ]
+
+    assert not stale, (
+        "drift allowlist 의 exception entry 가 더 이상 source 에 매치하지 "
+        "않는다. class 가 EXCEPTION_TO_SPEC 에 등록되었거나 code 속성을 "
+        "얻었으면 allowlist 에서 제거하라.\n" + "\n".join(stale)
+    )
+
+
+# ── 회귀 시연 anchor (#1841 plan verification) ───────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "section",
+    ["intended_no_code", "known_drift_fmt_error_no_code", "pending_migration"],
+)
+def test_drift_allowlist_section_present(section: str) -> None:
+    """allowlist YAML 에 3 section 이 모두 정의되어 있어야 한다 (구조 lock)."""
+    allowlist = load_drift_allowlist()
+    assert hasattr(allowlist, section), f"DriftAllowlist 가 {section} 을 노출해야 한다."


### PR DESCRIPTION
Closes #1841

## Summary

Error taxonomy drift 를 정적 sweep 으로 차단하는 contract test 3 family + 구조화 allowlist 도입. 기존 baseline (33 fmt + 38 exc) 은 YAML 에 등록해 #1843/#1842 후속이 단계적으로 제거한다.

## Scope

### Family A — fmt.error code 누락 drift (`test_error_drift.py`)
- 모든 `fmt.error(...)` callsite 는 code 가 있거나 `intended_no_code` / `known_drift_fmt_error_no_code` allowlist 에 등록되어야 한다
- 신규/수정 callsite 가 code 없이 추가되면 즉시 FAIL

### Family B — `*Error` class EXECUTION_ERROR 접힘 drift
- class-level `code` 또는 `EXCEPTION_TO_SPEC` 등록 또는 `pending_migration` allowlist 셋 중 하나 필수
- 셋 다 아니면 FAIL (`EXECUTION_ERROR` fallback drift)

### Family C — auth middleware lowercase 회귀 lock (`test_auth_middleware_code_policy.py`)
- `auth_required` / `auth_failed` / `permission_denied` lowercase 토큰 보존 (positive)
- `AUTH_REQUIRED` / `AUTH_FAILED` / `PERMISSION_DENIED` SCREAMING_SNAKE 변형 부재 (negative)
- migration 은 #1815 책임, 본 PR 범위 밖

### Staleness
- allowlist entry 의 path/line/snippet_sha1 또는 module/class_anchor 가 source 에 더 이상 존재하지 않으면 FAIL (fmt + exception 각각)

## Allowlist baseline

자동 산출 (helper iterator 실측, hardcode 회피):

- `intended_no_code`: **0** (의도된 code-less 케이스 없음)
- `known_drift_fmt_error_no_code`: **33** (#1843 후속)
- `pending_migration`: **38** (#1842/#1843 후속)

이슈 본문 예상치 (37 / 47) 와는 다르지만 plan 에 명시된 대로 #1816 measurement 에 hardcode 하지 않고 실측값 그대로 등록.

## Anchor 정책

- fmt entry: `(path, line, snippet_sha1)` 3 중 anchor. snippet_sha1 = SHA-1(snippet)[:12]
- exception entry: `(module, class_anchor)` 2 중 anchor

snippet/line 단독 anchor 의 false negative 차단.

## Files

- `tests/unit/contracts/error_drift_allowlist.yaml` (신규)
- `tests/unit/contracts/helpers.py` (`DriftAllowlist`/`load_drift_allowlist()` 추가)
- `tests/unit/contracts/test_error_drift.py` (신규)
- `tests/unit/contracts/test_auth_middleware_code_policy.py` (신규)
- `docs/architecture/generated/project-structure.md` (regen)

`src/ante/**` production code 변경 없음.

## Test plan

- [x] `pytest tests/unit/contracts -v` → **67 passed**
- [x] `pytest tests/unit/` → **5125 passed, 2 skipped** (회귀 0)
- [x] `mypy src/ante` → **Success: no issues found in 222 source files**
- [x] `ruff check + format --check tests/unit/contracts` → clean
- [x] 수동 회귀 시연: 임시 demo callsite 추가 → Family A FAIL (RC=1) → demo 삭제 → PASS (RC=0)
- [x] `python scripts/generate_project_structure.py` → 신규 3 file + timestamp 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)