### PR TITLE
refactor: #1847-7 broker + system domain OutputContract migration (~9 leaf entries)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -611,7 +611,9 @@ tests/
 │   ├── test_treasury_success_output_drift.py
 │   ├── test_strategy_success_output_drift.py
 │   ├── test_data_success_output_drift.py
-│   └── test_report_success_output_drift.py
+│   ├── test_report_success_output_drift.py
+│   ├── test_broker_success_output_drift.py
+│   └── test_system_success_output_drift.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -24,15 +24,20 @@ execution 계약을 한 곳에서 관리하는 registry 다.
   (#1847 sub-PR 6).
 * :data:`REPORT_CONTRACTS` — report 도메인 5 leaf contract tuple
   (#1847 sub-PR 6).
+* :data:`BROKER_CONTRACTS` — broker 도메인 4 leaf contract tuple
+  (#1847 sub-PR 7).
+* :data:`SYSTEM_CONTRACTS` — system 도메인 5 leaf contract tuple
+  (#1847 sub-PR 7).
 * :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
   PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
-  + strategy 7 + data 6 + report 5 = 69 entries 가 채워져 있다.
+  + strategy 7 + data 6 + report 5 + broker 4 + system 5 = 78 entries 가
+  채워져 있다.
 * :func:`get_contract` / :func:`all_contracts` — read-only accessor.
 
 본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
 
-* 잔여 도메인 entry 등록 (`#1847` sub-PR 7 이후 — broker / system /
-  instrument / config / rule / trade / backtest / audit / signal).
+* 잔여 도메인 entry 등록 (`#1847` sub-PR 8 이후 — instrument / config /
+  rule / trade / backtest / audit / signal).
 * output payload migration (`#1846` / `#1847` 는 raw_legacy 를 *문서화*
   만 하며 fmt callsite 를 바꾸지 않는다 — diff guard 가 본 PR 의 invariant).
 * drift test guard 완전 활성화 — 미등록 leaf FAIL 은 `#1848` 의 책임.
@@ -80,11 +85,13 @@ __all__ = [
     "ACCOUNT_CONTRACTS",
     "APPROVAL_CONTRACTS",
     "BOT_CONTRACTS",
+    "BROKER_CONTRACTS",
     "CLI_COMMAND_REGISTRY",
     "DATA_CONTRACTS",
     "MEMBER_CONTRACTS",
     "REPORT_CONTRACTS",
     "STRATEGY_CONTRACTS",
+    "SYSTEM_CONTRACTS",
     "TREASURY_CONTRACTS",
     "AuthContract",
     "CliCommandContract",
@@ -1183,6 +1190,204 @@ submit → list → performance → view) 와 시각적으로 일치하도록 �
 """
 
 
+# ── #1847 sub-PR 7: broker domain OutputContract migration ──────────────
+#
+# broker 도메인 4 leaf 의 contract entry. ``src/ante/cli/commands/broker.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:123-126`` (실행 분류) / ``449-463`` (커맨드
+# 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (4 commands, 전체): ``status`` / ``balance`` / ``positions``
+# / ``reconcile`` 모두 JSON 모드에서 ``fmt.output(result)`` 또는 ``fmt.table(
+# pos_list, columns)`` 평면 dict / row list 를 그대로 dump 한다. 도메인
+# envelope (``{connected, healthy, exchange, ...}``, ``{현금/매수가능 평면}``,
+# ``{positions: [...]}``, ``{total_symbols, discrepancies, match, ...}``) 이며
+# standard envelope ``{status, message, data}`` 3 키 셋과는 다르다.
+# ``OutputContract(kind="raw", envelope="raw_legacy")`` 조합으로 표현해 lock
+# 만 한다 — broker.py 본문 변경 없음 (drift test 가 callsite 변경 시 FAIL).
+#
+# ``positions`` 는 분기 mixed: empty → ``fmt.output({"message": ...,
+# "positions": []})`` (broker.py:278), non-empty JSON → ``fmt.output({"positions":
+# [...]})`` (broker.py:282), non-empty text → ``fmt.table(...)`` (broker.py:285).
+# 모두 도메인 envelope 평면 — raw_legacy 정책 (account/treasury/strategy/data
+# 분기 mixed 동형).
+#
+# scope 분류 (#1815 SSOT, broker.py @require_scope marker 와 1:1 정합):
+# - ``broker:read`` scope (4 개, 전체): ``status`` / ``balance`` /
+#   ``positions`` / ``reconcile``. ``reconcile --fix`` 는 mutating 분기이지만
+#   marker 는 ``broker:read`` 로 유지된다 (#1843 sub-PR 5 audit_actor scope
+#   결정 — write scope 분리 없음).
+# - public allowlist: 없음 — broker 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:123-126`` SSOT):
+# - ``runtime_ipc`` (4 개, 전체): 모든 broker live 커맨드는 spec 상 서버가
+#   시작 시 생성한 BrokerAdapter 를 통해 실행하는 런타임 IPC 커맨드다 (spec
+#   458-463 narrative). broker.py 의 실제 callsite 는 ``ipc_send(...)`` 우선
+#   + ``click.ClickException`` 발생 시 cold_path fallback (직접 BrokerAdapter
+#   생성) 분기를 보유하지만 spec primary 분류는 runtime_ipc 다 (account
+#   ``suspend``/``activate`` / member ``update-scopes`` / treasury
+#   ``set-balance`` / strategy ``set-status`` 동형 — fallback 분기가 있어도
+#   spec primary 분류만 lock).
+#
+# ``ipc_command`` 필드는 stub 값만 채운다 (예: ``"broker.status"``); 단순
+# 문자열 lock 이며 server-side IPC registry 와의 cross-ref drift test 는
+# #1819 의 책임이다 (account/member/bot/approval/treasury/strategy 동형 정책).
+# broker.py 호출 사이트의 IPC command name 과 그대로 일치한다 (``broker.status``
+# / ``broker.balance`` / ``broker.positions`` / ``broker.reconcile``).
+BROKER_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("broker", "status"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"broker:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{connected, healthy,
+        # exchange?, error?}``, broker.py:159). text 는 click.echo 다수 줄.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="broker.status",
+    ),
+    CliCommandContract(
+        path=("broker", "balance"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"broker:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 broker 잔고 dict
+        # (broker.py:220). 키 셋은 broker adapter 가 반환하는 그대로 (IPC
+        # 분기는 server BrokerAdapter response 의 평면 dict, fallback 분기는
+        # KIS/Mock adapter 의 ``get_account_balance()`` 반환값).
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="broker.balance",
+    ),
+    CliCommandContract(
+        path=("broker", "positions"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"broker:read"})),
+        # 분기 mixed: empty → ``fmt.output({"message": "보유 종목 없음",
+        # "positions": []})`` (broker.py:278), non-empty JSON →
+        # ``fmt.output({"positions": [...]})`` (broker.py:282), non-empty text
+        # → ``fmt.table(pos_list, columns)`` (broker.py:285). 모두 도메인
+        # envelope 평면.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="broker.positions",
+    ),
+    CliCommandContract(
+        path=("broker", "reconcile"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"broker:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict (``{total_symbols,
+        # discrepancies, match, fix_applied, corrections}``, broker.py:406).
+        # text 는 click.echo + (불일치가 있으면) fmt.table. ``--fix`` 분기는
+        # IPC mutating 호출이지만 success envelope shape 는 동일.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="broker.reconcile",
+    ),
+)
+"""Broker domain 4 leaf 의 contract tuple (#1847 sub-PR 7).
+
+순서는 ``docs/specs/cli/03-commands.md:123-126`` 의 broker 실행 분류 표
+(status → balance → positions → reconcile) 와 시각적으로 일치하도록
+정렬된다. ``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
+# ── #1847 sub-PR 7: system domain OutputContract migration ──────────────
+#
+# system 도메인 5 leaf 의 contract entry. ``src/ante/cli/commands/system.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:77-81`` (실행 분류) / ``156-164`` (커맨드
+# 표) 와 1:1 정합한다.
+#
+# standard envelope (4 commands): ``start`` / ``stop`` / ``halt`` /
+# ``clear-halt`` 는 단일 success 경로 ``fmt.success(message[, data])`` 만
+# 호출하며 표준 envelope (``{status, message, data}``) 을 dump 한다.
+# - ``start`` (system.py:94): ``fmt.success("시스템 시작 중...")`` — data
+#   인자 없음 (``OutputFormatter.success`` 가 ``None`` → ``{}`` 으로 normalize).
+#   JSON 모드에서 ``data: {}`` 평면 dict 슬롯이 있다.
+# - ``stop`` (system.py:152): ``fmt.success("종료 시그널 전송 완료", {"pid": pid})``.
+# - ``halt`` (system.py:224): ``fmt.success(f"시스템 HALTED — {count}개 ...", data)``.
+# - ``clear-halt`` (system.py:242): ``fmt.success(f"시스템 정지 해제 — ...", data)``.
+# JSON / text 분기 없음 (text 와 JSON 양쪽 모두 fmt.success).
+#
+# raw_legacy 분류 (1 command): ``status`` (system.py:202-206) 는 JSON 모드
+# 분기에서 ``fmt.output(result)`` 로 평면 dict (``{trading_state, bot_count}``)
+# 를 그대로 dump 한다. text 모드는 click.echo 2 줄. ``OutputContract(kind=
+# "raw", envelope="raw_legacy")`` 조합으로 표현해 lock 만 한다.
+#
+# scope 분류 (#1815 SSOT, system.py @require_scope marker 와 1:1 정합):
+# - ``system:read`` scope (1 개): ``status``.
+# - ``system:admin`` scope (4 개): ``start`` / ``stop`` / ``halt`` /
+#   ``clear-halt``.
+# - public allowlist: 없음 — system 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:77-81`` SSOT):
+# - ``long_running`` (2 개): ``start`` / ``stop``. spec 표는 ``external
+#   process`` 표기이며 본 registry 의 ExecutionClass vocab 매핑 (모듈 docstring
+#   normative 표) 에 따라 ``"long_running"`` 에 흡수된다.
+# - ``offline`` (1 개): ``status``. 로컬 DB / PID 상태 조회.
+# - ``runtime_ipc`` (2 개): ``halt`` / ``clear-halt``. ``ipc_send`` 로 IPC
+#   handler (``system.halt`` / ``system.clear_halt``) 를 호출.
+#
+# ``ipc_command`` 필드는 ``halt`` / ``clear-halt`` 의 IPC command name stub
+# 만 채운다 (``"system.halt"`` / ``"system.clear_halt"``); 단순 문자열 lock
+# 이며 server-side IPC registry 와의 cross-ref drift test 는 #1819 의 책임이다.
+# ``start`` / ``stop`` 은 IPC 가 아니라 OS process 제어 (``subprocess.run`` /
+# ``os.kill(SIGTERM)``) 이므로 ``ipc_command`` 는 ``None``.
+SYSTEM_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("system", "start"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"system:admin"})),
+        # 단일 success 경로 ``fmt.success("시스템 시작 중...")`` (system.py:94)
+        # — data 인자 없음. JSON 모드 dump 는 ``{status: "ok", message:
+        # "시스템 시작 중...", data: {}}`` standard envelope. 이후 subprocess
+        # 가 inherit 된 stderr 로 자식 로그를 흘려 ``json.loads`` 파싱이
+        # 단일 document 로 보장된다 (#1757 stdout 격리).
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="long_running",
+    ),
+    CliCommandContract(
+        path=("system", "stop"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"system:admin"})),
+        # 단일 success 경로 ``fmt.success("종료 시그널 전송 완료", {"pid": pid})``
+        # (system.py:152) → standard envelope (``data: {pid}``). error 분기는
+        # ``fmt.error`` 이며 본 drift test 의 success-output scope 밖.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="long_running",
+    ),
+    CliCommandContract(
+        path=("system", "status"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"system:read"})),
+        # JSON mode 분기: ``fmt.output(result)`` 평면 dict (``{trading_state,
+        # bot_count}``, system.py:203). text 는 click.echo 2 줄.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("system", "halt"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"system:admin"})),
+        # 단일 success 경로 ``fmt.success(f"시스템 HALTED — {count}개 계좌
+        # 거래 중지", data)`` (system.py:224) → standard envelope. IPC response
+        # 의 ``data`` slot (``{accounts_changed, ...}``) 을 그대로 wrapping.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="system.halt",
+    ),
+    CliCommandContract(
+        path=("system", "clear-halt"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"system:admin"})),
+        # 단일 success 경로 ``fmt.success(f"시스템 정지 해제 — ...", data)``
+        # (system.py:242) → standard envelope. halt 동형 IPC wrapping.
+        output=OutputContract(kind="operation", envelope="standard"),
+        execution="runtime_ipc",
+        ipc_command="system.clear_halt",
+    ),
+)
+"""System domain 5 leaf 의 contract tuple (#1847 sub-PR 7).
+
+순서는 ``docs/specs/cli/03-commands.md:77-81`` 의 system 실행 분류 표
+(start → stop → status → halt → clear-halt) 와 시각적으로 일치하도록
+정렬된다. ``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
 CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
     contract.path: contract
     for contract in (
@@ -1194,17 +1399,20 @@ CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
         *STRATEGY_CONTRACTS,
         *DATA_CONTRACTS,
         *REPORT_CONTRACTS,
+        *BROKER_CONTRACTS,
+        *SYSTEM_CONTRACTS,
     )
 }
 """Leaf command path → contract mapping.
 
 본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
