### PR TITLE
refactor: #1843-1 member error contract registry mirror + CLI direct ↔ IPC equivalence lock

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -590,7 +590,8 @@ tests/
 │   │   ├── error_drift_allowlist.yaml
 │   │   ├── test_auth_middleware_code_policy.py
 │   │   └── test_error_drift.py
-│   └── test_account_cli_ipc_error_equivalence.py
+│   ├── test_account_cli_ipc_error_equivalence.py
+│   └── test_member_cli_ipc_error_equivalence.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -27,6 +27,7 @@ from ante.cli.middleware import (
     require_master,
     require_scope,
 )
+from ante.contracts import emit_cli_error
 from ante.member.errors import (
     MemberAlreadyExistsError,
     MemberInvalidRecoveryCredentialError,
@@ -511,7 +512,10 @@ def member_register(
     try:
         result, token = _run(_run_register())
     except PermissionDeniedError:
-        fmt.error(_MASTER_REQUIRED_MESSAGE)
+        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 — master 검증 위반의
+        # 안정 코드. CLI surface override 보존: 사용자 친화 한국어 문구
+        # (``_MASTER_REQUIRED_MESSAGE``) 를 envelope message 로 surface 한다.
+        fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberAlreadyExistsError as e:
         # #1807 (Group R sweep): duplicate member_id 는 안정 코드
@@ -528,8 +532,8 @@ def member_register(
         fmt.error(str(e), code="MEMBER_INVALID_SCOPE")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output({**result, "token": token})
@@ -567,8 +571,8 @@ def member_set_emoji(ctx: click.Context, member_id: str, emoji: str) -> None:
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except ValueError as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     fmt.success(f"이모지 설정 완료: {member_id} → {result['emoji']}", result)
 
@@ -624,14 +628,16 @@ def member_update_scopes(ctx: click.Context, member_id: str, scopes: str) -> Non
         fmt.error(message, code=code)
         raise SystemExit(1) from e
     except PermissionDeniedError:
-        fmt.error(_MASTER_REQUIRED_MESSAGE)
+        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 — master 검증 위반.
+        # CLI surface override 보존 (한국어 친화 문구).
+        fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except InvalidScopeError as e:
         fmt.error(str(e), code="MEMBER_INVALID_SCOPE")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output(result)
@@ -660,7 +666,8 @@ def member_suspend(ctx: click.Context, member_id: str) -> None:
     try:
         result = _run(_run_suspend())
     except PermissionDeniedError:
-        fmt.error(_MASTER_REQUIRED_MESSAGE)
+        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 + CLI surface override.
+        fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberNotFoundError:
         # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
@@ -675,8 +682,8 @@ def member_suspend(ctx: click.Context, member_id: str) -> None:
         fmt.error(str(e), code="MEMBER_STATE_CONFLICT")
         raise SystemExit(1) from e
     except (ValueError, PermissionError) as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     fmt.success(f"멤버 정지 완료: {member_id}", result)
 
@@ -702,7 +709,8 @@ def member_reactivate(ctx: click.Context, member_id: str) -> None:
     try:
         result = _run(_run_reactivate())
     except PermissionDeniedError:
-        fmt.error(_MASTER_REQUIRED_MESSAGE)
+        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 + CLI surface override.
+        fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberNotFoundError:
         # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
@@ -717,8 +725,8 @@ def member_reactivate(ctx: click.Context, member_id: str) -> None:
         fmt.error(str(e), code="MEMBER_STATE_CONFLICT")
         raise SystemExit(1) from e
     except (ValueError, PermissionError) as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     fmt.success(f"멤버 재활성화 완료: {member_id}", result)
 
@@ -762,7 +770,8 @@ def member_revoke(ctx: click.Context, member_id: str, yes: bool) -> None:
     try:
         result = _run(_run_revoke())
     except PermissionDeniedError:
-        fmt.error(_MASTER_REQUIRED_MESSAGE)
+        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 + CLI surface override.
+        fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberNotFoundError:
         # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
@@ -770,8 +779,8 @@ def member_revoke(ctx: click.Context, member_id: str, yes: bool) -> None:
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     fmt.success(f"멤버 폐기 완료: {member_id}", result)
 
@@ -797,7 +806,8 @@ def member_rotate_token(ctx: click.Context, member_id: str) -> None:
     try:
         result, token = _run(_run_rotate())
     except PermissionDeniedError:
-        fmt.error(_MASTER_REQUIRED_MESSAGE)
+        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 + CLI surface override.
+        fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberNotFoundError:
         # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
@@ -805,8 +815,8 @@ def member_rotate_token(ctx: click.Context, member_id: str) -> None:
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output({**result, "token": token})
@@ -875,8 +885,8 @@ def member_reset_password(
         fmt.error(str(e), code=MemberInvalidRecoveryCredentialError.code)
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     fmt.success("패스워드가 변경되었습니다.")
 
@@ -938,8 +948,8 @@ def member_regenerate_recovery_key(
         fmt.error(str(e), code=MemberInvalidRecoveryCredentialError.code)
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output({"recovery_key": new_key})

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -41,6 +41,23 @@ category 정확화):
 ``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
 Non-Goals).
 
+#1843 sub-PR 1 (member sweep) 가 추가한 member domain 5 sub-class lock
+(실측 ``.code`` mirror, ``InvalidScopeError`` 는 #1840 lock 그대로 보존):
+
+- ``PermissionDeniedError`` → ``PERMISSION_DENIED`` / ``permission`` (본
+  PR 에서 ``.code`` 신규 부여 — master 검증 위반 fault 의 안정 코드)
+- ``MemberNotFoundError`` → ``MEMBER_NOT_FOUND`` / ``not_found`` (#1817)
+- ``MemberStateConflictError`` → ``MEMBER_STATE_CONFLICT`` /
+  ``state_conflict`` (#1825)
+- ``MemberAlreadyExistsError`` → ``MEMBER_ALREADY_EXISTS`` /
+  ``state_conflict`` (#1826)
+- ``MemberInvalidRecoveryCredentialError`` →
+  ``MEMBER_INVALID_RECOVERY_CREDENTIAL`` / ``auth`` (#1826)
+
+``MemberError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
+``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
+``AccountError`` 와 동일 패턴, #1843 sub-PR 1 Non-Goals).
+
 추가로 ``SERVICE_NOT_CONFIGURED`` 는 #1819 dispatch wrapper 가 도입할 예정인
 ``ServiceNotConfiguredError`` 의 ErrorSpec value 를 module-level constant
 (``_SERVICE_NOT_CONFIGURED_SPEC``) 로 reserved 보존한다. 해당 exception class
@@ -74,6 +91,13 @@ from ante.account.errors import (
 from ante.approval.errors import ApprovalNotFoundError
 from ante.bot.exceptions import BotNotFoundError
 from ante.contracts.errors import ErrorSpec
+from ante.member.errors import (
+    MemberAlreadyExistsError,
+    MemberInvalidRecoveryCredentialError,
+    MemberNotFoundError,
+    MemberStateConflictError,
+    PermissionDeniedError,
+)
 from ante.member.scopes import InvalidScopeError
 
 __all__ = [
@@ -176,6 +200,40 @@ _ACCOUNT_HAS_ACTIVE_BOTS_SPEC: Final[ErrorSpec] = ErrorSpec(
 )
 
 
+# ── member 5 sub-class lock (#1843 sub-PR 1, 실측 .code mirror) ──────────────
+
+# master 검증 위반의 안정 코드. 본 PR 에서 class-level ``.code`` 신규 부여
+# (errors.py:31 PermissionDeniedError) 와 동시에 registry 도 정렬한다 — IPC
+# server.py:322 ``getattr(e, "code", ...)`` 와 helper registry-first 가 동일
+# ``PERMISSION_DENIED`` 코드를 surface 한다.
+_MEMBER_PERMISSION_DENIED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="PERMISSION_DENIED",
+    category="permission",
+)
+
+_MEMBER_NOT_FOUND_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="MEMBER_NOT_FOUND",
+    category="not_found",
+)
+
+_MEMBER_STATE_CONFLICT_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="MEMBER_STATE_CONFLICT",
+    category="state_conflict",
+)
+
+_MEMBER_ALREADY_EXISTS_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="MEMBER_ALREADY_EXISTS",
+    category="state_conflict",
+)
+
+# recovery credential validation 거부는 의미상 인증(auth) 카테고리.
+# CLI 표면은 사용자 패스워드 / recovery key 미일치 (인증 실패) 를 의미한다.
+_MEMBER_INVALID_RECOVERY_CREDENTIAL_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="MEMBER_INVALID_RECOVERY_CREDENTIAL",
+    category="auth",
+)
+
+
 # ── reserved entry (#1819 후속 도입) ─────────────────────────────────────────
 #
 # ``SERVICE_NOT_CONFIGURED`` 는 taxonomy SSOT 가 ``service_unavailable`` 카테고리
@@ -225,6 +283,12 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     BrokerReconnectFailedError: _BROKER_RECONNECT_FAILED_SPEC,
     AccountStructuralChangeRequiresStoppedServerError: _ACCOUNT_STRUCTURAL_CHANGE_SPEC,
     AccountHasActiveBotsError: _ACCOUNT_HAS_ACTIVE_BOTS_SPEC,
+    # ── #1843 sub-PR 1 member 5 sub-class (실측 .code mirror) ─────────────
+    PermissionDeniedError: _MEMBER_PERMISSION_DENIED_SPEC,
+    MemberNotFoundError: _MEMBER_NOT_FOUND_SPEC,
+    MemberStateConflictError: _MEMBER_STATE_CONFLICT_SPEC,
+    MemberAlreadyExistsError: _MEMBER_ALREADY_EXISTS_SPEC,
+    MemberInvalidRecoveryCredentialError: _MEMBER_INVALID_RECOVERY_CREDENTIAL_SPEC,
 }
 """대표 fault lock registry (#1839 normative 4건).
 

--- a/src/ante/member/errors.py
+++ b/src/ante/member/errors.py
@@ -29,7 +29,21 @@ class MemberError(Exception):
 
 
 class PermissionDeniedError(MemberError):
-    """권한 부족 — master만 수행 가능한 작업을 비-master가 시도."""
+    """권한 부족 — master만 수행 가능한 작업을 비-master가 시도.
+
+    클래스 레벨 ``code`` 속성은 CLI/IPC envelope 이 안정 코드
+    ``"PERMISSION_DENIED"`` 로 surface 하도록 한다 (#1843 member sweep).
+
+    CLI direct path 의 ``except PermissionDeniedError:
+    fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")`` 명시
+    typed except 는 보존된다 — master 검증 위반의 사용자 친화 한국어 문구
+    (``_MASTER_REQUIRED_MESSAGE``) 가 envelope message 로 surface 되도록
+    명시 메시지 override 가 필요하다. IPC envelope (server.py:322) 는
+    ``getattr(e, "code", "EXECUTION_ERROR")`` 패스로 동일 ``PERMISSION_DENIED``
+    코드를 surface 한다 (CLI/IPC 동등성, #1842 plan v2 #6 패턴).
+    """
+
+    code: str = "PERMISSION_DENIED"
 
 
 class MemberNotFoundError(MemberError, ValueError):

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -72,66 +72,10 @@ known_drift_fmt_error_no_code:
     line: 179
     snippet_sha1: "1b05e8ebf6bd"
     reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 514
-    snippet_sha1: "5d87cae098dd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 531
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 570
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 627
-    snippet_sha1: "5d87cae098dd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 633
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 663
-    snippet_sha1: "5d87cae098dd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 678
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 705
-    snippet_sha1: "5d87cae098dd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 720
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 765
-    snippet_sha1: "5d87cae098dd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 773
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 800
-    snippet_sha1: "5d87cae098dd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 808
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 878
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/member.py
-    line: 941
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
+  # #1843 sub-PR 1: member.py entries 15건 제거 — emit_cli_error 정렬 완료
+  # (CLI direct path 가 IPC envelope 와 동일 public code surface).
+  # _MASTER_REQUIRED_MESSAGE override 보존하는 typed except 는 code 인자
+  # 명시 (``code="PERMISSION_DENIED"``) 로 정렬했다.
   - path: src/ante/cli/commands/strategy.py
     line: 149
     snippet_sha1: "439fab766435"
@@ -236,9 +180,8 @@ pending_migration:
   - module: ante.member.errors
     class_anchor: MemberError
     reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.member.errors
-    class_anchor: PermissionDeniedError
-    reason: "baseline (#1841); register in #1842/#1843"
+  # #1843 sub-PR 1: PermissionDeniedError 제거 — class-level
+  # ``code="PERMISSION_DENIED"`` 부여 + EXCEPTION_TO_SPEC 등록 완료.
   - module: ante.rule.exceptions
     class_anchor: RuleConfigError
     reason: "baseline (#1841); register in #1842/#1843"

--- a/tests/unit/test_member_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_member_cli_ipc_error_equivalence.py
@@ -1,0 +1,478 @@
+"""Member CLI direct path ↔ IPC path error code equivalence lock (#1843 sub-PR 1).
+
+본 모듈은 #1816 의 2차 migration domain (member) 의 대표 fault 5 건이 CLI
+direct path 와 IPC envelope path 양쪽에서 **동일한 public code** 를 노출
+함을 lock 한다. #1842 (account) 의 1:1 동형 패턴.
+
+검증 대상 fault:
+
+- ``MemberNotFoundError`` → ``MEMBER_NOT_FOUND`` (not_found)
+- ``MemberStateConflictError`` → ``MEMBER_STATE_CONFLICT`` (state_conflict;
+  ``suspend`` / ``reactivate`` 양쪽 표면)
+- ``MemberAlreadyExistsError`` → ``MEMBER_ALREADY_EXISTS`` (state_conflict;
+  ``register`` 표면)
+- ``MemberInvalidRecoveryCredentialError`` → ``MEMBER_INVALID_RECOVERY_CREDENTIAL``
+  (auth; ``reset-password`` 표면)
+- ``InvalidScopeError`` → ``MEMBER_INVALID_SCOPE`` (permission; ``register``
+  / ``update-scopes`` 표면 + 실제 ``member.update_scopes`` IPC handler 회귀)
+- ``PermissionDeniedError`` → ``PERMISSION_DENIED`` (permission; master 검증
+  위반, CLI surface override 인 ``_MASTER_REQUIRED_MESSAGE`` 한국어 문구
+  보존 확인)
+
+CLI direct path 는 ``CliRunner`` 로 ``ante --format json member ...`` 를
+실행해 ``OutputFormatter`` 의 JSON envelope code 를 단언한다 (subprocess
+오버헤드 없이 동일 dispatch).
+
+IPC path 는 ``ante.contracts.ipc_error_payload`` helper (server.py:322 의
+``getattr(e, "code", "EXECUTION_ERROR")`` 와 동일 코드를 생성 — 실측
+``.code`` 가 일치하는 한 contract 동등성, #1842 plan v2 #6) 로 직접 직렬화
+하거나, ``InvalidScopeError`` 의 경우 실제 ``member.update_scopes`` IPC
+handler 를 ``IPCServer`` 위에서 실행해 envelope code 를 확인한다.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.contracts import ipc_error_payload
+from ante.core.registry import ServiceRegistry
+from ante.ipc.client import IPCClient
+from ante.ipc.registry import CommandRegistry, register_all_handlers
+from ante.ipc.server import IPCServer
+from ante.member.errors import (
+    MemberAlreadyExistsError,
+    MemberInvalidRecoveryCredentialError,
+    MemberNotFoundError,
+    MemberStateConflictError,
+    PermissionDeniedError,
+)
+from ante.member.models import Member, MemberRole, MemberType
+from ante.member.scopes import InvalidScopeError
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """``ante --format json member ...`` 호출용 ``CliRunner`` fixture.
+
+    auth middleware 를 master member 로 우회한다 (account equivalence test
+    fixture 동형). ``require_master`` decorator 는 그대로 동작하므로 master
+    role 멤버를 주입한다.
+    """
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx) -> None:  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+def _ipc_envelope_code(exc: BaseException) -> str:
+    """주어진 exception 을 IPC envelope 으로 직렬화했을 때의 ``code``.
+
+    IPC server.py:322 가 적용하는 ``getattr(e, "code", "EXECUTION_ERROR")``
+    fallback 과 helper(``ipc_error_payload``)의 registry-first resolution 은
+    실측 ``.code`` 가 일치하는 한 동일 코드를 생성한다 (#1842 plan v2 #6).
+    본 helper 는 helper 경로를 그대로 사용해 contract 동등성을 단언한다.
+    """
+
+    payload = ipc_error_payload(exc)
+    return payload["code"]
+
+
+def _cli_envelope_payload(result_output: str) -> dict:
+    """``CliRunner.result.output`` 에서 JSON envelope 첫 객체를 추출."""
+    payload_line = next(
+        (line for line in result_output.splitlines() if line.startswith("{")),
+        None,
+    )
+    assert payload_line is not None, f"JSON envelope 발견 실패: {result_output!r}"
+    return json.loads(payload_line)
+
+
+# ── (1) MemberNotFoundError ↔ MEMBER_NOT_FOUND ──────────────────────────────
+
+
+class TestMemberNotFoundEquivalence:
+    """``MemberNotFoundError`` 는 양쪽에서 ``MEMBER_NOT_FOUND``.
+
+    CLI direct path: ``member suspend`` 표면 — ``except MemberNotFoundError:
+    fmt.error(..., code="MEMBER_NOT_FOUND")`` typed 매핑 (보존).
+    """
+
+    def test_cli_direct_not_found_via_suspend(self, runner: CliRunner) -> None:
+        exc = MemberNotFoundError("missing")
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.suspend.side_effect = exc
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "member", "suspend", "missing"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "MEMBER_NOT_FOUND"
+
+    def test_ipc_envelope_not_found(self) -> None:
+        exc = MemberNotFoundError("missing")
+        assert _ipc_envelope_code(exc) == "MEMBER_NOT_FOUND"
+
+
+# ── (2) MemberStateConflictError ↔ MEMBER_STATE_CONFLICT (suspend/reactivate)
+
+
+class TestMemberStateConflictEquivalence:
+    """``MemberStateConflictError`` 는 양쪽에서 ``MEMBER_STATE_CONFLICT``.
+
+    CLI direct path: ``member suspend`` / ``member reactivate`` 양쪽 표면
+    모두 typed 매핑 (``except MemberStateConflictError:
+    fmt.error(..., code="MEMBER_STATE_CONFLICT")``) 보존 — generic
+    fallback (``emit_cli_error``) 보다 typed 분기를 우선 매칭한다.
+    """
+
+    def test_cli_direct_state_conflict_via_suspend(self, runner: CliRunner) -> None:
+        exc = MemberStateConflictError(
+            member_id="m-test", current_status="suspended", requested_action="suspend"
+        )
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.suspend.side_effect = exc
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "member", "suspend", "m-test"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "MEMBER_STATE_CONFLICT"
+
+    def test_cli_direct_state_conflict_via_reactivate(self, runner: CliRunner) -> None:
+        exc = MemberStateConflictError(
+            member_id="m-test", current_status="active", requested_action="reactivate"
+        )
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.reactivate.side_effect = exc
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "member", "reactivate", "m-test"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "MEMBER_STATE_CONFLICT"
+
+    def test_ipc_envelope_state_conflict(self) -> None:
+        exc = MemberStateConflictError(
+            member_id="m-test", current_status="suspended", requested_action="suspend"
+        )
+        assert _ipc_envelope_code(exc) == "MEMBER_STATE_CONFLICT"
+
+
+# ── (3) MemberAlreadyExistsError ↔ MEMBER_ALREADY_EXISTS (register) ─────────
+
+
+class TestMemberAlreadyExistsEquivalence:
+    """``MemberAlreadyExistsError`` 는 양쪽에서 ``MEMBER_ALREADY_EXISTS``.
+
+    CLI direct path: ``member register`` 표면 — typed 매핑 (``except
+    MemberAlreadyExistsError: fmt.error(..., code=...)``) 보존.
+    """
+
+    def test_cli_direct_already_exists_via_register(self, runner: CliRunner) -> None:
+        exc = MemberAlreadyExistsError("dup")
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.register.side_effect = exc
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "register",
+                    "--id",
+                    "dup",
+                    "--type",
+                    "human",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "MEMBER_ALREADY_EXISTS"
+
+    def test_ipc_envelope_already_exists(self) -> None:
+        exc = MemberAlreadyExistsError("dup")
+        assert _ipc_envelope_code(exc) == "MEMBER_ALREADY_EXISTS"
+
+
+# ── (4) MemberInvalidRecoveryCredentialError ↔ MEMBER_INVALID_RECOVERY_CREDENTIAL
+
+
+class TestMemberInvalidRecoveryCredentialEquivalence:
+    """``MemberInvalidRecoveryCredentialError`` 는 양쪽에서
+    ``MEMBER_INVALID_RECOVERY_CREDENTIAL``.
+
+    CLI direct path: ``member reset-password`` 표면 — typed 매핑
+    (``except MemberInvalidRecoveryCredentialError: fmt.error(...,
+    code=MemberInvalidRecoveryCredentialError.code)``) 보존.
+    """
+
+    def test_cli_direct_invalid_recovery_via_reset_password(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        exc = MemberInvalidRecoveryCredentialError("잘못된 recovery key")
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.list_members = AsyncMock(
+            return_value=[
+                Member(
+                    member_id="master",
+                    type=MemberType.HUMAN,
+                    role=MemberRole.MASTER,
+                    org="default",
+                    name="Master",
+                    status="active",
+                    scopes=[],
+                )
+            ]
+        )
+        svc.reset_password = AsyncMock(side_effect=exc)
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        monkeypatch.setenv("ANTE_TEST_NEW_PASSWORD", "new-pw-12345")
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "wrong-key",
+                    "--new-password-env",
+                    "ANTE_TEST_NEW_PASSWORD",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "MEMBER_INVALID_RECOVERY_CREDENTIAL"
+
+    def test_ipc_envelope_invalid_recovery_credential(self) -> None:
+        exc = MemberInvalidRecoveryCredentialError("잘못된 recovery key")
+        assert _ipc_envelope_code(exc) == "MEMBER_INVALID_RECOVERY_CREDENTIAL"
+
+
+# ── (5) InvalidScopeError ↔ MEMBER_INVALID_SCOPE (CLI + real IPC handler) ───
+
+
+class TestMemberInvalidScopeEquivalence:
+    """``InvalidScopeError`` 는 양쪽에서 ``MEMBER_INVALID_SCOPE``.
+
+    CLI direct path: ``member register`` 표면 — typed 매핑 (``except
+    InvalidScopeError: fmt.error(..., code="MEMBER_INVALID_SCOPE")``) 보존.
+
+    IPC path: 실제 ``member.update_scopes`` handler 를 ``IPCServer`` 위에서
+    실행해 envelope code 를 확인한다 (#1842 ``account.suspend`` 1:1 동형).
+    """
+
+    def test_cli_direct_invalid_scope_via_register(self, runner: CliRunner) -> None:
+        exc = InvalidScopeError("oracle:invalid")
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.register.side_effect = exc
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "register",
+                    "--id",
+                    "m-test",
+                    "--type",
+                    "human",
+                    "--scopes",
+                    "oracle:invalid",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "MEMBER_INVALID_SCOPE"
+
+    def test_ipc_envelope_invalid_scope(self) -> None:
+        exc = InvalidScopeError("oracle:invalid")
+        assert _ipc_envelope_code(exc) == "MEMBER_INVALID_SCOPE"
+
+    @pytest.mark.asyncio
+    async def test_ipc_envelope_invalid_scope_via_real_handler(self) -> None:
+        """실제 ``member.update_scopes`` IPC handler 가 typed code 를 envelope
+        으로 surface 한다 (#1842 ``account.suspend`` 1:1 동형 회귀 lock)."""
+        td = tempfile.mkdtemp(prefix="ipc_member_equiv", dir="/tmp")
+        socket_path = str(Path(td) / "t.sock")
+
+        member_service = MagicMock()
+        member_service.update_scopes = AsyncMock(
+            side_effect=InvalidScopeError("oracle:invalid")
+        )
+        svc_registry = ServiceRegistry(
+            account=MagicMock(),
+            bot_manager=MagicMock(),
+            treasury_manager=MagicMock(),
+            dynamic_config=MagicMock(),
+            approval=MagicMock(),
+            reconciler=MagicMock(),
+            eventbus=MagicMock(),
+            member_service=member_service,
+        )
+        cmd_registry = CommandRegistry()
+        register_all_handlers(cmd_registry)
+
+        server = IPCServer(socket_path, svc_registry, cmd_registry)
+        await server.start()
+        try:
+            client = IPCClient(socket_path, timeout=5.0)
+            response = await client.send(
+                "member.update_scopes",
+                {"member_id": "m-test", "scopes": ["oracle:invalid"]},
+                actor="tester",
+            )
+            assert response["status"] == "error"
+            assert response["error"]["code"] == "MEMBER_INVALID_SCOPE"
+        finally:
+            await server.stop()
+
+
+# ── (6) PermissionDeniedError ↔ PERMISSION_DENIED (CLI override 보존) ───────
+
+
+class TestMemberPermissionDeniedEquivalence:
+    """``PermissionDeniedError`` 는 양쪽에서 ``PERMISSION_DENIED``.
+
+    CLI direct path: ``member suspend`` (등 master-guarded 표면) — typed
+    매핑 (``except PermissionDeniedError: fmt.error(_MASTER_REQUIRED_MESSAGE,
+    code="PERMISSION_DENIED")``) 보존. CLI surface override 는 envelope
+    message 에 한국어 친화 문구 (``_MASTER_REQUIRED_MESSAGE``) 를 surface
+    하는 책임 — code 는 동일하게 ``PERMISSION_DENIED``.
+
+    IPC path: server.py:322 의 ``getattr(e, "code", ...)`` 는 본 PR 에서
+    추가한 class-level ``.code = "PERMISSION_DENIED"`` 를 그대로 surface
+    한다 (helper-direct ``ipc_error_payload`` 와 동일 결과).
+    """
+
+    def test_cli_direct_permission_denied_via_suspend(self, runner: CliRunner) -> None:
+        exc = PermissionDeniedError("master 권한이 필요합니다")
+        svc = AsyncMock()
+        db = AsyncMock()
+        svc.suspend.side_effect = exc
+
+        async def _create_service():  # noqa: ANN202
+            return svc, db
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "member", "suspend", "m-test"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        # CLI surface override: code 는 동일 PERMISSION_DENIED 지만,
+        # message 는 ``_MASTER_REQUIRED_MESSAGE`` (한국어 친화 문구) 로
+        # surface 된다 — code 일관성과 UX message override 의 동시 보존.
+        assert payload["code"] == "PERMISSION_DENIED"
+        assert "master" in payload["message"]
+
+    def test_ipc_envelope_permission_denied(self) -> None:
+        exc = PermissionDeniedError("master 권한이 필요합니다")
+        # server.py:322 ``getattr(e, "code", ...)`` 와 helper ``ipc_error_payload``
+        # 가 동일 코드를 produce 함을 verify (CLI/IPC contract 동등성).
+        assert _ipc_envelope_code(exc) == "PERMISSION_DENIED"


### PR DESCRIPTION
Refs #1843 (per-domain 6 sweep PR 의 첫 번째). closes 는 sub-PR 6 에서.

#1842 (account, PR #1863) 패턴 1:1 동형으로 member domain 의 ad-hoc error
code 표면과 generic except fallback 을 taxonomy 기준으로 정렬한다.

## Summary

- `EXCEPTION_TO_SPEC` 에 member 5 sub-class 등록 (실측 `.code` mirror;
  16 + 5 = 21 entries)
- `PermissionDeniedError` 에 `code="PERMISSION_DENIED"` 신규 부여 — IPC
  envelope (server.py:322 `getattr(e, "code", ...)`) 과 helper 양쪽이
  동일 코드 surface (`master 권한 위반` 안정 코드)
- member CLI direct path 9 generic callsite 를 `emit_cli_error` 헬퍼로
  정렬 — IPC envelope 와 동일한 public code surface
- `PermissionDeniedError` typed except 6 callsite 보존 + code 명시 (CLI
  surface override: `_MASTER_REQUIRED_MESSAGE` 한국어 친화 문구)
- CLI direct ↔ IPC error code 동등성 14 test 신규 추가 (6 fault × CLI +
  IPC + suspend/reactivate variant + real-handler `member.update_scopes`
  IPC variant)

## Registry 신규 entries (5)

| Exception | code | category |
|-----------|------|----------|
| `PermissionDeniedError` | `PERMISSION_DENIED` | `permission` |
| `MemberNotFoundError` | `MEMBER_NOT_FOUND` | `not_found` |
| `MemberStateConflictError` | `MEMBER_STATE_CONFLICT` | `state_conflict` |
| `MemberAlreadyExistsError` | `MEMBER_ALREADY_EXISTS` | `state_conflict` |
| `MemberInvalidRecoveryCredentialError` | `MEMBER_INVALID_RECOVERY_CREDENTIAL` | `auth` |

`InvalidScopeError` (`MEMBER_INVALID_SCOPE`, `permission`) 는 이미 #1840
에 등록되어 있어 본 PR 범위 밖이다. 동등성 test 는 본 PR 에서 추가했다.

## 보존된 typed except (CLI surface override)

- `PermissionDeniedError` → `PERMISSION_DENIED` (register / update-scopes /
  suspend / reactivate / revoke / rotate-token; envelope message =
  `_MASTER_REQUIRED_MESSAGE` 한국어 친화 문구)
- `MemberNotFoundError` → `MEMBER_NOT_FOUND` (set-emoji / suspend /
  reactivate / revoke / rotate-token; envelope message 한국어 친화 문구)
- `MemberAlreadyExistsError` → `MEMBER_ALREADY_EXISTS` (register)
- `MemberStateConflictError` → `MEMBER_STATE_CONFLICT` (suspend / reactivate)
- `InvalidScopeError` → `MEMBER_INVALID_SCOPE` (register / update-scopes)
- `MemberInvalidRecoveryCredentialError` → `MEMBER_INVALID_RECOVERY_CREDENTIAL`
  (reset-password / regenerate-recovery-key)

## allowlist 정리

- `known_drift_fmt_error_no_code`: member.py 15 entries 제거 (Family A
  정렬 완료)
- `pending_migration`: `PermissionDeniedError` entry 제거 (Family B 정렬)
- `MemberError` base 는 그대로 유지 (#1842 `AccountError` 패턴 — 사용
  사례 없음, sub-PR 6 final allowlist clear 시 재검토)

## Non-Goals

- approval / bot / treasury / broker / strategy 등 다른 domain migration
  (#1843 sub-PR 2-6 가 단계적으로 처리)
- success JSON output 표준화 (#1815)
- IPC metadata 확장 (#1819)
- `MemberError` base class registry 등록 (사용 사례 없음)
- error message 문구 표준화 (#1816 Non-Goals)

## 후속 sub-PR

- sub-PR 2: approval sweep
- sub-PR 3: bot sweep
- sub-PR 4: treasury sweep
- sub-PR 5: broker sweep + 원천 code 분리
- sub-PR 6: strategy / config / rule / instrument / report sweep + final
  allowlist clear (ordering gate: sub-PR 1-5 모두 merge 후)

## Test plan

- [x] `pytest tests/unit/contracts -v` — 67 PASS (Family A/B drift + staleness)
- [x] `pytest tests/unit/test_member_cli_ipc_error_equivalence.py -v` — 14 PASS
- [x] `pytest tests/unit/test_cli_member_non_interactive.py + test_member.py +
  test_member_service.py` — 131 PASS (member 회귀 0)
- [x] `pytest tests/unit/` — 5156 passed, 2 skipped (회귀 0; 이전 baseline
  5142 + 14 신규)
- [x] `mypy src/ante` — Success: no issues found in 222 source files
- [x] `ruff check + format --check` — clean
- [x] `python scripts/generate_project_structure.py` — 신규 test file 반영
- [x] main HEAD 불변 (95cc2e0 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)