### PR TITLE
refactor: #1842 account error contract registry mirror + CLI direct ↔ IPC equivalence lock

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -582,14 +582,15 @@ tests/
 │   ├── test_cli_group_r_member_duplicate_validation_sweep.py
 │   ├── test_cli_group_s_treasury_typed_reject.py
 │   ├── test_ipc_treasury_allocate_missing_bot.py
-│   └── contracts/
-│       ├── __init__.py
-│       ├── helpers.py
-│       ├── test_helpers.py
-│       ├── test_error_helpers.py
-│       ├── error_drift_allowlist.yaml
-│       ├── test_auth_middleware_code_policy.py
-│       └── test_error_drift.py
+│   ├── contracts/
+│   │   ├── __init__.py
+│   │   ├── helpers.py
+│   │   ├── test_helpers.py
+│   │   ├── test_error_helpers.py
+│   │   ├── error_drift_allowlist.yaml
+│   │   ├── test_auth_middleware_code_policy.py
+│   │   └── test_error_drift.py
+│   └── test_account_cli_ipc_error_equivalence.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -36,6 +36,7 @@ from ante.cli.cold_path import (
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+from ante.contracts import emit_cli_error
 
 # `AccountStatus` enum이 `--status` 필터의 SSOT다. `account list`는 DB 진입 전
 # preflight에서 invalid 값을 차단해야 하며 (#1462), 이를 위해 함수 내부 import
@@ -605,8 +606,10 @@ def account_create(
     try:
         created = _run(_do_create())
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
-        raise SystemExit(1) from e
+        # #1842: emit_cli_error 가 registry-first → ``.code`` fallback →
+        # EXECUTION_ERROR 순서로 ErrorSpec 을 resolve해 IPC envelope 와 동일한
+        # public code 를 surface 한다.
+        emit_cli_error(fmt, e)
 
     fmt.success(
         f'계좌 "{created.account_id}" 생성 완료 '
@@ -663,8 +666,8 @@ def account_list(ctx: click.Context, status_filter: str | None) -> None:
     try:
         rows = _run(_do_list())
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
-        raise SystemExit(1) from e
+        # #1842: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     if not rows:
         fmt.output({"message": "등록된 계좌가 없습니다.", "accounts": []})
@@ -713,8 +716,9 @@ def account_info(ctx: click.Context, account_id: str) -> None:
     try:
         detail = _run(_do_info())
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
-        raise SystemExit(1) from e
+        # #1842: emit_cli_error 정렬 — AccountNotFoundError 등 typed exception
+        # 의 IPC envelope code (ACCOUNT_NOT_FOUND) 와 동일하게 surface.
+        emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output(detail)
@@ -759,8 +763,10 @@ def account_suspend(ctx: click.Context, account_id: str, reason: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1842: emit_cli_error 정렬 — code-less fmt.error 를 taxonomy 정렬된
+        # public code (IPC envelope 와 동일) 으로 surface 한다. baseline
+        # allowlist entry 제거 대상.
+        emit_cli_error(fmt, e)
 
     fmt.success(f'계좌 "{validated_account_id}" 정지 완료')
 
@@ -801,8 +807,10 @@ def account_activate(ctx: click.Context, account_id: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1842: emit_cli_error 정렬 — code-less fmt.error 를 taxonomy 정렬된
+        # public code (IPC envelope 와 동일) 으로 surface 한다. baseline
+        # allowlist entry 제거 대상.
+        emit_cli_error(fmt, e)
 
     fmt.success(f'계좌 "{validated_account_id}" 활성화 완료')
 
@@ -877,13 +885,17 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except AccountDeletedError as e:
+        # CLI surface override (보존): registry default ACCOUNT_DELETED 대신
+        # account delete UX 의 already-deleted 의미 (ACCOUNT_ALREADY_DELETED)
+        # 를 surface 한다 (#1812 / errors.py:96-100 NOTE / #1842 plan v2).
         fmt.error(str(e), code="ACCOUNT_ALREADY_DELETED")
         raise SystemExit(1) from e
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
-        raise SystemExit(1) from e
+        # #1842: emit_cli_error 정렬 — generic fallback 도 registry-first 로
+        # IPC envelope 와 동일 public code 를 surface.
+        emit_cli_error(fmt, e)
 
     fmt.success(f'계좌 "{validated_account_id}" 삭제 완료')
 
@@ -919,8 +931,8 @@ def account_credentials(ctx: click.Context, account_id: str) -> None:
     try:
         masked = _run(_do_credentials())
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
-        raise SystemExit(1) from e
+        # #1842: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     if not masked:
         fmt.output({"message": "등록된 인증 정보가 없습니다.", "credentials": {}})
@@ -1051,8 +1063,11 @@ def account_set_credentials(
     except SystemExit:
         raise
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
-        raise SystemExit(1) from e
+        # #1842: emit_cli_error 정렬 — MissingCredentialsError /
+        # BrokerReconnectFailedError 등 typed exception 도 registry-first 로
+        # 정확한 public code (ACCOUNT_MISSING_CREDENTIALS / BROKER_RECONNECT_FAILED)
+        # 를 surface 한다.
+        emit_cli_error(fmt, e)
 
 
 # ── repair-timezone ──────────────────────────────────────
@@ -1136,13 +1151,16 @@ def account_repair_timezone(
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except AccountDeletedError as e:
+        # CLI surface override (보존): registry default ACCOUNT_DELETED 대신
+        # repair-timezone 표면에서 already-deleted 의미 (ACCOUNT_ALREADY_DELETED)
+        # 를 surface 한다 (account_delete 와 동일 정책, #1842 plan v2).
         fmt.error(str(e), code="ACCOUNT_ALREADY_DELETED")
         raise SystemExit(1) from e
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "EXECUTION_ERROR"))
-        raise SystemExit(1) from e
+        # #1842: emit_cli_error 정렬 — registry-first 로 IPC envelope 와 동일.
+        emit_cli_error(fmt, e)
 
     fmt.success(
         f'계좌 "{repaired.account_id}" timezone 복구 완료 ({repaired.timezone})',

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -5,13 +5,41 @@ lock** 4 건을 코드로 mapping 한다. helper
 (``ante.contracts.helpers.error_spec_for_exception``) 는 본 registry 를 MRO
 기반 lookup 하여 exception → ``ErrorSpec`` 을 resolve 한다.
 
-본 PR(#1840) 범위에서 등록되는 lock 4건:
+본 PR(#1840) 범위에서 등록된 lock 4건:
 
 - ``InvalidAccountIdError`` → ``VALIDATION_ERROR`` / ``validation``
 - ``BotNotFoundError`` → ``BOT_NOT_FOUND`` / ``not_found``
 - ``ApprovalNotFoundError`` → ``APPROVAL_NOT_FOUND`` / ``not_found``
 - ``InvalidScopeError`` (member, code=``MEMBER_INVALID_SCOPE``) →
   ``MEMBER_INVALID_SCOPE`` / ``permission``
+
+#1842 가 추가한 account domain 12 sub-class lock (실측 ``.code`` mirror,
+category 정확화):
+
+- ``AccountNotFoundError`` → ``ACCOUNT_NOT_FOUND`` / ``not_found``
+- ``AccountAlreadyExistsError`` → ``ACCOUNT_ALREADY_EXISTS`` / ``state_conflict``
+- ``InvalidBrokerTypeError`` → ``ACCOUNT_INVALID_BROKER_TYPE`` / ``validation``
+- ``InvalidExchangeError`` → ``VALIDATION_ERROR`` / ``validation`` (실측
+  ``.code = VALIDATION_ERROR``, ``InvalidAccountIdError`` 와 동일한 account
+  검증 에러 SSOT)
+- ``MissingCredentialsError`` → ``ACCOUNT_MISSING_CREDENTIALS`` / ``validation``
+- ``AccountAlreadySuspendedError`` → ``ACCOUNT_ALREADY_SUSPENDED`` /
+  ``state_conflict``
+- ``AccountDeletedError`` → ``ACCOUNT_DELETED`` / ``state_conflict`` (CLI
+  ``account delete`` 의 ``ACCOUNT_ALREADY_DELETED`` surface override 는 별개
+  CLI UX layer 이며 ``except AccountDeletedError`` 명시 typed handling 으로
+  보존된다)
+- ``AccountSuspendedError`` → ``ACCOUNT_SUSPENDED`` / ``state_conflict``
+- ``AccountImmutableFieldError`` → ``ACCOUNT_IMMUTABLE_FIELD`` / ``validation``
+- ``BrokerReconnectFailedError`` → ``BROKER_RECONNECT_FAILED`` / ``external``
+- ``AccountStructuralChangeRequiresStoppedServerError`` →
+  ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER`` / ``state_conflict``
+- ``AccountHasActiveBotsError`` → ``ACCOUNT_HAS_ACTIVE_BOTS`` /
+  ``state_conflict``
+
+``AccountError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
+``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
+Non-Goals).
 
 추가로 ``SERVICE_NOT_CONFIGURED`` 는 #1819 dispatch wrapper 가 도입할 예정인
 ``ServiceNotConfiguredError`` 의 ErrorSpec value 를 module-level constant
@@ -28,7 +56,21 @@ from __future__ import annotations
 
 from typing import Final
 
-from ante.account.errors import InvalidAccountIdError
+from ante.account.errors import (
+    AccountAlreadyExistsError,
+    AccountAlreadySuspendedError,
+    AccountDeletedError,
+    AccountHasActiveBotsError,
+    AccountImmutableFieldError,
+    AccountNotFoundError,
+    AccountStructuralChangeRequiresStoppedServerError,
+    AccountSuspendedError,
+    BrokerReconnectFailedError,
+    InvalidAccountIdError,
+    InvalidBrokerTypeError,
+    InvalidExchangeError,
+    MissingCredentialsError,
+)
 from ante.approval.errors import ApprovalNotFoundError
 from ante.bot.exceptions import BotNotFoundError
 from ante.contracts.errors import ErrorSpec
@@ -60,6 +102,77 @@ _APPROVAL_NOT_FOUND_SPEC: Final[ErrorSpec] = ErrorSpec(
 _MEMBER_INVALID_SCOPE_SPEC: Final[ErrorSpec] = ErrorSpec(
     code="MEMBER_INVALID_SCOPE",
     category="permission",
+)
+
+
+# ── account 12 sub-class lock (#1842 normative, 실측 .code mirror) ───────────
+
+_ACCOUNT_NOT_FOUND_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_NOT_FOUND",
+    category="not_found",
+)
+
+_ACCOUNT_ALREADY_EXISTS_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_ALREADY_EXISTS",
+    category="state_conflict",
+)
+
+_ACCOUNT_INVALID_BROKER_TYPE_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_INVALID_BROKER_TYPE",
+    category="validation",
+)
+
+# ``InvalidExchangeError`` 의 실측 ``.code = "VALIDATION_ERROR"`` 와 동일
+# 한 값. ``InvalidAccountIdError`` 와 코드를 공유하지만 ErrorSpec instance
+# 는 의미상 별개의 entry 로 둔다 — registry MRO lookup 은 type 기반이므로
+# instance identity 가 영향을 주지 않는다.
+_ACCOUNT_INVALID_EXCHANGE_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="VALIDATION_ERROR",
+    category="validation",
+)
+
+_ACCOUNT_MISSING_CREDENTIALS_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_MISSING_CREDENTIALS",
+    category="validation",
+)
+
+_ACCOUNT_ALREADY_SUSPENDED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_ALREADY_SUSPENDED",
+    category="state_conflict",
+)
+
+# class-level ``.code = "ACCOUNT_DELETED"`` 와 정렬. CLI ``account delete``
+# 의 ``except AccountDeletedError → fmt.error(code="ACCOUNT_ALREADY_DELETED")``
+# surface override 는 CLI UX layer 의 별개 책임 — 명시 typed except 를
+# 보존한다 (#1842 plan v2 Codex blocker #2 / errors.py:96-100 NOTE 정렬).
+_ACCOUNT_DELETED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_DELETED",
+    category="state_conflict",
+)
+
+_ACCOUNT_SUSPENDED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_SUSPENDED",
+    category="state_conflict",
+)
+
+_ACCOUNT_IMMUTABLE_FIELD_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_IMMUTABLE_FIELD",
+    category="validation",
+)
+
+_BROKER_RECONNECT_FAILED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BROKER_RECONNECT_FAILED",
+    category="external",
+)
+
+_ACCOUNT_STRUCTURAL_CHANGE_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER",
+    category="state_conflict",
+)
+
+_ACCOUNT_HAS_ACTIVE_BOTS_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="ACCOUNT_HAS_ACTIVE_BOTS",
+    category="state_conflict",
 )
 
 
