### PR TITLE
refactor: #1843-5 broker error contract registry + origin msg_cd log-only separation

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -594,7 +594,9 @@ tests/
 │   ├── test_member_cli_ipc_error_equivalence.py
 │   ├── test_approval_cli_ipc_error_equivalence.py
 │   ├── test_bot_cli_ipc_error_equivalence.py
-│   └── test_treasury_cli_ipc_error_equivalence.py
+│   ├── test_treasury_cli_ipc_error_equivalence.py
+│   ├── test_broker_cli_ipc_error_equivalence.py
+│   └── test_broker_external_code_separation.py
 └── __init__.py
 ```
 

--- a/src/ante/broker/exceptions.py
+++ b/src/ante/broker/exceptions.py
@@ -1,20 +1,69 @@
-"""Broker Adapter 모듈 예외."""
+"""Broker Adapter 모듈 예외.
+
+#1843 sub-PR 5 — 본 모듈의 ``*Error`` sub-class 5건에 class-level ``.code``
+속성을 신규 부여한다. helper(``ante.contracts.error_spec_for_exception``)
+의 registry MRO lookup 과 IPC server.py:322 의 ``getattr(e, "code",
+"EXECUTION_ERROR")`` fallback 양쪽에서 동일한 안정 코드가 envelope 으로
+surface 되도록 정렬한다 (#1842 account 12 sub-class / #1843 sub-PR 1~4
+member/approval/bot/treasury 동형).
+
+원천 code 분리 정책 (#1843 sub-PR 5 Codex Plan Review v1 condition):
+
+- ``APIError`` 가 보존하는 ``error_code`` (KIS msg_cd 등 원천
+  external broker code) 는 **log-only / 디버깅 보조** 용도다.
+- public envelope (CLI ``OutputFormatter.error`` / IPC envelope ``{code,
+  message}``) 에는 ante taxonomy 의 안정 코드(``BROKER_API_ERROR``)만
+  노출한다 — envelope SSOT 갱신 필요한 ``details.broker_code`` 필드 도입은
+  본 PR 범위 밖이며 후속 spec PR 에서 책임진다.
+- 보존 채널: ``APIError.error_code`` 인스턴스 필드 (log / debug message /
+  EventBus ``OrderFailedEvent.error_code`` payload). public envelope 변환
+  경로는 본 필드를 surface 하지 않는다.
+"""
 
 
 class BrokerError(Exception):
-    """Broker 기본 예외."""
+    """Broker 기본 예외.
+
+    ``BrokerError`` base 자체는 의도적으로 ``EXCEPTION_TO_SPEC`` 에 등록하지
+    않는다 — sub-class 5건이 모두 안정 코드를 보유하므로 base class 가
+    fallback 으로 자체 raise 되는 사용 사례가 없다 (account/member/approval/
+    bot/treasury sweep 의 base class 처리 동형 — ``pending_migration``
+    allowlist 에 baseline 으로 유지).
+    """
 
     pass
 
 
 class AuthenticationError(BrokerError):
-    """인증 실패."""
+    """인증 실패.
 
-    pass
+    KIS OAuth 토큰 발급/갱신 실패 (HTTP 401/403, 잘못된 app_key/app_secret
+    등). taxonomy ``auth`` 카테고리.
+    """
+
+    code: str = "BROKER_AUTH_FAILED"
 
 
 class APIError(BrokerError):
-    """API 호출 실패."""
+    """API 호출 실패.
+
+    KIS API 호출 시 broker side business / HTTP error. ``status_code`` 에
+    HTTP status, ``error_code`` 에 원천 KIS ``msg_cd`` (예: ``APBK0501``) 가
+    log-only 채널로 보존된다.
+
+    public envelope code:
+        ``BROKER_API_ERROR`` (taxonomy ``external`` 카테고리).
+
+    원천 KIS ``msg_cd`` 노출 정책:
+        public envelope (CLI ``OutputFormatter.error`` / IPC envelope
+        ``{code, message}``) 에는 ante taxonomy 안정 코드만 노출한다.
+        원천 ``msg_cd`` 는 ``self.error_code`` 필드 + log message
+        (``KIS API Error [{msg_cd}]: {msg1}`` 형태) 에 보존되며, public
+        surface 로 변환되지 않는다 (#1843 sub-PR 5 Codex Plan Review v1
+        condition).
+    """
+
+    code: str = "BROKER_API_ERROR"
 
     def __init__(
         self,
@@ -30,18 +79,31 @@ class APIError(BrokerError):
 
 
 class OrderNotFoundError(BrokerError):
-    """주문을 찾을 수 없음."""
+    """주문을 찾을 수 없음.
 
-    pass
+    broker side 에서 조회/취소 대상 주문이 존재하지 않을 때. taxonomy
+    ``not_found`` 카테고리.
+    """
+
+    code: str = "BROKER_ORDER_NOT_FOUND"
 
 
 class RateLimitError(BrokerError):
-    """Rate limit 초과."""
+    """Rate limit 초과.
 
-    pass
+    KIS API per-minute rate limit 초과. retryable backoff 정책의 신호로 쓰인다.
+    taxonomy ``external`` 카테고리 (외부 시스템 throttling).
+    """
+
+    code: str = "BROKER_RATE_LIMITED"
 
 
 class CircuitOpenError(BrokerError):
-    """Circuit breaker가 OPEN 상태 — API 호출 차단."""
+    """Circuit breaker가 OPEN 상태 — API 호출 차단.
 
-    pass
+    연속 실패 임계 도달 시 circuit breaker 가 OPEN 으로 전이해 API 호출을
+    차단한다. taxonomy ``service_unavailable`` 카테고리 (broker 가용성
+    임시 차단).
+    """
+
+    code: str = "BROKER_CIRCUIT_OPEN"

--- a/src/ante/broker/registry.py
+++ b/src/ante/broker/registry.py
@@ -13,7 +13,16 @@ if TYPE_CHECKING:
 
 
 class InvalidBrokerTypeError(Exception):
-    """미등록 broker_type 요청 시 발생."""
+    """미등록 broker_type 요청 시 발생.
+
+    #1843 sub-PR 5 — class-level ``.code = "BROKER_INVALID_TYPE"`` 부여.
+    ``ante.account.errors.InvalidBrokerTypeError`` (``.code =
+    "ACCOUNT_INVALID_BROKER_TYPE"``) 와 동명이지만 module/code 가 분리된
+    별개 class 다 — drift guard 와 helper 의 type-based MRO lookup 모두
+    module 별로 정확히 분리한다.
+    """
+
+    code: str = "BROKER_INVALID_TYPE"
 
     def __init__(self, broker_type: str) -> None:
         self.broker_type = broker_type

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -9,6 +9,7 @@ import click
 from ante.account.errors import AccountNotFoundError
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
+from ante.contracts import emit_cli_error
 
 
 @click.group()
@@ -208,8 +209,12 @@ def balance(ctx: click.Context, account_id: str) -> None:
             fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
             raise SystemExit(1) from e
         except Exception as e:
-            fmt.error(str(e))
-            raise SystemExit(1) from e
+            # #1843 sub-PR 5: emit_cli_error 정렬 — CLI/IPC 동일 public code
+            # surface. broker typed exception (APIError / AuthenticationError /
+            # OrderNotFoundError / RateLimitError / CircuitOpenError) 은
+            # registry MRO lookup 으로 ``BROKER_*`` 안정 코드를 surface 하며,
+            # 미분류 fault 는 ``EXECUTION_ERROR`` fallback.
+            emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output(result)
@@ -263,8 +268,9 @@ def positions(ctx: click.Context, account_id: str) -> None:
             fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
             raise SystemExit(1) from e
         except Exception as e:
-            fmt.error(str(e))
-            raise SystemExit(1) from e
+            # #1843 sub-PR 5: emit_cli_error 정렬 — broker typed exception 의
+            # 안정 코드 surface (positions 표면 동일 정책).
+            emit_cli_error(fmt, e)
 
     pos_list = result.get("positions", [])
 
@@ -315,8 +321,9 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
         except click.ClickException:
             raise
         except Exception as e:
-            fmt.error(str(e))
-            raise SystemExit(1) from e
+            # #1843 sub-PR 5: emit_cli_error 정렬 — broker typed exception
+            # 의 안정 코드 surface (reconcile --fix mutating path).
+            emit_cli_error(fmt, e)
     else:
         # 읽기 전용: IPC 우선, 폴백으로 오프라인 방식
         try:
@@ -385,14 +392,15 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
 
             try:
                 result = _run(_run_reconcile())
-            except Exception as e:
-                fmt.error(
-                    str(e),
-                    code="ACCOUNT_NOT_FOUND"
-                    if isinstance(e, AccountNotFoundError)
-                    else "",
-                )
+            except AccountNotFoundError as e:
+                fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
                 raise SystemExit(1) from e
+            except Exception as e:
+                # #1843 sub-PR 5: emit_cli_error 정렬 — broker typed exception
+                # (APIError 등) 도 안정 코드 surface. 기존 ``code=""`` fallback
+                # 은 sweep 정신과 어긋나므로 helper 의 registry MRO lookup +
+                # EXECUTION_ERROR fallback 으로 일관 정렬한다.
+                emit_cli_error(fmt, e)
 
     if fmt.is_json:
         fmt.output(result)

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -120,6 +120,31 @@ mirror, ``BotNotFoundError`` 는 #1840 lock 그대로 보존):
 ``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
 ``AccountError`` 와 동일 패턴, #1843 sub-PR 1/2/3 Non-Goals 동형).
 
+#1843 sub-PR 5 (broker sweep) 가 추가한 broker domain 6 sub-class lock
+(실측 ``.code`` mirror, 본 PR 에서 신규 부여):
+
+- ``AuthenticationError`` → ``BROKER_AUTH_FAILED`` / ``auth`` (KIS OAuth
+  토큰 발급/갱신 실패; HTTP 401/403 또는 잘못된 app_key/secret)
+- ``APIError`` → ``BROKER_API_ERROR`` / ``external`` (KIS API business/HTTP
+  error; 원천 KIS ``msg_cd`` 는 ``APIError.error_code`` 필드에 log-only
+  보존되며 envelope 에는 안정 코드만 노출 — Codex Plan Review v1 condition)
+- ``OrderNotFoundError`` → ``BROKER_ORDER_NOT_FOUND`` / ``not_found``
+  (broker side 에서 조회/취소 대상 주문 부재)
+- ``RateLimitError`` → ``BROKER_RATE_LIMITED`` / ``external`` (KIS per-minute
+  rate limit 초과)
+- ``CircuitOpenError`` → ``BROKER_CIRCUIT_OPEN`` / ``service_unavailable``
+  (연속 실패 임계 도달로 circuit breaker OPEN — broker 가용성 임시 차단)
+- ``ante.broker.registry.InvalidBrokerTypeError`` → ``BROKER_INVALID_TYPE`` /
+  ``validation`` (registry 미등록 broker_type 요청). 동명 별개 class 인
+  ``ante.account.errors.InvalidBrokerTypeError`` 는 #1842 가 이미
+  ``ACCOUNT_INVALID_BROKER_TYPE`` 로 등록한 다른 entry 다 — helper 의
+  type-based MRO lookup 과 drift guard 의 ``(module, name)`` 2중 anchor 가
+  두 class 를 정확히 분리한다.
+
+``BrokerError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
+``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
+``AccountError`` 와 동일 패턴, #1843 sub-PR 1/2/3/4 Non-Goals 동형).
+
 추가로 ``SERVICE_NOT_CONFIGURED`` 는 #1819 dispatch wrapper 가 도입할 예정인
 ``ServiceNotConfiguredError`` 의 ErrorSpec value 를 module-level constant
 (``_SERVICE_NOT_CONFIGURED_SPEC``) 로 reserved 보존한다. 해당 exception class
@@ -159,6 +184,16 @@ from ante.bot.exceptions import (
     BotNotFoundError,
     BotStateConflict,
     BotStrategyAlreadyRunningError,
+)
+from ante.broker.exceptions import (
+    APIError,
+    AuthenticationError,
+    CircuitOpenError,
+    OrderNotFoundError,
+    RateLimitError,
+)
+from ante.broker.registry import (
+    InvalidBrokerTypeError as BrokerRegistryInvalidBrokerTypeError,
 )
 from ante.contracts.errors import ErrorSpec
 from ante.member.errors import (
@@ -446,6 +481,64 @@ _TREASURY_NOT_CONFIGURED_SPEC: Final[ErrorSpec] = ErrorSpec(
 )
 
 
+# ── broker 6 sub-class lock (#1843 sub-PR 5, 본 PR 신규 부여) ────────────────
+#
+# ``BrokerError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
+# ``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
+# ``AccountError`` 와 동일 패턴, #1843 sub-PR 1/2/3/4 Non-Goals 동형).
+
+# KIS OAuth 토큰 발급/갱신 실패 (HTTP 401/403, 잘못된 app_key/app_secret).
+# taxonomy ``auth`` 카테고리 — 인증 자격 거부.
+_BROKER_AUTH_FAILED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BROKER_AUTH_FAILED",
+    category="auth",
+)
+
+# KIS API 호출 시 broker side business / HTTP error. ``status_code`` 에 HTTP
+# status, ``error_code`` 에 원천 KIS ``msg_cd`` (예: ``APBK0501``) 가
+# log-only 채널로 보존된다. public envelope (CLI ``OutputFormatter.error`` /
+# IPC envelope) 에는 안정 코드 ``BROKER_API_ERROR`` 만 노출하며 원천
+# ``msg_cd`` 는 surface 하지 않는다 (#1843 sub-PR 5 Codex Plan Review v1
+# condition; envelope SSOT 갱신 필요한 ``details.broker_code`` 필드 도입은
+# 후속 spec PR 책임).
+_BROKER_API_ERROR_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BROKER_API_ERROR",
+    category="external",
+)
+
+# broker side 에서 조회/취소 대상 주문이 존재하지 않을 때. taxonomy
+# ``not_found`` 카테고리.
+_BROKER_ORDER_NOT_FOUND_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BROKER_ORDER_NOT_FOUND",
+    category="not_found",
+)
+
+# KIS API per-minute rate limit 초과. retryable backoff 정책의 신호로
+# 사용된다. taxonomy ``external`` 카테고리 (외부 시스템 throttling).
+_BROKER_RATE_LIMITED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BROKER_RATE_LIMITED",
+    category="external",
+)
+
+# 연속 실패 임계 도달 시 circuit breaker 가 OPEN 으로 전이해 API 호출을
+# 차단한다. taxonomy ``service_unavailable`` 카테고리 (broker 가용성
+# 임시 차단).
+_BROKER_CIRCUIT_OPEN_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BROKER_CIRCUIT_OPEN",
+    category="service_unavailable",
+)
+
+# ``ante.broker.registry`` 의 미등록 broker_type 요청 거부. 동명 별개 class
+# 인 ``ante.account.errors.InvalidBrokerTypeError`` (#1842,
+# ``ACCOUNT_INVALID_BROKER_TYPE``) 와는 별개의 module/code 다 — helper 의
+# type-based MRO lookup 과 drift guard 의 ``(module, name)`` 2중 anchor 가
+# 두 class 를 정확히 분리한다.
+_BROKER_INVALID_TYPE_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BROKER_INVALID_TYPE",
+    category="validation",
+)
+
+
 # ── reserved entry (#1819 후속 도입) ─────────────────────────────────────────
 #
 # ``SERVICE_NOT_CONFIGURED`` 는 taxonomy SSOT 가 ``service_unavailable`` 카테고리
@@ -520,6 +613,13 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     InsufficientFundsError: _TREASURY_INSUFFICIENT_FUNDS_SPEC,
     BotNotStoppedError: _TREASURY_BOT_NOT_STOPPED_SPEC,
     TreasuryNotConfiguredError: _TREASURY_NOT_CONFIGURED_SPEC,
+    # ── #1843 sub-PR 5 broker 6 sub-class (실측 .code mirror) ─────────────
+    AuthenticationError: _BROKER_AUTH_FAILED_SPEC,
+    APIError: _BROKER_API_ERROR_SPEC,
+    OrderNotFoundError: _BROKER_ORDER_NOT_FOUND_SPEC,
+    RateLimitError: _BROKER_RATE_LIMITED_SPEC,
+    CircuitOpenError: _BROKER_CIRCUIT_OPEN_SPEC,
+    BrokerRegistryInvalidBrokerTypeError: _BROKER_INVALID_TYPE_SPEC,
 }
 """대표 fault lock registry (#1839 normative 4건).
 

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -57,18 +57,10 @@ known_drift_fmt_error_no_code:
     line: 952
     snippet_sha1: "3dc4008c3fb0"
     reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock"
-  - path: src/ante/cli/commands/broker.py
-    line: 211
-    snippet_sha1: "f65e1080d3f2"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/broker.py
-    line: 266
-    snippet_sha1: "f65e1080d3f2"
-    reason: "baseline (#1841); migrate in #1843"
-  - path: src/ante/cli/commands/broker.py
-    line: 318
-    snippet_sha1: "f65e1080d3f2"
-    reason: "baseline (#1841); migrate in #1843"
+  # #1843 sub-PR 5: broker.py line 211/266/318 entries 제거 — emit_cli_error
+  # 정렬 완료 (broker typed exception 5 sub-class 가 ``BROKER_*`` 안정 코드를
+  # registry MRO lookup 으로 surface, 미분류 fault 는 ``EXECUTION_ERROR``
+  # fallback).
   - path: src/ante/cli/commands/config.py
     line: 176
     snippet_sha1: "3dc4008c3fb0"
@@ -130,27 +122,14 @@ pending_migration:
   - module: ante.bot.exceptions
     class_anchor: BotError
     reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.broker.exceptions
-    class_anchor: APIError
-    reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.broker.exceptions
-    class_anchor: AuthenticationError
-    reason: "baseline (#1841); register in #1842/#1843"
+  # #1843 sub-PR 5: broker 5 sub-class (APIError/AuthenticationError/
+  # CircuitOpenError/OrderNotFoundError/RateLimitError) + registry
+  # InvalidBrokerTypeError 제거 — class-level ``.code`` 부여 +
+  # EXCEPTION_TO_SPEC 등록 완료. ``BrokerError`` base 는 사용 사례가
+  # 없어 baseline 보존 (#1842 ``AccountError`` 동형).
   - module: ante.broker.exceptions
     class_anchor: BrokerError
-    reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.broker.exceptions
-    class_anchor: CircuitOpenError
-    reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.broker.exceptions
-    class_anchor: OrderNotFoundError
-    reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.broker.exceptions
-    class_anchor: RateLimitError
-    reason: "baseline (#1841); register in #1842/#1843"
-  - module: ante.broker.registry
-    class_anchor: InvalidBrokerTypeError
-    reason: "baseline (#1841); register in #1842/#1843"
+    reason: "base — no callsite; pending_migration baseline (#1842 AccountError 동형)"
   - module: ante.config.exceptions
     class_anchor: ConfigError
     reason: "baseline (#1841); register in #1842/#1843"

--- a/tests/unit/test_broker_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_broker_cli_ipc_error_equivalence.py
@@ -1,0 +1,340 @@
+"""Broker CLI direct path ↔ IPC path error code equivalence lock (#1843 sub-PR 5).
+
+본 모듈은 #1816 의 6차 migration domain (broker) 의 대표 fault 5 건이
+CLI path 와 IPC envelope path 양쪽에서 **동일한 public code** 를 노출함을
+lock 한다. #1842 (account) / #1843 sub-PR 1 (member) / sub-PR 2 (approval) /
+sub-PR 3 (bot) / sub-PR 4 (treasury) 의 1:1 동형 패턴.
+
+검증 대상 fault:
+
+- ``APIError`` → ``BROKER_API_ERROR`` (external; KIS API business/HTTP error)
+- ``AuthenticationError`` → ``BROKER_AUTH_FAILED`` (auth; KIS OAuth 토큰
+  발급/갱신 실패)
+- ``OrderNotFoundError`` → ``BROKER_ORDER_NOT_FOUND`` (not_found; broker side
+  주문 부재)
+- ``RateLimitError`` → ``BROKER_RATE_LIMITED`` (external; KIS per-minute
+  rate limit 초과)
+- ``CircuitOpenError`` → ``BROKER_CIRCUIT_OPEN`` (service_unavailable;
+  연속 실패 임계 도달로 circuit breaker OPEN)
+
+broker CLI 표면 (``balance``/``positions``/``reconcile``) 은 IPC 우선 →
+``except click.ClickException`` 으로 fallback path 에 진입한다. fallback
+의 ``_get_broker``/``_run_balance``/``_run_positions``/``_run_reconcile``
+이 broker typed exception 을 raise 하면 ``except Exception`` 분기의
+``emit_cli_error(fmt, e)`` 가 registry MRO lookup 으로 ``BROKER_*`` 안정
+코드를 surface 한다 — 본 test 는 그 경로를 mock 으로 단언한다.
+
+IPC path 는 ``ante.contracts.ipc_error_payload`` helper (server.py:322 의
+``getattr(e, "code", "EXECUTION_ERROR")`` 와 동일 코드를 생성 — 실측 ``.code``
+가 일치하는 한 contract 동등성, #1842 plan v2 #6) 로 직접 직렬화한다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.broker.exceptions import (
+    APIError,
+    AuthenticationError,
+    CircuitOpenError,
+    OrderNotFoundError,
+    RateLimitError,
+)
+from ante.cli.main import cli
+from ante.contracts import ipc_error_payload
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=["broker:read", "broker:write", "broker:admin"],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """``ante --format json broker ...`` 호출용 ``CliRunner`` fixture.
+
+    auth middleware 를 master member 로 우회한다 (#1843 sub-PR 1/2/3/4
+    fixture 1:1 동형). ``require_scope`` decorator 는 그대로 동작하므로
+    모든 broker scope 를 부여한다.
+    """
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx) -> None:  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+def _ipc_envelope_code(exc: BaseException) -> str:
+    """주어진 exception 을 IPC envelope 으로 직렬화했을 때의 ``code``.
+
+    IPC server.py:322 가 적용하는 ``getattr(e, "code", "EXECUTION_ERROR")``
+    fallback 과 helper(``ipc_error_payload``)의 registry-first resolution 은
+    실측 ``.code`` 가 일치하는 한 동일 코드를 생성한다 (#1842 plan v2 #6).
+    본 helper 는 helper 경로를 그대로 사용해 contract 동등성을 단언한다.
+    """
+
+    payload = ipc_error_payload(exc)
+    return payload["code"]
+
+
+def _cli_envelope_payload(result_output: str) -> dict:
+    """``CliRunner.result.output`` 에서 JSON envelope 첫 객체를 추출."""
+    payload_line = next(
+        (line for line in result_output.splitlines() if line.startswith("{")),
+        None,
+    )
+    assert payload_line is not None, f"JSON envelope 발견 실패: {result_output!r}"
+    return json.loads(payload_line)
+
+
+def _patch_balance_fallback_raises(exc: BaseException):  # noqa: ANN202
+    """broker.balance CLI 의 fallback path 에서 broker exception 을 강제로
+    raise 시키기 위한 context manager 묶음.
+
+    IPC 우선 시도는 ``ipc_send`` 가 ``ClickException`` 을 raise 하도록
+    mock — CLI ``balance`` 의 ``except click.ClickException`` 분기가 fallback
+    path 에 진입한다. fallback 의 ``_get_broker`` 가 mock adapter (raise 하는
+    ``get_account_balance``) 를 반환하면, ``_run_balance`` 가 broker exception
+    을 전파하고 ``except Exception → emit_cli_error`` 가 안정 코드를 surface
+    한다.
+    """
+    import click
+
+    from ante.broker.base import BrokerAdapter
+    from ante.cli.commands import broker as broker_cmd
+
+    async def _raise_click(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        raise click.ClickException("server unavailable")
+
+    mock_adapter = MagicMock(spec=BrokerAdapter)
+    mock_adapter.is_connected = True
+    mock_adapter.exchange = "KRX"
+    mock_adapter.get_account_balance = AsyncMock(side_effect=exc)
+    mock_adapter.get_positions = AsyncMock(side_effect=exc)
+    mock_adapter.get_account_positions = AsyncMock(side_effect=exc)
+    mock_adapter.disconnect = AsyncMock(return_value=None)
+
+    async def _fake_get_broker(account_id=None):  # noqa: ANN001, ANN202
+        return mock_adapter, None
+
+    return patch.object(
+        broker_cmd, "_ipc_broker_command", new=_raise_click
+    ), patch.object(broker_cmd, "_get_broker", new=_fake_get_broker)
+
+
+# ── (1) APIError ↔ BROKER_API_ERROR ─────────────────────────────────────────
+
+
+class TestBrokerApiErrorEquivalence:
+    """``APIError`` 는 양쪽에서 ``BROKER_API_ERROR``.
+
+    CLI direct path: ``broker balance`` fallback path 에서 broker adapter
+    가 raise → ``emit_cli_error`` 가 registry MRO lookup 으로
+    ``BROKER_API_ERROR`` 를 surface.
+
+    원천 KIS ``msg_cd`` (``APIError.error_code``) 는 envelope public surface
+    에 노출되지 않는다 — round-trip 분리 회귀는
+    ``test_broker_external_code_separation`` 가 책임진다.
+    """
+
+    def test_cli_direct_api_error_via_balance(self, runner: CliRunner) -> None:
+        exc = APIError(
+            "KIS API Error [APBK0501]: 주문 가능 금액 부족",
+            status_code=400,
+            error_code="APBK0501",
+        )
+        ipc_patch, broker_patch = _patch_balance_fallback_raises(exc)
+        with ipc_patch, broker_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "broker",
+                    "balance",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BROKER_API_ERROR"
+
+    def test_ipc_envelope_api_error(self) -> None:
+        exc = APIError(
+            "KIS API Error [APBK0501]: 주문 가능 금액 부족",
+            status_code=400,
+            error_code="APBK0501",
+        )
+        assert _ipc_envelope_code(exc) == "BROKER_API_ERROR"
+
+
+# ── (2) AuthenticationError ↔ BROKER_AUTH_FAILED ────────────────────────────
+
+
+class TestBrokerAuthFailedEquivalence:
+    """``AuthenticationError`` 는 양쪽에서 ``BROKER_AUTH_FAILED``.
+
+    CLI direct path: ``broker balance`` fallback path 에서 broker adapter
+    가 raise → ``emit_cli_error`` 가 ``BROKER_AUTH_FAILED`` 를 surface.
+    """
+
+    def test_cli_direct_auth_failed_via_balance(self, runner: CliRunner) -> None:
+        exc = AuthenticationError("인증 실패 (HTTP 401): invalid app_key")
+        ipc_patch, broker_patch = _patch_balance_fallback_raises(exc)
+        with ipc_patch, broker_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "broker",
+                    "balance",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BROKER_AUTH_FAILED"
+
+    def test_ipc_envelope_auth_failed(self) -> None:
+        exc = AuthenticationError("인증 실패 (HTTP 401): invalid app_key")
+        assert _ipc_envelope_code(exc) == "BROKER_AUTH_FAILED"
+
+
+# ── (3) OrderNotFoundError ↔ BROKER_ORDER_NOT_FOUND ─────────────────────────
+
+
+class TestBrokerOrderNotFoundEquivalence:
+    """``OrderNotFoundError`` 는 양쪽에서 ``BROKER_ORDER_NOT_FOUND``.
+
+    CLI direct path: ``broker balance`` fallback path 에서 broker adapter
+    가 raise (예: 보유 조회 시 cross-fault 시나리오) → ``emit_cli_error`` 가
+    ``BROKER_ORDER_NOT_FOUND`` 를 surface. ``broker`` CLI 자체에는 단일
+    order 조회 표면이 없지만 contract-level equivalence 는 fallback path
+    에서 typed exception 이 ``emit_cli_error`` 를 통해 동일 코드를 raise
+    함을 lock 한다.
+    """
+
+    def test_cli_direct_order_not_found_via_balance(self, runner: CliRunner) -> None:
+        exc = OrderNotFoundError("주문을 찾을 수 없음: ord-1")
+        ipc_patch, broker_patch = _patch_balance_fallback_raises(exc)
+        with ipc_patch, broker_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "broker",
+                    "balance",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BROKER_ORDER_NOT_FOUND"
+
+    def test_ipc_envelope_order_not_found(self) -> None:
+        exc = OrderNotFoundError("주문을 찾을 수 없음: ord-1")
+        assert _ipc_envelope_code(exc) == "BROKER_ORDER_NOT_FOUND"
+
+
+# ── (4) RateLimitError ↔ BROKER_RATE_LIMITED ────────────────────────────────
+
+
+class TestBrokerRateLimitedEquivalence:
+    """``RateLimitError`` 는 양쪽에서 ``BROKER_RATE_LIMITED``.
+
+    CLI direct path: ``broker balance`` fallback path 에서 broker adapter
+    가 raise → ``emit_cli_error`` 가 ``BROKER_RATE_LIMITED`` 를 surface.
+    """
+
+    def test_cli_direct_rate_limited_via_balance(self, runner: CliRunner) -> None:
+        exc = RateLimitError("Rate limit 초과: 분당 20회 초과")
+        ipc_patch, broker_patch = _patch_balance_fallback_raises(exc)
+        with ipc_patch, broker_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "broker",
+                    "balance",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BROKER_RATE_LIMITED"
+
+    def test_ipc_envelope_rate_limited(self) -> None:
+        exc = RateLimitError("Rate limit 초과: 분당 20회 초과")
+        assert _ipc_envelope_code(exc) == "BROKER_RATE_LIMITED"
+
+
+# ── (5) CircuitOpenError ↔ BROKER_CIRCUIT_OPEN ──────────────────────────────
+
+
+class TestBrokerCircuitOpenEquivalence:
+    """``CircuitOpenError`` 는 양쪽에서 ``BROKER_CIRCUIT_OPEN``.
+
+    CLI direct path: ``broker balance`` fallback path 에서 broker adapter
+    가 raise (circuit breaker OPEN) → ``emit_cli_error`` 가
+    ``BROKER_CIRCUIT_OPEN`` 을 surface.
+    """
+
+    def test_cli_direct_circuit_open_via_balance(self, runner: CliRunner) -> None:
+        exc = CircuitOpenError("Circuit breaker OPEN: KIS API 차단 중")
+        ipc_patch, broker_patch = _patch_balance_fallback_raises(exc)
+        with ipc_patch, broker_patch:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "broker",
+                    "balance",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code != 0, result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BROKER_CIRCUIT_OPEN"
+
+    def test_ipc_envelope_circuit_open(self) -> None:
+        exc = CircuitOpenError("Circuit breaker OPEN: KIS API 차단 중")
+        assert _ipc_envelope_code(exc) == "BROKER_CIRCUIT_OPEN"

--- a/tests/unit/test_broker_external_code_separation.py
+++ b/tests/unit/test_broker_external_code_separation.py
@@ -1,0 +1,162 @@
+"""Broker 원천 external code (KIS ``msg_cd``) log-only 분리 round-trip lock.
+
+#1843 sub-PR 5 Codex Plan Review v1 condition — broker ``APIError`` 가
+보존하는 원천 외부 broker code (KIS ``msg_cd``, 예: ``APBK0501``) 는
+**log/디버깅 보조** 채널에만 보존되며, public envelope (CLI ``OutputFormatter.
+error`` / IPC envelope ``{code, message}``) 의 ``code`` 필드에는 ante
+taxonomy 의 안정 코드 ``BROKER_API_ERROR`` 만 노출된다.
+
+본 모듈이 lock 하는 contract:
+
+- ``APIError(msg, status_code=..., error_code="<msg_cd>")`` 인스턴스의
+  ``.error_code`` 필드 보존 — log/EventBus 직접 소비자가 원천 코드를 사용
+  가능해야 한다.
+- 동일 인스턴스를 ``ipc_error_payload`` 로 직렬화한 결과의 ``code`` 는
+  ``BROKER_API_ERROR`` 만 노출 — 원천 ``msg_cd`` 가 envelope 상위 필드로
+  새지 않는다.
+- helper ``error_spec_for_exception`` 도 ``BROKER_API_ERROR`` 안정 코드
+  만 resolve — 원천 ``msg_cd`` 가 helper 경로로 외부에 노출되지 않는다.
+
+envelope SSOT 갱신 필요한 ``details.broker_code`` 필드 도입은 본 PR 범위
+밖이며, 후속 spec PR 이 책임진다. 본 모듈은 그 추가 도입 시점까지 원천
+``msg_cd`` 가 envelope 의 어떤 top-level 필드로도 누출되지 않음을 lock
+한다 (negative contract).
+
+NOTE: ``APIError`` 의 ``str(exc)`` (즉 envelope ``message`` 필드 후보) 는
+실측 KIS error format ``"KIS API Error [{msg_cd}]: {msg1}"`` 을 그대로
+포함할 수 있다 — 이는 사용자/로그 표시용 자연어 메시지이며 구조화된
+원천 코드 surface 가 아니다. 본 round-trip lock 은 envelope 의 구조화된
+``code`` 필드만을 단언한다.
+"""
+
+from __future__ import annotations
+
+from ante.broker.exceptions import APIError
+from ante.contracts import error_spec_for_exception, ipc_error_payload
+
+# ── (1) APIError 인스턴스가 원천 ``msg_cd`` 를 내부 필드로 보존한다 ──────────
+
+
+def test_api_error_preserves_origin_msg_cd_internally() -> None:
+    """``APIError.error_code`` 필드는 KIS 원천 ``msg_cd`` 를 그대로 보존한다.
+
+    이 필드는 log message / EventBus ``OrderFailedEvent.error_code`` payload
+    같은 내부 소비자가 디버깅/감사용으로 사용한다. public envelope 으로는
+    이후 단언처럼 노출되지 않는다.
+    """
+
+    exc = APIError(
+        "KIS API Error [APBK0501]: 주문 가능 금액 부족",
+        status_code=400,
+        error_code="APBK0501",
+        retryable=False,
+    )
+
+    assert exc.error_code == "APBK0501"
+    assert exc.status_code == 400
+    assert exc.retryable is False
+
+
+# ── (2) Public envelope 는 ante taxonomy 안정 코드만 노출한다 ────────────────
+
+
+def test_api_error_envelope_exposes_only_public_code() -> None:
+    """``ipc_error_payload(APIError(...))`` 는 ``BROKER_API_ERROR`` 만 노출.
+
+    envelope 의 top-level 필드는 ``{"code", "message"}`` 두 개로 고정되어
+    있다 (#1820 envelope SSOT). ``code`` 는 ante taxonomy 안정 코드여야 하며,
+    원천 KIS ``msg_cd`` (``APBK0501``) 가 ``code`` 필드로 새는 것을 금지한다.
+
+    ``details.broker_code`` 같은 별도 구조화 필드는 envelope SSOT 갱신
+    이후 후속 spec PR 에서 도입한다 (Codex Plan Review v1 condition) —
+    본 round-trip lock 은 그 도입 이전까지 envelope top-level 어디에도
+    원천 ``msg_cd`` 가 노출되지 않음을 단언한다.
+    """
+
+    exc = APIError(
+        "KIS API Error [APBK0501]: 주문 가능 금액 부족",
+        status_code=400,
+        error_code="APBK0501",
+    )
+
+    payload = ipc_error_payload(exc)
+
+    # 구조화 envelope 의 ``code`` 는 안정 ante 코드 — 원천 msg_cd 아님.
+    assert payload["code"] == "BROKER_API_ERROR"
+    assert payload["code"] != "APBK0501"
+
+    # ``message`` 는 사용자/로그 표시용 자연어 메시지 — 본 round-trip 은
+    # 구조화 필드만 단언한다 (str 메시지에 KIS 표기가 포함되는 것은 의도).
+    assert isinstance(payload["message"], str)
+
+    # envelope 은 top-level 에 추가 구조화 필드를 갖지 않는다 (현재 SSOT 기준).
+    # ``details.broker_code`` 등 후속 spec 도입 전까지 다른 키가 새지 않음.
+    assert set(payload.keys()) == {"code", "message"}
+
+
+def test_api_error_helper_resolves_only_public_spec() -> None:
+    """``error_spec_for_exception(APIError(...))`` 도 안정 코드만 resolve.
+
+    helper 경로의 ``ErrorSpec`` 도 동일하게 ``BROKER_API_ERROR`` /
+    ``external`` 만 노출한다. 원천 ``msg_cd`` 가 helper 의 ``ErrorSpec.code``
+    필드로 새는 것을 금지한다.
+    """
+
+    exc = APIError(
+        "KIS API Error [APBK0501]: 주문 가능 금액 부족",
+        status_code=400,
+        error_code="APBK0501",
+    )
+
+    spec = error_spec_for_exception(exc)
+
+    assert spec.code == "BROKER_API_ERROR"
+    assert spec.category == "external"
+    assert spec.code != "APBK0501"
+
+
+# ── (3) ``.error_code`` 빈 문자열 default 도 envelope 에 새지 않는다 ─────────
+
+
+def test_api_error_without_origin_code_envelope_stable() -> None:
+    """원천 코드 미설정 (예: 네트워크 timeout wrap APIError) 시에도 envelope
+    은 안정 ``BROKER_API_ERROR`` 만 노출 — ``""`` 가 ``code`` 로 새지 않는다.
+    """
+
+    exc = APIError("타임아웃 (5초 초과)", retryable=True)
+
+    assert exc.error_code == ""
+
+    payload = ipc_error_payload(exc)
+
+    assert payload["code"] == "BROKER_API_ERROR"
+    assert payload["code"] != ""
+
+
+# ── (4) ``APIError`` 와 분리된 typed exception 도 원천 코드와 무관 ───────────
+
+
+def test_api_error_origin_code_does_not_leak_to_other_typed_exceptions() -> None:
+    """``APIError`` 인스턴스의 원천 ``msg_cd`` 는 같은 typed 패밀리 다른
+    인스턴스로 leak 되지 않는다 — instance state 격리 sanity check.
+
+    (회귀 시연: 이전 helper 가 class-level state 로 원천 코드를 캐싱하면
+    instance 간 leak 가능. helper 는 instance attribute 만 본다.)
+    """
+
+    exc_a = APIError(
+        "KIS API Error [APBK0501]: 주문 가능 금액 부족",
+        error_code="APBK0501",
+    )
+    exc_b = APIError(
+        "KIS API Error [APBK0502]: 종목 코드 오류",
+        error_code="APBK0502",
+    )
+
+    # 인스턴스 별 원천 코드 격리.
+    assert exc_a.error_code == "APBK0501"
+    assert exc_b.error_code == "APBK0502"
+
+    # envelope 은 둘 다 동일 안정 코드만 노출.
+    assert ipc_error_payload(exc_a)["code"] == "BROKER_API_ERROR"
+    assert ipc_error_payload(exc_b)["code"] == "BROKER_API_ERROR"


### PR DESCRIPTION
Refs #1843. Closes는 sub-PR 6.

## Summary
- broker 5 sub-class .code 부여 + registry 등록
- KIS msg_cd 원천 code는 log-only (envelope public code만 노출)
- envelope SSOT 갱신 필요한 details.broker_code 필드 도입은 후속 spec PR

## Codex condition 흡수
- 원천 code log-only 한정
- broker integration 회귀 차단 (KIS adapter 회귀 0)
- round-trip test (raise → log → envelope public only)

## Registry 신규 (6건)
- `AuthenticationError` → `BROKER_AUTH_FAILED` / `auth`
- `APIError` → `BROKER_API_ERROR` / `external` (원천 KIS `msg_cd`는 `.error_code` 필드에 log-only 보존)
- `OrderNotFoundError` → `BROKER_ORDER_NOT_FOUND` / `not_found`
- `RateLimitError` → `BROKER_RATE_LIMITED` / `external`
- `CircuitOpenError` → `BROKER_CIRCUIT_OPEN` / `service_unavailable`
- `ante.broker.registry.InvalidBrokerTypeError` → `BROKER_INVALID_TYPE` / `validation`
  (account의 동명 별개 class와 module/code 분리, helper type-based MRO + drift guard 2중 anchor로 분리됨)

## CLI 정렬
`src/ante/cli/commands/broker.py` 의 4 callsite (balance/positions/reconcile×2) 를
`emit_cli_error(fmt, e)` helper 로 정렬. `AccountNotFoundError` 명시 typed
handling 은 보존.

## Allowlist 제거
- Family A: `broker.py` line 211/266/318 (3건)
- Family B: broker 5 sub-class + `broker.registry.InvalidBrokerTypeError` (6건)
- `BrokerError` base 만 baseline 보존 (#1842 `AccountError` 동형)

## Tests 추가
- `test_broker_cli_ipc_error_equivalence.py` 10 case (5 fault × 2 path)
- `test_broker_external_code_separation.py` 5 case (원천 msg_cd round-trip)

## 검증 결과
- `pytest tests/unit/contracts -v`: 67 passed
- `pytest tests/unit/test_broker* tests/unit/test_gateway tests/unit/test_test_broker -v`: 235 passed
- `pytest tests/unit/`: **5201 passed, 2 skipped** (회귀 0)
- `mypy src/`: Success (222 source files)
- `ruff check src/ tests/`: All checks passed
- `ruff format --check src/ tests/`: 515 files already formatted
- `scripts/generate_project_structure.py`: tree에 신규 test 2건 반영

## 보고
- branch: `refactor/1843-5-broker-error-contract`
- worktree: `/Users/jingulee/Projects/ante-worktrees/refactor/1843-5-broker-error-contract`
- HEAD: `aad5978c`
- main HEAD 불변: `4f239252` (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)