-+ strategy 7 + data 6 + report 5 = 69 entries 가 등록되어 있다 (#1846 /
-#1847 sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847
-sub-PR 5 / #1847 sub-PR 6). 나머지 도메인 (broker / system / instrument /
-config / rule / trade / backtest / audit / signal) 의 entry 등록은 후속
-PR (`#1847` sub-PR 7-9) 의 책임이다. registry 미등록 leaf 가 FAIL 이어야
-하는 drift guard 는 `#1848` 가 활성화한다.
++ strategy 7 + data 6 + report 5 + broker 4 + system 5 = 78 entries 가
+등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR 3
+/ #1847 sub-PR 4 / #1847 sub-PR 5 / #1847 sub-PR 6 / #1847 sub-PR 7).
+나머지 도메인 (instrument / config / rule / trade / backtest / audit /
+signal) 의 entry 등록은 후속 PR (`#1847` sub-PR 8-9) 의 책임이다.
+registry 미등록 leaf 가 FAIL 이어야 하는 drift guard 는 `#1848` 가
+활성화한다.
 """
 
 
@@ -1224,8 +1432,9 @@ def all_contracts() -> Iterator[CliCommandContract]:
     """등록된 모든 contract 를 dict 순회 순서로 yield 한다.
 
     본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury
