### PR TITLE
refactor: #1843-4 treasury error contract registry mirror + CLI direct ↔ IPC equivalence lock

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -593,7 +593,8 @@ tests/
 │   ├── test_account_cli_ipc_error_equivalence.py
 │   ├── test_member_cli_ipc_error_equivalence.py
 │   ├── test_approval_cli_ipc_error_equivalence.py
-│   └── test_bot_cli_ipc_error_equivalence.py
+│   ├── test_bot_cli_ipc_error_equivalence.py
+│   └── test_treasury_cli_ipc_error_equivalence.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -21,6 +21,7 @@ from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id as _get_member_id
 from ante.cli.middleware import require_auth, require_scope
+from ante.contracts import emit_cli_error
 
 logger = logging.getLogger(__name__)
 
@@ -310,8 +311,12 @@ def budgets(ctx: click.Context, account_id: str | None) -> None:
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # registry MRO lookup 으로 treasury typed exception 은 안정 코드
+        # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
+        # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
+        # click.exceptions.Exit(1) 로 동형 보존.
+        emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output(result)
@@ -371,8 +376,12 @@ def set_balance(ctx: click.Context, amount: float, account_id: str) -> None:
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # registry MRO lookup 으로 treasury typed exception 은 안정 코드
+        # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
+        # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
+        # click.exceptions.Exit(1) 로 동형 보존.
+        emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output(result)
@@ -431,8 +440,12 @@ def allocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) ->
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # registry MRO lookup 으로 treasury typed exception 은 안정 코드
+        # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
+        # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
+        # click.exceptions.Exit(1) 로 동형 보존.
+        emit_cli_error(fmt, e)
 
     # #1809: ``_handle_treasury_allocate`` 가 reject 시 typed exception 으로
     # raise 하므로 정상 응답은 항상 ``success=True``. 잔존 false 경로는