@@ -99,6 +212,19 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     BotNotFoundError: _BOT_NOT_FOUND_SPEC,
     ApprovalNotFoundError: _APPROVAL_NOT_FOUND_SPEC,
     InvalidScopeError: _MEMBER_INVALID_SCOPE_SPEC,
+    # ── #1842 account 12 sub-class (실측 .code mirror) ────────────────────
+    AccountNotFoundError: _ACCOUNT_NOT_FOUND_SPEC,
+    AccountAlreadyExistsError: _ACCOUNT_ALREADY_EXISTS_SPEC,
+    InvalidBrokerTypeError: _ACCOUNT_INVALID_BROKER_TYPE_SPEC,
+    InvalidExchangeError: _ACCOUNT_INVALID_EXCHANGE_SPEC,
+    MissingCredentialsError: _ACCOUNT_MISSING_CREDENTIALS_SPEC,
+    AccountAlreadySuspendedError: _ACCOUNT_ALREADY_SUSPENDED_SPEC,
+    AccountDeletedError: _ACCOUNT_DELETED_SPEC,
+    AccountSuspendedError: _ACCOUNT_SUSPENDED_SPEC,
+    AccountImmutableFieldError: _ACCOUNT_IMMUTABLE_FIELD_SPEC,
+    BrokerReconnectFailedError: _BROKER_RECONNECT_FAILED_SPEC,
+    AccountStructuralChangeRequiresStoppedServerError: _ACCOUNT_STRUCTURAL_CHANGE_SPEC,
+    AccountHasActiveBotsError: _ACCOUNT_HAS_ACTIVE_BOTS_SPEC,
 }
 """대표 fault lock registry (#1839 normative 4건).
 

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -30,14 +30,8 @@
 intended_no_code: []
 
 known_drift_fmt_error_no_code:
-  - path: src/ante/cli/commands/account.py
-    line: 762
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/account.py
-    line: 804
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
+  # #1842: account.py line 762/804 entries 제거 — emit_cli_error 정렬 완료
+  # (CLI direct path 가 IPC envelope 와 동일 public code surface).
   - path: src/ante/cli/commands/bot.py
     line: 384
     snippet_sha1: "826b5811c10c"

--- a/tests/unit/contracts/test_error_drift.py
+++ b/tests/unit/contracts/test_error_drift.py
@@ -102,6 +102,20 @@ def test_fmt_error_callsites_have_code_or_are_allowlisted() -> None:
 # ── Family B — domain exception EXECUTION_ERROR 접힘 drift ──────────────────
 
 
+def _registry_module_names() -> set[tuple[str, str]]:
+    """``EXCEPTION_TO_SPEC`` 의 ``(module, class_name)`` 짝 집합.
+
+    #1842 가 ``ante.account.errors.InvalidBrokerTypeError`` 를 registry 에
+    등록하면서, 동명의 별개 class 인 ``ante.broker.registry.InvalidBrokerTypeError``
+    가 이름만 비교하던 이전 staleness scanner 에서 stale 판정을 받는 회귀가
+    발견되었다. helper 의 MRO lookup 은 type 기반이라 두 class 를 정확히
+    분리하므로, drift test 도 ``(module, class_name)`` 2중 anchor 로 정렬해
+    동명 별개 class 가 서로의 보호 면적을 침범하지 않도록 한다.
+    """
+
+    return {(cls.__module__, cls.__name__) for cls in EXCEPTION_TO_SPEC.keys()}
+
+
 def test_exception_classes_have_code_or_registry_or_allowlisted() -> None:
     """모든 ``*Error`` class 는 다음 중 하나여야 한다.
 
