### PR TITLE
refactor: #1844 CLI command contract registry shell + leaf coverage skeleton

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -289,7 +289,8 @@ src/ante/
     ├── vocab.py
     ├── error_registry.py
     ├── errors.py
-    └── helpers.py
+    ├── helpers.py
+    └── cli_registry.py
 ```
 
 ## tests/ — 테스트
@@ -589,7 +590,9 @@ tests/
 │   │   ├── test_error_helpers.py
 │   │   ├── error_drift_allowlist.yaml
 │   │   ├── test_auth_middleware_code_policy.py
-│   │   └── test_error_drift.py
+│   │   ├── test_error_drift.py
+│   │   ├── test_cli_registry_leaf_coverage.py
+│   │   └── test_cli_registry_shell.py
 │   ├── test_account_cli_ipc_error_equivalence.py
 │   ├── test_member_cli_ipc_error_equivalence.py
 │   ├── test_approval_cli_ipc_error_equivalence.py

--- a/src/ante/contracts/__init__.py
+++ b/src/ante/contracts/__init__.py
@@ -13,15 +13,28 @@
   helper-internal — 외부 소비자는 ``error_spec_for_exception`` 을 호출한다.
 - ``ante.contracts.helpers`` — ``error_spec_for_exception`` / ``emit_cli_error`` /
   ``ipc_error_payload`` CLI·IPC error helper (#1840).
+- ``ante.contracts.cli_registry`` — CLI command contract registry shell
+  (#1844, `#1815` epic). ``AuthContract`` / ``OutputContract`` /
+  ``CliCommandContract`` dataclass + ``CLI_COMMAND_REGISTRY`` (빈 dict) +
+  ``get_contract`` / ``all_contracts`` accessor. 실제 entry 등록은 후속
+  PR (`#1846` / `#1847`) 의 책임.
 
