### PR TITLE
refactor: #1847-1 member domain OutputContract migration (12 leaf entries)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -604,7 +604,8 @@ tests/
 │   ├── test_config_cli_ipc_error_equivalence.py
 │   ├── test_rule_cli_ipc_error_equivalence.py
 │   ├── test_strategy_cli_ipc_error_equivalence.py
-│   └── test_account_success_output_drift.py
+│   ├── test_account_success_output_drift.py
+│   └── test_member_success_output_drift.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -1,4 +1,4 @@
-"""CLI command contract registry (#1844 shell, #1846 account migration).
+"""CLI command contract registry (#1844 shell, #1846 account, #1847 sweep).
 
 `#1815` 부모 epic 의 코드 결과물. CLI command 별 auth / output /
 execution 계약을 한 곳에서 관리하는 registry 다.
@@ -10,17 +10,22 @@ execution 계약을 한 곳에서 관리하는 registry 다.
 * :class:`CliCommandContract` — root-to-leaf command path + 3 sub-contract +
   execution class + (optional) IPC command name.
 * :data:`ACCOUNT_CONTRACTS` — account 도메인 9 leaf contract tuple (#1846).
+* :data:`MEMBER_CONTRACTS` — member 도메인 12 leaf contract tuple
+  (#1847 sub-PR 1).
 * :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
-  PR 시점에는 account 9 entries 가 채워져 있다.
+  PR 시점에는 account 9 + member 12 = 21 entries 가 채워져 있다.
 * :func:`get_contract` / :func:`all_contracts` — read-only accessor.
 
 본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
 
-* 나머지 도메인 entry 등록 (`#1847`).
-* output payload migration (`#1846` 은 account 4 raw_legacy 를 *문서화*
-  만 하며 fmt callsite 를 바꾸지 않는다).
+* 잔여 도메인 entry 등록 (`#1847` sub-PR 2 이후 — approval / bot / treasury /
+  strategy / broker / data / report / system / instrument / config / rule /
+  trade / backtest / audit / signal).
+* output payload migration (`#1846` / `#1847` 는 raw_legacy 를 *문서화*
+  만 하며 fmt callsite 를 바꾸지 않는다 — diff guard 가 본 PR 의 invariant).
 * drift test guard 완전 활성화 — 미등록 leaf FAIL 은 `#1848` 의 책임.
-* IPC server-side metadata (`#1819`).
+* IPC server-side metadata (`#1819`). ``ipc_command`` 필드는 stub 값만
+  채우며 cross-ref drift test 는 `#1819` 가 담당한다.
 * auth enforcement / error taxonomy 변경.
 
 `AuthMode` / `ContractKind` / `EnvelopeForm` vocabulary 는
@@ -62,6 +67,7 @@ from ante.contracts.vocab import AuthMode, ContractKind, EnvelopeForm
 __all__ = [
     "ACCOUNT_CONTRACTS",
     "CLI_COMMAND_REGISTRY",
+    "MEMBER_CONTRACTS",
     "AuthContract",
     "CliCommandContract",
     "ExecutionClass",
@@ -248,14 +254,158 @@ ACCOUNT_CONTRACTS: tuple[CliCommandContract, ...] = (
 """
 
 
+# ── #1847 sub-PR 1: member domain OutputContract migration ───────────────
+#
+# member 도메인 12 leaf 의 contract entry. ``src/ante/cli/commands/member.py``
+# 의 ``@require_scope`` / ``@require_master`` marker 와 ``fmt.*`` 호출 패턴,
+# 그리고 ``docs/specs/cli/03-commands.md:647-690`` (member 표 + 실행 분류
+# 141-148) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (7 commands): ``list`` / ``info`` / ``list-invalid-roles`` /
+# ``register`` / ``update-scopes`` / ``rotate-token`` / ``regenerate-recovery
+# -key`` 는 JSON mode 에서 ``fmt.output(dict)`` 평면 dict 를 그대로 dump 한다
+# (token / scopes / detail 평면 표현). ``OutputContract(kind="raw", envelope=
+# "raw_legacy")`` 조합으로 표현해 lock 만 한다 — member.py 본문 변경 없음
+# (drift test 가 callsite 변경 시 FAIL).
+#
+# standard envelope (5 commands): ``set-emoji`` / ``suspend`` / ``reactivate``
+# / ``revoke`` / ``reset-password`` 는 단일 경로 ``fmt.success(message,
+# data?=...)`` 만 호출하며 표준 envelope (`{status, message, data}`) 을 dump
+# 한다. JSON mode 분기 없음 (text 와 JSON 양쪽 모두 fmt.success).
+#
+# scope/master 분류:
+# - ``member:read`` scope: ``list`` / ``info`` / ``list-invalid-roles`` (3 개)
+# - master decorator: ``register`` / ``set-emoji`` / ``update-scopes`` /
+#   ``suspend`` / ``reactivate`` / ``revoke`` / ``rotate-token`` (7 개)
+# - public allowlist (``_AUTH_EXEMPT_COMMAND_PATHS``): ``reset-password`` /
+#   ``regenerate-recovery-key`` (2 개) — recovery key / 현재 패스워드 자체가
+#   인증 수단이므로 토큰 인증 미요구.
+#
+# execution 분류는 ``docs/specs/cli/03-commands.md:141-148`` 의 spec SSOT 를
+# 따른다 — ``member list/info/list-invalid-roles`` 는 ``offline`` 이며 그
+# 외 9 commands 는 ``runtime IPC`` 다. ``ipc_command`` 필드는 stub 값만
+# 채운다 (예: ``"member.register"``); 단순 문자열 lock 이며 server-side IPC
+# registry 와의 cross-ref drift test 는 #1819 의 책임이다 (이슈 #1847 본문
+# v2 결정). 현재 member.py 에서 ``ipc_send`` 분기를 실제로 실행하는 것은
+# ``update-scopes`` 1 개 뿐이고 나머지 8 commands 는 cold_path 로 직접
+# ``MemberService`` 를 호출하지만, 본 PR 은 spec SSOT 분류만 등록한다 —
+# 실제 ``ipc_send`` 분기 추가는 #1819 또는 별도 후속 이슈가 책임진다
+# (callsite envelope shape 자체는 drift test 가 lock).
+MEMBER_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("member", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"member:read"})),
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("member", "info"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"member:read"})),
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("member", "list-invalid-roles"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"member:read"})),
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("member", "register"),
+        auth=AuthContract(mode="master", scopes=frozenset()),
+        # JSON mode: ``fmt.output({**result, "token": token})`` 평면 dict.
+        # text mode 는 ``fmt.success`` + ``click.echo`` 로 token 을 별도
+        # 표시하지만 JSON mode shape 가 raw_legacy 우선 정책에 부합한다.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="member.register",
+    ),
+    CliCommandContract(
+        path=("member", "set-emoji"),
+        auth=AuthContract(mode="master", scopes=frozenset()),
+        # 단일 경로 ``fmt.success(message, data)`` — JSON/text 모두 standard.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="member.set_emoji",
+    ),
+    CliCommandContract(
+        path=("member", "update-scopes"),
+        auth=AuthContract(mode="master", scopes=frozenset()),
+        # JSON mode: ``fmt.output(result)`` 평면 dict; text 는 fmt.success.
+        # member.py 에서 실제로 ``ipc_send`` 분기를 실행하는 유일한 leaf 다
+        # (line 601-606). IPC handler 도 등록되어 있다
+        # (``src/ante/ipc/registry.py:727``).
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="member.update_scopes",
+    ),
+    CliCommandContract(
+        path=("member", "suspend"),
+        auth=AuthContract(mode="master", scopes=frozenset()),
+        # 단일 경로 ``fmt.success(f"멤버 정지 완료: ...", result)``.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="member.suspend",
+    ),
+    CliCommandContract(
+        path=("member", "reactivate"),
+        auth=AuthContract(mode="master", scopes=frozenset()),
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="member.reactivate",
+    ),
+    CliCommandContract(
+        path=("member", "revoke"),
+        auth=AuthContract(mode="master", scopes=frozenset()),
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="member.revoke",
+    ),
+    CliCommandContract(
+        path=("member", "rotate-token"),
+        auth=AuthContract(mode="master", scopes=frozenset()),
+        # JSON mode: ``fmt.output({**result, "token": token})`` 평면 dict.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="member.rotate_token",
+    ),
+    CliCommandContract(
+        path=("member", "reset-password"),
+        # ``_AUTH_EXEMPT_COMMAND_PATHS`` 등재 — recovery key 자체가 인증 수단.
+        auth=AuthContract(mode="public", scopes=frozenset()),
+        # 단일 경로 ``fmt.success("패스워드가 변경되었습니다.")`` — data 없음.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="member.reset_password",
+    ),
+    CliCommandContract(
+        path=("member", "regenerate-recovery-key"),
+        # ``_AUTH_EXEMPT_COMMAND_PATHS`` 등재 — 현재 패스워드 자체가 인증 수단.
+        auth=AuthContract(mode="public", scopes=frozenset()),
+        # JSON mode: ``fmt.output({"recovery_key": new_key})`` 평면 dict.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="member.regenerate_recovery_key",
+    ),
+)
+"""Member domain 12 leaf 의 contract tuple (#1847 sub-PR 1).
+
+순서는 ``docs/specs/cli/03-commands.md:647-690`` 의 member 표 (read →
+admin mutation → public allowlist) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
 CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
-    contract.path: contract for contract in ACCOUNT_CONTRACTS
+    contract.path: contract for contract in (*ACCOUNT_CONTRACTS, *MEMBER_CONTRACTS)
 }
 """Leaf command path → contract mapping.
 
-본 PR 시점에는 account 도메인 9 entries 가 등록되어 있다 (#1846). 나머지
-도메인 (member/approval/bot/treasury/broker/strategy/...) 의 entry 등록은
-후속 PR (`#1847`) 의 책임이다. registry 미등록 leaf 가 FAIL 이어야 하는
+본 PR 시점에는 account 9 + member 12 = 21 entries 가 등록되어 있다
+(#1846 / #1847 sub-PR 1). 나머지 도메인 (approval / bot / treasury /
+strategy / broker / data / report / system / instrument / config / rule /
+trade / backtest / audit / signal) 의 entry 등록은 후속 PR (`#1847`
+sub-PR 2-9) 의 책임이다. registry 미등록 leaf 가 FAIL 이어야 하는
 drift guard 는 `#1848` 가 활성화한다.
 """
 
@@ -275,6 +425,7 @@ def get_contract(path: tuple[str, ...]) -> CliCommandContract | None:
 def all_contracts() -> Iterator[CliCommandContract]:
     """등록된 모든 contract 를 dict 순회 순서로 yield 한다.
 
-    본 PR 시점에는 빈 iterator 다 — registry entry 가 0 이다.
+    본 PR 시점에는 account 9 + member 12 = 21 entries 가 등록되어 있다
+    (#1846 / #1847 sub-PR 1).
     """
     yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -218,6 +218,36 @@ def test_account_entries_registered_after_1846() -> None:
     )
 
 
+def test_member_entries_registered_after_1847_sub_pr_1() -> None:
+    """#1847 sub-PR 1 가 member 12 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 1 가 member migration 을 완료한 시점부터
+    lock 된다. 12 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family A/B/C) 와 :mod:`tests.unit.test_member_success_output_drift`
+    가 책임진다.
+    """
+    expected_member_paths = {
+        ("member", "list"),
+        ("member", "info"),
+        ("member", "list-invalid-roles"),
+        ("member", "register"),
+        ("member", "set-emoji"),
+        ("member", "update-scopes"),
+        ("member", "suspend"),
+        ("member", "reactivate"),
+        ("member", "revoke"),
+        ("member", "rotate-token"),
+        ("member", "reset-password"),
+        ("member", "regenerate-recovery-key"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_member_paths.issubset(registered), (
+        f"member 12 entry 가 모두 등록되어야 한다 (#1847 sub-PR 1). "
+        f"누락: {sorted(expected_member_paths - registered)}"
+    )
+
+
 # ── alias re-export from package __init__ ─────────────────────────────────
 
 

--- a/tests/unit/test_member_success_output_drift.py
+++ b/tests/unit/test_member_success_output_drift.py
@@ -1,0 +1,570 @@
+"""Member CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 1).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+member 도메인 12 leaf 의 ``OutputContract`` 와 ``ante member ... --format
+json`` 실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 로
+  평면 dict 를 그대로 dump 한다 (``status``/``message``/``data`` 3 키
+  모두 부재).
+
+본 PR 은 ``member.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면
+본 test 가 즉시 FAIL 한다 (registry 갱신 또는 callsite 정렬 중 한쪽이
+책임).
+
+13 시나리오 (12 leaf + registry sanity 1):
+
+0. registry sanity — member 12 entries 의 envelope 이 ``standard`` /
+   ``raw_legacy`` 분류 범위 내.
+1. ``list`` empty (rows 0) → ``raw_legacy`` (``{message, members}``)
+2. ``list`` non-empty (rows > 0) → ``raw_legacy`` (``{members: [...]}``)
+3. ``info`` → ``raw_legacy`` (평면 detail dict)
+4. ``list-invalid-roles`` empty → ``raw_legacy`` (``{recommended_action,
+   valid_roles, ..., actionable, legacy_revoked}`` 평면)
+5. ``register`` → ``raw_legacy`` (``{**result, token}`` 평면)
+6. ``set-emoji`` → ``standard`` (``fmt.success(message, data)``)
+7. ``update-scopes`` cold_path → ``raw_legacy`` (``fmt.output(result)``)
+8. ``suspend`` → ``standard`` (``fmt.success(message, data)``)
+9. ``reactivate`` → ``standard``
+10. ``revoke`` (--yes) → ``standard``
+11. ``rotate-token`` → ``raw_legacy`` (``{**result, token}`` 평면)
+12. ``reset-password`` → ``standard`` (``fmt.success("...")`` — data 없음)
+13. ``regenerate-recovery-key`` → ``raw_legacy`` (``{recovery_key}``)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, account drift test 동형) ──
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: dict[str, Any]) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_envelope(payload: dict[str, Any]) -> bool:
+    """평면 dict 이고 standard envelope 의 3 필수 키 셋이 모두 갖춰져 있지 않다.
+
+    raw_legacy 는 평면 도메인 payload 를 그대로 dump 한다. 만약 dict 가
+    ``{status, message, data}`` 3 키를 동시에 갖고 ``status == "ok"`` 면
+    standard envelope 으로 분류된다 (애매한 경계 방지).
+    """
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_member_entries_envelopes_classified() -> None:
+    """member 12 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 두 값만 사용한다.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 12 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    member_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("member",)
+    ]
+    assert len(member_entries) == 12, (
+        f"member 12 entries 가 모두 등록되어야 한다. 실제: {len(member_entries)}"
+    )
+    for path, contract in member_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (test_member_cli_ipc_error_equivalence.py 동형) ────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+def _mock_member(
+    member_id: str = "agent-1",
+    *,
+    type: str = MemberType.AGENT,
+    role: str = MemberRole.DEFAULT,
+    org: str = "default",
+    name: str = "Agent 1",
+    emoji: str = "",
+    status: str = MemberStatus.ACTIVE,
+    scopes: list[str] | None = None,
+    token_hash: str = "",
+    created_at: str = "2026-01-01T00:00:00",
+    created_by: str = "test-master",
+    last_active_at: str = "",
+    token_expires_at: str = "",
+) -> Member:
+    """테스트용 ``Member`` mock 객체."""
+    return Member(
+        member_id=member_id,
+        type=type,
+        role=role,
+        org=org,
+        name=name,
+        emoji=emoji,
+        status=status,
+        scopes=scopes if scopes is not None else [],
+        token_hash=token_hash,
+        created_at=created_at,
+        created_by=created_by,
+        last_active_at=last_active_at,
+        token_expires_at=token_expires_at,
+    )
+
+
+@pytest.fixture
+def mock_member_service():
+    """``MemberService`` mock fixture (member.py ``_create_service`` 우회)."""
+    svc = AsyncMock()
+    db = AsyncMock()
+
+    async def _create_service():
+        return svc, db
+
+    with patch(
+        "ante.cli.commands.member._create_service",
+        new=_create_service,
+    ):
+        yield svc
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증을 우회한다 (account drift test 동형)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+@pytest.fixture
+def offline_runtime():
+    """runtime_ipc 명령이 cold_path 분기로 떨어지도록 active runtime 을 무력화한다."""
+    with (
+        patch("ante.main.read_pid_file", return_value=None),
+        patch(
+            "ante.cli.commands.ipc_helpers.get_socket_path",
+            return_value="/tmp/__ante_member_drift_test__.sock",
+        ),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json member ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> dict[str, Any]:
+    """CLI ``--format json`` 출력의 첫 JSON 객체를 파싱한다.
+
+    Click ``CliRunner`` 가 한 invocation 의 stdout 을 합쳐주므로 일반적으로
+    한 객체의 JSON 만 나온다. ``OutputFormatter`` 가 ``json.dumps(...,
+    indent=2)`` 로 multi-line dump 하기 때문에 처음 ``{`` 부터 ``raw_decode``
+    로 한 객체를 먼저 파싱하고 나머지 stdout (text 모드 ``click.echo``
+    잔존물 등) 는 무시한다.
+    """
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start = text.find("{")
+    assert start >= 0, f"JSON 객체 시작을 찾을 수 없다: {output!r}"
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. member list (empty / non-empty) → raw_legacy ────────────────────────
+
+
+def test_member_list_empty_envelope_matches_raw_legacy(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member list`` empty 결과: ``{message, members}`` 평면 dict (raw_legacy)."""
+    mock_member_service.list_members.return_value = []
+    result = _invoke(["--format", "json", "member", "list"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"member list empty: standard envelope 아니어야 함 (registry "
+        f"envelope=raw_legacy 와 정합). 실제 payload={payload!r}"
+    )
+    assert payload == {"message": "등록된 멤버가 없습니다.", "members": []}
+
+
+def test_member_list_non_empty_envelope_matches_raw_legacy(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member list`` non-empty: ``{members: [...]}`` 평면 dict (raw_legacy)."""
+    mock_member_service.list_members.return_value = [_mock_member("agent-1")]
+    result = _invoke(["--format", "json", "member", "list"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"member list non-empty: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert "members" in payload
+    assert isinstance(payload["members"], list)
+    assert len(payload["members"]) == 1
+    assert payload["members"][0]["member_id"] == "agent-1"
+
+
+# ── 2. member info → raw_legacy ────────────────────────────────────────────
+
+
+def test_member_info_envelope_matches_raw_legacy(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member info``: 평면 detail dict (raw_legacy)."""
+    mock_member_service.get.return_value = _mock_member("agent-1")
+    result = _invoke(["--format", "json", "member", "info", "agent-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"member info: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload["member_id"] == "agent-1"
+    assert payload["role"] == MemberRole.DEFAULT
+
+
+# ── 3. member list-invalid-roles empty → raw_legacy ────────────────────────
+
+
+def test_member_list_invalid_roles_empty_envelope_matches_raw_legacy(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member list-invalid-roles`` empty: ``{recommended_action, valid_roles,
+    actionable_count, legacy_revoked_count, actionable, legacy_revoked}`` 평면.
+    """
+    from ante.member.service import InvalidRoleScan
+
+    mock_member_service.find_invalid_role_members.return_value = InvalidRoleScan(
+        actionable=[],
+        legacy_revoked=[],
+    )
+    result = _invoke(["--format", "json", "member", "list-invalid-roles"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"member list-invalid-roles: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload["recommended_action"] == "review_then_revoke"
+    assert payload["actionable_count"] == 0
+    assert payload["legacy_revoked_count"] == 0
+    assert payload["actionable"] == []
+    assert payload["legacy_revoked"] == []
+
+
+# ── 4. member register → raw_legacy ────────────────────────────────────────
+
+
+def test_member_register_envelope_matches_raw_legacy(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member register``: JSON 모드 ``{**result, "token": ...}`` 평면 dict.
+
+    text 모드는 ``fmt.success`` + ``click.echo(token)`` 분기지만, JSON 모드
+    는 token 을 평면 dict 에 합쳐 ``fmt.output`` 으로 dump 한다 (member.py
+    line 538-543). registry 의 ``raw_legacy`` 정책에 부합.
+    """
+    new_member = _mock_member("agent-2", role=MemberRole.DEFAULT, name="새 에이전트")
+    mock_member_service.register.return_value = (new_member, "fresh-token-xyz")
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "member",
+            "register",
+            "--id",
+            "agent-2",
+            "--type",
+            "agent",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"member register: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload["member_id"] == "agent-2"
+    assert payload["token"] == "fresh-token-xyz"
+
+
+# ── 5. member set-emoji → standard ─────────────────────────────────────────
+
+
+def test_member_set_emoji_envelope_matches_operation_standard(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member set-emoji``: 단일 경로 ``fmt.success(message, data)`` → standard."""
+    updated = _mock_member("agent-1", emoji="🤖")
+    mock_member_service.update_emoji.return_value = updated
+    result = _invoke(
+        ["--format", "json", "member", "set-emoji", "agent-1", "🤖"],
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"member set-emoji: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "이모지 설정 완료" in payload["message"]
+    assert payload["data"]["emoji"] == "🤖"
+
+
+# ── 6. member update-scopes (cold_path 분기) → raw_legacy ──────────────────
+
+
+def test_member_update_scopes_cold_path_envelope_matches_raw_legacy(
+    mock_member_service: AsyncMock, offline_runtime
+) -> None:
+    """``member update-scopes`` cold_path: ``fmt.output(result)`` 평면 dict.
+
+    member.py 599-621: ``is_active_runtime()`` 가 False (서버 미실행) 면
+    직접 ``MemberService.update_scopes`` 를 호출하고 결과 dict 를
+    ``fmt.output`` 으로 dump 한다. ``offline_runtime`` fixture 가 active
+    runtime 을 무력화해 cold_path 분기로 진입한다.
+    """
+    updated = _mock_member("agent-1", scopes=["account:read", "member:read"])
+    mock_member_service.update_scopes.return_value = updated
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "member",
+            "update-scopes",
+            "agent-1",
+            "--scopes",
+            "account:read,member:read",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"member update-scopes cold_path: standard envelope 아니어야 함. "
+        f"payload={payload!r}"
+    )
+    assert payload["member_id"] == "agent-1"
+    assert "account:read" in payload["scopes"]
+
+
+# ── 7. member suspend → standard ───────────────────────────────────────────
+
+
+def test_member_suspend_envelope_matches_operation_standard(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member suspend``: 단일 경로 ``fmt.success(message, data)`` → standard."""
+    suspended = _mock_member("agent-1", status=MemberStatus.SUSPENDED)
+    mock_member_service.suspend.return_value = suspended
+    result = _invoke(["--format", "json", "member", "suspend", "agent-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"member suspend: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "정지 완료" in payload["message"]
+    assert payload["data"]["status"] == MemberStatus.SUSPENDED
+
+
+# ── 8. member reactivate → standard ────────────────────────────────────────
+
+
+def test_member_reactivate_envelope_matches_operation_standard(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member reactivate``: ``fmt.success(message, data)`` → standard."""
+    reactivated = _mock_member("agent-1", status=MemberStatus.ACTIVE)
+    mock_member_service.reactivate.return_value = reactivated
+    result = _invoke(["--format", "json", "member", "reactivate", "agent-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"member reactivate: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "재활성화 완료" in payload["message"]
+    assert payload["data"]["status"] == MemberStatus.ACTIVE
+
+
+# ── 9. member revoke (--yes) → standard ────────────────────────────────────
+
+
+def test_member_revoke_envelope_matches_operation_standard(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member revoke --yes``: ``fmt.success(message, data)`` → standard."""
+    revoked = _mock_member("agent-1", status=MemberStatus.REVOKED)
+    mock_member_service.revoke.return_value = revoked
+    result = _invoke(
+        ["--format", "json", "member", "revoke", "agent-1", "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"member revoke: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "폐기 완료" in payload["message"]
+    assert payload["data"]["status"] == MemberStatus.REVOKED
+
+
+# ── 10. member rotate-token → raw_legacy ───────────────────────────────────
+
+
+def test_member_rotate_token_envelope_matches_raw_legacy(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member rotate-token``: JSON 모드 ``{**result, "token": ...}`` 평면 dict.
+
+    text 모드는 ``click.echo`` 로 새 토큰을 별도 표시하지만 JSON 모드는
+    평면 dict 에 token 을 합쳐 ``fmt.output`` 으로 dump 한다 (member.py
+    line 821-826). registry 의 ``raw_legacy`` 정책에 부합.
+    """
+    rotated = _mock_member("agent-1")
+    mock_member_service.rotate_token.return_value = (rotated, "new-token-abc")
+    result = _invoke(
+        ["--format", "json", "member", "rotate-token", "agent-1"],
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"member rotate-token: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload["member_id"] == "agent-1"
+    assert payload["token"] == "new-token-abc"
+
+
+# ── 11. member reset-password → standard ───────────────────────────────────
+
+
+def test_member_reset_password_envelope_matches_operation_standard(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member reset-password``: 단일 ``fmt.success(message)`` (data 없음) → standard.
+
+    fmt.success 가 data 인자를 주지 않으면 envelope 의 ``data`` 는 빈 dict
+    또는 None 으로 dump 된다. envelope predicate 는 ``data`` 가 dict /
+    None 둘 다 허용한다.
+    """
+    # reset-password 는 master 멤버를 찾아 reset_password 를 호출한다.
+    mock_member_service.list_members.return_value = [_MOCK_MASTER]
+    mock_member_service.reset_password.return_value = None
+
+    env_key = "ANTE_TEST_NEW_PASSWORD_DRIFT"
+    with patch.dict(os.environ, {env_key: "new-password-123"}):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "member",
+                "reset-password",
+                "--recovery-key",
+                "test-recovery-key",
+                "--new-password-env",
+                env_key,
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"member reset-password: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "패스워드가 변경" in payload["message"]
+
+
+# ── 12. member regenerate-recovery-key → raw_legacy ────────────────────────
+
+
+def test_member_regenerate_recovery_key_envelope_matches_raw_legacy(
+    mock_member_service: AsyncMock,
+) -> None:
+    """``member regenerate-recovery-key``: JSON ``{"recovery_key": ...}`` 평면 dict.
+
+    text 모드는 ``click.echo`` 로 신규 키를 별도 표시하지만 JSON 모드는
+    ``fmt.output({"recovery_key": new_key})`` 평면 dict (member.py
+    line 954-955). registry 의 ``raw_legacy`` 정책에 부합.
+    """
+    mock_member_service.list_members.return_value = [_MOCK_MASTER]
+    mock_member_service.regenerate_recovery_key.return_value = "fresh-recovery-key-xyz"
+
+    env_key = "ANTE_TEST_CURRENT_PASSWORD_DRIFT"
+    with patch.dict(os.environ, {env_key: "current-password-456"}):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "member",
+                "regenerate-recovery-key",
+                "--password-env",
+                env_key,
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"member regenerate-recovery-key: standard envelope 아니어야 함. "
+        f"payload={payload!r}"
+    )
+    assert payload == {"recovery_key": "fresh-recovery-key-xyz"}


### PR DESCRIPTION
Refs #1847 (sub-PR 1 of 9)

## Summary

#1847 sub-PR 1: member domain `OutputContract` migration. Registers 12
member leaf entries in `CLI_COMMAND_REGISTRY` following the #1846
(account) 1:1 mirror pattern. No callsite changes — registry entries
lock the current observed shape, and a new drift test fires
immediately if any `member.py` JSON-mode envelope drifts.

## 12 leaf entries

| # | path | auth | output (kind / envelope) | execution | ipc_command |
|---|------|------|--------------------------|-----------|-------------|
| 1 | `("member", "list")` | scoped `{member:read}` | raw / raw_legacy | offline | — |
| 2 | `("member", "info")` | scoped `{member:read}` | raw / raw_legacy | offline | — |
| 3 | `("member", "list-invalid-roles")` | scoped `{member:read}` | raw / raw_legacy | offline | — |
| 4 | `("member", "register")` | master | raw / raw_legacy | runtime_ipc | `member.register` |
| 5 | `("member", "set-emoji")` | master | operation / standard | runtime_ipc | `member.set_emoji` |
| 6 | `("member", "update-scopes")` | master | raw / raw_legacy | runtime_ipc | `member.update_scopes` |
| 7 | `("member", "suspend")` | master | operation / standard | runtime_ipc | `member.suspend` |
| 8 | `("member", "reactivate")` | master | operation / standard | runtime_ipc | `member.reactivate` |
| 9 | `("member", "revoke")` | master | operation / standard | runtime_ipc | `member.revoke` |
| 10 | `("member", "rotate-token")` | master | raw / raw_legacy | runtime_ipc | `member.rotate_token` |
| 11 | `("member", "reset-password")` | public | operation / standard | runtime_ipc | `member.reset_password` |
| 12 | `("member", "regenerate-recovery-key")` | public | raw / raw_legacy | runtime_ipc | `member.regenerate_recovery_key` |

**raw_legacy 7 commands**: `list`, `info`, `list-invalid-roles`,
`register`, `update-scopes`, `rotate-token`, `regenerate-recovery-key`
— JSON-mode `fmt.output(plain_dict)` (`status`/`message`/`data` 3 키
미보유).

**standard 5 commands**: `set-emoji`, `suspend`, `reactivate`,
`revoke`, `reset-password` — `fmt.success(message, data?)` (envelopes.md
SSOT `{status, message, data}`).

**Auth split**: 3 scoped (`member:read`), 7 master, 2 public allowlist
(`_AUTH_EXEMPT_COMMAND_PATHS`: `reset-password` /
`regenerate-recovery-key` — recovery key / 현재 패스워드 자체가 인증
수단).

**Execution**: `offline` for 3 read commands, `runtime_ipc` for the
other 9 per `docs/specs/cli/03-commands.md:141-148` SSOT. Stub
`ipc_command` filled per #1847 v2 ambiguity decision; cross-ref with
server-side IPC registry is #1819's responsibility. (Currently only
`update-scopes` actually executes the `ipc_send` branch — the rest
fall through to cold-path direct `MemberService` calls; this is a
known spec ↔ code drift that #1819 / a separate follow-up will
resolve. Envelope shape itself is locked by the drift test
regardless.)

## Diff guard

- `src/ante/cli/commands/member.py` — **0 lines changed** (verified
  via `git diff origin/main..HEAD -- src/ante/cli/commands/member.py`)

## Changed files

- `src/ante/contracts/cli_registry.py` (+150/−16): `MEMBER_CONTRACTS`
  12 entries + `CLI_COMMAND_REGISTRY` extended via tuple-of-tuples
  comprehension + docstring update.
- `tests/unit/contracts/test_cli_registry_shell.py` (+30/0):
  `test_member_entries_registered_after_1847_sub_pr_1` lock added next
  to the account 1846 lock.
- `tests/unit/test_member_success_output_drift.py` (+570, **new**):
  registry envelope ↔ actual `--format json` output shape drift lock
  (registry sanity + 12 envelope shape scenarios = 13 tests).
- `docs/architecture/generated/project-structure.md` (+2/−1): regen.

## Test plan

- [x] `pytest tests/unit/contracts -v` — 101 PASS (4 family drift
  Families A/B/C/D applied to member 12 entries + shell baseline +
  account/member lock + helpers)
- [x] `pytest tests/unit/test_member_success_output_drift.py -v` —
  14 PASS (registry sanity + 12 envelope shape + 1 list non-empty
  case)
- [x] `pytest tests/unit/test_account_success_output_drift.py -v` —
  13 PASS (account #1846 regression)
- [x] `pytest tests/unit/` — 5058 passed (+15 vs main: 12 member
  drift + 1 member sanity + 1 list non-empty + 1 shell member lock).
  No regression: pre-existing 217 failures are identical between main
  HEAD `e334589c` and this branch.
- [x] `mypy src/ante` — clean (223 source files, no issues)
- [x] `ruff check src/ante/contracts tests/unit/contracts
  tests/unit/test_member_success_output_drift.py` — All checks passed
- [x] `ruff format --check` (changed files) — 16 already formatted
- [x] `python scripts/generate_project_structure.py` regen
- [x] diff guard: `member.py` **0 lines changed**
- [x] main HEAD immutability: `e334589c` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)