### PR TITLE
refactor: #1847-6 data + report domain OutputContract migration (11 leaf entries)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -609,7 +609,9 @@ tests/
 │   ├── test_bot_success_output_drift.py
 │   ├── test_approval_success_output_drift.py
 │   ├── test_treasury_success_output_drift.py
-│   └── test_strategy_success_output_drift.py
+│   ├── test_strategy_success_output_drift.py
+│   ├── test_data_success_output_drift.py
+│   └── test_report_success_output_drift.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -20,15 +20,19 @@ execution 계약을 한 곳에서 관리하는 registry 다.
   (#1847 sub-PR 4).
 * :data:`STRATEGY_CONTRACTS` — strategy 도메인 7 leaf contract tuple
   (#1847 sub-PR 5).
+* :data:`DATA_CONTRACTS` — data 도메인 6 leaf contract tuple
+  (#1847 sub-PR 6).
+* :data:`REPORT_CONTRACTS` — report 도메인 5 leaf contract tuple
+  (#1847 sub-PR 6).
 * :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
   PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
-  + strategy 7 = 58 entries 가 채워져 있다.
+  + strategy 7 + data 6 + report 5 = 69 entries 가 채워져 있다.
 * :func:`get_contract` / :func:`all_contracts` — read-only accessor.
 
 본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
 
-* 잔여 도메인 entry 등록 (`#1847` sub-PR 6 이후 — broker / data / report /
-  system / instrument / config / rule / trade / backtest / audit / signal).
+* 잔여 도메인 entry 등록 (`#1847` sub-PR 7 이후 — broker / system /
+  instrument / config / rule / trade / backtest / audit / signal).
 * output payload migration (`#1846` / `#1847` 는 raw_legacy 를 *문서화*
   만 하며 fmt callsite 를 바꾸지 않는다 — diff guard 가 본 PR 의 invariant).
 * drift test guard 완전 활성화 — 미등록 leaf FAIL 은 `#1848` 의 책임.
@@ -77,7 +81,9 @@ __all__ = [
     "APPROVAL_CONTRACTS",
     "BOT_CONTRACTS",
     "CLI_COMMAND_REGISTRY",
+    "DATA_CONTRACTS",
     "MEMBER_CONTRACTS",
+    "REPORT_CONTRACTS",
     "STRATEGY_CONTRACTS",
     "TREASURY_CONTRACTS",
     "AuthContract",
@@ -983,6 +989,200 @@ STRATEGY_CONTRACTS: tuple[CliCommandContract, ...] = (
 """
 
 
+# ── #1847 sub-PR 6: data domain OutputContract migration ────────────────
+#
+# data 도메인 6 leaf 의 contract entry. ``src/ante/cli/commands/data.py`` 의
+# ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:481-492`` (data 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (6 commands, 전체): ``list`` / ``info`` / ``delete`` /
+# ``schema`` / ``storage`` / ``validate`` 모두 JSON 모드에서 ``fmt.output(
+# dict)`` 평면 dict 를 그대로 dump 한다. 도메인 envelope (``{datasets,
+# count}``, ``{dataset, preview}``, schema flat dict, ``{total_bytes,
+# total_mb, by_timeframe}``, ``{results, summary}``) 이며 standard envelope
+# ``{status, message, data}`` 3 키 셋과는 다르다. ``OutputContract(kind=
+# "raw", envelope="raw_legacy")`` 조합으로 표현해 lock 만 한다 — data.py
+# 본문 변경 없음 (drift test 가 callsite 변경 시 FAIL).
+#
+# ``delete`` 는 분기 mixed: JSON 모드는 ``fmt.output(result)`` 평면 dict
+# (line 208), text 모드는 ``fmt.success(f"데이터셋 삭제 완료: ...", result)``
+# (line 210). plan v2 decision 에 따라 raw 우선으로 표현 (account
+# ``set-credentials`` / bot ``signal-key`` / treasury ``set-balance`` 동형
+# raw_legacy 정책) — drift test 가 JSON 모드를 단언한다.
+#
+# scope 분류 (#1815 SSOT, data.py @require_scope marker 와 1:1 정합):
+# - ``data:read`` scope (5 개): ``list`` / ``info`` / ``schema`` /
+#   ``storage`` / ``validate``.
+# - ``data:write`` scope (1 개): ``delete``.
+# - public allowlist: 없음 — data 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:481-492`` SSOT):
+# - ``offline`` (6 개, 전체): 모든 data 명령은 local ``ParquetStore`` 와
+#   (필요 시) local ``Database`` 를 직접 생성한다. runtime IPC handler 없음.
+DATA_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("data", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:read"})),
+        # JSON mode: empty → ``fmt.output({"datasets": [], "count": 0})``
+        # 평면, non-empty → ``fmt.output({"datasets": [...], "count": N})``
+        # 평면 (data.py:75/95). text 는 fmt.table.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("data", "info"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{dataset: {...},
+        # preview: [...]}``). text 는 click.echo (data.py:135-154).
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("data", "delete"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:write"})),
+        # 분기 mixed: JSON mode 는 ``fmt.output(result)`` 평면 dict
+        # (data.py:208), text 는 ``fmt.success(f"데이터셋 삭제 완료: ...",
+        # result)`` (data.py:210). plan v2 decision 에 따라 raw 우선으로 표현
+        # (account ``set-credentials`` / bot ``signal-key`` / treasury
+        # ``set-balance`` 동형 raw_legacy 정책) — drift test 가 JSON 모드를
+        # 단언한다.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("data", "schema"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:read"})),
+        # JSON mode: ``fmt.output({k: str(v) for k, v in OHLCV_SCHEMA.items()})``
+        # 평면 dict (data.py:223). text 모드도 동일 호출 — fmt.output 내부
+        # 분기.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("data", "storage"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:read"})),
+        # JSON mode: ``fmt.output(summary, "Total: {total_mb} MB")`` 평면 dict
+        # (``{total_bytes, total_mb, by_timeframe}``, data.py:247). text 는
+        # template format string 으로 출력.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("data", "validate"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:read"})),
+        # JSON mode: empty → ``fmt.output({"message": "검증할 데이터가
+        # 없습니다.", "results": []})`` (data.py:313), non-empty → ``fmt.output(
+        # {"results": [...], "summary": {total_files, valid, corrupted,
+        # fixed}})`` (data.py:326). text 는 click.echo.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+)
+"""Data domain 6 leaf 의 contract tuple (#1847 sub-PR 6).
+
+순서는 ``docs/specs/cli/03-commands.md:481-492`` 의 data 표 (list →
+info → delete → schema → storage → validate) 와 정합하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+
+spec 표 (487-492) 는 4 leaf (list/schema/storage/validate) 만 명시하지만
+``info`` / ``delete`` 는 실제 ``data.py`` 에 존재하는 leaf 로 ``ante data
+--help`` Click subgroup iteration 이 6 leaf 를 반환한다. registry 는
+canonical Click tree (leaf coverage helper SSOT) 기준이므로 6 entries 를
+모두 등록한다 (treasury sub-PR 4 ``portfolio value/history`` 동형 — spec
+표가 일부 leaf 만 명시하더라도 실측 Click tree 가 SSOT).
+"""
+
+
+# ── #1847 sub-PR 6: report domain OutputContract migration ──────────────
+#
+# report 도메인 5 leaf 의 contract entry. ``src/ante/cli/commands/report.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:503-531`` (report 표 + performance
+# narrative) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (4 commands): ``schema`` / ``list`` / ``performance`` /
+# ``view`` 는 JSON 모드에서 ``fmt.output(dict)`` 또는 ``fmt.table(rows, ...)``
+# 로 평면 dict / row list 를 그대로 dump 한다. 도메인 envelope (``{fields,
+# required, optional, ...}``, row list, ``{period, summaries}``, detail dict)
+# 이며 standard envelope ``{status, message, data}`` 3 키 셋과는 다르다.
+# ``OutputContract(kind="raw", envelope="raw_legacy")`` 조합으로 표현해 lock
+# 만 한다 — report.py 본문 변경 없음 (drift test 가 callsite 변경 시 FAIL).
+#
+# standard envelope (1 command): ``submit`` 는 단일 success 경로
+# ``fmt.success(f"Report submitted: ...", result)`` (report.py:182) 만 호출
+# 하며 표준 envelope (``{status, message, data}``) 을 dump 한다. JSON / text
+# 분기 없음 — 성공 시 fmt.success 만 호출. error 분기는 ``fmt.error`` 이지만
+# 본 drift test 의 success-output scope 밖.
+#
+# scope 분류 (#1815 SSOT, report.py @require_scope marker 와 1:1 정합):
+# - ``report:read`` scope (4 개): ``schema`` / ``list`` / ``performance`` /
+#   ``view``.
+# - ``report:write`` scope (1 개): ``submit``.
+# - public allowlist: 없음 — report 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:503-531`` SSOT):
+# - ``offline`` (5 개, 전체): 모든 report 명령은 local ``Database`` 와
+#   ``ReportStore`` / ``BacktestRunStore`` / ``PerformanceTracker`` 를 직접
+#   생성한다. runtime IPC handler 없음.
+REPORT_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("report", "schema"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"report:read"})),
+        # JSON mode: ``fmt.output(store.get_schema())`` 평면 dict
+        # (``{fields, required, optional, ...}`` 형태, report.py:44).
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("report", "submit"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"report:write"})),
+        # 단일 success 경로 ``fmt.success(f"Report submitted: {report_id}",
+        # result)`` (report.py:182) → standard envelope. error 분기는
+        # ``fmt.error`` 이지만 success-output drift scope 밖.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("report", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"report:read"})),
+        # JSON mode: ``fmt.table(rows, ["report_id", "strategy", "status",
+        # "submitted_at"])`` → row list 를 그대로 dump (report.py:256).
+        # row dict shape: ``{report_id, strategy, status, submitted_at}``.
+        # text 는 동일 fmt.table 분기.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("report", "performance"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"report:read"})),
+        # JSON mode: empty → ``fmt.output({"message": "집계 데이터가 없습니다.",
+        # "summaries": []})`` (report.py:375), non-empty → ``fmt.output({"period",
+        # "summaries": [...]})`` (report.py:379). text 는 fmt.table 분기.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("report", "view"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"report:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 detail dict (report.py:441)
+        # — ``{report_id, strategy, status, submitted_at, submitted_by,
+        # backtest_period, total_return_pct, total_trades, sharpe_ratio,
+        # max_drawdown_pct, win_rate, summary, rationale, risks,
+        # recommendations}``. text 는 click.echo 다수 줄.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+)
+"""Report domain 5 leaf 의 contract tuple (#1847 sub-PR 6).
+
+순서는 ``docs/specs/cli/03-commands.md:505-510`` 의 report 표 (schema →
+submit → list → performance → view) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
 CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
     contract.path: contract
     for contract in (
@@ -992,17 +1192,19 @@ CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
         *APPROVAL_CONTRACTS,
         *TREASURY_CONTRACTS,
         *STRATEGY_CONTRACTS,
+        *DATA_CONTRACTS,
+        *REPORT_CONTRACTS,
     )
 }
 """Leaf command path → contract mapping.
 
 본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
-+ strategy 7 = 58 entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847
-sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5). 나머지 도메인
-(broker / data / report / system / instrument / config / rule / trade /
-backtest / audit / signal) 의 entry 등록은 후속 PR (`#1847` sub-PR 6-9) 의
-책임이다. registry 미등록 leaf 가 FAIL 이어야 하는 drift guard 는 `#1848`
-가 활성화한다.
++ strategy 7 + data 6 + report 5 = 69 entries 가 등록되어 있다 (#1846 /
+#1847 sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847
+sub-PR 5 / #1847 sub-PR 6). 나머지 도메인 (broker / system / instrument /
+config / rule / trade / backtest / audit / signal) 의 entry 등록은 후속
+PR (`#1847` sub-PR 7-9) 의 책임이다. registry 미등록 leaf 가 FAIL 이어야
+하는 drift guard 는 `#1848` 가 활성화한다.
 """
 
 
@@ -1022,7 +1224,8 @@ def all_contracts() -> Iterator[CliCommandContract]:
     """등록된 모든 contract 를 dict 순회 순서로 yield 한다.
 
     본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury
-    9 + strategy 7 = 58 entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 /
-    #1847 sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5).
+    9 + strategy 7 + data 6 + report 5 = 69 entries 가 등록되어 있다
+    (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR 3 / #1847
+    sub-PR 4 / #1847 sub-PR 5 / #1847 sub-PR 6).
     """
     yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -180,15 +180,16 @@ def test_raw_legacy_is_envelope_form_not_contract_kind() -> None:
 
 
 def test_get_contract_returns_none_when_missing() -> None:
-    """미등록 path 는 ``None`` 을 반환한다 (등록된 6 도메인 외).
+    """미등록 path 는 ``None`` 을 반환한다 (등록된 8 도메인 외).
 
-    등록 도메인: account / member / bot / approval / treasury / strategy.
+    등록 도메인: account / member / bot / approval / treasury / strategy /
+    data / report.
     """
     # nonexistent path 는 항상 ``None``.
     assert get_contract(("nonexistent",)) is None
-    # broker 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 6 이후) 의
-    # 책임이므로 본 PR 시점에는 ``None`` 이다 (strategy domain 은 sub-PR 5
-    # 에서 등록되었다).
+    # broker 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 7 이후) 의
+    # 책임이므로 본 PR 시점에는 ``None`` 이다 (data / report domain 은
+    # sub-PR 6 에서 등록되었다).
     assert get_contract(("broker", "status")) is None
 
 
@@ -365,6 +366,60 @@ def test_strategy_entries_registered_after_1847_sub_pr_5() -> None:
     assert expected_strategy_paths.issubset(registered), (
         f"strategy 7 entry 가 모두 등록되어야 한다 (#1847 sub-PR 5). "
         f"누락: {sorted(expected_strategy_paths - registered)}"
+    )
+
+
+def test_data_entries_registered_after_1847_sub_pr_6() -> None:
+    """#1847 sub-PR 6 가 data 6 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 6 가 data migration 을 완료한 시점부터
+    lock 된다. 6 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_data_success_output_drift` 가
+    책임진다.
+
+    spec 표 (``docs/specs/cli/03-commands.md:487-492``) 는 4 leaf
+    (``list`` / ``schema`` / ``storage`` / ``validate``) 만 명시하지만
+    ``info`` / ``delete`` 는 실제 ``data.py`` 에 존재하는 leaf 로 Click
+    subgroup iteration 이 6 leaf 를 반환한다. registry 는 canonical Click
+    tree (leaf coverage helper SSOT) 기준이므로 6 entries 를 모두 등록한다
+    (treasury sub-PR 4 ``portfolio value/history`` 동형).
+    """
+    expected_data_paths = {
+        ("data", "list"),
+        ("data", "info"),
+        ("data", "delete"),
+        ("data", "schema"),
+        ("data", "storage"),
+        ("data", "validate"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_data_paths.issubset(registered), (
+        f"data 6 entry 가 모두 등록되어야 한다 (#1847 sub-PR 6). "
+        f"누락: {sorted(expected_data_paths - registered)}"
+    )
+
+
+def test_report_entries_registered_after_1847_sub_pr_6() -> None:
+    """#1847 sub-PR 6 가 report 5 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 6 가 report migration 을 완료한 시점부터
+    lock 된다. 5 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_report_success_output_drift` 가
+    책임진다.
+    """
+    expected_report_paths = {
+        ("report", "schema"),
+        ("report", "submit"),
+        ("report", "list"),
+        ("report", "performance"),
+        ("report", "view"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_report_paths.issubset(registered), (
+        f"report 5 entry 가 모두 등록되어야 한다 (#1847 sub-PR 6). "
+        f"누락: {sorted(expected_report_paths - registered)}"
     )
 
 

--- a/tests/unit/test_data_success_output_drift.py
+++ b/tests/unit/test_data_success_output_drift.py
@@ -1,0 +1,517 @@
+"""Data CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 6).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+data 도메인 6 leaf 의 ``OutputContract`` 와 ``ante data ... --format json``
+실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1 (member) / sub-PR 2 (bot) / sub-PR 3
+(approval) / sub-PR 4 (treasury) / sub-PR 5 (strategy) 1:1 동형 패턴.
+drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump 한다
+  (standard envelope 의 3 키 셋이 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``data.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제 callsite
+shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면 본 test 가
+즉시 FAIL 한다 (registry 갱신 또는 callsite 정렬 중 한쪽이 책임).
+
+10 시나리오 (6 leaf + registry sanity +1 + list empty 분기 +1 + list
+non-empty +1 + validate empty 분기 +1):
+
+0. registry sanity — data 6 entries 의 envelope 이 ``standard`` /
+   ``raw_legacy`` 분류 범위 내.
+1. ``list`` empty → ``raw_legacy`` (``{datasets: [], count: 0}``)
+2. ``list`` non-empty → ``raw_legacy`` (``{datasets: [...], count: N}``)
+3. ``info`` (found) → ``raw_legacy`` (``fmt.output({dataset, preview})``)
+4. ``delete`` (success) → ``raw_legacy`` (JSON 모드 ``fmt.output(result)``)
+5. ``schema`` → ``raw_legacy`` (``fmt.output({column: dtype_str})``)
+6. ``storage`` → ``raw_legacy`` (``fmt.output(summary, "Total: ...")``)
+7. ``validate`` empty (no symbols) → ``raw_legacy`` (``{message, results: []}``)
+8. ``validate`` non-empty → ``raw_legacy`` (``{results, summary}``)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언.
+
+    raw_legacy 는 ``fmt.output(dict)`` / ``fmt.table(rows)`` 출력의 super-set
+    이다. ``status``/``message``/``data`` 3 키가 동시에 갖춰지고 ``status ==
+    "ok"`` 면 standard envelope 으로 분류 (애매한 경계 방지). 그렇지 않으면
+    모든 평면 도메인 payload 는 raw_legacy.
+    """
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_data_entries_envelopes_classified() -> None:
+    """data 6 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 6 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    data_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("data",)
+    ]
+    assert len(data_entries) == 6, (
+        f"data 6 entries 가 모두 등록되어야 한다. 실제: {len(data_entries)}"
+    )
+    for path, contract in data_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (account/member/bot/approval/treasury/strategy 동형) ───────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json data ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다.
+
+    ``OutputFormatter`` 가 ``json.dumps(..., indent=2)`` 로 multi-line dump
+    하기 때문에 처음 ``{`` 또는 ``[`` 부터 ``raw_decode`` 로 한 value 를
+    파싱하고 나머지 stdout (text 모드 잔존물 등) 는 무시한다 (treasury /
+    strategy drift test 동형).
+    """
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. list empty → raw_legacy ─────────────────────────────────────────────
+
+
+def test_data_list_empty_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``data list`` empty: ``{datasets: [], count: 0}`` 평면 (raw_legacy).
+
+    data.py:75: ``fmt.output({"datasets": [], "count": 0})`` 분기. text/JSON
+    양쪽 모두 동일 평면 dict 를 echo (`fmt.output` 내부 branch). JSON 모드를
+    정확히 단언한다.
+    """
+    with patch(
+        "ante.data.datasets.list_datasets",
+        return_value={"items": [], "total": 0},
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "data",
+                "list",
+                "--data-path",
+                str(tmp_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"data list empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"datasets": [], "count": 0}
+
+
+# ── 2. list non-empty → raw_legacy ─────────────────────────────────────────
+
+
+def test_data_list_non_empty_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``data list`` non-empty: ``{datasets: [...], count: N}`` 평면.
+
+    data.py:95: ``fmt.output({"datasets": datasets, "count": result["total"]})``
+    JSON 분기. ``_enrich`` 후 InstrumentService 가 name 을 추가하지만 본
+    fixture 는 InstrumentService 까지 mock 하기 어려우므로 ``get_name`` 만
+    patch 한다.
+    """
+    items = [
+        {
+            "id": "005930__1d",
+            "symbol": "005930",
+            "timeframe": "1d",
+            "data_type": "ohlcv",
+            "start_date": "2024-01-02",
+            "end_date": "2026-01-15",
+            "row_count": 0,
+            "file_size": 0,
+        }
+    ]
+    with (
+        patch(
+            "ante.data.datasets.list_datasets",
+            return_value={"items": items, "total": 1},
+        ),
+        patch(
+            "ante.instrument.service.InstrumentService.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.instrument.service.InstrumentService.get_name",
+            return_value="삼성전자",
+        ),
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "data",
+                "list",
+                "--data-path",
+                str(tmp_path),
+                "--db-path",
+                str(tmp_path / "ante.db"),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"data list non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["count"] == 1
+    assert isinstance(payload["datasets"], list)
+    assert payload["datasets"][0]["id"] == "005930__1d"
+    assert payload["datasets"][0]["name"] == "삼성전자"
+
+
+# ── 3. info (found) → raw_legacy ───────────────────────────────────────────
+
+
+def test_data_info_found_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``data info`` 발견: ``fmt.output(result)`` 평면 ``{dataset, preview}``.
+
+    data.py:135: ``if fmt.is_json: fmt.output(result)`` → ``{dataset: {id,
+    symbol, timeframe, data_type, start_date, end_date, row_count, file_size},
+    preview: [...]}``.
+    """
+    detail = {
+        "dataset": {
+            "id": "005930__1d",
+            "symbol": "005930",
+            "timeframe": "1d",
+            "data_type": "ohlcv",
+            "start_date": "2024-01-02",
+            "end_date": "2026-01-15",
+            "row_count": 500,
+            "file_size": 12_345,
+        },
+        "preview": [
+            {"date": "2024-01-02", "open": 70000, "close": 71000},
+        ],
+    }
+    with patch(
+        "ante.data.datasets.get_dataset_detail",
+        return_value=detail,
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "data",
+                "info",
+                "005930__1d",
+                "--data-path",
+                str(tmp_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"data info found: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["dataset"]["id"] == "005930__1d"
+    assert payload["preview"][0]["open"] == 70000
+
+
+# ── 4. delete (success) → raw_legacy (JSON 분기) ───────────────────────────
+
+
+def test_data_delete_success_json_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``data delete`` 성공: JSON 모드 ``fmt.output(result)`` 평면 dict.
+
+    data.py:207-208: ``if fmt.is_json: fmt.output(result)`` → ``{dataset_id,
+    symbol, timeframe, data_type, path, deleted}`` 평면. text 모드는
+    ``fmt.success(f"데이터셋 삭제 완료: ...", result)`` 이지만 JSON 모드는
+    raw_legacy (account ``set-credentials`` / bot ``signal-key`` / treasury
+    ``set-balance`` 동형 정책).
+    """
+    deletion_result = {
+        "dataset_id": "005930__1d",
+        "symbol": "005930",
+        "timeframe": "1d",
+        "data_type": "ohlcv",
+        "path": str(tmp_path / "ohlcv" / "1d" / "005930"),
+        "deleted": True,
+    }
+    with patch(
+        "ante.data.datasets.delete_dataset",
+        return_value=deletion_result,
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "data",
+                "delete",
+                "005930__1d",
+                "--yes",
+                "--data-path",
+                str(tmp_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"data delete success JSON: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["dataset_id"] == "005930__1d"
+    assert payload["deleted"] is True
+
+
+# ── 5. schema → raw_legacy ─────────────────────────────────────────────────
+
+
+def test_data_schema_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``data schema``: ``fmt.output({k: str(v) ...})`` 평면 dict.
+
+    data.py:223: ``fmt.output({k: str(v) for k, v in OHLCV_SCHEMA.items()})``.
+    OHLCV_SCHEMA 평면 dict (column → dtype_str).
+    """
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "data",
+            "schema",
+            "--data-path",
+            str(tmp_path),
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"data schema: standard envelope 아님. payload={payload!r}"
+    )
+    # OHLCV_SCHEMA 의 정규 column 들이 포함되는지 sanity check
+    # (data/schemas.py SSOT — timestamp/symbol/open/high/low/close/volume/...).
+    assert "timestamp" in payload
+    assert "open" in payload
+    assert "close" in payload
+    assert "volume" in payload
+
+
+# ── 6. storage → raw_legacy ────────────────────────────────────────────────
+
+
+def test_data_storage_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``data storage``: ``fmt.output(summary, "Total: ...")`` 평면 dict.
+
+    data.py:247-250: ``fmt.output({total_bytes, total_mb, by_timeframe},
+    "Total: {total_mb} MB")``. JSON 모드는 template ignore 하고 평면 dict
+    그대로 dump (formatter.py:54-55).
+    """
+    with patch(
+        "ante.data.store.ParquetStore.get_storage_usage",
+        return_value={"1d": 1_048_576, "1m": 524_288},
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "data",
+                "storage",
+                "--data-path",
+                str(tmp_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"data storage: standard envelope 아님. payload={payload!r}"
+    )
+    assert "total_bytes" in payload
+    assert "total_mb" in payload
+    assert "by_timeframe" in payload
+    assert payload["total_bytes"] == 1_048_576 + 524_288
+
+
+# ── 7. validate empty (no symbols) → raw_legacy ───────────────────────────
+
+
+def test_data_validate_empty_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``data validate`` empty: ``{message, results: []}`` 평면.
+
+    data.py:313: ``fmt.output({"message": "검증할 데이터가 없습니다.",
+    "results": []})`` 분기. ``list_symbols`` 가 빈 리스트를 반환할 때.
+    """
+    with patch(
+        "ante.data.store.ParquetStore.list_symbols",
+        return_value=[],
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "data",
+                "validate",
+                "--timeframe",
+                "1d",
+                "--data-path",
+                str(tmp_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"data validate empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"message": "검증할 데이터가 없습니다.", "results": []}
+
+
+# ── 8. validate non-empty → raw_legacy ────────────────────────────────────
+
+
+def test_data_validate_non_empty_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``data validate`` non-empty: ``{results, summary}`` 평면.
+
+    data.py:326: ``if fmt.is_json: fmt.output({"results": [...], "summary":
+    {total_files, valid, corrupted, fixed}})``. ``ParquetStore.validate`` 가
+    per-symbol 결과 dict 를 반환.
+    """
+    validate_result = {
+        "symbol": "005930",
+        "timeframe": "1d",
+        "total": 3,
+        "valid": 3,
+        "corrupted": 0,
+        "corrupted_files": [],
+    }
+    with (
+        patch(
+            "ante.data.store.ParquetStore.list_symbols",
+            return_value=["005930"],
+        ),
+        patch(
+            "ante.data.store.ParquetStore.validate",
+            return_value=validate_result,
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "data",
+                "validate",
+                "--timeframe",
+                "1d",
+                "--data-path",
+                str(tmp_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"data validate non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert "results" in payload
+    assert "summary" in payload
+    assert payload["summary"]["total_files"] == 3
+    assert payload["summary"]["valid"] == 3
+    assert payload["summary"]["corrupted"] == 0
+    assert payload["summary"]["fixed"] is False

--- a/tests/unit/test_report_success_output_drift.py
+++ b/tests/unit/test_report_success_output_drift.py
@@ -1,0 +1,488 @@
+"""Report CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 6).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+report 도메인 5 leaf 의 ``OutputContract`` 와 ``ante report ... --format json``
+실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1 (member) / sub-PR 2 (bot) / sub-PR 3
+(approval) / sub-PR 4 (treasury) / sub-PR 5 (strategy) / sub-PR 6 (data)
+1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump 한다
+  (standard envelope 의 3 키 셋이 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``report.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제 callsite
+shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면 본 test 가
+즉시 FAIL 한다.
+
+9 시나리오 (5 leaf + registry sanity +1 + list empty 분기 +1 + performance
+empty 분기 +1 + performance non-empty +1):
+
+0. registry sanity — report 5 entries 의 envelope 이 ``standard`` /
+   ``raw_legacy`` 분류 범위 내.
+1. ``schema`` → ``raw_legacy`` (``fmt.output(get_schema())``)
+2. ``submit`` (success) → ``standard`` (``fmt.success(message, result)``)
+3. ``list`` empty → ``raw_legacy`` (``fmt.table([], columns)`` → ``[]``)
+4. ``list`` non-empty → ``raw_legacy`` (``fmt.table(rows, columns)`` → row list)
+5. ``performance`` empty → ``raw_legacy`` (``{message, summaries: []}``)
+6. ``performance`` non-empty (daily) → ``raw_legacy`` (``{period, summaries}``)
+7. ``view`` (found) → ``raw_legacy`` (``fmt.output(result)``)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.report.models import ReportStatus, StrategyReport
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언."""
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_report_entries_envelopes_classified() -> None:
+    """report 5 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 5 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    report_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("report",)
+    ]
+    assert len(report_entries) == 5, (
+        f"report 5 entries 가 모두 등록되어야 한다. 실제: {len(report_entries)}"
+    )
+    for path, contract in report_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (account/member/bot/approval/treasury/strategy/data 동형) ──
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json report ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다."""
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── helpers: StrategyReport factory ────────────────────────────────────────
+
+
+def _make_report(
+    *,
+    report_id: str = "rpt-1",
+    strategy_name: str = "my_strategy",
+    status: ReportStatus = ReportStatus.SUBMITTED,
+) -> StrategyReport:
+    """테스트용 ``StrategyReport`` factory."""
+    return StrategyReport(
+        report_id=report_id,
+        strategy_name=strategy_name,
+        strategy_version="1.0.0",
+        strategy_path="strategies/my_strategy.py",
+        status=status,
+        submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        submitted_by="agent",
+        backtest_period="2024-01 ~ 2026-03",
+        total_return_pct=15.3,
+        total_trades=42,
+        sharpe_ratio=1.2,
+        max_drawdown_pct=-8.5,
+        win_rate=58.0,
+        summary="테스트 전략",
+        rationale="모멘텀",
+        risks="없음",
+    )
+
+
+# ── 1. schema → raw_legacy ─────────────────────────────────────────────────
+
+
+def test_report_schema_envelope_matches_raw_legacy() -> None:
+    """``report schema``: ``fmt.output(store.get_schema())`` 평면 dict.
+
+    report.py:44: ``fmt.output(store.get_schema())``. ``ReportStore.get_schema``
+    는 ``{required_fields, optional_fields, format, example}`` 평면 dict 를
+    반환한다 (store.py:248-284).
+    """
+    result = _invoke(["--format", "json", "report", "schema"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"report schema: standard envelope 아님. payload={payload!r}"
+    )
+    assert "required_fields" in payload
+    assert "optional_fields" in payload
+    assert "format" in payload
+    assert isinstance(payload["required_fields"], list)
+
+
+# ── 2. submit (success) → standard ─────────────────────────────────────────
+
+
+def test_report_submit_success_envelope_matches_operation_standard(tmp_path) -> None:
+    """``report submit`` 성공: ``fmt.success(message, result)`` → standard.
+
+    report.py:182: ``fmt.success(f"Report submitted: {result['report_id']}",
+    result)``. 단일 success 경로 — JSON / text 모두 standard envelope.
+    """
+    payload_data = {
+        "strategy_name": "my_strategy",
+        "strategy_version": "1.0.0",
+        "strategy_path": "strategies/my_strategy.py",
+        "backtest_period": "2024-01 ~ 2026-03",
+        "total_return_pct": 15.3,
+        "total_trades": 42,
+        "sharpe_ratio": 1.2,
+        "max_drawdown_pct": -8.5,
+        "win_rate": 58.0,
+        "summary": "테스트 전략",
+        "rationale": "모멘텀",
+    }
+    json_path = tmp_path / "report.json"
+    json_path.write_text(json.dumps(payload_data), encoding="utf-8")
+
+    # ReportStore.initialize + submit 를 mock. Database connect/close 도.
+    with (
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.report.ReportStore.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.report.ReportStore.submit",
+            new=AsyncMock(return_value="rpt-new-1"),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "report",
+                "submit",
+                str(json_path),
+                "--db-path",
+                str(tmp_path / "ante.db"),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"report submit success: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "submitted" in payload["message"].lower()
+    assert payload["data"]["report_id"] == "rpt-new-1"
+    assert payload["data"]["strategy"] == "my_strategy"
+
+
+# ── 3. list empty → raw_legacy ─────────────────────────────────────────────
+
+
+def test_report_list_empty_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``report list`` empty: ``fmt.table([], columns)`` → ``[]`` (JSON mode).
+
+    report.py:256: ``fmt.table(rows, ["report_id", "strategy", "status",
+    "submitted_at"])``. ``OutputFormatter.table`` JSON 모드는 row list 를
+    ``json.dumps`` 한다 (formatter.py:63-64). 빈 리스트는 ``[]`` 그대로.
+    """
+    with (
+        patch("ante.core.database.Database.connect", new=AsyncMock()),
+        patch("ante.core.database.Database.close", new=AsyncMock()),
+        patch("ante.report.ReportStore.initialize", new=AsyncMock()),
+        patch(
+            "ante.report.ReportStore.list_reports",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "report",
+                "list",
+                "--db-path",
+                str(tmp_path / "ante.db"),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"report list empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == []
+
+
+# ── 4. list non-empty → raw_legacy ─────────────────────────────────────────
+
+
+def test_report_list_non_empty_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``report list`` non-empty: row list 그대로 dump (raw_legacy).
+
+    report.py:256: ``fmt.table(rows, ...)``. JSON 모드는 row list dump.
+    row shape: ``{report_id, strategy, status, submitted_at}``.
+    """
+    reports = [_make_report(report_id="rpt-1", strategy_name="strat-A")]
+    with (
+        patch("ante.core.database.Database.connect", new=AsyncMock()),
+        patch("ante.core.database.Database.close", new=AsyncMock()),
+        patch("ante.report.ReportStore.initialize", new=AsyncMock()),
+        patch(
+            "ante.report.ReportStore.list_reports",
+            new=AsyncMock(return_value=reports),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "report",
+                "list",
+                "--db-path",
+                str(tmp_path / "ante.db"),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"report list non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["report_id"] == "rpt-1"
+    assert payload[0]["strategy"] == "strat-A"
+    assert payload[0]["status"] == "submitted"
+
+
+# ── 5. performance empty → raw_legacy ──────────────────────────────────────
+
+
+def test_report_performance_empty_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``report performance`` empty: ``{message, summaries: []}`` 평면.
+
+    report.py:375: ``fmt.output({"message": "집계 데이터가 없습니다.",
+    "summaries": []})``. ``PerformanceTracker.get_daily_summary`` 가 빈 list
+    반환할 때.
+    """
+    with (
+        patch("ante.core.database.Database.connect", new=AsyncMock()),
+        patch("ante.core.database.Database.close", new=AsyncMock()),
+        patch(
+            "ante.trade.performance.PerformanceTracker.get_daily_summary",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "ante.cli.main.get_db_path",
+            return_value=str(tmp_path / "ante.db"),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "report",
+                "performance",
+                "--period",
+                "daily",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"report performance empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"message": "집계 데이터가 없습니다.", "summaries": []}
+
+
+# ── 6. performance non-empty (daily) → raw_legacy ──────────────────────────
+
+
+def test_report_performance_non_empty_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``report performance`` non-empty: ``{period, summaries: [...]}``.
+
+    report.py:379: ``if fmt.is_json: fmt.output({"period": period,
+    "summaries": result})``. ``DailySummary`` asdict 가 row 리스트로 변환된다.
+    """
+    from ante.trade.models import DailySummary
+
+    daily = DailySummary(
+        date="2026-01-01",
+        realized_pnl=10_000.0,
+        trade_count=3,
+        win_rate=0.67,
+    )
+
+    with (
+        patch("ante.core.database.Database.connect", new=AsyncMock()),
+        patch("ante.core.database.Database.close", new=AsyncMock()),
+        patch(
+            "ante.trade.performance.PerformanceTracker.get_daily_summary",
+            new=AsyncMock(return_value=[daily]),
+        ),
+        patch(
+            "ante.cli.main.get_db_path",
+            return_value=str(tmp_path / "ante.db"),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "report",
+                "performance",
+                "--period",
+                "daily",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"report performance non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["period"] == "daily"
+    assert isinstance(payload["summaries"], list)
+    assert payload["summaries"][0]["date"] == "2026-01-01"
+    assert payload["summaries"][0]["realized_pnl"] == 10_000.0
+
+
+# ── 7. view (found) → raw_legacy ───────────────────────────────────────────
+
+
+def test_report_view_found_envelope_matches_raw_legacy(tmp_path) -> None:
+    """``report view`` 발견: ``fmt.output(result)`` 평면 detail dict.
+
+    report.py:441: ``if fmt.is_json: fmt.output(result)`` → 평면 dict
+    (``{report_id, strategy, status, submitted_at, submitted_by,
+    backtest_period, total_return_pct, total_trades, sharpe_ratio,
+    max_drawdown_pct, win_rate, summary, rationale, risks,
+    recommendations}``). text 는 click.echo.
+    """
+    report = _make_report(report_id="rpt-view-1", strategy_name="strat-V")
+    with (
+        patch("ante.core.database.Database.connect", new=AsyncMock()),
+        patch("ante.core.database.Database.close", new=AsyncMock()),
+        patch("ante.report.ReportStore.initialize", new=AsyncMock()),
+        patch(
+            "ante.report.ReportStore.get",
+            new=AsyncMock(return_value=report),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "report",
+                "view",
+                "rpt-view-1",
+                "--db-path",
+                str(tmp_path / "ante.db"),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"report view found: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["report_id"] == "rpt-view-1"
+    assert payload["status"] == "submitted"
+    assert payload["total_trades"] == 42
+    assert "strategy" in payload  # ``{name} v{version}`` 형식.


### PR DESCRIPTION
## Sub-PR 6 (data + report domain) — Refs #1847

`#1846` (account 9) / `#1847` sub-PR 1 (member 12) / sub-PR 2 (bot 11) /
sub-PR 3 (approval 10) / sub-PR 4 (treasury 9) / sub-PR 5 (strategy 7)
동형 패턴으로 data + report 도메인 **11 leaf** (data 6 + report 5) 의
`OutputContract` / `AuthContract` / `ExecutionClass` 를
`CLI_COMMAND_REGISTRY` SSOT 에 등록.

### 등록 entry — data 6 leaf

| # | path | auth | output | execution |
|---|------|------|--------|-----------|
| 1 | `data list` | `data:read` | raw_legacy | offline |
| 2 | `data info` | `data:read` | raw_legacy | offline |
| 3 | `data delete` | `data:write` | raw_legacy (mixed JSON/text) | offline |
| 4 | `data schema` | `data:read` | raw_legacy | offline |
| 5 | `data storage` | `data:read` | raw_legacy | offline |
| 6 | `data validate` | `data:read` | raw_legacy | offline |

`data delete` 는 분기 mixed: JSON 모드는 `fmt.output(result)` 평면 dict
(data.py:208), text 모드는 `fmt.success(f"데이터셋 삭제 완료: ...", result)`
(data.py:210). plan v2 decision 에 따라 raw 우선으로 표현 (account
`set-credentials` / bot `signal-key` / treasury `set-balance` 동형 raw_legacy
정책).

spec 표 (`docs/specs/cli/03-commands.md:487-492`) 는 4 leaf
(`list` / `schema` / `storage` / `validate`) 만 명시하지만 `info` /
`delete` 는 실제 `data.py` 에 존재하는 leaf 로 Click subgroup iteration 이
6 leaf 를 반환한다. registry 는 canonical Click tree (leaf coverage helper
SSOT) 기준이므로 6 entries 를 모두 등록한다 (treasury sub-PR 4 `portfolio
value/history` 동형 — spec 표가 일부 leaf 만 명시하더라도 실측 Click tree
가 SSOT).

### 등록 entry — report 5 leaf

| # | path | auth | output | execution |
|---|------|------|--------|-----------|
| 1 | `report schema` | `report:read` | raw_legacy | offline |
| 2 | `report submit` | `report:write` | standard | offline |
| 3 | `report list` | `report:read` | raw_legacy | offline |
| 4 | `report performance` | `report:read` | raw_legacy | offline |
| 5 | `report view` | `report:read` | raw_legacy | offline |

`report submit` 는 단일 success 경로 `fmt.success(f"Report submitted: ...",
result)` (report.py:182) 만 호출 — JSON / text 양쪽 모두 standard envelope
(`{status, message, data}`). report 도메인의 유일한 standard envelope leaf.

### Diff guard

- `git diff origin/main..HEAD -- src/ante/cli/commands/data.py` → **0 lines**
- `git diff origin/main..HEAD -- src/ante/cli/commands/report.py` → **0 lines**

### 검증

- `pytest tests/unit/contracts -v` → **107 PASS** (Family A/B/C/D drift +
  shell baseline + 6 per-domain locks 포함 account/member/bot/approval/
  treasury/strategy/data/report)
- `pytest tests/unit/test_data_success_output_drift.py -v` → **9 PASS**
  (registry sanity + 6 leaf + list empty/non-empty 분리 + delete success
  JSON 분기 + schema + storage + validate empty/non-empty 분리)
- `pytest tests/unit/test_report_success_output_drift.py -v` → **8 PASS**
  (registry sanity + 5 leaf + list empty/non-empty 분리 + performance
  empty/non-empty 분리)
- `pytest tests/unit/test_{account,member,bot,approval,treasury,strategy}_success_output_drift.py`
  → **80 PASS** (sub-PR 1-5 회귀 0)
- `pytest tests/unit/` (worktree) → **5131 passed / 217 failed / 2 skipped**
- `pytest tests/unit/` (origin/main baseline `fa9ccbb0`) → **5112 passed /
  217 failed / 2 skipped**
- 차이: **passed +19** (= 9 data drift + 8 report drift + 2 shell entries
  lock), **FAILED set 217 byte-identical** (pre-existing 그대로 재현). 본 PR
  회귀 0.
- `mypy src/ante` → clean (223 files)
- `ruff check` + `ruff format --check` → clean
- `docs/architecture/generated/project-structure.md` regen (drift test 2줄
  추가)
- main HEAD `fa9ccbb0` 불변 확인

### Registry 누적 등록 현황

account 9 + member 12 + bot 11 + approval 10 + treasury 9 + strategy 7 +
data 6 + report 5 = **69 entries** (잔여 ~6 도메인은 sub-PR 7-9).

### 다음 sub-PR

- sub-PR 7: broker + system (4+5 = 9 leaf, broker offline + system
  external_process). #1846 / #1847 sub-PR 1-6 의 mechanical sweep 패턴 가속
  적용 가능.

Refs #1847

🤖 Generated with [Claude Code](https://claude.com/claude-code)