@@ -492,8 +505,12 @@ def deallocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) 
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # registry MRO lookup 으로 treasury typed exception 은 안정 코드
+        # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
+        # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
+        # click.exceptions.Exit(1) 로 동형 보존.
+        emit_cli_error(fmt, e)
 
     if result.get("success"):
         fmt.success(
@@ -715,8 +732,12 @@ def portfolio_value(ctx: click.Context, account_id: str | None) -> None:
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # registry MRO lookup 으로 treasury typed exception 은 안정 코드
+        # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
+        # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
+        # click.exceptions.Exit(1) 로 동형 보존.
+        emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output(result)
@@ -803,8 +824,12 @@ def portfolio_history(
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        fmt.error(str(e), code=getattr(e, "code", "TREASURY_ERROR"))
-        raise SystemExit(1) from e
+        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # registry MRO lookup 으로 treasury typed exception 은 안정 코드
+        # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
+        # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
+        # click.exceptions.Exit(1) 로 동형 보존.
+        emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output(result)

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -95,6 +95,31 @@ mirror, ``BotNotFoundError`` 는 #1840 lock 그대로 보존):
 ``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
 ``AccountError`` 와 동일 패턴, #1843 sub-PR 3 Non-Goals).
 
+#1843 sub-PR 4 (treasury sweep) 가 추가한 treasury domain 7 sub-class lock
+(실측 ``.code`` mirror; #1809 가 도입한 4건 + 본 PR 신규 부여 3건):
+
+- ``TreasuryInvalidAmountError`` → ``TREASURY_INVALID_AMOUNT`` / ``validation``
+  (#1809; ``allocate``/``deallocate`` 의 finite-positive 가드 위반)
+- ``TreasuryInsufficientUnallocatedError`` → ``TREASURY_INSUFFICIENT_BALANCE``
+  / ``validation`` (#1809; ``allocate`` 시 ``self._unallocated < amount``)
+- ``TreasuryBudgetNotFoundError`` → ``TREASURY_BUDGET_NOT_FOUND`` /
+  ``not_found`` (#1809; ``deallocate`` 시 budget record 부재)
+- ``TreasuryDeallocateExceedsAvailableError`` →
+  ``TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE`` / ``validation`` (#1809;
+  over-deallocate)
+- ``InsufficientFundsError`` → ``TREASURY_INSUFFICIENT_FUNDS`` / ``validation``
+  (본 PR 신규 부여; ``update_budget`` caller-facing wrap fault —
+  ``TREASURY_INSUFFICIENT_BALANCE`` 와 의미 분리)
+- ``BotNotStoppedError`` → ``TREASURY_BOT_NOT_STOPPED`` / ``state_conflict``
+  (본 PR 신규 부여; running 상태 봇의 예산 변경 거부)
+- ``TreasuryNotConfiguredError`` → ``TREASURY_NOT_CONFIGURED`` /
+  ``service_unavailable`` (본 PR 신규 부여; #1335 ``TreasuryManager`` 미주입
+  / 등록된 Treasury 부재)
+
+``TreasuryError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
+``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
+``AccountError`` 와 동일 패턴, #1843 sub-PR 1/2/3 Non-Goals 동형).
+
 추가로 ``SERVICE_NOT_CONFIGURED`` 는 #1819 dispatch wrapper 가 도입할 예정인
 ``ServiceNotConfiguredError`` 의 ErrorSpec value 를 module-level constant
 (``_SERVICE_NOT_CONFIGURED_SPEC``) 로 reserved 보존한다. 해당 exception class
@@ -144,6 +169,15 @@ from ante.member.errors import (
     PermissionDeniedError,
 )
 from ante.member.scopes import InvalidScopeError
+from ante.treasury.exceptions import (
+    BotNotStoppedError,
+    InsufficientFundsError,
+    TreasuryBudgetNotFoundError,
+    TreasuryDeallocateExceedsAvailableError,
+    TreasuryInsufficientUnallocatedError,
+    TreasuryInvalidAmountError,
+    TreasuryNotConfiguredError,
+)
 
 __all__ = [
     "EXCEPTION_TO_SPEC",
@@ -348,6 +382,70 @@ _BOT_STRATEGY_ALREADY_RUNNING_SPEC: Final[ErrorSpec] = ErrorSpec(
 )
 
 
+# ── treasury 7 sub-class lock (#1843 sub-PR 4, 실측 .code mirror) ────────────
+#
+# ``TreasuryError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
+# ``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
+# ``AccountError`` 와 동일 패턴, #1843 sub-PR 1/2/3 Non-Goals 동형).
+
+# ``allocate``/``deallocate`` amount 가 finite-positive 가 아닐 때
+# (NaN/±Inf/<=0). #1411 finite-positive 가드 위반. CLI ingress
+# (``validate_positive_finite_amount``) 가 1차 거부하지만 service layer 가
+# 2차 invariant 로 raise — IPC envelope 도 동일 코드 surface.
+_TREASURY_INVALID_AMOUNT_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="TREASURY_INVALID_AMOUNT",
+    category="validation",
+)
+
+# ``allocate`` 시 미할당 잔액 부족 (``self._unallocated < amount``).
+# class-level ``.code = "TREASURY_INSUFFICIENT_BALANCE"`` (#1809) 와 정렬.
+_TREASURY_INSUFFICIENT_BALANCE_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="TREASURY_INSUFFICIENT_BALANCE",
+    category="validation",
+)
+
+# ``deallocate`` 시 budget record 부재. ``self._budgets`` 에 해당 ``bot_id``
+# budget 이 없을 때 raise. IPC handler 가 ``BotNotFoundError`` 로 cross-module
+# 검증을 선행하므로 budget record 만 없는 드문 경로이지만 invariant 명시.
+_TREASURY_BUDGET_NOT_FOUND_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="TREASURY_BUDGET_NOT_FOUND",
+    category="not_found",
+)
+
+# ``deallocate`` 시 요청 amount 가 budget.available 초과 (over-deallocate).
+_TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE",
+    category="validation",
+)
+
+# ``update_budget`` 의 caller-facing wrap fault. ``allocate``/``deallocate``
+# 가 reject 한 typed reason 을 caller invariant 보존을 위해 동일
+# ``InsufficientFundsError`` 로 변환하는 경로 (treasury.py:599-606) 에서
+# raise 된다. 본 PR 에서 class-level ``.code`` 신규 부여
+# ``TREASURY_INSUFFICIENT_FUNDS`` — ``TREASURY_INSUFFICIENT_BALANCE``
+# (allocate-side raw reject) 와 의미 분리 (semantic distinction 보존).
+_TREASURY_INSUFFICIENT_FUNDS_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="TREASURY_INSUFFICIENT_FUNDS",
+    category="validation",
+)
+
+# running 상태 봇의 예산 변경 거부 (운영 상태 머신 위반). 본 PR 에서
+# class-level ``.code`` 신규 부여 ``TREASURY_BOT_NOT_STOPPED``.
+_TREASURY_BOT_NOT_STOPPED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="TREASURY_BOT_NOT_STOPPED",
+    category="state_conflict",
+)
+
+# ``TreasuryManager`` 미주입 / ``account_id`` 에 등록된 Treasury 부재로 인한
+# budget 작업 거부 (#1335). 본 PR 에서 class-level ``.code`` 신규 부여
+# ``TREASURY_NOT_CONFIGURED`` (service 인프라 부재 — ``service_unavailable``
+# 카테고리).
+_TREASURY_NOT_CONFIGURED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="TREASURY_NOT_CONFIGURED",
+    category="service_unavailable",
+)
+
+
 # ── reserved entry (#1819 후속 도입) ─────────────────────────────────────────
 #
 # ``SERVICE_NOT_CONFIGURED`` 는 taxonomy SSOT 가 ``service_unavailable`` 카테고리
