### PR TITLE
refactor: #1843-3 bot error contract registry mirror + CLI direct ↔ IPC equivalence lock

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -592,7 +592,8 @@ tests/
 │   │   └── test_error_drift.py
 │   ├── test_account_cli_ipc_error_equivalence.py
 │   ├── test_member_cli_ipc_error_equivalence.py
-│   └── test_approval_cli_ipc_error_equivalence.py
+│   ├── test_approval_cli_ipc_error_equivalence.py
+│   └── test_bot_cli_ipc_error_equivalence.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -18,6 +18,7 @@ from ante.cli.cold_path import is_active_runtime
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+from ante.contracts import emit_cli_error
 
 logger = logging.getLogger(__name__)
 
@@ -324,11 +325,13 @@ def bot_create(
     except click.ClickException:
         raise
     except Exception as e:
-        # #1800: typed exception 의 class-level ``code`` 속성을 우선 surface
-        # 한다 (예: ``BotAlreadyExistsError.code = "BOT_ALREADY_EXISTS"``).
-        # 속성이 없는 일반 ``BotError`` 는 빈 code 로 종전 동작을 보존한다.
-        fmt.error(str(e), code=getattr(e, "code", ""))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 3: emit_cli_error 가 registry-first (#1843 sub-PR 3 등록한
+        # BotAlreadyExistsError / BotStrategyAlreadyRunningError 등) → ``.code``
+        # fallback → ``EXECUTION_ERROR`` 순서로 public code 를 resolve 한다.
+        # IPC envelope (server.py:322 ``getattr(e, "code", ...)``) 와 동일 코드
+        # surface — #1800 ``BotAlreadyExistsError.code = "BOT_ALREADY_EXISTS"``
+        # 등 typed 동작은 그대로 유지된다.
+        emit_cli_error(fmt, e)
 
     fmt.success(f"봇 생성 완료: {result.get('bot_id', '')}", result)
 
@@ -374,14 +377,19 @@ def bot_remove(ctx: click.Context, bot_id: str, yes: bool) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", ""))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 3: emit_cli_error 가 ``BotNotFoundError`` (cold-path
+        # 미존재 봇 거부) 의 등록 spec ``BOT_NOT_FOUND`` 를 우선 surface 한다.
+        # registry miss + ``.code`` 부재 시 ``EXECUTION_ERROR`` fallback.
+        emit_cli_error(fmt, e)
 
     if result.get("removed"):
         suffix = "(cold-path)" if result.get("cold_path") else ""
         fmt.success(f"봇 삭제 완료{suffix}: {bot_id}", result)
     else:
-        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+        # #1843 sub-PR 3: removed=False sentinel 도 미존재 봇 의미이므로
+        # ``BOT_NOT_FOUND`` 안정 코드를 명시 부여한다 (``bot info`` 형제
+        # 패턴 미러, IPC envelope 와 동일 public code surface).
+        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         raise SystemExit(1)
 
 
@@ -494,10 +502,12 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
         # (malformed/locked DB 등)가 재던져지면 여기로 떨어진다. JSON error를
         # 출력하면서도 exit 0 으로 끝나면 자동화 호출자가 실패를 감지하지
         # 못하므로, 형제 ``bot remove`` (raise SystemExit(1) from e)와 동일하게
-        # non-zero exit 로 종료한다 (#1596). 메시지 톤은 기존 bot_signal_key
-        # 그대로 유지한다 (code 미부착 — Non-Goal: 신규 에러코드 신설 금지).
-        fmt.error(str(e))
-        raise SystemExit(1) from e
+        # non-zero exit 로 종료한다 (#1596).
+        # #1843 sub-PR 3: emit_cli_error 가 ``EXECUTION_ERROR`` 안정 코드를
+        # surface (registry miss + ``.code`` 부재 fallback). 신규 도메인
+        # 에러코드 신설 없이 taxonomy 기본 fallback 으로 정렬 — Non-Goal
+        # (신규 에러코드 신설 금지) 보존.
+        emit_cli_error(fmt, e)
 
     if result.get("missing"):
         # #1784: 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 한다

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -74,6 +74,27 @@ Non-Goals).
 ``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
 ``AccountError`` 와 동일 패턴, #1843 sub-PR 2 Non-Goals).
 
+#1843 sub-PR 3 (bot sweep) 가 추가한 bot domain 5 sub-class lock (실측 ``.code``
+mirror, ``BotNotFoundError`` 는 #1840 lock 그대로 보존):
+
+- ``BotAccountCredentialsNotConfigured`` →
+  ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` / ``validation`` (#1712; ``bot
+  start`` 표면 ``app_key`` preflight 거부 — 입력 계약/필수 정보 누락은
+  taxonomy ``validation`` 카테고리)
+- ``BotStateConflict`` → ``BOT_STATE_CONFLICT`` / ``state_conflict`` (#1712;
+  ``start_bot``/``stop_bot`` 상태머신 거부)
+- ``BotNotAcceptingSignals`` → ``BOT_NOT_ACCEPTING_SIGNALS`` /
+  ``state_conflict`` (#1761; ``accepts_external_signals=False`` 전략이 외부
+  시그널 발급 요청을 거부 — 운영 상태가 해당 전이를 허용하지 않음)
+- ``BotAlreadyExistsError`` → ``BOT_ALREADY_EXISTS`` / ``state_conflict``
+  (#1800; ``bot create`` 시 동일 ``bot_id`` 중복)
+- ``BotStrategyAlreadyRunningError`` → ``BOT_STRATEGY_ALREADY_RUNNING`` /
+  ``state_conflict`` (#1800; "1전략 1봇" 정책 거부)
+
+``BotError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
+``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
+``AccountError`` 와 동일 패턴, #1843 sub-PR 3 Non-Goals).
+
 추가로 ``SERVICE_NOT_CONFIGURED`` 는 #1819 dispatch wrapper 가 도입할 예정인
 ``ServiceNotConfiguredError`` 의 ErrorSpec value 를 module-level constant
 (``_SERVICE_NOT_CONFIGURED_SPEC``) 로 reserved 보존한다. 해당 exception class
@@ -106,7 +127,14 @@ from ante.account.errors import (
 )
 from ante.approval.errors import ApprovalNotFoundError, ApprovalStatusConflictError
 from ante.approval.models import ApprovalValidationError
-from ante.bot.exceptions import BotNotFoundError
+from ante.bot.exceptions import (
+    BotAccountCredentialsNotConfigured,
+    BotAlreadyExistsError,
+    BotNotAcceptingSignals,
+    BotNotFoundError,
+    BotStateConflict,
+    BotStrategyAlreadyRunningError,
+)
 from ante.contracts.errors import ErrorSpec
 from ante.member.errors import (
     MemberAlreadyExistsError,
@@ -273,6 +301,53 @@ _APPROVAL_VALIDATION_ERROR_SPEC: Final[ErrorSpec] = ErrorSpec(
 )
 
 
+# ── bot 5 sub-class lock (#1843 sub-PR 3, 실측 .code mirror) ─────────────────
+#
+# ``BotNotFoundError`` 는 #1840 lock (`_BOT_NOT_FOUND_SPEC`) 을 그대로 보존
+# 한다 — 본 PR 은 신규 5건만 추가한다 (account/member/approval sweep 1:1 동형).
+
+# ``bot start`` 표면의 ``app_key`` preflight 거부. 입력 계약/필수 정보
+# 누락이므로 taxonomy ``validation`` 카테고리. IPC server.py:322
+# ``getattr(e, "code", ...)`` 와 helper registry-first 가 동일
+# ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` 코드를 surface 한다.
+_BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED",
+    category="validation",
+)
+
+# ``start_bot``/``stop_bot`` 상태머신 거부 (running ↔ stopped 전이 위반).
+# IPC ``bot.start``/``bot.stop`` 표면이 ``BotError`` → ``BotStateConflict``
+# 로 감싸 raise 하며, 본 ErrorSpec 이 동일 코드를 envelope surface 한다.
+_BOT_STATE_CONFLICT_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BOT_STATE_CONFLICT",
+    category="state_conflict",
+)
+
+# ``accepts_external_signals=False`` 전략이 외부 시그널 발급 요청을 거부.
+# 운영 상태가 해당 전이를 허용하지 않으므로 ``state_conflict``. CLI
+# ``signal connect``/``bot signal-key --rotate`` 양쪽 표면이 동일 코드를
+# surface 한다.
+_BOT_NOT_ACCEPTING_SIGNALS_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BOT_NOT_ACCEPTING_SIGNALS",
+    category="state_conflict",
+)
+
+# ``bot create`` 표면의 동일 ``bot_id`` 중복 등록 거부. resource 존재
+# 충돌이므로 ``state_conflict`` (account ``ACCOUNT_ALREADY_EXISTS`` 동형).
+_BOT_ALREADY_EXISTS_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BOT_ALREADY_EXISTS",
+    category="state_conflict",
+)
+
+# "1전략 1봇" 정책 거부 (동일 ``strategy_id`` 가 이미 실행 중인 다른 봇이
+# 보유). 운영 상태(running) 가 해당 전이를 허용하지 않으므로
+# ``state_conflict``.
+_BOT_STRATEGY_ALREADY_RUNNING_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BOT_STRATEGY_ALREADY_RUNNING",
+    category="state_conflict",
+)
+
+
 # ── reserved entry (#1819 후속 도입) ─────────────────────────────────────────
 #
 # ``SERVICE_NOT_CONFIGURED`` 는 taxonomy SSOT 가 ``service_unavailable`` 카테고리