@@ -112,8 +126,11 @@ def test_exception_classes_have_code_or_registry_or_allowlisted() -> None:
 
     셋 모두에 해당하지 않는 class 는 ``EXECUTION_ERROR`` 로 fallback 되어
     taxonomy drift 가 발생한다.
+
+    #1842: 동명 별개 class 를 정확히 분리하기 위해 registry membership 판정
+    을 ``(module, name)`` 2중 anchor 로 한다 (allowlist entry shape 와 정렬).
     """
-    registry_names = {cls.__name__ for cls in EXCEPTION_TO_SPEC.keys()}
+    registry_module_names = _registry_module_names()
     allowlist = load_drift_allowlist()
     allowed: set[tuple[str, str]] = {
         (entry.module, entry.class_anchor) for entry in allowlist.pending_migration
@@ -123,9 +140,9 @@ def test_exception_classes_have_code_or_registry_or_allowlisted() -> None:
     for exc in iter_exception_classes(_SRC_ROOT):
         if exc.has_code:
             continue
-        if exc.name in registry_names:
-            continue
         module = _module_dotted(exc.path)
+        if (module, exc.name) in registry_module_names:
+            continue
         if (module, exc.name) in allowed:
             continue
         drift.append(f"{module}::{exc.name} (L{exc.lineno})")
@@ -154,15 +171,22 @@ def _scan_fmt_anchors() -> set[tuple[str, int, str]]:
 
 
 def _scan_exception_anchors() -> set[tuple[str, str]]:
-    """현재 source 에서 검출되는 모든 code-less, registry-미등록 ``*Error`` anchor."""
-    registry_names = {cls.__name__ for cls in EXCEPTION_TO_SPEC.keys()}
+    """현재 source 에서 검출되는 모든 code-less, registry-미등록 ``*Error`` anchor.
+
+    #1842: registry membership 판정을 ``(module, name)`` 2중 anchor 로 한다 —
+    동명 별개 class (예: ``account.errors.InvalidBrokerTypeError`` vs
+    ``broker.registry.InvalidBrokerTypeError``)가 서로의 staleness 보호 면적을
+    침범하지 않게 한다.
+    """
+    registry_module_names = _registry_module_names()
     anchors: set[tuple[str, str]] = set()
     for exc in iter_exception_classes(_SRC_ROOT):
         if exc.has_code:
             continue
-        if exc.name in registry_names:
+        module = _module_dotted(exc.path)
+        if (module, exc.name) in registry_module_names:
             continue
-        anchors.add((_module_dotted(exc.path), exc.name))
+        anchors.add((module, exc.name))
     return anchors
 
 

--- a/tests/unit/test_account_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_account_cli_ipc_error_equivalence.py
@@ -1,0 +1,609 @@
+"""Account CLI direct path ↔ IPC path error code equivalence lock (#1842).
+
+본 모듈은 #1816 의 1차 migration domain (account) 의 대표 fault 9 건이 CLI
+direct path 와 IPC envelope path 양쪽에서 **동일한 public code** 를 노출
+함을 lock 한다.
+
+검증 대상 fault:
+
+- ``InvalidAccountIdError`` → ``VALIDATION_ERROR`` (validation)
+- ``InvalidExchangeError`` → ``VALIDATION_ERROR`` (validation)
+- ``AccountNotFoundError`` → ``ACCOUNT_NOT_FOUND`` (not_found)
+- ``AccountAlreadyExistsError`` → ``ACCOUNT_ALREADY_EXISTS`` (state_conflict)
+- ``AccountAlreadySuspendedError`` → ``ACCOUNT_ALREADY_SUSPENDED`` (state_conflict)
+- ``AccountDeletedError`` → ``ACCOUNT_DELETED`` (state_conflict, update/activate
+  surface; ``account delete`` 의 ``ACCOUNT_ALREADY_DELETED`` surface override
+  는 별도 lock test 로 분리)
+- ``AccountHasActiveBotsError`` → ``ACCOUNT_HAS_ACTIVE_BOTS`` (state_conflict)
+- ``BrokerReconnectFailedError`` → ``BROKER_RECONNECT_FAILED`` (external)
+- CLI surface override 보존: ``account delete`` 의 ``AccountDeletedError`` →
+  ``ACCOUNT_ALREADY_DELETED`` (registry default 와 분기 — UX 의미 보존)
+
+CLI direct path 는 ``CliRunner`` 로 ``ante --format json account ...`` 를
+실행해 ``OutputFormatter`` 의 JSON envelope code 를 단언한다 (subprocess
+오버헤드 없이 동일 dispatch).
+
+IPC path 는 ``ante.ipc.registry`` 의 실제 핸들러 (account.suspend/activate)
+를 ``IPCServer`` 위에서 실행하거나, IPC envelope helper (``ipc_error_payload``)
+로 직접 직렬화해 동일 code 를 단언한다.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.account.errors import (
+    AccountAlreadyExistsError,
+    AccountAlreadySuspendedError,
+    AccountDeletedError,
+    AccountHasActiveBotsError,
+    AccountNotFoundError,
+    BrokerReconnectFailedError,
+    InvalidExchangeError,
+)
+from ante.cli.main import cli
+from ante.contracts import ipc_error_payload
+from ante.core.registry import ServiceRegistry
+from ante.ipc.client import IPCClient
+from ante.ipc.registry import CommandRegistry, register_all_handlers
+from ante.ipc.server import IPCServer
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """``ante --format json account ...`` 호출용 ``CliRunner`` fixture.
+
+    auth middleware 를 master member 로 우회한다 (E bucket fixture 동형).
+    """
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx) -> None:  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+def _ipc_envelope_code(exc: BaseException) -> str:
+    """주어진 exception 을 IPC envelope 으로 직렬화했을 때의 ``code``.
+
+    IPC server.py:322 가 적용하는 ``getattr(e, "code", "EXECUTION_ERROR")``
+    fallback 과 helper(``ipc_error_payload``)의 registry-first resolution 은
+    실측 ``.code`` 가 일치하는 한 동일 코드를 생성한다 (#1842 plan v2 #6).
+    본 helper 는 helper 경로를 그대로 사용해 contract 동등성을 단언한다.
+    """
+
+    payload = ipc_error_payload(exc)
+    return payload["code"]
+
+
+def _cli_envelope_code(runner: CliRunner, args: list[str], exc: BaseException) -> str:
+    """``_create_account_service`` 를 patch 해 주어진 exception 을 raise 시키고
+    CLI ``--format json`` envelope 의 ``code`` 를 반환한다.
+    """
+
+    svc = AsyncMock()
+    db = AsyncMock()
+
+    async def _create_service():  # noqa: ANN202
+        return svc, db
+
+    # account list/get/update 등 모든 service entry 가 exc 를 raise 하도록
+    # 광범위 side_effect 를 설정한다 (대상 callsite 가 어느 메서드든 동일
+    # generic except 분기를 타도록).
+    for method in ("list", "get", "create", "update", "delete", "repair_timezone"):
+        getattr(svc, method).side_effect = exc
+
+    with patch(
+        "ante.cli.commands.account._create_account_service",
+        new=_create_service,
+    ):
+        result = runner.invoke(cli, ["--format", "json", *args])
+
+    # CLI 가 exit 1 이 아니면 envelope code 추출이 무의미하다 — 즉시 fail.
+    assert result.exit_code != 0, (
+        f"CLI 가 정상 종료했다 (exit={result.exit_code}). output={result.output!r}"
+    )
+    # JSON envelope 첫 객체 추출. ``fmt.success`` mode 와 달리 ``fmt.error``
+    # 는 indent 없이 한 줄 — splitlines 첫 번째에서 JSON parse 가능.
+    payload_line = next(
+        (line for line in result.output.splitlines() if line.startswith("{")),
+        None,
+    )
+    assert payload_line is not None, f"JSON envelope 발견 실패: {result.output!r}"
+    payload = json.loads(payload_line)
+    assert payload["status"] == "error", payload
+    return payload["code"]
+
+
+# ── (1) InvalidAccountIdError ↔ VALIDATION_ERROR ────────────────────────────
+
+
+class TestInvalidAccountIdEquivalence:
+    """invalid account_id 는 CLI direct path 와 IPC path 모두 ``VALIDATION_ERROR``.
+
+    CLI ingress 가 ``reject_invalid_account_id`` 로 service 호출 이전에 거부
+    하므로 service mock 이 raise 하지 않아도 envelope 가 ``VALIDATION_ERROR``
+    이다. IPC handler-first ``require_account_id`` 도 동일 코드를 raise한다.
+    """
+
+    def test_cli_direct_invalid_account_id_validation_error(
+        self, runner: CliRunner
+    ) -> None:
+        # invalid account_id ("default") → CLI ingress 가 reject_invalid_account_id
+        # 로 거부하며 service mock 까지 도달하지 않는다.
+        svc = AsyncMock()
+        db = AsyncMock()
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "account", "info", "default"]
+            )
+
+        assert result.exit_code != 0
+        payload_line = next(
+            (line for line in result.output.splitlines() if line.startswith("{")),
+            None,
+        )
+        assert payload_line is not None
+        payload = json.loads(payload_line)
+        assert payload["status"] == "error"
+        assert payload["code"] == "VALIDATION_ERROR"
+
+    def test_ipc_envelope_invalid_account_id_validation_error(self) -> None:
+        """IPC envelope 도 동일하게 ``VALIDATION_ERROR``."""
+        from ante.account.errors import InvalidAccountIdError
+
+        assert _ipc_envelope_code(InvalidAccountIdError("bad id")) == "VALIDATION_ERROR"
+
+
+# ── (2) InvalidExchangeError ↔ VALIDATION_ERROR ─────────────────────────────
+
+
+class TestInvalidExchangeEquivalence:
+    """``InvalidExchangeError`` 는 양쪽에서 ``VALIDATION_ERROR``.
+
+    ``InvalidAccountIdError`` 와 코드를 공유한다 (account 검증 SSOT —
+    errors.py:54-57 보강 정렬).
+    """
+
+    def test_cli_direct_invalid_exchange_validation_error(
+        self, runner: CliRunner
+    ) -> None:
+        exc = InvalidExchangeError("invalid exchange: *")
+        code = _cli_envelope_code(
+            runner,
+            ["account", "list"],
+            exc,
+        )
+        assert code == "VALIDATION_ERROR"
+
+    def test_ipc_envelope_invalid_exchange_validation_error(self) -> None:
+        exc = InvalidExchangeError("invalid exchange: *")
+        assert _ipc_envelope_code(exc) == "VALIDATION_ERROR"
+
+
+# ── (3) AccountNotFoundError ↔ ACCOUNT_NOT_FOUND ────────────────────────────
+
+
+class TestAccountNotFoundEquivalence:
+    """``AccountNotFoundError`` 는 양쪽에서 ``ACCOUNT_NOT_FOUND``."""
+
+    def test_cli_direct_not_found_account_not_found(self, runner: CliRunner) -> None:
+        exc = AccountNotFoundError("missing")
+        code = _cli_envelope_code(
+            runner,
+            ["account", "info", "acc-missing"],
+            exc,
+        )
+        assert code == "ACCOUNT_NOT_FOUND"
+
+    def test_ipc_envelope_not_found_account_not_found(self) -> None:
+        exc = AccountNotFoundError("missing")
+        assert _ipc_envelope_code(exc) == "ACCOUNT_NOT_FOUND"
+
+
+# ── (4) AccountAlreadyExistsError ↔ ACCOUNT_ALREADY_EXISTS ──────────────────
+
+
+class TestAccountAlreadyExistsEquivalence:
+    """``AccountAlreadyExistsError`` 는 양쪽에서 ``ACCOUNT_ALREADY_EXISTS``."""
+
+    def test_cli_direct_already_exists(self, runner: CliRunner) -> None:
+        exc = AccountAlreadyExistsError("dup")
+        # account create 표면. 필수 옵션 (broker-type/account-id/name/trading-mode)
+        # + test broker 의 required_credentials (app_key/app_secret) 를 모두
+        # 제공해 service.create 호출까지 도달시킨다. cold-path runtime guard
+        # 도 우회한다 (CLI defense-in-depth 는 본 lock 범위 밖).
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.create.side_effect = exc
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with (
+            patch(
+                "ante.cli.commands.account._create_account_service",
+                new=_create_service,
+            ),
+            patch(
+                "ante.cli.commands.account._assert_no_active_runtime",
+                return_value=None,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "account",
+                    "create",
+                    "--account-id",
+                    "acc-dup",
+                    "--name",
+                    "dup",
+                    "--broker-type",
+                    "test",
+                    "--trading-mode",
+                    "virtual",
+                    "--credential",
+                    "app_key=k",
+                    "--credential",
+                    "app_secret=s",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload_line = next(
+            (line for line in result.output.splitlines() if line.startswith("{")),
+            None,
+        )
+        assert payload_line is not None, result.output
+        payload = json.loads(payload_line)
+        assert payload["status"] == "error"
+        assert payload["code"] == "ACCOUNT_ALREADY_EXISTS"
+
+    def test_ipc_envelope_already_exists(self) -> None:
+        exc = AccountAlreadyExistsError("dup")
+        assert _ipc_envelope_code(exc) == "ACCOUNT_ALREADY_EXISTS"
+
+
+# ── (5) AccountAlreadySuspendedError ↔ ACCOUNT_ALREADY_SUSPENDED ────────────
+
+
+class TestAccountAlreadySuspendedEquivalence:
+    """``AccountAlreadySuspendedError`` 는 양쪽에서 ``ACCOUNT_ALREADY_SUSPENDED``.
+
+    CLI direct path: ``account suspend`` 는 ``ipc_send`` 위임. ``ipc_send``
+    를 raise 하도록 patch 한 뒤 generic except → emit_cli_error 흐름이
+    registry-first 로 typed code 를 surface 함을 확인한다.
+
+    IPC path: 실제 ``account.suspend`` handler 를 ``IPCServer`` 위에서 실행해
+    envelope code 를 확인한다.
+    """
+
+    def test_cli_direct_already_suspended(self, runner: CliRunner) -> None:
+        exc = AccountAlreadySuspendedError("이미 정지됨")
+
+        async def _raise(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise exc
+
+        with patch(
+            "ante.cli.commands.ipc_helpers.ipc_send",
+            new=AsyncMock(side_effect=_raise),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "account", "suspend", "acc-test"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload_line = next(
+            (line for line in result.output.splitlines() if line.startswith("{")),
+            None,
+        )
+        assert payload_line is not None, result.output
+        payload = json.loads(payload_line)
+        assert payload["status"] == "error"
+        assert payload["code"] == "ACCOUNT_ALREADY_SUSPENDED"
+
+    @pytest.mark.asyncio
+    async def test_ipc_envelope_already_suspended_via_real_handler(self) -> None:
+        """실제 ``account.suspend`` IPC handler 가 typed code 를 envelope 으로
+        surface 한다.
+
+        ``test_ipc_error_code_mapping.py`` 의 dummy-handler 기반 단언과 1:1
+        동형의 실제-handler 기반 회귀 lock.
+        """
+        td = tempfile.mkdtemp(prefix="ipc_equiv", dir="/tmp")
+        socket_path = str(Path(td) / "t.sock")
+
+        account_svc = MagicMock()
+        account_svc.suspend = AsyncMock(
+            side_effect=AccountAlreadySuspendedError("이미 정지됨")
+        )
+        svc_registry = ServiceRegistry(
+            account=account_svc,
+            bot_manager=MagicMock(),
+            treasury_manager=MagicMock(),
+            dynamic_config=MagicMock(),
+            approval=MagicMock(),
+            reconciler=MagicMock(),
+            eventbus=MagicMock(),
+        )
+        cmd_registry = CommandRegistry()
+        register_all_handlers(cmd_registry)
+
+        server = IPCServer(socket_path, svc_registry, cmd_registry)
+        await server.start()
+        try:
+            client = IPCClient(socket_path, timeout=5.0)
+            response = await client.send(
+                "account.suspend",
+                {"account_id": "acc-test"},
+                actor="tester",
+            )
+            assert response["status"] == "error"
+            assert response["error"]["code"] == "ACCOUNT_ALREADY_SUSPENDED"
+        finally:
+            await server.stop()
+
+
+# ── (6) AccountDeletedError ↔ ACCOUNT_DELETED (update/activate surface) ─────
+
+
+class TestAccountDeletedEquivalence:
+    """``AccountDeletedError`` 는 ``account activate`` 등 generic 표면에서 양쪽
+    ``ACCOUNT_DELETED`` (registry default).
+
+    ``account delete`` 의 ``ACCOUNT_ALREADY_DELETED`` surface override 는
+    별도 ``TestAccountDeleteSurfaceOverride`` lock 으로 분리.
+    """
+
+    def test_cli_direct_deleted_via_activate(self, runner: CliRunner) -> None:
+        """``account activate`` (ipc_send 위임 표면) 에서 IPC handler 가
+        ``AccountDeletedError`` 를 raise 하면 CLI envelope 가 typed code
+        (``ACCOUNT_DELETED``) 를 surface 한다.
+        """
+        exc = AccountDeletedError("deleted")
+
+        async def _raise(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise exc
+
+        with patch(
+            "ante.cli.commands.ipc_helpers.ipc_send",
+            new=AsyncMock(side_effect=_raise),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "account", "activate", "acc-test"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload_line = next(
+            (line for line in result.output.splitlines() if line.startswith("{")),
+            None,
+        )
+        assert payload_line is not None, result.output
+        payload = json.loads(payload_line)
+        assert payload["status"] == "error"
+        assert payload["code"] == "ACCOUNT_DELETED"
+
+    def test_ipc_envelope_deleted(self) -> None:
+        exc = AccountDeletedError("deleted")
+        assert _ipc_envelope_code(exc) == "ACCOUNT_DELETED"
+
+
+# ── (7) AccountHasActiveBotsError ↔ ACCOUNT_HAS_ACTIVE_BOTS ─────────────────
+
+
+class TestAccountHasActiveBotsEquivalence:
+    """``AccountHasActiveBotsError`` 는 양쪽에서 ``ACCOUNT_HAS_ACTIVE_BOTS``."""
+
+    def test_cli_direct_has_active_bots(self, runner: CliRunner) -> None:
+        exc = AccountHasActiveBotsError("acc-test", 2)
+        # account delete 표면 — typed except 명시 매핑이 ``ACCOUNT_HAS_ACTIVE_BOTS``
+        # 코드를 명시 surface 한다 (보존).
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.delete.side_effect = exc
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with (
+            patch(
+                "ante.cli.commands.account._create_account_service",
+                new=_create_service,
+            ),
+            patch(
+                "ante.cli.commands.account._assert_no_active_runtime",
+                return_value=None,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "account", "delete", "acc-test", "--yes"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload_line = next(
+            (line for line in result.output.splitlines() if line.startswith("{")),
+            None,
+        )
+        assert payload_line is not None, result.output
+        payload = json.loads(payload_line)
+        assert payload["status"] == "error"
+        assert payload["code"] == "ACCOUNT_HAS_ACTIVE_BOTS"
+
+    def test_ipc_envelope_has_active_bots(self) -> None:
+        exc = AccountHasActiveBotsError("acc-test", 2)
+        assert _ipc_envelope_code(exc) == "ACCOUNT_HAS_ACTIVE_BOTS"
+
+
+# ── (8) BrokerReconnectFailedError ↔ BROKER_RECONNECT_FAILED ────────────────
+
+
+class TestBrokerReconnectFailedEquivalence:
+    """``BrokerReconnectFailedError`` 는 양쪽에서 ``BROKER_RECONNECT_FAILED``."""
+
+    def test_cli_direct_broker_reconnect_failed(self, runner: CliRunner) -> None:
+        exc = BrokerReconnectFailedError("재연결 실패")
+        # set-credentials 표면 — service.update 가 raise → generic except →
+        # emit_cli_error 로 typed code surface.
+        svc = AsyncMock()
+        db = AsyncMock()
+
+        # _resolve_credentials 가 도달하기 전 svc.get 으로 broker_type 을 알아야
+        # 한다 — preset 이 있는 broker_type 으로 mock account 를 반환한다.
+        from decimal import Decimal
+
+        from ante.account.models import Account, AccountStatus, TradingMode
+
+        svc.get = AsyncMock(
+            return_value=Account(
+                account_id="acc-test",
+                name="test",
+                exchange="TEST",
+                currency="KRW",
+                broker_type="test",
+                status=AccountStatus("active"),
+                trading_mode=TradingMode("virtual"),
+                credentials={},
+                buy_commission_rate=Decimal("0.00015"),
+                sell_commission_rate=Decimal("0.00195"),
+            )
+        )
+        svc.update = AsyncMock(side_effect=exc)
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with (
+            patch(
+                "ante.cli.commands.account._create_account_service",
+                new=_create_service,
+            ),
+            patch(
+                "ante.cli.commands.account._assert_no_active_runtime",
+                return_value=None,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "account",
+                    "set-credentials",
+                    "acc-test",
+                    "--credential",
+                    "app_key=k",
+                    "--credential",
+                    "app_secret=s",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload_line = next(
+            (line for line in result.output.splitlines() if line.startswith("{")),
+            None,
+        )
+        assert payload_line is not None, result.output
+        payload = json.loads(payload_line)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BROKER_RECONNECT_FAILED"
+
+    def test_ipc_envelope_broker_reconnect_failed(self) -> None:
+        exc = BrokerReconnectFailedError("재연결 실패")
+        assert _ipc_envelope_code(exc) == "BROKER_RECONNECT_FAILED"
+
+
+# ── (9) CLI surface override 보존 ───────────────────────────────────────────
+
+
+class TestAccountDeleteSurfaceOverride:
+    """``account delete`` 의 ``AccountDeletedError`` → ``ACCOUNT_ALREADY_DELETED``
+    surface override 보존 (CLI UX layer — registry default 와 분기).
+
+    registry default 는 ``ACCOUNT_DELETED`` (state_conflict) 이지만,
+    ``account delete`` 표면은 already-deleted UX 의미를 명시 surface 하기
+    위해 typed except 로 ``ACCOUNT_ALREADY_DELETED`` 코드를 surface 한다
+    (errors.py:96-100 NOTE / #1812 sweep).
+
+    emit_cli_error 정렬 후에도 typed except 가 generic 분기보다 먼저 매치
+    하므로 override 가 보존됨을 lock 한다.
+    """
+
+    def test_account_delete_preserves_already_deleted_code(
+        self, runner: CliRunner
+    ) -> None:
+        exc = AccountDeletedError("deleted")
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.delete.side_effect = exc
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with (
+            patch(
+                "ante.cli.commands.account._create_account_service",
+                new=_create_service,
+            ),
+            patch(
+                "ante.cli.commands.account._assert_no_active_runtime",
+                return_value=None,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "account", "delete", "acc-test", "--yes"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload_line = next(
+            (line for line in result.output.splitlines() if line.startswith("{")),
+            None,
+        )
+        assert payload_line is not None, result.output
+        payload = json.loads(payload_line)
+        assert payload["status"] == "error"
+        # CLI surface override: registry default (ACCOUNT_DELETED) 가 아닌
+        # CLI UX 코드 (ACCOUNT_ALREADY_DELETED) 가 surface 된다.
+        assert payload["code"] == "ACCOUNT_ALREADY_DELETED"
+        # 분리 lock: IPC envelope 는 여전히 registry default 인 ACCOUNT_DELETED
+        # 이다 (CLI/IPC divergence 가 의도적임을 명시).
+        assert _ipc_envelope_code(exc) == "ACCOUNT_DELETED"


### PR DESCRIPTION
Closes #1842

## Summary

- `EXCEPTION_TO_SPEC`에 account.errors 12 sub-class를 실측 `.code` mirror로 등록 (4 + 12 = 16 entries)
- account CLI direct path 9 callsite를 `emit_cli_error` helper로 정렬 — IPC envelope과 동일한 public code surface
- CLI direct ↔ IPC error code 동등성 17 test 신규 추가 (대표 9 fault + IPC pair)
- drift test의 staleness scanner를 `(module, name)` 2중 anchor로 정렬 (동명 별개 class 분리 — account.errors vs broker.registry의 `InvalidBrokerTypeError`)

## Codex Plan Review

- v1 verdict: request-changes (5 blocker)
- v2 verdict: approve-implement
- v2에서 흡수한 정정:
  1. registry mapping을 실측 `.code` mirror (`AccountDeletedError → ACCOUNT_DELETED`, `InvalidExchangeError → VALIDATION_ERROR`)
  2. `AccountError` base는 pending_migration에 baseline 유지 (Non-Goals)
  3. drift guard 동명 false positive: helper는 type-based MRO, drift test도 `(module, name)` 2중 anchor로 정렬
  4. 동등성 test 4 → 8 + CLI surface override 보존 test 추가
  5. CLI/IPC divergence: registry 값 = 실측 `.code` → CLI helper(registry-first)와 IPC server(`.code`-only) 동일 결과

## 보존된 typed except (CLI surface override)

- `AccountDeletedError → ACCOUNT_ALREADY_DELETED` (account delete / repair-timezone UX)
- `AccountHasActiveBotsError → ACCOUNT_HAS_ACTIVE_BOTS`
- `AccountNotFoundError → ACCOUNT_NOT_FOUND`
- `AccountStructuralChangeRequiresStoppedServerError → ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER`

## Non-Goals

- member/approval/bot/treasury 등 다른 domain migration (#1843)
- account command success output 표준화 (#1815)
- AccountError base class registry 등록 (사용 사례 없음)
- IPC server.py:322 generic fallback 제거

## Test plan

- [x] `pytest tests/unit/contracts -v` — 67 PASS (drift Family A/B + staleness)
- [x] `pytest tests/unit/test_account_cli_ipc_error_equivalence.py -v` — 17 PASS
- [x] `pytest tests/unit/` — 5142 passed, 2 skipped (회귀 0)
- [x] `mypy src/ante` — Success: no issues found in 222 source files
- [x] `ruff check + format --check` — clean
- [x] `python scripts/generate_project_structure.py` — 신규 test file 반영
- [x] main HEAD 불변 (862e37c 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)