### PR TITLE
refactor: #1850 IPC dispatch wrapper required_services + account_id_policy preflight

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -400,7 +400,8 @@ tests/
 │   │   ├── test_protocol.py
 │   │   ├── test_registry.py
 │   │   ├── test_server_client.py
-│   │   └── test_service_registry.py
+│   │   ├── test_service_registry.py
+│   │   └── test_dispatch_wrapper_preflight.py
 │   ├── specs/
 │   │   ├── __init__.py
 │   │   ├── test_cold_path_terminology.py

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -261,6 +261,41 @@ class IPCServer:
             },
         }
 
+    @staticmethod
+    def _service_not_configured(request_id: str, service_name: str) -> dict:
+        """``SERVICE_NOT_CONFIGURED`` error 응답 dict 생성.
+
+        Refs #1850 / #1816: dispatch wrapper의 ``required_services`` preflight 가
+        ``ServiceRegistry`` 에 의존 service 가 부재한 경우 사용한다. taxonomy
+        SSOT(``docs/specs/contracts/error-taxonomy.md``) 의 ``service_unavailable``
+        category 안정 코드. ``SERVICE_UNAVAILABLE``(lifecycle 상태) 와는 의미가
+        분리된다 — 본 코드는 영구적 misconfiguration 을 가리킨다.
+        """
+        return {
+            "id": request_id,
+            "status": "error",
+            "error": {
+                "code": "SERVICE_NOT_CONFIGURED",
+                "message": (f"의존 서비스가 구성되지 않았습니다: {service_name}"),
+            },
+        }
+
+    def _missing_required_service(self, spec_required: frozenset[str]) -> str | None:
+        """``required_services`` preflight — 부재한 첫 service 이름 반환.
+
+        Refs #1850: ``CommandSpec.required_services`` 의 각 attribute 이름을
+        ``ServiceRegistry`` 에서 ``getattr(..., None)`` 으로 조회한다.
+        ``ServiceRegistry`` 는 dataclass 이고 optional service(예: ``audit_logger``,
+        ``member_service``, ``trade_service``, ``strategy_registry``)는 default
+        ``None`` 을 가지므로 ``None`` 도 부재로 판정한다. 모두 존재하면 ``None``
+        반환. 부재 발생 시 등록 순서가 frozenset 이라 비결정적이므로 단일 결정
+        결과(첫 발견)만 사용한다.
+        """
+        for service_name in spec_required:
+            if getattr(self._service_registry, service_name, None) is None:
+                return service_name
+        return None
+
     async def _dispatch(self, request: dict) -> dict:
         """요청을 적절한 핸들러로 라우팅.
 
@@ -272,6 +307,23 @@ class IPCServer:
         * ``SHUTTING_DOWN`` + mutating: ``SERVICE_UNAVAILABLE``.
         * ``SHUTTING_DOWN`` + read-only: 통과 (BotManager/DB 살아있음 가정).
         * ``RUNNING``: 정상 dispatch.
+
+        Refs #1850 (#1819 부모 epic): lifecycle gate 통과 후 handler 호출 전에
+        ``CommandSpec`` metadata 기반 preflight 두 단계를 수행한다.
+
+        1. ``required_services`` 부재 시 ``SERVICE_NOT_CONFIGURED`` envelope
+           으로 거부한다 — handler 가 ``svc.<name>`` 접근에서 ``None`` /
+           ``AttributeError`` 로 폭주하기 전에 차단한다.
+        2. ``account_id_policy`` 검증 — try 블록 내부에서
+           ``require_account_id`` 를 호출해 ``InvalidAccountIdError``
+           (``code="VALIDATION_ERROR"``) 를 raise 시키고, 기존 except 가
+           ``getattr(e, "code", ...)`` 로 ``VALIDATION_ERROR`` envelope 으로
+           변환하게 한다(handler 본문의 기존 ``require_account_id`` 호출과
+           1:1 동형 매핑).
+
+        lifecycle gate 가 preflight 보다 항상 먼저 — DRAINING/STOPPED 또는
+        SHUTTING_DOWN+mutating 인 경우 preflight 에 도달하지 않는다(Codex v2
+        condition 3).
         """
         request_id = request.get("id", str(uuid.uuid4()))
         command = request.get("command", "")
