### PR TITLE
refactor: #1847-4 treasury domain OutputContract migration (9 leaf entries)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -607,7 +607,8 @@ tests/
 │   ├── test_account_success_output_drift.py
 │   ├── test_member_success_output_drift.py
 │   ├── test_bot_success_output_drift.py
-│   └── test_approval_success_output_drift.py
+│   ├── test_approval_success_output_drift.py
+│   └── test_treasury_success_output_drift.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -16,16 +16,18 @@ execution 계약을 한 곳에서 관리하는 registry 다.
   (#1847 sub-PR 2).
 * :data:`APPROVAL_CONTRACTS` — approval 도메인 10 leaf contract tuple
   (#1847 sub-PR 3).
+* :data:`TREASURY_CONTRACTS` — treasury 도메인 9 leaf contract tuple
+  (#1847 sub-PR 4).
 * :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
-  PR 시점에는 account 9 + member 12 + bot 11 + approval 10 = 42 entries 가
-  채워져 있다.
+  PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
+  = 51 entries 가 채워져 있다.
 * :func:`get_contract` / :func:`all_contracts` — read-only accessor.
 
 본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
 
-* 잔여 도메인 entry 등록 (`#1847` sub-PR 4 이후 — treasury / strategy /
-  broker / data / report / system / instrument / config / rule / trade /
-  backtest / audit / signal).
+* 잔여 도메인 entry 등록 (`#1847` sub-PR 5 이후 — strategy / broker /
+  data / report / system / instrument / config / rule / trade / backtest /
+  audit / signal).
 * output payload migration (`#1846` / `#1847` 는 raw_legacy 를 *문서화*
   만 하며 fmt callsite 를 바꾸지 않는다 — diff guard 가 본 PR 의 invariant).
 * drift test guard 완전 활성화 — 미등록 leaf FAIL 은 `#1848` 의 책임.
@@ -75,6 +77,7 @@ __all__ = [
     "BOT_CONTRACTS",
     "CLI_COMMAND_REGISTRY",
     "MEMBER_CONTRACTS",
+    "TREASURY_CONTRACTS",
     "AuthContract",
     "CliCommandContract",
     "ExecutionClass",
@@ -698,6 +701,157 @@ write → admin) 와 시각적으로 일치하도록 정렬된다.
 """
 
 
+# ── #1847 sub-PR 4: treasury domain OutputContract migration ────────────
+#
+# treasury 도메인 9 leaf 의 contract entry. ``src/ante/cli/commands/treasury.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:112-119`` (실행 분류) / ``408-427`` (커맨드
+# 표) 와 1:1 정합한다.
+#
+# 이슈 #1847 본문은 treasury "8 leaf" 로 추정했지만 실측 Click leaf iterator
+# (:func:`tests.unit.contracts.helpers.iter_click_leaf_commands`) 는 9 leaf 를
+# 반환한다 — spec 표 (408-427) 가 ``portfolio value/history`` 를 한 줄로 묶어
+# 표현하지만 Click subgroup ``treasury portfolio`` 아래 ``value`` /
+# ``history`` 두 leaf 가 별도로 존재하기 때문이다. registry 는 canonical
+# Click tree 기준이므로 9 entries 를 모두 등록한다 (leaf coverage helper SSOT).
+#
+# raw_legacy 분류 (7 commands): ``status`` / ``transactions`` / ``budgets`` /
+# ``set-balance`` / ``snapshot`` / ``portfolio value`` / ``portfolio history``
+# 는 JSON 모드에서 ``fmt.output(result)`` 평면 dict 를 그대로 dump 한다
+# (``transactions`` / ``budgets`` / ``portfolio history`` 는 text 모드에서
+# ``fmt.table`` 사용; JSON 모드는 분기로 ``fmt.output`` 호출). 도메인 envelope
+# 형태 (``{account_balance, ...}``, ``{items, total}``, ``{budgets: [...]}``,
+# ``{total_value, ...}``, ``{data, start_date, end_date}``) 이며 standard
+# envelope ``{status, message, data}`` 3 키 셋과는 다르다. ``OutputContract(
+# kind="raw", envelope="raw_legacy")`` 조합으로 표현해 lock 만 한다 —
+# treasury.py 본문 변경 없음 (drift test 가 callsite 변경 시 FAIL).
+#
+# standard envelope (2 commands): ``allocate`` / ``deallocate`` 는
+# ``fmt.success(message, data)`` 만 호출하며 표준 envelope (``{status,
+# message, data}``) 을 dump 한다 (success 분기 — error 분기는 ``fmt.error``
+# 이므로 본 drift test 의 success-output scope 밖). JSON / text 분기 없음.
+#
+# scope 분류 (#1815 SSOT, treasury.py @require_scope marker 와 1:1 정합):
+# - ``treasury:read`` scope (6 개): ``status`` / ``transactions`` /
+#   ``budgets`` / ``snapshot`` / ``portfolio value`` / ``portfolio history``.
+# - ``treasury:admin`` scope (3 개): ``set-balance`` / ``allocate`` /
+#   ``deallocate``.
+# - public allowlist: 없음 — treasury 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:112-119`` SSOT):
+# - ``offline`` (6 개): ``status`` / ``transactions`` / ``budgets`` /
+#   ``snapshot`` / ``portfolio value`` / ``portfolio history``. 각 leaf 는
+#   ``Database`` 와 ``Treasury`` / ``TreasuryManager`` 를 직접 생성해
+#   persisted snapshot/budget/transaction 을 조회한다.
+# - ``runtime_ipc`` (3 개): ``allocate`` / ``deallocate`` / ``set-balance``.
+#   ``ipc_send`` 로 IPC handler (``treasury.allocate`` / ``treasury.deallocate``
+#   / ``treasury.set_balance``) 를 호출한다. ``set-balance`` 는
+#   ``is_active_runtime()`` 분기로 cold_path fallback 을 보유하지만 spec
+#   primary 분류는 runtime_ipc 다 (account ``suspend``/``activate`` /
+#   member ``update-scopes`` 동형 — fallback 분기가 있어도 spec primary
+#   분류만 lock).
+#
+# ``ipc_command`` 필드는 stub 값만 채운다 (예: ``"treasury.allocate"``);
+# 단순 문자열 lock 이며 server-side IPC registry 와의 cross-ref drift test 는
+# #1819 의 책임이다 (account/member/bot/approval 동형 정책). treasury.py
+# 호출 사이트의 IPC command name 과 그대로 일치한다 (``treasury.allocate`` /
+# ``treasury.deallocate`` / ``treasury.set_balance``).
+TREASURY_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("treasury", "status"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"treasury:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{account_balance,
+        # purchasable_amount, total_evaluation, total_profit_loss,
+        # total_allocated, total_reserved, unallocated, bot_count}``). text 는
+        # click.echo 8 줄.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("treasury", "transactions"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"treasury:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{items: [...], total}``).
+        # text 는 fmt.table.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("treasury", "budgets"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"treasury:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{budgets: [...]}``).
+        # text 는 fmt.table.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("treasury", "set-balance"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"treasury:admin"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict — IPC 분기와 cold_path
+        # 분기 모두 ``{account_id, total_balance, updated_at, ...}`` 평면 shape
+        # 를 그대로 dump 한다 (account ``set-credentials`` 동형 raw_legacy
+        # 정책). spec 은 ``runtime IPC`` 이며 ``is_active_runtime()`` 분기로
+        # cold_path fallback 을 보유하지만 primary 분류만 lock.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="treasury.set_balance",
+    ),
+    CliCommandContract(
+        path=("treasury", "allocate"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"treasury:admin"})),
+        # 단일 success 경로 ``fmt.success(f"예산 할당 완료: ...", data)`` →
+        # standard envelope (#1809 typed reject 이후 success 분기는 항상
+        # ``success=True``). error 분기는 ``fmt.error`` 이므로 본 drift test
+        # 의 success-output scope 밖.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="treasury.allocate",
+    ),
+    CliCommandContract(
+        path=("treasury", "deallocate"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"treasury:admin"})),
+        # 단일 success 경로 ``fmt.success(f"예산 회수 완료: ...", data)`` →
+        # standard envelope (allocate 동형).
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="treasury.deallocate",
+    ),
+    CliCommandContract(
+        path=("treasury", "snapshot"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"treasury:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict 또는 list (단일 일자는
+        # snapshot dict, 기간 조회는 snapshot dict list). 어느 분기든 평면
+        # shape 그대로 dump.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("treasury", "portfolio", "value"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"treasury:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{total_value,
+        # daily_pnl, daily_return, unrealized_pnl, accounts: [...],
+        # updated_at}``). text 는 click.echo 4 줄.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("treasury", "portfolio", "history"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"treasury:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{data: [...],
+        # start_date, end_date}``). text 는 fmt.table.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+)
+"""Treasury domain 9 leaf 의 contract tuple (#1847 sub-PR 4).
+
+순서는 ``docs/specs/cli/03-commands.md:112-119`` 의 treasury 실행 분류 표
+(status → transactions → budgets → set-balance → allocate → deallocate →
+snapshot → portfolio value/history) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
 CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
     contract.path: contract
     for contract in (
@@ -705,16 +859,17 @@ CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
         *MEMBER_CONTRACTS,
         *BOT_CONTRACTS,
         *APPROVAL_CONTRACTS,
+        *TREASURY_CONTRACTS,
     )
 }
 """Leaf command path → contract mapping.
 
-본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 = 42 entries
-가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR
-3). 나머지 도메인 (treasury / strategy / broker / data / report / system /
-instrument / config / rule / trade / backtest / audit / signal) 의 entry
-등록은 후속 PR (`#1847` sub-PR 4-9) 의 책임이다. registry 미등록 leaf 가
-FAIL 이어야 하는 drift guard 는 `#1848` 가 활성화한다.
+본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
+= 51 entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 /
+#1847 sub-PR 3 / #1847 sub-PR 4). 나머지 도메인 (strategy / broker / data
+/ report / system / instrument / config / rule / trade / backtest / audit /
+signal) 의 entry 등록은 후속 PR (`#1847` sub-PR 5-9) 의 책임이다. registry
+미등록 leaf 가 FAIL 이어야 하는 drift guard 는 `#1848` 가 활성화한다.
 """
 
 
@@ -733,8 +888,8 @@ def get_contract(path: tuple[str, ...]) -> CliCommandContract | None:
 def all_contracts() -> Iterator[CliCommandContract]:
     """등록된 모든 contract 를 dict 순회 순서로 yield 한다.
 
-    본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 = 42
-    entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 /
-    #1847 sub-PR 3).
+    본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury
+    9 = 51 entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR
+    2 / #1847 sub-PR 3 / #1847 sub-PR 4).
     """
     yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -180,13 +180,13 @@ def test_raw_legacy_is_envelope_form_not_contract_kind() -> None:
 
 
 def test_get_contract_returns_none_when_missing() -> None:
-    """미등록 path 는 ``None`` 을 반환한다 (account/member/bot/approval 외)."""
+    """미등록 path 는 ``None`` 을 반환한다 (account/member/bot/approval/treasury 외)."""
     # nonexistent path 는 항상 ``None``.
     assert get_contract(("nonexistent",)) is None
-    # treasury 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 4 이후) 의
-    # 책임이므로 본 PR 시점에는 ``None`` 이다 (approval domain 은 sub-PR 3
+    # strategy 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 5 이후) 의
+    # 책임이므로 본 PR 시점에는 ``None`` 이다 (treasury domain 은 sub-PR 4
     # 에서 등록되었다).
-    assert get_contract(("treasury", "transactions")) is None
+    assert get_contract(("strategy", "list")) is None
 
 
 def test_registry_is_mutable_dict() -> None:
@@ -304,6 +304,39 @@ def test_approval_entries_registered_after_1847_sub_pr_3() -> None:
     assert expected_approval_paths.issubset(registered), (
         f"approval 10 entry 가 모두 등록되어야 한다 (#1847 sub-PR 3). "
         f"누락: {sorted(expected_approval_paths - registered)}"
+    )
+
+
+def test_treasury_entries_registered_after_1847_sub_pr_4() -> None:
+    """#1847 sub-PR 4 가 treasury 9 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 4 가 treasury migration 을 완료한 시점부터
+    lock 된다. 9 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_treasury_success_output_drift` 가
+    책임진다.
+
+    이슈 #1847 본문은 treasury "8 leaf" 로 추정했지만 실측 Click leaf
+    iterator 는 9 leaf 를 반환한다 (spec 표 408-427 가 ``portfolio
+    value/history`` 를 한 줄로 묶어 표현하지만 Click subgroup ``treasury
+    portfolio`` 아래 ``value`` / ``history`` 두 leaf 가 별도로 존재). 본
+    test 는 9 leaf 모두를 단언한다.
+    """
+    expected_treasury_paths = {
+        ("treasury", "status"),
+        ("treasury", "transactions"),
+        ("treasury", "budgets"),
+        ("treasury", "set-balance"),
+        ("treasury", "allocate"),
+        ("treasury", "deallocate"),
+        ("treasury", "snapshot"),
+        ("treasury", "portfolio", "value"),
+        ("treasury", "portfolio", "history"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_treasury_paths.issubset(registered), (
+        f"treasury 9 entry 가 모두 등록되어야 한다 (#1847 sub-PR 4). "
+        f"누락: {sorted(expected_treasury_paths - registered)}"
     )
 
 

--- a/tests/unit/test_treasury_success_output_drift.py
+++ b/tests/unit/test_treasury_success_output_drift.py
@@ -1,0 +1,702 @@
+"""Treasury CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 4).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+treasury 도메인 9 leaf 의 ``OutputContract`` 와 ``ante treasury ... --format
+json`` 실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1 (member) / #1847 sub-PR 2 (bot) / #1847
+sub-PR 3 (approval) 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 으로
+  평면 dict 를 그대로 dump 한다 (``status`` / ``message`` / ``data`` 3 키
+  모두 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``treasury.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면
+본 test 가 즉시 FAIL 한다 (registry 갱신 또는 callsite 정렬 중 한쪽이
+책임).
+
+12 시나리오 (9 leaf + registry sanity +1 + transactions empty 분리 +1 +
+snapshot range 분리 +1):
+
+0. registry sanity — treasury 9 entries 의 envelope 이 ``standard`` /
+   ``raw_legacy`` 분류 범위 내.
+1. ``status`` → ``raw_legacy`` (``fmt.output(result)`` 평면 ``{account_balance,
+   ...}``)
+2. ``transactions`` empty (no such table 분기) → ``raw_legacy`` (``{items: [],
+   total: 0}``)
+3. ``transactions`` non-empty → ``raw_legacy`` (``{items: [...], total}``)
+4. ``budgets`` → ``raw_legacy`` (``fmt.output(result)`` 평면 ``{budgets:
+   [...]}``)
+5. ``set-balance`` → ``raw_legacy`` (``fmt.output(result)`` 평면 ``{account_id,
+   total_balance, updated_at}`` — IPC 분기)
+6. ``allocate`` → ``standard`` (``fmt.success(message, data)``)
+7. ``deallocate`` → ``standard`` (``fmt.success(message, data)``)
+8. ``snapshot`` single → ``raw_legacy`` (``fmt.output(result)`` 평면 snapshot dict)
+9. ``snapshot`` range → ``raw_legacy`` (``fmt.output(result)`` 평면 snapshot list)
+10. ``portfolio value`` → ``raw_legacy`` (``fmt.output(result)`` 평면
+    ``{total_value, daily_pnl, ...}``)
+11. ``portfolio history`` → ``raw_legacy`` (``fmt.output(result)`` 평면
+    ``{data: [...], start_date, end_date}``)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.treasury.models import BotBudget
+
+# ── envelope shape predicates (envelopes.md SSOT, account/member/bot/approval 동형) ──
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict 또는 list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언.
+
+    raw_legacy 는 ``fmt.output(dict)`` 출력의 super-set 이다. ``fmt.table``
+    callsite 는 본 treasury 도메인에서 *text 모드 전용* 이고 JSON 모드는
+    별도 분기로 ``fmt.output(dict)`` 를 호출한다 (bot ``list``/``positions``
+    동형 — JSON 분기와 text 분기가 다른 shape).
+    """
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_treasury_entries_envelopes_classified() -> None:
+    """treasury 9 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 9 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    treasury_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("treasury",)
+    ]
+    assert len(treasury_entries) == 9, (
+        f"treasury 9 entries 가 모두 등록되어야 한다. 실제: {len(treasury_entries)}"
+    )
+    for path, contract in treasury_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (account/member/bot/approval drift test 동형) ──────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (account/member/bot/approval drift test 동형)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json treasury ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다.
+
+    ``OutputFormatter`` 가 ``json.dumps(..., indent=2)`` 로 multi-line dump
+    하기 때문에 처음 ``{`` 또는 ``[`` 부터 ``raw_decode`` 로 한 value 를
+    파싱하고 나머지 stdout (text 모드 잔존물 등) 는 무시한다 (approval
+    drift test 동형). ``fmt.success``/``fmt.output`` 출력은 dict.
+    """
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+def _make_mock_db(
+    fetch_one: Any = None,
+    fetch_all: list[Any] | None = None,
+    raise_on_query: Exception | None = None,
+) -> AsyncMock:
+    """``Database`` mock — ``connect`` / ``close`` / ``fetch_*`` async 메서드.
+
+    ``transactions`` leaf 는 ``Database(get_db_path())`` 를 직접 생성하므로
+    이 mock 이 필요하다. ``raise_on_query`` 가 주어지면 ``fetch_one`` /
+    ``fetch_all`` 가 그 예외를 raise (``no such table`` 분기 lock 용).
+    """
+    db = AsyncMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    if raise_on_query is not None:
+        db.fetch_one = AsyncMock(side_effect=raise_on_query)
+        db.fetch_all = AsyncMock(side_effect=raise_on_query)
+    else:
+        db.fetch_one = AsyncMock(return_value=fetch_one)
+        db.fetch_all = AsyncMock(return_value=fetch_all or [])
+    db.execute = AsyncMock()
+    return db
+
+
+def _make_mock_treasury(
+    *,
+    summary: dict[str, Any] | None = None,
+    budgets: list[BotBudget] | None = None,
+    daily_snapshot: dict[str, Any] | None = None,
+    snapshots_range: list[dict[str, Any]] | None = None,
+    latest_snapshot: dict[str, Any] | None = None,
+    account_id: str = "acc-1",
+) -> AsyncMock:
+    """``Treasury`` mock — CLI 가 호출하는 메서드들의 응답을 customize.
+
+    ``Treasury`` 는 sync/async 메서드 mix 다 (``get_summary``/``list_budgets``
+    은 sync; ``get_daily_snapshot``/``get_snapshots``/``get_latest_snapshot``/
+    ``set_account_balance`` 는 async). ``AsyncMock`` 은 모든 attribute 접근에
+    AsyncMock 을 반환하므로 sync 메서드는 ``MagicMock`` 으로 덮어쓴다.
+    """
+    t = AsyncMock()
+    t.account_id = account_id
+    # sync 메서드는 MagicMock 으로 덮어쓴다.
+    t.get_summary = MagicMock(
+        return_value=summary
+        or {
+            "account_balance": 10_000_000.0,
+            "purchasable_amount": 10_000_000.0,
+            "total_evaluation": 12_500_000.0,
+            "total_profit_loss": 500_000.0,
+            "total_allocated": 2_500_000.0,
+            "total_reserved": 0.0,
+            "unallocated": 7_500_000.0,
+            "bot_count": 2,
+        }
+    )
+    t.list_budgets = MagicMock(return_value=budgets or [])
+    # async 메서드.
+    t.get_daily_snapshot = AsyncMock(return_value=daily_snapshot)
+    t.get_snapshots = AsyncMock(return_value=snapshots_range or [])
+    t.get_latest_snapshot = AsyncMock(return_value=latest_snapshot)
+    t.set_account_balance = AsyncMock()
+    # 잔고 (set-balance cold_path 분기 fallback shape).
+    t.account_balance = (summary or {}).get("account_balance", 10_000_000.0)
+    return t
+
+
+@pytest.fixture
+def mock_create_treasury():
+    """``treasury._create_treasury`` 를 patch — ``(treasury_mock, db_mock)`` 반환.
+
+    treasury.py 의 ``status`` / ``set-balance`` (cold_path 분기) / ``snapshot``
+    / ``portfolio value`` (with --account) / ``portfolio history`` (with
+    --account) / ``budgets`` (with --account) 가 사용한다.
+    """
+    t = _make_mock_treasury()
+    db = AsyncMock()
+    db.close = AsyncMock()
+
+    async def _stub_create(account_id=None):  # noqa: ANN001, ANN202
+        return t, db
+
+    with patch(
+        "ante.cli.commands.treasury._create_treasury",
+        side_effect=_stub_create,
+    ):
+        yield t, db
+
+
+@pytest.fixture
+def mock_ipc_send():
+    """``ipc_send`` 를 mock 한다 (runtime_ipc 분기 leaf 용).
+
+    각 테스트가 ``mock_ipc.return_value`` 를 설정해 IPC 응답을 customize.
+    treasury.py 는 ``from ante.cli.commands.ipc_helpers import ipc_send``
+    를 함수 내부에서 lazy import 하므로 원본 모듈을 patch 해야 한다.
+    ``set-balance`` 는 ``is_active_runtime() == True`` 분기로만 IPC 를
+    사용하므로 그 게이트도 함께 patch 해야 한다 (account/bot 동형).
+    """
+    with patch("ante.cli.commands.ipc_helpers.ipc_send", new=AsyncMock()) as m:
+        yield m
+
+
+# ── 1. treasury status → raw_legacy ────────────────────────────────────────
+
+
+def test_treasury_status_envelope_matches_raw_legacy(mock_create_treasury) -> None:
+    """``treasury status``: ``fmt.output(result)`` 평면 summary dict (raw_legacy)."""
+    _t, _db = mock_create_treasury
+
+    result = _invoke(["--format", "json", "treasury", "status", "--account", "acc-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"treasury status: standard envelope 아니어야 함 (registry "
+        f"envelope=raw_legacy 와 정합). 실제 payload={payload!r}"
+    )
+    # summary 평면 키 셋: account_balance / purchasable_amount /
+    # total_evaluation / total_profit_loss / total_allocated /
+    # total_reserved / unallocated / bot_count.
+    assert payload["account_balance"] == 10_000_000.0
+    assert payload["bot_count"] == 2
+
+
+# ── 2. treasury transactions (empty no-table / non-empty) → raw_legacy ────
+
+
+def test_treasury_transactions_empty_envelope_matches_raw_legacy() -> None:
+    """``treasury transactions`` (no such table 분기): ``{items: [], total: 0}``.
+
+    treasury.py 240-243: ``treasury_transactions`` 테이블이 부재하면 SELECT
+    실패가 빈 결과로 다운그레이드된다. JSON 모드는 ``fmt.output(result)``.
+    """
+    db = _make_mock_db(raise_on_query=Exception("no such table: treasury_transactions"))
+    # treasury.py 가 함수 내부에서 ``from ante.core.database import Database``
+    # 를 lazy import 하므로 원본 모듈만 patch 한다.
+    with patch("ante.core.database.Database", return_value=db):
+        result = _invoke(["--format", "json", "treasury", "transactions"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"treasury transactions empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"items": [], "total": 0}
+
+
+def test_treasury_transactions_non_empty_envelope_matches_raw_legacy() -> None:
+    """``treasury transactions`` non-empty: ``{items: [...], total}`` 평면.
+
+    treasury.py 244-256: row mapping 으로 ``items`` 리스트 + ``total`` 카운트.
+    """
+    sample_row = {
+        "id": 1,
+        "account_id": "acc-1",
+        "transaction_type": "allocate",
+        "bot_id": "bot-1",
+        "amount": 100_000.0,
+        "description": "테스트 할당",
+        "created_at": "2026-01-01T00:00:00",
+    }
+    db = _make_mock_db(
+        fetch_one={"cnt": 1},
+        fetch_all=[sample_row],
+    )
+    with patch("ante.core.database.Database", return_value=db):
+        result = _invoke(["--format", "json", "treasury", "transactions"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"treasury transactions non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["total"] == 1
+    assert len(payload["items"]) == 1
+    assert payload["items"][0]["id"] == 1
+    assert payload["items"][0]["type"] == "allocate"
+    assert payload["items"][0]["bot_id"] == "bot-1"
+
+
+# ── 3. treasury budgets → raw_legacy ─────────────────────────────────────
+
+
+def test_treasury_budgets_envelope_matches_raw_legacy(mock_create_treasury) -> None:
+    """``treasury budgets`` (with --account): ``{budgets: [...]}`` 평면.
+
+    treasury.py 290-327: ``fmt.output({"budgets": items})`` JSON 모드.
+    """
+    t, _db = mock_create_treasury
+    t.list_budgets = MagicMock(
+        return_value=[
+            BotBudget(
+                bot_id="bot-1",
+                account_id="acc-1",
+                allocated=1_000_000.0,
+                available=900_000.0,
+                reserved=100_000.0,
+            )
+        ]
+    )
+
+    result = _invoke(["--format", "json", "treasury", "budgets", "--account", "acc-1"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"treasury budgets: standard envelope 아님. payload={payload!r}"
+    )
+    assert "budgets" in payload
+    assert isinstance(payload["budgets"], list)
+    assert payload["budgets"][0]["bot_id"] == "bot-1"
+    assert payload["budgets"][0]["allocated"] == 1_000_000.0
+
+
+# ── 4. treasury set-balance → raw_legacy ─────────────────────────────────
+
+
+def test_treasury_set_balance_envelope_matches_raw_legacy(mock_ipc_send) -> None:
+    """``treasury set-balance`` (IPC 분기): ``{account_id, total_balance, ...}`` 평면.
+
+    treasury.py 386-389: ``fmt.output(result)`` JSON 모드. IPC 응답을 그대로
+    dump 한다 (account ``set-credentials`` 동형 — IPC envelope passthrough).
+    runtime IPC 분기를 강제하기 위해 ``is_active_runtime`` 도 True 로 patch.
+    """
+    mock_ipc_send.return_value = {
+        "account_id": "acc-1",
+        "total_balance": 15_000_000.0,
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    with patch("ante.cli.cold_path.is_active_runtime", return_value=True):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "treasury",
+                "set-balance",
+                "15000000",
+                "--account",
+                "acc-1",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"treasury set-balance: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["account_id"] == "acc-1"
+    assert payload["total_balance"] == 15_000_000.0
+
+
+# ── 5. treasury allocate → standard ──────────────────────────────────────
+
+
+def test_treasury_allocate_envelope_matches_operation_standard(mock_ipc_send) -> None:
+    """``treasury allocate``: 단일 success 경로 ``fmt.success(message, data)``.
+
+    treasury.py 453-457: ``fmt.success(message, {"bot_id", "amount",
+    "account_id"})`` standard envelope.
+    """
+    mock_ipc_send.return_value = {
+        "success": True,
+        "bot_id": "bot-1",
+        "amount": 100_000.0,
+    }
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "treasury",
+            "allocate",
+            "bot-1",
+            "100000",
+            "--account",
+            "acc-1",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"treasury allocate: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "예산 할당 완료" in payload["message"]
+    assert payload["data"]["bot_id"] == "bot-1"
+    assert payload["data"]["amount"] == 100_000.0
+    assert payload["data"]["account_id"] == "acc-1"
+
+
+# ── 6. treasury deallocate → standard ────────────────────────────────────
+
+
+def test_treasury_deallocate_envelope_matches_operation_standard(
+    mock_ipc_send,
+) -> None:
+    """``treasury deallocate``: 단일 success 경로 ``fmt.success(message, data)``.
+
+    treasury.py 515-519: ``fmt.success(message, {"bot_id", "amount",
+    "account_id"})`` standard envelope (allocate 동형).
+    """
+    mock_ipc_send.return_value = {
+        "success": True,
+        "bot_id": "bot-1",
+        "amount": 50_000.0,
+    }
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "treasury",
+            "deallocate",
+            "bot-1",
+            "50000",
+            "--account",
+            "acc-1",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"treasury deallocate: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "예산 회수 완료" in payload["message"]
+    assert payload["data"]["bot_id"] == "bot-1"
+    assert payload["data"]["amount"] == 50_000.0
+
+
+# ── 7. treasury snapshot (single / range) → raw_legacy ───────────────────
+
+
+_SAMPLE_SNAPSHOT = {
+    "account_id": "acc-1",
+    "snapshot_date": "2026-01-01",
+    "total_asset": 12_500_000.0,
+    "ante_eval_amount": 2_500_000.0,
+    "ante_purchase_amount": 2_500_000.0,
+    "unallocated": 10_000_000.0,
+    "account_balance": 10_000_000.0,
+    "total_allocated": 2_500_000.0,
+    "bot_count": 2,
+    "daily_pnl": 0.0,
+    "daily_return": 0.0,
+    "net_trade_amount": 0.0,
+    "unrealized_pnl": 0.0,
+    "created_at": "2026-01-01T23:59:59+00:00",
+}
+
+
+def test_treasury_snapshot_single_envelope_matches_raw_legacy(
+    mock_create_treasury,
+) -> None:
+    """``treasury snapshot --date``: 평면 snapshot dict (raw_legacy)."""
+    t, _db = mock_create_treasury
+    t.get_daily_snapshot = AsyncMock(return_value=_SAMPLE_SNAPSHOT)
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "treasury",
+            "snapshot",
+            "--date",
+            "2026-01-01",
+            "--account",
+            "acc-1",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"treasury snapshot single: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["snapshot_date"] == "2026-01-01"
+    assert payload["total_asset"] == 12_500_000.0
+
+
+def test_treasury_snapshot_range_envelope_matches_raw_legacy(
+    mock_create_treasury,
+) -> None:
+    """``treasury snapshot --from --to``: 평면 snapshot list (raw_legacy).
+
+    treasury.py 596-601: 기간 조회 분기는 ``get_snapshots`` 가 list 를 반환,
+    JSON 모드는 ``fmt.output(result)`` 가 list 를 그대로 dump.
+    """
+    t, _db = mock_create_treasury
+    t.get_snapshots = AsyncMock(
+        return_value=[
+            _SAMPLE_SNAPSHOT,
+            {**_SAMPLE_SNAPSHOT, "snapshot_date": "2026-01-02"},
+        ]
+    )
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "treasury",
+            "snapshot",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-02",
+            "--account",
+            "acc-1",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"treasury snapshot range: standard envelope 아님. payload={payload!r}"
+    )
+    assert isinstance(payload, list)
+    assert len(payload) == 2
+    assert payload[0]["snapshot_date"] == "2026-01-01"
+
+
+# ── 8. treasury portfolio value → raw_legacy ─────────────────────────────
+
+
+def test_treasury_portfolio_value_envelope_matches_raw_legacy(
+    mock_create_treasury,
+) -> None:
+    """``treasury portfolio value`` (with --account): ``{total_value, ...}`` 평면.
+
+    treasury.py 715-722: ``fmt.output(result)`` 평면 dict (``total_value``,
+    ``daily_pnl``, ``daily_return``, ``unrealized_pnl``, ``accounts``,
+    ``updated_at``).
+    """
+    t, _db = mock_create_treasury
+    t.get_latest_snapshot = AsyncMock(
+        return_value={
+            "total_asset": 12_500_000.0,
+            "daily_pnl": 150_000.0,
+            "daily_return": 1.2,
+            "unrealized_pnl": 50_000.0,
+            "snapshot_date": "2026-01-01",
+            "created_at": "2026-01-01T23:59:59+00:00",
+        }
+    )
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "treasury",
+            "portfolio",
+            "value",
+            "--account",
+            "acc-1",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"treasury portfolio value: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["total_value"] == 12_500_000.0
+    assert payload["daily_pnl"] == 150_000.0
+    assert "accounts" in payload
+    assert isinstance(payload["accounts"], list)
+
+
+# ── 9. treasury portfolio history → raw_legacy ───────────────────────────
+
+
+def test_treasury_portfolio_history_envelope_matches_raw_legacy(
+    mock_create_treasury,
+) -> None:
+    """``treasury portfolio history`` (with --account): ``{data, start_date,
+    end_date}`` 평면.
+
+    treasury.py 814: ``return {"data": data, "start_date": ..., "end_date":
+    ...}`` → JSON 모드는 ``fmt.output(result)``.
+    """
+    t, _db = mock_create_treasury
+    t.get_snapshots = AsyncMock(
+        return_value=[
+            {
+                "snapshot_date": "2026-01-01",
+                "total_asset": 12_500_000.0,
+                "daily_pnl": 0.0,
+                "daily_return": 0.0,
+                "unrealized_pnl": 0.0,
+            },
+            {
+                "snapshot_date": "2026-01-02",
+                "total_asset": 12_650_000.0,
+                "daily_pnl": 150_000.0,
+                "daily_return": 1.2,
+                "unrealized_pnl": 50_000.0,
+            },
+        ]
+    )
+
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "treasury",
+            "portfolio",
+            "history",
+            "--account",
+            "acc-1",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-02",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"treasury portfolio history: standard envelope 아님. payload={payload!r}"
+    )
+    assert "data" in payload
+    assert isinstance(payload["data"], list)
+    assert len(payload["data"]) == 2
+    assert payload["start_date"] == "2026-01-01"
+    assert payload["end_date"] == "2026-01-02"


### PR DESCRIPTION
## Summary

#1846 (account 9) / #1847 sub-PR 1 (member 12) / sub-PR 2 (bot 11) / sub-PR 3 (approval 10) 동형 패턴으로 treasury 도메인 9 leaf 의 `OutputContract` / `AuthContract` / `ExecutionClass` 를 `CLI_COMMAND_REGISTRY` SSOT 에 등록한다.

이슈 #1847 본문은 treasury "8 leaf" 로 추정했지만 실측 Click leaf iterator (`tests.unit.contracts.helpers.iter_click_leaf_commands`) 는 9 leaf 를 반환한다 — spec 표 (`docs/specs/cli/03-commands.md:408-427`) 가 `portfolio value/history` 를 한 줄로 묶어 표현하지만 Click subgroup `treasury portfolio` 아래 두 leaf 가 별도로 존재한다. registry 는 canonical Click tree 기준이므로 9 entries 모두 등록한다.

## 등록 entry (9 leaf)

| # | path | auth | output | execution | ipc_command stub |
|---|------|------|--------|-----------|------------------|
| 1 | `("treasury", "status")` | scoped `{treasury:read}` | raw / raw_legacy | offline | — |
| 2 | `("treasury", "transactions")` | scoped `{treasury:read}` | raw / raw_legacy | offline | — |
| 3 | `("treasury", "budgets")` | scoped `{treasury:read}` | raw / raw_legacy | offline | — |
| 4 | `("treasury", "set-balance")` | scoped `{treasury:admin}` | raw / raw_legacy | runtime_ipc | `treasury.set_balance` |
| 5 | `("treasury", "allocate")` | scoped `{treasury:admin}` | operation / standard | runtime_ipc | `treasury.allocate` |
| 6 | `("treasury", "deallocate")` | scoped `{treasury:admin}` | operation / standard | runtime_ipc | `treasury.deallocate` |
| 7 | `("treasury", "snapshot")` | scoped `{treasury:read}` | raw / raw_legacy | offline | — |
| 8 | `("treasury", "portfolio", "value")` | scoped `{treasury:read}` | raw / raw_legacy | offline | — |
| 9 | `("treasury", "portfolio", "history")` | scoped `{treasury:read}` | raw / raw_legacy | offline | — |

execution 분류 (03-commands.md:112-119 SSOT):
- offline (6): `status` / `transactions` / `budgets` / `snapshot` / `portfolio value` / `portfolio history`
- runtime_ipc (3): `set-balance` / `allocate` / `deallocate`

`set-balance` 는 `is_active_runtime()` 분기로 cold_path fallback 을 보유하지만 spec primary 분류 `runtime_ipc` 만 lock (account `suspend`/`activate` / member `update-scopes` / bot 동형 정책).

`ipc_command` 필드는 stub 값만 채움. server-side IPC registry 와의 cross-ref drift test 는 `#1819` 의 책임이다.

## Diff guard

`src/ante/cli/commands/treasury.py` 본문 0 lines 변경 (`git diff origin/main..HEAD -- src/ante/cli/commands/treasury.py | wc -l` = 0).

## 검증

- `pytest tests/unit/contracts -v` → 105 PASS (registry shell + treasury shell test 신규 + auth/error drift)
- `pytest tests/unit/test_treasury_success_output_drift.py -v` → 12 PASS (registry sanity + 9 leaf + transactions empty/non-empty 분리 + snapshot single/range 분리)
- `pytest tests/unit/test_{account,member,bot,approval}_success_output_drift.py` → 55 PASS (sub-PR 1-3 회귀 0)
- `pytest tests/unit/` (worktree) → 5101 passed, 217 failed, 2 skipped, 26 warnings
- `pytest tests/unit/` (origin/main baseline) → 5088 passed, 217 failed, 2 skipped, 21 warnings
- 차이: passed +13 (= 12 drift + 1 shell), failed FAILED set byte-identical. **본 PR 회귀 0** (217 pre-existing failures 는 main HEAD `caeb3fec` 에서 동일하게 재현)
- `mypy src/ante` → clean (223 files)
- `ruff check` + `ruff format --check` → clean
- `git diff origin/main..HEAD -- src/ante/cli/commands/treasury.py` → 0 lines (**diff guard PASS**)
- main HEAD `caeb3fec` 불변 확인

## Spec ↔ code 메모 (#1819 / 별도 follow-up 대상)

`set-balance` 는 `is_active_runtime() == True` 일 때만 `ipc_send("treasury.set_balance", ...)` 분기를 실행한다. `allocate` / `deallocate` 는 항상 IPC 분기다. server-side IPC handler 등록 cross-ref 검증은 `#1819` 의 책임.

## 다음 sub-PR

- sub-PR 5: strategy (7 leaf, offline + cold_path). #1846 / #1847 sub-PR 1-4 의 mechanical sweep 패턴 가속 적용 가능.

Refs #1847