### PR TITLE
fix: add pyyaml to dev dependencies (CI test fix for #1841 drift allowlist loader)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest-asyncio>=0.24",
     "pytest-cov>=6.0",
     "pytest-xdist>=3.5",
+    "pyyaml>=6.0",
     "ruff>=0.8",
     "mypy>=1.13",
 ]


### PR DESCRIPTION
main CI test 단계가 ModuleNotFoundError: No module named 'yaml' 로 실패 중.

#1841 (PR #1862)에서 helpers.py에 import yaml + load_drift_allowlist() 추가했지만 pyproject.toml dev dependency에 누락.

이 PR은 pyyaml>=6.0 한 줄 추가.