### PR TITLE
refactor: #1851 IPC dispatch wrapper audit_action auto-fire + _audit_detail reserved strip

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -401,7 +401,8 @@ tests/
 │   │   ├── test_registry.py
 │   │   ├── test_server_client.py
 │   │   ├── test_service_registry.py
-│   │   └── test_dispatch_wrapper_preflight.py
+│   │   ├── test_dispatch_wrapper_preflight.py
+│   │   └── test_dispatch_wrapper_audit.py
 │   ├── specs/
 │   │   ├── __init__.py
 │   │   ├── test_cold_path_terminology.py

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -282,8 +282,10 @@ async def _handle_bot_start(
     이 ``BOT_NOT_FOUND`` / ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` /
     ``BOT_STATE_CONFLICT`` 로 변환한다.
 
-    audit logger 가 주입된 환경에서는 ``approval.cancel_invalid`` 선례와 동형
-    으로 ``bot.start`` action 을 기록한다(``getattr`` safe-access).
+    Refs #1851: audit 호출은 ``_dispatch`` wrapper 가 ``CommandSpec.audit_action
+    = "bot.start"`` 기반으로 자동 발화한다. handler 는 ``_audit_detail``
+    reserved key 로 ``resource`` 만 전달하며, wrapper 가 ``pop`` 으로
+    public envelope 진입 전에 strip 한다.
     """
     from ante.bot.exceptions import (
         BotAccountCredentialsNotConfigured,
@@ -309,16 +311,14 @@ async def _handle_bot_start(
     except BotError as e:
         raise BotStateConflict(str(e)) from e
 
-    audit_logger = getattr(svc, "audit_logger", None)
-    if audit_logger is not None:
-        await audit_logger.log(
-            member_id=actor,
-            action="bot.start",
-            resource=f"bot:{bot_id}",
-            ip="",
-        )
-
-    return {"bot": bot.get_info()}
+    return {
+        "bot": bot.get_info(),
+        "_audit_detail": {
+            "resource": f"bot:{bot_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_bot_stop(
@@ -327,8 +327,11 @@ async def _handle_bot_stop(
     """봇 중지 IPC handler.
 
     Refs #1712: bot 부재 / BotError를 stable coded exception으로 매핑한다.
-    ``app_key`` preflight 는 stop 경로에 없다. audit logger 가 주입된 환경에서는
-    ``bot.stop`` action 을 기록한다.
+    ``app_key`` preflight 는 stop 경로에 없다.
+
+    Refs #1851: audit 호출은 ``_dispatch`` wrapper 가 ``CommandSpec.audit_action
+    = "bot.stop"`` 기반으로 자동 발화한다. handler 는 ``_audit_detail``
+    reserved key 로 ``resource`` 만 전달한다.
     """
     from ante.bot.exceptions import (
         BotError,
@@ -346,16 +349,14 @@ async def _handle_bot_stop(
     except BotError as e:
         raise BotStateConflict(str(e)) from e
 
-    audit_logger = getattr(svc, "audit_logger", None)
-    if audit_logger is not None:
-        await audit_logger.log(
-            member_id=actor,
-            action="bot.stop",
-            resource=f"bot:{bot_id}",
-            ip="",
-        )
-
-    return {"bot": bot.get_info()}
+    return {
+        "bot": bot.get_info(),
+        "_audit_detail": {
+            "resource": f"bot:{bot_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_bot_status(
@@ -403,6 +404,12 @@ async def _handle_bot_status(
 async def _handle_bot_update(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """봇 업데이트 IPC handler.
+
+    Refs #1851: audit 호출은 ``_dispatch`` wrapper 가 ``CommandSpec.audit_action
+    = "bot.update"`` 기반으로 자동 발화한다. handler 는 ``_audit_detail``
+    reserved key 로 ``resource`` 와 ``detail`` (변경 필드 목록) 을 전달한다.
+    """
     from ante.bot.exceptions import BotError
 
     bot_id = args["bot_id"]
@@ -417,16 +424,14 @@ async def _handle_bot_update(
     except BotError:
         raise
 
-    audit_logger = getattr(svc, "audit_logger", None)
-    if audit_logger is not None:
-        await audit_logger.log(
-            member_id=actor,
-            action="bot.update",
-            resource=f"bot:{bot_id}",
-            detail=f"fields={list(updates.keys())}",
-            ip="",
-        )
-    return {"bot": bot.get_info()}
+    return {
+        "bot": bot.get_info(),
+        "_audit_detail": {
+            "resource": f"bot:{bot_id}",
+            "detail": f"fields={list(updates.keys())}",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_treasury_allocate(
@@ -503,6 +508,13 @@ async def _handle_treasury_deallocate(
 async def _handle_treasury_set_balance(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """Treasury balance 설정 IPC handler.
+
+    Refs #1851: audit 호출은 ``_dispatch`` wrapper 가 ``CommandSpec.audit_action
+    = "treasury.set_balance"`` 기반으로 자동 발화한다. handler 는
+    ``_audit_detail`` reserved key 로 ``resource`` 와 ``detail`` (설정된
+    balance) 을 전달한다.
+    """
     from datetime import UTC, datetime
 
     from ante.account.scoping import require_account_id
@@ -514,19 +526,15 @@ async def _handle_treasury_set_balance(
     treasury = svc.treasury_manager.get(account_id)
     await treasury.set_account_balance(balance)
 
-    audit_logger = getattr(svc, "audit_logger", None)
-    if audit_logger is not None:
-        await audit_logger.log(
-            member_id=actor,
-            action="treasury.set_balance",
-            resource=f"treasury:{account_id}",
-            detail=f"balance={balance:,.0f}",
-            ip="",
-        )
     return {
         "account_id": account_id,
         "total_balance": treasury.account_balance,
         "updated_at": datetime.now(UTC).isoformat(),
+        "_audit_detail": {
+            "resource": f"treasury:{account_id}",
+            "detail": f"balance={balance:,.0f}",
+            "ip": "",
+        },
     }
 
 
@@ -552,27 +560,40 @@ async def _handle_rule_update(
 async def _handle_strategy_set_status(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """전략 상태 변경 IPC handler.
+
+    Refs #1851: audit 호출은 ``_dispatch`` wrapper 가 ``CommandSpec.audit_action
+    = "strategy.set_status"`` 기반으로 자동 발화한다. handler 는
+    ``_audit_detail`` reserved key 로 ``resource`` 와 ``detail`` (status) 을
+    전달한다.
+    """
     from ante.strategy.registry import StrategyStatus
 
     strategy_id = args["strategy_id"]
     status = StrategyStatus(args["status"])
     await svc.strategy_registry.update_status(strategy_id, status)
 
-    audit_logger = getattr(svc, "audit_logger", None)
-    if audit_logger is not None:
-        await audit_logger.log(
-            member_id=actor,
-            action="strategy.set_status",
-            resource=f"strategy:{strategy_id}",
-            detail=f"status={status.value}",
-            ip="",
-        )
-    return {"strategy_id": strategy_id, "status": status.value}
+    return {
+        "strategy_id": strategy_id,
+        "status": status.value,
+        "_audit_detail": {
+            "resource": f"strategy:{strategy_id}",
+            "detail": f"status={status.value}",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_member_update_scopes(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """멤버 scope 업데이트 IPC handler.
+
+    Refs #1851: audit 호출은 ``_dispatch`` wrapper 가 ``CommandSpec.audit_action
+    = "member.update_scopes"`` 기반으로 자동 발화한다. handler 는
+    ``_audit_detail`` reserved key 로 ``resource`` 와 ``detail`` (scopes 목록) 을
+    전달한다.
+    """
     member_id = args["member_id"]
     scopes = list(args.get("scopes") or [])
     member_service = getattr(svc, "member_service", None)
@@ -580,19 +601,15 @@ async def _handle_member_update_scopes(
         raise RuntimeError("member service not configured")
     member = await member_service.update_scopes(member_id, scopes, updated_by=actor)
 
-    audit_logger = getattr(svc, "audit_logger", None)
-    if audit_logger is not None:
-        await audit_logger.log(
-            member_id=actor,
-            action="member.update_scopes",
-            resource=f"member:{member_id}",
-            detail=f"scopes={scopes}",
-            ip="",
-        )
     return {
         "member_id": member.member_id,
         "scopes": member.scopes,
         "status": member.status,
+        "_audit_detail": {
+            "resource": f"member:{member_id}",
+            "detail": f"scopes={scopes}",
+            "ip": "",
+        },
     }
 
 
@@ -652,10 +669,14 @@ async def _handle_approval_cancel_invalid(
     """Administrative cancellation of a legacy invalid-type approval.
 
     Refs #1418 → #1472 SPLIT-D. CLI ``approval:admin`` scope 를 보유한 운영자가
-    ``ante approval cancel-invalid <id>`` 로 호출한다. 성공 후 ``audit_logger``
-    가 주입된 환경(production)에서는 ``audit_log`` 테이블에 기록을 남긴다.
-    테스트/legacy 환경에서 ``audit_logger`` 가 ``None`` 이면 audit 호출을 건너
-    뛰며, 서비스의 ``history`` append 가 fallback 추적 경로다.
+    ``ante approval cancel-invalid <id>`` 로 호출한다. 성공 후 ``audit_log``
+    테이블에 기록을 남기며, 서비스의 ``history`` append 가 fallback 추적
+    경로다.
+
+    Refs #1851: audit 호출은 ``_dispatch`` wrapper 가 ``CommandSpec.audit_action
+    = "approval.cancel_invalid"`` 기반으로 자동 발화한다. handler 는
+    ``_audit_detail`` reserved key 로 ``resource`` 와 ``detail`` (request.type)
+    을 전달한다.
     """
     approval_id = args["approval_id"]
     request = await svc.approval.cancel_invalid_type_request(
@@ -663,16 +684,16 @@ async def _handle_approval_cancel_invalid(
         resolved_by=actor,
     )
 
-    audit_logger = getattr(svc, "audit_logger", None)
-    if audit_logger is not None:
-        await audit_logger.log(
-            member_id=actor,
-            action="approval.cancel_invalid",
-            resource=f"approval:{approval_id}",
-            detail=request.type,
-        )
-
-    return {"id": request.id, "status": str(request.status), "type": request.type}
+    return {
+        "id": request.id,
+        "status": str(request.status),
+        "type": request.type,
+        "_audit_detail": {
+            "resource": f"approval:{approval_id}",
+            "detail": request.type,
+            "ip": "",
+        },
+    }
 
 
 async def _handle_approval_reopen(

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -324,6 +324,17 @@ class IPCServer:
         lifecycle gate 가 preflight 보다 항상 먼저 — DRAINING/STOPPED 또는
         SHUTTING_DOWN+mutating 인 경우 preflight 에 도달하지 않는다(Codex v2
         condition 3).
+
+        Refs #1851 (#1819 부모 epic): handler 가 정상 종료된 후
+        ``CommandSpec.audit_action`` 이 ``None`` 이 아니면 ``audit_logger`` 를
+        통해 자동으로 audit 로그를 1회 남긴다. handler 는 반환 dict 안의
+        ``_audit_detail`` reserved key 로 ``{resource, detail, ip}`` 를 wrapper
+        에 전달할 수 있으며, public envelope 으로 새 나가지 않도록 wrapper 가
+        ``pop`` 으로 strip 한 뒤 envelope ``result`` 에 담는다. handler 가
+        예외로 종료되면 audit 호출은 일어나지 않는다(실패 시 audit invariant).
+        ``audit_action`` 이 부여된 7 commands 는 ``required_services`` 에
+        ``audit_logger`` 가 명시되어 있어 preflight 단계에서 부재가 차단된다
+        (#1849 등록 시 동형 lock).
         """
         request_id = request.get("id", str(uuid.uuid4()))
         command = request.get("command", "")
@@ -388,6 +399,29 @@ class IPCServer:
                     require_account_id(account_id_arg, context=f"ipc.{command}")
 
             result = await spec.handler(self._service_registry, args, actor)
+            # Refs #1851: handler 정상 종료 후 audit_action 자동 발화.
+            # ``_audit_detail`` reserved key 는 ``pop`` 으로 envelope 노출
+            # 전에 strip 된다 (public payload 누출 invariant).
+            # ``audit_action`` 부여 7 commands 는 ``required_services`` 에
+            # ``audit_logger`` 가 포함되어 있어 preflight 단계에서 부재가
+            # 이미 차단됨 — 여기서는 ``getattr`` safe-access 로 한 번 더
+            # 방어한다 (handler 가 dict 가 아닌 다른 shape 을 반환하는
+            # 경우에도 strip 시도가 실패하지 않도록 isinstance 가드).
+            audit_detail: dict | None = None
+            if isinstance(result, dict):
+                audit_detail = result.pop("_audit_detail", None)
+            if spec.audit_action is not None:
+                audit_logger = getattr(self._service_registry, "audit_logger", None)
+                if audit_logger is not None:
+                    if audit_detail is None:
+                        audit_detail = {}
+                    await audit_logger.log(
+                        member_id=actor,
+                        action=spec.audit_action,
+                        resource=audit_detail.get("resource") or "",
+                        detail=audit_detail.get("detail") or "",
+                        ip=audit_detail.get("ip") or "",
+                    )
             return {
                 "id": request_id,
                 "status": "ok",

--- a/tests/unit/ipc/test_dispatch_wrapper_audit.py
+++ b/tests/unit/ipc/test_dispatch_wrapper_audit.py
@@ -1,0 +1,453 @@
+"""IPCServer ``_dispatch`` audit_action 자동 발화 wrapper 검증.
+
+Refs #1851 (#1819 부모 epic): dispatch wrapper 가 handler 정상 종료 후
+``CommandSpec.audit_action`` metadata 를 기반으로 ``audit_logger.log`` 를
+자동 발화하는지, 그리고 reserved key ``_audit_detail`` 이 public envelope
+``result`` 로 새 나가지 않는지 확인한다.
+
+invariant:
+- ``audit_action`` 부여 + handler 성공 → ``audit_logger.log`` 1회 호출.
+- handler 가 예외로 종료 → audit log 호출 없음.
+- ``audit_action=None`` (default) → audit log 호출 없음.
+- ``_audit_detail`` 은 public envelope ``result`` 에 절대 포함되지 않는다.
+- ``audit_logger.log`` 시그니처는 ``member_id, action, resource, detail, ip``
+  keyword-only 5 인자 (``AuditLogger.log``, ``src/ante/audit/logger.py:39``).
+- handler 가 ``_audit_detail`` 을 누락해도 wrapper 가 default ("") 로 호출.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.core.registry import ServiceRegistry
+from ante.ipc.registry import CommandRegistry
+from ante.ipc.server import IPCServer
+
+
+def _make_service_registry(
+    *, audit_logger: Any = None, **overrides: Any
+) -> ServiceRegistry:
+    """기본 7 service + optional audit_logger 채운 ServiceRegistry."""
+    defaults: dict[str, Any] = {
+        "account": MagicMock(),
+        "bot_manager": MagicMock(),
+        "treasury_manager": MagicMock(),
+        "dynamic_config": MagicMock(),
+        "approval": MagicMock(),
+        "reconciler": MagicMock(),
+        "eventbus": MagicMock(),
+    }
+    defaults.update(overrides)
+    if audit_logger is not None:
+        defaults["audit_logger"] = audit_logger
+    return ServiceRegistry(**defaults)
+
+
+def _make_audit_logger_mock() -> MagicMock:
+    """``AuditLogger.log`` 시그니처(async) 를 따르는 mock."""
+    logger = MagicMock()
+    logger.log = AsyncMock(return_value=None)
+    return logger
+
+
+@pytest.fixture
+def socket_path() -> str:
+    """Unix 소켓 경로 길이 제한(104B) 회피 — /tmp 직접 사용."""
+    td = tempfile.mkdtemp(prefix="ipc-audit", dir="/tmp")
+    return str(Path(td) / "t.sock")
+
+
+# ── audit_action 자동 발화 ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_action_fires_on_success(socket_path: str) -> None:
+    """audit_action 부여 + handler 성공 → audit_logger.log 1회 호출."""
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {
+            "ok": True,
+            "_audit_detail": {
+                "resource": "bot:my-bot",
+                "detail": "fields=['name']",
+                "ip": "127.0.0.1",
+            },
+        }
+
+    cmd_registry.register(
+        "test.audit_cmd",
+        handler,
+        is_mutating=True,
+        required_services=frozenset({"audit_logger"}),
+        audit_action="test.audit_cmd",
+    )
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(audit_logger=audit_logger)
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {"id": "1", "command": "test.audit_cmd", "args": {}, "actor": "alice"}
+        )
+        assert response["status"] == "ok"
+        # audit_logger.log 가 정확히 1회 호출됨.
+        assert audit_logger.log.await_count == 1
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_audit_action_does_not_fire_on_failure(socket_path: str) -> None:
+    """handler 가 예외로 종료 → audit_logger.log 호출 안 됨."""
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        raise RuntimeError("boom")
+
+    cmd_registry.register(
+        "test.audit_fail",
+        handler,
+        is_mutating=True,
+        required_services=frozenset({"audit_logger"}),
+        audit_action="test.audit_fail",
+    )
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(audit_logger=audit_logger)
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {"id": "1", "command": "test.audit_fail", "args": {}, "actor": "alice"}
+        )
+        assert response["status"] == "error"
+        # 실패한 handler 는 audit 안 남김.
+        assert audit_logger.log.await_count == 0
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_no_audit_action_does_not_fire(socket_path: str) -> None:
+    """audit_action=None (default) → audit_logger.log 호출 안 됨.
+
+    audit_logger 가 주입되어 있어도 spec.audit_action 이 None 이면 wrapper 가
+    호출하지 않는다.
+    """
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.no_audit",
+        handler,
+        is_mutating=False,
+        # audit_action=None (default)
+    )
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(audit_logger=audit_logger)
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {"id": "1", "command": "test.no_audit", "args": {}, "actor": "alice"}
+        )
+        assert response["status"] == "ok"
+        assert audit_logger.log.await_count == 0
+    finally:
+        await server.stop()
+
+
+# ── reserved key strip invariant ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_detail_stripped_from_public_envelope(socket_path: str) -> None:
+    """``_audit_detail`` 은 public envelope ``result`` 에 절대 포함되지 않는다."""
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {
+            "bot": {"id": "x"},
+            "_audit_detail": {
+                "resource": "bot:x",
+                "detail": "secret-internal-detail",
+                "ip": "10.0.0.1",
+            },
+        }
+
+    cmd_registry.register(
+        "test.audit_strip",
+        handler,
+        is_mutating=True,
+        required_services=frozenset({"audit_logger"}),
+        audit_action="test.audit_strip",
+    )
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(audit_logger=audit_logger)
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {"id": "1", "command": "test.audit_strip", "args": {}, "actor": "alice"}
+        )
+        assert response["status"] == "ok"
+        # public envelope 의 result 에는 _audit_detail 이 없다.
+        assert "_audit_detail" not in response["result"]
+        # 정상 result 키는 보존.
+        assert response["result"] == {"bot": {"id": "x"}}
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_audit_detail_stripped_even_without_audit_action(
+    socket_path: str,
+) -> None:
+    """audit_action=None 이어도 ``_audit_detail`` 은 envelope 에서 strip 된다.
+
+    handler 가 실수로 reserved key 를 반환하더라도 wrapper 가 보호한다.
+    """
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {
+            "ok": True,
+            "_audit_detail": {"resource": "x"},
+        }
+
+    cmd_registry.register(
+        "test.strip_only",
+        handler,
+        is_mutating=False,
+        # audit_action=None — audit 호출은 안 일어남.
+    )
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(audit_logger=audit_logger)
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {"id": "1", "command": "test.strip_only", "args": {}, "actor": "alice"}
+        )
+        assert response["status"] == "ok"
+        assert "_audit_detail" not in response["result"]
+        assert audit_logger.log.await_count == 0
+    finally:
+        await server.stop()
+
+
+# ── audit_logger.log 시그니처 정확성 ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_logger_signature_uses_member_id_action_resource_detail_ip(
+    socket_path: str,
+) -> None:
+    """wrapper 는 AuditLogger.log 의 실제 시그니처를 따른다.
+
+    ``AuditLogger.log`` (``src/ante/audit/logger.py:39``) 시그니처:
+    ``log(*, member_id, action, resource="", detail="", ip="")``.
+
+    wrapper 는 ``member_id=actor`` (request.actor) + ``action=spec.audit_action``
+    + ``resource/detail/ip`` (``_audit_detail`` 에서 추출) 로 호출한다.
+    """
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {
+            "ok": True,
+            "_audit_detail": {
+                "resource": "bot:42",
+                "detail": "fields=['name']",
+                "ip": "10.0.0.5",
+            },
+        }
+
+    cmd_registry.register(
+        "test.audit_sig",
+        handler,
+        is_mutating=True,
+        required_services=frozenset({"audit_logger"}),
+        audit_action="bot.update",
+    )
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(audit_logger=audit_logger)
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        await server._dispatch(
+            {"id": "1", "command": "test.audit_sig", "args": {}, "actor": "bob"}
+        )
+        # keyword-only 5 인자로 호출되었어야 한다.
+        audit_logger.log.assert_awaited_once_with(
+            member_id="bob",
+            action="bot.update",
+            resource="bot:42",
+            detail="fields=['name']",
+            ip="10.0.0.5",
+        )
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_handler_missing_audit_detail_uses_defaults(socket_path: str) -> None:
+    """handler 가 ``_audit_detail`` 키를 누락하면 wrapper 가 default "" 로 호출.
+
+    ``AuditLogger.log`` 의 ``resource``/``detail``/``ip`` 는 default ``""`` 이며,
+    wrapper 는 None 인 경우 ``""`` 로 정규화해 시그니처와 정합을 유지한다.
+    """
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        # _audit_detail 누락 — wrapper 가 default 로 처리해야 함.
+        return {"ok": True}
+
+    cmd_registry.register(
+        "test.audit_no_detail",
+        handler,
+        is_mutating=True,
+        required_services=frozenset({"audit_logger"}),
+        audit_action="test.audit_no_detail",
+    )
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(audit_logger=audit_logger)
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.audit_no_detail",
+                "args": {},
+                "actor": "carol",
+            }
+        )
+        assert response["status"] == "ok"
+        # default "" 로 호출되었어야 한다.
+        audit_logger.log.assert_awaited_once_with(
+            member_id="carol",
+            action="test.audit_no_detail",
+            resource="",
+            detail="",
+            ip="",
+        )
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_audit_detail_partial_fields_filled_with_defaults(
+    socket_path: str,
+) -> None:
+    """``_audit_detail`` 이 일부 필드만 채워도 누락 필드는 default "" 로 호출."""
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {
+            "ok": True,
+            # resource 만 채우고 detail / ip 누락.
+            "_audit_detail": {"resource": "treasury:acc-1"},
+        }
+
+    cmd_registry.register(
+        "test.audit_partial",
+        handler,
+        is_mutating=True,
+        required_services=frozenset({"audit_logger"}),
+        audit_action="treasury.set_balance",
+    )
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(audit_logger=audit_logger)
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.audit_partial",
+                "args": {},
+                "actor": "ops",
+            }
+        )
+        audit_logger.log.assert_awaited_once_with(
+            member_id="ops",
+            action="treasury.set_balance",
+            resource="treasury:acc-1",
+            detail="",
+            ip="",
+        )
+    finally:
+        await server.stop()
+
+
+# ── audit_action + audit_logger 부재 (lifecycle ordering 보조) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_action_without_audit_logger_no_crash(socket_path: str) -> None:
+    """방어 케이스 — audit_action 부여되었지만 audit_logger 가 None.
+
+    실제로는 ``required_services={"audit_logger"}`` 가 preflight 에서 차단하므로
+    이 경로는 ``required_services`` 미선언 또는 defensive defense-in-depth
+    영역이다. wrapper 가 ``getattr(svc, "audit_logger", None) is None`` 인 경우
+    호출을 skip 하고 정상 응답을 반환해야 한다 — crash 금지.
+    """
+    cmd_registry = CommandRegistry()
+
+    async def handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {
+            "ok": True,
+            "_audit_detail": {"resource": "x"},
+        }
+
+    # required_services 에 audit_logger 미포함 — preflight 차단 없음.
+    cmd_registry.register(
+        "test.audit_defensive",
+        handler,
+        is_mutating=True,
+        audit_action="test.audit_defensive",
+    )
+
+    svc_registry = _make_service_registry()  # audit_logger=None (default)
+    assert svc_registry.audit_logger is None
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "test.audit_defensive",
+                "args": {},
+                "actor": "x",
+            }
+        )
+        # crash 없이 정상 응답 + _audit_detail strip.
+        assert response["status"] == "ok"
+        assert "_audit_detail" not in response["result"]
+    finally:
+        await server.stop()

--- a/tests/unit/test_ipc_approval_cancel_invalid.py
+++ b/tests/unit/test_ipc_approval_cancel_invalid.py
@@ -1,17 +1,19 @@
-"""IPC 핸들러 ``_handle_approval_cancel_invalid`` 검증 (#1472).
+"""IPC 핸들러 ``_handle_approval_cancel_invalid`` 검증 (#1472, #1851).
 
 검증 대상:
 - 정상 처리 시 ``svc.approval.cancel_invalid_type_request`` 가 ``resolved_by=actor``
   로 호출된다.
-- ``svc.audit_logger`` 가 주입된 경우 ``audit_logger.log`` 가 정확한
-  ``(member_id=actor, action="approval.cancel_invalid",
-  resource=f"approval:{id}", detail=<request.type>)`` 인자로 호출된다.
-- ``svc.audit_logger=None`` 인 경우에도 핸들러는 예외 없이 성공한다 (audit
-  호출은 skip 된다).
+- handler 반환 envelope 에 ``_audit_detail`` reserved key 가 채워져 있다 —
+  ``resource=f"approval:{id}"``, ``detail=<request.type>``. 실제
+  ``audit_logger.log`` 호출은 ``_dispatch`` wrapper 가 ``CommandSpec.audit_action
+  = "approval.cancel_invalid"`` 기반으로 envelope 생성 전에 자동 발화한다
+  (#1851 wrapper 책임).
+- handler 본문은 더 이상 ``audit_logger.log`` 를 직접 호출하지 않는다.
 - ``approval.cancel_invalid`` 가 ``CommandRegistry`` 에 ``is_mutating=True`` 로
   등록되어 있다.
 - ``svc.approval.cancel_invalid_type_request`` 가 ``ValueError`` 를 raise 하면
-  핸들러도 그대로 raise 한다 (audit 호출은 일어나지 않는다).
+  핸들러도 그대로 raise 한다 (wrapper 가 audit 호출도 일어나지 않는다 —
+  ``test_audit_action_does_not_fire_on_failure``).
 """
 
 from __future__ import annotations
@@ -60,13 +62,17 @@ class TestHandleApprovalCancelInvalid:
     """IPC 핸들러 정상 경로."""
 
     async def test_calls_service_with_actor_as_resolved_by(self) -> None:
-        """approval_id 와 actor 가 서비스로 정확히 전달된다."""
+        """approval_id 와 actor 가 서비스로 정확히 전달되고 audit detail 포함.
+
+        Refs #1851: handler 본문은 audit 를 직접 호출하지 않는다. 대신
+        ``_audit_detail`` reserved key 로 wrapper 에 audit detail 만 넘긴다.
+        """
         request_obj = SimpleNamespace(
             id="inv-1",
             status="cancelled",
             type="oracle_invalid_type",
         )
-        svc, cancel_mock, _audit_log = _make_svc(cancel_return=request_obj)
+        svc, cancel_mock, audit_log = _make_svc(cancel_return=request_obj)
 
         result = await _handle_approval_cancel_invalid(
             svc, {"approval_id": "inv-1"}, "admin-master"
@@ -77,10 +83,24 @@ class TestHandleApprovalCancelInvalid:
             "id": "inv-1",
             "status": "cancelled",
             "type": "oracle_invalid_type",
+            "_audit_detail": {
+                "resource": "approval:inv-1",
+                "detail": "oracle_invalid_type",
+                "ip": "",
+            },
         }
+        # handler 본문은 audit 직접 호출을 더 이상 수행하지 않는다(#1851).
+        assert audit_log is not None
+        audit_log.assert_not_awaited()
 
-    async def test_audit_logger_called_with_correct_args(self) -> None:
-        """AuditLogger.log 가 member_id=actor, action, resource, detail 인자로 호출."""
+    async def test_audit_detail_carries_resource_and_request_type(self) -> None:
+        """``_audit_detail`` reserved key 에 resource + detail (request.type) 채움.
+
+        Refs #1851: wrapper 가 이 reserved key 를 envelope 생성 전에 strip 하고
+        ``audit_logger.log(member_id=actor, action="approval.cancel_invalid",
+        resource=..., detail=..., ip="")`` 로 발화한다. handler 단계에서는
+        reserved key 만 검증한다.
+        """
         request_obj = SimpleNamespace(
             id="inv-2",
             status="cancelled",
@@ -89,16 +109,17 @@ class TestHandleApprovalCancelInvalid:
         svc, _cancel_mock, audit_log = _make_svc(cancel_return=request_obj)
         assert audit_log is not None
 
-        await _handle_approval_cancel_invalid(
+        result = await _handle_approval_cancel_invalid(
             svc, {"approval_id": "inv-2"}, "admin-master"
         )
 
-        audit_log.assert_awaited_once_with(
-            member_id="admin-master",
-            action="approval.cancel_invalid",
-            resource="approval:inv-2",
-            detail="legacy_type_x",
-        )
+        assert result["_audit_detail"] == {
+            "resource": "approval:inv-2",
+            "detail": "legacy_type_x",
+            "ip": "",
+        }
+        # handler 본문은 audit 호출 안 함 — wrapper 책임으로 이관.
+        audit_log.assert_not_awaited()
 
     async def test_handler_succeeds_when_audit_logger_is_none(self) -> None:
         """audit_logger=None 환경에서도 핸들러는 정상 성공."""

--- a/tests/unit/test_ipc_bot_lifecycle.py
+++ b/tests/unit/test_ipc_bot_lifecycle.py
@@ -7,10 +7,12 @@
   - ``BotAccountCredentialsNotConfigured``
     (code=BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED).
   - ``BotStateConflict`` (code=BOT_STATE_CONFLICT).
-- audit logger optional 처리:
-  - ``bot.start`` / ``bot.stop`` 성공 시 audit ``bot.start`` / ``bot.stop`` 기록.
-  - ``bot.status`` 는 read-only — audit 없음.
-  - ``audit_logger=None`` / 속성 부재 환경에서도 핸들러 정상 성공.
+- audit detail handover (#1851):
+  - ``bot.start`` / ``bot.stop`` 성공 시 handler 반환 dict 안의 reserved key
+    ``_audit_detail`` 에 ``resource=f"bot:{bot_id}"`` 가 채워져 있다 — 실제
+    audit 호출은 ``_dispatch`` wrapper 가 ``CommandSpec.audit_action`` 기반으로
+    수행한다.
+  - ``bot.status`` 는 read-only — ``_audit_detail`` 자체가 없다.
 - ``trade_service`` optional:
   - 주입 시 positions 보강.
   - 부재 시 ``positions`` 키 부재(회귀 lock, #1712 cold-path 호환).
@@ -111,22 +113,32 @@ class TestHandleBotStart:
     """``_handle_bot_start`` 정상 + 거부 경로."""
 
     async def test_success_returns_bot_envelope(self) -> None:
-        """성공 시 ``{"bot": info}`` envelope + audit ``bot.start`` 기록."""
+        """성공 시 ``{"bot": info, "_audit_detail": {...}}`` envelope.
+
+        Refs #1851: handler 본문은 더 이상 ``audit_logger.log`` 를 직접
+        호출하지 않는다 — ``_audit_detail`` reserved key 로 wrapper 에 audit
+        detail 만 넘긴다. 실제 audit 발화 + reserved key strip 은 ``_dispatch``
+        wrapper 가 envelope 생성 전에 수행한다(통합 검증은
+        ``test_dispatch_wrapper_audit.py``).
+        """
         bot = _make_bot(bot_id="bot-1", account_id="acc-1")
         account = SimpleNamespace(credentials={"app_key": "AK-XYZ"})
         svc, audit_log = _make_svc(bot=bot, account=account)
 
         result = await _handle_bot_start(svc, {"bot_id": "bot-1"}, "admin-master")
 
-        assert result == {"bot": {"bot_id": "bot-1", "status": "stopped"}}
+        assert result == {
+            "bot": {"bot_id": "bot-1", "status": "stopped"},
+            "_audit_detail": {
+                "resource": "bot:bot-1",
+                "detail": "",
+                "ip": "",
+            },
+        }
         svc.bot_manager.start_bot.assert_awaited_once_with("bot-1")
+        # handler 본문은 audit 호출을 더 이상 직접 수행하지 않는다(#1851).
         assert audit_log is not None
-        audit_log.assert_awaited_once_with(
-            member_id="admin-master",
-            action="bot.start",
-            resource="bot:bot-1",
-            ip="",
-        )
+        audit_log.assert_not_awaited()
 
     async def test_missing_bot_raises_bot_not_found(self) -> None:
         """봇 부재 → ``BotNotFoundError`` (code=BOT_NOT_FOUND)."""
@@ -173,14 +185,27 @@ class TestHandleBotStart:
         audit_log.assert_not_awaited()
 
     async def test_succeeds_when_audit_logger_is_none(self) -> None:
-        """``audit_logger=None`` 환경에서도 핸들러는 정상 성공."""
+        """``audit_logger=None`` 환경에서도 핸들러는 정상 성공.
+
+        Refs #1851: handler 가 audit 를 직접 호출하지 않으므로 ``audit_logger``
+        부재가 handler 정상 경로에 영향을 주지 않는다. ``_audit_detail`` 만
+        envelope 에 담겨 반환되며, wrapper 가 ``audit_logger`` 부재를 감지하면
+        skip 한다(``test_audit_action_without_audit_logger_no_crash``).
+        """
         bot = _make_bot()
         account = SimpleNamespace(credentials={"app_key": "AK"})
         svc, _ = _make_svc(bot=bot, account=account, with_audit_logger=False)
 
         result = await _handle_bot_start(svc, {"bot_id": "bot-1"}, "admin-master")
 
-        assert result == {"bot": {"bot_id": "bot-1", "status": "stopped"}}
+        assert result == {
+            "bot": {"bot_id": "bot-1", "status": "stopped"},
+            "_audit_detail": {
+                "resource": "bot:bot-1",
+                "detail": "",
+                "ip": "",
+            },
+        }
         svc.bot_manager.start_bot.assert_awaited_once_with("bot-1")
 
 
@@ -191,23 +216,30 @@ class TestHandleBotStop:
     """``_handle_bot_stop`` 정상 + 거부 경로."""
 
     async def test_success_returns_bot_envelope(self) -> None:
-        """성공 시 ``{"bot": info}`` envelope + audit ``bot.stop`` 기록."""
+        """성공 시 ``{"bot": info, "_audit_detail": {...}}`` envelope.
+
+        Refs #1851: ``bot.start`` 와 동형 — handler 는 ``_audit_detail`` 만
+        반환하고, 실제 audit 발화는 ``_dispatch`` wrapper 가 수행한다.
+        """
         bot = _make_bot(bot_id="bot-1")
         svc, audit_log = _make_svc(bot=bot)
 
         result = await _handle_bot_stop(svc, {"bot_id": "bot-1"}, "admin-master")
 
-        assert result == {"bot": {"bot_id": "bot-1", "status": "stopped"}}
+        assert result == {
+            "bot": {"bot_id": "bot-1", "status": "stopped"},
+            "_audit_detail": {
+                "resource": "bot:bot-1",
+                "detail": "",
+                "ip": "",
+            },
+        }
         svc.bot_manager.stop_bot.assert_awaited_once_with("bot-1")
         # ``bot.stop`` 은 app_key preflight 가 없다 — account_service.get 미호출.
         svc.account.get.assert_not_awaited()
+        # handler 본문에서 audit 직접 호출 제거(#1851).
         assert audit_log is not None
-        audit_log.assert_awaited_once_with(
-            member_id="admin-master",
-            action="bot.stop",
-            resource="bot:bot-1",
-            ip="",
-        )
+        audit_log.assert_not_awaited()
 
     async def test_missing_bot_raises_bot_not_found(self) -> None:
         """봇 부재 → ``BotNotFoundError`` (code=BOT_NOT_FOUND)."""
@@ -236,13 +268,20 @@ class TestHandleBotStop:
         audit_log.assert_not_awaited()
 
     async def test_succeeds_when_audit_logger_is_none(self) -> None:
-        """``audit_logger=None`` 환경에서도 핸들러는 정상 성공."""
+        """``audit_logger=None`` 환경에서도 핸들러는 정상 성공 (#1851)."""
         bot = _make_bot()
         svc, _ = _make_svc(bot=bot, with_audit_logger=False)
 
         result = await _handle_bot_stop(svc, {"bot_id": "bot-1"}, "admin-master")
 
-        assert result == {"bot": {"bot_id": "bot-1", "status": "stopped"}}
+        assert result == {
+            "bot": {"bot_id": "bot-1", "status": "stopped"},
+            "_audit_detail": {
+                "resource": "bot:bot-1",
+                "detail": "",
+                "ip": "",
+            },
+        }
         svc.bot_manager.stop_bot.assert_awaited_once_with("bot-1")
 
 


### PR DESCRIPTION
Closes #1851
Refs #1819 (epic), #1849 (CommandSpec metadata), #1850 (preflight wrapper)

## Summary

- ``IPCServer._dispatch`` 가 handler 정상 종료 후 ``CommandSpec.audit_action`` 메타데이터(#1849) 를 기반으로 ``audit_logger.log`` 를 1회 자동 발화하도록 흡수.
- handler 가 audit detail 을 전달할 reserved key ``_audit_detail`` (``{resource, detail, ip}``) 도입. wrapper 가 envelope 생성 **전**에 ``pop`` 으로 strip — public payload 노출 금지 invariant lock.
- 7 handlers (``bot.start`` / ``bot.stop`` / ``bot.update`` / ``treasury.set_balance`` / ``strategy.set_status`` / ``member.update_scopes`` / ``approval.cancel_invalid``) 의 본문 ``audit_logger.log(...)`` 호출 제거. 기존 호출 인자(resource/detail/ip) 는 그대로 ``_audit_detail`` reserved key 로 1:1 옮김 — 중복 발화 위험 없음.

## Behavior Invariants

- ``audit_action`` 부여 + handler 성공 → audit log 1회.
- handler 예외 종료 → audit log 호출 없음 (실패 시 audit 안 남김).
- ``audit_action=None`` (default) → audit log 호출 없음.
- ``_audit_detail`` envelope 노출 절대 금지 — ``audit_action`` 유무 무관.
- ``AuditLogger.log`` 실제 시그니처(``member_id, action, resource, detail, ip`` keyword-only) 정확히 보존.

## Scope 분리 — rule.update

``rule.update`` (registry.py:540) 는 #1849 에서 ``audit_action`` 부여 안 됨. handler 본문의 직접 audit 호출 경로(``update_account_rule_config`` helper) 그대로 유지. **본 PR scope 외** — 후속 sub-PR 이 ``audit_action`` 부여 + handler audit 호출 제거 + ``_audit_detail`` 이관 책임.

## Codex Plan Review v2 (approve-implement) 흡수

1. ``AuditLogger.log`` 실제 시그니처 정정 (member_id/action/resource/detail/ip — NOT actor/details).
2. ``_audit_detail`` schema 명시 — ``{resource: str|None, detail: str|None, ip: str|None}``.
3. envelope strip 경로 명시 — handler 성공 후 ``result.pop(...)`` → envelope ``result`` 생성 전.
4. ``rule.update`` scope 분리 — 본 PR 미포함.

## Test plan

- [x] ``pytest tests/unit/ipc/test_dispatch_wrapper_audit.py -v`` 신규 9 케이스 PASS
- [x] ``pytest tests/unit/test_ipc_bot_lifecycle.py tests/unit/test_ipc_approval_cancel_invalid.py -v`` 27 PASS (handler 직접 호출 unit test 업데이트)
- [x] ``pytest tests/unit/ipc tests/unit/test_audit* tests/unit/test_*cli_ipc_error_equivalence.py tests/unit/test_*success_output_drift.py tests/unit/test_cli_bot_lifecycle.py tests/unit/test_cli_approval_invalid_type_cleanup.py tests/unit/test_treasury.py tests/unit/test_approval.py tests/unit/test_approval_executors.py tests/unit/test_member_scope_drift.py`` 475 PASS — PR 영향 영역 회귀 0
- [x] ``mypy src/`` 223 source files clean
- [x] ``ruff check`` / ``ruff format --check`` 변경 5 파일 통과
- [x] ``scripts/generate_project_structure.py`` regen — test_dispatch_wrapper_audit.py 추가 반영
- [x] main HEAD ``860125db`` 불변 확인

## 변경 요약

| Layer | 파일 | 변경 |
|---|---|---|
| dispatch wrapper | ``src/ante/ipc/server.py`` | ``_dispatch`` 성공 경로에 audit auto-fire + ``_audit_detail`` strip 도입 |
| handlers | ``src/ante/ipc/registry.py`` | 7 handlers 의 직접 ``audit_logger.log`` 호출 제거, ``_audit_detail`` reserved key 로 detail 이관 |
| tests (new) | ``tests/unit/ipc/test_dispatch_wrapper_audit.py`` | 9 케이스 (fire/no-fire/strip/signature/defaults/defensive) |
| tests (updated) | ``tests/unit/test_ipc_bot_lifecycle.py`` | bot.start/bot.stop handler envelope shape 정렬 |
| tests (updated) | ``tests/unit/test_ipc_approval_cancel_invalid.py`` | approval.cancel_invalid handler envelope shape 정렬 |
| docs (generated) | ``docs/architecture/generated/project-structure.md`` | 신규 test 파일 entry 반영 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)