@@ -331,6 +406,12 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     # ── #1843 sub-PR 2 approval 2 sub-class (실측 .code mirror) ───────────
     ApprovalStatusConflictError: _APPROVAL_STATUS_CONFLICT_SPEC,
     ApprovalValidationError: _APPROVAL_VALIDATION_ERROR_SPEC,
+    # ── #1843 sub-PR 3 bot 5 sub-class (실측 .code mirror) ────────────────
+    BotAccountCredentialsNotConfigured: _BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_SPEC,
+    BotStateConflict: _BOT_STATE_CONFLICT_SPEC,
+    BotNotAcceptingSignals: _BOT_NOT_ACCEPTING_SIGNALS_SPEC,
+    BotAlreadyExistsError: _BOT_ALREADY_EXISTS_SPEC,
+    BotStrategyAlreadyRunningError: _BOT_STRATEGY_ALREADY_RUNNING_SPEC,
 }
 """대표 fault lock registry (#1839 normative 4건).
 

--- a/tests/unit/cli/test_bot_create_exit_code.py
+++ b/tests/unit/cli/test_bot_create_exit_code.py
@@ -242,7 +242,15 @@ class TestBotCreateIPCExceptionExitCode:
         )
         payload = _parse_json_line(result.stdout)
         assert payload["status"] == "error", payload
-        assert payload["code"] == "", payload
+        # #1843 sub-PR 3: ``bot create`` generic except 가 ``emit_cli_error``
+        # 로 정렬되어, registry 미등록 + ``.code`` 부재 (RuntimeError) 인
+        # 경우 taxonomy SSOT (``docs/specs/contracts/error-taxonomy.md``)
+        # 의 ``EXECUTION_ERROR`` fallback 으로 surface 한다. 이전 ad-hoc
+        # ``code=""`` 동작은 의도된 taxonomy 정렬 (#1840 helper SSOT) 로
+        # 교체된 결과다. CLI direct ↔ IPC envelope 동일 코드 surface 의
+        # 의도된 결과 — IPC server.py:322 도 ``getattr(e, "code",
+        # "EXECUTION_ERROR")`` 로 동일 fallback 을 사용한다.
+        assert payload["code"] == "EXECUTION_ERROR", payload
         assert "IPC 연결 실패" in str(payload["message"]), payload
         # text fallback 이 stderr 로 동시에 새지 않아야 한다.
         assert "IPC 연결 실패" not in result.stderr, result.stderr

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -32,26 +32,31 @@ intended_no_code: []
 known_drift_fmt_error_no_code:
   # #1842: account.py line 762/804 entries 제거 — emit_cli_error 정렬 완료
   # (CLI direct path 가 IPC envelope 와 동일 public code surface).
+  #
+  # #1843 sub-PR 3: bot.py line 384/499 entries 제거 — line 384 ("봇을 찾을
+  # 수 없습니다" sentinel) 는 ``code="BOT_NOT_FOUND"`` 명시 부여로 정렬,
+  # line 499 (non-table-missing OperationalError fallback) 는 emit_cli_error
+  # 로 ``EXECUTION_ERROR`` (registry miss fallback) surface 로 정렬.
+  #
+  # bot.py line 882/918/952 (구 872/908/942) 는 ``ipc_send`` ClickException
+  # text-mode 분기의 ``text = f"{code}: {message}"`` 패턴 — config.py 와
+  # 동형의 #1673 ``config set`` 선례 deferred 유지. 회귀 lock
+  # ``test_bot_start_error_text_mode_carries_code_prefix`` 가 text 모드의
+  # ``code: message`` prefix 톤을 명시 요구하므로 단순
+  # ``fmt.error(message, code=code)`` 정렬이 UX 회귀가 된다. config.py 의
+  # 동형 deferred 정리와 함께 별도 follow-up 에서 책임진다.
   - path: src/ante/cli/commands/bot.py
-    line: 384
-    snippet_sha1: "826b5811c10c"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/bot.py
-    line: 499
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/bot.py
-    line: 872
+    line: 882
     snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); migrate in #1843"
+    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock"
   - path: src/ante/cli/commands/bot.py
-    line: 908
+    line: 918
     snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); migrate in #1843"
+    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock"
   - path: src/ante/cli/commands/bot.py
-    line: 942
+    line: 952
     snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); migrate in #1843"
+    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock"
   - path: src/ante/cli/commands/broker.py
     line: 211
     snippet_sha1: "f65e1080d3f2"

--- a/tests/unit/test_bot_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_bot_cli_ipc_error_equivalence.py
@@ -1,0 +1,454 @@
+"""Bot CLI direct path ↔ IPC path error code equivalence lock (#1843 sub-PR 3).
+
+본 모듈은 #1816 의 4차 migration domain (bot) 의 대표 fault 6 건이 CLI path
+와 IPC envelope path 양쪽에서 **동일한 public code** 를 노출함을 lock 한다.
+#1842 (account) / #1843 sub-PR 1 (member) / sub-PR 2 (approval) 의 1:1 동형
+패턴.
+
+검증 대상 fault:
+
+- ``BotNotFoundError`` → ``BOT_NOT_FOUND`` (not_found; ``bot remove`` /
+  ``bot start`` 표면, IPC envelope helper)
+- ``BotAccountCredentialsNotConfigured`` → ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED``
+  (validation; ``bot start`` 표면 ``app_key`` preflight 거부)
+- ``BotStateConflict`` → ``BOT_STATE_CONFLICT`` (state_conflict; ``bot start``
+  / ``bot stop`` 표면 상태머신 거부)
+- ``BotNotAcceptingSignals`` → ``BOT_NOT_ACCEPTING_SIGNALS`` (state_conflict;
+  ``accepts_external_signals=False`` 전략 거부)
+- ``BotAlreadyExistsError`` → ``BOT_ALREADY_EXISTS`` (state_conflict;
+  ``bot create`` 표면 중복 등록 거부, 실제 ``bot.create`` IPC handler 회귀)
+- ``BotStrategyAlreadyRunningError`` → ``BOT_STRATEGY_ALREADY_RUNNING``
+  (state_conflict; ``bot create`` 표면 "1전략 1봇" 정책 거부)
+
+bot CLI 의 mutating 표면 (``create``/``remove``/``start``/``stop``/``status``)
+은 모두 ``ipc_send`` 경유이므로 CLI direct path equivalence 는 ``ipc_send``
+mock 으로 server-side envelope (``ipc_error_code``/``ipc_error_message``) 을
+주입한 뒤 CLI middleware ClickException 분기가 동일 코드를 surface 함을 확인
+한다. ``signal-key --rotate`` 는 CLI 안에서 직접 sentinel (``code`` 키) 을
+반환하므로 별도 분기.
+
+IPC path 는 ``ante.contracts.ipc_error_payload`` helper (server.py:322 의
+``getattr(e, "code", "EXECUTION_ERROR")`` 와 동일 코드를 생성 — 실측 ``.code``
+가 일치하는 한 contract 동등성, #1842 plan v2 #6) 로 직접 직렬화하거나,
+``BotAlreadyExistsError`` 의 경우 실제 ``bot.create`` IPC handler 를
+``IPCServer`` 위에서 실행해 envelope code 를 확인한다 (#1842 ``account.suspend``
+1:1 동형 회귀 lock).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from ante.bot.exceptions import (
+    BotAccountCredentialsNotConfigured,
+    BotAlreadyExistsError,
+    BotNotAcceptingSignals,
+    BotNotFoundError,
+    BotStateConflict,
+    BotStrategyAlreadyRunningError,
+)
+from ante.cli.main import cli
+from ante.contracts import ipc_error_payload
+from ante.core.registry import ServiceRegistry
+from ante.ipc.client import IPCClient
+from ante.ipc.registry import CommandRegistry, register_all_handlers
+from ante.ipc.server import IPCServer
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=["bot:read", "bot:write", "bot:admin"],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """``ante --format json bot ...`` 호출용 ``CliRunner`` fixture.
+
+    auth middleware 를 master member 로 우회한다 (#1865 ``member`` /
+    #1866 ``approval`` equivalence test fixture 동형). ``require_scope``
+    decorator 는 그대로 동작하므로 모든 bot scope 를 부여한다.
+    """
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx) -> None:  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+def _ipc_envelope_code(exc: BaseException) -> str:
+    """주어진 exception 을 IPC envelope 으로 직렬화했을 때의 ``code``.
+
+    IPC server.py:322 가 적용하는 ``getattr(e, "code", "EXECUTION_ERROR")``
+    fallback 과 helper(``ipc_error_payload``)의 registry-first resolution 은
+    실측 ``.code`` 가 일치하는 한 동일 코드를 생성한다 (#1842 plan v2 #6).
+    본 helper 는 helper 경로를 그대로 사용해 contract 동등성을 단언한다.
+    """
+
+    payload = ipc_error_payload(exc)
+    return payload["code"]
+
+
+def _cli_envelope_payload(result_output: str) -> dict:
+    """``CliRunner.result.output`` 에서 JSON envelope 첫 객체를 추출."""
+    payload_line = next(
+        (line for line in result_output.splitlines() if line.startswith("{")),
+        None,
+    )
+    assert payload_line is not None, f"JSON envelope 발견 실패: {result_output!r}"
+    return json.loads(payload_line)
+
+
+def _make_click_exc(code: str, message: str) -> click.ClickException:
+    """``ipc_send`` 가 server error envelope 을 변환할 때 부착하는
+    ``ipc_error_code``/``ipc_error_message`` 속성을 가진 ClickException 을
+    구성한다. CLI command 의 ``except click.ClickException`` 분기에서 동일한
+    형태로 message/code 를 복원한다.
+    """
+
+    exc = click.ClickException(f"{code}: {message}")
+    exc.ipc_error_code = code  # type: ignore[attr-defined]
+    exc.ipc_error_message = message  # type: ignore[attr-defined]
+    return exc
+
+
+# ── (1) BotNotFoundError ↔ BOT_NOT_FOUND ────────────────────────────────────
+
+
+class TestBotNotFoundEquivalence:
+    """``BotNotFoundError`` 는 양쪽에서 ``BOT_NOT_FOUND``.
+
+    CLI direct path: ``bot remove`` 표면 — ``ipc_send`` 가 server error
+    envelope (code=``BOT_NOT_FOUND``) 을 ClickException 으로 변환하고,
+    ``except Exception: emit_cli_error(fmt, e)`` 분기가 동일 코드로 CLI
+    envelope 을 surface 한다. ``BotNotFoundError`` 는 #1840 에서 이미 registry
+    등록되어 있으므로 helper resolver 가 ``BOT_NOT_FOUND`` 로 resolve 한다.
+    """
+
+    def test_cli_direct_not_found_via_remove(self, runner: CliRunner) -> None:
+        click_exc = _make_click_exc("BOT_NOT_FOUND", "Bot not found: missing")
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "bot", "remove", "missing", "--yes"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BOT_NOT_FOUND"
+
+    def test_ipc_envelope_not_found(self) -> None:
+        exc = BotNotFoundError("missing")
+        assert _ipc_envelope_code(exc) == "BOT_NOT_FOUND"
+
+
+# ── (2) BotAccountCredentialsNotConfigured ↔ BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED
+
+
+class TestBotAccountCredentialsNotConfiguredEquivalence:
+    """``BotAccountCredentialsNotConfigured`` 는 양쪽에서
+    ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` (validation; ``app_key`` 부재
+    preflight 거부).
+
+    CLI direct path: ``bot start`` 표면 — ``ipc_send`` 가 server preflight
+    envelope (code=``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED``) 을
+    ClickException 으로 변환하고, ``except click.ClickException`` 분기가
+    JSON 모드에서 동일 코드로 CLI envelope 을 surface 한다.
+    """
+
+    def test_cli_direct_credentials_not_configured_via_start(
+        self, runner: CliRunner
+    ) -> None:
+        click_exc = _make_click_exc(
+            "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED",
+            "계좌에 인증정보(app_key)가 설정되지 않았습니다",
+        )
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "bot", "start", "bot-1"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED"
+
+    def test_ipc_envelope_credentials_not_configured(self) -> None:
+        exc = BotAccountCredentialsNotConfigured(
+            "계좌에 인증정보(app_key)가 설정되지 않았습니다"
+        )
+        assert _ipc_envelope_code(exc) == "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED"
+
+
+# ── (3) BotStateConflict ↔ BOT_STATE_CONFLICT (start/stop) ──────────────────
+
+
+class TestBotStateConflictEquivalence:
+    """``BotStateConflict`` 는 양쪽에서 ``BOT_STATE_CONFLICT``.
+
+    CLI direct path: ``bot start`` / ``bot stop`` 양쪽 표면 모두 IPC envelope
+    을 ClickException 으로 받아 surface 한다. middleware 분기는 ``bot
+    start``/``bot stop`` 가 공유하는 동일 패턴 (#1673 미러).
+    """
+
+    def test_cli_direct_state_conflict_via_start(self, runner: CliRunner) -> None:
+        click_exc = _make_click_exc(
+            "BOT_STATE_CONFLICT", "이미 실행 중인 봇입니다: bot-1"
+        )
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "bot", "start", "bot-1"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BOT_STATE_CONFLICT"
+
+    def test_cli_direct_state_conflict_via_stop(self, runner: CliRunner) -> None:
+        click_exc = _make_click_exc(
+            "BOT_STATE_CONFLICT", "중지된 봇은 중지할 수 없습니다: bot-1"
+        )
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "bot", "stop", "bot-1"],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BOT_STATE_CONFLICT"
+
+    def test_ipc_envelope_state_conflict(self) -> None:
+        exc = BotStateConflict("이미 실행 중인 봇입니다")
+        assert _ipc_envelope_code(exc) == "BOT_STATE_CONFLICT"
+
+
+# ── (4) BotNotAcceptingSignals ↔ BOT_NOT_ACCEPTING_SIGNALS ──────────────────
+
+
+class TestBotNotAcceptingSignalsEquivalence:
+    """``BotNotAcceptingSignals`` 는 양쪽에서ApprovalStatusConflict
+    안정 코드 ``BOT_NOT_ACCEPTING_SIGNALS`` (state_conflict 카테고리;
+    ``accepts_external_signals=False`` 전략 거부).
+
+    CLI direct path 는 IPC envelope helper-direct path 와 동일 코드를
+    surface 한다는 contract 동등성을 lock 한다. CLI 실제 surface 는
+    ``signal connect``/``bot signal-key --rotate`` 가 cold-path sentinel
+    분기에서 동일 코드를 발급하지만, 본 test 는 contract level (registry
+    helper) 동등성만 단언한다 — 회귀 lock 은 별도 `test_bot_signal_key*`/
+    `signal connect` 표면 test (#1761) 가 책임진다.
+    """
+
+    def test_ipc_envelope_not_accepting_signals(self) -> None:
+        exc = BotNotAcceptingSignals(
+            "이 봇의 전략은 외부 시그널을 받지 않습니다: bot_id=bot-1"
+        )
+        assert _ipc_envelope_code(exc) == "BOT_NOT_ACCEPTING_SIGNALS"
+
+
+# ── (5) BotAlreadyExistsError ↔ BOT_ALREADY_EXISTS (create) ─────────────────
+
+
+class TestBotAlreadyExistsEquivalence:
+    """``BotAlreadyExistsError`` 는 양쪽에서 ``BOT_ALREADY_EXISTS``.
+
+    CLI direct path: ``bot create`` 표면 — ``ipc_send`` 가 server error
+    envelope 을 ClickException 으로 변환하고, ``except Exception:
+    emit_cli_error(fmt, e)`` 가 동일 코드를 surface 한다. registry MRO
+    lookup 으로 ``BotAlreadyExistsError`` → ``BOT_ALREADY_EXISTS`` resolve.
+
+    IPC path: 실제 ``bot.create`` IPC handler 를 ``IPCServer`` 위에서
+    실행해 envelope code 를 확인한다 (#1842 ``account.suspend`` 1:1 동형
+    회귀 lock).
+    """
+
+    def test_cli_direct_already_exists_via_create(self, runner: CliRunner) -> None:
+        click_exc = _make_click_exc("BOT_ALREADY_EXISTS", "Bot already exists: bot-dup")
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "create",
+                    "--name",
+                    "test",
+                    "--strategy",
+                    "s1",
+                    "--account",
+                    "acc1",
+                    "--id",
+                    "bot-dup",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BOT_ALREADY_EXISTS"
+
+    def test_ipc_envelope_already_exists(self) -> None:
+        exc = BotAlreadyExistsError("Bot already exists: bot-dup")
+        assert _ipc_envelope_code(exc) == "BOT_ALREADY_EXISTS"
+
+    @pytest.mark.asyncio
+    async def test_ipc_envelope_already_exists_via_real_handler(self) -> None:
+        """실제 ``bot.create`` IPC handler 가 typed code 를 envelope 으로
+        surface 한다 (#1842 ``account.suspend`` 1:1 동형 회귀 lock).
+
+        ``BotManager.create_bot`` 가 ``BotAlreadyExistsError`` 를 raise 하는
+        시나리오를 mock 으로 재현하고, ``StrategyRegistry.get`` 도 mock 으로
+        valid record 를 돌려준 뒤 ``StrategyLoader.load`` 를 patch 해 cold-path
+        파일 IO 를 피한다 (handler 가 strategy lookup 이후에 ``create_bot`` 을
+        호출하므로 둘 다 필요).
+        """
+
+        td = tempfile.mkdtemp(prefix="ipc_bot_equiv", dir="/tmp")
+        socket_path = str(Path(td) / "t.sock")
+
+        bot_manager = MagicMock()
+        bot_manager.create_bot = AsyncMock(
+            side_effect=BotAlreadyExistsError("Bot already exists: bot-dup")
+        )
+
+        strategy_record = MagicMock()
+        strategy_record.filepath = "/tmp/_fake_strategy.py"
+        strategy_registry = MagicMock()
+        strategy_registry.get = AsyncMock(return_value=strategy_record)
+
+        svc_registry = ServiceRegistry(
+            account=MagicMock(),
+            bot_manager=bot_manager,
+            treasury_manager=MagicMock(),
+            dynamic_config=MagicMock(),
+            approval=MagicMock(),
+            reconciler=MagicMock(),
+            eventbus=MagicMock(),
+            member_service=MagicMock(),
+            strategy_registry=strategy_registry,
+        )
+        cmd_registry = CommandRegistry()
+        register_all_handlers(cmd_registry)
+
+        server = IPCServer(socket_path, svc_registry, cmd_registry)
+        await server.start()
+        try:
+            client = IPCClient(socket_path, timeout=5.0)
+            with patch("ante.strategy.loader.StrategyLoader.load") as mock_load:
+                mock_load.return_value = MagicMock()
+                response = await client.send(
+                    "bot.create",
+                    {
+                        "account_id": "acc1",
+                        "strategy_id": "s1",
+                        "name": "test",
+                        "bot_id": "bot-dup",
+                    },
+                    actor="tester",
+                )
+            assert response["status"] == "error"
+            assert response["error"]["code"] == "BOT_ALREADY_EXISTS"
+        finally:
+            await server.stop()
+
+
+# ── (6) BotStrategyAlreadyRunningError ↔ BOT_STRATEGY_ALREADY_RUNNING ──────
+
+
+class TestBotStrategyAlreadyRunningEquivalence:
+    """``BotStrategyAlreadyRunningError`` 는 양쪽에서
+    ``BOT_STRATEGY_ALREADY_RUNNING`` ("1전략 1봇" 정책 거부).
+
+    CLI direct path: ``bot create`` 표면 — ``ipc_send`` 가 server error
+    envelope 을 ClickException 으로 변환하고, ``except Exception:
+    emit_cli_error(fmt, e)`` 가 동일 코드를 surface 한다. registry MRO
+    lookup 으로 ``BotStrategyAlreadyRunningError`` →
+    ``BOT_STRATEGY_ALREADY_RUNNING`` resolve.
+    """
+
+    def test_cli_direct_strategy_already_running_via_create(
+        self, runner: CliRunner
+    ) -> None:
+        click_exc = _make_click_exc(
+            "BOT_STRATEGY_ALREADY_RUNNING",
+            "전략 s1 은 이미 실행 중인 다른 봇이 사용 중입니다",
+        )
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "create",
+                    "--name",
+                    "test",
+                    "--strategy",
+                    "s1",
+                    "--account",
+                    "acc1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BOT_STRATEGY_ALREADY_RUNNING"
+
+    def test_ipc_envelope_strategy_already_running(self) -> None:
+        exc = BotStrategyAlreadyRunningError(
+            "전략 s1 은 이미 실행 중인 다른 봇이 사용 중입니다"
+        )
+        assert _ipc_envelope_code(exc) == "BOT_STRATEGY_ALREADY_RUNNING"