-    9 + strategy 7 + data 6 + report 5 = 69 entries 가 등록되어 있다
-    (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR 3 / #1847
-    sub-PR 4 / #1847 sub-PR 5 / #1847 sub-PR 6).
+    9 + strategy 7 + data 6 + report 5 + broker 4 + system 5 = 78 entries
+    가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 / #1847
+    sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5 / #1847 sub-PR 6 / #1847
+    sub-PR 7).
     """
     yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -180,17 +180,17 @@ def test_raw_legacy_is_envelope_form_not_contract_kind() -> None:
 
 
 def test_get_contract_returns_none_when_missing() -> None:
-    """미등록 path 는 ``None`` 을 반환한다 (등록된 8 도메인 외).
+    """미등록 path 는 ``None`` 을 반환한다 (등록된 10 도메인 외).
 
     등록 도메인: account / member / bot / approval / treasury / strategy /
-    data / report.
+    data / report / broker / system.
     """
     # nonexistent path 는 항상 ``None``.
     assert get_contract(("nonexistent",)) is None
-    # broker 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 7 이후) 의
-    # 책임이므로 본 PR 시점에는 ``None`` 이다 (data / report domain 은
-    # sub-PR 6 에서 등록되었다).
-    assert get_contract(("broker", "status")) is None
+    # instrument 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 8 이후) 의
+    # 책임이므로 본 PR 시점에는 ``None`` 이다 (broker / system domain 은
+    # sub-PR 7 에서 등록되었다).
+    assert get_contract(("instrument", "list")) is None
 
 
 def test_registry_is_mutable_dict() -> None:
