### PR TITLE
refactor: #1843-2 approval error contract registry mirror + CLI direct ↔ IPC equivalence lock

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -591,7 +591,8 @@ tests/
 │   │   ├── test_auth_middleware_code_policy.py
 │   │   └── test_error_drift.py
 │   ├── test_account_cli_ipc_error_equivalence.py
-│   └── test_member_cli_ipc_error_equivalence.py
+│   ├── test_member_cli_ipc_error_equivalence.py
+│   └── test_approval_cli_ipc_error_equivalence.py
 └── __init__.py
 ```
 

--- a/src/ante/approval/models.py
+++ b/src/ante/approval/models.py
@@ -70,7 +70,17 @@ class ValidationResult:
 
 
 class ApprovalValidationError(Exception):
-    """사전 검증 실패 — 요청 생성 차단."""
+    """사전 검증 실패 — 요청 생성 차단.
+
+    클래스 레벨 ``code`` 속성은 IPC 서버 envelope 이 안정 코드
+    ``"APPROVAL_VALIDATION_ERROR"`` 로 surface 하도록 한다 (#1843 sub-PR 2;
+    CLI ``approval request`` 의 ``--params`` / ``--type`` / ``--expires-in``
+    ingress validation 과 동일한 안정 코드). helper
+    (``error_spec_for_exception``) 의 registry MRO lookup 도 동일 코드로
+    resolve 한다.
+    """
+
+    code: str = "APPROVAL_VALIDATION_ERROR"
 
     def __init__(self, detail: str) -> None:
         self.detail = detail

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -13,6 +13,7 @@ from ante.approval.models import ApprovalStatus, ApprovalType
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+from ante.contracts import emit_cli_error
 
 # `ApprovalStatus`/`ApprovalType` enum이 `--status`/`--type` 필터의 SSOT다.
 # `approval list`는 DB 진입 전 preflight에서 invalid 값을 차단해야 하며 (#1462),
@@ -122,8 +123,12 @@ def request(
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: typed exception (.code) 또는 registry MRO lookup 으로
+        # IPC envelope 과 동일한 public code (APPROVAL_VALIDATION_ERROR /
+        # APPROVAL_STATUS_CONFLICT 등) 를 surface 한다. registry miss 시
+        # EXECUTION_ERROR fallback (기존 ad-hoc "APPROVAL_ERROR" 와 별개의
+        # taxonomy lock 코드).
+        emit_cli_error(fmt, e)
 
 
 @approval.command("list")
@@ -212,8 +217,9 @@ def approval_list(
         rows = asyncio.run(_list())
         fmt.table(rows, ["id", "type", "status", "requester", "title", "created_at"])
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
+        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        emit_cli_error(fmt, e)
 
 
 @approval.command()
@@ -282,11 +288,15 @@ def info(ctx: click.Context, id: str, db_path: str | None) -> None:
     except ApprovalNotFoundError as e:
         # #1811: missing approval 은 안정 코드 ``APPROVAL_NOT_FOUND`` 로
         # surface 한다 (Group A ``ApprovalNotFoundError.code`` 와 동형).
+        # #1843 sub-PR 2: typed except 보존 — registry 등록된 동일 코드와
+        # surface 일치하지만, ``info``/``review`` 양쪽이 _find_request 의
+        # ValueError(multi-match) 분기와도 구분되어야 하므로 명시 매핑 유지.
         fmt.error(str(e), code="APPROVAL_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
+        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        emit_cli_error(fmt, e)
 
 
 @approval.command()
@@ -365,12 +375,13 @@ def review(
     except ApprovalNotFoundError as e:
         # #1811: missing approval 은 안정 코드 ``APPROVAL_NOT_FOUND`` 로
         # surface 한다 (Group A ``ApprovalNotFoundError.code`` 와 동형,
-        # ``approval info`` 형제 패턴 미러).
+        # ``approval info`` 형제 패턴 미러). #1843 sub-PR 2: typed except 보존.
         fmt.error(str(e), code="APPROVAL_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
+        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        emit_cli_error(fmt, e)
 
 
 @approval.command("reopen")
@@ -439,8 +450,9 @@ def reopen(
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
+        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        emit_cli_error(fmt, e)
 
 
 @approval.command("audit-types")
@@ -526,8 +538,9 @@ def audit_types(
             ["id", "type", "status", "requester", "created_at", "expires_at"],
         )
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
+        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        emit_cli_error(fmt, e)
 
 
 @approval.command("cancel-invalid")
@@ -569,8 +582,9 @@ def cancel_invalid(ctx: click.Context, id: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
+        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        emit_cli_error(fmt, e)
 
 
 @approval.command("cancel")
@@ -598,8 +612,9 @@ def cancel(ctx: click.Context, id: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
+        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        emit_cli_error(fmt, e)
 
 
 @approval.command("approve")
@@ -626,8 +641,10 @@ def approve(ctx: click.Context, id: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
+        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface
+        # (ApprovalStatusConflictError → APPROVAL_STATUS_CONFLICT 등).
+        emit_cli_error(fmt, e)
 
 
 @approval.command("reject")
@@ -659,8 +676,10 @@ def reject(ctx: click.Context, id: str, reason: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e), code="APPROVAL_ERROR")
-        raise SystemExit(1) from e
+        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
+        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface
+        # (ApprovalStatusConflictError → APPROVAL_STATUS_CONFLICT 등).
+        emit_cli_error(fmt, e)
 
 
 async def _find_request(service, id: str):  # type: ignore[no-untyped-def]
@@ -669,8 +688,9 @@ async def _find_request(service, id: str):  # type: ignore[no-untyped-def]
     not-found 는 ``ApprovalNotFoundError`` 로 raise 해 CLI ``approval info``
     / ``approval review`` 가 typed envelope code ``APPROVAL_NOT_FOUND`` 로
     surface 할 수 있도록 한다 (#1811). multi-match 는 ``ValueError`` 로
-    유지 — 별도 의미(``"여러 건이 일치"``)이며 기존 generic 핸들러가
-    ``APPROVAL_ERROR`` 로 surface 한다.
+    유지 — 별도 의미(``"여러 건이 일치"``)이며 #1843 sub-PR 2 정렬 이후
+    generic ``emit_cli_error(fmt, e)`` 핸들러가 helper resolver 의 fallback
+    ``EXECUTION_ERROR`` 코드로 surface 한다 (registry 미등록 / ``.code`` 부재).
     """
     from ante.approval.errors import ApprovalNotFoundError
 

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -58,6 +58,22 @@ Non-Goals).
 ``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
 ``AccountError`` 와 동일 패턴, #1843 sub-PR 1 Non-Goals).
 
+#1843 sub-PR 2 (approval sweep) 가 추가한 approval domain 2 sub-class lock
+(실측 ``.code`` mirror, ``ApprovalNotFoundError`` 는 #1840 lock 그대로 보존):
+
+- ``ApprovalStatusConflictError`` → ``APPROVAL_STATUS_CONFLICT`` /
+  ``state_conflict`` (#1813 Group Q sweep; ``approve``/``reject`` 표면의
+  status flow 위반)
+- ``ApprovalValidationError`` → ``APPROVAL_VALIDATION_ERROR`` /
+  ``validation`` (``ApprovalService.create`` 사전검증 ``fail`` grade 거부;
+  CLI ``approval request`` 의 ``--params`` / ``--type`` / ``--expires-in``
+  ingress validation 과 동일한 안정 코드 surface — 본 PR 에서 class-level
+  ``.code`` 신규 부여)
+
+``ApprovalError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
+``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
+``AccountError`` 와 동일 패턴, #1843 sub-PR 2 Non-Goals).
+
 추가로 ``SERVICE_NOT_CONFIGURED`` 는 #1819 dispatch wrapper 가 도입할 예정인
 ``ServiceNotConfiguredError`` 의 ErrorSpec value 를 module-level constant
 (``_SERVICE_NOT_CONFIGURED_SPEC``) 로 reserved 보존한다. 해당 exception class
@@ -88,7 +104,8 @@ from ante.account.errors import (
     InvalidExchangeError,
     MissingCredentialsError,
 )
-from ante.approval.errors import ApprovalNotFoundError
+from ante.approval.errors import ApprovalNotFoundError, ApprovalStatusConflictError
+from ante.approval.models import ApprovalValidationError
 from ante.bot.exceptions import BotNotFoundError
 from ante.contracts.errors import ErrorSpec
 from ante.member.errors import (
@@ -234,6 +251,28 @@ _MEMBER_INVALID_RECOVERY_CREDENTIAL_SPEC: Final[ErrorSpec] = ErrorSpec(
 )
 
 
+# ── approval 2 sub-class lock (#1843 sub-PR 2, 실측 .code mirror) ────────────
+
+# ``approve``/``reject`` 표면의 status flow 위반 (rejected → 재reject,
+# approved → 재approve 등). class-level ``.code = "APPROVAL_STATUS_CONFLICT"``
+# (#1813 Group Q sweep) 와 정렬 — IPC server.py:322 ``getattr(e, "code", ...)``
+# 와 helper registry-first 가 동일 코드를 surface 한다.
+_APPROVAL_STATUS_CONFLICT_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="APPROVAL_STATUS_CONFLICT",
+    category="state_conflict",
+)
+
+# ``ApprovalService.create`` 사전검증 ``fail`` grade 거부. CLI ``approval
+# request`` 의 ingress validation (``--params`` JSON object 가드, ``--type``
+# enum 검증, ``--expires-in`` 파싱) 과 동일한 안정 코드 ``APPROVAL_VALIDATION_ERROR``
+# 를 service-side typed exception 도 surface 한다. 본 PR 에서 class-level
+# ``.code`` 신규 부여 (``ante.approval.models.ApprovalValidationError``).
+_APPROVAL_VALIDATION_ERROR_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="APPROVAL_VALIDATION_ERROR",
+    category="validation",
+)
+
+
 # ── reserved entry (#1819 후속 도입) ─────────────────────────────────────────
 #
 # ``SERVICE_NOT_CONFIGURED`` 는 taxonomy SSOT 가 ``service_unavailable`` 카테고리
@@ -289,6 +328,9 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     MemberStateConflictError: _MEMBER_STATE_CONFLICT_SPEC,
     MemberAlreadyExistsError: _MEMBER_ALREADY_EXISTS_SPEC,
     MemberInvalidRecoveryCredentialError: _MEMBER_INVALID_RECOVERY_CREDENTIAL_SPEC,
+    # ── #1843 sub-PR 2 approval 2 sub-class (실측 .code mirror) ───────────
+    ApprovalStatusConflictError: _APPROVAL_STATUS_CONFLICT_SPEC,
+    ApprovalValidationError: _APPROVAL_VALIDATION_ERROR_SPEC,
 }
 """대표 fault lock registry (#1839 normative 4건).
 

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -108,9 +108,11 @@ pending_migration:
   - module: ante.approval.errors
     class_anchor: ApprovalError
     reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.approval.models
-    class_anchor: ApprovalValidationError
-    reason: "baseline (#1841); register in #1842/#1843"
+  # #1843 sub-PR 2: ApprovalValidationError 제거 — class-level
+  # ``code="APPROVAL_VALIDATION_ERROR"`` 부여 + EXCEPTION_TO_SPEC 등록 완료.
+  # ApprovalStatusConflictError 는 이미 class-level ``.code`` (#1813 Group Q)
+  # 를 보유해 본 allowlist 에 등록되어 있지 않았다 — 본 PR 의 registry 등록
+  # 만으로 helper 가 typed code 를 resolve 한다.
   - module: ante.backtest.exceptions
     class_anchor: BacktestConfigError
     reason: "baseline (#1841); register in #1842/#1843"

--- a/tests/unit/test_approval_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_approval_cli_ipc_error_equivalence.py
@@ -1,0 +1,332 @@
+"""Approval CLI direct path ↔ IPC path error code equivalence lock (#1843 sub-PR 2).
+
+본 모듈은 #1816 의 3차 migration domain (approval) 의 대표 fault 3 건이 CLI
+path 와 IPC envelope path 양쪽에서 **동일한 public code** 를 노출함을 lock
+한다. #1842 (account, 17 PASS) / #1843 sub-PR 1 (member, 14 PASS) 의 1:1
+동형 패턴.
+
+검증 대상 fault:
+
+- ``ApprovalNotFoundError`` → ``APPROVAL_NOT_FOUND`` (not_found; ``info``
+  / ``review`` 표면 typed except 매핑, IPC envelope helper)
+- ``ApprovalStatusConflictError`` → ``APPROVAL_STATUS_CONFLICT`` (state_conflict;
+  ``approve`` / ``reject`` 표면 helper resolver — class-level ``.code``,
+  실제 ``approval.approve`` IPC handler 회귀 통합)
+- ``ApprovalValidationError`` → ``APPROVAL_VALIDATION_ERROR`` (validation;
+  ``request`` 표면 service-side 사전검증 거부, IPC envelope helper)
+
+approval CLI 는 service 호출이 모두 IPC 경유 (``ipc_send`` → server →
+service) 이므로 CLI direct path equivalence 는 다음 두 axis 로 검증한다:
+
+1. ``ipc_send`` mock 로 IPC envelope 의 ``{code, message}`` 를 주입한 뒤,
+   middleware ``ClickException`` 분기 (``ipc_error_code`` 부착) 가 동일
+   code 로 CLI envelope 을 surface 함을 확인.
+2. ``info`` / ``review`` 처럼 ``_find_request`` 가 CLI 안에서 직접
+   ``ApprovalNotFoundError`` 를 raise 하는 경우는 typed except 매핑으로
+   동일 코드를 surface 함을 확인.
+3. IPC path 는 ``ante.contracts.ipc_error_payload`` helper (server.py:322
+   의 ``getattr(e, "code", "EXECUTION_ERROR")`` 와 동일 코드를 생성 —
+   실측 ``.code`` 가 일치하는 한 contract 동등성, #1842 plan v2 #6) 로
+   직접 직렬화하거나, ``ApprovalStatusConflictError`` 의 경우 실제
+   ``approval.approve`` IPC handler 를 ``IPCServer`` 위에서 실행해 envelope
+   code 를 확인한다 (#1842 ``account.suspend`` 1:1 동형 회귀 lock).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.approval.errors import ApprovalNotFoundError, ApprovalStatusConflictError
+from ante.approval.models import ApprovalValidationError
+from ante.cli.main import cli
+from ante.contracts import ipc_error_payload
+from ante.core.registry import ServiceRegistry
+from ante.ipc.client import IPCClient
+from ante.ipc.registry import CommandRegistry, register_all_handlers
+from ante.ipc.server import IPCServer
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=["approval:read", "approval:write", "approval:admin"],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """``ante --format json approval ...`` 호출용 ``CliRunner`` fixture.
+
+    auth middleware 를 master member 로 우회한다 (#1865 ``member`` equivalence
+    test fixture 동형). ``require_scope`` decorator 는 그대로 동작하므로 모든
+    approval scope (``read`` / ``write`` / ``admin``) 를 부여한다.
+    """
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx) -> None:  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+def _ipc_envelope_code(exc: BaseException) -> str:
+    """주어진 exception 을 IPC envelope 으로 직렬화했을 때의 ``code``.
+
+    IPC server.py:322 가 적용하는 ``getattr(e, "code", "EXECUTION_ERROR")``
+    fallback 과 helper(``ipc_error_payload``)의 registry-first resolution 은
+    실측 ``.code`` 가 일치하는 한 동일 코드를 생성한다 (#1842 plan v2 #6).
+    본 helper 는 helper 경로를 그대로 사용해 contract 동등성을 단언한다.
+    """
+
+    payload = ipc_error_payload(exc)
+    return payload["code"]
+
+
+def _cli_envelope_payload(result_output: str) -> dict:
+    """``CliRunner.result.output`` 에서 JSON envelope 첫 객체를 추출."""
+    payload_line = next(
+        (line for line in result_output.splitlines() if line.startswith("{")),
+        None,
+    )
+    assert payload_line is not None, f"JSON envelope 발견 실패: {result_output!r}"
+    return json.loads(payload_line)
+
+
+# ── (1) ApprovalNotFoundError ↔ APPROVAL_NOT_FOUND ──────────────────────────
+
+
+class TestApprovalNotFoundEquivalence:
+    """``ApprovalNotFoundError`` 는 양쪽에서 ``APPROVAL_NOT_FOUND``.
+
+    CLI direct path: ``approval info`` 표면 — typed 매핑 (``except
+    ApprovalNotFoundError: fmt.error(..., code="APPROVAL_NOT_FOUND")``)
+    보존. ``info`` 는 ``_find_request`` (CLI 내부 service 호출) 가 raise
+    하므로 IPC 경유가 아니고 CLI 안에서 typed except 가 직접 매칭된다.
+    """
+
+    def test_cli_direct_not_found_via_info(self, runner: CliRunner) -> None:
+        # ``approval info`` 는 ``asyncio.run(_info())`` → 내부에서 Database
+        # connect + ApprovalService initialize + ``_find_request`` 실행.
+        # ``_find_request`` 가 service.get(id) → None, list_approvals
+        # prefix 매치 0 → ``ApprovalNotFoundError`` raise 하는 시나리오를
+        # ApprovalService mock 으로 단순화한다.
+        svc = MagicMock()
+        svc.initialize = AsyncMock()
+        svc.get = AsyncMock(return_value=None)
+        svc.list_approvals = AsyncMock(return_value=[])
+
+        db_mock = MagicMock()
+        db_mock.connect = AsyncMock()
+        db_mock.close = AsyncMock()
+
+        with (
+            patch(
+                "ante.approval.ApprovalService",
+                return_value=svc,
+            ),
+            patch(
+                "ante.core.database.Database",
+                return_value=db_mock,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "info",
+                    "missing-id",
+                    "--db-path",
+                    "/tmp/test_approval_equiv.db",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "APPROVAL_NOT_FOUND"
+
+    def test_ipc_envelope_not_found(self) -> None:
+        exc = ApprovalNotFoundError("missing-id")
+        assert _ipc_envelope_code(exc) == "APPROVAL_NOT_FOUND"
+
+
+# ── (2) ApprovalStatusConflictError ↔ APPROVAL_STATUS_CONFLICT (approve) ────
+
+
+class TestApprovalStatusConflictEquivalence:
+    """``ApprovalStatusConflictError`` 는 양쪽에서ApprovalStatusConflict
+    안정 코드 ``APPROVAL_STATUS_CONFLICT`` (state_conflict 카테고리).
+
+    CLI direct path: ``approval approve`` 표면 — ``ipc_send`` 가 server error
+    envelope (code=``APPROVAL_STATUS_CONFLICT``) 를 ``ClickException`` 으로
+    변환하고 ``ipc_error_code`` 를 부착한다. middleware 의 ClickException
+    분기가 동일 코드로 CLI envelope 을 surface 한다 (``approval.py`` line
+    627-628 의 ``except click.ClickException: raise`` 가 middleware 까지 그대로
+    bubble).
+
+    IPC path: 실제 ``approval.approve`` handler 를 ``IPCServer`` 위에서
+    실행해 envelope code 를 확인한다 (#1842 ``account.suspend`` 1:1 동형
+    회귀 lock).
+    """
+
+    def test_cli_direct_status_conflict_via_approve(self, runner: CliRunner) -> None:
+        # ``ipc_send`` 가 server error envelope 을 ClickException 으로 변환할 때
+        # ``ipc_error_code`` 를 부착한다. middleware ``ClickException`` 분기가
+        # 동일 코드로 CLI envelope 을 surface.
+        import click
+
+        click_exc = click.ClickException(
+            "APPROVAL_STATUS_CONFLICT: 결재 'aaa' 상태 'approved' 에서 "
+            "'approve' 작업을 수행할 수 없습니다."
+        )
+        click_exc.ipc_error_code = "APPROVAL_STATUS_CONFLICT"  # type: ignore[attr-defined]
+        click_exc.ipc_error_message = (  # type: ignore[attr-defined]
+            "결재 'aaa' 상태 'approved' 에서 'approve' 작업을 수행할 수 없습니다."
+        )
+
+        async def _raise_status_conflict(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch(
+            "ante.cli.commands.ipc_helpers.ipc_send",
+            new=_raise_status_conflict,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "approval", "approve", "aaa"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "APPROVAL_STATUS_CONFLICT"
+
+    def test_ipc_envelope_status_conflict(self) -> None:
+        exc = ApprovalStatusConflictError(
+            approval_id="aaa",
+            current_status="approved",
+            requested_action="approve",
+        )
+        assert _ipc_envelope_code(exc) == "APPROVAL_STATUS_CONFLICT"
+
+    @pytest.mark.asyncio
+    async def test_ipc_envelope_status_conflict_via_real_handler(self) -> None:
+        """실제 ``approval.approve`` IPC handler 가 typed code 를 envelope
+        으로 surface 한다 (#1842 ``account.suspend`` 1:1 동형 회귀 lock)."""
+        td = tempfile.mkdtemp(prefix="ipc_approval_equiv", dir="/tmp")
+        socket_path = str(Path(td) / "t.sock")
+
+        approval_service = MagicMock()
+        approval_service.approve = AsyncMock(
+            side_effect=ApprovalStatusConflictError(
+                approval_id="aaa",
+                current_status="approved",
+                requested_action="approve",
+            )
+        )
+        svc_registry = ServiceRegistry(
+            account=MagicMock(),
+            bot_manager=MagicMock(),
+            treasury_manager=MagicMock(),
+            dynamic_config=MagicMock(),
+            approval=approval_service,
+            reconciler=MagicMock(),
+            eventbus=MagicMock(),
+            member_service=MagicMock(),
+        )
+        cmd_registry = CommandRegistry()
+        register_all_handlers(cmd_registry)
+
+        server = IPCServer(socket_path, svc_registry, cmd_registry)
+        await server.start()
+        try:
+            client = IPCClient(socket_path, timeout=5.0)
+            response = await client.send(
+                "approval.approve",
+                {"id": "aaa"},
+                actor="tester",
+            )
+            assert response["status"] == "error"
+            assert response["error"]["code"] == "APPROVAL_STATUS_CONFLICT"
+        finally:
+            await server.stop()
+
+
+# ── (3) ApprovalValidationError ↔ APPROVAL_VALIDATION_ERROR (request) ───────
+
+
+class TestApprovalValidationEquivalence:
+    """``ApprovalValidationError`` 는 양쪽에서 ``APPROVAL_VALIDATION_ERROR``.
+
+    CLI direct path: ``approval request`` 표면 — service ``create()`` 의
+    사전검증 ``fail`` grade 거부가 IPC envelope (code=``APPROVAL_VALIDATION_ERROR``)
+    로 surface 된다. ``ipc_send`` 가 ClickException 으로 변환하고
+    ``ipc_error_code`` 를 부착하면 middleware 가 동일 코드로 CLI envelope 을
+    surface 한다.
+
+    IPC path: ``ipc_error_payload`` helper 가 class-level ``.code`` (본 PR
+    sub-PR 2 에서 신규 부여) 와 registry 등록을 모두 이용해 동일 코드를
+    resolve 한다.
+    """
+
+    def test_cli_direct_validation_via_request(self, runner: CliRunner) -> None:
+        import click
+
+        click_exc = click.ClickException(
+            "APPROVAL_VALIDATION_ERROR: 사전 검증 실패: strategy not adoptable"
+        )
+        click_exc.ipc_error_code = "APPROVAL_VALIDATION_ERROR"  # type: ignore[attr-defined]
+        click_exc.ipc_error_message = (  # type: ignore[attr-defined]
+            "사전 검증 실패: strategy not adoptable"
+        )
+
+        async def _raise_validation(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch(
+            "ante.cli.commands.ipc_helpers.ipc_send",
+            new=_raise_validation,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "request",
+                    "--type",
+                    "strategy_adopt",
+                    "--title",
+                    "test",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "APPROVAL_VALIDATION_ERROR"
+
+    def test_ipc_envelope_validation(self) -> None:
+        exc = ApprovalValidationError("strategy not adoptable")
+        assert _ipc_envelope_code(exc) == "APPROVAL_VALIDATION_ERROR"


### PR DESCRIPTION
Refs #1843 (per-domain 6 sweep PR 의 두 번째). closes 는 sub-PR 6 에서.

#1842 (account, PR #1863) / #1843-1 (member, PR #1865) 패턴 1:1 동형으로 approval domain 의 ad-hoc error code 표면과 generic except fallback 을 taxonomy 기준으로 정렬한다.

## Summary

- `EXCEPTION_TO_SPEC` 에 approval 2 sub-class 등록 (실측 `.code` mirror; 21 + 2 = 23 entries)
- `ApprovalValidationError` 에 `code="APPROVAL_VALIDATION_ERROR"` 신규 부여 — IPC envelope (`server.py:322 getattr(e, "code", ...)`) 과 helper 양쪽이 동일 코드 surface (CLI ingress validation 과 동일한 안정 코드)
- approval CLI direct path 9 generic callsite 를 `emit_cli_error` 헬퍼로 정렬 — IPC envelope 과 동일한 public code surface
- `ApprovalNotFoundError` typed except 2 callsite (info / review) 보존 + code 명시
- CLI direct ↔ IPC error code 동등성 7 test 신규 추가 (3 fault × CLI + IPC + real-handler `approval.approve` IPC variant)

## Registry 신규 entries (2)

| Exception | code | category |
|-----------|------|----------|
| `ApprovalStatusConflictError` | `APPROVAL_STATUS_CONFLICT` | `state_conflict` |
| `ApprovalValidationError` | `APPROVAL_VALIDATION_ERROR` | `validation` |

`ApprovalNotFoundError` (`APPROVAL_NOT_FOUND`, `not_found`) 는 이미 #1840 에 등록되어 있어 본 PR 범위 밖이다. 동등성 test 는 본 PR 에서 추가했다.

## 보존된 typed except (CLI surface override)

- `ApprovalNotFoundError` → `APPROVAL_NOT_FOUND` (info / review; `_find_request` ValueError(multi-match) 분기와의 명시 구분 유지)

## allowlist 정리

- `pending_migration`: `ApprovalValidationError` entry 제거 (Family B 정렬)
- `ApprovalStatusConflictError` 는 이미 class-level `.code` (#1813 Group Q) 를 보유해 allowlist 에 등록되어 있지 않았다 — 본 PR 의 registry 등록만으로 helper 가 typed code 를 resolve 한다.
- `ApprovalError` base 는 그대로 유지 (#1842 `AccountError` 패턴 — 사용 사례 없음, sub-PR 6 final allowlist clear 시 재검토)
- `known_drift_fmt_error_no_code` 에는 approval.py 항목이 처음부터 없었다 (모든 generic callsite 가 `code="APPROVAL_ERROR"` 를 명시했기 때문). 본 PR 은 ad-hoc `APPROVAL_ERROR` 를 helper 의 taxonomy-정렬 코드로 교체한다.

## Non-Goals

- bot / treasury / broker / strategy 등 다른 domain migration (#1843 sub-PR 3-6 가 단계적으로 처리)
- success JSON output 표준화 (#1815)
- IPC metadata 확장 (#1819)
- `ApprovalError` base class registry 등록 (사용 사례 없음)
- error message 문구 표준화 (#1816 Non-Goals)

## 후속 sub-PR

- sub-PR 3: bot sweep
- sub-PR 4: treasury sweep
- sub-PR 5: broker sweep + 원천 code 분리
- sub-PR 6: strategy / config / rule / instrument / report sweep + final allowlist clear (ordering gate: sub-PR 1-5 모두 merge 후)

## Test plan

- [x] `pytest tests/unit/contracts -v` → 67 PASS (Family A/B drift + staleness)
- [x] `pytest tests/unit/test_approval_cli_ipc_error_equivalence.py -v` → 7 PASS
- [x] `pytest tests/unit/test_cli_approval_*.py` → 60+ PASS (approval CLI 회귀 0)
- [x] `pytest tests/unit/` → 5163 passed, 2 skipped (회귀 0; 이전 baseline 5156 + 7 신규)
- [x] `mypy src/ante` → Success: no issues found in 222 source files
- [x] `ruff check + format --check` → clean
- [x] `python scripts/generate_project_structure.py` → 신규 test file 반영
- [x] main HEAD 불변 (419ddf5 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)