@@ -412,6 +510,16 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     BotNotAcceptingSignals: _BOT_NOT_ACCEPTING_SIGNALS_SPEC,
     BotAlreadyExistsError: _BOT_ALREADY_EXISTS_SPEC,
     BotStrategyAlreadyRunningError: _BOT_STRATEGY_ALREADY_RUNNING_SPEC,
+    # ── #1843 sub-PR 4 treasury 7 sub-class (실측 .code mirror) ───────────
+    TreasuryInvalidAmountError: _TREASURY_INVALID_AMOUNT_SPEC,
+    TreasuryInsufficientUnallocatedError: _TREASURY_INSUFFICIENT_BALANCE_SPEC,
+    TreasuryBudgetNotFoundError: _TREASURY_BUDGET_NOT_FOUND_SPEC,
+    TreasuryDeallocateExceedsAvailableError: (
+        _TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE_SPEC
+    ),
+    InsufficientFundsError: _TREASURY_INSUFFICIENT_FUNDS_SPEC,
+    BotNotStoppedError: _TREASURY_BOT_NOT_STOPPED_SPEC,
+    TreasuryNotConfiguredError: _TREASURY_NOT_CONFIGURED_SPEC,
 }
 """대표 fault lock registry (#1839 normative 4건).
 

--- a/src/ante/treasury/exceptions.py
+++ b/src/ante/treasury/exceptions.py
@@ -8,15 +8,34 @@ class TreasuryError(Exception):
 
 
 class InsufficientFundsError(TreasuryError):
-    """자금 부족."""
+    """자금 부족.
 