@@ -420,6 +420,56 @@ def test_report_entries_registered_after_1847_sub_pr_6() -> None:
     assert expected_report_paths.issubset(registered), (
         f"report 5 entry 가 모두 등록되어야 한다 (#1847 sub-PR 6). "
         f"누락: {sorted(expected_report_paths - registered)}"
+    )
+
+
+def test_broker_entries_registered_after_1847_sub_pr_7() -> None:
+    """#1847 sub-PR 7 가 broker 4 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 7 가 broker migration 을 완료한 시점부터
+    lock 된다. 4 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_broker_success_output_drift` 가
+    책임진다.
+    """
+    expected_broker_paths = {
+        ("broker", "status"),
+        ("broker", "balance"),
+        ("broker", "positions"),
+        ("broker", "reconcile"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_broker_paths.issubset(registered), (
+        f"broker 4 entry 가 모두 등록되어야 한다 (#1847 sub-PR 7). "
+        f"누락: {sorted(expected_broker_paths - registered)}"
+    )
+
+
+def test_system_entries_registered_after_1847_sub_pr_7() -> None:
+    """#1847 sub-PR 7 가 system 5 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 7 가 system migration 을 완료한 시점부터
+    lock 된다. 5 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_system_success_output_drift` 가
+    책임진다.
+
+    spec 표 (``docs/specs/cli/03-commands.md:77-78``) 는 ``start`` /
+    ``stop`` 을 ``external process`` 로 분류하지만 본 registry 의
+    ``ExecutionClass`` vocab 매핑 (모듈 docstring normative 표) 에 따라
+    ``"long_running"`` 에 흡수된다 (#1815 5 값 결정).
+    """
+    expected_system_paths = {
+        ("system", "start"),
+        ("system", "stop"),
+        ("system", "status"),
+        ("system", "halt"),
+        ("system", "clear-halt"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_system_paths.issubset(registered), (
+        f"system 5 entry 가 모두 등록되어야 한다 (#1847 sub-PR 7). "
+        f"누락: {sorted(expected_system_paths - registered)}"
     )
 
 

--- a/tests/unit/test_broker_success_output_drift.py
+++ b/tests/unit/test_broker_success_output_drift.py
@@ -1,0 +1,415 @@
+"""Broker CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 7).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+broker 도메인 4 leaf 의 ``OutputContract`` 와 ``ante broker ... --format json``
+실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1 (member) / sub-PR 2 (bot) / sub-PR 3
+(approval) / sub-PR 4 (treasury) / sub-PR 5 (strategy) / sub-PR 6 (data /
+report) 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump 한다
+  (standard envelope 의 3 키 셋이 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``broker.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제 callsite
+shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면 본 test 가
+즉시 FAIL 한다 (registry 갱신 또는 callsite 정렬 중 한쪽이 책임).
+
+broker.py 는 모든 4 leaf 가 IPC 우선 + cold_path fallback 구조 (``ipc_send``
+가 ``click.ClickException`` 을 raise 하면 fallback) 를 가진다. 본 drift test
+는 IPC 분기를 강제로 success path 로 mock 해 success envelope 단언만 한다
+— fallback 분기의 drift 는 별도 covered 가 필요하면 후속 sub-PR 가 추가한다.
+
+8 시나리오 (4 leaf + registry sanity +1 + positions empty 분기 +1 +
+positions non-empty +1 + reconcile match 분기 +1):
+
+0. registry sanity — broker 4 entries 의 envelope 이 ``standard`` /
+   ``raw_legacy`` 분류 범위 내.
+1. ``status`` → ``raw_legacy`` (``fmt.output(result)``)
+2. ``balance`` → ``raw_legacy`` (``fmt.output(result)``)
+3. ``positions`` empty → ``raw_legacy`` (``{message, positions: []}``)
+4. ``positions`` non-empty → ``raw_legacy`` (``{positions: [...]}``)
+5. ``reconcile`` (match) → ``raw_legacy`` (``{total_symbols, ..., match: True}``)
+6. ``reconcile`` --fix → ``raw_legacy`` (``{total_symbols, ..., fix_applied: True}``)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언.
+
+    raw_legacy 는 ``fmt.output(dict)`` / ``fmt.table(rows)`` 출력의 super-set
+    이다. ``status``/``message``/``data`` 3 키가 동시에 갖춰지고 ``status ==
+    "ok"`` 면 standard envelope 으로 분류 (애매한 경계 방지). 그렇지 않으면
+    모든 평면 도메인 payload 는 raw_legacy.
+    """
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_broker_entries_envelopes_classified() -> None:
+    """broker 4 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 4 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    broker_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("broker",)
+    ]
+    assert len(broker_entries) == 4, (
+        f"broker 4 entries 가 모두 등록되어야 한다. 실제: {len(broker_entries)}"
+    )
+    for path, contract in broker_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (account/member/bot/approval/treasury/strategy/data 동형) ──
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json broker ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다.
+
+    ``OutputFormatter`` 가 ``json.dumps(..., indent=2)`` 로 multi-line dump
+    하기 때문에 처음 ``{`` 또는 ``[`` 부터 ``raw_decode`` 로 한 value 를
+    파싱하고 나머지 stdout (text 모드 잔존물 등) 는 무시한다 (data / report
+    drift test 동형).
+    """
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. status → raw_legacy ─────────────────────────────────────────────────
+
+
+def test_broker_status_envelope_matches_raw_legacy() -> None:
+    """``broker status``: ``fmt.output(result)`` 평면 dict (raw_legacy).
+
+    broker.py:159: ``if fmt.is_json: fmt.output(result)`` → IPC server
+    BrokerAdapter response 평면 dict (``{connected, healthy, exchange?,
+    error?}``). 본 fixture 는 ``ipc_send`` 를 mock 해 IPC 분기를 강제한다.
+    """
+    ipc_response = {
+        "connected": True,
+        "healthy": True,
+        "exchange": "KIS",
+    }
+    with patch(
+        "ante.cli.commands.ipc_helpers.ipc_send",
+        new=AsyncMock(return_value=ipc_response),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "broker",
+                "status",
+                "--account",
+                "acct-001",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"broker status: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["connected"] is True
+    assert payload["healthy"] is True
+    assert payload["exchange"] == "KIS"
+
+
+# ── 2. balance → raw_legacy ────────────────────────────────────────────────
+
+
+def test_broker_balance_envelope_matches_raw_legacy() -> None:
+    """``broker balance``: ``fmt.output(result)`` 평면 dict (raw_legacy).
+
+    broker.py:220: ``if fmt.is_json: fmt.output(result)`` → broker adapter
+    가 반환하는 평면 잔고 dict. 본 fixture 는 IPC 분기를 mock 한다.
+    """
+    ipc_response = {
+        "account_balance": 10_000_000.0,
+        "purchasable_amount": 8_000_000.0,
+        "total_evaluation": 12_500_000.0,
+        "total_profit_loss": 2_500_000.0,
+    }
+    with patch(
+        "ante.cli.commands.ipc_helpers.ipc_send",
+        new=AsyncMock(return_value=ipc_response),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "broker",
+                "balance",
+                "--account",
+                "acct-001",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"broker balance: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["account_balance"] == 10_000_000.0
+    assert payload["total_evaluation"] == 12_500_000.0
+
+
+# ── 3. positions empty → raw_legacy ────────────────────────────────────────
+
+
+def test_broker_positions_empty_envelope_matches_raw_legacy() -> None:
+    """``broker positions`` empty: ``{message, positions: []}`` 평면.
+
+    broker.py:278: ``fmt.output({"message": "보유 종목 없음", "positions": []})``.
+    IPC 가 빈 positions 를 반환할 때 분기.
+    """
+    ipc_response = {"positions": []}
+    with patch(
+        "ante.cli.commands.ipc_helpers.ipc_send",
+        new=AsyncMock(return_value=ipc_response),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "broker",
+                "positions",
+                "--account",
+                "acct-001",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"broker positions empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"message": "보유 종목 없음", "positions": []}
+
+
+# ── 4. positions non-empty → raw_legacy ────────────────────────────────────
+
+
+def test_broker_positions_non_empty_envelope_matches_raw_legacy() -> None:
+    """``broker positions`` non-empty: ``{positions: [...]}`` 평면.
+
+    broker.py:282: ``if fmt.is_json: fmt.output({"positions": pos_list})``.
+    """
+    pos_rows = [
+        {
+            "symbol": "005930",
+            "quantity": 10,
+            "avg_price": 70000,
+            "eval_amount": 720000,
+        },
+        {
+            "symbol": "000660",
+            "quantity": 5,
+            "avg_price": 120000,
+            "eval_amount": 600000,
+        },
+    ]
+    ipc_response = {"positions": pos_rows}
+    with patch(
+        "ante.cli.commands.ipc_helpers.ipc_send",
+        new=AsyncMock(return_value=ipc_response),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "broker",
+                "positions",
+                "--account",
+                "acct-001",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"broker positions non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert isinstance(payload["positions"], list)
+    assert len(payload["positions"]) == 2
+    assert payload["positions"][0]["symbol"] == "005930"
+
+
+# ── 5. reconcile (match) → raw_legacy ──────────────────────────────────────
+
+
+def test_broker_reconcile_match_envelope_matches_raw_legacy() -> None:
+    """``broker reconcile`` (match): ``fmt.output(result)`` 평면 dict.
+
+    broker.py:406: ``if fmt.is_json: fmt.output(result)`` → ``{total_symbols,
+    discrepancies, match, fix_applied, corrections}``.
+    """
+    ipc_response = {
+        "total_symbols": 3,
+        "discrepancies": [],
+        "match": True,
+        "fix_applied": False,
+        "corrections": 0,
+    }
+    with patch(
+        "ante.cli.commands.ipc_helpers.ipc_send",
+        new=AsyncMock(return_value=ipc_response),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "broker",
+                "reconcile",
+                "--account",
+                "acct-001",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"broker reconcile match: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["total_symbols"] == 3
+    assert payload["match"] is True
+    assert payload["fix_applied"] is False
+
+
+# ── 6. reconcile --fix → raw_legacy ────────────────────────────────────────
+
+
+def test_broker_reconcile_fix_envelope_matches_raw_legacy() -> None:
+    """``broker reconcile --fix``: IPC mutating ``fmt.output(result)`` 평면.
+
+    broker.py:406 동일 callsite. ``--fix`` 분기는 IPC ``broker.reconcile``
+    호출 (line 317) 후 동일 success envelope shape 로 dump.
+    """
+    ipc_response = {
+        "total_symbols": 4,
+        "discrepancies": [
+            {
+                "symbol": "005930",
+                "broker_qty": 10.0,
+                "internal_qty": 8.0,
+                "diff": 2.0,
+            },
+        ],
+        "match": False,
+        "fix_applied": True,
+        "corrections": 1,
+    }
+    with patch(
+        "ante.cli.commands.ipc_helpers.ipc_send",
+        new=AsyncMock(return_value=ipc_response),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "broker",
+                "reconcile",
+                "--account",
+                "acct-001",
+                "--fix",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"broker reconcile --fix: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["fix_applied"] is True
+    assert payload["corrections"] == 1
+    assert isinstance(payload["discrepancies"], list)

--- a/tests/unit/test_system_success_output_drift.py
+++ b/tests/unit/test_system_success_output_drift.py
@@ -1,0 +1,388 @@
+"""System CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 7).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+system 도메인 5 leaf 의 ``OutputContract`` 와 ``ante system ... --format json``
+실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1 (member) / sub-PR 2 (bot) / sub-PR 3
+(approval) / sub-PR 4 (treasury) / sub-PR 5 (strategy) / sub-PR 6 (data /
+report) / sub-PR 7 (broker) 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump 한다
+  (standard envelope 의 3 필수 키 셋이 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``system.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제 callsite
+shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면 본 test 가
+즉시 FAIL 한다 (registry 갱신 또는 callsite 정렬 중 한쪽이 책임).
+
+system.py 특이사항:
+
+- ``start`` 는 ``fmt.success("시스템 시작 중...")`` 후 ``subprocess.run`` 으로
+  자식 ``python -m ante.main`` 을 실행하고 ``SystemExit(proc.returncode)`` 한다.
+  본 fixture 는 ``subprocess.run`` 을 mock 해 자식 실행을 건너뛰고 returncode 0
+  으로 만든 뒤 success envelope 만 단언한다.
+- ``stop`` 은 PID 파일 + ``os.kill(pid, SIGTERM)`` 을 호출한다. 본 fixture 는
+  ``read_pid_file`` / ``_is_process_alive`` / ``os.kill`` 을 mock 해 success
+  분기를 강제한다.
+- ``status`` 는 로컬 DB 와 AccountService 를 직접 사용한다. 본 fixture 는
+  DB / AccountService 를 mock 한다.
+- ``halt`` / ``clear-halt`` 는 ``ipc_send`` 호출 결과를 wrapping 한다 — IPC
+  response 를 mock 한다.
+
+6 시나리오 (5 leaf + registry sanity +1):
+
+0. registry sanity — system 5 entries 의 envelope 이 ``standard`` /
+   ``raw_legacy`` 분류 범위 내.
+1. ``start`` → ``standard`` (``fmt.success("시스템 시작 중...")``)
+2. ``stop`` → ``standard`` (``fmt.success(..., {"pid": pid})``)
+3. ``status`` → ``raw_legacy`` (``fmt.output({trading_state, bot_count})``)
+4. ``halt`` → ``standard`` (``fmt.success(f"...", data)``)
+5. ``clear-halt`` → ``standard`` (``fmt.success(f"...", data)``)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지.
+
+    ``data`` 슬롯은 dict (``{}``, ``{pid: ...}`` 등) 또는 ``None`` 모두 허용.
+    ``OutputFormatter.success`` 가 ``data=None`` 입력을 ``{}`` 으로
+    normalize 하므로 실제 출력은 dict 다.
+    """
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언."""
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_system_entries_envelopes_classified() -> None:
+    """system 5 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 5 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    system_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("system",)
+    ]
+    assert len(system_entries) == 5, (
+        f"system 5 entries 가 모두 등록되어야 한다. 실제: {len(system_entries)}"
+    )
+    for path, contract in system_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (account/member/bot/approval/treasury/strategy/data/report/
+#                broker 동형) ──
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json system ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다."""
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. start → standard ────────────────────────────────────────────────────
+
+
+def test_system_start_envelope_matches_operation_standard(tmp_path) -> None:
+    """``system start``: ``fmt.success("시스템 시작 중...")`` → standard envelope.
+
+    system.py:94: ``fmt.success("시스템 시작 중...")`` — data 인자 없음.
+    ``OutputFormatter.success`` 가 ``data=None`` → ``{}`` 으로 normalize 한다
+    (formatter.py:93). JSON 모드 dump: ``{status:"ok", message:"시스템 시작
+    중...", data: {}}``.
+
+    이후 ``subprocess.run`` 으로 자식 ``python -m ante.main`` 을 실행하고
+    ``SystemExit(proc.returncode)`` 한다. 본 fixture 는 ``subprocess.run`` 을
+    mock 해 자식 실행을 건너뛰고 returncode 0 으로 만든다. ``read_pid_file``
+    는 None (실행 중인 인스턴스 없음) 으로 mock 한다.
+    """
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+
+    with (
+        patch("ante.main.read_pid_file", return_value=None),
+        patch("subprocess.run", return_value=mock_proc) as run_mock,
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "system",
+                "start",
+                "--config-dir",
+                str(tmp_path),
+            ]
+        )
+
+    # ``SystemExit(0)`` 후 exit_code 0.
+    assert result.exit_code == 0, result.output
+    # subprocess.run 이 mock 되어 실제 자식 spawn 은 일어나지 않는다.
+    run_mock.assert_called_once()
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"system start: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert payload["message"] == "시스템 시작 중..."
+    # data 슬롯은 빈 dict.
+    assert payload["data"] == {}
+
+
+# ── 2. stop → standard ─────────────────────────────────────────────────────
+
+
+def test_system_stop_envelope_matches_operation_standard(tmp_path) -> None:
+    """``system stop``: ``fmt.success("종료 시그널 전송 완료", {"pid": pid})`` →
+    standard envelope.
+
+    system.py:152: ``fmt.success("종료 시그널 전송 완료", {"pid": pid})``.
+    """
+    fake_pid = 12345
+    with (
+        patch("ante.main.read_pid_file", return_value=fake_pid),
+        patch(
+            "ante.cli.commands.system._is_process_alive",
+            return_value=True,
+        ),
+        patch("ante.cli.commands.system.os.kill") as kill_mock,
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "--config-dir",
+                str(tmp_path),
+                "system",
+                "stop",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+    kill_mock.assert_called_once()
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"system stop: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "종료 시그널" in payload["message"]
+    assert payload["data"] == {"pid": fake_pid}
+
+
+# ── 3. status → raw_legacy ─────────────────────────────────────────────────
+
+
+def test_system_status_envelope_matches_raw_legacy() -> None:
+    """``system status``: JSON 모드 ``fmt.output(result)`` → raw_legacy.
+
+    system.py:203: ``if fmt.is_json: fmt.output(result)`` → ``{trading_state,
+    bot_count}`` 평면 dict. text 모드는 click.echo 2 줄.
+
+    fixture: AccountService.list + Database.fetch_one 을 mock 한다.
+    """
+    from ante.account.models import Account, AccountStatus, TradingMode
+
+    fake_account = Account(
+        account_id="acct-1",
+        name="Test Account",
+        exchange="KRX",
+        currency="KRW",
+        trading_mode=TradingMode.VIRTUAL,
+        broker_type="test",
+        status=AccountStatus.ACTIVE,
+    )
+    with (
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.account.service.AccountService.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.account.service.AccountService.list",
+            new=AsyncMock(return_value=[fake_account]),
+        ),
+        patch(
+            "ante.core.database.Database.fetch_one",
+            new=AsyncMock(return_value={"cnt": 3}),
+        ),
+    ):
+        result = _invoke(["--format", "json", "system", "status"])
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"system status: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["trading_state"] == "active"
+    assert payload["bot_count"] == 3
+
+
+# ── 4. halt → standard ─────────────────────────────────────────────────────
+
+
+def test_system_halt_envelope_matches_operation_standard() -> None:
+    """``system halt``: ``fmt.success(f"시스템 HALTED ...", data)`` → standard.
+
+    system.py:224: ``fmt.success(f"시스템 HALTED — {count}개 계좌 거래 중지",
+    data)``. IPC response (``data`` slot) 를 그대로 wrapping.
+    """
+    ipc_response = {
+        "data": {
+            "accounts_changed": 5,
+            "actor": "test-master",
+            "reason": "drill",
+        }
+    }
+    with patch(
+        "ante.cli.commands.ipc_helpers.ipc_send",
+        new=AsyncMock(return_value=ipc_response),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "system",
+                "halt",
+                "--reason",
+                "drill",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"system halt: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "HALTED" in payload["message"]
+    assert payload["data"]["accounts_changed"] == 5
+
+
+# ── 5. clear-halt → standard ───────────────────────────────────────────────
+
+
+def test_system_clear_halt_envelope_matches_operation_standard() -> None:
+    """``system clear-halt``: ``fmt.success(f"...", data)`` → standard.
+
+    system.py:242: ``fmt.success(f"시스템 정지 해제 — {count}개 계좌 ACTIVE
+    복구 (봇은 자동 재시작되지 않음)", data)``. halt 동형 IPC wrapping.
+    """
+    ipc_response = {
+        "data": {
+            "accounts_changed": 2,
+            "actor": "test-master",
+            "reason": "post-drill",
+        }
+    }
+    with patch(
+        "ante.cli.commands.ipc_helpers.ipc_send",
+        new=AsyncMock(return_value=ipc_response),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "system",
+                "clear-halt",
+                "--reason",
+                "post-drill",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"system clear-halt: standard envelope 이어야 함. payload={payload!r}"
+    )
+    assert "정지 해제" in payload["message"]
+    assert payload["data"]["accounts_changed"] == 2


### PR DESCRIPTION
Refs #1847
Refs #1815

#1846 (account 9) / #1847 sub-PR 1 (member 12) / sub-PR 2 (bot 11) /
sub-PR 3 (approval 10) / sub-PR 4 (treasury 9) / sub-PR 5 (strategy 7) /
sub-PR 6 (data 6 + report 5) 동형 패턴으로 broker + system 도메인 9 leaf
(broker 4 + system 5) 의 ``OutputContract`` / ``AuthContract`` /
``ExecutionClass`` 를 ``CLI_COMMAND_REGISTRY`` SSOT 에 등록.

## 등록 entry — broker 4 leaf

| # | path | auth | output | execution | ipc_command stub |
|---|------|------|--------|-----------|------------------|
| 1 | `broker status` | `broker:read` | raw / raw_legacy | runtime_ipc | `broker.status` |
| 2 | `broker balance` | `broker:read` | raw / raw_legacy | runtime_ipc | `broker.balance` |
| 3 | `broker positions` | `broker:read` | raw / raw_legacy (mixed empty/non-empty) | runtime_ipc | `broker.positions` |
| 4 | `broker reconcile` | `broker:read` | raw / raw_legacy (mixed read/--fix) | runtime_ipc | `broker.reconcile` |

모든 broker live 커맨드는 spec (``docs/specs/cli/03-commands.md:123-126`` +
``449-463`` narrative) 상 서버 BrokerAdapter 를 통해 실행하는 런타임 IPC
커맨드다. broker.py 의 실제 callsite 는 ``ipc_send`` 우선 + cold_path
fallback 분기를 보유하지만 spec primary 분류는 runtime_ipc 다 (account
``suspend``/``activate`` / member ``update-scopes`` / treasury ``set-balance`` /
strategy ``set-status`` 동형 — fallback 분기가 있어도 spec primary 분류만
lock).

## 등록 entry — system 5 leaf

| # | path | auth | output | execution | ipc_command stub |
|---|------|------|--------|-----------|------------------|
| 1 | `system start` | `system:admin` | operation / standard | long_running | — |
| 2 | `system stop` | `system:admin` | operation / standard | long_running | — |
| 3 | `system status` | `system:read` | raw / raw_legacy | offline | — |
| 4 | `system halt` | `system:admin` | operation / standard | runtime_ipc | `system.halt` |
| 5 | `system clear-halt` | `system:admin` | operation / standard | runtime_ipc | `system.clear_halt` |

spec 표 (``docs/specs/cli/03-commands.md:77-78``) 는 ``start`` / ``stop`` 을
``external process`` 로 분류하지만 본 registry 의 ``ExecutionClass`` vocab
매핑 (모듈 docstring normative 표) 에 따라 ``"long_running"`` 에 흡수된다
(#1815 5 값 결정). ``start`` 의 ``fmt.success("시스템 시작 중...")`` 는 data
인자 없음 — JSON 모드에서 ``OutputFormatter.success`` 가 ``None`` → ``{}`` 으로
normalize 해 standard envelope 의 ``data: {}`` 슬롯이 보존된다.

## 검증

- `pytest tests/unit/contracts -v` → **109 PASS** (107 → +2 broker/system
  shell entries lock)
- `pytest tests/unit/test_broker_success_output_drift.py -v` → **7 PASS**
  (registry sanity + 4 leaf + positions empty/non-empty 분기 +2 + reconcile
  match/--fix 분기 +2)
- `pytest tests/unit/test_system_success_output_drift.py -v` → **6 PASS**
  (registry sanity + 5 leaf 각 1 시나리오)
- prior sub-PR drift tests (account/member/bot/approval/treasury/strategy/
  data/report) → **94 PASS** (sub-PR 1-6 회귀 0)
- `mypy src/` → clean (223 files)
- `ruff check` + `ruff format --check` → clean
- `git diff origin/main..HEAD -- src/ante/cli/commands/broker.py src/ante/cli/commands/system.py` → **0 lines** (diff guard PASS)
- main HEAD `01723744` 불변 확인
- `docs/architecture/generated/project-structure.md` regen (drift test 2
  줄 추가만)

## Registry 누적 등록 현황

account 9 + member 12 + bot 11 + approval 10 + treasury 9 + strategy 7 +
data 6 + report 5 + broker 4 + system 5 = **78 entries** (잔여 ~7 도메인은
sub-PR 8-9).

## 다음 sub-PR

- sub-PR 8: instrument + config + rule (4+3+3 = 10 leaf, offline/runtime_ipc
  혼합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)