### PR TITLE
test: #1845 CLI registry auth-scope-master drift tests (4 family deferred lock)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -592,7 +592,8 @@ tests/
 │   │   ├── test_auth_middleware_code_policy.py
 │   │   ├── test_error_drift.py
 │   │   ├── test_cli_registry_leaf_coverage.py
-│   │   └── test_cli_registry_shell.py
+│   │   ├── test_cli_registry_shell.py
+│   │   └── test_cli_registry_auth_drift.py
 │   ├── test_account_cli_ipc_error_equivalence.py
 │   ├── test_member_cli_ipc_error_equivalence.py
 │   ├── test_approval_cli_ipc_error_equivalence.py

--- a/tests/unit/contracts/helpers.py
+++ b/tests/unit/contracts/helpers.py
@@ -133,6 +133,102 @@ def iter_click_leaf_commands(
     yield from _walk_click(root, ())
 
 
+@dataclass(frozen=True)
+class AuthMetadata:
+    """CLI leaf command 의 인증 marker 메타데이터 (#1845).
+
+    :mod:`ante.cli.middleware` 의 decorator marker / allowlist 를 runtime
+    introspection 으로 추출한다. 본 메타데이터는
+    :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 의
+    :class:`~ante.contracts.cli_registry.AuthContract` 와 drift 가 있는지
+    검증하기 위해 사용된다.
+
+    추출 규칙 (`src/ante/cli/middleware.py` 정의 기준):
+
+    - ``is_public``: ``path in _AUTH_EXEMPT_COMMAND_PATHS`` (line 29).
+      ``init`` / ``member reset-password`` / ``member regenerate-recovery-key``
+      3 path 가 등재되어 있다.
+    - ``is_master``: callback 의 ``_require_master_applied == True``
+      attribute (line 257, ``@require_master`` 가 부착).
+    - ``scopes``: callback 의 ``_required_scopes`` tuple
+      (line 300, ``@require_scope(*scopes)`` 가 부착). ``frozenset`` 으로
+      정규화한다. 없으면 빈 frozenset.
+    - ``requires_auth``: callback 이 ``_require_auth_applied == True``
+      (line 188) **또는** ``_wrapped_by_authenticated_group == True``
+      (line 866). 후자는 :class:`AuthenticatedGroup.add_command` 가 leaf
+      callback 을 자동 wrap 할 때 부착한다.
+
+    분류 우선순위 (Family A → D):
+
+    1. ``is_public`` (Family A) — allowlist 매치는 다른 marker 보다 우선.
+    2. ``is_master`` (Family C) — master decorator 가 scope decorator 보다
+       우선 (``@require_master`` 가 부착되면 ``_required_scopes`` 는 보통
+       비어 있다).
+    3. ``scopes`` non-empty (Family B) — scope decorator 가 부착된 경우.
+    4. ``requires_auth`` only (Family D) — public/master/scoped 가 아니지만
+       인증은 요구되는 fallback (``@require_auth`` 만 또는
+       ``AuthenticatedGroup`` 자동 wrap 만).
+
+    Attributes:
+        path: ``ante`` prefix 를 제외한 root-to-leaf segment 튜플
+            (예: ``("bot", "start")``). :class:`CliLeafCommand.path` 와 동일.
+        is_public: ``_AUTH_EXEMPT_COMMAND_PATHS`` 매치 여부.
+        is_master: ``_require_master_applied`` marker 존재.
+        scopes: ``_required_scopes`` (frozenset 정규화). 없으면 빈 frozenset.
+        requires_auth: ``_require_auth_applied`` 또는
+            ``_wrapped_by_authenticated_group`` marker 존재.
+    """
+
+    path: tuple[str, ...]
+    is_public: bool
+    is_master: bool
+    scopes: frozenset[str]
+    requires_auth: bool
+
+
+def iter_command_auth_metadata(
+    root: click.Group | None = None,
+) -> Iterator[AuthMetadata]:
+    """모든 Click leaf command 의 :class:`AuthMetadata` 를 yield (#1845).
+
+    :func:`iter_click_leaf_commands` 와 동일한 leaf 순회 순서를 따른다 —
+    hidden subtree 는 제외, 그룹은 yield 하지 않는다.
+
+    runtime introspection 만 사용하며, ``src/ante/cli/middleware.py`` 의
+    sentinel marker / allowlist 를 직접 읽는다 (AST parsing 없음). 본
+    helper 는 middleware 의 marker 정의가 바뀌면 같은 PR 에서 함께 갱신
+    되어야 한다 — :class:`AuthMetadata` docstring 의 marker 위치 정보를
+    참조한다.
+
+    Args:
+        root: 검사할 Click root. ``None`` 이면 ``ante.cli.main.cli`` 를
+            가져온다. :func:`iter_click_leaf_commands` 와 동일.
+
+    Yields:
+        :class:`AuthMetadata`: leaf 별 인증 marker 메타데이터.
+    """
+    from ante.cli.middleware import _AUTH_EXEMPT_COMMAND_PATHS
+
+    allowlist = set(_AUTH_EXEMPT_COMMAND_PATHS)
+    for leaf in iter_click_leaf_commands(root):
+        callback = leaf.command.callback
+        is_public = leaf.path in allowlist
+        is_master = bool(getattr(callback, "_require_master_applied", False))
+        raw_scopes = getattr(callback, "_required_scopes", None)
+        scopes: frozenset[str] = frozenset(raw_scopes) if raw_scopes else frozenset()
+        requires_auth = bool(
+            getattr(callback, "_require_auth_applied", False)
+            or getattr(callback, "_wrapped_by_authenticated_group", False)
+        )
+        yield AuthMetadata(
+            path=leaf.path,
+            is_public=is_public,
+            is_master=is_master,
+            scopes=scopes,
+            requires_auth=requires_auth,
+        )
+
+
 def iter_ipc_command_specs(
     registry: CommandRegistry | None = None,
 ) -> Iterator[CommandSpec]:
@@ -551,6 +647,7 @@ def load_drift_allowlist(path: Path | None = None) -> DriftAllowlist:
 
 
 __all__ = [
+    "AuthMetadata",
     "CliLeafCommand",
     "DriftAllowlist",
     "ExceptionAllowlistEntry",
@@ -558,6 +655,7 @@ __all__ = [
     "FmtErrorAllowlistEntry",
     "FmtErrorCallsite",
     "iter_click_leaf_commands",
+    "iter_command_auth_metadata",
     "iter_exception_classes",
     "iter_fmt_error_calls",
     "iter_ipc_command_specs",

--- a/tests/unit/contracts/test_cli_registry_auth_drift.py
+++ b/tests/unit/contracts/test_cli_registry_auth_drift.py
@@ -1,0 +1,240 @@
+"""CLI registry auth-scope-master drift tests (#1845).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 의
+:class:`~ante.contracts.cli_registry.AuthContract` 와 다음 3 source-of-truth
+사이의 drift 를 잠근다:
+
+1. :data:`ante.cli.middleware._AUTH_EXEMPT_COMMAND_PATHS` allowlist (public).
+2. ``@require_scope(*scopes)`` 데코레이터 (`_required_scopes` marker, scoped).
+3. ``@require_master`` 데코레이터 (`_require_master_applied` marker, master).
+4. ``@require_auth`` 데코레이터 / :class:`AuthenticatedGroup` 자동 wrap
+   (`_require_auth_applied` 또는 `_wrapped_by_authenticated_group` marker,
+   authenticated fallback).
+
+본 PR 시점 :data:`CLI_COMMAND_REGISTRY` 는 빈 dict (`#1844` baseline) 이므로
+모든 4 drift test 는 **vacuous pass** 한다 — registered entry 가 없으면
+검증 대상이 없다. 후속 PR (`#1846` account / `#1847` remaining) 이 entry 를
+등록하기 시작하면 본 4 test 가 registered entry vs decorator/allowlist 의
+정합을 검증한다 (의도된 deferred lock pattern).
+
+**Day-0 cascade** (`#1846` / `#1847` 가 entry 등록 시):
+
+- 본 PR 4 drift test 는 registered entry 의 auth mode/scope 가 marker 와
+  일치하는지 검증.
+- :mod:`tests.unit.contracts.test_cli_registry_shell` 의
+  ``test_registry_baseline_is_empty`` / ``test_all_contracts_baseline_is_empty``
+  는 entry 추가 즉시 FAIL 한다 — `#1846` / `#1847` 의 책임으로 본 baseline
+  단언을 갱신 (등록 entry > 0) 또는 제거한다.
+- :mod:`tests.unit.contracts.test_cli_registry_leaf_coverage` 의
+  ``test_cli_registry_leaf_coverage_report`` 의 baseline 단언도 동일 cascade.
+
+본 test 가 **하지 않는 것** (다른 PR 의 책임):
+
+- 누락 leaf 의 enforcement (`#1848` final coverage).
+- registry 실제 entry 등록 (`#1846` / `#1847`).
+- output payload migration (`#1846` / `#1847`).
+- auth middleware enforcement rewrite (스펙 `#1815` 본문 변경 금지).
+
+본 4 test 는 모두 미등록 leaf 에 대해서는 skip-equivalent (vacuous pass) 한다
+— 검증 대상이 없으면 false negative 없이 그냥 통과한다. registered entry 가
+등장하면 그 entry 만 검증한다.
+"""
+
+from __future__ import annotations
+
+from ante.cli.middleware import _AUTH_EXEMPT_COMMAND_PATHS
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from tests.unit.contracts.helpers import iter_command_auth_metadata
+
+# ── Family A — registry ↔ _AUTH_EXEMPT_COMMAND_PATHS (public) ─────────────
+
+
+def test_family_a_public_allowlist_drift() -> None:
+    """Family A: registered entry 의 ``public`` 모드는 allowlist 와 일치해야 한다.
+
+    Drift 조건 (FAIL):
+
+    - registry 에 ``auth.mode == "public"`` 으로 등록된 path 가
+      ``_AUTH_EXEMPT_COMMAND_PATHS`` 에 없음.
+    - registry 에 등록된 path 가 ``_AUTH_EXEMPT_COMMAND_PATHS`` 에 있는데
+      ``auth.mode`` 가 ``"public"`` 이 아님.
+
+    미등록 leaf 는 검증하지 않는다 (`#1845` 의 책임 한계, deferred lock).
+    """
+    allowlist = set(_AUTH_EXEMPT_COMMAND_PATHS)
+
+    for path, contract in CLI_COMMAND_REGISTRY.items():
+        if contract.auth.mode == "public":
+            assert path in allowlist, (
+                f"{path}: registry auth.mode='public' 이지만 "
+                f"_AUTH_EXEMPT_COMMAND_PATHS 에 없음. middleware 의 allowlist "
+                f"또는 registry entry 중 한 쪽이 drift."
+            )
+        elif path in allowlist:
+            raise AssertionError(
+                f"{path}: _AUTH_EXEMPT_COMMAND_PATHS 에 등재되어 있지만 "
+                f"registry auth.mode='{contract.auth.mode}' (public 기대). "
+                f"allowlist 또는 registry entry 중 한 쪽이 drift."
+            )
+
+
+# ── Family B — registry ↔ @require_scope (scoped) ─────────────────────────
+
+
+def test_family_b_require_scope_decorator_drift() -> None:
+    """Family B: registered scoped entry 의 scope 가 decorator marker 와 일치.
+
+    Drift 조건 (FAIL):
+
+    - registry ``auth.mode == "scoped"`` 인 path 의 ``auth.scopes`` 가
+      callback 의 ``_required_scopes`` marker 와 다름.
+    - decorator marker (``_required_scopes`` non-empty) 가 있는데 registry
+      ``auth.mode`` 가 ``"scoped"`` 가 아님.
+
+    미등록 leaf 는 검증하지 않는다. ``@require_master`` 가 부착된 leaf 는
+    Family C 가 책임지므로 ``is_master`` 인 metadata 는 본 test 가 scope
+    drift 로 잡지 않는다 (master 가 scope decorator 보다 우선).
+    """
+    meta_by_path = {m.path: m for m in iter_command_auth_metadata()}
+
+    for path, contract in CLI_COMMAND_REGISTRY.items():
+        meta = meta_by_path.get(path)
+        if meta is None:
+            # Click tree 에 없는 path 가 등록된 경우 — leaf_coverage test 가
+            # 별도로 잡는다. 본 test 는 auth-shape 정합만 본다.
+            continue
+
+        if contract.auth.mode == "scoped":
+            assert contract.auth.scopes == meta.scopes, (
+                f"{path}: registry auth.scopes={sorted(contract.auth.scopes)} "
+                f"이지만 @require_scope marker={sorted(meta.scopes)}. "
+                f"decorator 또는 registry entry 중 한 쪽이 drift."
+            )
+        elif meta.scopes and not meta.is_master:
+            # master 가 부착된 경우는 Family C 가 책임. master 가 아닌데
+            # decorator scope marker 가 있는데 registry mode 가 scoped 가
+            # 아니면 drift.
+            raise AssertionError(
+                f"{path}: callback 에 @require_scope marker="
+                f"{sorted(meta.scopes)} 가 있지만 registry "
+                f"auth.mode='{contract.auth.mode}' (scoped 기대). "
+                f"decorator 또는 registry entry 중 한 쪽이 drift."
+            )
+
+
+# ── Family C — registry ↔ @require_master (master) ────────────────────────
+
+
+def test_family_c_require_master_decorator_drift() -> None:
+    """Family C: registered master entry 와 decorator marker 일치.
+
+    Drift 조건 (FAIL):
+
+    - registry ``auth.mode == "master"`` 인 path 의 callback 에
+      ``_require_master_applied`` marker 가 없음.
+    - decorator marker (``_require_master_applied``) 가 있는데 registry
+      ``auth.mode`` 가 ``"master"`` 가 아님.
+
+    미등록 leaf 는 검증하지 않는다.
+    """
+    meta_by_path = {m.path: m for m in iter_command_auth_metadata()}
+
+    for path, contract in CLI_COMMAND_REGISTRY.items():
+        meta = meta_by_path.get(path)
+        if meta is None:
+            continue
+
+        if contract.auth.mode == "master":
+            assert meta.is_master, (
+                f"{path}: registry auth.mode='master' 이지만 callback 에 "
+                f"@require_master marker 가 없다. decorator 누락 또는 "
+                f"registry entry 가 drift."
+            )
+        elif meta.is_master:
+            raise AssertionError(
+                f"{path}: callback 에 @require_master marker 가 있지만 "
+                f"registry auth.mode='{contract.auth.mode}' (master 기대). "
+                f"decorator 또는 registry entry 중 한 쪽이 drift."
+            )
+
+
+# ── Family D — registry ↔ @require_auth (authenticated fallback) ──────────
+
+
+def test_family_d_authenticated_fallback_drift() -> None:
+    """Family D: requires_auth 만 부착된 leaf 는 ``auth.mode == "authenticated"``.
+
+    Drift 조건 (FAIL):
+
+    - registry ``auth.mode == "authenticated"`` 인데 callback 의
+      ``_require_auth_applied`` / ``_wrapped_by_authenticated_group`` marker
+      가 없거나, 또는 master/scoped 가 함께 표시되어 있음 (fallback 의미
+      충돌).
+    - callback 이 public/master/scoped 가 아니지만 인증은 요구되는
+      (requires_auth=True, is_master=False, scopes=empty, is_public=False)
+      leaf 가 registry 에 등록되었는데 ``auth.mode`` 가 ``"authenticated"``
+      가 아님.
+
+    분류 우선순위 (`AuthMetadata` docstring 참조):
+    public → master → scoped → authenticated. 본 test 는 마지막 fallback
+    인 authenticated 만 책임진다.
+
+    미등록 leaf 는 검증하지 않는다.
+    """
+    meta_by_path = {m.path: m for m in iter_command_auth_metadata()}
+
+    for path, contract in CLI_COMMAND_REGISTRY.items():
+        meta = meta_by_path.get(path)
+        if meta is None:
+            continue
+
+        # authenticated 분류 조건: requires_auth=True 이고 public/master/
+        # scoped 어느 family 에도 매치하지 않음.
+        is_authenticated_only = (
+            meta.requires_auth
+            and not meta.is_public
+            and not meta.is_master
+            and not meta.scopes
+        )
+
+        if contract.auth.mode == "authenticated":
+            assert meta.requires_auth, (
+                f"{path}: registry auth.mode='authenticated' 이지만 callback "
+                f"에 인증 marker (@require_auth 또는 AuthenticatedGroup) 가 "
+                f"없다. decorator 누락 또는 registry entry 가 drift."
+            )
+            assert is_authenticated_only, (
+                f"{path}: registry auth.mode='authenticated' 인데 callback "
+                f"이 다른 family marker 도 가짐 (is_public={meta.is_public}, "
+                f"is_master={meta.is_master}, scopes={sorted(meta.scopes)}). "
+                f"Family 우선순위(public → master → scoped → authenticated) "
+                f"위반."
+            )
+        elif is_authenticated_only:
+            raise AssertionError(
+                f"{path}: callback 이 authenticated-only fallback (인증만 "
+                f"요구, scope/master 없음) 인데 registry "
+                f"auth.mode='{contract.auth.mode}' (authenticated 기대). "
+                f"decorator 또는 registry entry 중 한 쪽이 drift."
+            )
+
+
+# ── baseline coverage report (deferred lock 가시화) ───────────────────────
+
+
+def test_registry_auth_drift_baseline_is_vacuous() -> None:
+    """본 PR (#1845) 시점 registry 가 빈 dict 인지 확인 (deferred lock baseline).
+
+    본 단언은 후속 `#1846` / `#1847` 가 entry 를 등록하기 시작하면 자연스럽게
+    제거된다. 4 drift test 는 registered entry > 0 인 시점부터 실제 검증을
+    시작한다.
+
+    cascade 동등 단언이 :mod:`test_cli_registry_shell` 와 ``test_cli_registry
+    _leaf_coverage`` 에도 있다 — `#1846` / `#1847` 가 한꺼번에 갱신한다.
+    """
+    assert CLI_COMMAND_REGISTRY == {}, (
+        "본 PR (#1845) 시점 CLI_COMMAND_REGISTRY 는 빈 dict 여야 한다 "
+        "(deferred lock pattern). entry 등록은 #1846 / #1847 의 책임이며, "
+        "그 시점에 본 baseline 단언과 #1844 의 동등 단언을 함께 갱신한다. "
+        f"현재 등록: {sorted(CLI_COMMAND_REGISTRY)}"
+    )

--- a/tests/unit/contracts/test_helpers.py
+++ b/tests/unit/contracts/test_helpers.py
@@ -14,10 +14,12 @@ import click
 import pytest
 
 from tests.unit.contracts.helpers import (
+    AuthMetadata,
     CliLeafCommand,
     ExceptionClassInfo,
     FmtErrorCallsite,
     iter_click_leaf_commands,
+    iter_command_auth_metadata,
     iter_exception_classes,
     iter_fmt_error_calls,
     iter_ipc_command_specs,
@@ -116,6 +118,75 @@ class TestIterClickLeafCommands:
             assert isinstance(item.path, tuple)
             assert len(item.path) >= 1
             assert isinstance(item.command, click.Command)
+
+
+# ── iter_command_auth_metadata ────────────────────────────────────────────
+
+
+class TestIterCommandAuthMetadata:
+    """CLI leaf command 의 auth marker introspection (#1845)."""
+
+    def test_default_root_yields_metadata_for_every_leaf(self) -> None:
+        """root 미지정 시 ``ante.cli.main.cli`` 의 모든 leaf 에 1:1 매핑."""
+        leaves = {leaf.path for leaf in iter_click_leaf_commands()}
+        metadata = list(iter_command_auth_metadata())
+        meta_paths = {m.path for m in metadata}
+        assert meta_paths == leaves
+        for m in metadata:
+            assert isinstance(m, AuthMetadata)
+            assert isinstance(m.scopes, frozenset)
+
+    def test_public_allowlist_path_marked_public(self) -> None:
+        """``_AUTH_EXEMPT_COMMAND_PATHS`` 등재 path 는 ``is_public=True``."""
+        from ante.cli.middleware import _AUTH_EXEMPT_COMMAND_PATHS
+
+        meta_by_path = {m.path: m for m in iter_command_auth_metadata()}
+        for path in _AUTH_EXEMPT_COMMAND_PATHS:
+            meta = meta_by_path.get(path)
+            assert meta is not None, f"{path}: allowlist path 가 leaf 에 없다"
+            assert meta.is_public is True
+
+    def test_scope_decorator_extracts_marker_tuple(self) -> None:
+        """``@require_scope(*scopes)`` 부착 leaf 는 ``scopes`` 추출."""
+        meta_by_path = {m.path: m for m in iter_command_auth_metadata()}
+        # ``bot list`` 는 ``@require_scope("bot:read")`` 로 부착되어 있다
+        # (src/ante/cli/commands/bot.py:90).
+        meta = meta_by_path.get(("bot", "list"))
+        assert meta is not None
+        assert meta.scopes == frozenset({"bot:read"})
+        assert meta.is_master is False
+        assert meta.requires_auth is True
+
+    def test_master_decorator_marker_extracted(self) -> None:
+        """``@require_master`` 부착 leaf 는 ``is_master=True``."""
+        meta_by_path = {m.path: m for m in iter_command_auth_metadata()}
+        # ``member register`` 는 ``@require_master`` 로 부착되어 있다
+        # (src/ante/cli/commands/member.py:477).
+        meta = meta_by_path.get(("member", "register"))
+        assert meta is not None
+        assert meta.is_master is True
+        assert meta.requires_auth is True
+
+    def test_injected_root_isolates_subtree(self) -> None:
+        """주입된 root 에서도 marker 추출이 동작한다."""
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command()
+        def plain() -> None:
+            """no decorator."""
+
+        results = list(iter_command_auth_metadata(root))
+        assert len(results) == 1
+        meta = results[0]
+        assert meta.path == ("plain",)
+        # plain leaf: allowlist 없음, marker 없음.
+        assert meta.is_public is False
+        assert meta.is_master is False
+        assert meta.scopes == frozenset()
+        assert meta.requires_auth is False
 
 
 # ── iter_ipc_command_specs ────────────────────────────────────────────────
@@ -484,10 +555,12 @@ def test_public_surface_importable() -> None:
     from tests.unit.contracts import helpers
 
     expected = {
+        "AuthMetadata",
         "CliLeafCommand",
         "ExceptionClassInfo",
         "FmtErrorCallsite",
         "iter_click_leaf_commands",
+        "iter_command_auth_metadata",
         "iter_exception_classes",
         "iter_fmt_error_calls",
         "iter_ipc_command_specs",


### PR DESCRIPTION
Closes #1845. Refs #1815 #1844.

## Summary

- CLI command contract registry (#1844) 의 `AuthContract` 와 middleware 의 allowlist/decorator marker 사이 drift 를 검출하는 **4 family drift test** 를 신설한다.
- 본 PR 시점 `CLI_COMMAND_REGISTRY` 는 빈 dict (`#1844` baseline) 이므로 모든 drift test 는 **vacuous pass** 한다 — 후속 #1846/#1847 가 entry 를 등록하기 시작하면 자동으로 drift 검증이 발동한다 (의도된 **deferred lock pattern**).
- `tests/unit/contracts/helpers.py` 에 `AuthMetadata` dataclass + `iter_command_auth_metadata()` runtime introspection helper 를 추가한다. middleware 변경 없이 기존 marker (`_required_scopes`, `_require_master_applied`, `_require_auth_applied`, `_wrapped_by_authenticated_group`, `_AUTH_EXEMPT_COMMAND_PATHS`) 만 읽는다.

## 4 Family scope

### Family A — public ↔ `_AUTH_EXEMPT_COMMAND_PATHS`
- `src/ante/cli/middleware.py:29-33` 에 등재된 3 path: `("init",)`, `("member", "reset-password")`, `("member", "regenerate-recovery-key")`.
- registry entry 가 `auth.mode == "public"` 이면 allowlist 에 있어야 하고, allowlist path 가 등록되면 mode 가 `public` 이어야 한다.

### Family B — scoped ↔ `@require_scope(*scopes)`
- `_required_scopes` marker (`src/ante/cli/middleware.py:300`) 를 callback 에서 추출.
- registry `auth.mode == "scoped"` 인 path 의 `auth.scopes` 가 marker 와 정확히 일치해야 한다.

### Family C — master ↔ `@require_master`
- `_require_master_applied` marker (`src/ante/cli/middleware.py:257`) 를 callback 에서 추출.
- registry `auth.mode == "master"` 인 path 의 callback 에 marker 가 있어야 하고, 그 역도 성립.

### Family D — authenticated fallback ↔ `@require_auth` / `AuthenticatedGroup`
- `_require_auth_applied` (line 188) 또는 `_wrapped_by_authenticated_group` (line 866) marker 를 추출.
- public/master/scoped 어느 family 에도 매치하지 않지만 인증은 요구되는 leaf 가 등록되면 `auth.mode == "authenticated"` 여야 한다.

분류 우선순위: public → master → scoped → authenticated (`AuthMetadata` docstring SSOT).

## Day-0 Cascade 명시

#1846/#1847 이 첫 entry 를 등록하는 시점에 다음 baseline 단언들이 **동시에 FAIL** 한다:

- `tests/unit/contracts/test_cli_registry_shell.py::test_registry_baseline_is_empty`
- `tests/unit/contracts/test_cli_registry_shell.py::test_all_contracts_baseline_is_empty`
- `tests/unit/contracts/test_cli_registry_leaf_coverage.py::test_cli_registry_leaf_coverage_report` (`registered == set()` 단언)
- `tests/unit/contracts/test_cli_registry_auth_drift.py::test_registry_auth_drift_baseline_is_vacuous` (본 PR 신설)

이는 **의도된 deferred lock 동작**이다. #1846/#1847 의 책임으로 baseline 단언을 갱신 (등록 entry > 0) 또는 제거하고, 그 시점부터 본 PR 의 4 drift test 가 registered entry vs marker/allowlist 정합 검증을 실행한다.

각 family 의 cross-ref:
- `#1846` (account / first entries) — Family A/B/C/D 4 drift test 가 처음으로 실효 검증을 시작.
- `#1847` (remaining entries) — 전 surface 등록 완료 시 4 family 가 거의 모든 등록된 leaf 를 cover.
- `#1848` (final coverage + docs/probe drift) — 누락 leaf 의 enforcement 책임.

## 검증

- `pytest tests/unit/contracts -v` → 101 passed (기존 91 + 신규 5 helper test + 신규 5 drift test).
- 4 drift test sanity check: fake entry 4종 (allowlist 미일치 public / scope mismatch / master mismatch / authenticated-mismatch) 을 in-process 주입해 모두 FAIL 발화 확인.
- 105 leaf 분포 introspection 결과: public 3 / master 7 / scoped 93 / authenticated 2 (전 leaf 가 family 중 정확히 하나에 매치).
- `ruff check tests/unit/contracts` clean.
- `ruff format --check tests/unit/contracts` clean.
- `mypy src/ante` clean (src 변경 없음; 223 source files).
- `python scripts/generate_project_structure.py` regen → 신규 test 파일만 트리에 반영.

## Non-Goals (다른 PR 의 책임)

- 누락 leaf 의 enforcement (`#1848`)
- registry 실제 entry 등록 (`#1846` / `#1847`)
- output payload migration (`#1846` / `#1847`)
- auth middleware enforcement rewrite (스펙 `#1815` 본문 변경 금지)

## Test plan

- [x] `pytest tests/unit/contracts -v` 모두 PASS
- [x] 4 family drift detection sanity check (fake entry 주입 시 모두 FAIL)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy src/ante` clean
- [x] `python scripts/generate_project_structure.py` regen
- [x] main HEAD `cebd617d` 불변 (worktree 격리)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>