### PR TITLE
refactor: #1847-5 strategy domain OutputContract migration (7 leaf entries)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -608,7 +608,8 @@ tests/
 │   ├── test_member_success_output_drift.py
 │   ├── test_bot_success_output_drift.py
 │   ├── test_approval_success_output_drift.py
-│   └── test_treasury_success_output_drift.py
+│   ├── test_treasury_success_output_drift.py
+│   └── test_strategy_success_output_drift.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -18,16 +18,17 @@ execution 계약을 한 곳에서 관리하는 registry 다.
   (#1847 sub-PR 3).
 * :data:`TREASURY_CONTRACTS` — treasury 도메인 9 leaf contract tuple
   (#1847 sub-PR 4).
+* :data:`STRATEGY_CONTRACTS` — strategy 도메인 7 leaf contract tuple
+  (#1847 sub-PR 5).
 * :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
   PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
-  = 51 entries 가 채워져 있다.
+  + strategy 7 = 58 entries 가 채워져 있다.
 * :func:`get_contract` / :func:`all_contracts` — read-only accessor.
 
 본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
 
-* 잔여 도메인 entry 등록 (`#1847` sub-PR 5 이후 — strategy / broker /
-  data / report / system / instrument / config / rule / trade / backtest /
-  audit / signal).
+* 잔여 도메인 entry 등록 (`#1847` sub-PR 6 이후 — broker / data / report /
+  system / instrument / config / rule / trade / backtest / audit / signal).
 * output payload migration (`#1846` / `#1847` 는 raw_legacy 를 *문서화*
   만 하며 fmt callsite 를 바꾸지 않는다 — diff guard 가 본 PR 의 invariant).
 * drift test guard 완전 활성화 — 미등록 leaf FAIL 은 `#1848` 의 책임.
@@ -77,6 +78,7 @@ __all__ = [
     "BOT_CONTRACTS",
     "CLI_COMMAND_REGISTRY",
     "MEMBER_CONTRACTS",
+    "STRATEGY_CONTRACTS",
     "TREASURY_CONTRACTS",
     "AuthContract",
     "CliCommandContract",
@@ -852,6 +854,135 @@ snapshot → portfolio value/history) 와 시각적으로 일치하도록 정렬
 """
 
 
+# ── #1847 sub-PR 5: strategy domain OutputContract migration ────────────
+#
+# strategy 도메인 7 leaf 의 contract entry. ``src/ante/cli/commands/strategy.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:105-111`` (실행 분류) / ``395-403`` (커맨드
+# 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (6 commands): ``submit`` / ``list`` / ``set-status`` /
+# ``info`` / ``summary`` / ``performance`` 는 JSON 모드에서 ``fmt.output(
+# result)`` 평면 dict 를 그대로 dump 한다. ``submit`` 는 성공 시 ``{submitted:
+# True, strategy_id, ...}`` 평면 dict, ``list`` 는 ``{strategies: [...]}`` 또는
+# ``{message, strategies: []}`` 평면, ``set-status`` 는 IPC 또는 cold_path
+# 분기 결과 평면, ``info`` 는 metadata + params 평면 dict, ``summary`` 는
+# ``{strategy_id, period, bot_id, items}`` 평면, ``performance`` 는
+# ``{strategy_name, strategy_id, metrics}`` 평면. 도메인 envelope 형태이며
+# standard envelope ``{status, message, data}`` 3 키 셋과는 다르다.
+# ``OutputContract(kind="raw", envelope="raw_legacy")`` 조합으로 표현해 lock
+# 만 한다 — strategy.py 본문 변경 없음 (drift test 가 callsite 변경 시 FAIL).
+#
+# standard envelope (1 command): ``validate`` 는 단일 success 경로
+# ``fmt.success(f"Strategy validation passed: ...", data)`` 만 호출하며 표준
+# envelope (``{status, message, data}``) 을 dump 한다. invalid 분기는 별도
+# ``fmt.error`` 또는 ``fmt.output({"status": "error", ...})`` 이지만 본 drift
+# test 의 success-output scope 밖이다.
+#
+# scope 분류 (#1815 SSOT, strategy.py @require_scope marker 와 1:1 정합):
+# - ``strategy:read`` scope (4 개): ``list`` / ``info`` / ``summary`` /
+#   ``performance``.
+# - ``strategy:write`` scope (3 개): ``validate`` / ``submit`` / ``set-status``.
+# - public allowlist: 없음 — strategy 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:105-111`` SSOT):
+# - ``offline`` (6 개): ``validate`` / ``submit`` / ``list`` / ``info`` /
+#   ``summary`` / ``performance``. 각 leaf 는 ``Database`` 와
+#   ``StrategyRegistry`` / ``PerformanceTracker`` / ``StrategyValidator`` /
+#   ``StrategyLoader`` 를 직접 생성한다.
+# - ``runtime_ipc`` (1 개): ``set-status``. ``is_active_runtime()`` 분기로
+#   ``ipc_send("strategy.set_status", ...)`` 를 호출하고, runtime 비활성 시
+#   cold_path fallback 으로 ``StrategyRegistry`` 를 직접 사용한다. spec
+#   primary 분류는 runtime_ipc 다 (account ``suspend``/``activate`` /
+#   member ``update-scopes`` / treasury ``set-balance`` 동형 — fallback 분기가
+#   있어도 spec primary 분류만 lock).
+#
+# ``ipc_command`` 필드는 stub 값만 채운다 (``"strategy.set_status"``); 단순
+# 문자열 lock 이며 server-side IPC registry 와의 cross-ref drift test 는
+# #1819 의 책임이다 (account/member/bot/approval/treasury 동형 정책).
+# strategy.py 호출 사이트의 IPC command name 과 그대로 일치한다.
+STRATEGY_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("strategy", "validate"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"strategy:write"})),
+        # 단일 success 경로 ``fmt.success(f"Strategy validation passed: ...",
+        # data)`` → standard envelope. invalid 분기는 ``fmt.error`` / ``fmt.output(
+        # {"status": "error", ...})`` 이지만 success-output drift scope 밖.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("strategy", "submit"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"strategy:write"})),
+        # JSON mode 성공 경로: ``fmt.output(result)`` 평면 dict (``{submitted:
+        # True, strategy_id, name, version, ...}``). text 모드는 ``fmt.success``
+        # 분기. validation/load/meta_validation/register 실패 분기도 모두
+        # ``fmt.output({"submitted": False, "stage", "code", ...})`` 평면 dict
+        # 이지만 success-output drift scope 밖 (실패 분기는 별도).
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("strategy", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"strategy:read"})),
+        # JSON mode: empty → ``fmt.output({"message": "등록된 전략 없음",
+        # "strategies": []})`` 평면, non-empty → ``fmt.output({"strategies":
+        # [...]})`` 평면. text 는 fmt.table.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("strategy", "info"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"strategy:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 metadata + params dict
+        # (``{strategy_id, name, version, status, description, author_name,
+        # author_id, filepath, registered_at, validation_warnings, params?,
+        # param_schema?, rationale?, risks?, other_versions?}``). text 는
+        # click.echo 8+ 줄.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("strategy", "performance"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"strategy:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{strategy_name,
+        # strategy_id, metrics: {...}}``). text 는 click.echo 다수 줄.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("strategy", "set-status"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"strategy:write"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict — IPC 분기와 cold_path
+        # 분기 모두 ``{strategy_id, status, name, version, ...}`` 평면 shape
+        # 를 그대로 dump 한다 (account ``set-credentials`` / treasury
+        # ``set-balance`` 동형 raw_legacy 정책). spec 은 ``runtime IPC`` 이며
+        # ``is_active_runtime()`` 분기로 cold_path fallback 을 보유하지만
+        # primary 분류만 lock.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="strategy.set_status",
+    ),
+    CliCommandContract(
+        path=("strategy", "summary"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"strategy:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{strategy_id, period,
+        # bot_id, items: [...]}``). text 는 fmt.table 또는 empty 분기에서
+        # ``fmt.output({"message": "성과 집계 없음", "items": []})``.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+)
+"""Strategy domain 7 leaf 의 contract tuple (#1847 sub-PR 5).
+
+순서는 ``docs/specs/cli/03-commands.md:105-111`` 의 strategy 실행 분류 표
+(validate → submit → list → info → performance → set-status → summary) 와
+시각적으로 일치하도록 정렬된다. ``CLI_COMMAND_REGISTRY`` 에는 모듈 import
+시 자동으로 등록된다.
+"""
+
+
 CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
     contract.path: contract
     for contract in (
@@ -860,16 +991,18 @@ CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
         *BOT_CONTRACTS,
         *APPROVAL_CONTRACTS,
         *TREASURY_CONTRACTS,
+        *STRATEGY_CONTRACTS,
     )
 }
 """Leaf command path → contract mapping.
 
 본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
-= 51 entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 /
-#1847 sub-PR 3 / #1847 sub-PR 4). 나머지 도메인 (strategy / broker / data
-/ report / system / instrument / config / rule / trade / backtest / audit /
-signal) 의 entry 등록은 후속 PR (`#1847` sub-PR 5-9) 의 책임이다. registry
-미등록 leaf 가 FAIL 이어야 하는 drift guard 는 `#1848` 가 활성화한다.
++ strategy 7 = 58 entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847
+sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5). 나머지 도메인
+(broker / data / report / system / instrument / config / rule / trade /
+backtest / audit / signal) 의 entry 등록은 후속 PR (`#1847` sub-PR 6-9) 의
+책임이다. registry 미등록 leaf 가 FAIL 이어야 하는 drift guard 는 `#1848`
+가 활성화한다.
 """
 
 
@@ -889,7 +1022,7 @@ def all_contracts() -> Iterator[CliCommandContract]:
     """등록된 모든 contract 를 dict 순회 순서로 yield 한다.
 
     본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury
-    9 = 51 entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR
-    2 / #1847 sub-PR 3 / #1847 sub-PR 4).
+    9 + strategy 7 = 58 entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 /
+    #1847 sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5).
     """
     yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -180,13 +180,16 @@ def test_raw_legacy_is_envelope_form_not_contract_kind() -> None:
 
 
 def test_get_contract_returns_none_when_missing() -> None:
-    """미등록 path 는 ``None`` 을 반환한다 (account/member/bot/approval/treasury 외)."""
+    """미등록 path 는 ``None`` 을 반환한다 (등록된 6 도메인 외).
+
+    등록 도메인: account / member / bot / approval / treasury / strategy.
+    """
     # nonexistent path 는 항상 ``None``.
     assert get_contract(("nonexistent",)) is None
-    # strategy 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 5 이후) 의
-    # 책임이므로 본 PR 시점에는 ``None`` 이다 (treasury domain 은 sub-PR 4
+    # broker 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 6 이후) 의
+    # 책임이므로 본 PR 시점에는 ``None`` 이다 (strategy domain 은 sub-PR 5
     # 에서 등록되었다).
-    assert get_contract(("strategy", "list")) is None
+    assert get_contract(("broker", "status")) is None
 
 
 def test_registry_is_mutable_dict() -> None:
@@ -337,6 +340,31 @@ def test_treasury_entries_registered_after_1847_sub_pr_4() -> None:
     assert expected_treasury_paths.issubset(registered), (
         f"treasury 9 entry 가 모두 등록되어야 한다 (#1847 sub-PR 4). "
         f"누락: {sorted(expected_treasury_paths - registered)}"
+    )
+
+
+def test_strategy_entries_registered_after_1847_sub_pr_5() -> None:
+    """#1847 sub-PR 5 가 strategy 7 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 5 가 strategy migration 을 완료한 시점부터
+    lock 된다. 7 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_strategy_success_output_drift` 가
+    책임진다.
+    """
+    expected_strategy_paths = {
+        ("strategy", "validate"),
+        ("strategy", "submit"),
+        ("strategy", "list"),
+        ("strategy", "info"),
+        ("strategy", "performance"),
+        ("strategy", "set-status"),
+        ("strategy", "summary"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_strategy_paths.issubset(registered), (
+        f"strategy 7 entry 가 모두 등록되어야 한다 (#1847 sub-PR 5). "
+        f"누락: {sorted(expected_strategy_paths - registered)}"
     )
 
 

--- a/tests/unit/test_strategy_success_output_drift.py
+++ b/tests/unit/test_strategy_success_output_drift.py
@@ -1,0 +1,616 @@
+"""Strategy CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 5).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+strategy 도메인 7 leaf 의 ``OutputContract`` 와 ``ante strategy ... --format
+json`` 실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1 (member) / #1847 sub-PR 2 (bot) / #1847
+sub-PR 3 (approval) / #1847 sub-PR 4 (treasury) 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 으로
+  평면 dict 를 그대로 dump 한다 (``status`` / ``message`` / ``data`` 3 키
+  모두 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``strategy.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면
+본 test 가 즉시 FAIL 한다 (registry 갱신 또는 callsite 정렬 중 한쪽이 책임).
+
+10 시나리오 (7 leaf + registry sanity +1 + list empty 분기 +1 + summary
+empty JSON 분기 +1):
+
+0. registry sanity — strategy 7 entries 의 envelope 이 ``standard`` /
+   ``raw_legacy`` 분류 범위 내.
+1. ``validate`` (valid 분기) → ``standard`` (``fmt.success(message, data)``)
+2. ``submit`` (성공 register) → ``raw_legacy`` (``fmt.output(result)`` 평면
+   ``{submitted: True, strategy_id, ...}``)
+3. ``list`` empty → ``raw_legacy`` (``{message, strategies: []}``)
+4. ``list`` non-empty → ``raw_legacy`` (``{strategies: [...]}``)
+5. ``info`` (found) → ``raw_legacy`` (``fmt.output(result)`` 평면 metadata
+   + params dict)
+6. ``summary`` (with items) → ``raw_legacy`` (``fmt.output(result)`` 평면
+   ``{strategy_id, period, bot_id, items}``)
+7. ``summary`` empty JSON 분기 → ``raw_legacy`` (``fmt.output(result)``
+   동일 평면 ``{strategy_id, period, bot_id, items: []}``)
+8. ``performance`` (found) → ``raw_legacy`` (``fmt.output(result)`` 평면
+   ``{strategy_name, strategy_id, metrics}``)
+9. ``set-status`` (IPC 분기) → ``raw_legacy`` (``fmt.output(result)`` 평면
+   ``{strategy_id, status, name, version}``)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.strategy.registry import StrategyRecord, StrategyStatus
+from ante.strategy.validator import ValidationResult
+from ante.trade.models import PerformanceMetrics
+
+# ── envelope shape predicates (envelopes.md SSOT, account/member/bot/approval 동형) ──
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict 또는 list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언.
+
+    raw_legacy 는 ``fmt.output(dict)`` 출력의 super-set 이다. ``status``/
+    ``message``/``data`` 3 키가 동시에 갖춰지고 ``status == "ok"`` 면
+    standard envelope 으로 분류 (애매한 경계 방지). 그렇지 않으면 모든
+    평면 도메인 payload 는 raw_legacy.
+    """
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_strategy_entries_envelopes_classified() -> None:
+    """strategy 7 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 7 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    strategy_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("strategy",)
+    ]
+    assert len(strategy_entries) == 7, (
+        f"strategy 7 entries 가 모두 등록되어야 한다. 실제: {len(strategy_entries)}"
+    )
+    for path, contract in strategy_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (account/member/bot/approval/treasury drift test 동형) ──────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (account/member/bot/approval/treasury 동형)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json strategy ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다.
+
+    ``OutputFormatter`` 가 ``json.dumps(..., indent=2)`` 로 multi-line dump
+    하기 때문에 처음 ``{`` 또는 ``[`` 부터 ``raw_decode`` 로 한 value 를
+    파싱하고 나머지 stdout (text 모드 잔존물 등) 는 무시한다 (treasury
+    drift test 동형).
+    """
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── fixture: mock StrategyRegistry + Database (offline path) ───────────────
+
+
+def _make_record(
+    *,
+    strategy_id: str = "strat-1",
+    name: str = "my_strategy",
+    version: str = "1.0.0",
+    status: StrategyStatus = StrategyStatus.REGISTERED,
+) -> StrategyRecord:
+    """테스트용 ``StrategyRecord`` factory."""
+    return StrategyRecord(
+        strategy_id=strategy_id,
+        name=name,
+        version=version,
+        filepath="/tmp/nonexistent_strategy.py",
+        status=status,
+        registered_at=datetime(2026, 1, 1, tzinfo=UTC),
+        description="테스트 전략",
+        author_name="agent",
+        author_id="agent",
+        validation_warnings=[],
+    )
+
+
+@pytest.fixture
+def mock_create_registry():
+    """``strategy._create_registry`` 를 patch — ``(registry_mock, db_mock)`` 반환.
+
+    strategy.py 의 ``list`` / ``set-status`` (cold_path 분기) / ``info`` /
+    ``summary`` / ``submit`` (register) 가 사용한다. ``performance`` 는 자체
+    ``Database`` + ``StrategyRegistry`` 를 직접 생성하므로 별도 fixture 가
+    필요하다.
+    """
+    registry = AsyncMock()
+    db = AsyncMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    db.fetch_one = AsyncMock(return_value=None)
+    db.fetch_all = AsyncMock(return_value=[])
+    registry.initialize = AsyncMock()
+
+    async def _stub_create():
+        return registry, db
+
+    with patch(
+        "ante.cli.commands.strategy._create_registry",
+        side_effect=_stub_create,
+    ):
+        yield registry, db
+
+
+# ── 1. validate (valid) → standard ─────────────────────────────────────────
+
+
+def test_strategy_validate_valid_envelope_matches_operation_standard(tmp_path) -> None:
+    """``strategy validate``: valid 분기는 ``fmt.success(message, data)`` → standard.
+
+    strategy.py:86: ``fmt.success(f"Strategy validation passed: ...", data)``
+    분기. invalid 분기는 별도 ``fmt.error`` / ``fmt.output({"status": "error",
+    ...})`` 이지만 본 drift test 의 success-output scope 밖.
+    """
+    fake_path = tmp_path / "strat.py"
+    fake_path.write_text("# stub\n", encoding="utf-8")
+
+    valid_result = ValidationResult(valid=True, errors=[], warnings=[])
+    with patch(
+        "ante.strategy.validator.StrategyValidator.validate",
+        return_value=valid_result,
+    ):
+        result = _invoke(["--format", "json", "strategy", "validate", str(fake_path)])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"strategy validate: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "validation passed" in payload["message"].lower()
+    assert payload["data"]["valid"] is True
+
+
+# ── 2. submit (success register) → raw_legacy ──────────────────────────────
+
+
+def test_strategy_submit_success_envelope_matches_raw_legacy(
+    tmp_path, mock_create_registry
+) -> None:
+    """``strategy submit``: 성공 시 JSON 모드 ``fmt.output(result)`` 평면.
+
+    strategy.py:276-277: ``if fmt.is_json: fmt.output(result)`` 평면
+    ``{submitted: True, strategy_id, name, version, description, author_name,
+    author_id, filepath, registered_at, validation_warnings}``. text 모드는
+    ``fmt.success`` 분기지만 JSON 모드는 raw_legacy.
+    """
+    fake_path = tmp_path / "strat.py"
+    fake_path.write_text("# stub\n", encoding="utf-8")
+
+    registry, _db = mock_create_registry
+    record = _make_record()
+    registry.register = AsyncMock(return_value=record)
+
+    # ValidationResult.valid=True 와 StrategyLoader 가 dummy class 반환을 mock.
+    valid_result = ValidationResult(valid=True, errors=[], warnings=[])
+
+    # dummy Strategy class 와 meta (실제 StrategyMeta 인스턴스가 필요).
+    from ante.strategy.base import StrategyMeta
+
+    fake_meta = StrategyMeta(
+        name="my_strategy",
+        version="1.0.0",
+        description="테스트 전략",
+        author_name="agent",
+        author_id="agent",
+    )
+
+    class _FakeStrategy:
+        meta = fake_meta
+
+        def __init__(self, ctx):
+            pass
+
+        def get_rationale(self):
+            return ""
+
+        def get_risks(self):
+            return []
+
+    with (
+        patch(
+            "ante.strategy.validator.StrategyValidator.validate",
+            return_value=valid_result,
+        ),
+        patch(
+            "ante.strategy.loader.StrategyLoader.load",
+            return_value=_FakeStrategy,
+        ),
+    ):
+        result = _invoke(["--format", "json", "strategy", "submit", str(fake_path)])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"strategy submit success: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["submitted"] is True
+    assert payload["strategy_id"] == "strat-1"
+    assert payload["name"] == "my_strategy"
+    assert payload["version"] == "1.0.0"
+
+
+# ── 3. list empty → raw_legacy ─────────────────────────────────────────────
+
+
+def test_strategy_list_empty_envelope_matches_raw_legacy(mock_create_registry) -> None:
+    """``strategy list`` empty: ``{message, strategies: []}`` 평면 (raw_legacy).
+
+    strategy.py:352: ``fmt.output({"message": "등록된 전략 없음", "strategies":
+    []})`` 분기. text/JSON 양쪽 모두 본 평면 dict 를 echo (`fmt.output` 내부
+    branch). 정확히 JSON 모드를 단언한다.
+    """
+    registry, _db = mock_create_registry
+    registry.list_strategies = AsyncMock(return_value=[])
+
+    result = _invoke(["--format", "json", "strategy", "list"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"strategy list empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"message": "등록된 전략 없음", "strategies": []}
+
+
+# ── 4. list non-empty → raw_legacy ─────────────────────────────────────────
+
+
+def test_strategy_list_non_empty_envelope_matches_raw_legacy(
+    mock_create_registry,
+) -> None:
+    """``strategy list`` non-empty: ``{strategies: [...]}`` 평면 (raw_legacy).
+
+    strategy.py:355-356: ``if fmt.is_json: fmt.output({"strategies": rows})``.
+    """
+    registry, _db = mock_create_registry
+    registry.list_strategies = AsyncMock(return_value=[_make_record()])
+
+    result = _invoke(["--format", "json", "strategy", "list"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"strategy list non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert "strategies" in payload
+    assert isinstance(payload["strategies"], list)
+    assert payload["strategies"][0]["strategy_id"] == "strat-1"
+    assert payload["strategies"][0]["status"] == "registered"
+
+
+# ── 5. info (found) → raw_legacy ───────────────────────────────────────────
+
+
+def test_strategy_info_found_envelope_matches_raw_legacy(mock_create_registry) -> None:
+    """``strategy info`` 발견: ``fmt.output(result)`` 평면 metadata dict.
+
+    strategy.py:512-513: ``if fmt.is_json: fmt.output(result)`` → ``{strategy_id,
+    name, version, status, description, author_name, author_id, filepath,
+    registered_at, validation_warnings, ...}``. ``params`` / ``param_schema``
+    는 ``_load_strategy_params`` 가 ``filepath`` 부재로 ``None`` 일 때 생략.
+    """
+    registry, _db = mock_create_registry
+    record = _make_record(name="my_strategy")
+    registry.get_by_name = AsyncMock(return_value=[record])
+
+    result = _invoke(["--format", "json", "strategy", "info", "my_strategy"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"strategy info: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["name"] == "my_strategy"
+    assert payload["strategy_id"] == "strat-1"
+    assert payload["status"] == "registered"
+
+
+# ── 6. summary (with items) → raw_legacy ───────────────────────────────────
+
+
+def test_strategy_summary_with_items_envelope_matches_raw_legacy(
+    mock_create_registry,
+) -> None:
+    """``strategy summary`` with items: ``fmt.output(result)`` 평면 dict.
+
+    strategy.py:662-663: ``if fmt.is_json: fmt.output(result)`` → ``{strategy_id,
+    period, bot_id, items: [...]}``. text 모드는 fmt.table 분기.
+    """
+    from ante.trade.models import DailySummary
+
+    registry, _db = mock_create_registry
+    record = _make_record()
+    registry.get = AsyncMock(return_value=record)
+
+    # _find_bot_id_for_strategy 는 db.fetch_one 을 호출한다.
+    # mock_create_registry fixture 의 db 가 default 로 ``None`` 을 반환하지만,
+    # 본 케이스에서 bot_id 가 있는 결과를 보고 싶다면 fetch_one 을 customize.
+    _db.fetch_one = AsyncMock(return_value={"bot_id": "bot-1"})
+
+    daily = DailySummary(
+        date="2026-01-01",
+        realized_pnl=10_000.0,
+        trade_count=3,
+        win_rate=0.67,
+    )
+
+    # PerformanceTracker.get_daily_summary 를 mock.
+    with patch(
+        "ante.trade.performance.PerformanceTracker.get_daily_summary",
+        new=AsyncMock(return_value=[daily]),
+    ):
+        result = _invoke(
+            ["--format", "json", "strategy", "summary", "strat-1", "--period", "daily"]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"strategy summary with items: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["strategy_id"] == "strat-1"
+    assert payload["period"] == "daily"
+    assert payload["bot_id"] == "bot-1"
+    assert isinstance(payload["items"], list)
+    assert len(payload["items"]) == 1
+    assert payload["items"][0]["date"] == "2026-01-01"
+
+
+# ── 7. summary empty JSON 분기 → raw_legacy ────────────────────────────────
+
+
+def test_strategy_summary_empty_json_envelope_matches_raw_legacy(
+    mock_create_registry,
+) -> None:
+    """``strategy summary`` JSON 모드 empty items: ``fmt.output(result)`` 평면.
+
+    JSON 모드는 line 662 의 ``fmt.output(result)`` 로 평면 dict 를 그대로
+    dump 한다 (items 가 비어도 동일 평면). text 모드 분기 (line 665-668) 의
+    ``fmt.output({"message": "성과 집계 없음", "items": []})`` 는 별도
+    분기지만 JSON 모드 entry 와는 무관 (`fmt.is_json:` 가 먼저 true).
+    """
+    registry, _db = mock_create_registry
+    record = _make_record()
+    registry.get = AsyncMock(return_value=record)
+    _db.fetch_one = AsyncMock(return_value=None)  # bot_id 부재 → None.
+
+    # PerformanceTracker.get_daily_summary 가 빈 list 반환.
+    with patch(
+        "ante.trade.performance.PerformanceTracker.get_daily_summary",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = _invoke(
+            ["--format", "json", "strategy", "summary", "strat-1", "--period", "daily"]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"strategy summary empty json: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["strategy_id"] == "strat-1"
+    assert payload["bot_id"] is None
+    assert payload["items"] == []
+
+
+# ── 8. performance (found) → raw_legacy ────────────────────────────────────
+
+
+def test_strategy_performance_found_envelope_matches_raw_legacy() -> None:
+    """``strategy performance`` (found): ``fmt.output(result)`` 평면 dict.
+
+    strategy.py:807-808: ``if fmt.is_json: fmt.output(result)`` → ``{strategy_name,
+    strategy_id, metrics: {...}}``. ``performance`` 는 ``_create_registry`` 를
+    사용하지 않고 자체 ``Database`` + ``StrategyRegistry`` 를 만든다 — 그래서
+    ``Database`` 클래스를 직접 patch 한다.
+    """
+    record = _make_record(name="my_strategy")
+
+    # Database mock (account 존재 확인 쿼리 + close).
+    db = AsyncMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    db.fetch_one = AsyncMock(return_value={"1": 1})  # accounts 존재.
+    db.fetch_all = AsyncMock(return_value=[])
+    db.execute = AsyncMock()
+
+    metrics = PerformanceMetrics(
+        total_trades=10,
+        winning_trades=6,
+        losing_trades=4,
+        win_rate=0.6,
+        total_pnl=100_000.0,
+        total_commission=1_000.0,
+        net_pnl=99_000.0,
+        avg_profit=20_000.0,
+        avg_loss=5_000.0,
+        profit_factor=4.0,
+        max_drawdown=0.05,
+        max_drawdown_amount=5_000.0,
+        sharpe_ratio=None,
+        first_trade_at=None,
+        last_trade_at=None,
+        active_days=5,
+    )
+
+    # StrategyRegistry.get_by_name 와 PerformanceTracker.calculate 를 mock.
+    with (
+        patch("ante.core.database.Database", return_value=db),
+        patch(
+            "ante.strategy.registry.StrategyRegistry.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.strategy.registry.StrategyRegistry.get_by_name",
+            new=AsyncMock(return_value=[record]),
+        ),
+        patch(
+            "ante.trade.performance.PerformanceTracker.calculate",
+            new=AsyncMock(return_value=metrics),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "strategy",
+                "performance",
+                "my_strategy",
+                "--account-id",
+                "acc-1",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"strategy performance: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["strategy_name"] == "my_strategy"
+    assert payload["strategy_id"] == "strat-1"
+    assert "metrics" in payload
+    assert payload["metrics"]["total_trades"] == 10
+    assert payload["metrics"]["win_rate"] == 0.6
+
+
+# ── 9. set-status (IPC 분기) → raw_legacy ──────────────────────────────────
+
+
+def test_strategy_set_status_ipc_envelope_matches_raw_legacy() -> None:
+    """``strategy set-status`` (runtime IPC 분기): ``fmt.output(result)`` 평면.
+
+    strategy.py:425-426: ``if fmt.is_json: fmt.output(result)`` → IPC 응답
+    평면 dict (``{strategy_id, status, name, version}`` 또는 IPC handler 가
+    돌려준 임의 평면). spec 은 runtime IPC primary 이며 cold_path fallback
+    분기는 본 케이스에서 비활성화 (``is_active_runtime() == True`` 강제).
+
+    treasury ``set-balance`` / account ``set-credentials`` 동형 raw_legacy
+    정책 — IPC 응답을 wrapping 없이 그대로 dump.
+    """
+    ipc_response = {
+        "strategy_id": "strat-1",
+        "status": "adopted",
+        "name": "my_strategy",
+        "version": "1.0.0",
+    }
+
+    with (
+        patch("ante.cli.cold_path.is_active_runtime", return_value=True),
+        patch(
+            "ante.cli.commands.ipc_helpers.ipc_send",
+            new=AsyncMock(return_value=ipc_response),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "strategy",
+                "set-status",
+                "strat-1",
+                "--status",
+                "adopted",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"strategy set-status: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["strategy_id"] == "strat-1"
+    assert payload["status"] == "adopted"
+    assert payload["name"] == "my_strategy"


### PR DESCRIPTION
## 요약

`#1847` epic sub-PR 5 — strategy 도메인 7 leaf 의 OutputContract 를
`ante.contracts.cli_registry` 에 등록한다. `#1846` (account 9) /
`#1847-1` (member 12) / `#1847-2` (bot 11) / `#1847-3` (approval 10) /
`#1847-4` (treasury 9) 와 1:1 동형 패턴.

본 PR 누적 후 registry entry: account 9 + member 12 + bot 11 + approval 10 +
treasury 9 + strategy 7 = **58 entries**.

## 변경 범위

- `src/ante/contracts/cli_registry.py` — `STRATEGY_CONTRACTS` (7 leaf) +
  `CLI_COMMAND_REGISTRY` 누적 + `__all__` / docstring 갱신
- `tests/unit/contracts/test_cli_registry_shell.py` — `get_contract` 미등록
  sentinel 을 `broker` 로 이동 + `test_strategy_entries_registered_after_1847_sub_pr_5` 추가
- `tests/unit/test_strategy_success_output_drift.py` — 신규 (10 시나리오)
- `docs/architecture/generated/project-structure.md` — regen (새 drift test 반영)
- `src/ante/cli/commands/strategy.py` — **0 lines** (#1847 diff guard 정책)

## Leaf 표

| leaf path | auth scope | execution | OutputContract |
|-----------|-----------|-----------|----------------|
| `("strategy", "validate")` | `strategy:write` | `offline` | `operation` / `standard` |
| `("strategy", "submit")` | `strategy:write` | `offline` | `raw` / `raw_legacy` |
| `("strategy", "list")` | `strategy:read` | `offline` | `raw` / `raw_legacy` |
| `("strategy", "info")` | `strategy:read` | `offline` | `raw` / `raw_legacy` |
| `("strategy", "performance")` | `strategy:read` | `offline` | `raw` / `raw_legacy` |
| `("strategy", "set-status")` | `strategy:write` | `runtime_ipc` | `raw` / `raw_legacy` |
| `("strategy", "summary")` | `strategy:read` | `offline` | `raw` / `raw_legacy` |

`set-status` 의 `ipc_command` 필드는 `"strategy.set_status"` stub 으로 등록 —
server-side IPC registry cross-ref drift test 는 `#1819` 책임 (이슈 본문 v2
결정). `is_active_runtime() == True` 분기로만 IPC 를 호출하며 cold_path
fallback 분기를 보유하지만 spec primary 분류만 lock (account `suspend`/
`activate` / member `update-scopes` / treasury `set-balance` 동형).

## Drift test 시나리오 (10개)

`tests/unit/test_strategy_success_output_drift.py`:

0. registry sanity (7 entries envelope 분류)
1. `validate` (valid) → standard
2. `submit` (success register) → raw_legacy
3. `list` empty → raw_legacy
4. `list` non-empty → raw_legacy
5. `info` (found) → raw_legacy
6. `summary` (with items) → raw_legacy
7. `summary` empty JSON 분기 → raw_legacy
8. `performance` (found) → raw_legacy
9. `set-status` (IPC 분기) → raw_legacy

## 보존 invariant

- `strategy.py` 본문 0 lines diff (#1847 diff guard)
- callsite shape 가 drift 하면 drift test 가 즉시 FAIL
- `set-status` IPC 분기는 runtime IPC primary, cold_path fallback 분기는
  본 PR 의 lock 대상 외 (spec primary 만 등록)

## 검증

- `pytest tests/unit/contracts -v` → **105 passed**
- `pytest tests/unit/test_strategy_success_output_drift.py -v` → **10 passed**
- `pytest tests/unit/test_strategy_success_output_drift.py tests/unit/contracts tests/unit/test_strategy.py` → **199 passed**
- `mypy src/` → **Success: no issues found in 223 source files**
- `ruff check src/ tests/` → **All checks passed!**
- `ruff format --check src/ tests/` → **528 files already formatted**
- `git diff origin/main -- src/ante/cli/commands/strategy.py` → **0 lines**
- `docs/architecture/generated/project-structure.md` regen → 신규 drift test 1줄 반영

> 참고: `pytest -n 4` xdist 전체 unit 실행 시 30 fails (broker / cli_account_id / cli_account_integration / authenticated_group 류) 가 등장하지만 main 에서도 동일 xdist race 가 관찰되며 (확인 완료) strategy 도메인과 무관한 fixture isolation 회귀 — 본 PR 책임 아님.

## Refs

Refs #1847

🤖 Generated with [Claude Code](https://claude.com/claude-code)