### PR TITLE
refactor: #1847-9 trade+backtest+audit+signal + leaf coverage final lock (closes #1847, #1815)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -613,7 +613,14 @@ tests/
 │   ├── test_data_success_output_drift.py
 │   ├── test_report_success_output_drift.py
 │   ├── test_broker_success_output_drift.py
-│   └── test_system_success_output_drift.py
+│   ├── test_system_success_output_drift.py
+│   ├── test_audit_success_output_drift.py
+│   ├── test_backtest_success_output_drift.py
+│   ├── test_config_success_output_drift.py
+│   ├── test_instrument_success_output_drift.py
+│   ├── test_rule_success_output_drift.py
+│   ├── test_signal_success_output_drift.py
+│   └── test_trade_success_output_drift.py
 └── __init__.py
 ```
 

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -34,16 +34,23 @@ execution 계약을 한 곳에서 관리하는 registry 다.
   (#1847 sub-PR 8).
 * :data:`RULE_CONTRACTS` — rule 도메인 3 leaf contract tuple
   (#1847 sub-PR 8).
+* :data:`TRADE_CONTRACTS` — trade 도메인 2 leaf contract tuple
+  (#1847 sub-PR 9 — final).
+* :data:`BACKTEST_CONTRACTS` — backtest 도메인 2 leaf contract tuple
+  (#1847 sub-PR 9 — final).
+* :data:`AUDIT_CONTRACTS` — audit 도메인 1 leaf contract tuple
+  (#1847 sub-PR 9 — final).
+* :data:`SIGNAL_CONTRACTS` — signal 도메인 1 leaf contract tuple
+  (#1847 sub-PR 9 — final).
 * :data:`CLI_COMMAND_REGISTRY` — leaf path tuple → contract mapping. 본
   PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
   + strategy 7 + data 6 + report 5 + broker 4 + system 5 + instrument 4
-  + config 3 + rule 3 = 88 entries 가 채워져 있다.
+  + config 3 + rule 3 + trade 2 + backtest 2 + audit 1 + signal 1 = 94
+  entries 가 채워져 있다.
 * :func:`get_contract` / :func:`all_contracts` — read-only accessor.
 
 본 모듈이 의도적으로 *제공하지 않는* 것 (스펙 non-goal):
 
-* 잔여 도메인 entry 등록 (`#1847` sub-PR 9 이후 — trade / backtest /
-  audit / signal).
 * output payload migration (`#1846` / `#1847` 는 raw_legacy 를 *문서화*
   만 하며 fmt callsite 를 바꾸지 않는다 — diff guard 가 본 PR 의 invariant).
 * drift test guard 완전 활성화 — 미등록 leaf FAIL 은 `#1848` 의 책임.