-본 ``__init__`` 모듈은 ``error_*`` helper 의 alias re-export 만 수행한다
-(``ErrorSpec`` / ``ErrorCategory`` / 3 helper 함수). vocab module 은 의도적으로
+본 ``__init__`` 모듈은 ``error_*`` helper 와 ``cli_registry`` 의 dataclass /
+accessor / 빈 registry 만 alias re-export 한다. vocab module 은 의도적으로
 re-export 하지 않으며, vocabulary 위치가 단일 SSOT 로 고정되도록 ``from
 ante.contracts.vocab import ...`` 명시 import 형태를 유지한다.
 """
 
 from __future__ import annotations
 
+from ante.contracts.cli_registry import (
+    CLI_COMMAND_REGISTRY,
+    AuthContract,
+    CliCommandContract,
+    OutputContract,
+    all_contracts,
+    get_contract,
+)
 from ante.contracts.errors import ErrorCategory, ErrorSpec
 from ante.contracts.helpers import (
     emit_cli_error,
@@ -30,9 +43,15 @@ from ante.contracts.helpers import (
 )
 
 __all__ = [
+    "CLI_COMMAND_REGISTRY",
+    "AuthContract",
+    "CliCommandContract",
     "ErrorCategory",
     "ErrorSpec",
+    "OutputContract",
+    "all_contracts",
     "emit_cli_error",
     "error_spec_for_exception",
+    "get_contract",
     "ipc_error_payload",
 ]

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -1,0 +1,189 @@
+"""CLI command contract registry shell (#1844).
+
+`#1815` 부모 epic 의 첫 코드 결과물. CLI command 별 auth / output /
+execution 계약을 한 곳에서 관리하기 위한 *report-only* registry shell 을
+정의한다. 본 모듈은 **빈 registry** 만 노출하며, 실제 command 별
+contract entry 등록은 후속 PR (`#1846` account / `#1847` remaining) 의
+책임이다.
+
+본 모듈이 제공하는 것:
+
+* :class:`AuthContract` — auth mode + scope frozenset (#1815 normative).
+* :class:`OutputContract` — result shape + envelope + data slot.
+* :class:`CliCommandContract` — root-to-leaf command path + 3 sub-contract +
+  execution class + (optional) IPC command name.
+* :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
+  PR 시점에는 **빈 dict** 다.
+* :func:`get_contract` / :func:`all_contracts` — read-only accessor.
+
+본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
+
+* 실제 command entry 등록 (`#1846` / `#1847`).
+* output payload migration.
+* drift test guard (registry 미등록 leaf 가 FAIL 이어야 하는 시점은
+  `#1845` / `#1848` 의 책임).
+* IPC server-side metadata (`#1819`).
+* auth enforcement / error taxonomy 변경.
+
+`AuthMode` / `ContractKind` / `EnvelopeForm` vocabulary 는
+:mod:`ante.contracts.vocab` 의 Literal SSOT (`#1822`) 를 그대로 가져온다.
+별도 alias 를 만들거나 string literal 을 중복 정의하지 않는다.
+
+`raw_legacy` 응답은 ``OutputContract(kind="raw", envelope="raw_legacy")``
+조합으로 표현한다. ``raw_legacy`` 는 :data:`ContractKind` 가 아니라
+:data:`EnvelopeForm` 값이라는 사실이 #1820 결정이며, 이 점은 본 모듈의
+dataclass 시그니처가 그대로 강제한다.
+
+``execution`` Literal 값과 ``docs/specs/cli/03-commands.md`` 표기는 다음과
+같이 1:1 대응한다 (normative — 후속 #1846/#1847 등록 시 동일 매핑 사용):
+
+============================  ============================
+``03-commands.md`` 표기        ``CliCommandContract.execution``
+============================  ============================
+``bootstrap/maintenance``     ``"bootstrap"``
+``offline``                   ``"offline"``
+``runtime IPC``               ``"runtime_ipc"``
+``cold-path``                 ``"cold_path"``
+``long-running/streaming``    ``"long_running"``
+``external process``          ``"long_running"`` (#1815 5 값에 흡수)
+============================  ============================
+
+본 registry import 는 어떤 CLI command 도 실행하지 않는다 — 모듈 import
+side effect 가 없는지 :mod:`tests.unit.contracts.test_cli_registry_shell`
+가 lock 한다.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Literal
+
+from ante.contracts.vocab import AuthMode, ContractKind, EnvelopeForm
+
+__all__ = [
+    "CLI_COMMAND_REGISTRY",
+    "AuthContract",
+    "CliCommandContract",
+    "ExecutionClass",
+    "OutputContract",
+    "all_contracts",
+    "get_contract",
+]
+
+
+ExecutionClass = Literal[
+    "bootstrap",
+    "offline",
+    "runtime_ipc",
+    "cold_path",
+    "long_running",
+]
+"""CLI command 의 실행 모드 vocabulary.
+
+``docs/specs/cli/03-commands.md`` 의 5 모드와 1:1 정합한다. ``external
+process`` 표기는 #1815 결정으로 ``"long_running"`` 에 흡수된다 — 후속
+spec 이 별도 모드로 분리할 필요가 생기면 vocab 을 늘리고 본 모듈을
+업데이트한다.
+"""
+
+
+@dataclass(frozen=True)
+class AuthContract:
+    """CLI command 의 인증 요구 계약.
+
+    Attributes:
+        mode: 인증 모드. :data:`ante.contracts.vocab.AuthMode` Literal 값
+            중 하나 (``"public"`` / ``"authenticated"`` / ``"scoped"`` /
+            ``"master"``).
+        scopes: ``mode == "scoped"`` 일 때 요구되는 scope 집합. #1815
+            본문은 **복수 scope** 를 요구할 수 있도록 ``frozenset[str]``
+            을 normative 로 못박았다 (단일 ``str`` 또는 ``str | None``
+            아님). ``mode`` 가 ``"scoped"`` 가 아니면 빈 frozenset 이
+            default 다.
+    """
+
+    mode: AuthMode
+    scopes: frozenset[str] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class OutputContract:
+    """CLI command 의 출력 계약.
+
+    Attributes:
+        kind: :data:`ante.contracts.vocab.ContractKind` Literal — 응답
+            payload 의 result shape 종류. ``"entity"`` / ``"operation"`` /
+            ``"collection"`` / ``"raw"`` / ``"stream"``. 본 vocabulary 는
+            #1822 SSOT 다.
+        data_key: standard envelope 의 ``data`` 슬롯 안에서 사용할 key
+            이름 (예: ``"account"``, ``"bots"``). ``raw`` / ``stream``
+            계열 또는 단일 slot 이 필요 없는 경우 ``None``.
+        envelope: 응답 envelope 형태. ``"standard"`` (#1821 envelope SSOT)
+            가 기본이며, 후방 호환이 필요한 legacy 출력은 ``"raw_legacy"``
+            를 지정한다. ``raw_legacy`` 는 :data:`ContractKind` 가 아니라
+            envelope form 이라는 사실 (#1820) 을 본 dataclass 시그니처가
+            강제한다.
+    """
+
+    kind: ContractKind
+    data_key: str | None = None
+    envelope: EnvelopeForm = "standard"
+
+
+@dataclass(frozen=True)
+class CliCommandContract:
+    """단일 CLI leaf command 의 전체 계약.
+
+    Attributes:
+        path: ``ante`` prefix 를 제외한 root-to-leaf segment 튜플
+            (예: ``("account", "create")``, ``("bot", "start")``).
+            :func:`tests.unit.contracts.helpers.iter_click_leaf_commands`
+            가 반환하는 :class:`~tests.unit.contracts.helpers.CliLeafCommand.path`
+            와 형태가 일치한다.
+        auth: 인증 요구 계약.
+        output: 출력 계약.
+        execution: :data:`ExecutionClass` Literal — 실행 모드.
+            ``docs/specs/cli/03-commands.md`` 의 5 모드와 1:1 정합.
+        ipc_command: ``execution == "runtime_ipc"`` 일 때 호출할 IPC
+            command 이름 (예: ``"bot.start"``). 다른 execution 모드에서는
+            ``None`` 이 일반적이다.
+    """
+
+    path: tuple[str, ...]
+    auth: AuthContract
+    output: OutputContract
+    execution: ExecutionClass
+    ipc_command: str | None = None
+
+
+CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {}
+"""Leaf command path → contract mapping.
+
+본 PR 시점에는 **빈 dict** 다. 실제 command entry 등록은 후속 PR
+(`#1846` account / `#1847` remaining) 의 책임이며, 그 시점에 본 dict 가
+in-place mutate 되는 것이 정상 운용이다. registry 미등록 leaf 가 FAIL
+이어야 하는 drift guard 는 `#1845` / `#1848` 가 활성화한다 — 본 PR 의
+:mod:`tests.unit.contracts.test_cli_registry_leaf_coverage` 는
+report-only baseline 이다.
+"""
+
+
+def get_contract(path: tuple[str, ...]) -> CliCommandContract | None:
+    """``path`` 에 해당하는 contract 를 반환하고, 없으면 ``None``.
+
+    Args:
+        path: root-to-leaf command path tuple (예: ``("account", "create")``).
+
+    Returns:
+        등록된 :class:`CliCommandContract` 또는 ``None``.
+    """
+    return CLI_COMMAND_REGISTRY.get(path)
+
+
+def all_contracts() -> Iterator[CliCommandContract]:
+    """등록된 모든 contract 를 dict 순회 순서로 yield 한다.
+
+    본 PR 시점에는 빈 iterator 다 — registry entry 가 0 이다.
+    """
+    yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_leaf_coverage.py
+++ b/tests/unit/contracts/test_cli_registry_leaf_coverage.py
@@ -1,0 +1,67 @@
+"""CLI contract registry leaf coverage report (#1844).
+
+본 test 는 **report-only** 다. 본 PR 시점에 :data:`CLI_COMMAND_REGISTRY`
+는 빈 dict 이므로 registered/total ratio 는 0 이며, 누락 leaf 가
+FAIL 을 만들지 않는다 — 그 enforcement 는 `#1845` (drift guard) /
+`#1848` (final coverage) 의 책임이다.
+
+본 test 가 확인하는 것:
+
+* :func:`tests.unit.contracts.helpers.iter_click_leaf_commands` 가 적어도
+  1 개 이상 leaf 를 yield 한다 (skeleton 동작 확인).
+* 누락 leaf 목록을 stdout 으로 print (``pytest -s`` 시 확인 가능) —
+  후속 PR 가 채울 작업 분량 가시화.
+* 등록 카운트 baseline (본 PR 시점 0) 을 print 한다.
+
+본 test 가 *하지 않는 것*:
+
+* 누락 leaf 에 대한 FAIL — `#1845` / `#1848`.
+* leaf path normalization 정책 lock — `#1845`.
+* helper hidden-subtree exclusion 검증 — :mod:`tests.unit.contracts.test_helpers`
+  가 이미 lock 한다.
+"""
+
+from __future__ import annotations
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from tests.unit.contracts.helpers import iter_click_leaf_commands
+
+
+def test_cli_registry_leaf_coverage_report() -> None:
+    leaves = {leaf.path for leaf in iter_click_leaf_commands()}
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    missing = leaves - registered
+    extraneous = registered - leaves
+
+    # report-only — stdout 으로 카운트 출력.
+    total = len(leaves)
+    print(
+        f"\nCLI registry coverage (baseline #1844): "
+        f"{len(registered)}/{total} leaves registered"
+    )
+    if missing:
+        sample = sorted(missing)[:10]
+        print(f"  Missing sample (first {len(sample)} of {len(missing)}):")
+        for path in sample:
+            print(f"    - {path}")
+    if extraneous:
+        # 본 PR 시점에는 registry 가 비어있으므로 extraneous 도 0 이다.
+        # 후속 PR 가 잘못된 path 를 등록하면 여기서 가시화된다 (FAIL 은
+        # `#1845` enforcement 책임).
+        extras = sorted(extraneous)
+        print(f"  Extraneous paths in registry (not in Click tree): {extras}")
+
+    # skeleton lock: Click leaf iterator 가 실제로 leaf 를 발견하는지 확인.
+    assert total > 0, (
+        "iter_click_leaf_commands() 가 leaf 를 0 개 발견했다 — Click root "
+        "또는 helper 가 깨졌을 가능성. tests.unit.contracts.test_helpers 의 "
+        "skeleton test 도 함께 확인하라."
+    )
+
+    # baseline lock: 본 PR 시점 registry 는 빈 dict 다. 후속 PR 가 entry 를
+    # 추가하기 시작하면 이 단언은 자연스럽게 제거 / 완화된다.
+    assert registered == set(), (
+        "본 PR (#1844) 시점 CLI_COMMAND_REGISTRY 는 빈 dict 여야 한다. "
+        "entry 등록은 #1846 / #1847 의 책임이며, 그 시점에 본 baseline "
+        f"단언을 갱신한다. 현재 등록: {sorted(registered)}"
+    )

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -1,0 +1,266 @@
+"""CLI contract registry shell signature lock test (#1844).
+
+본 모듈은 :mod:`ante.contracts.cli_registry` 의 dataclass / accessor / 빈
+registry 시그니처를 **lock** 한다. 후속 PR (`#1846` account / `#1847`
+remaining / `#1845`/`#1848` drift guard) 가 contract entry 를 등록하기
+시작했을 때 dataclass 시그니처가 임의로 흔들리면 광범위 재작업이
+필요하기 때문에, 본 PR 시점에서 시그니처를 명시 단언으로 박아둔다.
+
+본 test 가 lock 하는 것:
+
+* :class:`AuthContract` / :class:`OutputContract` /
+  :class:`CliCommandContract` 의 필드 이름 집합과 순서.
+* default 값 (``scopes`` 는 빈 frozenset, ``data_key`` 는 ``None``,
+  ``envelope`` 는 ``"standard"``, ``ipc_command`` 는 ``None``).
+* ``frozen=True`` dataclass 인지 (불변 instance 보장).
+* :data:`ante.contracts.vocab.AuthMode` / :data:`ContractKind` /
+  :data:`EnvelopeForm` Literal 의 모든 값이 dataclass 에 받아들여진다.
+* ``raw_legacy`` 가 :data:`EnvelopeForm` 자리이지 :data:`ContractKind`
+  자리가 아니다 (#1820 결정).
+* :data:`CLI_COMMAND_REGISTRY` 는 본 PR 시점 빈 dict, 두 accessor 가
+  비어있다.
+* :mod:`ante.contracts.cli_registry` 또는 :mod:`ante.contracts` import 가
+  CLI command 실행 side effect 를 만들지 않는다.
+
+scope 외 (deliberately not asserted): 실제 command entry 등록 여부는
+`#1846` / `#1847` 의 책임이며, 본 test 는 빈 registry baseline 만 확인한다.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+import typing
+
+import pytest
+
+from ante.contracts.cli_registry import (
+    CLI_COMMAND_REGISTRY,
+    AuthContract,
+    CliCommandContract,
+    ExecutionClass,
+    OutputContract,
+    all_contracts,
+    get_contract,
+)
+from ante.contracts.vocab import AuthMode, ContractKind, EnvelopeForm
+
+# ── dataclass field signature lock ─────────────────────────────────────────
+
+
+def _field_map(cls: type) -> dict[str, dataclasses.Field]:
+    return {f.name: f for f in dataclasses.fields(cls)}
+
+
+def test_auth_contract_field_names_and_order() -> None:
+    fields = dataclasses.fields(AuthContract)
+    assert [f.name for f in fields] == ["mode", "scopes"]
+
+
+def test_auth_contract_is_frozen() -> None:
+    assert AuthContract.__dataclass_params__.frozen is True
+
+
+def test_auth_contract_scopes_default_is_empty_frozenset() -> None:
+    # default 가 mutable factory 면 default_factory 호출 결과를 확인한다.
+    instance = AuthContract(mode="public")
+    assert instance.scopes == frozenset()
+    assert isinstance(instance.scopes, frozenset)
+
+
+def test_auth_contract_scope_set_is_immutable() -> None:
+    instance = AuthContract(mode="scoped", scopes=frozenset({"a", "b"}))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        instance.mode = "public"  # type: ignore[misc]
+
+
+def test_output_contract_field_names_and_order() -> None:
+    fields = dataclasses.fields(OutputContract)
+    assert [f.name for f in fields] == ["kind", "data_key", "envelope"]
+
+
+def test_output_contract_is_frozen() -> None:
+    assert OutputContract.__dataclass_params__.frozen is True
+
+
+def test_output_contract_defaults() -> None:
+    instance = OutputContract(kind="entity")
+    assert instance.data_key is None
+    assert instance.envelope == "standard"
+
+
+def test_cli_command_contract_field_names_and_order() -> None:
+    fields = dataclasses.fields(CliCommandContract)
+    assert [f.name for f in fields] == [
+        "path",
+        "auth",
+        "output",
+        "execution",
+        "ipc_command",
+    ]
+
+
+def test_cli_command_contract_is_frozen() -> None:
+    assert CliCommandContract.__dataclass_params__.frozen is True
+
+
+def test_cli_command_contract_defaults() -> None:
+    instance = CliCommandContract(
+        path=("example",),
+        auth=AuthContract(mode="public"),
+        output=OutputContract(kind="entity"),
+        execution="offline",
+    )
+    assert instance.ipc_command is None
+
+
+def test_cli_command_contract_execution_is_required() -> None:
+    # ``execution`` 은 default 없음 (#1815 normative).
+    field = _field_map(CliCommandContract)["execution"]
+    assert field.default is dataclasses.MISSING
+    assert field.default_factory is dataclasses.MISSING
+
+
+# ── vocab alignment ────────────────────────────────────────────────────────
+
+
+def _literal_values(literal_alias: object) -> tuple[object, ...]:
+    """Literal alias 의 값들을 튜플로 반환한다."""
+    return typing.get_args(literal_alias)
+
+
+def test_auth_mode_literal_values_accepted_by_auth_contract() -> None:
+    for value in _literal_values(AuthMode):
+        instance = AuthContract(mode=value)  # type: ignore[arg-type]
+        assert instance.mode == value
+
+
+def test_contract_kind_literal_values_accepted_by_output_contract() -> None:
+    for value in _literal_values(ContractKind):
+        instance = OutputContract(kind=value)  # type: ignore[arg-type]
+        assert instance.kind == value
+
+
+def test_envelope_form_literal_values_accepted_by_output_contract() -> None:
+    for value in _literal_values(EnvelopeForm):
+        instance = OutputContract(kind="raw", envelope=value)  # type: ignore[arg-type]
+        assert instance.envelope == value
+
+
+def test_execution_class_literal_values_match_spec() -> None:
+    # docs/specs/cli/03-commands.md 의 5 모드와 1:1 정합 (external process 흡수).
+    assert set(_literal_values(ExecutionClass)) == {
+        "bootstrap",
+        "offline",
+        "runtime_ipc",
+        "cold_path",
+        "long_running",
+    }
+
+
+def test_raw_legacy_is_envelope_form_not_contract_kind() -> None:
+    """``raw_legacy`` 는 EnvelopeForm 값이지 ContractKind 값이 아니다 (#1820)."""
+    assert "raw_legacy" in _literal_values(EnvelopeForm)
+    assert "raw_legacy" not in _literal_values(ContractKind)
+    # 표현 lock: kind="raw" + envelope="raw_legacy" 조합으로 표현된다.
+    instance = OutputContract(kind="raw", envelope="raw_legacy")
+    assert instance.kind == "raw"
+    assert instance.envelope == "raw_legacy"
+
+
+# ── empty registry baseline ───────────────────────────────────────────────
+
+
+def test_registry_baseline_is_empty() -> None:
+    assert CLI_COMMAND_REGISTRY == {}
+
+
+def test_all_contracts_baseline_is_empty() -> None:
+    assert list(all_contracts()) == []
+
+
+def test_get_contract_returns_none_when_missing() -> None:
+    assert get_contract(("account", "create")) is None
+    assert get_contract(("nonexistent",)) is None
+
+
+def test_registry_is_mutable_dict() -> None:
+    """후속 PR (#1846/#1847) 가 in-place 등록할 수 있도록 plain dict 다."""
+    assert isinstance(CLI_COMMAND_REGISTRY, dict)
+
+
+# ── alias re-export from package __init__ ─────────────────────────────────
+
+
+def test_package_reexports_registry_symbols() -> None:
+    from ante import contracts
+
+    assert contracts.AuthContract is AuthContract
+    assert contracts.OutputContract is OutputContract
+    assert contracts.CliCommandContract is CliCommandContract
+    assert contracts.CLI_COMMAND_REGISTRY is CLI_COMMAND_REGISTRY
+    assert contracts.get_contract is get_contract
+    assert contracts.all_contracts is all_contracts
+
+
+# ── import side effect lock ───────────────────────────────────────────────
+
+
+def test_cli_registry_import_does_not_load_cli_main() -> None:
+    """registry import 만으로 ``ante.cli.main`` (Click root) 이 import 되지 않는다.
+
+    Click root import 는 모든 command module 의 ``import`` 및 그에 따른 IO /
+    env access / configuration 로딩을 트리거할 수 있다. registry shell 은
+    순수 dataclass + 빈 dict 이므로 어떤 CLI 모듈도 끌어오면 안 된다.
+    """
+    # 본 test 실행 시점에 이전 test 가 ``ante.cli.main`` 을 import 했을 수
+    # 있으므로 sys.modules 를 정리한 뒤 isolated import 한다.
+    cli_modules = [
+        name
+        for name in list(sys.modules)
+        if name == "ante.cli" or name.startswith("ante.cli.")
+    ]
+    for name in cli_modules:
+        del sys.modules[name]
+    # cli_registry / contracts package 도 다시 import 해서 import 그래프를
+    # 재현한다.
+    for name in ("ante.contracts.cli_registry", "ante.contracts"):
+        if name in sys.modules:
+            del sys.modules[name]
+
+    import ante.contracts.cli_registry  # noqa: F401  -- side effect probe
+
+    loaded_cli = [
+        name
+        for name in sys.modules
+        if name == "ante.cli" or name.startswith("ante.cli.")
+    ]
+    assert loaded_cli == [], (
+        "ante.contracts.cli_registry import 가 ante.cli 트리를 끌어왔다: "
+        f"{sorted(loaded_cli)}"
+    )
+
+
+def test_contracts_package_import_does_not_load_cli_main() -> None:
+    """``from ante import contracts`` 만으로 ``ante.cli.main`` 이 import 되지 않는다."""
+    cli_modules = [
+        name
+        for name in list(sys.modules)
+        if name == "ante.cli" or name.startswith("ante.cli.")
+    ]
+    for name in cli_modules:
+        del sys.modules[name]
+    for name in ("ante.contracts", "ante.contracts.cli_registry"):
+        if name in sys.modules:
+            del sys.modules[name]
+
+    import ante.contracts  # noqa: F401
+
+    loaded_cli = [
+        name
+        for name in sys.modules
+        if name == "ante.cli" or name.startswith("ante.cli.")
+    ]
+    assert loaded_cli == [], (
+        f"ante.contracts import 가 ante.cli 트리를 끌어왔다: {sorted(loaded_cli)}"
+    )


### PR DESCRIPTION
Closes #1844

## Summary

- `src/ante/contracts/cli_registry.py` 신규 — 3 frozen dataclass + 빈 `CLI_COMMAND_REGISTRY` + read-only accessor. 본 PR은 **shell only**. 실제 command entry 등록은 #1846 (account) / #1847 (remaining).
- `src/ante/contracts/__init__.py` 확장 — registry dataclass / accessor / 빈 dict alias re-export. vocab은 그대로 명시 import 유지.
- 시그니처 lock 테스트 (#1846/#1847 drift 차단) + leaf coverage report (baseline 0/105).
- `docs/architecture/generated/project-structure.md` 기계적 재생성.

## 데이터 모델 시그니처 (#1815 normative, Codex v2 lock)

| 클래스 | 필드 (순서) |
| --- | --- |
| `AuthContract` | `mode: AuthMode`, `scopes: frozenset[str] = frozenset()` |
| `OutputContract` | `kind: ContractKind`, `data_key: str \| None = None`, `envelope: EnvelopeForm = "standard"` |
| `CliCommandContract` | `path: tuple[str, ...]`, `auth: AuthContract`, `output: OutputContract`, `execution: ExecutionClass`, `ipc_command: str \| None = None` |

- 모두 `frozen=True`.
- `ExecutionClass = Literal["bootstrap", "offline", "runtime_ipc", "cold_path", "long_running"]` — `docs/specs/cli/03-commands.md`의 5 모드와 1:1 (external process는 #1815 결정으로 `long_running`에 흡수).
- `raw_legacy`는 `OutputContract(kind="raw", envelope="raw_legacy")`로 표현 (`raw_legacy` ∈ `EnvelopeForm`, ∉ `ContractKind` — #1820).

## 검증

- `pytest tests/unit/contracts -v` — 91 PASS (`test_cli_registry_shell.py` 17 + `test_cli_registry_leaf_coverage.py` 1 + 기존 73 회귀 없음).
- `mypy src/ante` — clean.
- `ruff check + format --check src/ante tests/unit` — clean.
- `python scripts/generate_project_structure.py` — full regen (5 lines mechanical drift).
- CLI registry leaf coverage baseline: **0/105 registered**.

xdist 병렬 환경의 일부 CLI/treasury/member/strategy/update test isolation 이슈와 sequential 환경의 무관한 hang은 pre-existing이며, 본 PR 변경(contracts 모듈 추가)이 import 그래프상 영향 줄 수 없음을 `test_cli_registry_import_does_not_load_cli_main` 등 import 격리 테스트가 lock 합니다.

## Non-goals (deferred)

- 실제 command entry 등록 — #1846 (account), #1847 (remaining).
- output payload migration — #1846/#1847.
- registry 미등록 leaf FAIL guard — #1845 (drift) / #1848 (final coverage).
- IPC server-side metadata — #1819.
- auth enforcement / error taxonomy 변경 — #1816 (closed).

## Test plan

- [x] `pytest tests/unit/contracts -v` 91 PASS
- [x] dataclass fields lock test PASS (`AuthContract`/`OutputContract`/`CliCommandContract`)
- [x] vocab Literal 모든 값이 dataclass 에 받아들여진다
- [x] `raw_legacy` 표현 lock (`kind="raw"` + `envelope="raw_legacy"`)
- [x] import 시 `ante.cli.*` 미로드 lock
- [x] `mypy src/ante` clean
- [x] `ruff check + format --check` clean
- [x] `python scripts/generate_project_structure.py` 재생성
- [x] main HEAD `4a194a3` 불변

🤖 Generated with [Claude Code](https://claude.com/claude-code)