-    pass
+    클래스 레벨 ``code`` 속성은 #1843 sub-PR 4 (treasury sweep) 에서
+    신규 부여한 안정 코드 ``TREASURY_INSUFFICIENT_FUNDS`` 다 — CLI/IPC
+    envelope 이 동일 코드를 surface 한다. ``update_budget`` 이 typed
+    reject (``TreasuryInsufficientUnallocatedError`` →
+    ``TREASURY_INSUFFICIENT_BALANCE``) 를 catch 해 ``InsufficientFundsError``
+    로 변환하는 caller invariant (treasury.py:599-606) 를 보존하기 위해
+    별개의 코드를 부여한다 — 의미가 다른 두 fault (allocate-side
+    미할당부족 vs update_budget caller-facing wrap) 를 같은 코드로 묶지
+    않는다.
+
+    IPC server.py:322 ``getattr(e, "code", ...)`` 와 helper registry-first
+    가 동일 ``TREASURY_INSUFFICIENT_FUNDS`` 코드를 surface 한다.
+    """
+
+    code = "TREASURY_INSUFFICIENT_FUNDS"
 
 
 class BotNotStoppedError(TreasuryError):
-    """봇이 중지 상태가 아니어서 예산 변경 불가."""
+    """봇이 중지 상태가 아니어서 예산 변경 불가.
 
-    pass
+    클래스 레벨 ``code`` 속성은 #1843 sub-PR 4 에서 신규 부여한 안정
+    코드 ``TREASURY_BOT_NOT_STOPPED`` 다 — running 상태 봇의 예산 변경
+    거부는 운영 상태 머신 위반 (taxonomy ``state_conflict``).
+    """
+
+    code = "TREASURY_BOT_NOT_STOPPED"
 
 
 class TreasuryNotConfiguredError(TreasuryError):
@@ -27,9 +46,13 @@ class TreasuryNotConfiguredError(TreasuryError):
     예산을 할당할 수 없을 때 발생한다. 라우트 계층은 이 예외를 422 로
     매핑한다 (`TreasuryError` 하위 클래스이므로 기존 422 매핑이 자동
     적용된다).
+
+    클래스 레벨 ``code`` 속성은 #1843 sub-PR 4 에서 신규 부여한 안정
+    코드 ``TREASURY_NOT_CONFIGURED`` 다 — service 인프라 부재로 인한
+    거부 (taxonomy ``service_unavailable``).
     """
 
-    pass
+    code = "TREASURY_NOT_CONFIGURED"
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -211,14 +211,5 @@ pending_migration:
     class_anchor: StrategyValidationError
     reason: "baseline (#1841); register in #1842/#1843"
   - module: ante.treasury.exceptions
-    class_anchor: BotNotStoppedError
-    reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.treasury.exceptions
-    class_anchor: InsufficientFundsError
-    reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.treasury.exceptions
     class_anchor: TreasuryError
-    reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.treasury.exceptions
-    class_anchor: TreasuryNotConfiguredError
-    reason: "baseline (#1841); register in #1842/#1843"
+    reason: "base — no callsite; pending_migration baseline (#1842 AccountError 동형)"