### PR DESCRIPTION
Refs #1843

## Summary

#1842 (account) / #1843 sub-PR 1 (member) / sub-PR 2 (approval) 패턴 동형으로 bot domain 의 error contract 를 정렬한다.

- EXCEPTION_TO_SPEC 에 bot 5 sub-class 등록 (실측 .code mirror; BotNotFoundError 는 #1840 lock 보존, BotError base 는 pending_migration 보존)
- bot CLI direct path (bot_create / bot_remove / bot_signal_key) 의 generic except / code-less fmt.error 를 emit_cli_error 헬퍼 또는 명시 BOT_NOT_FOUND 부여로 정렬
- allowlist 정리 + 신규 동등성 test 6 fault (13 PASS)
- bot.py text-mode `text = f"{code}: {message}"` 패턴 (line 882/918/952) 는 test_bot_start_error_text_mode_carries_code_prefix 회귀 lock 으로 config.py 와 동형 deferred 유지

## bot 5 sub-class lock (실측 .code mirror)

| Class | code | category | 표면 |
|-------|------|----------|------|
| `BotAccountCredentialsNotConfigured` | `BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED` | `validation` | `bot start` app_key preflight (#1712) |
| `BotStateConflict` | `BOT_STATE_CONFLICT` | `state_conflict` | `bot start`/`bot stop` 상태머신 (#1712) |
| `BotNotAcceptingSignals` | `BOT_NOT_ACCEPTING_SIGNALS` | `state_conflict` | `accepts_external_signals=False` 거부 (#1761) |
| `BotAlreadyExistsError` | `BOT_ALREADY_EXISTS` | `state_conflict` | `bot create` 중복 (#1800) |
| `BotStrategyAlreadyRunningError` | `BOT_STRATEGY_ALREADY_RUNNING` | `state_conflict` | "1전략 1봇" 정책 (#1800) |

`BotNotFoundError` → `BOT_NOT_FOUND` / `not_found` 는 #1840 lock 그대로 보존.

## Equivalence test (13 PASS, tests/unit/test_bot_cli_ipc_error_equivalence.py)

- TestBotNotFoundEquivalence (2: cli + ipc)
- TestBotAccountCredentialsNotConfiguredEquivalence (2)
- TestBotStateConflictEquivalence (3: start + stop + ipc)
- TestBotNotAcceptingSignalsEquivalence (1: contract level)
- TestBotAlreadyExistsEquivalence (3: cli + ipc + real bot.create handler 회귀)
- TestBotStrategyAlreadyRunningEquivalence (2)

## Test plan

- [x] `pytest tests/unit/contracts -v`: 67 PASS (drift guard 정상)
- [x] `pytest tests/unit/test_bot_cli_ipc_error_equivalence.py -v`: 13/13 PASS
- [x] `pytest tests/unit/cli/test_bot_create_exit_code.py`: 5/5 PASS (code="" → "EXECUTION_ERROR" 정렬, emit_cli_error migration 의 의도된 결과)
- [x] `pytest tests/unit/`: 5176 PASS, 2 skipped (5163 baseline + 13 신규, 회귀 X)
- [x] `mypy src/ante/`: Success (222 files)
- [x] `ruff check src tests` + `ruff format --check`: 통과
- [x] `python scripts/generate_project_structure.py --check`: up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)