### PR TITLE
refactor: #1847-3 approval domain OutputContract migration (10 leaf entries)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -606,7 +606,8 @@ tests/
 │   ├── test_strategy_cli_ipc_error_equivalence.py
 │   ├── test_account_success_output_drift.py
 │   ├── test_member_success_output_drift.py
-│   └── test_bot_success_output_drift.py
+│   ├── test_bot_success_output_drift.py
+│   └── test_approval_success_output_drift.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -14,15 +14,18 @@ execution 계약을 한 곳에서 관리하는 registry 다.
   (#1847 sub-PR 1).
 * :data:`BOT_CONTRACTS` — bot 도메인 11 leaf contract tuple
   (#1847 sub-PR 2).
+* :data:`APPROVAL_CONTRACTS` — approval 도메인 10 leaf contract tuple
+  (#1847 sub-PR 3).
 * :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
-  PR 시점에는 account 9 + member 12 + bot 11 = 32 entries 가 채워져 있다.
+  PR 시점에는 account 9 + member 12 + bot 11 + approval 10 = 42 entries 가
+  채워져 있다.
 * :func:`get_contract` / :func:`all_contracts` — read-only accessor.
 
 본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
 
-* 잔여 도메인 entry 등록 (`#1847` sub-PR 3 이후 — approval / treasury /
-  strategy / broker / data / report / system / instrument / config / rule /
-  trade / backtest / audit / signal).
+* 잔여 도메인 entry 등록 (`#1847` sub-PR 4 이후 — treasury / strategy /
+  broker / data / report / system / instrument / config / rule / trade /
+  backtest / audit / signal).
 * output payload migration (`#1846` / `#1847` 는 raw_legacy 를 *문서화*
   만 하며 fmt callsite 를 바꾸지 않는다 — diff guard 가 본 PR 의 invariant).
 * drift test guard 완전 활성화 — 미등록 leaf FAIL 은 `#1848` 의 책임.
@@ -68,6 +71,7 @@ from ante.contracts.vocab import AuthMode, ContractKind, EnvelopeForm
 
 __all__ = [
     "ACCOUNT_CONTRACTS",
+    "APPROVAL_CONTRACTS",
     "BOT_CONTRACTS",
     "CLI_COMMAND_REGISTRY",
     "MEMBER_CONTRACTS",
@@ -555,18 +559,162 @@ mutation → lifecycle) 와 시각적으로 일치하도록 정렬된다.
 """
 
 
+# ── #1847 sub-PR 3: approval domain OutputContract migration ────────────
+#
+# approval 도메인 10 leaf 의 contract entry. ``src/ante/cli/commands/approval.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:136-139`` (실행 분류) / ``572-585`` (커맨드
+# 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (3 commands): ``list`` / ``audit-types`` 는 ``fmt.table(rows,
+# columns)`` 로 JSON 모드에서 row list 를 그대로 dump 한다 (``[{id, type,
+# status, ...}, ...]`` 평면 list — standard envelope 의 ``{status, message,
+# data}`` 3 키 셋 부재). ``info`` 는 ``fmt.output(result)`` 로 평면 detail dict
+# 를 그대로 dump 한다. 세 leaf 모두 ``OutputContract(kind="raw", envelope=
+# "raw_legacy")`` 조합으로 lock — approval.py 본문 변경 없음 (drift test 가
+# callsite 변경 시 FAIL).
+#
+# standard envelope (7 commands): ``request`` / ``review`` / ``reopen`` /
+# ``cancel-invalid`` / ``cancel`` / ``approve`` / ``reject`` 는 단일 경로
+# ``fmt.success(message, data)`` 만 호출하며 표준 envelope (``{status,
+# message, data}``) 을 dump 한다. JSON mode 분기 없음 (text 와 JSON 양쪽
+# 모두 fmt.success).
+#
+# scope 분류 (#1815 SSOT, approval.py @require_scope marker 와 1:1 정합):
+# - ``approval:read`` scope (4 개): ``list`` / ``info`` / ``review`` /
+#   ``audit-types``. ``review`` 는 검토 의견 추가이지만 spec / marker SSOT 가
+#   ``approval:read`` 로 지정한다 (의견 기록은 결재 자체 mutation 이 아니라
+#   side-channel 메타데이터 추가라는 #1462 결정).
+# - ``approval:write`` scope (3 개): ``request`` / ``reopen`` / ``cancel``.
+#   ``cancel`` 은 requester ownership rule (본인만) 으로 보호되어 ``write`` 만
+#   요구. 다른 사람의 결재 cleanup 은 ``cancel-invalid`` (admin) 으로 분리.
+# - ``approval:admin`` scope (3 개): ``approve`` / ``reject`` / ``cancel-invalid``.
+# - public allowlist: 없음 — approval 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:136-139`` SSOT):
+# - ``offline`` (4 개): ``list`` / ``info`` / ``review`` / ``audit-types``.
+#   각 leaf 내부에서 ``Database`` 를 직접 생성해 ``ApprovalService`` 를
+#   호출한다 (cold-path 동형이나 spec 분류는 ``offline``).
+# - ``runtime_ipc`` (6 개): ``request`` / ``reopen`` / ``cancel-invalid`` /
+#   ``cancel`` / ``approve`` / ``reject``. ``ipc_send`` 로 IPC handler 를 호출.
+#
+# ``ipc_command`` 필드는 stub 값만 채운다 (예: ``"approval.request"``); 단순
+# 문자열 lock 이며 server-side IPC registry 와의 cross-ref drift test 는
+# #1819 의 책임이다 (member/bot domain 동형 정책). approval.py 호출 사이트
+# 의 IPC command name 과 그대로 일치한다 (``approval.request`` /
+# ``approval.reopen`` / ``approval.cancel_invalid`` / ``approval.cancel`` /
+# ``approval.approve`` / ``approval.reject``).
+APPROVAL_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("approval", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:read"})),
+        # JSON mode: ``fmt.table(rows, columns)`` → row list 를 그대로 dump.
+        # row dict shape: ``{id, type, status, requester, title, created_at}``.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("approval", "info"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:read"})),
+        # JSON mode: ``fmt.output(result)`` → 평면 detail dict
+        # ({id, type, status, requester, title, body, params, reviews,
+        # history, reference_id, expires_at, created_at, resolved_at,
+        # resolved_by, reject_reason}).
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("approval", "review"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:read"})),
+        # 단일 경로 ``fmt.success(f"검토 의견 추가: ...", result)`` → standard.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("approval", "audit-types"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:read"})),
+        # JSON mode: ``fmt.table(rows, columns)`` → row list 를 그대로 dump.
+        # row dict shape: ``{id, type, status, requester, created_at,
+        # expires_at}`` (legacy invalid-type row 만 결과로 포함, #1472).
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("approval", "request"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:write"})),
+        # 단일 경로 ``fmt.success(f"결재 요청 생성: ...", result)`` → standard.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="approval.request",
+    ),
+    CliCommandContract(
+        path=("approval", "reopen"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:write"})),
+        # 단일 경로 ``fmt.success(f"결재 재상신: ...", result)`` → standard.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="approval.reopen",
+    ),
+    CliCommandContract(
+        path=("approval", "cancel"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:write"})),
+        # 단일 경로 ``fmt.success(f"결재 철회: ...", result)`` → standard.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="approval.cancel",
+    ),
+    CliCommandContract(
+        path=("approval", "approve"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:admin"})),
+        # 단일 경로 ``fmt.success(f"결재 승인: ...", result)`` → standard.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="approval.approve",
+    ),
+    CliCommandContract(
+        path=("approval", "reject"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:admin"})),
+        # 단일 경로 ``fmt.success(f"결재 거절: ...", result)`` → standard.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="approval.reject",
+    ),
+    CliCommandContract(
+        path=("approval", "cancel-invalid"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"approval:admin"})),
+        # 단일 경로 ``fmt.success(f"invalid-type 결재 cleanup: ...", result)`` →
+        # standard. legacy invalid-type row administrative cleanup (#1472).
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="approval.cancel_invalid",
+    ),
+)
+"""Approval domain 10 leaf 의 contract tuple (#1847 sub-PR 3).
+
+순서는 ``docs/specs/cli/03-commands.md:572-585`` 의 approval 표 (read →
+write → admin) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
 CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
     contract.path: contract
-    for contract in (*ACCOUNT_CONTRACTS, *MEMBER_CONTRACTS, *BOT_CONTRACTS)
+    for contract in (
+        *ACCOUNT_CONTRACTS,
+        *MEMBER_CONTRACTS,
+        *BOT_CONTRACTS,
+        *APPROVAL_CONTRACTS,
+    )
 }
 """Leaf command path → contract mapping.
 
-본 PR 시점에는 account 9 + member 12 + bot 11 = 32 entries 가 등록되어
-있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2). 나머지 도메인 (approval /
-treasury / strategy / broker / data / report / system / instrument /
-config / rule / trade / backtest / audit / signal) 의 entry 등록은 후속
-PR (`#1847` sub-PR 3-9) 의 책임이다. registry 미등록 leaf 가 FAIL 이어야
-하는 drift guard 는 `#1848` 가 활성화한다.
+본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 = 42 entries
+가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR
+3). 나머지 도메인 (treasury / strategy / broker / data / report / system /
+instrument / config / rule / trade / backtest / audit / signal) 의 entry
+등록은 후속 PR (`#1847` sub-PR 4-9) 의 책임이다. registry 미등록 leaf 가
+FAIL 이어야 하는 drift guard 는 `#1848` 가 활성화한다.
 """
 
 
@@ -585,7 +733,8 @@ def get_contract(path: tuple[str, ...]) -> CliCommandContract | None:
 def all_contracts() -> Iterator[CliCommandContract]:
     """등록된 모든 contract 를 dict 순회 순서로 yield 한다.
 
-    본 PR 시점에는 account 9 + member 12 + bot 11 = 32 entries 가 등록되어
-    있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2).
+    본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 = 42
+    entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 /
+    #1847 sub-PR 3).
     """
     yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -180,11 +180,12 @@ def test_raw_legacy_is_envelope_form_not_contract_kind() -> None:
 
 
 def test_get_contract_returns_none_when_missing() -> None:
-    """미등록 path 는 ``None`` 을 반환한다 (account 9 + member 12 + bot 11 외)."""
+    """미등록 path 는 ``None`` 을 반환한다 (account/member/bot/approval 외)."""
     # nonexistent path 는 항상 ``None``.
     assert get_contract(("nonexistent",)) is None
-    # treasury 도메인 entry 등록은 후속 #1847 sub-PR 의 책임이므로 본 PR 시점에는
-    # ``None`` 이다 (bot domain 은 sub-PR 2 에서 등록되었다).
+    # treasury 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 4 이후) 의
+    # 책임이므로 본 PR 시점에는 ``None`` 이다 (approval domain 은 sub-PR 3
+    # 에서 등록되었다).
     assert get_contract(("treasury", "transactions")) is None
 
 
@@ -275,6 +276,34 @@ def test_bot_entries_registered_after_1847_sub_pr_2() -> None:
     assert expected_bot_paths.issubset(registered), (
         f"bot 11 entry 가 모두 등록되어야 한다 (#1847 sub-PR 2). "
         f"누락: {sorted(expected_bot_paths - registered)}"
+    )
+
+
+def test_approval_entries_registered_after_1847_sub_pr_3() -> None:
+    """#1847 sub-PR 3 가 approval 10 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 3 가 approval migration 을 완료한 시점부터
+    lock 된다. 10 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_approval_success_output_drift` 가
+    책임진다.
+    """
+    expected_approval_paths = {
+        ("approval", "list"),
+        ("approval", "info"),
+        ("approval", "review"),
+        ("approval", "audit-types"),
+        ("approval", "request"),
+        ("approval", "reopen"),
+        ("approval", "cancel"),
+        ("approval", "approve"),
+        ("approval", "reject"),
+        ("approval", "cancel-invalid"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_approval_paths.issubset(registered), (
+        f"approval 10 entry 가 모두 등록되어야 한다 (#1847 sub-PR 3). "
+        f"누락: {sorted(expected_approval_paths - registered)}"
     )
 
 

--- a/tests/unit/test_approval_success_output_drift.py
+++ b/tests/unit/test_approval_success_output_drift.py
@@ -1,0 +1,603 @@
+"""Approval CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 3).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+approval 도메인 10 leaf 의 ``OutputContract`` 와 ``ante approval ... --format
+json`` 실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1 (member) / #1847 sub-PR 2 (bot) 1:1 동형
+패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 list 를 그대로 dump 한다 (``status``
+  / ``message`` / ``data`` 3 키 모두 동시에 부재; ``fmt.table`` 은 list 를
+  dump 하므로 dict shape 자체가 아님).
+
+본 PR 은 ``approval.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면
+본 test 가 즉시 FAIL 한다 (registry 갱신 또는 callsite 정렬 중 한쪽이
+책임).
+
+13 시나리오 (10 leaf + list/audit-types empty/non-empty 분리 +1 + registry
+sanity +1):
+
+0. registry sanity — approval 10 entries 의 envelope 이 ``standard`` /
+   ``raw_legacy`` 분류 범위 내.
+1. ``list`` empty → ``raw_legacy`` (``fmt.table([], columns)`` → ``[]``)
+2. ``list`` non-empty → ``raw_legacy`` (row list)
+3. ``info`` → ``raw_legacy`` (``fmt.output(result)`` 평면 detail dict)
+4. ``review`` → ``standard`` (``fmt.success(message, data)``)
+5. ``audit-types`` empty → ``raw_legacy`` (``fmt.table([], columns)`` → ``[]``)
+6. ``audit-types`` non-empty → ``raw_legacy`` (row list)
+7. ``request`` → ``standard`` (``fmt.success(message, data)``)
+8. ``reopen`` → ``standard`` (``fmt.success(message, data)``)
+9. ``cancel`` → ``standard`` (``fmt.success(message, data)``)
+10. ``approve`` → ``standard`` (``fmt.success(message, data)``)
+11. ``reject`` → ``standard`` (``fmt.success(message, data)``)
+12. ``cancel-invalid`` → ``standard`` (``fmt.success(message, data)``)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.approval.models import ApprovalRequest
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, account/member/bot 동형) ──
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict 또는 list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언.
+
+    raw_legacy 는 ``fmt.output(dict)`` 또는 ``fmt.table(rows, cols)`` 출력의
+    super-set 이다. 후자는 dict 가 아닌 list 를 dump 하므로 standard envelope
+    predicate 가 자동으로 false 가 된다.
+    """
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_approval_entries_envelopes_classified() -> None:
+    """approval 10 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 10 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    approval_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("approval",)
+    ]
+    assert len(approval_entries) == 10, (
+        f"approval 10 entries 가 모두 등록되어야 한다. 실제: {len(approval_entries)}"
+    )
+    for path, contract in approval_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (account/member/bot drift test 동형) ───────────────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증을 우회한다 (account/member/bot drift test 동형)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json approval ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다.
+
+    ``OutputFormatter`` 가 ``json.dumps(..., indent=2)`` 로 multi-line dump
+    하기 때문에 처음 ``{`` 또는 ``[`` 부터 ``raw_decode`` 로 한 value 를
+    파싱하고 나머지 stdout (text 모드 잔존물 등) 는 무시한다 (member/bot
+    drift test 동형). ``fmt.table`` 출력은 list, ``fmt.success``/``fmt.output``
+    출력은 dict.
+    """
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+def _make_mock_db() -> AsyncMock:
+    """``Database`` mock — ``connect`` / ``close`` / ``fetch_*`` async 메서드.
+
+    approval.py 의 offline leaf (``list``/``info``/``review``/``audit-types``)
+    는 ``Database`` 를 직접 생성 + ``ApprovalService(db, eventbus)`` 패턴을
+    사용하므로 ``Database`` 생성자 자체를 patch 하는 fixture 와 짝지어 쓴다.
+    """
+    db = AsyncMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    db.fetch_all = AsyncMock(return_value=[])
+    db.fetch_one = AsyncMock(return_value=None)
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def mock_approval_service():
+    """``ApprovalService`` 생성자를 patch 해 service.method 응답을 customize.
+
+    approval.py 의 offline leaf 는 ``from ante.approval import ApprovalService``
+    를 함수 내부에서 import 한 뒤 생성자를 호출하므로 ``ante.approval.service``
+    모듈에서 patch 한다 (``ante.approval`` 패키지의 re-export 와 일치).
+    """
+    service = AsyncMock()
+    service.initialize = AsyncMock()
+
+    db = _make_mock_db()
+    with (
+        patch("ante.approval.ApprovalService", return_value=service),
+        patch("ante.core.database.Database", return_value=db),
+        patch("ante.eventbus.bus.EventBus", return_value=MagicMock()),
+    ):
+        yield service, db
+
+
+@pytest.fixture
+def mock_ipc_send():
+    """``ipc_send`` 를 mock 한다 (runtime_ipc 분기 leaf 용).
+
+    각 테스트가 ``mock_ipc.return_value`` 를 설정해 IPC 응답을 customize.
+    approval.py 는 ``from ante.cli.commands.ipc_helpers import ipc_send``
+    를 함수 내부에서 lazy import 하므로 원본 모듈을 patch 해야 한다.
+    """
+    with patch("ante.cli.commands.ipc_helpers.ipc_send", new=AsyncMock()) as m:
+        yield m
+
+
+def _make_request(
+    id: str = "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+    type: str = "bot_create",
+    status: str = "pending",
+    requester: str = "test-master",
+    title: str = "Test 결재",
+    **overrides: Any,
+) -> ApprovalRequest:
+    """테스트용 ``ApprovalRequest`` 인스턴스."""
+    base = dict(
+        id=id,
+        type=type,
+        status=status,
+        requester=requester,
+        title=title,
+        body="",
+        params={},
+        reviews=[],
+        history=[],
+        reference_id="",
+        expires_at="",
+        created_at="2026-01-01T00:00:00",
+        resolved_at="",
+        resolved_by="",
+        reject_reason="",
+    )
+    base.update(overrides)
+    return ApprovalRequest(**base)  # type: ignore[arg-type]
+
+
+# ── 1. approval list (empty / non-empty) → raw_legacy ─────────────────────
+
+
+def test_approval_list_empty_envelope_matches_raw_legacy(mock_approval_service) -> None:
+    """``approval list`` empty: ``fmt.table([], cols)`` → ``[]`` JSON list."""
+    service, _db = mock_approval_service
+    service.list_approvals = AsyncMock(return_value=[])
+
+    result = _invoke(["--format", "json", "approval", "list"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"approval list empty: standard envelope 아니어야 함 (registry "
+        f"envelope=raw_legacy 와 정합). 실제 payload={payload!r}"
+    )
+    assert payload == []
+
+
+def test_approval_list_non_empty_envelope_matches_raw_legacy(
+    mock_approval_service,
+) -> None:
+    """``approval list`` non-empty: ``fmt.table(rows, cols)`` → row JSON list."""
+    service, _db = mock_approval_service
+    service.list_approvals = AsyncMock(
+        return_value=[
+            _make_request(
+                id="abcd1234aaaabbbb",
+                type="bot_create",
+                status="pending",
+                title="Test 결재",
+            )
+        ]
+    )
+
+    result = _invoke(["--format", "json", "approval", "list"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"approval list non-empty: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    # row dict 키 셋: id (prefix 8), type, status, requester, title, created_at
+    row = payload[0]
+    assert row["id"] == "abcd1234"
+    assert row["type"] == "bot_create"
+    assert row["status"] == "pending"
+    assert row["title"] == "Test 결재"
+
+
+# ── 2. approval info → raw_legacy ─────────────────────────────────────────
+
+
+def test_approval_info_envelope_matches_raw_legacy(mock_approval_service) -> None:
+    """``approval info``: ``fmt.output(result)`` 평면 detail dict (raw_legacy).
+
+    approval.py 287: JSON 모드는 ``fmt.output(result)`` 로 평면 dict 를 dump.
+    """
+    service, _db = mock_approval_service
+    req = _make_request(
+        id="abcd1234-aaaa-bbbb-cccc-1234567890ab",
+        type="bot_create",
+        status="pending",
+        title="Test 결재",
+        body="본문",
+    )
+    service.get = AsyncMock(return_value=req)
+    service.list_approvals = AsyncMock(return_value=[req])
+
+    result = _invoke(
+        ["--format", "json", "approval", "info", "abcd1234-aaaa-bbbb-cccc-1234567890ab"]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"approval info: standard envelope 아니어야 함. payload={payload!r}"
+    )
+    assert payload["id"] == "abcd1234-aaaa-bbbb-cccc-1234567890ab"
+    assert payload["type"] == "bot_create"
+    assert payload["status"] == "pending"
+
+
+# ── 3. approval review → standard ─────────────────────────────────────────
+
+
+def test_approval_review_envelope_matches_operation_standard(
+    mock_approval_service,
+) -> None:
+    """``approval review``: 단일 경로 ``fmt.success(message, data)`` → standard."""
+    service, _db = mock_approval_service
+    service.add_review = AsyncMock(
+        return_value=_make_request(
+            id="abcd1234-aaaa-bbbb-cccc-1234567890ab",
+            reviews=[{"reviewer": "test-master", "result": "pass", "detail": ""}],
+        )
+    )
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "approval",
+            "review",
+            "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+            "--result",
+            "pass",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"approval review: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "검토 의견 추가" in payload["message"]
+    assert payload["data"]["reviewer"] == "test-master"
+    assert payload["data"]["result"] == "pass"
+
+
+# ── 4. approval audit-types (empty / non-empty) → raw_legacy ──────────────
+
+
+def test_approval_audit_types_empty_envelope_matches_raw_legacy(
+    mock_approval_service,
+) -> None:
+    """``approval audit-types`` empty: ``fmt.table([], cols)`` → ``[]`` list."""
+    service, _db = mock_approval_service
+    service.list_invalid_type_requests = AsyncMock(return_value=[])
+
+    result = _invoke(["--format", "json", "approval", "audit-types"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"approval audit-types empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == []
+
+
+def test_approval_audit_types_non_empty_envelope_matches_raw_legacy(
+    mock_approval_service,
+) -> None:
+    """``approval audit-types`` non-empty: ``fmt.table(rows, cols)`` row list."""
+    service, _db = mock_approval_service
+    service.list_invalid_type_requests = AsyncMock(
+        return_value=[
+            _make_request(
+                id="invalid-row-1",
+                type="legacy_invalid_type",
+                status="pending",
+                expires_at="2026-12-31T00:00:00",
+            )
+        ]
+    )
+
+    result = _invoke(["--format", "json", "approval", "audit-types"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"approval audit-types non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    # audit-types row 키 셋: id, type, status, requester, created_at, expires_at
+    assert payload[0]["id"] == "invalid-row-1"
+    assert payload[0]["type"] == "legacy_invalid_type"
+
+
+# ── 5. approval request → standard ────────────────────────────────────────
+
+
+def test_approval_request_envelope_matches_operation_standard(mock_ipc_send) -> None:
+    """``approval request``: 단일 경로 ``fmt.success(message, result)`` → standard."""
+    mock_ipc_send.return_value = {
+        "id": "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+        "type": "bot_create",
+        "status": "pending",
+        "requester": "test-master",
+        "title": "Test 결재",
+    }
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "approval",
+            "request",
+            "--type",
+            "bot_create",
+            "--title",
+            "Test 결재",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"approval request: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "결재 요청 생성" in payload["message"]
+    assert payload["data"]["id"] == "abcd1234-aaaa-bbbb-cccc-1234567890ab"
+
+
+# ── 6. approval reopen → standard ─────────────────────────────────────────
+
+
+def test_approval_reopen_envelope_matches_operation_standard(mock_ipc_send) -> None:
+    """``approval reopen``: 단일 경로 ``fmt.success(message, result)`` → standard."""
+    mock_ipc_send.return_value = {
+        "id": "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+        "status": "pending",
+    }
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "approval",
+            "reopen",
+            "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"approval reopen: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "결재 재상신" in payload["message"]
+    assert payload["data"]["id"] == "abcd1234-aaaa-bbbb-cccc-1234567890ab"
+
+
+# ── 7. approval cancel → standard ─────────────────────────────────────────
+
+
+def test_approval_cancel_envelope_matches_operation_standard(mock_ipc_send) -> None:
+    """``approval cancel``: 단일 경로 ``fmt.success(message, result)`` → standard."""
+    mock_ipc_send.return_value = {
+        "id": "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+        "status": "cancelled",
+    }
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "approval",
+            "cancel",
+            "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"approval cancel: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "결재 철회" in payload["message"]
+    assert payload["data"]["status"] == "cancelled"
+
+
+# ── 8. approval approve → standard ────────────────────────────────────────
+
+
+def test_approval_approve_envelope_matches_operation_standard(mock_ipc_send) -> None:
+    """``approval approve``: 단일 경로 ``fmt.success(message, result)`` → standard."""
+    mock_ipc_send.return_value = {
+        "id": "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+        "status": "approved",
+    }
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "approval",
+            "approve",
+            "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"approval approve: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "결재 승인" in payload["message"]
+    assert payload["data"]["status"] == "approved"
+
+
+# ── 9. approval reject → standard ─────────────────────────────────────────
+
+
+def test_approval_reject_envelope_matches_operation_standard(mock_ipc_send) -> None:
+    """``approval reject``: 단일 경로 ``fmt.success(message, result)`` → standard."""
+    mock_ipc_send.return_value = {
+        "id": "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+        "status": "rejected",
+        "reject_reason": "검토 미흡",
+    }
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "approval",
+            "reject",
+            "abcd1234-aaaa-bbbb-cccc-1234567890ab",
+            "--reason",
+            "검토 미흡",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"approval reject: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "결재 거절" in payload["message"]
+    assert payload["data"]["status"] == "rejected"
+
+
+# ── 10. approval cancel-invalid → standard ────────────────────────────────
+
+
+def test_approval_cancel_invalid_envelope_matches_operation_standard(
+    mock_ipc_send,
+) -> None:
+    """``approval cancel-invalid``: ``fmt.success(message, result)`` → standard.
+
+    legacy invalid-type row administrative cleanup (#1472). ``cancel`` 과 달리
+    ``approval_id`` IPC key 를 사용하지만, 호출 사이트의 envelope shape 자체
+    는 ``fmt.success(...)`` → standard 로 동일하다.
+    """
+    mock_ipc_send.return_value = {
+        "id": "invalid-row-1",
+        "status": "cancelled",
+        "cleanup": True,
+    }
+
+    result = _invoke(
+        ["--format", "json", "approval", "cancel-invalid", "invalid-row-1"]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"approval cancel-invalid: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "invalid-type 결재 cleanup" in payload["message"]
+    assert payload["data"]["status"] == "cancelled"


### PR DESCRIPTION
## Summary

`#1846` (account 9 leaf) / `#1847` sub-PR 1 (member 12 leaf) / `#1847` sub-PR 2 (bot 11 leaf) 동형 패턴으로 approval 도메인 10 leaf 의 `OutputContract` / `AuthContract` / `ExecutionClass` 를 `CLI_COMMAND_REGISTRY` SSOT 에 등록한다. `approval.py` 본문은 변경하지 않으며 (diff guard: 0 lines, sha256 `b5a1d7a3795e9527fa31c583d0362878c137145325d9d034c8b8363fcda44875` 불변), drift test 가 callsite shape (`fmt.success` / `fmt.output` / `fmt.table`) ↔ registry entry 정합을 lock 한다.

Refs #1847

### 등록 leaf (10)

| # | path | auth | output | execution | ipc_command |
|---|------|------|--------|-----------|-------------|
| 1 | `("approval","list")` | scoped `approval:read` | raw_legacy (`fmt.table` rows) | offline | — |
| 2 | `("approval","info")` | scoped `approval:read` | raw_legacy (`fmt.output` flat dict) | offline | — |
| 3 | `("approval","review")` | scoped `approval:read` | standard (operation) | offline | — |
| 4 | `("approval","audit-types")` | scoped `approval:read` | raw_legacy (`fmt.table` rows) | offline | — |
| 5 | `("approval","request")` | scoped `approval:write` | standard (operation) | runtime_ipc | `approval.request` |
| 6 | `("approval","reopen")` | scoped `approval:write` | standard (operation) | runtime_ipc | `approval.reopen` |
| 7 | `("approval","cancel")` | scoped `approval:write` | standard (operation) | runtime_ipc | `approval.cancel` |
| 8 | `("approval","approve")` | scoped `approval:admin` | standard (operation) | runtime_ipc | `approval.approve` |
| 9 | `("approval","reject")` | scoped `approval:admin` | standard (operation) | runtime_ipc | `approval.reject` |
| 10 | `("approval","cancel-invalid")` | scoped `approval:admin` | standard (operation) | runtime_ipc | `approval.cancel_invalid` |

- `approval:read` (4): list / info / review / audit-types
- `approval:write` (3): request / reopen / cancel
- `approval:admin` (3): approve / reject / cancel-invalid
- public allowlist: 없음

execution 분류는 `docs/specs/cli/03-commands.md:136-139` SSOT 를 따른다 — offline 4 (`list` / `info` / `review` / `audit-types`), runtime_ipc 6 (`request` / `reopen` / `cancel` / `approve` / `reject` / `cancel-invalid`). `review` 는 검토 의견 추가이지만 spec / `@require_scope` marker SSOT 가 `approval:read` 로 지정한다 (의견 기록은 결재 자체 mutation 이 아니라 side-channel 메타데이터 추가라는 #1462 결정).

### Diff guard

- `src/ante/cli/commands/approval.py` 본문 0 lines (sha256 `b5a1d7a3795e9527fa31c583d0362878c137145325d9d034c8b8363fcda44875` 불변).
- approval.py 본문 변경 없음 — drift test 가 callsite shape (`fmt.success(message, data)` / `fmt.output(평면 dict)` / `fmt.table(rows, cols)` → JSON list) 와 registry entry 정합을 lock.

### shell test cascade

- `test_get_contract_returns_none_when_missing` sentinel path 주석 갱신 (`("treasury", "transactions")` 그대로 — 다음 미등록 도메인이 treasury 인 사실은 sub-PR 4 이후의 책임이라는 정렬).
- `test_approval_entries_registered_after_1847_sub_pr_3` 신규 추가 (10 path subset lock; account / member / bot lock 패턴 미러).

### drift test 시나리오 수

`tests/unit/test_approval_success_output_drift.py` — **13 시나리오** (10 leaf + list/audit-types empty/non-empty 분기 +2 + registry sanity 1):

- list empty / non-empty → raw_legacy (`fmt.table([], cols)` → `[]` / `fmt.table(rows, cols)` → row list)
- info → raw_legacy (`fmt.output(result)` flat detail dict)
- review → standard (`fmt.success(message, data)`)
- audit-types empty / non-empty → raw_legacy (`fmt.table([], cols)` → `[]` / row list)
- request → standard (`fmt.success(message, data)`)
- reopen → standard (`fmt.success(message, data)`)
- cancel → standard (`fmt.success(message, data)`)
- approve → standard (`fmt.success(message, data)`)
- reject → standard (`fmt.success(message, data)`)
- cancel-invalid → standard (`fmt.success(message, data)`)

## Test plan

- [x] `pytest tests/unit/contracts -v` — 103 passed (auth-drift Family A/B/C/D + shell + leaf coverage + helpers, 신규 `test_approval_entries_registered_after_1847_sub_pr_3` 포함)
- [x] `pytest tests/unit/test_approval_success_output_drift.py -v` — 13 passed
- [x] `pytest tests/unit/contracts tests/unit/test_approval_success_output_drift.py tests/unit/test_bot_success_output_drift.py tests/unit/test_member_success_output_drift.py tests/unit/test_account_success_output_drift.py -q` — 158 passed (4 도메인 drift + contracts 전체 회귀)
- [x] `pytest tests/unit/ -q -k "approval or contract or cli"` (worktree) — 1838 passed, 208 failed
- [x] `pytest tests/unit/ -q -k "approval or contract or cli"` (origin/main 3debab91 baseline) — 1824 passed, 208 failed (passed +14 = approval 13 새 drift + 1 새 shell test; failed 동일 → pre-existing, 본 PR 무관함 확인)
- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 526 files already formatted
- [x] `mypy src/` — Success: no issues found in 223 source files
- [x] `git diff origin/main -- src/ante/cli/commands/approval.py | wc -l` → 0
- [x] `scripts/generate_project_structure.py` 재생성 — `tests/unit/test_approval_success_output_drift.py` 한 줄 추가만 발생 (mechanical drift, 본 PR 등록 파일과 정합)
- [x] main HEAD 불변 확인 (`3debab91`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)