--- a/tests/unit/test_treasury_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_treasury_cli_ipc_error_equivalence.py
@@ -1,0 +1,371 @@
+"""Treasury CLI direct path ↔ IPC path error code equivalence lock (#1843 sub-PR 4).
+
+본 모듈은 #1816 의 5차 migration domain (treasury) 의 대표 fault 6 건이
+CLI path 와 IPC envelope path 양쪽에서 **동일한 public code** 를 노출함을
+lock 한다. #1842 (account) / #1843 sub-PR 1 (member) / sub-PR 2 (approval) /
+sub-PR 3 (bot) 의 1:1 동형 패턴.
+
+검증 대상 fault:
+
+- ``TreasuryInvalidAmountError`` → ``TREASURY_INVALID_AMOUNT`` (validation;
+  ``allocate``/``deallocate`` 의 finite-positive 가드 위반)
+- ``TreasuryInsufficientUnallocatedError`` → ``TREASURY_INSUFFICIENT_BALANCE``
+  (validation; ``allocate`` 시 ``self._unallocated < amount``)
+- ``TreasuryBudgetNotFoundError`` → ``TREASURY_BUDGET_NOT_FOUND`` (not_found;
+  ``deallocate`` 시 budget record 부재)
+- ``TreasuryDeallocateExceedsAvailableError`` →
+  ``TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE`` (validation; over-deallocate)
+- ``BotNotStoppedError`` → ``TREASURY_BOT_NOT_STOPPED`` (state_conflict;
+  ``update_budget`` 시 running 봇 거부)
+- ``TreasuryNotConfiguredError`` → ``TREASURY_NOT_CONFIGURED``
+  (service_unavailable; ``TreasuryManager`` 미주입 / 등록된 Treasury 부재)
+
+treasury CLI 의 mutating 표면 (``allocate``/``deallocate``/``set-balance``)
+은 모두 ``ipc_send`` 경유이므로 CLI direct path equivalence 는 ``ipc_send``
+mock 으로 server-side envelope (``ipc_error_code``/``ipc_error_message``) 을
+주입한 뒤 CLI middleware ClickException 분기가 동일 코드를 surface 함을
+확인한다 (#1843 sub-PR 3 bot 1:1 동형).
+
+IPC path 는 ``ante.contracts.ipc_error_payload`` helper (server.py:322 의
+``getattr(e, "code", "EXECUTION_ERROR")`` 와 동일 코드를 생성 — 실측 ``.code``
+가 일치하는 한 contract 동등성, #1842 plan v2 #6) 로 직접 직렬화한다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.contracts import ipc_error_payload
+from ante.member.models import Member, MemberRole, MemberType
+from ante.treasury.exceptions import (
+    BotNotStoppedError,
+    TreasuryBudgetNotFoundError,
+    TreasuryDeallocateExceedsAvailableError,
+    TreasuryInsufficientUnallocatedError,
+    TreasuryInvalidAmountError,
+    TreasuryNotConfiguredError,
+)
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=["treasury:read", "treasury:write", "treasury:admin"],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """``ante --format json treasury ...`` 호출용 ``CliRunner`` fixture.
+
+    auth middleware 를 master member 로 우회한다 (#1843 sub-PR 1/2/3
+    fixture 1:1 동형). ``require_scope`` decorator 는 그대로 동작하므로
+    모든 treasury scope 를 부여한다.
+    """
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx) -> None:  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+def _ipc_envelope_code(exc: BaseException) -> str:
+    """주어진 exception 을 IPC envelope 으로 직렬화했을 때의 ``code``.
+
+    IPC server.py:322 가 적용하는 ``getattr(e, "code", "EXECUTION_ERROR")``
+    fallback 과 helper(``ipc_error_payload``)의 registry-first resolution 은
+    실측 ``.code`` 가 일치하는 한 동일 코드를 생성한다 (#1842 plan v2 #6).
+    본 helper 는 helper 경로를 그대로 사용해 contract 동등성을 단언한다.
+    """
+
+    payload = ipc_error_payload(exc)
+    return payload["code"]
+
+
+def _cli_envelope_payload(result_output: str) -> dict:
+    """``CliRunner.result.output`` 에서 JSON envelope 첫 객체를 추출."""
+    payload_line = next(
+        (line for line in result_output.splitlines() if line.startswith("{")),
+        None,
+    )
+    assert payload_line is not None, f"JSON envelope 발견 실패: {result_output!r}"
+    return json.loads(payload_line)
+
+
+def _make_click_exc(code: str, message: str) -> click.ClickException:
+    """``ipc_send`` 가 server error envelope 을 변환할 때 부착하는
+    ``ipc_error_code``/``ipc_error_message`` 속성을 가진 ClickException 을
+    구성한다. CLI command 의 ``except click.ClickException`` 분기에서 동일한
+    형태로 message/code 를 복원한다 (#1843 sub-PR 3 ``_make_click_exc`` 동형).
+    """
+
+    exc = click.ClickException(f"{code}: {message}")
+    exc.ipc_error_code = code  # type: ignore[attr-defined]
+    exc.ipc_error_message = message  # type: ignore[attr-defined]
+    return exc
+
+
+# ── (1) TreasuryInvalidAmountError ↔ TREASURY_INVALID_AMOUNT ────────────────
+
+
+class TestTreasuryInvalidAmountEquivalence:
+    """``TreasuryInvalidAmountError`` 는 양쪽에서 ``TREASURY_INVALID_AMOUNT``.
+
+    CLI direct path: ``treasury allocate`` 표면 — ``ipc_send`` 가 server
+    typed envelope (code=``TREASURY_INVALID_AMOUNT``) 을 ClickException 으로
+    변환하고, ``except click.ClickException`` 분기가 JSON 모드에서 동일
+    코드로 CLI envelope 을 surface 한다.
+
+    NB: CLI ingress(``validate_positive_finite_amount``) 가 amount <= 0/NaN/
+    Inf 를 ``VALIDATION_ERROR`` 로 1차 거부하므로, 본 test 는 service-layer
+    invariant 가 IPC envelope 까지 통과한 경로 (server-side raise) 의 코드
+    surface 동등성만 검증한다. CLI ingress validation 거부 회귀는 별도
+    ``test_treasury_*_ingress`` 테스트가 책임진다.
+    """
+
+    def test_cli_direct_invalid_amount_via_allocate(self, runner: CliRunner) -> None:
+        click_exc = _make_click_exc(
+            "TREASURY_INVALID_AMOUNT",
+            "treasury.allocate: amount는 유한한 양수여야 합니다",
+        )
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "allocate",
+                    "bot-1",
+                    "100",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "TREASURY_INVALID_AMOUNT"
+
+    def test_ipc_envelope_invalid_amount(self) -> None:
+        exc = TreasuryInvalidAmountError(0.0, operation="allocate")
+        assert _ipc_envelope_code(exc) == "TREASURY_INVALID_AMOUNT"
+
+
+# ── (2) TreasuryInsufficientUnallocatedError ↔ TREASURY_INSUFFICIENT_BALANCE
+
+
+class TestTreasuryInsufficientBalanceEquivalence:
+    """``TreasuryInsufficientUnallocatedError`` 는 양쪽에서
+    ``TREASURY_INSUFFICIENT_BALANCE``.
+
+    CLI direct path: ``treasury allocate`` 표면 — ``ipc_send`` 가 server
+    typed envelope (code=``TREASURY_INSUFFICIENT_BALANCE``) 을 ClickException
+    으로 변환하고, ``except click.ClickException`` 분기가 동일 코드를
+    surface 한다.
+    """
+
+    def test_cli_direct_insufficient_balance_via_allocate(
+        self, runner: CliRunner
+    ) -> None:
+        click_exc = _make_click_exc(
+            "TREASURY_INSUFFICIENT_BALANCE",
+            "treasury.allocate: 미할당 잔액 부족",
+        )
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "allocate",
+                    "bot-1",
+                    "1000000",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "TREASURY_INSUFFICIENT_BALANCE"
+
+    def test_ipc_envelope_insufficient_balance(self) -> None:
+        exc = TreasuryInsufficientUnallocatedError(
+            bot_id="bot-1", amount=1_000_000.0, unallocated=500_000.0
+        )
+        assert _ipc_envelope_code(exc) == "TREASURY_INSUFFICIENT_BALANCE"
+
+
+# ── (3) TreasuryBudgetNotFoundError ↔ TREASURY_BUDGET_NOT_FOUND ─────────────
+
+
+class TestTreasuryBudgetNotFoundEquivalence:
+    """``TreasuryBudgetNotFoundError`` 는 양쪽에서 ``TREASURY_BUDGET_NOT_FOUND``.
+
+    CLI direct path: ``treasury deallocate`` 표면 — ``ipc_send`` 가 server
+    typed envelope (code=``TREASURY_BUDGET_NOT_FOUND``) 을 ClickException
+    으로 변환하고, ``except click.ClickException`` 분기가 동일 코드를
+    surface 한다.
+    """
+
+    def test_cli_direct_budget_not_found_via_deallocate(
+        self, runner: CliRunner
+    ) -> None:
+        click_exc = _make_click_exc(
+            "TREASURY_BUDGET_NOT_FOUND",
+            "treasury.deallocate: bot 'bot-1' 의 budget record 가 없습니다",
+        )
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "deallocate",
+                    "bot-1",
+                    "100",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "TREASURY_BUDGET_NOT_FOUND"
+
+    def test_ipc_envelope_budget_not_found(self) -> None:
+        exc = TreasuryBudgetNotFoundError(bot_id="bot-1")
+        assert _ipc_envelope_code(exc) == "TREASURY_BUDGET_NOT_FOUND"
+
+
+# ── (4) TreasuryDeallocateExceedsAvailableError ↔
+#       TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE ─────────────────────────────────
+
+
+class TestTreasuryDeallocateExceedsAvailableEquivalence:
+    """``TreasuryDeallocateExceedsAvailableError`` 는 양쪽에서
+    ``TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE``.
+
+    CLI direct path: ``treasury deallocate`` 표면 — ``ipc_send`` 가 server
+    typed envelope (code=``TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE``) 을
+    ClickException 으로 변환하고, ``except click.ClickException`` 분기가
+    동일 코드를 surface 한다.
+    """
+
+    def test_cli_direct_deallocate_exceeds_available_via_deallocate(
+        self, runner: CliRunner
+    ) -> None:
+        click_exc = _make_click_exc(
+            "TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE",
+            "treasury.deallocate: 가용 예산 초과",
+        )
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "deallocate",
+                    "bot-1",
+                    "1000000",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE"
+
+    def test_ipc_envelope_deallocate_exceeds_available(self) -> None:
+        exc = TreasuryDeallocateExceedsAvailableError(
+            bot_id="bot-1", amount=1_000_000.0, available=500_000.0
+        )
+        assert _ipc_envelope_code(exc) == "TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE"
+
+
+# ── (5) BotNotStoppedError ↔ TREASURY_BOT_NOT_STOPPED ───────────────────────
+
+
+class TestTreasuryBotNotStoppedEquivalence:
+    """``BotNotStoppedError`` 는 양쪽에서 ``TREASURY_BOT_NOT_STOPPED``
+    (state_conflict; running 봇의 예산 변경 거부).
+
+    본 PR 에서 신규 부여한 ``.code = "TREASURY_BOT_NOT_STOPPED"`` 가
+    IPC envelope helper-direct path 와 registry MRO lookup 양쪽에서 동일
+    코드를 surface 한다는 contract 동등성을 lock 한다. CLI 표면은
+    ``update_budget`` 호출 경로 (예: ``bot update --budget``) 에서 raise
+    되며, ``treasury`` CLI 자체는 ``update_budget`` 직접 표면이 없으므로
+    IPC envelope path 단독 단언한다 (#1843 sub-PR 3 ``BotNotAcceptingSignals``
+    동형 — contract-level equivalence).
+    """
+
+    def test_ipc_envelope_bot_not_stopped(self) -> None:
+        exc = BotNotStoppedError("봇이 운용 중이라 예산 변경 불가: bot-1")
+        assert _ipc_envelope_code(exc) == "TREASURY_BOT_NOT_STOPPED"
+
+
+# ── (6) TreasuryNotConfiguredError ↔ TREASURY_NOT_CONFIGURED ────────────────
+
+
+class TestTreasuryNotConfiguredEquivalence:
+    """``TreasuryNotConfiguredError`` 는 양쪽에서ApprovalStatusConflict
+    안정 코드 ``TREASURY_NOT_CONFIGURED`` (service_unavailable; #1335
+    ``TreasuryManager`` 미주입 / 등록된 Treasury 부재).
+
+    본 PR 에서 신규 부여한 ``.code = "TREASURY_NOT_CONFIGURED"`` 가
+    IPC envelope helper-direct path 와 registry MRO lookup 양쪽에서 동일
+    코드를 surface 한다는 contract 동등성을 lock 한다. CLI 표면은
+    ``BotManager`` 가 budget 작업 시 raise 하므로 ``bot create
+    --budget``/``bot update --budget`` 경로에서 surface 되며, ``treasury``
+    CLI 자체는 직접 표면이 없으므로 IPC envelope path 단독 단언한다.
+    """
+
+    def test_ipc_envelope_not_configured(self) -> None:
+        exc = TreasuryNotConfiguredError(
+            "account 'acc-1' 에 Treasury 가 구성되지 않았습니다"
+        )
+        assert _ipc_envelope_code(exc) == "TREASURY_NOT_CONFIGURED"


### PR DESCRIPTION
Refs #1843

#1843 sub-PR 4 (treasury sweep). #1842 (account) / #1843 sub-PR 1 (member) /
sub-PR 2 (approval) / sub-PR 3 (bot) 의 1:1 동형 패턴.

## Summary
- treasury 7 typed sub-class 를 ``EXCEPTION_TO_SPEC`` registry 에 등록
  (실측 ``.code`` mirror). 3건 (`InsufficientFundsError` /
  `BotNotStoppedError` / `TreasuryNotConfiguredError`) 은 class-level
  `.code` 신규 부여.
- CLI ``treasury.py`` 6개 callsite (`budgets` / `set_balance` / `allocate`
  / `deallocate` / `portfolio_value` / `portfolio_history`) 의 generic
  `except Exception` 패턴을 `emit_cli_error(fmt, e)` 로 정렬.
- ``error_drift_allowlist.yaml`` pending_migration 에서 treasury 3건 제거
  (`TreasuryError` base 만 보존).
- ``tests/unit/test_treasury_cli_ipc_error_equivalence.py`` 신규 — 6 대표
  fault 의 CLI↔IPC 동일 public code surface lock (10 test).

## 등록된 registry entries (7건)
| Exception | Code | Category |
|---|---|---|
| `TreasuryInvalidAmountError` | `TREASURY_INVALID_AMOUNT` | validation |
| `TreasuryInsufficientUnallocatedError` | `TREASURY_INSUFFICIENT_BALANCE` | validation |
| `TreasuryBudgetNotFoundError` | `TREASURY_BUDGET_NOT_FOUND` | not_found |
| `TreasuryDeallocateExceedsAvailableError` | `TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE` | validation |
| `InsufficientFundsError` | `TREASURY_INSUFFICIENT_FUNDS` (신규) | validation |
| `BotNotStoppedError` | `TREASURY_BOT_NOT_STOPPED` (신규) | state_conflict |
| `TreasuryNotConfiguredError` | `TREASURY_NOT_CONFIGURED` (신규) | service_unavailable |

`TreasuryError` base 는 의도적으로 미등록 — 사용 사례가 없으며
`pending_migration` allowlist 에 baseline 으로 유지 (#1842 `AccountError` 동형).

## Semantic distinction note
`InsufficientFundsError` → `TREASURY_INSUFFICIENT_FUNDS` 는
`TreasuryInsufficientUnallocatedError` → `TREASURY_INSUFFICIENT_BALANCE`
와 의미 분리한다. 전자는 `update_budget` 의 caller-facing wrap fault
(treasury.py:599-606 가 raw reject 를 동일 타입으로 변환), 후자는
allocate-side raw reject. 두 fault 가 raise 되는 경로/계약이 다르므로
같은 코드로 묶지 않는다.

## Test plan
- [x] `pytest tests/unit/contracts` (67 passed)
- [x] `pytest tests/unit/test_treasury_cli_ipc_error_equivalence.py` (10 passed)
- [x] `pytest tests/unit/` (5186 passed, 2 skipped) — 회귀 없음
- [x] `mypy src/` (Success: no issues found in 222 source files)
- [x] `ruff check src/ tests/` + `ruff format --check` (All checks passed)
- [x] `scripts/generate_project_structure.py` regen — equivalence test 등록

🤖 Generated with [Claude Code](https://claude.com/claude-code)