@@ -306,7 +358,35 @@ class IPCServer:
                 "서버가 종료 중입니다. 변경 명령을 받지 않습니다.",
             )
 
+        # Refs #1850: required_services preflight — handler 호출 전에 검증.
+        # ServiceRegistry 는 dataclass 이며 optional service 는 default=None
+        # 이므로 ``getattr(..., None) is None`` 이면 부재로 판정한다.
+        missing = self._missing_required_service(spec.required_services)
+        if missing is not None:
+            return self._service_not_configured(request_id, missing)
+
         try:
+            # Refs #1850: account_id_policy preflight — try 블록 내부에서
+            # ``require_account_id`` 를 호출해 ``InvalidAccountIdError``
+            # (``code="VALIDATION_ERROR"``) 가 아래 except 에서
+            # ``VALIDATION_ERROR`` envelope 으로 자동 변환되도록 한다.
+            # ``required``: account_id 가 반드시 존재해야 하므로 ``args.get``
+            # 결과(부재 시 ``None``) 를 그대로 require_account_id 에 넘긴다.
+            # ``optional_filter``: filter 인자로 사용되며 부재면 skip, 존재
+            # 하면 검증한다. ``none``: skip. handler 본문의 기존
+            # ``require_account_id`` 호출은 본 PR scope 외 — valid 값에서는
+            # 멱등하므로 중복 호출이어도 안전(#1852 후속에서 제거 가능).
+            if spec.account_id_policy == "required":
+                from ante.account.scoping import require_account_id
+
+                require_account_id(args.get("account_id"), context=f"ipc.{command}")
+            elif spec.account_id_policy == "optional_filter":
+                account_id_arg = args.get("account_id")
+                if account_id_arg is not None:
+                    from ante.account.scoping import require_account_id
+
+                    require_account_id(account_id_arg, context=f"ipc.{command}")
+
             result = await spec.handler(self._service_registry, args, actor)
             return {
                 "id": request_id,
@@ -318,7 +398,8 @@ class IPCServer:
             # 예외 인스턴스/클래스에 ``code`` 속성이 있으면 안정 코드로
             # 노출한다 (#1144 invariant S5). 기존 예외(account.suspend/activate
             # 등)는 ``code`` 속성이 없어 자동으로 ``EXECUTION_ERROR``로
-            # 폴백된다 — 회귀 없음.
+            # 폴백된다 — 회귀 없음. Refs #1850: ``InvalidAccountIdError``
+            # (``code="VALIDATION_ERROR"``) 도 본 경로로 envelope 변환된다.
             error_code = getattr(e, "code", "EXECUTION_ERROR")
             return {
                 "id": request_id,

--- a/tests/unit/ipc/test_dispatch_wrapper_preflight.py
+++ b/tests/unit/ipc/test_dispatch_wrapper_preflight.py
@@ -1,0 +1,575 @@
+"""IPCServer ``_dispatch`` preflight wrapper 검증.
+
+Refs #1850 (#1819 부모 epic): dispatch wrapper 가 handler 호출 전에
+``CommandSpec.required_services`` 부재 / ``CommandSpec.account_id_policy``
+위반을 사전 차단하는지 확인한다.
+
+- ``required_services`` 부재 → ``SERVICE_NOT_CONFIGURED`` envelope (handler
+  미호출). ``ServiceRegistry`` 는 dataclass 이며 optional service 는 default
+  ``None`` 이라 ``getattr(svc, name, None) is None`` 로 판정한다.
+- ``account_id_policy == "required"`` 누락/invalid → ``InvalidAccountIdError``
+  (``code="VALIDATION_ERROR"``) raise → 기존 ``server.py`` except 가
+  ``VALIDATION_ERROR`` envelope 으로 변환.
+- ``account_id_policy == "optional_filter"`` → 값 있으면 검증, 없으면 skip.
+- lifecycle gate (``DRAINING`` / ``STOPPED`` / ``SHUTTING_DOWN`` + mutating)
+  는 preflight 보다 항상 먼저 — preflight 로 인한 envelope 이 lifecycle
+  거부를 덮어쓰지 않는다.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ante.core.registry import ServiceRegistry
+from ante.ipc.registry import CommandRegistry
+from ante.ipc.server import IPCServer
+
+
+def _make_service_registry(**overrides: Any) -> ServiceRegistry:
+    """기본 7 service 채운 ServiceRegistry. overrides 로 특정 필드 교체."""
+    defaults: dict[str, Any] = {
+        "account": MagicMock(),
+        "bot_manager": MagicMock(),
+        "treasury_manager": MagicMock(),
+        "dynamic_config": MagicMock(),
+        "approval": MagicMock(),
+        "reconciler": MagicMock(),
+        "eventbus": MagicMock(),
+    }
+    defaults.update(overrides)
+    return ServiceRegistry(**defaults)
+
+
+@pytest.fixture
+def socket_path() -> str:
+    """Unix 소켓 경로 길이 제한(104B) 회피 — /tmp 직접 사용."""
+    td = tempfile.mkdtemp(prefix="ipc-preflight", dir="/tmp")
+    return str(Path(td) / "t.sock")
+
+
+# ── required_services preflight ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_required_services_present_calls_handler(socket_path: str) -> None:
+    """required_services 모두 존재하면 handler 가 호출되고 정상 응답."""
+    cmd_registry = CommandRegistry()
+    called = False
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.needs_account",
+        handler,
+        is_mutating=False,
+        required_services=frozenset({"account"}),
+    )
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {"id": "1", "command": "test.needs_account", "args": {}, "actor": "t"}
+        )
+        assert response["status"] == "ok"
+        assert response["result"] == {"ok": True}
+        assert called is True
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_required_services_missing_returns_service_not_configured(
+    socket_path: str,
+) -> None:
+    """required_services 부재 시 SERVICE_NOT_CONFIGURED envelope, handler 미호출.
+
+    ``audit_logger`` 는 ServiceRegistry default=None 이므로 미주입 시 부재.
+    """
+    cmd_registry = CommandRegistry()
+    called = False
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.needs_audit",
+        handler,
+        is_mutating=True,
+        required_services=frozenset({"audit_logger"}),
+    )
+
+    # audit_logger 를 주입하지 않은 ServiceRegistry — default=None.
+    svc_registry = _make_service_registry()
+    assert svc_registry.audit_logger is None
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {"id": "1", "command": "test.needs_audit", "args": {}, "actor": "t"}
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "SERVICE_NOT_CONFIGURED"
+        assert "audit_logger" in response["error"]["message"]
+        assert called is False
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_required_services_missing_attribute_returns_service_not_configured(
+    socket_path: str,
+) -> None:
+    """ServiceRegistry 에 정의조차 없는 attribute 도 부재로 판정 — getattr default None.
+
+    실제로는 등록 시 검증되어야 할 spec 문제이지만, dispatch wrapper 가
+    defensive 하게 처리하는지 확인.
+    """
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.needs_nonexistent",
+        handler,
+        is_mutating=False,
+        required_services=frozenset({"nonexistent_service"}),
+    )
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.needs_nonexistent",
+                "args": {},
+                "actor": "t",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "SERVICE_NOT_CONFIGURED"
+        assert "nonexistent_service" in response["error"]["message"]
+    finally:
+        await server.stop()
+
+
+# ── account_id_policy="required" preflight ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_account_id_required_present_calls_handler(socket_path: str) -> None:
+    """account_id_policy=required + valid account_id 시 handler 호출 정상."""
+    cmd_registry = CommandRegistry()
+    received: dict[str, Any] = {}
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        received.update(args)
+        return {"account_id": args["account_id"]}
+
+    cmd_registry.register(
+        "test.account_required",
+        handler,
+        is_mutating=True,
+        account_id_policy="required",
+    )
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.account_required",
+                "args": {"account_id": "live-001"},
+                "actor": "t",
+            }
+        )
+        assert response["status"] == "ok"
+        assert response["result"]["account_id"] == "live-001"
+        assert received["account_id"] == "live-001"
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_account_id_required_missing_returns_validation_error(
+    socket_path: str,
+) -> None:
+    """account_id_policy=required + args 에 account_id 없으면 VALIDATION_ERROR.
+
+    ``require_account_id(None)`` 이 ``InvalidAccountIdError``
+    (``code="VALIDATION_ERROR"``) 를 raise 하고, 기존 except 의
+    ``getattr(e, "code", ...)`` 가 ``VALIDATION_ERROR`` envelope 으로 변환.
+    handler 는 호출되지 않는다.
+    """
+    cmd_registry = CommandRegistry()
+    called = False
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.account_required",
+        handler,
+        is_mutating=True,
+        account_id_policy="required",
+    )
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.account_required",
+                "args": {},
+                "actor": "t",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR"
+        assert called is False
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_account_id_required_invalid_returns_validation_error(
+    socket_path: str,
+) -> None:
+    """account_id_policy=required + invalid (예: "default") 도 VALIDATION_ERROR.
+
+    ``"default"`` 는 ``INVALID_RUNTIME_ACCOUNT_IDS`` fallback 예약어이므로
+    ``require_account_id`` 가 거부한다.
+    """
+    cmd_registry = CommandRegistry()
+    called = False
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.account_required",
+        handler,
+        is_mutating=True,
+        account_id_policy="required",
+    )
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.account_required",
+                "args": {"account_id": "default"},
+                "actor": "t",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR"
+        assert called is False
+    finally:
+        await server.stop()
+
+
+# ── account_id_policy="optional_filter" preflight ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_account_id_optional_filter_present_validates(socket_path: str) -> None:
+    """optional_filter + 값 존재 시 검증 통과하면 handler 호출."""
+    cmd_registry = CommandRegistry()
+    received: dict[str, Any] = {}
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        received.update(args)
+        return {"filtered": args.get("account_id")}
+
+    cmd_registry.register(
+        "test.account_filter",
+        handler,
+        is_mutating=False,
+        account_id_policy="optional_filter",
+    )
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.account_filter",
+                "args": {"account_id": "live-001"},
+                "actor": "t",
+            }
+        )
+        assert response["status"] == "ok"
+        assert response["result"] == {"filtered": "live-001"}
+        assert received["account_id"] == "live-001"
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_account_id_optional_filter_invalid_returns_validation_error(
+    socket_path: str,
+) -> None:
+    """optional_filter + 값이 invalid 면 VALIDATION_ERROR 로 거부."""
+    cmd_registry = CommandRegistry()
+    called = False
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.account_filter",
+        handler,
+        is_mutating=False,
+        account_id_policy="optional_filter",
+    )
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.account_filter",
+                "args": {"account_id": "default"},
+                "actor": "t",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR"
+        assert called is False
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_account_id_optional_filter_absent_skips(socket_path: str) -> None:
+    """optional_filter + account_id 부재 시 검증 skip — handler 정상 호출."""
+    cmd_registry = CommandRegistry()
+    called = False
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        nonlocal called
+        called = True
+        return {"filtered": args.get("account_id")}
+
+    cmd_registry.register(
+        "test.account_filter",
+        handler,
+        is_mutating=False,
+        account_id_policy="optional_filter",
+    )
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.account_filter",
+                "args": {},
+                "actor": "t",
+            }
+        )
+        assert response["status"] == "ok"
+        assert response["result"] == {"filtered": None}
+        assert called is True
+    finally:
+        await server.stop()
+
+
+# ── account_id_policy="none" (default) ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_account_id_none_skips_validation(socket_path: str) -> None:
+    """account_id_policy=none (default) 면 args 의 account_id 값과 무관하게 skip."""
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"acc": args.get("account_id")}
+
+    # default account_id_policy="none"
+    cmd_registry.register("test.no_policy", handler, is_mutating=False)
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        # invalid "default" 값을 보내도 wrapper 가 검증 skip
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.no_policy",
+                "args": {"account_id": "default"},
+                "actor": "t",
+            }
+        )
+        assert response["status"] == "ok"
+        assert response["result"] == {"acc": "default"}
+    finally:
+        await server.stop()
+
+
+# ── lifecycle gate ordering (preflight 보다 항상 먼저) ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_gate_before_preflight_draining(socket_path: str) -> None:
+    """DRAINING 상태 시 required_services preflight 에 도달 전 SERVICE_UNAVAILABLE.
+
+    lifecycle 거부가 우선이므로 부재한 service 가 있어도 SERVICE_NOT_CONFIGURED
+    envelope 이 노출되어서는 안 된다(envelope drift 방지).
+    """
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.needs_audit",
+        handler,
+        is_mutating=False,
+        required_services=frozenset({"audit_logger"}),
+    )
+
+    # audit_logger 부재 — 평소라면 SERVICE_NOT_CONFIGURED 발화.
+    svc_registry = _make_service_registry()
+    assert svc_registry.audit_logger is None
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    await server.stop_accepting()
+    server.stop_dispatching()  # DRAINING 전환
+
+    response = await server._dispatch(
+        {"id": "1", "command": "test.needs_audit", "args": {}, "actor": "t"}
+    )
+    # lifecycle gate 가 먼저 — SERVICE_UNAVAILABLE 이 노출되어야 함.
+    assert response["status"] == "error"
+    assert response["error"]["code"] == "SERVICE_UNAVAILABLE"
+    assert "리소스 종료 중" in response["error"]["message"]
+
+    await server.drain_connections(timeout=0.1)
+    if Path(socket_path).exists():
+        server.unlink_socket()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_mutating_blocked_before_preflight(socket_path: str) -> None:
+    """SHUTTING_DOWN + mutating 시 preflight 에 도달 전 SERVICE_UNAVAILABLE.
+
+    account_id_policy=required 라도 lifecycle gate 가 먼저 — VALIDATION_ERROR
+    envelope 이 노출되어서는 안 된다.
+    """
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.account_required_mut",
+        handler,
+        is_mutating=True,
+        account_id_policy="required",
+    )
+
+    svc_registry = _make_service_registry()
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        await server.stop_accepting()  # SHUTTING_DOWN 전환
+
+        # account_id 누락 — 평소라면 VALIDATION_ERROR 발화.
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.account_required_mut",
+                "args": {},
+                "actor": "t",
+            }
+        )
+        # lifecycle gate 가 먼저 — SERVICE_UNAVAILABLE 이 노출되어야 함.
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "SERVICE_UNAVAILABLE"
+        assert "종료 중" in response["error"]["message"]
+    finally:
+        await server.drain_connections(timeout=0.1)
+        if Path(socket_path).exists():
+            server.unlink_socket()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_readonly_passes_through_preflight(socket_path: str) -> None:
+    """SHUTTING_DOWN + read-only 면 preflight 까지 진행 — required_services 검증 동작.
+
+    SHUTTING_DOWN 단계에서 read-only 명령은 lifecycle gate 를 통과하므로
+    이어지는 required_services preflight 가 정상 동작해야 한다.
+    """
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.readonly_needs_audit",
+        handler,
+        is_mutating=False,
+        required_services=frozenset({"audit_logger"}),
+    )
+
+    svc_registry = _make_service_registry()  # audit_logger 미주입
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        await server.stop_accepting()  # SHUTTING_DOWN 전환
+
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.readonly_needs_audit",
+                "args": {},
+                "actor": "t",
+            }
+        )
+        # read-only 는 lifecycle gate 통과 → preflight 도달 → audit_logger 부재
+        # 로 SERVICE_NOT_CONFIGURED.
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "SERVICE_NOT_CONFIGURED"
+        assert "audit_logger" in response["error"]["message"]
+    finally:
+        await server.drain_connections(timeout=0.1)
+        if Path(socket_path).exists():
+            server.unlink_socket()

--- a/tests/unit/test_ipc_error_code_mapping.py
+++ b/tests/unit/test_ipc_error_code_mapping.py
@@ -20,7 +20,14 @@ from ante.ipc.server import IPCServer
 
 
 def _make_service_registry() -> ServiceRegistry:
-    """테스트용 ServiceRegistry — 모든 서비스 mock."""
+    """테스트용 ServiceRegistry — 모든 서비스 mock.
+
+    Refs #1850: dispatch wrapper 가 ``required_services`` preflight 를
+    수행하므로 ``register_all_handlers`` 가 선언한 의존 service 가
+    ``None`` 이면 ``SERVICE_NOT_CONFIGURED`` 로 차단된다. 본 fixture 는
+    production-like 한 service set 을 갖춰 handler 실행 경로까지 도달
+    가능하도록 ``strategy_registry`` / ``audit_logger`` 도 명시 주입한다.
+    """
     return ServiceRegistry(
         account=MagicMock(),
         bot_manager=MagicMock(),
@@ -29,6 +36,8 @@ def _make_service_registry() -> ServiceRegistry:
         approval=MagicMock(),
         reconciler=MagicMock(),
         eventbus=MagicMock(),
+        strategy_registry=MagicMock(),
+        audit_logger=MagicMock(),
     )
 
 

--- a/tests/unit/test_member_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_member_cli_ipc_error_equivalence.py
@@ -408,6 +408,10 @@ class TestMemberInvalidScopeEquivalence:
             reconciler=MagicMock(),
             eventbus=MagicMock(),
             member_service=member_service,
+            # Refs #1850: ``member.update_scopes`` 는 ``required_services``
+            # 에 ``audit_logger`` 를 선언한다 — dispatch wrapper preflight 가
+            # 부재 시 SERVICE_NOT_CONFIGURED 로 차단하므로 mock 주입한다.
+            audit_logger=MagicMock(),
         )
         cmd_registry = CommandRegistry()
         register_all_handlers(cmd_registry)


### PR DESCRIPTION
Closes #1850

## 개요

`#1849` 가 `CommandSpec` 에 채운 `required_services` / `account_id_policy` metadata 를 `IPCServer._dispatch` 가 handler 호출 전에 사전 검증한다.

## _dispatch flow

```
lifecycle gate (DRAINING/STOPPED → SERVICE_UNAVAILABLE)
  ↓
spec lookup (UNKNOWN_COMMAND)
  ↓
SHUTTING_DOWN + mutating → SERVICE_UNAVAILABLE
  ↓
required_services preflight (#1850 신규)
  → getattr(svc, name, None) is None ⇒ SERVICE_NOT_CONFIGURED
  ↓
try:
  account_id_policy preflight (#1850 신규)
    "required"        ⇒ require_account_id(args.get("account_id"))
    "optional_filter" ⇒ args["account_id"] 존재 시 require_account_id
    "none"            ⇒ skip
  InvalidAccountIdError → except 의 getattr(e,"code",...) 가
                          VALIDATION_ERROR envelope 으로 자동 변환
  ↓
  handler(svc, args, actor)
```

## Codex v2 verdict 흡수

- **condition 1** (services container 타입): `ServiceRegistry` 는 dataclass — `getattr(self._service_registry, name, None)` 으로 attribute 접근. dict 아님.
- **condition 2** (account_id_policy 위치): try 블록 내부에서 `require_account_id` 호출 → 기존 `except` 의 `getattr(e, "code", "EXECUTION_ERROR")` 패턴이 `InvalidAccountIdError.code="VALIDATION_ERROR"` 를 envelope 으로 변환. 별도 catch 절 도입 없음.
- **condition 3** (lifecycle gate ordering): `DRAINING`/`STOPPED` / `SHUTTING_DOWN`+mutating 거부가 항상 preflight 보다 먼저 — envelope drift 차단.

## Non-goals

- `audit_action` 자동 발화 → `#1851`
- handler 본문의 중복 `require_account_id` 호출 제거 → `#1852`
- `cross_validators` 활성화 / Pydantic args validation → 별도

## 변경 파일

- `src/ante/ipc/server.py` — `_dispatch()` 에 preflight 두 단계 추가, `_service_not_configured` / `_missing_required_service` helper 도입
- `tests/unit/ipc/test_dispatch_wrapper_preflight.py` — 신규 13 시나리오
- `tests/unit/test_ipc_error_code_mapping.py` — fixture 의 ServiceRegistry 에 `strategy_registry` / `audit_logger` 추가 (preflight 통과 유지)
- `tests/unit/test_member_cli_ipc_error_equivalence.py` — `test_ipc_envelope_invalid_scope_via_real_handler` 의 inline ServiceRegistry 에 `audit_logger` 추가
- `docs/architecture/generated/project-structure.md` — regen

## 검증

- `pytest tests/unit/ipc -q` → **69 passed** (기존 56 + 신규 13)
- `pytest tests/unit -q --tb=no` → **5211 passed / 217 failed** (전부 baseline #1849 시점에서 이미 failing — 본 PR 신규 회귀 0건, baseline diff empty)
- `mypy src/ante` → clean (223 source files)
- `ruff check .` / `ruff format --check .` → clean
- `python scripts/generate_project_structure.py` → regen 반영

## Test plan

- [ ] CI 회귀 게이트 통과 (lint + mypy + 신규 pytest)
- [ ] `bot.create` / `treasury.allocate` / `broker.*` 등 `account_id_policy="required"` 27 handlers 동작 검증
- [ ] `bot.start` 등 `audit_logger` 의존 handler 가 production-like ServiceRegistry 에서 정상 동작
- [ ] SHUTTING_DOWN + mutating 시 lifecycle envelope 우선 노출 (preflight envelope 으로 덮어쓰지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)