### PR TITLE
refactor: #1847-8 instrument + config + rule domain OutputContract migration (~10 leaf)

### DIFF
--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -28,16 +28,22 @@ execution 계약을 한 곳에서 관리하는 registry 다.
   (#1847 sub-PR 7).
 * :data:`SYSTEM_CONTRACTS` — system 도메인 5 leaf contract tuple
   (#1847 sub-PR 7).
+* :data:`INSTRUMENT_CONTRACTS` — instrument 도메인 4 leaf contract tuple
+  (#1847 sub-PR 8).
+* :data:`CONFIG_CONTRACTS` — config 도메인 3 leaf contract tuple
+  (#1847 sub-PR 8).
+* :data:`RULE_CONTRACTS` — rule 도메인 3 leaf contract tuple
+  (#1847 sub-PR 8).
 * :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
   PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
-  + strategy 7 + data 6 + report 5 + broker 4 + system 5 = 78 entries 가
-  채워져 있다.
+  + strategy 7 + data 6 + report 5 + broker 4 + system 5 + instrument 4
+  + config 3 + rule 3 = 88 entries 가 채워져 있다.
 * :func:`get_contract` / :func:`all_contracts` — read-only accessor.
 
 본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
 
-* 잔여 도메인 entry 등록 (`#1847` sub-PR 8 이후 — instrument / config /
-  rule / trade / backtest / audit / signal).
+* 잔여 도메인 entry 등록 (`#1847` sub-PR 9 이후 — trade / backtest /
+  audit / signal).
 * output payload migration (`#1846` / `#1847` 는 raw_legacy 를 *문서화*
   만 하며 fmt callsite 를 바꾸지 않는다 — diff guard 가 본 PR 의 invariant).
 * drift test guard 완전 활성화 — 미등록 leaf FAIL 은 `#1848` 의 책임.
@@ -87,9 +93,12 @@ __all__ = [
     "BOT_CONTRACTS",
     "BROKER_CONTRACTS",
     "CLI_COMMAND_REGISTRY",
+    "CONFIG_CONTRACTS",
     "DATA_CONTRACTS",
+    "INSTRUMENT_CONTRACTS",
     "MEMBER_CONTRACTS",
     "REPORT_CONTRACTS",
+    "RULE_CONTRACTS",
     "STRATEGY_CONTRACTS",
     "SYSTEM_CONTRACTS",
     "TREASURY_CONTRACTS",
@@ -1388,6 +1397,259 @@ SYSTEM_CONTRACTS: tuple[CliCommandContract, ...] = (
 """
 
 
+# ── #1847 sub-PR 8: instrument domain OutputContract migration ──────────
+#
+# instrument 도메인 4 leaf 의 contract entry. ``src/ante/cli/commands/
+# instrument.py`` 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴,
+# 그리고 ``docs/specs/cli/03-commands.md:150`` (실행 분류) / ``691-704``
+# (커맨드 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (3 commands): ``list`` / ``sync`` / ``search`` 는 JSON
+# 모드에서 ``fmt.output(dict)`` 또는 ``fmt.table(rows, columns)`` 평면
+# dict / row list 를 그대로 dump 한다.
+# - ``list`` (instrument.py:107/110): empty → ``fmt.output({"instruments":
+#   [], "count": 0})`` 평면; non-empty → ``fmt.table(results, [symbol,
+#   name, name_en, type, listed])`` row list.
+# - ``sync`` (instrument.py:233-243): ``fmt.output({"sync_result": {...},
+#   "message": "동기화 완료: ..."})`` 평면 — standard envelope 의 ``status``
+#   키 부재이므로 raw_legacy. text 와 JSON 양쪽 동일 호출.
+# - ``search`` (instrument.py:296/299): empty → ``fmt.output({"results":
+#   [], "count": 0})`` 평면; non-empty → ``fmt.table(results, [symbol,
+#   exchange, name, name_en, type])`` row list.
+#
+# standard / raw_legacy 분기 mixed (1 command): ``import`` 는 두 분기를
+# 가진다.
+# - dry-run 경로 (instrument.py:441-454): JSON → ``fmt.output({"dry_run":
+#   True, "total": N, "preview": [...]})`` 평면 dict; text → click.echo +
+#   fmt.table.
+# - 실제 import 경로 (instrument.py:471-474): ``fmt.success(f"종목 import
+#   완료: {count}건", {"count": count, "file": str(path)})`` standard
+#   envelope.
+# plan v2 mixed-branch policy (account ``set-credentials`` / bot ``signal-
+# key`` / treasury ``set-balance`` / strategy ``set-status`` / data
+# ``delete`` 동형) 에 따라 raw 우선으로 표현해 ``raw_legacy`` 로 lock.
+# drift test 가 양쪽 분기를 모두 단언한다.
+#
+# scope 분류 (#1815 SSOT, instrument.py @require_scope marker 와 1:1 정합):
+# - ``data:read`` scope (2 개): ``list`` / ``search``.
+# - ``data:write`` scope (2 개): ``sync`` / ``import``.
+# - public allowlist: 없음 — instrument 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:150`` SSOT):
+# - ``offline`` (4 개, 전체): 모든 instrument 명령은 local ``Database`` 와
+#   ``InstrumentService`` 를 직접 생성한다. ``sync`` 는 ``KISAdapter`` 외부
+#   호출이 있지만 spec 분류는 ``offline`` (runtime IPC handler 없음).
+#   runtime IPC handler 없음.
+INSTRUMENT_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("instrument", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:read"})),
+        # JSON mode: empty → ``fmt.output({"instruments": [], "count": 0})``
+        # 평면 (instrument.py:107), non-empty → ``fmt.table(results, [...])``
+        # row list (instrument.py:110). text 는 동일 fmt.table.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("instrument", "sync"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:write"})),
+        # JSON mode: ``fmt.output({"sync_result": {...}, "message": ...})``
+        # 평면 dict (instrument.py:233-243). text 도 동일 호출.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("instrument", "search"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:read"})),
+        # JSON mode: empty → ``fmt.output({"results": [], "count": 0})``
+        # 평면 (instrument.py:296), non-empty → ``fmt.table(results, [...])``
+        # row list (instrument.py:299). text 는 동일 fmt.table.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("instrument", "import"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"data:write"})),
+        # 분기 mixed: dry-run JSON → ``fmt.output({"dry_run": True, "total":
+        # N, "preview": [...]})`` 평면 (instrument.py:442-448); 실제 import
+        # → ``fmt.success(f"종목 import 완료: {count}건", {"count": count,
+        # "file": str(path)})`` standard envelope (instrument.py:471-474).
+        # plan v2 mixed-branch policy (account ``set-credentials`` / bot
+        # ``signal-key`` / treasury ``set-balance`` / strategy ``set-status``
+        # / data ``delete`` 동형) — raw 우선으로 표현. drift test 가 양쪽
+        # 분기를 단언한다.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+)
+"""Instrument domain 4 leaf 의 contract tuple (#1847 sub-PR 8).
+
+순서는 ``docs/specs/cli/03-commands.md:691-704`` 의 instrument 표
+(list → sync → search → import) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
+# ── #1847 sub-PR 8: config domain OutputContract migration ──────────────
+#
+# config 도메인 3 leaf 의 contract entry. ``src/ante/cli/commands/config.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:133-135`` (실행 분류) / ``564-571`` (커맨드
+# 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (3 commands, 전체): ``get`` / ``set`` / ``history`` 모두
+# JSON 모드에서 ``fmt.output(dict)`` 평면 dict 를 그대로 dump 한다.
+# - ``get`` (config.py:81/91): 단일 키 → ``fmt.output(result)`` 평면
+#   (``{key, value, source}``); 전체 목록 → ``fmt.output({"configs":
+#   result})`` 평면. text 는 click.echo.
+# - ``set`` (config.py:182-184): ``fmt.output({"status": "success", **result})``
+#   평면. ``status`` 키가 존재하나 값이 ``"success"`` (standard envelope 의
+#   ``status == "ok"`` 와 다름) → raw_legacy 분류 (drift predicate 가
+#   ``status == "ok"`` 만 standard 로 인정).
+# - ``history`` (config.py:219): ``fmt.output({"key": key, "history": rows})``
+#   평면. text 는 click.echo 다수 줄.
+#
+# scope 분류 (#1815 SSOT, config.py @require_scope marker 와 1:1 정합):
+# - ``config:read`` scope (2 개): ``get`` / ``history``.
+# - ``config:write`` scope (1 개): ``set``.
+# - public allowlist: 없음 — config 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:133-135`` SSOT):
+# - ``offline`` (2 개): ``get`` / ``history``. 각 leaf 는 local ``Database``
+#   와 ``DynamicConfigService`` 를 직접 생성한다.
+# - ``runtime_ipc`` (1 개): ``set``. ``ipc_send("config.set", ...)`` 를
+#   호출한다 (config.py:148). IPC handler 등록: ``ipc/registry.py:729``.
+#
+# ``ipc_command`` 필드는 stub 값만 채운다 (``"config.set"``); 단순 문자열
+# lock 이며 server-side IPC registry 와의 cross-ref drift test 는 #1819
+# 의 책임이다 (account/member/bot/approval/treasury/strategy/broker/system
+# 동형 정책). config.py 호출 사이트의 IPC command name 과 그대로 일치한다.
+CONFIG_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("config", "get"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"config:read"})),
+        # JSON mode: 단일 키 → ``fmt.output(result)`` 평면 (``{key, value,
+        # source}``, config.py:81); 전체 목록 → ``fmt.output({"configs":
+        # result})`` 평면 (config.py:91). text 는 click.echo. missing 분기
+        # (``source == "not_found"``) 는 fmt.error 이지만 success-output
+        # drift scope 밖.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("config", "set"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"config:write"})),
+        # JSON mode: ``fmt.output({"status": "success", **result})`` 평면
+        # (config.py:183-184). ``status`` 키가 존재하나 값이 ``"success"``
+        # (standard envelope ``status == "ok"`` 와 다름) → raw_legacy 분류.
+        # text 는 ``fmt.success(...)`` 호출 (config.py:186-189) 이지만 본
+        # registry 는 JSON mode shape 를 SSOT 로 한다 (passthrough policy).
+        # error 분기는 ``fmt.error`` 이며 success-output drift scope 밖.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="config.set",
+    ),
+    CliCommandContract(
+        path=("config", "history"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"config:read"})),
+        # JSON mode: ``fmt.output({"key": key, "history": rows})`` 평면
+        # (config.py:219). text 는 click.echo 다수 줄.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+)
+"""Config domain 3 leaf 의 contract tuple (#1847 sub-PR 8).
+
+순서는 ``docs/specs/cli/03-commands.md:564-571`` 의 config 표
+(get → set → history) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
+# ── #1847 sub-PR 8: rule domain OutputContract migration ────────────────
+#
+# rule 도메인 3 leaf 의 contract entry. ``src/ante/cli/commands/rule.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:120-122`` (실행 분류) / ``429-448`` (커맨드
+# 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (3 commands, 전체): ``list`` / ``info`` / ``update`` 모두
+# JSON 모드에서 ``fmt.output(dict)`` 또는 ``fmt.table(rows, columns)`` 평면
+# dict / row list 를 그대로 dump 한다.
+# - ``list`` (rule.py:224/228/230): empty → ``fmt.output({"message": "등록된
+#   룰이 없습니다.", "rules": []})`` 평면; non-empty JSON → ``fmt.output(
+#   {"rules": result})`` 평면; non-empty text → fmt.table.
+# - ``info`` (rule.py:276): ``fmt.output(result)`` 평면 detail dict
+#   (``{rule_id, name, scope, enabled, priority, description}``). text 는
+#   click.echo.
+# - ``update`` (rule.py:412): JSON → ``fmt.output(result)`` 평면 dict
+#   (IPC 응답 또는 cold_path response 평면 shape 그대로). text 는 click.echo.
+#
+# scope 분류 (#1815 SSOT, rule.py @require_scope marker 와 1:1 정합):
+# - ``rule:read`` scope (2 개): ``list`` / ``info``.
+# - ``rule:admin`` scope (1 개): ``update``.
+# - public allowlist: 없음 — rule 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:120-122`` SSOT):
+# - ``offline`` (2 개): ``list`` / ``info``. 각 leaf 는 local ``Database`` /
+#   ``RuleEngine`` 를 직접 생성한다.
+# - ``runtime_ipc`` (1 개): ``update``. ``is_active_runtime()`` 분기로
+#   ``ipc_send("rule.update", ...)`` 를 호출하고, runtime 비활성 시 cold_path
+#   fallback 으로 ``update_account_rule_config`` 를 직접 사용한다. spec
+#   primary 분류는 runtime_ipc 다 (account ``suspend``/``activate`` /
+#   member ``update-scopes`` / treasury ``set-balance`` / strategy
+#   ``set-status`` 동형 — fallback 분기가 있어도 spec primary 분류만 lock).
+#
+# ``ipc_command`` 필드는 stub 값만 채운다 (``"rule.update"``); 단순 문자열
+# lock 이며 server-side IPC registry 와의 cross-ref drift test 는 #1819 의
+# 책임이다. rule.py 호출 사이트의 IPC command name 과 그대로 일치한다.
+# IPC handler 등록: ``ipc/registry.py:722``.
+RULE_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("rule", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"rule:read"})),
+        # JSON mode: empty → ``fmt.output({"message": "등록된 룰이 없습니다.",
+        # "rules": []})`` 평면 (rule.py:224); non-empty JSON → ``fmt.output(
+        # {"rules": result})`` 평면 (rule.py:228); text → fmt.table
+        # (rule.py:230). missing account / invalid account_id 분기는
+        # fmt.error 이며 success-output drift scope 밖.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("rule", "info"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"rule:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 detail dict (``{rule_id,
+        # name, scope, enabled, priority, description}``, rule.py:276).
+        # text 는 click.echo 다수 줄. missing rule 분기는 fmt.error
+        # (RULE_NOT_FOUND) 이며 success-output drift scope 밖.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("rule", "update"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"rule:admin"})),
+        # JSON mode: ``fmt.output(result)`` 평면 dict — IPC 분기와 cold_path
+        # 분기 모두 동일 평면 shape (``{account_id, rule_type, rule: {...},
+        # ...}``) 를 그대로 dump 한다 (rule.py:412). text 는 click.echo.
+        # spec 은 ``runtime IPC`` 이며 ``is_active_runtime()`` 분기로
+        # cold_path fallback 을 보유하지만 primary 분류만 lock.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="runtime_ipc",
+        ipc_command="rule.update",
+    ),
+)
+"""Rule domain 3 leaf 의 contract tuple (#1847 sub-PR 8).
+
+순서는 ``docs/specs/cli/03-commands.md:429-448`` 의 rule 표
+(list → info → update) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
 CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
     contract.path: contract
     for contract in (
@@ -1401,18 +1663,21 @@ CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
         *REPORT_CONTRACTS,
         *BROKER_CONTRACTS,
         *SYSTEM_CONTRACTS,
+        *INSTRUMENT_CONTRACTS,
+        *CONFIG_CONTRACTS,
+        *RULE_CONTRACTS,
     )
 }
 """Leaf command path → contract mapping.
 
 본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
-+ strategy 7 + data 6 + report 5 + broker 4 + system 5 = 78 entries 가
-등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR 3
-/ #1847 sub-PR 4 / #1847 sub-PR 5 / #1847 sub-PR 6 / #1847 sub-PR 7).
-나머지 도메인 (instrument / config / rule / trade / backtest / audit /
-signal) 의 entry 등록은 후속 PR (`#1847` sub-PR 8-9) 의 책임이다.
-registry 미등록 leaf 가 FAIL 이어야 하는 drift guard 는 `#1848` 가
-활성화한다.
++ strategy 7 + data 6 + report 5 + broker 4 + system 5 + instrument 4
++ config 3 + rule 3 = 88 entries 가 등록되어 있다 (#1846 / #1847 sub-PR
+1 / #1847 sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5 /
+#1847 sub-PR 6 / #1847 sub-PR 7 / #1847 sub-PR 8). 나머지 도메인 (trade
+/ backtest / audit / signal) 의 entry 등록은 후속 PR (`#1847` sub-PR 9)
+의 책임이다. registry 미등록 leaf 가 FAIL 이어야 하는 drift guard 는
+`#1848` 가 활성화한다.
 """
 
 
@@ -1432,9 +1697,9 @@ def all_contracts() -> Iterator[CliCommandContract]:
     """등록된 모든 contract 를 dict 순회 순서로 yield 한다.
 
     본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury
-    9 + strategy 7 + data 6 + report 5 + broker 4 + system 5 = 78 entries
-    가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 / #1847
-    sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5 / #1847 sub-PR 6 / #1847
-    sub-PR 7).
+    9 + strategy 7 + data 6 + report 5 + broker 4 + system 5 + instrument
+    4 + config 3 + rule 3 = 88 entries 가 등록되어 있다 (#1846 / #1847
+    sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847
+    sub-PR 5 / #1847 sub-PR 6 / #1847 sub-PR 7 / #1847 sub-PR 8).
     """
     yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -180,17 +180,17 @@ def test_raw_legacy_is_envelope_form_not_contract_kind() -> None:
 
 
 def test_get_contract_returns_none_when_missing() -> None:
-    """미등록 path 는 ``None`` 을 반환한다 (등록된 10 도메인 외).
+    """미등록 path 는 ``None`` 을 반환한다 (등록된 13 도메인 외).
 
     등록 도메인: account / member / bot / approval / treasury / strategy /
-    data / report / broker / system.
+    data / report / broker / system / instrument / config / rule.
     """
     # nonexistent path 는 항상 ``None``.
     assert get_contract(("nonexistent",)) is None
-    # instrument 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 8 이후) 의
-    # 책임이므로 본 PR 시점에는 ``None`` 이다 (broker / system domain 은
-    # sub-PR 7 에서 등록되었다).
-    assert get_contract(("instrument", "list")) is None
+    # trade 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 9 이후) 의
+    # 책임이므로 본 PR 시점에는 ``None`` 이다 (instrument / config / rule
+    # domain 은 sub-PR 8 에서 등록되었다).
+    assert get_contract(("trade", "list")) is None
 
 
 def test_registry_is_mutable_dict() -> None:
@@ -470,6 +470,70 @@ def test_system_entries_registered_after_1847_sub_pr_7() -> None:
     assert expected_system_paths.issubset(registered), (
         f"system 5 entry 가 모두 등록되어야 한다 (#1847 sub-PR 7). "
         f"누락: {sorted(expected_system_paths - registered)}"
+    )
+
+
+def test_instrument_entries_registered_after_1847_sub_pr_8() -> None:
+    """#1847 sub-PR 8 가 instrument 4 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 8 가 instrument migration 을 완료한 시점부터
+    lock 된다. 4 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_instrument_success_output_drift`
+    가 책임진다.
+    """
+    expected_instrument_paths = {
+        ("instrument", "list"),
+        ("instrument", "sync"),
+        ("instrument", "search"),
+        ("instrument", "import"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_instrument_paths.issubset(registered), (
+        f"instrument 4 entry 가 모두 등록되어야 한다 (#1847 sub-PR 8). "
+        f"누락: {sorted(expected_instrument_paths - registered)}"
+    )
+
+
+def test_config_entries_registered_after_1847_sub_pr_8() -> None:
+    """#1847 sub-PR 8 가 config 3 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 8 가 config migration 을 완료한 시점부터
+    lock 된다. 3 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_config_success_output_drift` 가
+    책임진다.
+    """
+    expected_config_paths = {
+        ("config", "get"),
+        ("config", "set"),
+        ("config", "history"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_config_paths.issubset(registered), (
+        f"config 3 entry 가 모두 등록되어야 한다 (#1847 sub-PR 8). "
+        f"누락: {sorted(expected_config_paths - registered)}"
+    )
+
+
+def test_rule_entries_registered_after_1847_sub_pr_8() -> None:
+    """#1847 sub-PR 8 가 rule 3 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 8 가 rule migration 을 완료한 시점부터
+    lock 된다. 3 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_rule_success_output_drift` 가
+    책임진다.
+    """
+    expected_rule_paths = {
+        ("rule", "list"),
+        ("rule", "info"),
+        ("rule", "update"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_rule_paths.issubset(registered), (
+        f"rule 3 entry 가 모두 등록되어야 한다 (#1847 sub-PR 8). "
+        f"누락: {sorted(expected_rule_paths - registered)}"
     )
 
 

--- a/tests/unit/test_config_success_output_drift.py
+++ b/tests/unit/test_config_success_output_drift.py
@@ -1,0 +1,300 @@
+"""Config CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 8).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+config 도메인 3 leaf 의 ``OutputContract`` 와 ``ante config ... --format
+json`` 실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 / #1847 sub-PR 1-7 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status: "ok",
+  message, data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가
+  dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump 한다
+  (standard envelope 의 3 키 셋이 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``config.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift
+하면 본 test 가 즉시 FAIL 한다.
+
+``config set`` 은 JSON mode 에서 ``fmt.output({"status": "success",
+**result})`` 평면 dict 를 dump 한다 (config.py:182-184). ``status`` 키가
+존재하나 값이 ``"success"`` (``"ok"`` 아님) 이므로 raw_legacy 분류 SSOT
+predicate 의 standard envelope 인식에서 벗어난다 — registry 는 ``raw_legacy``
+로 lock.
+
+5 시나리오 (registry sanity +1 + 3 leaf raw_legacy + history empty +1):
+
+0. registry sanity — config 3 entries 의 envelope 분류기 범위 내.
+1. ``get`` 단일 키 → ``raw_legacy`` (``{key, value, source}``)
+2. ``get`` 전체 목록 → ``raw_legacy`` (``{configs: [...]}``)
+3. ``set`` → ``raw_legacy`` (``{status: "success", **result}``)
+4. ``history`` empty → ``raw_legacy`` (``{key, history: []}``)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언.
+
+    raw_legacy 는 ``fmt.output(dict)`` / ``fmt.table(rows)`` 출력의 super-set
+    이다. ``status``/``message``/``data`` 3 키가 동시에 갖춰지고 ``status ==
+    "ok"`` 면 standard envelope 으로 분류 (애매한 경계 방지). 그렇지 않으면
+    모든 평면 도메인 payload 는 raw_legacy.
+    """
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_config_entries_envelopes_classified() -> None:
+    """config 3 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 3 entry 를
+    모두 분류할 수 있음을 lock 한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    config_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("config",)
+    ]
+    assert len(config_entries) == 3, (
+        f"config 3 entries 가 모두 등록되어야 한다. 실제: {len(config_entries)}"
+    )
+    for path, contract in config_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남."
+        )
+
+
+# ── CLI fixture (동형 패턴) ────────────────────────────────────────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json config ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다 (동형 패턴)."""
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. get 단일 키 → raw_legacy ───────────────────────────────────────────
+
+
+def test_config_get_single_key_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``config get <key>`` 단일: ``{key, value, source}`` 평면.
+
+    config.py:81: ``fmt.output(result)`` 단일 키 결과 평면 dict.
+    DynamicConfigService / Config 를 mock 해 static source 결과 강제.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    # ``get_db_path`` 가 config_dir 기준 ``db/ante.db`` 를 resolve 한다.
+    (config_dir / "db").mkdir()
+
+    # 정적 default 키 (예: ``system.log_level``) 는 ``defaults.DEFAULTS`` 에
+    # 등재되어 있어 ``_resolve_single`` 이 ``source: static`` 으로 반환한다.
+    # dynamic.exists 가 False 이면 static 경로로 흐른다.
+    result = _invoke(
+        [
+            "--config-dir",
+            str(config_dir),
+            "--format",
+            "json",
+            "config",
+            "get",
+            "system.log_level",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"config get 단일: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["key"] == "system.log_level"
+    assert "value" in payload
+    assert payload["source"] in {"static", "dynamic"}
+
+
+# ── 2. get 전체 목록 → raw_legacy ─────────────────────────────────────────
+
+
+def test_config_get_all_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``config get`` 전체 목록: ``{configs: [...]}`` 평면.
+
+    config.py:91: ``fmt.output({"configs": result})`` 전체 목록 평면 dict.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "db").mkdir()
+
+    result = _invoke(
+        [
+            "--config-dir",
+            str(config_dir),
+            "--format",
+            "json",
+            "config",
+            "get",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"config get 전체: standard envelope 아님. payload={payload!r}"
+    )
+    assert "configs" in payload
+    assert isinstance(payload["configs"], list)
+
+
+# ── 3. set → raw_legacy ───────────────────────────────────────────────────
+
+
+def test_config_set_envelope_matches_raw_legacy() -> None:
+    """``config set <k> <v>``: ``{status: "success", **result}`` 평면.
+
+    config.py:182-184: ``fmt.output({"status": "success", **result})`` 평면.
+    ``status`` 키가 ``"success"`` (``"ok"`` 아님) 이므로 raw_legacy 분류.
+    """
+    ipc_response = {
+        "key": "system.log_level",
+        "value": "INFO",
+        "previous": "WARNING",
+        "changed_by": "test-master",
+    }
+    with patch(
+        "ante.cli.commands.ipc_helpers.ipc_send",
+        new=AsyncMock(return_value=ipc_response),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "config",
+                "set",
+                "system.log_level",
+                "INFO",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"config set: standard envelope 아님. payload={payload!r}"
+    )
+    # ``status: "success"`` 는 standard envelope ``"ok"`` 와 다르다.
+    assert payload["status"] == "success"
+    assert payload["key"] == "system.log_level"
+    assert payload["value"] == "INFO"
+
+
+# ── 4. history empty → raw_legacy ─────────────────────────────────────────
+
+
+def test_config_history_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``config history <key>`` empty: ``{key, history: []}`` 평면.
+
+    config.py:219: ``fmt.output({"key": key, "history": rows})`` 평면 dict.
+    빈 DB 로 history empty 분기 강제.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "db").mkdir()
+
+    result = _invoke(
+        [
+            "--config-dir",
+            str(config_dir),
+            "--format",
+            "json",
+            "config",
+            "history",
+            "system.log_level",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"config history empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["key"] == "system.log_level"
+    assert payload["history"] == []

--- a/tests/unit/test_instrument_success_output_drift.py
+++ b/tests/unit/test_instrument_success_output_drift.py
@@ -1,0 +1,381 @@
+"""Instrument CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 8).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+instrument 도메인 4 leaf 의 ``OutputContract`` 와 ``ante instrument ...
+--format json`` 실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1 (member) / sub-PR 2 (bot) / sub-PR 3
+(approval) / sub-PR 4 (treasury) / sub-PR 5 (strategy) / sub-PR 6 (data /
+report) / sub-PR 7 (broker / system) 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump 한다
+  (standard envelope 의 3 키 셋이 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``instrument.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면
+본 test 가 즉시 FAIL 한다 (registry 갱신 또는 callsite 정렬 중 한쪽이 책임).
+
+``instrument import`` 는 dry-run / 실제 import 분기 mixed 다 — plan v2
+mixed-branch policy 에 따라 registry 는 raw_legacy 로 lock 하고, 본 test
+가 dry-run (raw_legacy) 과 실제 import (standard envelope 분기) 의 양쪽
+실제 dump shape 를 모두 단언한다.
+
+6 시나리오 (registry sanity +1 + 4 leaf raw_legacy +4 + import dry-run +1):
+
+0. registry sanity — instrument 4 entries 의 envelope 분류기 범위 내.
+1. ``list`` empty → ``raw_legacy`` (``{"instruments": [], "count": 0}``)
+2. ``sync`` → ``raw_legacy`` (``{"sync_result": {...}, "message": ...}``)
+3. ``search`` empty → ``raw_legacy`` (``{"results": [], "count": 0}``)
+4. ``import`` dry-run → ``raw_legacy`` (``{dry_run, total, preview}``)
+5. ``import`` 실제 import → standard envelope 분기 (``{status: "ok",
+   message, data: {count, file}}``); raw_legacy lock 정책에 대한 mixed
+   분기 인식 단언.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언.
+
+    raw_legacy 는 ``fmt.output(dict)`` / ``fmt.table(rows)`` 출력의 super-set
+    이다. ``status``/``message``/``data`` 3 키가 동시에 갖춰지고 ``status ==
+    "ok"`` 면 standard envelope 으로 분류 (애매한 경계 방지). 그렇지 않으면
+    모든 평면 도메인 payload 는 raw_legacy.
+    """
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_instrument_entries_envelopes_classified() -> None:
+    """instrument 4 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용.
+
+    본 단언은 본 모듈 fixture 의 envelope predicate 두 함수가 4 entry 를
+    모두 분류할 수 있음을 lock 한다. envelope SSOT (#1821) 에 새 값이
+    추가되면 본 분류기를 갱신해야 함을 표면화한다.
+    """
+    accepted = {"standard", "raw_legacy"}
+    instrument_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("instrument",)
+    ]
+    assert len(instrument_entries) == 4, (
+        f"instrument 4 entries 가 모두 등록되어야 한다. 실제: {len(instrument_entries)}"
+    )
+    for path, contract in instrument_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남. "
+            "envelope SSOT (#1821) 가 새 값을 추가했다면 본 분류기를 갱신하라."
+        )
+
+
+# ── CLI fixture (동형 패턴) ────────────────────────────────────────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json instrument ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다.
+
+    ``OutputFormatter`` 가 ``json.dumps(..., indent=2)`` 로 multi-line dump
+    하기 때문에 처음 ``{`` 또는 ``[`` 부터 ``raw_decode`` 로 한 value 를
+    파싱하고 나머지 stdout (text 모드 잔존물 등) 는 무시한다 (동형 패턴).
+    """
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. list empty → raw_legacy ─────────────────────────────────────────────
+
+
+def test_instrument_list_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``instrument list`` empty: ``{"instruments": [], "count": 0}`` 평면.
+
+    instrument.py:107: ``if not results: fmt.output({"instruments": [],
+    "count": 0})``. 비어있는 DB 로 empty 분기 강제.
+    """
+    db_path = tmp_path / "test.db"
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "instrument",
+            "list",
+            "--db-path",
+            str(db_path),
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"instrument list empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"instruments": [], "count": 0}
+
+
+# ── 2. sync → raw_legacy ───────────────────────────────────────────────────
+
+
+def test_instrument_sync_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``instrument sync``: ``fmt.output({"sync_result": ..., "message": ...})``.
+
+    instrument.py:233-243: ``fmt.output({"sync_result": result, "message":
+    "동기화 완료: ..."})`` 평면 dict. KISAdapter 와 InstrumentService 를
+    mock 해 sync success 경로를 강제한다.
+    """
+    db_path = tmp_path / "test.db"
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    # system.toml 에 broker.app_key 가 있어야 ``broker_config.get("app_key")``
+    # falsy 분기 (line 163-164) 를 회피한다.
+    (config_dir / "system.toml").write_text(
+        '[broker]\napp_key = "dummy-key"\napp_secret = "dummy-secret"\n',
+        encoding="utf-8",
+    )
+
+    raw_instruments = [
+        {
+            "symbol": "005930",
+            "name": "삼성전자",
+            "name_en": "Samsung Electronics",
+            "instrument_type": "stock",
+            "listed": True,
+        },
+        {
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "name_en": "SK Hynix",
+            "instrument_type": "stock",
+            "listed": True,
+        },
+    ]
+
+    # KISAdapter 의 connect/disconnect 와 get_instruments 를 mock.
+    mock_adapter = AsyncMock()
+    mock_adapter.connect = AsyncMock()
+    mock_adapter.disconnect = AsyncMock()
+    mock_adapter.get_instruments = AsyncMock(return_value=raw_instruments)
+
+    with patch(
+        "ante.broker.kis.KISAdapter",
+        return_value=mock_adapter,
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(config_dir),
+                "--format",
+                "json",
+                "instrument",
+                "sync",
+                "--db-path",
+                str(db_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"instrument sync: standard envelope 아님. payload={payload!r}"
+    )
+    assert "sync_result" in payload
+    assert "message" in payload
+    assert payload["sync_result"]["total"] == 2
+
+
+# ── 3. search empty → raw_legacy ──────────────────────────────────────────
+
+
+def test_instrument_search_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``instrument search`` empty: ``{"results": [], "count": 0}`` 평면.
+
+    instrument.py:296: ``if not results: fmt.output({"results": [],
+    "count": 0})``. 비어있는 DB 로 empty 분기 강제.
+    """
+    db_path = tmp_path / "test.db"
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "instrument",
+            "search",
+            "nonexistent-keyword",
+            "--db-path",
+            str(db_path),
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"instrument search empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"results": [], "count": 0}
+
+
+# ── 4. import dry-run → raw_legacy ────────────────────────────────────────
+
+
+def test_instrument_import_dry_run_envelope_matches_raw_legacy(
+    tmp_path: Path,
+) -> None:
+    """``instrument import --dry-run`` JSON: ``{dry_run, total, preview}`` 평면.
+
+    instrument.py:441-448: ``if fmt.is_json: fmt.output({"dry_run": True,
+    "total": N, "preview": [...]})``. CSV 파일을 임시 작성해 dry-run 호출.
+    """
+    db_path = tmp_path / "test.db"
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text(
+        "symbol,exchange,name,name_en,instrument_type,listed\n"
+        "005930,KRX,삼성전자,Samsung Electronics,stock,true\n"
+        "000660,KRX,SK하이닉스,SK Hynix,stock,true\n",
+        encoding="utf-8",
+    )
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "instrument",
+            "import",
+            str(csv_path),
+            "--dry-run",
+            "--db-path",
+            str(db_path),
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"instrument import dry-run: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["dry_run"] is True
+    assert payload["total"] == 2
+    assert isinstance(payload["preview"], list)
+    assert len(payload["preview"]) == 2
+
+
+# ── 5. import 실제 → standard envelope 분기 (mixed-branch awareness) ───────
+
+
+def test_instrument_import_actual_envelope_is_standard_branch(
+    tmp_path: Path,
+) -> None:
+    """``instrument import`` (실제) 분기: ``fmt.success(..., {count, file})`` standard.
+
+    instrument.py:471-474: ``fmt.success(f"종목 import 완료: {count}건",
+    {"count": count, "file": str(path)})`` → standard envelope. registry 는
+    raw 우선 정책 (mixed-branch policy — account ``set-credentials`` / bot
+    ``signal-key`` / treasury ``set-balance`` / strategy ``set-status`` /
+    data ``delete`` 동형) 으로 ``raw_legacy`` 로 lock 되어 있으나, 본 test
+    는 실제 import 분기의 standard envelope shape 가 깨지지 않음을
+    독립적으로 단언한다.
+    """
+    db_path = tmp_path / "test.db"
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text(
+        "symbol,exchange,name,name_en,instrument_type,listed\n"
+        "005930,KRX,삼성전자,Samsung Electronics,stock,true\n",
+        encoding="utf-8",
+    )
+    result = _invoke(
+        [
+            "--format",
+            "json",
+            "instrument",
+            "import",
+            str(csv_path),
+            "--db-path",
+            str(db_path),
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_standard_envelope(payload), (
+        f"instrument import 실제 분기: standard envelope 이어야 한다 "
+        f"(mixed-branch awareness). payload={payload!r}"
+    )
+    assert payload["data"]["count"] == 1
+    assert payload["data"]["file"].endswith("sample.csv")

--- a/tests/unit/test_rule_success_output_drift.py
+++ b/tests/unit/test_rule_success_output_drift.py
@@ -1,0 +1,406 @@
+"""Rule CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 8).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+rule 도메인 3 leaf 의 ``OutputContract`` 와 ``ante rule ... --format json``
+실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 / #1847 sub-PR 1-7 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status: "ok",
+  message, data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가
+  dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump 한다
+  (standard envelope 의 3 키 셋이 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``rule.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift
+하면 본 test 가 즉시 FAIL 한다.
+
+``rule update`` 는 IPC 우선 + cold_path fallback 구조 (``is_active_runtime()``
+분기로 ``ipc_send`` 호출, 비활성 시 ``update_account_rule_config`` 직접
+호출) 다. 본 drift test 는 IPC 분기를 강제로 success path 로 mock 해
+success envelope 단언만 한다 — fallback 분기 cover 는 후속 PR 책임.
+
+6 시나리오 (registry sanity +1 + list empty +1 + list non-empty +1 +
+info found +1 + info not-found는 error라 제외 + update success +1 +
+update payload shape +1):
+
+0. registry sanity — rule 3 entries 의 envelope 분류기 범위 내.
+1. ``list`` empty (account 존재) → ``raw_legacy`` (``{message, rules: []}``)
+2. ``list`` non-empty (config 로딩) → ``raw_legacy`` (``{rules: [...]}``)
+3. ``info`` found → ``raw_legacy`` (``{rule_id, name, ...}``)
+4. ``update`` IPC success → ``raw_legacy`` (``{account_id, rule, ...}``)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언."""
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_rule_entries_envelopes_classified() -> None:
+    """rule 3 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용."""
+    accepted = {"standard", "raw_legacy"}
+    rule_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("rule",)
+    ]
+    assert len(rule_entries) == 3, (
+        f"rule 3 entries 가 모두 등록되어야 한다. 실제: {len(rule_entries)}"
+    )
+    for path, contract in rule_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남."
+        )
+
+
+# ── CLI fixture (동형 패턴) ────────────────────────────────────────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json rule ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다 (동형 패턴)."""
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── account 생성 helper (rule list/info 는 account 존재 검증을 수행) ────
+
+
+def _seed_account(config_dir: Path, account_id: str = "acct-001") -> Path:
+    """rule list/info 가 요구하는 account 가 존재하는 DB 를 생성한다.
+
+    ``_create_rule_engine`` (rule.py:91-103) 은 ``SELECT 1 FROM accounts``
+    로 lightweight 존재 검증을 수행하며 미존재 시 ``AccountNotFoundError``
+    를 raise 한다. ``AccountService.initialize()`` 를 한 번 호출해 schema
+    DDL 만 적용하고, 직접 INSERT 로 account_id 단일 row 를 시드한다
+    (``AccountService.create`` 는 cold-path guard 와 credentials 정책
+    검증을 수반하므로 본 fixture 의 minimal seeding 에는 적합하지 않다).
+    """
+    import asyncio
+
+    from ante.account.service import AccountService
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+    (config_dir / "db").mkdir(parents=True, exist_ok=True)
+    db_path = config_dir / "db" / "ante.db"
+
+    async def _seed() -> None:
+        db = Database(str(db_path))
+        await db.connect()
+        try:
+            eventbus = EventBus()
+            svc = AccountService(db=db, eventbus=eventbus)
+            # initialize() 가 ``accounts`` schema DDL 만 보장하고, 본 fixture
+            # 는 후속 INSERT 로 single test row 를 시드한다.
+            await svc.initialize()
+            await db.execute(
+                "INSERT INTO accounts ("
+                "  account_id, name, exchange, currency, broker_type, "
+                "  trading_mode, credentials, broker_config, status"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    account_id,
+                    "Test Account",
+                    "KRX",
+                    "KRW",
+                    "test",
+                    "virtual",
+                    "{}",
+                    "{}",
+                    "active",
+                ),
+            )
+        finally:
+            await db.close()
+
+    asyncio.run(_seed())
+    return db_path
+
+
+# ── 1. list empty → raw_legacy ────────────────────────────────────────────
+
+
+def test_rule_list_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``rule list`` empty (account 존재): ``{message, rules: []}`` 평면.
+
+    rule.py:224: ``if not result: fmt.output({"message": ..., "rules": []})``.
+    account 는 시드하지만 룰 설정 파일이 없으므로 ``_collect_rules`` 가
+    빈 리스트 반환.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    _seed_account(config_dir)
+
+    result = _invoke(
+        [
+            "--config-dir",
+            str(config_dir),
+            "--format",
+            "json",
+            "rule",
+            "list",
+            "--account",
+            "acct-001",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"rule list empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"message": "등록된 룰이 없습니다.", "rules": []}
+
+
+# ── 2. list non-empty → raw_legacy ────────────────────────────────────────
+
+
+def test_rule_list_non_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``rule list`` non-empty: ``{rules: [...]}`` 평면.
+
+    rule.py:228: ``if fmt.is_json: fmt.output({"rules": result})``.
+    ``rules.global`` 을 system.toml 에 설정해 ``RuleEngine`` 이 로드하도록
+    강제한다.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    _seed_account(config_dir)
+
+    # rules.global 을 inline 으로 정의해 RuleEngine.load_rules_from_config 가
+    # 1 개 룰을 로드하도록 한다.
+    # ``trading_hours`` 는 ``RULE_REGISTRY`` (engine.py:240-247) 에 등재된
+    # 6 rule type 중 하나로, 본 fixture 가 RuleEngine 에 정상 로드된다.
+    (config_dir / "system.toml").write_text(
+        "[[rules.global]]\n"
+        'id = "trading_hours"\n'
+        'name = "거래 시간 제한"\n'
+        'type = "trading_hours"\n'
+        "enabled = true\n"
+        "priority = 100\n"
+        'description = "test rule"\n'
+        "\n"
+        "[rules.global.params]\n"
+        'start = "09:00"\n'
+        'end = "15:30"\n',
+        encoding="utf-8",
+    )
+
+    result = _invoke(
+        [
+            "--config-dir",
+            str(config_dir),
+            "--format",
+            "json",
+            "rule",
+            "list",
+            "--account",
+            "acct-001",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"rule list non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert "rules" in payload
+    assert isinstance(payload["rules"], list)
+    assert len(payload["rules"]) >= 1
+    first = payload["rules"][0]
+    assert "rule_id" in first
+    assert "scope" in first
+    assert "enabled" in first
+
+
+# ── 3. info found → raw_legacy ─────────────────────────────────────────────
+
+
+def test_rule_info_found_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``rule info <rule_id>`` found: ``{rule_id, name, ...}`` 평면.
+
+    rule.py:276: ``if fmt.is_json: fmt.output(result)``. 단일 룰 정보의
+    평면 detail dict.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    _seed_account(config_dir)
+
+    # ``trading_hours`` 는 ``RULE_REGISTRY`` (engine.py:240-247) 에 등재된
+    # 6 rule type 중 하나로, 본 fixture 가 RuleEngine 에 정상 로드된다.
+    (config_dir / "system.toml").write_text(
+        "[[rules.global]]\n"
+        'id = "trading_hours"\n'
+        'name = "거래 시간 제한"\n'
+        'type = "trading_hours"\n'
+        "enabled = true\n"
+        "priority = 100\n"
+        'description = "test rule"\n'
+        "\n"
+        "[rules.global.params]\n"
+        'start = "09:00"\n'
+        'end = "15:30"\n',
+        encoding="utf-8",
+    )
+
+    result = _invoke(
+        [
+            "--config-dir",
+            str(config_dir),
+            "--format",
+            "json",
+            "rule",
+            "info",
+            "trading_hours",
+            "--account",
+            "acct-001",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"rule info found: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["rule_id"] == "trading_hours"
+    assert "name" in payload
+    assert "scope" in payload
+    assert payload["enabled"] is True
+
+
+# ── 4. update IPC success → raw_legacy ─────────────────────────────────────
+
+
+def test_rule_update_ipc_envelope_matches_raw_legacy() -> None:
+    """``rule update`` IPC: ``fmt.output(result)`` 평면 dict.
+
+    rule.py:412: ``if fmt.is_json: fmt.output(result)``. IPC success 분기를
+    강제로 mock — ``is_active_runtime`` True, ``ipc_send`` 가 평면 response
+    반환.
+    """
+    ipc_response = {
+        "account_id": "acct-001",
+        "rule_type": "max_position_count",
+        "rule": {
+            "type": "max_position_count",
+            "enabled": True,
+            "params": {"max_count": 20},
+        },
+        "changed_by": "test-master",
+    }
+    with (
+        patch(
+            "ante.cli.cold_path.is_active_runtime",
+            return_value=True,
+        ),
+        patch(
+            "ante.cli.commands.ipc_helpers.ipc_send",
+            new=AsyncMock(return_value=ipc_response),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "rule",
+                "update",
+                "max_position_count",
+                "--account",
+                "acct-001",
+                "--enabled",
+                "--param",
+                "max_count=20",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"rule update IPC: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["account_id"] == "acct-001"
+    assert payload["rule_type"] == "max_position_count"
+    assert payload["rule"]["enabled"] is True
+    assert payload["rule"]["params"]["max_count"] == 20


### PR DESCRIPTION
## Summary

#1847 sub-PR 8. instrument 4 + config 3 + rule 3 = **10 leaf** entries 를 `CLI_COMMAND_REGISTRY` 에 등록한다. #1846 / #1847 sub-PR 1-7 1:1 동형 패턴.

본 PR 의 invariant:

- `src/ante/cli/commands/{instrument,config,rule}.py` 본문 변경 없음 (3 file diff = 0 lines).
- 10 leaf 모두 raw_legacy 로 lock. `instrument import` 는 dry-run / 실제 import 분기 mixed (plan v2 raw 우선 정책). `config set` 은 `status: "success"` 평면 (standard envelope `"ok"` 와 다름) 이므로 raw_legacy.
- 3 신규 drift test (instrument 6 시나리오 + config 5 + rule 5 = **16 시나리오**) 가 callsite 와 registry shape 의 drift 를 lock 한다.
- `test_cli_registry_shell.py` 의 missing-domain 예시를 `trade` 로 교체하고 sub-PR 8 등록 단언 3 개 추가.

## Leaf 분류 표

### instrument (4 leaf, offline)

| path | scope | output | execution |
|------|-------|--------|-----------|
| `instrument list` | `data:read` | raw_legacy (`fmt.output({instruments,count})` / `fmt.table`) | offline |
| `instrument sync` | `data:write` | raw_legacy (`fmt.output({sync_result,message})`) | offline |
| `instrument search` | `data:read` | raw_legacy (`fmt.output({results,count})` / `fmt.table`) | offline |
| `instrument import` | `data:write` | raw_legacy (mixed: dry-run `fmt.output` vs 실제 `fmt.success`) | offline |

### config (3 leaf)

| path | scope | output | execution | ipc_command |
|------|-------|--------|-----------|-------------|
| `config get` | `config:read` | raw_legacy (`fmt.output({key,value,source})` / `{configs:[...]}`) | offline | — |
| `config set` | `config:write` | raw_legacy (`fmt.output({status:"success",**result})`) | runtime_ipc | `config.set` |
| `config history` | `config:read` | raw_legacy (`fmt.output({key,history})`) | offline | — |

### rule (3 leaf)

| path | scope | output | execution | ipc_command |
|------|-------|--------|-----------|-------------|
| `rule list` | `rule:read` | raw_legacy (`fmt.output({message,rules})` / `{rules:[...]}`) | offline | — |
| `rule info` | `rule:read` | raw_legacy (`fmt.output(result)`) | offline | — |
| `rule update` | `rule:admin` | raw_legacy (`fmt.output(result)` IPC + cold_path 동일 shape) | runtime_ipc | `rule.update` |

## Diff guard

`src/ante/cli/commands/instrument.py` / `config.py` / `rule.py` 모두 **0 lines** 변경. 본 PR 은 registry 등록 + drift test 추가만 수행한다 (callsite shape 변경은 drift test 가 FAIL 로 surface).

총 registry entries: **78 → 88** (account 9 + member 12 + bot 11 + approval 10 + treasury 9 + strategy 7 + data 6 + report 5 + broker 4 + system 5 + instrument 4 + config 3 + rule 3).

## Test plan

- [x] `pytest tests/unit/contracts -v` — 78 PASS (sub-PR 8 등록 단언 3 개 포함)
- [x] `pytest tests/unit/test_instrument_success_output_drift.py -v` — 6 PASS
- [x] `pytest tests/unit/test_config_success_output_drift.py -v` — 5 PASS
- [x] `pytest tests/unit/test_rule_success_output_drift.py -v` — 5 PASS
- [x] `pytest tests/unit/` 회귀: baseline (origin/main) 5146 PASS / 217 FAIL == worktree 5165 PASS (+19 신규 test) / 217 FAIL — 본 PR 회귀 0 (failures 는 main pre-existing)
- [x] `git diff src/ante/cli/commands/instrument.py src/ante/cli/commands/config.py src/ante/cli/commands/rule.py` = 0 lines
- [x] `mypy src/` — 223 source files, no issues
- [x] `ruff check` / `ruff format --check` 변경 파일 — PASS
- [x] main HEAD 불변 확인 (`45d51639...`)

Refs #1847

🤖 Generated with [Claude Code](https://claude.com/claude-code)