@@ -90,6 +97,8 @@ from ante.contracts.vocab import AuthMode, ContractKind, EnvelopeForm
 __all__ = [
     "ACCOUNT_CONTRACTS",
     "APPROVAL_CONTRACTS",
+    "AUDIT_CONTRACTS",
+    "BACKTEST_CONTRACTS",
     "BOT_CONTRACTS",
     "BROKER_CONTRACTS",
     "CLI_COMMAND_REGISTRY",
@@ -99,8 +108,10 @@ __all__ = [
     "MEMBER_CONTRACTS",
     "REPORT_CONTRACTS",
     "RULE_CONTRACTS",
+    "SIGNAL_CONTRACTS",
     "STRATEGY_CONTRACTS",
     "SYSTEM_CONTRACTS",
+    "TRADE_CONTRACTS",
     "TREASURY_CONTRACTS",
     "AuthContract",
     "CliCommandContract",
@@ -1650,6 +1661,228 @@ RULE_CONTRACTS: tuple[CliCommandContract, ...] = (
 """
 
 
+# ── #1847 sub-PR 9 (final): trade domain OutputContract migration ───────
+#
+# trade 도메인 2 leaf 의 contract entry. ``src/ante/cli/commands/trade.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:383-394`` (trade 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (2 commands, 전체): ``list`` / ``info`` 모두 JSON 모드에서
+# ``fmt.output(dict)`` 또는 ``fmt.table(rows, columns)`` 평면 dict / row list
+# 를 그대로 dump 한다.
+# - ``list`` (trade.py:121/125/127): empty → ``fmt.output({"message": "거래
+#   내역 없음", "trades": []})`` 평면; non-empty JSON → ``fmt.output(
+#   {"trades": [...]})`` 평면; non-empty text → fmt.table.
+# - ``info`` (trade.py:190): JSON → ``fmt.output(result)`` 평면 detail dict
+#   (``{trade_id, bot_id, strategy_id, symbol, side, quantity, price, status,
+#   timestamp, ...}``). text 는 click.echo 다수 줄. not-found 분기는
+#   ``fmt.error("거래를 찾을 수 없습니다: ...", code="TRADE_NOT_FOUND")``
+#   이며 success-output drift scope 밖.
+#
+# scope 분류 (#1815 SSOT, trade.py @require_scope marker 와 1:1 정합):
+# - ``trade:read`` scope (2 개, 전체): ``list`` / ``info``.
+# - public allowlist: 없음 — trade 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:140`` SSOT — trade 는
+# offline 분류):
+# - ``offline`` (2 개, 전체): ``list`` / ``info``. 각 leaf 는 local
+#   ``Database`` 와 ``TradeService`` / ``PositionHistory`` / ``TradeRecorder``
+#   를 직접 생성한다. runtime IPC handler 없음.
+TRADE_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("trade", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"trade:read"})),
+        # JSON mode: empty → ``fmt.output({"message": "거래 내역 없음",
+        # "trades": []})`` 평면 (trade.py:121); non-empty JSON → ``fmt.output(
+        # {"trades": [...]})`` 평면 (trade.py:125); text → fmt.table
+        # (trade.py:127). inverted date range 분기는 ``fmt.error`` 이며
+        # success-output drift scope 밖.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+    CliCommandContract(
+        path=("trade", "info"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"trade:read"})),
+        # JSON mode: ``fmt.output(result)`` 평면 detail dict (trade.py:190)
+        # — ``{trade_id, bot_id, strategy_id, symbol, side, quantity, price,
+        # status, timestamp, ...}``. text 는 click.echo. not-found / generic
+        # 오류 분기는 ``fmt.error`` 이며 success-output drift scope 밖.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+)
+"""Trade domain 2 leaf 의 contract tuple (#1847 sub-PR 9, final).
+
+순서는 ``docs/specs/cli/03-commands.md:383-394`` 의 trade 표
+(list → info) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
+# ── #1847 sub-PR 9 (final): backtest domain OutputContract migration ────
+#
+# backtest 도메인 2 leaf 의 contract entry. ``src/ante/cli/commands/
+# backtest.py`` 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:494-503`` (backtest 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (2 commands, 전체): ``run`` / ``history`` 모두 JSON 모드에서
+# ``fmt.output(result_dict)`` 또는 ``fmt.output(...)`` 평면 dict 를 그대로
+# dump 한다.
+# - ``run`` (backtest.py:173-181): ``fmt.output(result_dict, "Run ID:
+#   {run_id}\\n...")`` 평면. ``result_dict`` 는 backtest 결과의 평면 shape
+#   (``{strategy, period, total_return_pct, total_trades, final_balance,
+#   trades, metrics, run_id, ...}``) 으로 standard envelope 3 키 셋과 다름.
+#   text 모드는 template 으로 출력되고, JSON 모드는 평면 dict 그대로 dump.
+# - ``history`` (backtest.py:262/269/271): empty → ``fmt.output({"message":
+#   ..., "runs": []}, ...)`` 평면; non-empty JSON → ``fmt.output(
+#   {"strategy_name": strategy_name, "runs": rows})`` 평면; non-empty text →
+#   fmt.table. invalid date 분기는 ``fmt.error`` 이며 success-output drift
+#   scope 밖.
+#
+# scope 분류 (#1815 SSOT, backtest.py @require_scope marker 와 1:1 정합):
+# - ``backtest:run`` scope (2 개, 전체): ``run`` / ``history``.
+# - public allowlist: 없음 — backtest 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md:149`` SSOT — backtest run
+# 은 long-running, history 는 offline):
+# - ``long_running`` (1 개): ``run``. 백테스트 실행은 progress bar 를 보여주는
+#   장시간 작업이다. spec 표는 ``long-running`` 표기이며 본 registry 의
+#   ExecutionClass vocab 매핑 (모듈 docstring normative 표) 에 따라
+#   ``"long_running"`` 으로 분류.
+# - ``offline`` (1 개): ``history``. local ``Database`` 와 ``BacktestRunStore``
+#   를 직접 생성해 persisted run history 를 조회한다.
+BACKTEST_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("backtest", "run"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"backtest:run"})),
+        # JSON mode: ``fmt.output(result_dict, "Run ID: {run_id}\\n...")``
+        # 평면 dict (backtest.py:173-181). ``result_dict`` 는 backtest 결과의
+        # 평면 shape (strategy / period / total_return_pct / total_trades /
+        # final_balance / trades / metrics / run_id) — standard envelope 3 키
+        # 셋과 다르므로 raw_legacy. invalid date/exchange/timeframe/symbol /
+        # generic error 분기는 ``fmt.error`` 이며 success-output drift scope
+        # 밖.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="long_running",
+    ),
+    CliCommandContract(
+        path=("backtest", "history"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"backtest:run"})),
+        # JSON mode: empty → ``fmt.output({"message": ..., "runs": []}, ...)``
+        # 평면 (backtest.py:262-265); non-empty JSON → ``fmt.output(
+        # {"strategy_name": strategy_name, "runs": rows})`` 평면 (backtest.py:
+        # 269); non-empty text → fmt.table (backtest.py:271). generic error
+        # 분기는 ``fmt.error`` 이며 success-output drift scope 밖.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+)
+"""Backtest domain 2 leaf 의 contract tuple (#1847 sub-PR 9, final).
+
+순서는 ``docs/specs/cli/03-commands.md:494-503`` 의 backtest 표
+(run → history) 와 시각적으로 일치하도록 정렬된다.
+``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로 등록된다.
+"""
+
+
+# ── #1847 sub-PR 9 (final): audit domain OutputContract migration ───────
+#
+# audit 도메인 1 leaf 의 contract entry. ``src/ante/cli/commands/audit.py``
+# 의 ``@require_scope`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:710-720`` (audit 표) 와 1:1 정합한다.
+#
+# raw_legacy 분류 (1 command, 전체): ``list`` 는 JSON 모드에서 ``fmt.output(
+# dict)`` 평면 dict 를 그대로 dump 한다.
+# - ``list`` (audit.py:89/93/95): empty → ``fmt.output({"message": "감사
+#   로그가 없습니다.", "logs": []})`` 평면; non-empty JSON → ``fmt.output(
+#   {"logs": [...]})`` 평면; non-empty text → fmt.table. inverted date
+#   range 분기는 ``fmt.error("INVALID_DATE_RANGE", ...)`` 이며 success-output
+#   drift scope 밖.
+#
+# scope 분류 (#1815 SSOT, audit.py @require_scope marker 와 1:1 정합):
+# - ``audit:read`` scope (1 개, 전체): ``list``.
+# - public allowlist: 없음 — audit 도메인은 ``_AUTH_EXEMPT_COMMAND_PATHS``
+#   에 등재된 leaf 가 0 개다.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md`` SSOT — audit list 는
+# offline 분류):
+# - ``offline`` (1 개, 전체): ``list``. local ``Database`` 와 ``AuditLogger``
+#   를 직접 생성해 persisted audit row 를 조회한다. runtime IPC handler 없음.
+AUDIT_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("audit", "list"),
+        auth=AuthContract(mode="scoped", scopes=frozenset({"audit:read"})),
+        # JSON mode: empty → ``fmt.output({"message": "감사 로그가 없습니다.",
+        # "logs": []})`` 평면 (audit.py:89); non-empty JSON → ``fmt.output(
+        # {"logs": [...]})`` 평면 (audit.py:93); text → fmt.table
+        # (audit.py:95). inverted date range 분기는 ``fmt.error`` 이며
+        # success-output drift scope 밖.
+        output=OutputContract(kind="raw", envelope="raw_legacy"),
+        execution="offline",
+    ),
+)
+"""Audit domain 1 leaf 의 contract tuple (#1847 sub-PR 9, final).
+
+순서는 ``docs/specs/cli/03-commands.md:710-720`` 의 audit 표 (list 단일) 와
+시각적으로 일치한다. ``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로
+등록된다.
+"""
+
+
+# ── #1847 sub-PR 9 (final): signal domain OutputContract migration ──────
+#
+# signal 도메인 1 leaf 의 contract entry. ``src/ante/cli/commands/signal.py``
+# 의 ``@require_auth`` marker 와 ``fmt.*`` 호출 패턴, 그리고
+# ``docs/specs/cli/03-commands.md:721-727`` (signal 표) 와 1:1 정합한다.
+#
+# stream 분류 (1 command, 전체): ``connect`` 는 bidirectional JSON Lines
+# 시그널 채널을 stdin/stdout 위로 수립한다 (long-running / streaming 실행).
+# 일반 ``fmt.success`` / ``fmt.output`` 단일 envelope dump 는 *발생하지
+# 않는다* — validation 실패 분기 (``_fail``) 만 JSON 모드에서 ``fmt.error(
+# msg, code=...)`` envelope 을 dump 하고 즉시 SystemExit 한다 (signal.py:93-
+# 104). 채널 수립 후에는 ``SignalChannel.run()`` 이 JSON Lines stream 을
+# 직접 stdin/stdout 으로 처리한다 — fmt 계열 호출 없음. envelope SSOT
+# (#1821) 의 ``ContractKind = "stream"`` 으로 분류한다.
+#
+# envelope 표기: 본 leaf 는 단일 envelope dump 가 없으므로 ``raw_legacy``
+# 로 표시한다 — 일반 success/data envelope 이 부재하다는 의미를 본 registry
+# 의 두 envelope 분류 (``standard`` / ``raw_legacy``) 안에서 표현하기 위한
+# 정책. drift test 는 success-output dump 가 없음을 sanity 차원에서만 lock
+# 한다 (registry envelope vocab 분류기 sanity 만 적용).
+#
+# auth 분류 (signal.py @require_auth marker — scope 없음):
+# - public allowlist 미적용 (signal.py:25 의 ``@require_auth`` 데코레이터는
+#   토큰 인증을 요구한다). scope 는 없으므로 ``authenticated`` 분류.
+#
+# execution 분류 (``docs/specs/cli/03-commands.md`` SSOT — signal connect
+# 는 long-running / streaming 분류):
+# - ``long_running`` (1 개, 전체): ``connect``. ``asyncio.run(_run_connect)``
+#   로 ``SignalChannel.run()`` (stream loop) 을 실행. 본 registry 의
+#   ExecutionClass vocab 매핑 (모듈 docstring normative 표) 에 따라
+#   ``"long_running"`` 으로 분류 (streaming 도 흡수).
+SIGNAL_CONTRACTS: tuple[CliCommandContract, ...] = (
+    CliCommandContract(
+        path=("signal", "connect"),
+        # signal.py:25 의 ``@require_auth`` 만 적용 — scope 없음.
+        auth=AuthContract(mode="authenticated", scopes=frozenset()),
+        # stream 채널 leaf: 단일 success envelope dump 가 없으므로 raw_legacy
+        # 로 표시한다 (registry 의 두 envelope 분류 안에서 "envelope 부재"
+        # 를 표현하기 위한 정책). kind="stream" 으로 streaming nature 를
+        # 명시.
+        output=OutputContract(kind="stream", envelope="raw_legacy"),
+        execution="long_running",
+    ),
+)
+"""Signal domain 1 leaf 의 contract tuple (#1847 sub-PR 9, final).
+
+순서는 ``docs/specs/cli/03-commands.md:721-727`` 의 signal 표 (connect 단일)
+와 시각적으로 일치한다. ``CLI_COMMAND_REGISTRY`` 에는 모듈 import 시 자동으로
+등록된다.
+"""
+
+
 CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
     contract.path: contract
     for contract in (
@@ -1666,18 +1899,29 @@ CLI_COMMAND_REGISTRY: dict[tuple[str, ...], CliCommandContract] = {
         *INSTRUMENT_CONTRACTS,
         *CONFIG_CONTRACTS,
         *RULE_CONTRACTS,
+        *TRADE_CONTRACTS,
+        *BACKTEST_CONTRACTS,
+        *AUDIT_CONTRACTS,
+        *SIGNAL_CONTRACTS,
     )
 }
 """Leaf command path → contract mapping.
 
 본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury 9
 + strategy 7 + data 6 + report 5 + broker 4 + system 5 + instrument 4
-+ config 3 + rule 3 = 88 entries 가 등록되어 있다 (#1846 / #1847 sub-PR
-1 / #1847 sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5 /
-#1847 sub-PR 6 / #1847 sub-PR 7 / #1847 sub-PR 8). 나머지 도메인 (trade
-/ backtest / audit / signal) 의 entry 등록은 후속 PR (`#1847` sub-PR 9)
-의 책임이다. registry 미등록 leaf 가 FAIL 이어야 하는 drift guard 는
-`#1848` 가 활성화한다.
++ config 3 + rule 3 + trade 2 + backtest 2 + audit 1 + signal 1 = 94
+entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 /
+#1847 sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5 / #1847 sub-PR 6 /
+#1847 sub-PR 7 / #1847 sub-PR 8 / #1847 sub-PR 9). #1847 sweep 은 본
+PR 로 완료되며 (sub-PR 9 = final), registry 미등록 leaf 가 FAIL 이어야
+하는 drift guard 는 `#1848` 가 활성화한다.
+
+미등록 잔여 leaf (94 / 실측 Click leaf count 비교): ``ante`` root 의
+init / update / notification group 은 leaf 가 없거나 (notification은
+0 leaf — spec 707-708 narrative), update 단일 leaf 는 root-level command
+로 본 registry sweep 범위 밖이다. 정확한 잔여 leaf 식별은
+:func:`tests.unit.contracts.helpers.iter_click_leaf_commands` 의 실측을
+기준으로 한다 (leaf coverage report 참조).
 """
 
 
