### PR TITLE
refactor: #1847-2 bot domain OutputContract migration (11 leaf entries)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -605,7 +605,8 @@ tests/
 │   ├── test_rule_cli_ipc_error_equivalence.py
 │   ├── test_strategy_cli_ipc_error_equivalence.py
 │   ├── test_account_success_output_drift.py
-│   └── test_member_success_output_drift.py
+│   ├── test_member_success_output_drift.py
+│   └── test_bot_success_output_drift.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -12,13 +12,15 @@ execution 계약을 한 곳에서 관리하는 registry 다.
 * :data:`ACCOUNT_CONTRACTS` — account 도메인 9 leaf contract tuple (#1846).
 * :data:`MEMBER_CONTRACTS` — member 도메인 12 leaf contract tuple
   (#1847 sub-PR 1).
+* :data:`BOT_CONTRACTS` — bot 도메인 11 leaf contract tuple
+  (#1847 sub-PR 2).
 * :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
-  PR 시점에는 account 9 + member 12 = 21 entries 가 채워져 있다.
+  PR 시점에는 account 9 + member 12 + bot 11 = 32 entries 가 채워져 있다.
 * :func:`get_contract` / :func:`all_contracts` — read-only accessor.
 
 본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
 
-* 잔여 도메인 entry 등록 (`#1847` sub-PR 2 이후 — approval / bot / treasury /
+* 잔여 도메인 entry 등록 (`#1847` sub-PR 3 이후 — approval / treasury /
   strategy / broker / data / report / system / instrument / config / rule /
   trade / backtest / audit / signal).
 * output payload migration (`#1846` / `#1847` 는 raw_legacy 를 *문서화*
@@ -66,6 +68,7 @@ from ante.contracts.vocab import AuthMode, ContractKind, EnvelopeForm
 
 __all__ = [
     "ACCOUNT_CONTRACTS",
+    "BOT_CONTRACTS",
     "CLI_COMMAND_REGISTRY",
     "MEMBER_CONTRACTS",
     "AuthContract",
@@ -396,17 +399,174 @@ admin mutation → public allowlist) 와 시각적으로 일치하도록 정렬�
 """
 
 
+# ── #1847 sub-PR 2: bot domain OutputContract migration ─────────────────
+#
+# bot 도메인 11 leaf 의 contract entry. ``src/ante/cli/commands/bot.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:91-102`` (bot 표) / ``329-372`` (생명주기
+# narrative) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (8 commands): ``list`` / ``info`` / ``positions`` /
+# ``signal-key`` / ``logs`` / ``update`` / ``start`` / ``stop`` / ``status``
+# 는 JSON 모드에서 ``fmt.output(dict)`` 또는 ``fmt.output(result)`` 평면
+# dict 를 그대로 dump 한다. ``status`` / ``positions`` 등은 도메인
+# envelope (``{bot: ...}`` / ``{positions: [...]}``) 형태이며 standard
+# envelope (``{status, message, data}``) 3 키 셋과는 다르다 — ``fmt.success``
+# 로 wrapping 하지 않고 IPC payload 를 그대로 passthrough 하는 정책
+# (feedback_cli_json_envelope_passthrough 메모) 의 결과다.
+# ``OutputContract(kind="raw", envelope="raw_legacy")`` 조합으로 표현해 lock
+# 만 한다 — bot.py 본문 변경 없음 (drift test 가 callsite 변경 시 FAIL).
+#
+# standard envelope (2 commands): ``create`` / ``remove`` 는 단일 경로
+# ``fmt.success(message, data)`` 만 호출하며 표준 envelope
+# (``{status, message, data}``) 을 dump 한다. JSON mode 분기 없음 (text 와
+# JSON 양쪽 모두 fmt.success).
+#
+# ``signal-key`` 는 분기 mixed: ``--rotate`` 경로는 ``fmt.success`` (standard),
+# 그러나 단순 조회 경로는 JSON 에서 ``fmt.output(result)`` 평면 dict 를
+# dump 한다 (line 540-547). account ``set-credentials`` 와 동형 분기 mixed
+# 이며, plan 정책에 따라 raw 우선으로 표현한다. drift test 가 양쪽 경로를
+# 모두 단언한다.
+#
+# scope 분류:
+# - ``bot:read`` scope (5 개): ``list`` / ``info`` / ``positions`` /
+#   ``logs`` / ``status``
+# - ``bot:admin`` scope (6 개): ``create`` / ``remove`` / ``signal-key`` /
+#   ``update`` / ``start`` / ``stop``
+# - public allowlist: 없음 — bot 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류는 ``docs/specs/cli/03-commands.md:91-102`` 의 spec SSOT 를
+# 따른다 — ``bot logs`` 는 ``offline`` 이며 그 외 10 commands 는 ``runtime
+# IPC`` (또는 ``runtime IPC + snapshot/cold-path fallback``) 다. spec 의
+# fallback 표기는 primary 분류 ``runtime_ipc`` 에 흡수된다 (account
+# ``suspend/activate`` / member ``update-scopes`` 와 동형 정책 — fallback
+# 분기가 있어도 spec primary 분류만 lock). ``ipc_command`` 필드는 stub
+# 값만 채운다 (예: ``"bot.start"``); 단순 문자열 lock 이며 server-side IPC
+# registry 와의 cross-ref drift test 는 #1819 의 책임이다.
+BOT_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("bot", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:read"})),
+        # JSON mode: empty → ``fmt.output({"message": ..., "bots": []})`` 평면,
+        # non-empty → ``fmt.output({"bots": [...]})`` 평면. text 는 fmt.table.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="bot.list",
+    ),
+    CliCommandContract(
+        path=("bot", "info"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 detail dict. text 는 click.echo.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="bot.info",
+    ),
+    CliCommandContract(
+        path=("bot", "create"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:admin"})),
+        # 단일 경로 ``fmt.success(f"봇 생성 완료: ...", result)`` — standard.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="bot.create",
+    ),
+    CliCommandContract(
+        path=("bot", "remove"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:admin"})),
+        # 단일 경로 ``fmt.success(f"봇 삭제 완료...", result)`` — standard.
+        # spec 은 ``runtime IPC + cold-path fallback`` 이지만 primary 분류만
+        # lock (account ``suspend/activate`` 동형 정책).
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="bot.remove",
+    ),
+    CliCommandContract(
+        path=("bot", "signal-key"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:admin"})),
+        # 분기 mixed: ``--rotate`` 경로는 ``fmt.success`` (standard), 단순
+        # 조회 경로는 JSON 모드에서 ``fmt.output(result)`` 평면 dict
+        # (bot.py line 540-547). plan v2 decision 에 따라 raw 우선으로
+        # 표현 (account ``set-credentials`` 동형 정책) — drift test 가 양쪽
+        # 분기를 모두 단언한다.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="bot.signal_key",
+    ),
+    CliCommandContract(
+        path=("bot", "positions"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:read"})),
+        # JSON mode: empty → ``{"message": ..., "positions": []}``,
+        # non-empty → ``{"positions": [...]}`` 평면.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="bot.positions",
+    ),
+    CliCommandContract(
+        path=("bot", "update"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:admin"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict; text 는 click.echo.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="bot.update",
+    ),
+    CliCommandContract(
+        path=("bot", "logs"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 ``{bot_id, logs, total}``
+        # dict; text 는 fmt.table 또는 "(logs 없음)".
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("bot", "start"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:admin"})),
+        # JSON mode: IPC ``{bot: ...}`` envelope passthrough via
+        # ``fmt.output(result)``; text 는 friendly message.
+        # (feedback_cli_json_envelope_passthrough 메모 정책 — IPC/Web API
+        # envelope 와 같은 shape 보존을 위해 ``fmt.success`` wrapping 하지
+        # 않음).
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="bot.start",
+    ),
+    CliCommandContract(
+        path=("bot", "stop"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:admin"})),
+        # JSON mode: IPC envelope passthrough via ``fmt.output(result)``.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="bot.stop",
+    ),
+    CliCommandContract(
+        path=("bot", "status"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"bot:read"})),
+        # JSON mode: IPC ``{bot: ...}`` envelope passthrough via
+        # ``fmt.output(result)``; text 는 click.echo detail.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="bot.status",
+    ),
+)
+"""Bot domain 11 leaf 의 contract tuple (#1847 sub-PR 2).
+
+순서는 ``docs/specs/cli/03-commands.md:91-102`` 의 bot 표 (read → admin
+mutation → lifecycle) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
 CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
-    contract.path: contract for contract in (*ACCOUNT_CONTRACTS, *MEMBER_CONTRACTS)
+    contract.path: contract
+    for contract in (*ACCOUNT_CONTRACTS, *MEMBER_CONTRACTS, *BOT_CONTRACTS)
 }
 """Leaf command path → contract mapping.
 
-본 PR 시점에는 account 9 + member 12 = 21 entries 가 등록되어 있다
-(#1846 / #1847 sub-PR 1). 나머지 도메인 (approval / bot / treasury /
-strategy / broker / data / report / system / instrument / config / rule /
-trade / backtest / audit / signal) 의 entry 등록은 후속 PR (`#1847`
-sub-PR 2-9) 의 책임이다. registry 미등록 leaf 가 FAIL 이어야 하는
-drift guard 는 `#1848` 가 활성화한다.
+본 PR 시점에는 account 9 + member 12 + bot 11 = 32 entries 가 등록되어
+있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2). 나머지 도메인 (approval /
+treasury / strategy / broker / data / report / system / instrument /
+config / rule / trade / backtest / audit / signal) 의 entry 등록은 후속
+PR (`#1847` sub-PR 3-9) 의 책임이다. registry 미등록 leaf 가 FAIL 이어야
+하는 drift guard 는 `#1848` 가 활성화한다.
 """
 
 
@@ -425,7 +585,7 @@ def get_contract(path: tuple[str, ...]) -> CliCommandContract | None:
 def all_contracts() -> Iterator[CliCommandContract]:
     """등록된 모든 contract 를 dict 순회 순서로 yield 한다.
 
-    본 PR 시점에는 account 9 + member 12 = 21 entries 가 등록되어 있다
-    (#1846 / #1847 sub-PR 1).
+    본 PR 시점에는 account 9 + member 12 + bot 11 = 32 entries 가 등록되어
+    있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2).
     """
     yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -180,11 +180,12 @@ def test_raw_legacy_is_envelope_form_not_contract_kind() -> None:
 
 
 def test_get_contract_returns_none_when_missing() -> None:
-    """미등록 path 는 ``None`` 을 반환한다 (account 9 entry 외)."""
+    """미등록 path 는 ``None`` 을 반환한다 (account 9 + member 12 + bot 11 외)."""
     # nonexistent path 는 항상 ``None``.
     assert get_contract(("nonexistent",)) is None
-    # bot 도메인 entry 등록은 #1847 의 책임이므로 본 PR 시점에는 ``None``.
-    assert get_contract(("bot", "start")) is None
+    # treasury 도메인 entry 등록은 후속 #1847 sub-PR 의 책임이므로 본 PR 시점에는
+    # ``None`` 이다 (bot domain 은 sub-PR 2 에서 등록되었다).
+    assert get_contract(("treasury", "transactions")) is None
 
 
 def test_registry_is_mutable_dict() -> None:
@@ -245,6 +246,35 @@ def test_member_entries_registered_after_1847_sub_pr_1() -> None:
     assert expected_member_paths.issubset(registered), (
         f"member 12 entry 가 모두 등록되어야 한다 (#1847 sub-PR 1). "
         f"누락: {sorted(expected_member_paths - registered)}"
+    )
+
+
+def test_bot_entries_registered_after_1847_sub_pr_2() -> None:
+    """#1847 sub-PR 2 가 bot 11 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 2 가 bot migration 을 완료한 시점부터
+    lock 된다. 11 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_bot_success_output_drift` 가
+    책임진다.
+    """
+    expected_bot_paths = {
+        ("bot", "list"),
+        ("bot", "info"),
+        ("bot", "create"),
+        ("bot", "remove"),
+        ("bot", "signal-key"),
+        ("bot", "positions"),
+        ("bot", "update"),
+        ("bot", "logs"),
+        ("bot", "start"),
+        ("bot", "stop"),
+        ("bot", "status"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_bot_paths.issubset(registered), (
+        f"bot 11 entry 가 모두 등록되어야 한다 (#1847 sub-PR 2). "
+        f"누락: {sorted(expected_bot_paths - registered)}"
     )
 
 

--- a/tests/unit/test_bot_success_output_drift.py
+++ b/tests/unit/test_bot_success_output_drift.py
@@ -1,0 +1,692 @@
+"""Bot CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 2).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+bot 도메인 11 leaf 의 ``OutputContract`` 와 ``ante bot ... --format json``
+실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1 (member) 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 로
+  평면 dict (혹은 IPC envelope passthrough) 를 그대로 dump 한다
+  (``status``/``message``/``data`` 3 키 모두 동시에 부재).
+
+본 PR 은 ``bot.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제 callsite
+shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면 본 test
+가 즉시 FAIL 한다 (registry 갱신 또는 callsite 정렬 중 한쪽이 책임).
+
+13 시나리오 (11 leaf + signal-key 분기 mixed +1 + registry sanity +1):
+
+0. registry sanity — bot 11 entries 의 envelope 이 ``standard`` /
+   ``raw_legacy`` 분류 범위 내.
+1. ``list`` empty (rows 0) → ``raw_legacy`` (``{message, bots}``)
+2. ``list`` non-empty → ``raw_legacy`` (``{bots: [...]}``)
+3. ``info`` → ``raw_legacy`` (평면 detail dict)
+4. ``create`` → ``standard`` (``fmt.success(message, data)``)
+5. ``remove`` → ``standard`` (``fmt.success(message, data)``)
+6. ``signal-key`` query (no --rotate) → ``raw_legacy`` (``{bot_id, signal_key}``)
+7. ``signal-key --rotate`` → ``standard`` (``fmt.success(message, data)``)
+   분기 mixed lock — registry 는 raw_legacy 우선이지만 rotate 분기가
+   standard envelope 임을 별도 lock 해 분기 mixed 사실을 명시한다
+   (account ``set-credentials`` 동형 정책).
+8. ``positions`` empty → ``raw_legacy`` (``{message, positions}``)
+9. ``positions`` non-empty → ``raw_legacy`` (``{positions: [...]}``)
+10. ``update`` → ``raw_legacy`` (``fmt.output(result)`` 평면)
+11. ``logs`` → ``raw_legacy`` (``fmt.output(result)`` 평면 ``{bot_id, logs,
+    total}``)
+12. ``start`` → ``raw_legacy`` (IPC ``{bot: ...}`` envelope passthrough)
+13. ``stop`` → ``raw_legacy`` (IPC envelope passthrough)
+14. ``status`` → ``raw_legacy`` (IPC ``{bot: ...}`` envelope passthrough)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, account/member 동형) ────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: dict[str, Any]) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_envelope(payload: dict[str, Any]) -> bool:
+    """평면 dict 이고 standard envelope 의 3 필수 키 셋이 모두 갖춰져 있지 않다.
+
+    raw_legacy 는 평면 도메인 payload (혹은 IPC envelope passthrough) 를
+    그대로 dump 한다. 만약 dict 가 ``{status, message, data}`` 3 키를 동시에
+    갖고 ``status == "ok"`` 면 standard envelope 으로 분류된다 (애매한 경계
+    방지).
+    """
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_bot_entries_envelopes_classified() -> None:
+    """bot 11 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 두 값만 사용한다.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 11 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    bot_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("bot",)
+    ]
+    assert len(bot_entries) == 11, (
+        f"bot 11 entries 가 모두 등록되어야 한다. 실제: {len(bot_entries)}"
+    )
+    for path, contract in bot_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (member drift test 동형) ───────────────────────────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증을 우회한다 (account/member drift test 동형)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json bot ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> dict[str, Any]:
+    """CLI ``--format json`` 출력의 첫 JSON 객체를 파싱한다.
+
+    ``OutputFormatter`` 가 ``json.dumps(..., indent=2)`` 로 multi-line dump
+    하기 때문에 처음 ``{`` 부터 ``raw_decode`` 로 한 객체를 파싱하고 나머지
+    stdout (text 모드 잔존물 등) 는 무시한다 (member drift test 동형).
+    """
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start = text.find("{")
+    assert start >= 0, f"JSON 객체 시작을 찾을 수 없다: {output!r}"
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+def _make_mock_db(rows_by_query: dict[str, Any] | None = None) -> AsyncMock:
+    """``Database`` mock — ``connect`` / ``close`` / ``fetch_*`` async 메서드.
+
+    ``rows_by_query`` 는 ``fetch_all`` / ``fetch_one`` 호출 시 반환할
+    *기본* 응답을 dict 로 받는다. 실제 분기별 응답을 세밀하게 제어하려면
+    호출자가 mock 객체를 받은 뒤 ``side_effect`` 를 덮어쓰면 된다.
+    """
+    db = AsyncMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    db.fetch_all = AsyncMock(return_value=(rows_by_query or {}).get("fetch_all", []))
+    db.fetch_one = AsyncMock(return_value=(rows_by_query or {}).get("fetch_one", None))
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def mock_create_services():
+    """``ante.cli.commands.bot._create_services`` 를 mock 한다.
+
+    반환값 ``(db, eventbus, manager, account_service)`` 의 4-tuple 을 그대로
+    돌려준다. 각 테스트는 yield 받은 ``(db, manager, account_service)`` 의
+    mock 메서드 응답을 자체적으로 customize 한다.
+    """
+    db = _make_mock_db()
+    eventbus = MagicMock()
+    manager = AsyncMock()
+    account_service = AsyncMock()
+
+    async def _stub_create_services():
+        return db, eventbus, manager, account_service
+
+    with patch(
+        "ante.cli.commands.bot._create_services",
+        new=_stub_create_services,
+    ):
+        yield db, eventbus, manager, account_service
+
+
+@pytest.fixture
+def mock_ipc_send():
+    """``ipc_send`` 를 mock 한다 (runtime_ipc 분기 leaf 용).
+
+    각 테스트가 ``mock_ipc.return_value`` 를 설정해 IPC 응답을 customize
+    한다. ``bot.py`` 는 ``from ante.cli.commands.ipc_helpers import ipc_send``
+    를 함수 내부에서 lazy import 하므로 원본 모듈을 patch 해야 한다.
+    """
+    with patch("ante.cli.commands.ipc_helpers.ipc_send", new=AsyncMock()) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_database_direct():
+    """``ante.core.database.Database`` 생성자를 mock 한다 (positions/logs 용).
+
+    ``bot positions`` / ``bot logs`` 는 ``_create_services`` 를 거치지 않고
+    ``Database(get_db_path())`` 를 직접 호출하므로 이 fixture 가 별도로
+    필요하다.
+    """
+    db = _make_mock_db()
+    with patch("ante.core.database.Database", return_value=db) as cls:
+        yield db, cls
+
+
+# ── 1. bot list (empty / non-empty) → raw_legacy ──────────────────────────
+
+
+def test_bot_list_empty_envelope_matches_raw_legacy(mock_create_services) -> None:
+    """``bot list`` empty: ``{message, bots: []}`` 평면 dict (raw_legacy)."""
+    db, _, _, _ = mock_create_services
+    db.fetch_all.return_value = []
+
+    result = _invoke(["--format", "json", "bot", "list"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot list empty: standard envelope 아니어야 함 (registry "
+        f"envelope=raw_legacy 와 정합). 실제 payload={payload!r}"
+    )
+    assert payload == {"message": "등록된 봇이 없습니다.", "bots": []}
+
+
+def test_bot_list_non_empty_envelope_matches_raw_legacy(mock_create_services) -> None:
+    """``bot list`` non-empty: ``{bots: [...]}`` 평면 dict (raw_legacy)."""
+    db, _, _, _ = mock_create_services
+    db.fetch_all.return_value = [
+        {
+            "bot_id": "bot-1",
+            "name": "테스트 봇",
+            "strategy_id": "strat-1",
+            "account_id": "acc-1",
+            "status": "stopped",
+            "created_at": "2026-01-01T00:00:00",
+        }
+    ]
+
+    result = _invoke(["--format", "json", "bot", "list"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot list non-empty: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert "bots" in payload
+    assert isinstance(payload["bots"], list)
+    assert len(payload["bots"]) == 1
+    assert payload["bots"][0]["bot_id"] == "bot-1"
+
+
+# ── 2. bot info → raw_legacy ───────────────────────────────────────────────
+
+
+def test_bot_info_envelope_matches_raw_legacy(mock_create_services) -> None:
+    """``bot info``: 평면 detail dict (raw_legacy)."""
+    db, _, _, _ = mock_create_services
+    db.fetch_one.return_value = {
+        "bot_id": "bot-1",
+        "name": "테스트 봇",
+        "strategy_id": "strat-1",
+        "account_id": "acc-1",
+        "status": "running",
+        "created_at": "2026-01-01T00:00:00",
+    }
+
+    result = _invoke(["--format", "json", "bot", "info", "bot-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot info: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload["bot_id"] == "bot-1"
+    assert payload["status"] == "running"
+
+
+# ── 3. bot create → standard ──────────────────────────────────────────────
+
+
+def test_bot_create_envelope_matches_operation_standard(mock_ipc_send) -> None:
+    """``bot create``: 단일 경로 ``fmt.success(message, data)`` → standard."""
+    mock_ipc_send.return_value = {
+        "bot_id": "bot-1",
+        "name": "새 봇",
+        "strategy_id": "strat-1",
+        "account_id": "acc-1",
+        "status": "stopped",
+    }
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "bot",
+            "create",
+            "--name",
+            "새 봇",
+            "--strategy",
+            "strat-1",
+            "--account",
+            "acc-1",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"bot create: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "봇 생성 완료" in payload["message"]
+    assert payload["data"]["bot_id"] == "bot-1"
+
+
+# ── 4. bot remove → standard ──────────────────────────────────────────────
+
+
+def test_bot_remove_envelope_matches_operation_standard(mock_ipc_send) -> None:
+    """``bot remove --yes``: 단일 경로 ``fmt.success(message, data)`` → standard.
+
+    runtime IPC 분기 (``is_active_runtime() == True``) 를 사용하기 위해
+    ``is_active_runtime`` 도 함께 patch 한다. cold-path fallback shape 는
+    동일 ``fmt.success`` 분기이므로 IPC 경로 단언만으로 envelope 분류는
+    충분하다 (account ``suspend/activate`` 동형 정책).
+    """
+    mock_ipc_send.return_value = {
+        "removed": True,
+        "bot_id": "bot-1",
+    }
+
+    with patch("ante.cli.commands.bot.is_active_runtime", return_value=True):
+        result = _invoke(
+            ["--format", "json", "bot", "remove", "bot-1", "--yes"],
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"bot remove: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "봇 삭제 완료" in payload["message"]
+    assert payload["data"]["removed"] is True
+
+
+# ── 5. bot signal-key (query) → raw_legacy ────────────────────────────────
+
+
+def test_bot_signal_key_query_envelope_matches_raw_legacy(
+    mock_create_services,
+) -> None:
+    """``bot signal-key`` (no --rotate): ``{bot_id, signal_key}`` 평면 dict.
+
+    bot.py 540-547: 단순 조회 경로는 JSON 모드에서 ``fmt.output(result)`` 로
+    평면 dict 를 dump 한다. registry 의 ``raw_legacy`` 정책에 부합.
+    """
+    db, _, _, _ = mock_create_services
+    # bot 존재 + strategy_id 필요 (rotate 게이트용이지만 query 분기도 SELECT)
+    db.fetch_one.return_value = {"strategy_id": "strat-1"}
+
+    # SignalKeyManager 의 initialize / get_key 를 mock 한다.
+    skm = AsyncMock()
+    skm.initialize = AsyncMock()
+    skm.get_key = AsyncMock(return_value="sig-key-abc")
+
+    with patch("ante.bot.signal_key.SignalKeyManager", return_value=skm):
+        result = _invoke(["--format", "json", "bot", "signal-key", "bot-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot signal-key query: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload["bot_id"] == "bot-1"
+    assert payload["signal_key"] == "sig-key-abc"
+
+
+# ── 6. bot signal-key --rotate → standard (mixed-branch lock) ─────────────
+
+
+def test_bot_signal_key_rotate_envelope_matches_operation_standard(
+    mock_create_services,
+) -> None:
+    """``bot signal-key --rotate``: ``fmt.success(message, data)`` → standard.
+
+    분기 mixed lock — registry 는 raw_legacy 우선이지만 rotate 분기가
+    standard envelope 임을 별도 lock 해 분기 mixed 사실을 명시한다
+    (account ``set-credentials`` 동형 정책). registry 가 ``raw_legacy`` 우선
+    분류임은 query 분기 test 가 lock 한다.
+    """
+    db, _, _, _ = mock_create_services
+    db.fetch_one.return_value = {"strategy_id": "strat-1"}
+
+    skm = AsyncMock()
+    skm.initialize = AsyncMock()
+    skm.rotate = AsyncMock(return_value="new-sig-key-xyz")
+
+    # strategy registry / loader 도 rotate 경로에서 호출되므로 mock 한다.
+    strategy_registry = AsyncMock()
+    strategy_registry.initialize = AsyncMock()
+    record = MagicMock()
+    record.filepath = "strategies/strat-1.py"
+    strategy_registry.get = AsyncMock(return_value=record)
+
+    strategy_cls = MagicMock()
+    strategy_cls.meta = MagicMock()
+    strategy_cls.meta.accepts_external_signals = True
+
+    with (
+        patch("ante.bot.signal_key.SignalKeyManager", return_value=skm),
+        patch(
+            "ante.strategy.registry.StrategyRegistry", return_value=strategy_registry
+        ),
+        patch("ante.strategy.loader.StrategyLoader.load", return_value=strategy_cls),
+    ):
+        result = _invoke(
+            ["--format", "json", "bot", "signal-key", "bot-1", "--rotate"],
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"bot signal-key --rotate: standard envelope 이어야 함 (분기 mixed). "
+        f"payload={payload!r}"
+    )
+    assert "시그널 키 재발급 완료" in payload["message"]
+    assert payload["data"]["signal_key"] == "new-sig-key-xyz"
+
+
+# ── 7. bot positions (empty / non-empty) → raw_legacy ─────────────────────
+
+
+def test_bot_positions_empty_envelope_matches_raw_legacy(
+    mock_database_direct,
+) -> None:
+    """``bot positions`` empty: ``{message, positions: []}`` 평면 dict.
+
+    실재 bot, 0 포지션 분기 (bot.py 622-625) 를 lock 한다. 미존재 bot 분기
+    (BOT_NOT_FOUND) 는 success envelope 단언 대상이 아니므로 본 test 의
+    책임 밖이다.
+    """
+    db, _ = mock_database_direct
+    # bot 존재 확인 → 실재 (SELECT 1 FROM bots WHERE bot_id = ?)
+    db.fetch_one.return_value = {"1": 1}
+
+    # TradeService.get_positions 가 빈 list 반환하도록 mock.
+    trade_service = AsyncMock()
+    trade_service.get_positions = AsyncMock(return_value=[])
+
+    # PositionHistory / TradeRecorder / PerformanceTracker initialize 도
+    # 호출되므로 stub.
+    position_history = AsyncMock()
+    position_history.initialize = AsyncMock()
+    recorder = AsyncMock()
+    recorder.initialize = AsyncMock()
+
+    with (
+        patch("ante.trade.position.PositionHistory", return_value=position_history),
+        patch("ante.trade.recorder.TradeRecorder", return_value=recorder),
+        patch("ante.trade.performance.PerformanceTracker", return_value=AsyncMock()),
+        patch("ante.trade.service.TradeService", return_value=trade_service),
+    ):
+        result = _invoke(["--format", "json", "bot", "positions", "bot-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot positions empty: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload == {"message": "보유 포지션 없음", "positions": []}
+
+
+def test_bot_positions_non_empty_envelope_matches_raw_legacy(
+    mock_database_direct,
+) -> None:
+    """``bot positions`` non-empty: ``{positions: [...]}`` 평면 dict."""
+    db, _ = mock_database_direct
+    db.fetch_one.return_value = {"1": 1}
+
+    # Position dataclass 같은 객체 mock.
+    pos = MagicMock()
+    pos.symbol = "AAPL"
+    pos.quantity = 10.0
+    pos.avg_entry_price = 150.0
+    pos.realized_pnl = 5.0
+
+    trade_service = AsyncMock()
+    trade_service.get_positions = AsyncMock(return_value=[pos])
+
+    position_history = AsyncMock()
+    position_history.initialize = AsyncMock()
+    recorder = AsyncMock()
+    recorder.initialize = AsyncMock()
+
+    with (
+        patch("ante.trade.position.PositionHistory", return_value=position_history),
+        patch("ante.trade.recorder.TradeRecorder", return_value=recorder),
+        patch("ante.trade.performance.PerformanceTracker", return_value=AsyncMock()),
+        patch("ante.trade.service.TradeService", return_value=trade_service),
+    ):
+        result = _invoke(["--format", "json", "bot", "positions", "bot-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot positions non-empty: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert "positions" in payload
+    assert len(payload["positions"]) == 1
+    assert payload["positions"][0]["symbol"] == "AAPL"
+
+
+# ── 8. bot update → raw_legacy ────────────────────────────────────────────
+
+
+def test_bot_update_envelope_matches_raw_legacy(mock_ipc_send) -> None:
+    """``bot update``: JSON 모드 ``fmt.output(result)`` 평면 dict (raw_legacy).
+
+    bot.py 716-717: JSON 모드는 IPC 응답을 그대로 dump. text 는 click.echo.
+    registry 의 ``raw_legacy`` 정책에 부합.
+    """
+    mock_ipc_send.return_value = {
+        "bot_id": "bot-1",
+        "updates": {"name": "새 이름"},
+    }
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "bot",
+            "update",
+            "bot-1",
+            "--name",
+            "새 이름",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot update: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload["bot_id"] == "bot-1"
+
+
+# ── 9. bot logs → raw_legacy ──────────────────────────────────────────────
+
+
+def test_bot_logs_envelope_matches_raw_legacy(mock_database_direct) -> None:
+    """``bot logs``: JSON 모드 ``fmt.output(result)`` 평면 ``{bot_id, logs, total}``.
+
+    bot.py 836-837: JSON 모드는 평면 dict 를 dump. text 는 fmt.table 또는
+    "(logs 없음)". registry 의 ``raw_legacy`` 정책에 부합.
+    """
+    db, _ = mock_database_direct
+    db.fetch_one.return_value = {"1": 1}  # bot 존재
+
+    # EventHistoryStore.query / count mock.
+    store = AsyncMock()
+    store.initialize = AsyncMock()
+    store.query = AsyncMock(
+        return_value=[
+            {
+                "event_id": "evt-1",
+                "timestamp": "2026-01-01T00:00:00",
+                "payload": {"result": "ok", "message": "step 완료"},
+            }
+        ]
+    )
+    store.count = AsyncMock(return_value=1)
+
+    with patch("ante.eventbus.history.EventHistoryStore", return_value=store):
+        result = _invoke(["--format", "json", "bot", "logs", "bot-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot logs: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload["bot_id"] == "bot-1"
+    assert payload["total"] == 1
+    assert isinstance(payload["logs"], list)
+    assert payload["logs"][0]["event_id"] == "evt-1"
+
+
+# ── 10. bot start → raw_legacy (IPC envelope passthrough) ─────────────────
+
+
+def test_bot_start_envelope_matches_raw_legacy(mock_ipc_send) -> None:
+    """``bot start``: JSON 모드 IPC ``{bot: ...}`` envelope passthrough.
+
+    bot.py 887-888: JSON 모드는 IPC 응답을 ``fmt.output(result)`` 로 그대로
+    dump (``fmt.success`` wrapping 없음 — feedback_cli_json_envelope_
+    passthrough 메모 정책). registry 의 ``raw_legacy`` 정책에 부합.
+    """
+    mock_ipc_send.return_value = {
+        "bot": {
+            "bot_id": "bot-1",
+            "status": "running",
+            "name": "테스트 봇",
+        }
+    }
+
+    result = _invoke(["--format", "json", "bot", "start", "bot-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot start: standard envelope 아니어야 함 (IPC passthrough). "
+        f"payload={payload!r}"
+    )
+    assert payload["bot"]["bot_id"] == "bot-1"
+    assert payload["bot"]["status"] == "running"
+
+
+# ── 11. bot stop → raw_legacy (IPC envelope passthrough) ──────────────────
+
+
+def test_bot_stop_envelope_matches_raw_legacy(mock_ipc_send) -> None:
+    """``bot stop``: JSON 모드 IPC envelope passthrough."""
+    mock_ipc_send.return_value = {
+        "bot": {
+            "bot_id": "bot-1",
+            "status": "stopped",
+        }
+    }
+
+    result = _invoke(["--format", "json", "bot", "stop", "bot-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot stop: standard envelope 아니어야 함 (IPC passthrough). "
+        f"payload={payload!r}"
+    )
+    assert payload["bot"]["bot_id"] == "bot-1"
+    assert payload["bot"]["status"] == "stopped"
+
+
+# ── 12. bot status → raw_legacy (IPC envelope passthrough) ────────────────
+
+
+def test_bot_status_envelope_matches_raw_legacy(mock_ipc_send) -> None:
+    """``bot status``: JSON 모드 IPC ``{bot: ...}`` envelope passthrough.
+
+    bot.py 962-963: JSON 모드는 IPC 응답을 ``fmt.output(result)`` 로 그대로
+    dump. text 모드는 click.echo detail. registry 의 ``raw_legacy`` 정책에
+    부합.
+    """
+    mock_ipc_send.return_value = {
+        "bot": {
+            "bot_id": "bot-1",
+            "name": "테스트 봇",
+            "status": "running",
+            "account_id": "acc-1",
+            "strategy_id": "strat-1",
+        }
+    }
+
+    result = _invoke(["--format", "json", "bot", "status", "bot-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot status: standard envelope 아니어야 함 (IPC passthrough). "
+        f"payload={payload!r}"
+    )
+    assert payload["bot"]["bot_id"] == "bot-1"


### PR DESCRIPTION
## Summary

`#1846` (account 9 leaf) / `#1847` sub-PR 1 (member 12 leaf) 동형 패턴으로 bot 도메인 11 leaf 의 `OutputContract` / `AuthContract` / `ExecutionClass` 를 `CLI_COMMAND_REGISTRY` SSOT 에 등록한다. `bot.py` 본문은 변경하지 않으며 (diff guard: 0 lines, sha256 불변), drift test 가 callsite shape ↔ registry entry 정합을 lock 한다.

Refs #1847

### 등록 leaf (11)

| # | path | auth | output | execution | ipc_command |
|---|------|------|--------|-----------|-------------|
| 1 | `("bot","list")` | scoped `bot:read` | raw_legacy | runtime_ipc | `bot.list` |
| 2 | `("bot","info")` | scoped `bot:read` | raw_legacy | runtime_ipc | `bot.info` |
| 3 | `("bot","create")` | scoped `bot:admin` | standard (operation) | runtime_ipc | `bot.create` |
| 4 | `("bot","remove")` | scoped `bot:admin` | standard (operation) | runtime_ipc | `bot.remove` |
| 5 | `("bot","signal-key")` | scoped `bot:admin` | raw_legacy (mixed: rotate 분기 standard) | runtime_ipc | `bot.signal_key` |
| 6 | `("bot","positions")` | scoped `bot:read` | raw_legacy | runtime_ipc | `bot.positions` |
| 7 | `("bot","update")` | scoped `bot:admin` | raw_legacy | runtime_ipc | `bot.update` |
| 8 | `("bot","logs")` | scoped `bot:read` | raw_legacy | offline | — |
| 9 | `("bot","start")` | scoped `bot:admin` | raw_legacy (IPC passthrough) | runtime_ipc | `bot.start` |
| 10 | `("bot","stop")` | scoped `bot:admin` | raw_legacy (IPC passthrough) | runtime_ipc | `bot.stop` |
| 11 | `("bot","status")` | scoped `bot:read` | raw_legacy (IPC passthrough) | runtime_ipc | `bot.status` |

- `bot:read` (5): list / info / positions / logs / status
- `bot:admin` (6): create / remove / signal-key / update / start / stop
- public allowlist: 없음

execution 분류는 `docs/specs/cli/03-commands.md:91-102` SSOT 를 따른다. spec 의 `runtime IPC + snapshot fallback` / `+ cold-path fallback` 표기는 primary 분류 `runtime_ipc` 에 흡수된다 (account `suspend/activate` / member `update-scopes` 동형 정책). `logs` 만 `offline`.

### Diff guard

- `src/ante/cli/commands/bot.py` 본문 0 lines (sha256 `6e807fc7c4899584cd6de925b56bc0786b7a3a10d4de90444cd1c2124c3d7380` 불변).
- bot.py 본문 변경 없음 — drift test 가 callsite shape (`fmt.success(message, data)` / `fmt.output(평면 dict)`) 와 registry entry 정합을 lock.

### shell test cascade

- `test_get_contract_returns_none_when_missing` 의 sentinel path 를 `("bot", "start")` → `("treasury", "transactions")` 로 갱신 (bot domain 이 등록되었으므로).
- `test_bot_entries_registered_after_1847_sub_pr_2` 신규 추가 (11 path subset lock).

### drift test 시나리오 수

`tests/unit/test_bot_success_output_drift.py` — **15 시나리오** (11 leaf + signal-key 분기 mixed +1 + list/positions empty/non-empty 분기 +2 + registry sanity 1):

- list empty / non-empty → raw_legacy (`{message, bots}` / `{bots}`)
- info → raw_legacy
- create → standard (`fmt.success(message, data)`)
- remove --yes → standard (`fmt.success(message, data)`, IPC 분기)
- signal-key query → raw_legacy (`{bot_id, signal_key}`)
- signal-key --rotate → standard (분기 mixed lock, account `set-credentials` 동형 정책)
- positions empty / non-empty → raw_legacy
- update → raw_legacy (IPC `fmt.output`)
- logs → raw_legacy
- start / stop / status → raw_legacy (IPC `{bot: ...}` envelope passthrough — `feedback_cli_json_envelope_passthrough` 메모 정책)

## Test plan

- [x] `pytest tests/unit/contracts -v` — 102 passed (auth-drift Family A/B/C + shell + leaf coverage + helpers)
- [x] `pytest tests/unit/test_bot_success_output_drift.py -v` — 15 passed
- [x] `pytest tests/unit/` 전체 — 5074 passed (baseline 대비 +16 = 15 새 drift + 1 새 shell test), 217 failed (origin/main d728fc1d 에서도 동일하게 217 failed — pre-existing, 본 PR 무관함을 베이스라인 재현으로 확인)
- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 525 files already formatted
- [x] `mypy src/ante/contracts/` — Success, no issues found in 6 source files
- [x] `git diff origin/main -- src/ante/cli/commands/bot.py | wc -l` → 0
- [x] `scripts/generate_project_structure.py` 재생성 — `tests/unit/test_bot_success_output_drift.py` 한 줄 추가만 발생
- [x] main HEAD 불변 확인 (`d728fc1d`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)