@@ -1698,8 +1942,9 @@ def all_contracts() -> Iterator[CliCommandContract]:
 
     본 PR 시점에는 account 9 + member 12 + bot 11 + approval 10 + treasury
     9 + strategy 7 + data 6 + report 5 + broker 4 + system 5 + instrument
-    4 + config 3 + rule 3 = 88 entries 가 등록되어 있다 (#1846 / #1847
-    sub-PR 1 / #1847 sub-PR 2 / #1847 sub-PR 3 / #1847 sub-PR 4 / #1847
-    sub-PR 5 / #1847 sub-PR 6 / #1847 sub-PR 7 / #1847 sub-PR 8).
+    4 + config 3 + rule 3 + trade 2 + backtest 2 + audit 1 + signal 1 = 94
+    entries 가 등록되어 있다 (#1846 / #1847 sub-PR 1 / #1847 sub-PR 2 /
+    #1847 sub-PR 3 / #1847 sub-PR 4 / #1847 sub-PR 5 / #1847 sub-PR 6 /
+    #1847 sub-PR 7 / #1847 sub-PR 8 / #1847 sub-PR 9).
     """
     yield from CLI_COMMAND_REGISTRY.values()

--- a/tests/unit/contracts/test_cli_registry_leaf_coverage.py
+++ b/tests/unit/contracts/test_cli_registry_leaf_coverage.py
@@ -1,21 +1,29 @@
-"""CLI contract registry leaf coverage report (#1844, #1846 update).
+"""CLI contract registry leaf coverage report (#1844 / #1846 / #1847 sub-PR 9 final).
 
-본 test 는 **report-only** 다. #1846 가 account 9 entries 를 등록하면서
-``CLI_COMMAND_REGISTRY`` 가 더 이상 빈 dict 가 아니지만, 누락 leaf 가
-FAIL 을 만들지 않는다 — 그 enforcement 는 `#1848` (final coverage) 의
-책임이다. 본 PR 의 단언은 "등록 카운트 > 0" 으로 완화되었다.
+본 test 는 #1847 sub-PR 9 (final) 시점의 leaf coverage 를 **명시 lock**
+한다. #1844 시점에는 빈 baseline 이었고, #1846 가 account 9 entries 를
+등록하면서 "registered > 0" 으로 완화되었으며, #1847 sub-PR 1-9 가 13
+도메인을 순차 등록해 본 sub-PR 9 final 시점에서는 **94 leaf 가 등록**
+되어 있다. 미등록 잔여 leaf 11 개 (feed 9 + init 1 + update 1) 는 본
+sub-PR scope 밖이며 별도 follow-up 의 책임이다.
 
 본 test 가 확인하는 것:
 
 * :func:`tests.unit.contracts.helpers.iter_click_leaf_commands` 가 적어도
   1 개 이상 leaf 를 yield 한다 (skeleton 동작 확인).
 * 누락 leaf 목록을 stdout 으로 print (``pytest -s`` 시 확인 가능) —
-  후속 PR (`#1847`) 가 채울 작업 분량 가시화.
-* 등록 카운트가 > 0 임을 lock (account 9 entry 등록 후).
+  후속 PR 가 채울 작업 분량 가시화.
+* 13 sweep 도메인 (account / member / bot / approval / treasury / strategy /
+  data / report / broker / system / instrument / config / rule / trade /
+  backtest / audit / signal) 의 17 family 가 모두 등록되어 있음을 **명시
+  lock**.
+* 누락 leaf 가 known follow-up set (feed 도메인 9 + init + update) 안에
+  머물러 있음을 lock — 본 sub-PR 9 가 등록 완료한 17 family 외 새 leaf
+  가 발견되면 본 단언이 FAIL 하여 등록 누락을 표면화한다.
 
 본 test 가 *하지 않는 것*:
 
-* 누락 leaf 에 대한 FAIL — `#1848`.
+* 누락 leaf 11 개에 대한 일반 FAIL — known follow-up 으로 명시 처리.
 * leaf path normalization 정책 lock — `#1845`.
 * helper hidden-subtree exclusion 검증 — :mod:`tests.unit.contracts.test_helpers`
   가 이미 lock 한다.
@@ -26,6 +34,52 @@ from __future__ import annotations
 from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
 from tests.unit.contracts.helpers import iter_click_leaf_commands
 
+# #1847 sub-PR 9 final 시점의 known follow-up 미등록 leaf set.
+# - feed 도메인 9 leaf: spec 533-538 + 실측 Click tree 에 존재하나 본
+#   #1847 sweep (13 도메인) 의 명시 범위 밖. 후속 별도 sub-PR 또는
+#   epic 이 책임진다.
+# - ``("init",)`` / ``("update",)``: ``ante init`` / ``ante update`` root-
+#   level leaf. 본 #1847 sweep (subcommand group 13 도메인) 의 명시 범위 밖.
+_KNOWN_FOLLOWUP_UNREGISTERED: frozenset[tuple[str, ...]] = frozenset(
+    {
+        ("feed", "config", "check"),
+        ("feed", "config", "list"),
+        ("feed", "config", "set"),
+        ("feed", "init"),
+        ("feed", "inject"),
+        ("feed", "run", "backfill"),
+        ("feed", "run", "daily"),
+        ("feed", "start"),
+        ("feed", "status"),
+        ("init",),
+        ("update",),
+    }
+)
+
+# #1847 sub-PR 9 final 시점의 17 sweep 도메인 1-prefix.
+# 본 set 는 본 sub-PR 9 가 lock 하는 도메인 family 의 normative roster.
+_SWEEP_DOMAINS: frozenset[str] = frozenset(
+    {
+        "account",
+        "member",
+        "bot",
+        "approval",
+        "treasury",
+        "strategy",
+        "data",
+        "report",
+        "broker",
+        "system",
+        "instrument",
+        "config",
+        "rule",
+        "trade",
+        "backtest",
+        "audit",
+        "signal",
+    }
+)
+
 
 def test_cli_registry_leaf_coverage_report() -> None:
     leaves = {leaf.path for leaf in iter_click_leaf_commands()}
@@ -35,19 +89,19 @@ def test_cli_registry_leaf_coverage_report() -> None:
 
     # report-only — stdout 으로 카운트 출력.
     total = len(leaves)
+    ratio_pct = round(100.0 * len(registered) / total, 1) if total else 0.0
     print(
-        f"\nCLI registry coverage (baseline #1844): "
-        f"{len(registered)}/{total} leaves registered"
+        f"\nCLI registry coverage (#1847 sub-PR 9 final): "
+        f"{len(registered)}/{total} leaves registered ({ratio_pct}%)"
     )
     if missing:
-        sample = sorted(missing)[:10]
-        print(f"  Missing sample (first {len(sample)} of {len(missing)}):")
-        for path in sample:
+        all_missing = sorted(missing)
+        print(f"  Missing ({len(all_missing)} total, known follow-up):")
+        for path in all_missing:
             print(f"    - {path}")
     if extraneous:
-        # 본 PR 시점에는 registry 가 비어있으므로 extraneous 도 0 이다.
-        # 후속 PR 가 잘못된 path 를 등록하면 여기서 가시화된다 (FAIL 은
-        # `#1845` enforcement 책임).
+        # registry path 가 Click tree 에 없는 stale entry. 본 PR 이 정상
+        # 종료되면 0 이어야 한다 (#1845 enforcement 가 별도 lock 예정).
         extras = sorted(extraneous)
         print(f"  Extraneous paths in registry (not in Click tree): {extras}")
 
@@ -58,10 +112,39 @@ def test_cli_registry_leaf_coverage_report() -> None:
         "skeleton test 도 함께 확인하라."
     )
 
-    # baseline lock (#1846 완화): 본 PR (#1846) 부터 registry 에는 account 9
-    # entries 가 등록되어 있다. 미등록 leaf 가 FAIL 이어야 하는 enforcement
-    # 는 `#1848` 의 책임이며, 본 단언은 "등록 카운트 > 0" 만 lock 한다.
-    assert len(registered) > 0, (
-        "본 PR (#1846) 시점 CLI_COMMAND_REGISTRY 는 account 9 entries 가 "
-        "등록되어 있어야 한다. account migration 회귀가 의심된다."
+    # ── #1847 sub-PR 9 final lock: 17 sweep 도메인이 모두 등록되어 있음을 단언 ──
+    #
+    # 각 도메인이 최소 1 entry 이상 registry 에 등록되어 있어야 한다.
+    # 13 sweep 도메인 (account/member/bot/approval/treasury/strategy/data/
+    # report/broker/system/instrument/config/rule) 은 sub-PR 1-8 가, 4 sweep
+    # 도메인 (trade/backtest/audit/signal) 은 본 sub-PR 9 가 책임진다.
+    registered_top_prefixes = {p[0] for p in registered}
+    missing_domains = _SWEEP_DOMAINS - registered_top_prefixes
+    assert not missing_domains, (
+        f"#1847 sub-PR 9 final 시점에 sweep 도메인이 일부 누락되었다: "
+        f"{sorted(missing_domains)}. registry entry 등록 회귀가 의심된다."
+    )
+
+    # ── #1847 sub-PR 9 final lock: 미등록 leaf 는 known follow-up set 안에만 ──
+    #
+    # 17 sweep 도메인 안에서 미등록 leaf 가 발견되면 (sweep 도메인 안의 새 leaf
+    # 가 추가되었거나, 본 PR 가 등록을 누락했거나) 본 단언이 FAIL 한다.
+    # known follow-up (feed 9 + init + update) 외의 leaf 는 모두 registry 에
+    # 등록되어 있어야 한다.
+    unexpected_missing = missing - _KNOWN_FOLLOWUP_UNREGISTERED
+    assert not unexpected_missing, (
+        f"#1847 sub-PR 9 final 시점에 known follow-up 외 미등록 leaf 발견: "
+        f"{sorted(unexpected_missing)}. 새 leaf 가 추가되었다면 registry 에 "
+        "entry 를 등록하거나 known follow-up set 에 명시적으로 추가하라."
+    )
+
+    # ── #1847 sub-PR 9 final lock: 등록 카운트 ≥ 94 ──
+    #
+    # 본 sub-PR 9 시점에 13 sweep 도메인 + 4 sweep 도메인 = 17 family 의
+    # 등록 leaf 가 합쳐 94 개임을 명시 lock. 추후 follow-up 이 feed/init/
+    # update 를 등록하면 늘어날 수 있으므로 ≥ 94 로 단언한다.
+    assert len(registered) >= 94, (
+        f"#1847 sub-PR 9 final 시점 registry 는 ≥ 94 entries 여야 한다 "
+        f"(실제: {len(registered)}). sub-PR 1-9 가 등록한 17 family 합산 "
+        "회귀가 의심된다."
     )

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -180,17 +180,16 @@ def test_raw_legacy_is_envelope_form_not_contract_kind() -> None:
 
 
 def test_get_contract_returns_none_when_missing() -> None:
-    """미등록 path 는 ``None`` 을 반환한다 (등록된 13 도메인 외).
+    """미등록 path 는 ``None`` 을 반환한다 (등록된 17 도메인 외).
 
     등록 도메인: account / member / bot / approval / treasury / strategy /
-    data / report / broker / system / instrument / config / rule.
+    data / report / broker / system / instrument / config / rule / trade /
+    backtest / audit / signal. #1847 sub-PR 9 (final) 로 sweep 완료.
     """
     # nonexistent path 는 항상 ``None``.
     assert get_contract(("nonexistent",)) is None
-    # trade 도메인 entry 등록은 후속 #1847 sub-PR (sub-PR 9 이후) 의
-    # 책임이므로 본 PR 시점에는 ``None`` 이다 (instrument / config / rule
-    # domain 은 sub-PR 8 에서 등록되었다).
-    assert get_contract(("trade", "list")) is None
+    # 등록 도메인 외 임의 path 도 ``None``.
+    assert get_contract(("nonexistent", "subcmd")) is None
 
 
 def test_registry_is_mutable_dict() -> None:
@@ -534,6 +533,84 @@ def test_rule_entries_registered_after_1847_sub_pr_8() -> None:
     assert expected_rule_paths.issubset(registered), (
         f"rule 3 entry 가 모두 등록되어야 한다 (#1847 sub-PR 8). "
         f"누락: {sorted(expected_rule_paths - registered)}"
+    )
+
+
+def test_trade_entries_registered_after_1847_sub_pr_9() -> None:
+    """#1847 sub-PR 9 (final) 가 trade 2 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 9 가 trade migration 을 완료한 시점부터
+    lock 된다. 2 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_trade_success_output_drift` 가
+    책임진다.
+    """
+    expected_trade_paths = {
+        ("trade", "list"),
+        ("trade", "info"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_trade_paths.issubset(registered), (
+        f"trade 2 entry 가 모두 등록되어야 한다 (#1847 sub-PR 9). "
+        f"누락: {sorted(expected_trade_paths - registered)}"
+    )
+
+
+def test_backtest_entries_registered_after_1847_sub_pr_9() -> None:
+    """#1847 sub-PR 9 (final) 가 backtest 2 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 9 가 backtest migration 을 완료한 시점부터
+    lock 된다. 2 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_backtest_success_output_drift` 가
+    책임진다.
+    """
+    expected_backtest_paths = {
+        ("backtest", "run"),
+        ("backtest", "history"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_backtest_paths.issubset(registered), (
+        f"backtest 2 entry 가 모두 등록되어야 한다 (#1847 sub-PR 9). "
+        f"누락: {sorted(expected_backtest_paths - registered)}"
+    )
+
+
+def test_audit_entries_registered_after_1847_sub_pr_9() -> None:
+    """#1847 sub-PR 9 (final) 가 audit 1 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 9 가 audit migration 을 완료한 시점부터
+    lock 된다. 1 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_audit_success_output_drift` 가
+    책임진다.
+    """
+    expected_audit_paths = {
+        ("audit", "list"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_audit_paths.issubset(registered), (
+        f"audit 1 entry 가 모두 등록되어야 한다 (#1847 sub-PR 9). "
+        f"누락: {sorted(expected_audit_paths - registered)}"
+    )
+
+
+def test_signal_entries_registered_after_1847_sub_pr_9() -> None:
+    """#1847 sub-PR 9 (final) 가 signal 1 leaf entry 를 등록했음을 lock 한다.
+
+    본 단언은 #1847 sub-PR 9 가 signal migration 을 완료한 시점부터
+    lock 된다. 1 entry 의 정확한 ``OutputContract`` / ``AuthContract``
+    정합 검증은 :mod:`tests.unit.contracts.test_cli_registry_auth_drift`
+    (Family B) 와 :mod:`tests.unit.test_signal_success_output_drift` 가
+    책임진다.
+    """
+    expected_signal_paths = {
+        ("signal", "connect"),
+    }
+    registered = set(CLI_COMMAND_REGISTRY.keys())
+    assert expected_signal_paths.issubset(registered), (
+        f"signal 1 entry 가 모두 등록되어야 한다 (#1847 sub-PR 9). "
+        f"누락: {sorted(expected_signal_paths - registered)}"
     )
 
 

--- a/tests/unit/test_audit_success_output_drift.py
+++ b/tests/unit/test_audit_success_output_drift.py
@@ -1,0 +1,251 @@
+"""Audit CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 9).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+audit 도메인 1 leaf 의 ``OutputContract`` 와 ``ante audit ... --format json``
+실제 출력 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1-8 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT). ``fmt.success(...)`` callsite 가 dump 한다.
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump 한다
+  (standard envelope 의 3 키 셋이 동시에 부재 또는 ``status != "ok"``).
+
+본 PR 은 ``audit.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift
+하면 본 test 가 즉시 FAIL 한다.
+
+3 시나리오 (registry sanity +1 + list empty +1 + list non-empty +1):
+
+0. registry sanity — audit 1 entry 의 envelope 분류기 범위 내.
+1. ``list`` empty → ``raw_legacy`` (``{message, logs: []}``).
+2. ``list`` non-empty → ``raw_legacy`` (``{logs: [...]}``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언."""
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_audit_entries_envelopes_classified() -> None:
+    """audit 1 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용."""
+    accepted = {"standard", "raw_legacy"}
+    audit_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("audit",)
+    ]
+    assert len(audit_entries) == 1, (
+        f"audit 1 entry 가 모두 등록되어야 한다. 실제: {len(audit_entries)}"
+    )
+    for path, contract in audit_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남."
+        )
+
+
+# ── CLI fixture (동형 패턴) ────────────────────────────────────────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json audit ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다 (동형 패턴)."""
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. list empty → raw_legacy ─────────────────────────────────────────────
+
+
+def test_audit_list_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``audit list`` empty: ``{message, logs: []}`` 평면 (raw_legacy).
+
+    audit.py:89: ``fmt.output({"message": "감사 로그가 없습니다.", "logs": []})``
+    분기. ``AuditLogger.query`` 가 빈 리스트를 반환할 때.
+    """
+    with (
+        patch(
+            "ante.audit.AuditLogger.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.audit.AuditLogger.query",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(tmp_path),
+                "--format",
+                "json",
+                "audit",
+                "list",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"audit list empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"message": "감사 로그가 없습니다.", "logs": []}
+
+
+# ── 2. list non-empty → raw_legacy ─────────────────────────────────────────
+
+
+def test_audit_list_non_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``audit list`` non-empty: ``{logs: [...]}`` 평면.
+
+    audit.py:93: ``if fmt.is_json: fmt.output({"logs": result})`` 분기.
+    ``AuditLogger.query`` 가 row dict list 를 반환할 때.
+    """
+    rows = [
+        {
+            "id": 1,
+            "member_id": "test-master",
+            "action": "test.action",
+            "resource": "test-resource",
+            "detail": "{}",
+            "ip": "127.0.0.1",
+            "created_at": "2026-01-15T10:00:00",
+        },
+        {
+            "id": 2,
+            "member_id": "test-master",
+            "action": "test.other",
+            "resource": "another",
+            "detail": "{}",
+            "ip": "127.0.0.1",
+            "created_at": "2026-01-15T10:01:00",
+        },
+    ]
+    with (
+        patch(
+            "ante.audit.AuditLogger.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.audit.AuditLogger.query",
+            new=AsyncMock(return_value=rows),
+        ),
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(tmp_path),
+                "--format",
+                "json",
+                "audit",
+                "list",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"audit list non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert "logs" in payload
+    assert isinstance(payload["logs"], list)
+    assert len(payload["logs"]) == 2
+    assert payload["logs"][0]["id"] == 1
+    assert payload["logs"][0]["action"] == "test.action"

--- a/tests/unit/test_backtest_success_output_drift.py
+++ b/tests/unit/test_backtest_success_output_drift.py
@@ -1,0 +1,353 @@
+"""Backtest CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 9).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+backtest 도메인 2 leaf (``backtest run`` / ``backtest history``) 의
+``OutputContract`` 와 ``ante backtest ... --format json`` 실제 출력 envelope
+shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1-8 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT).
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump.
+
+본 PR 은 ``backtest.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift
+하면 본 test 가 즉시 FAIL 한다.
+
+4 시나리오 (registry sanity +1 + run success +1 + history empty +1 +
+history non-empty +1):
+
+0. registry sanity — backtest 2 entries 의 envelope 분류기 범위 내.
+1. ``run`` success (mock service.run) → ``raw_legacy`` (BacktestResult dict).
+2. ``history`` empty → ``raw_legacy`` (``{message, runs: []}``).
+3. ``history`` non-empty → ``raw_legacy`` (``{strategy_name, runs: [...]}``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언."""
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_backtest_entries_envelopes_classified() -> None:
+    """backtest 2 entries 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용."""
+    accepted = {"standard", "raw_legacy"}
+    backtest_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("backtest",)
+    ]
+    assert len(backtest_entries) == 2, (
+        f"backtest 2 entries 가 모두 등록되어야 한다. 실제: {len(backtest_entries)}"
+    )
+    for path, contract in backtest_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남."
+        )
+
+
+# ── CLI fixture (동형 패턴) ────────────────────────────────────────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json backtest ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다 (동형 패턴)."""
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. run success → raw_legacy ───────────────────────────────────────────
+
+
+def test_backtest_run_success_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``backtest run`` success: ``fmt.output(result_dict, template)`` 평면 dict.
+
+    backtest.py:173-181: ``fmt.output(result_dict, ...)`` 평면 dict. ``result_dict``
+    는 ``BacktestResult.to_dict()`` 의 결과로 ``{strategy, period,
+    total_return_pct, total_trades, final_balance, trades, metrics,
+    equity_curve, config, datasets, run_id}`` 평면 shape. ``BacktestService.run``
+    을 mock 해 성공 경로를 강제한다.
+    """
+    # strategy file (Path(exists=True) callback 통과용)
+    strat_path = tmp_path / "strat.py"
+    strat_path.write_text("# dummy strategy file\n", encoding="utf-8")
+    db_path = tmp_path / "ante.db"
+
+    # BacktestResult mock — to_dict() 가 평면 dict 반환.
+    result_obj = MagicMock()
+    result_obj.strategy_name = "test_strategy"
+    result_obj.strategy_version = "1.0.0"
+    result_obj.total_return = 12.5
+    result_obj.trades = []
+    result_obj.to_dict.return_value = {
+        "strategy": "test_strategy_v1.0.0",
+        "period": "2025-01-01 ~ 2025-12-31",
+        "initial_balance": 10_000_000.0,
+        "final_balance": 11_250_000.0,
+        "total_return_pct": 12.5,
+        "total_trades": 0,
+        "metrics": {
+            "sharpe_ratio": 1.5,
+            "max_drawdown": 5.0,
+            "win_rate": 0.6,
+        },
+        "equity_curve": [],
+        "trades": [],
+        "config": {},
+        "datasets": [],
+    }
+
+    with (
+        patch(
+            "ante.backtest.service.BacktestService.run",
+            new=AsyncMock(return_value=result_obj),
+        ),
+        patch(
+            "ante.backtest.run_store.BacktestRunStore.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.backtest.run_store.BacktestRunStore.save",
+            new=AsyncMock(return_value="run-001"),
+        ),
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(tmp_path),
+                "--format",
+                "json",
+                "backtest",
+                "run",
+                str(strat_path),
+                "--start",
+                "2025-01-01",
+                "--end",
+                "2025-12-31",
+                "--symbols",
+                "005930",
+                "--db-path",
+                str(db_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"backtest run success: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["strategy"] == "test_strategy_v1.0.0"
+    assert payload["total_return_pct"] == 12.5
+    assert payload["run_id"] == "run-001"
+    assert "metrics" in payload
+
+
+# ── 2. history empty → raw_legacy ──────────────────────────────────────────
+
+
+def test_backtest_history_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``backtest history <name>`` empty: ``{message, runs: []}`` 평면.
+
+    backtest.py:262-265: empty → ``fmt.output({"message": ..., "runs": []},
+    ...)`` 분기. ``BacktestRunStore.list_by_strategy`` 가 빈 리스트 반환.
+    """
+    db_path = tmp_path / "ante.db"
+    with (
+        patch(
+            "ante.backtest.run_store.BacktestRunStore.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.backtest.run_store.BacktestRunStore.list_by_strategy",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(tmp_path),
+                "--format",
+                "json",
+                "backtest",
+                "history",
+                "test_strategy",
+                "--db-path",
+                str(db_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"backtest history empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {
+        "message": "'test_strategy' 백테스트 이력이 없습니다.",
+        "runs": [],
+    }
+
+
+# ── 3. history non-empty → raw_legacy ──────────────────────────────────────
+
+
+def test_backtest_history_non_empty_envelope_matches_raw_legacy(
+    tmp_path: Path,
+) -> None:
+    """``backtest history <name>`` non-empty: ``{strategy_name, runs: [...]}`` 평면.
+
+    backtest.py:269: ``if fmt.is_json: fmt.output({"strategy_name":
+    strategy_name, "runs": rows})``. ``BacktestRunStore.list_by_strategy`` 가
+    ``BacktestRun`` list 를 반환하고 각 row 는 ``to_dict()`` 결과로 평면 dict.
+    """
+    run_row = MagicMock()
+    run_row.to_dict.return_value = {
+        "run_id": "run-001",
+        "strategy_name": "test_strategy",
+        "strategy_version": "1.0.0",
+        "total_return_pct": 12.5,
+        "sharpe_ratio": 1.5,
+        "max_drawdown_pct": 5.0,
+        "total_trades": 10,
+        "win_rate": 0.6,
+        "created_at": "2026-01-15T10:00:00",
+    }
+    db_path = tmp_path / "ante.db"
+    with (
+        patch(
+            "ante.backtest.run_store.BacktestRunStore.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.backtest.run_store.BacktestRunStore.list_by_strategy",
+            new=AsyncMock(return_value=[run_row]),
+        ),
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(tmp_path),
+                "--format",
+                "json",
+                "backtest",
+                "history",
+                "test_strategy",
+                "--db-path",
+                str(db_path),
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"backtest history non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["strategy_name"] == "test_strategy"
+    assert isinstance(payload["runs"], list)
+    assert len(payload["runs"]) == 1
+    assert payload["runs"][0]["run_id"] == "run-001"
+    assert payload["runs"][0]["total_return_pct"] == 12.5

--- a/tests/unit/test_signal_success_output_drift.py
+++ b/tests/unit/test_signal_success_output_drift.py
@@ -1,0 +1,232 @@
+"""Signal CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 9).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+signal 도메인 1 leaf (``signal connect``) 의 ``OutputContract`` 와 실제
+callsite 의 envelope shape 사이의 drift 를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1-8 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT).
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict / row list 또는 envelope 부재.
+
+``signal connect`` 는 bidirectional JSON Lines stream 채널을 stdin/stdout
+위로 수립한다 (long-running / streaming). ``fmt.success`` / ``fmt.output``
+단일 envelope dump 는 *발생하지 않는다*. validation 실패 분기 (``_fail``)
+만 JSON 모드에서 ``fmt.error(msg, code=...)`` envelope 을 dump 하고 즉시
+SystemExit (signal.py:93-104). success-output drift test 의 일반 envelope
+매칭 scope 밖이며, 본 모듈은 registry envelope 분류기 sanity 만 lock.
+
+3 시나리오 (registry sanity +1 + validation error envelope +1 + connect
+가 fmt.success 를 호출하지 않음 +1):
+
+0. registry sanity — signal 1 entry 의 envelope 분류기 범위 내.
+1. invalid key → ``fmt.error`` envelope (``{status: "error", code:
+   "INVALID_SIGNAL_KEY", message: ...}``) — JSON 모드 stdout, exit 1.
+2. signal.py source 가 ``fmt.success`` / ``fmt.output`` 을 호출하지 않음 —
+   stream leaf 이므로 success envelope 부재가 정상 (raw_legacy 분류 의도와
+   1:1 정합).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언."""
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_signal_entries_envelopes_classified() -> None:
+    """signal 1 entry 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용."""
+    accepted = {"standard", "raw_legacy"}
+    signal_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("signal",)
+    ]
+    assert len(signal_entries) == 1, (
+        f"signal 1 entry 가 모두 등록되어야 한다. 실제: {len(signal_entries)}"
+    )
+    for path, contract in signal_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남."
+        )
+
+
+# ── CLI fixture (동형 패턴) ────────────────────────────────────────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json signal ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner(mix_stderr=False)
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다 (동형 패턴)."""
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. validation error envelope (invalid key) — fmt.error envelope ─────
+
+
+def test_signal_connect_invalid_key_emits_error_envelope(tmp_path: Path) -> None:
+    """``signal connect`` invalid key: ``fmt.error`` JSON envelope 발화.
+
+    signal.py:50-52: ``validate_key`` 가 ``None`` 반환 시 ``_fail(fmt,
+    "Invalid signal key", "INVALID_SIGNAL_KEY")``. JSON 모드는 stdout 으로
+    ``{status: "error", code, message}`` envelope 을 dump 하고 exit 1.
+
+    본 시나리오는 success-output drift 의 일반 envelope 매칭 scope 밖이지만,
+    signal connect 의 유일한 stdout JSON dump 경로이므로 본 모듈이 함께
+    lock 한다 (registry stream leaf 의 "success envelope 부재" 를 보완).
+    """
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    skm = MagicMock()
+    skm.initialize = AsyncMock()
+    skm.validate_key = AsyncMock(return_value=None)
+
+    # signal.py 는 ``_run_connect`` 내부에서 lazy import 하므로 원본 모듈을
+    # 직접 patch 한다.
+    with (
+        patch("ante.core.database.Database", return_value=db),
+        patch(
+            "ante.bot.signal_key.SignalKeyManager",
+            return_value=skm,
+        ),
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(tmp_path),
+                "--format",
+                "json",
+                "signal",
+                "connect",
+                "--key",
+                "sk_invalid",
+            ]
+        )
+
+    # invalid key 분기는 exit 1.
+    assert result.exit_code == 1, result.stdout
+
+    # JSON envelope 는 stdout 에 dump 된다 (fmt.error).
+    payload = _load_json_payload(result.stdout)
+    assert isinstance(payload, dict)
+    assert payload.get("status") == "error"
+    assert payload.get("code") == "INVALID_SIGNAL_KEY"
+    assert "message" in payload
+
+
+# ── 2. signal.py callsite 부재 단언 (success envelope 미생성) ───────────
+
+
+def test_signal_connect_source_does_not_emit_fmt_success_or_output() -> None:
+    """``signal.py`` 본문이 ``fmt.success`` / ``fmt.output`` 를 호출하지 않음.
+
+    signal connect 는 stream leaf 이므로 standard envelope success path 가
+    *부재* 함이 정상이다 (raw_legacy 분류 의도와 1:1 정합). 본 단언은
+    callsite 가 미래에 success envelope 을 추가하면 (그러면 stream nature
+    가 깨지므로) FAIL 하여 registry envelope 분류 갱신을 강제한다.
+    """
+    from pathlib import Path as _Path
+
+    # signal.py source 를 모듈 파일 경로로 직접 read — repo-relative path 로
+    # stable. 단순 string 검색으로 lock.
+    import ante.cli.commands.signal as signal_mod
+
+    src_path = _Path(signal_mod.__file__)
+    body = src_path.read_text(encoding="utf-8")
+    assert "fmt.success(" not in body, (
+        "signal.py 가 ``fmt.success(`` 를 호출한다 — stream leaf 의 envelope "
+        "분류 (raw_legacy) 와 충돌한다. registry envelope 을 갱신하거나 "
+        "callsite 를 다시 stream-only 로 되돌리라."
+    )
+    assert "fmt.output(" not in body, (
+        "signal.py 가 ``fmt.output(`` 를 호출한다 — stream leaf 의 envelope "
+        "분류 (raw_legacy) 와 충돌한다. registry envelope 을 갱신하거나 "
+        "callsite 를 다시 stream-only 로 되돌리라."
+    )
+    # fmt.error 만 발화 (validation 실패 경로).
+    assert "fmt.error(" in body, (
+        "signal.py 가 ``fmt.error(`` 를 호출하지 않는다 — validation 실패 "
+        "envelope (test_signal_connect_invalid_key_emits_error_envelope) 도 "
+        "drift 했을 가능성. registry / callsite 정합을 확인하라."
+    )

--- a/tests/unit/test_trade_success_output_drift.py
+++ b/tests/unit/test_trade_success_output_drift.py
@@ -1,0 +1,310 @@
+"""Trade CLI success output ↔ registry OutputContract drift lock (#1847 sub-PR 9).
+
+본 모듈은 :data:`ante.contracts.cli_registry.CLI_COMMAND_REGISTRY` 에 등록된
+trade 도메인 2 leaf (``trade list`` / ``trade info``) 의 ``OutputContract``
+와 ``ante trade ... --format json`` 실제 출력 envelope shape 사이의 drift
+를 lock 한다.
+
+#1846 (account) / #1847 sub-PR 1-8 1:1 동형 패턴. drift 모델:
+
+- ``envelope="standard"`` entry → CLI success envelope ``{status, message,
+  data}`` (envelopes.md SSOT).
+- ``envelope="raw_legacy"`` entry → JSON mode 에서 ``fmt.output(...)`` 또는
+  ``fmt.table(...)`` 으로 평면 dict 또는 row list 를 그대로 dump.
+
+본 PR 은 ``trade.py`` 본문을 *바꾸지 않으며*, registry entry 가 실제
+callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift
+하면 본 test 가 즉시 FAIL 한다.
+
+4 시나리오 (registry sanity +1 + list empty +1 + list non-empty +1 +
+info found +1):
+
+0. registry sanity — trade 2 entries 의 envelope 분류기 범위 내.
+1. ``list`` empty → ``raw_legacy`` (``{message, trades: []}``).
+2. ``list`` non-empty → ``raw_legacy`` (``{trades: [...]}``).
+3. ``info`` found → ``raw_legacy`` (``{trade_id, bot_id, ..., timestamp}``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# ── envelope shape predicates (envelopes.md SSOT, 동형 정책) ───────────────
+
+_STANDARD_KEYS = frozenset({"status", "message", "data"})
+
+
+def _is_standard_envelope(payload: Any) -> bool:
+    """``{status: "ok", message, data}`` 3 필수 키가 모두 존재하는지."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "ok"
+        and set(payload.keys()) >= _STANDARD_KEYS
+        and isinstance(payload.get("message"), str)
+        and isinstance(payload.get("data"), (dict, type(None)))
+    )
+
+
+def _is_raw_legacy_payload(payload: Any) -> bool:
+    """평면 dict / list 로 standard envelope 의 3 필수 키 셋이 부재함을 단언."""
+    if isinstance(payload, list):
+        return True
+    if not isinstance(payload, dict):
+        return False
+    if (
+        set(payload.keys()) >= _STANDARD_KEYS
+        and payload.get("status") == "ok"
+        and isinstance(payload.get("data"), dict)
+    ):
+        return False
+    return True
+
+
+# ── registry entry 정합 sanity (envelope vocab) ───────────────────────────
+
+
+def test_registry_trade_entries_envelopes_classified() -> None:
+    """trade 2 entries 의 envelope 이 ``standard`` 또는 ``raw_legacy`` 만 사용."""
+    accepted = {"standard", "raw_legacy"}
+    trade_entries = [
+        (path, contract)
+        for path, contract in CLI_COMMAND_REGISTRY.items()
+        if path[:1] == ("trade",)
+    ]
+    assert len(trade_entries) == 2, (
+        f"trade 2 entries 가 모두 등록되어야 한다. 실제: {len(trade_entries)}"
+    )
+    for path, contract in trade_entries:
+        assert contract.output.envelope in accepted, (
+            f"{path}: registry envelope='{contract.output.envelope}' 가 본 "
+            f"drift test 의 분류 범위 ({sorted(accepted)}) 를 벗어남."
+        )
+
+
+# ── CLI fixture (동형 패턴) ────────────────────────────────────────────────
+
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """master member 로 인증 우회 (동형 패턴)."""
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    """``ante --format json trade ...`` 를 실행하고 결과를 반환한다."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+def _load_json_payload(output: str) -> Any:
+    """CLI ``--format json`` 출력의 첫 JSON value 를 파싱한다 (동형 패턴)."""
+    text = output.lstrip()
+    assert text, f"CLI 출력이 비어 있다: {output!r}"
+    start_brace = text.find("{")
+    start_bracket = text.find("[")
+    candidates = [s for s in (start_brace, start_bracket) if s >= 0]
+    assert candidates, f"JSON 시작 토큰을 찾을 수 없다: {output!r}"
+    start = min(candidates)
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(text[start:])
+    return obj
+
+
+# ── 1. list empty → raw_legacy ─────────────────────────────────────────────
+
+
+def test_trade_list_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``trade list`` empty: ``{message, trades: []}`` 평면 (raw_legacy).
+
+    trade.py:121: ``fmt.output({"message": "거래 내역 없음", "trades": []})``
+    분기. ``TradeService.get_trades`` 가 빈 리스트를 반환할 때.
+    """
+    with (
+        patch(
+            "ante.trade.service.TradeService.get_trades",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "ante.trade.recorder.TradeRecorder.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.trade.position.PositionHistory.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(tmp_path),
+                "--format",
+                "json",
+                "trade",
+                "list",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"trade list empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"message": "거래 내역 없음", "trades": []}
+
+
+# ── 2. list non-empty → raw_legacy ─────────────────────────────────────────
+
+
+def test_trade_list_non_empty_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``trade list`` non-empty: ``{trades: [...]}`` 평면.
+
+    trade.py:125: ``if fmt.is_json: fmt.output({"trades": result})`` 분기.
+    ``TradeService.get_trades`` 가 trade 객체 list 를 반환할 때.
+    """
+    trade1 = MagicMock()
+    trade1.trade_id = "trade-001"
+    trade1.bot_id = "bot-001"
+    trade1.strategy_id = "strat-001"
+    trade1.symbol = "005930"
+    trade1.side = "buy"
+    trade1.quantity = 10
+    trade1.price = 70000.0
+    trade1.status = "filled"
+    trade1.timestamp = datetime(2026, 1, 15, 10, 0, 0)
+
+    with (
+        patch(
+            "ante.trade.service.TradeService.get_trades",
+            new=AsyncMock(return_value=[trade1]),
+        ),
+        patch(
+            "ante.trade.recorder.TradeRecorder.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.trade.position.PositionHistory.initialize",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(tmp_path),
+                "--format",
+                "json",
+                "trade",
+                "list",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"trade list non-empty: standard envelope 아님. payload={payload!r}"
+    )
+    assert "trades" in payload
+    assert isinstance(payload["trades"], list)
+    assert len(payload["trades"]) == 1
+    assert payload["trades"][0]["trade_id"] == "trade-001"
+    assert payload["trades"][0]["symbol"] == "005930"
+    assert payload["trades"][0]["side"] == "buy"
+
+
+# ── 3. info found → raw_legacy ─────────────────────────────────────────────
+
+
+def test_trade_info_found_envelope_matches_raw_legacy(tmp_path: Path) -> None:
+    """``trade info <trade_id>`` found: ``{trade_id, bot_id, ...}`` 평면.
+
+    trade.py:190: ``if fmt.is_json: fmt.output(result)`` 분기. ``db.fetch_one``
+    이 trade row 를 반환할 때.
+    """
+    trade_row = {
+        "trade_id": "trade-001",
+        "bot_id": "bot-001",
+        "strategy_id": "strat-001",
+        "symbol": "005930",
+        "side": "buy",
+        "quantity": 10,
+        "price": 70000.0,
+        "status": "filled",
+        "timestamp": "2026-01-15T10:00:00",
+    }
+    with (
+        patch(
+            "ante.core.database.Database.fetch_one",
+            new=AsyncMock(return_value=trade_row),
+        ),
+        patch(
+            "ante.core.database.Database.connect",
+            new=AsyncMock(),
+        ),
+        patch(
+            "ante.core.database.Database.close",
+            new=AsyncMock(),
+        ),
+    ):
+        result = _invoke(
+            [
+                "--config-dir",
+                str(tmp_path),
+                "--format",
+                "json",
+                "trade",
+                "info",
+                "trade-001",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"trade info found: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload["trade_id"] == "trade-001"
+    assert payload["symbol"] == "005930"
+    assert payload["side"] == "buy"


### PR DESCRIPTION
Closes #1847
Closes #1815

## Summary
- #1847 마지막 sub-PR (per-domain 9 분할 완료) — 4 도메인 sweep
- trade 2 + backtest 2 + audit 1 + signal 1 = 6 leaf entries 등록
- registry 합산 **94 entries** (account 9 + member 12 + bot 11 + approval 10 + treasury 9 + strategy 7 + data 6 + report 5 + broker 4 + system 5 + instrument 4 + config 3 + rule 3 + trade 2 + backtest 2 + audit 1 + signal 1)
- leaf coverage final lock — 17 sweep 도메인 명시 + known follow-up 11 leaf (feed 9 + init + update) 외 미등록 leaf 발견 시 FAIL
- `signal connect`: `kind="stream"` + `envelope="raw_legacy"` 분류 (success envelope 부재; validation 실패만 `fmt.error` JSON envelope)
- 4 CLI command 파일 diff **0 lines** (passthrough policy)
- #1815 epic 종결

## 변경 사항
- `src/ante/contracts/cli_registry.py`: `TRADE_CONTRACTS`/`BACKTEST_CONTRACTS`/`AUDIT_CONTRACTS`/`SIGNAL_CONTRACTS` 추가, `CLI_COMMAND_REGISTRY` 결합 갱신
- `tests/unit/contracts/test_cli_registry_shell.py`: per-sub-PR registry lock 4 추가 (trade/backtest/audit/signal), stale `get_contract` not-found assertion 갱신
- `tests/unit/contracts/test_cli_registry_leaf_coverage.py`: final coverage lock (17 sweep 도메인 + known follow-up set) 활성화
- 신규 4 drift test: `test_trade_success_output_drift.py` (4 시나리오) / `test_backtest_success_output_drift.py` (4) / `test_audit_success_output_drift.py` (3) / `test_signal_success_output_drift.py` (3)
- `docs/architecture/generated/project-structure.md`: regenerate (4 신규 drift test 반영)

## Test plan
- [x] `pytest tests/unit/contracts -v` → 116 passed (skeleton + auth drift + leaf coverage + per-sub-PR lock 17개)
- [x] `pytest tests/unit/test_{trade,backtest,audit,signal}_success_output_drift.py` → 14 passed
- [x] 17 family drift test (sub-PR 1-9) → 137 passed
- [x] 전체 unit suite (`tests/unit`) → 5183 passed, 2 skipped (217 fail은 pre-existing 환경 의존 — 본 PR scope 4 신규 + 2 변경 contracts 파일은 모두 PASS 확인)
- [x] `mypy src` → 0 issues (223 files)
- [x] `ruff check src tests` → All checks passed
- [x] `ruff format --check src tests` → 539 files already formatted
- [x] `git diff src/ante/cli/commands/{trade,backtest,audit,signal}.py` → 0 lines (passthrough policy 충족)
- [x] `scripts/generate_project_structure.py` → 4 drift test 반영
- [x] main HEAD 불변 확인 (`ba222c57`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)