### PR TITLE
refactor: #1852 account IPC handler wrapper migration (suspend/activate audit + account_id_policy)

### DIFF
--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -205,18 +205,52 @@ async def _handle_system_clear_halt(
 async def _handle_account_suspend(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """계좌 정지 IPC handler.
+
+    Refs #1852 (#1819 부모 epic): account_id 검증은 ``_dispatch`` wrapper 가
+    ``CommandSpec.account_id_policy="required"`` 기반으로 사전 수행하며,
+    audit 호출은 wrapper 가 ``CommandSpec.audit_action="account.suspend"``
+    기반으로 자동 발화한다. handler 는 ``_audit_detail`` reserved key 로
+    ``resource`` / ``detail`` 만 전달하고, wrapper 가 ``pop`` 으로 public
+    envelope 진입 전에 strip 한다.
+    """
     account_id = args["account_id"]
     reason = args.get("reason", "IPC suspend")
     await svc.account.suspend(account_id, reason=reason, suspended_by=actor)
-    return {"account_id": account_id, "status": "suspended"}
+    return {
+        "account_id": account_id,
+        "status": "suspended",
+        "_audit_detail": {
+            "resource": f"account:{account_id}",
+            "detail": f"reason={reason}",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_account_activate(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """계좌 활성화 IPC handler.
+
+    Refs #1852 (#1819 부모 epic): account_id 검증은 ``_dispatch`` wrapper 가
+    ``CommandSpec.account_id_policy="required"`` 기반으로 사전 수행하며,
+    audit 호출은 wrapper 가 ``CommandSpec.audit_action="account.activate"``
+    기반으로 자동 발화한다. handler 는 ``_audit_detail`` reserved key 로
+    ``resource`` 만 전달하고, wrapper 가 ``pop`` 으로 public envelope 진입
+    전에 strip 한다.
+    """
     account_id = args["account_id"]
     await svc.account.activate(account_id, activated_by=actor)
-    return {"account_id": account_id, "status": "active"}
+    return {
+        "account_id": account_id,
+        "status": "active",
+        "_audit_detail": {
+            "resource": f"account:{account_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_bot_create(
@@ -830,22 +864,28 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         result_kind="operation",
         required_services=frozenset({"account"}),
     )
-    # account.* — account_id 인자는 require_account_id 미사용(args["account_id"]
-    # 직접 인덱싱)이라 policy는 ``none``으로 분류한다. 실제 검증 강제는 #1850
-    # 후속에서 정책 정렬 시 재평가한다.
+    # account.* — Refs #1852 (#1819 epic): account_id_policy="required" 로
+    # wrapper preflight 가 invalid/missing account_id 를 InvalidAccountIdError
+    # (VALIDATION_ERROR envelope) 로 거부한다. audit_action 부여 + handler 의
+    # ``_audit_detail`` 반환으로 wrapper 가 audit_logger.log 를 자동 발화한다.
+    # required_services 에 audit_logger 가 포함되어 부재 시 preflight 가 차단.
     registry.register(
         "account.suspend",
         _handle_account_suspend,
         is_mutating=True,
         result_kind="operation",
-        required_services=frozenset({"account"}),
+        required_services=frozenset({"account", "audit_logger"}),
+        account_id_policy="required",
+        audit_action="account.suspend",
     )
     registry.register(
         "account.activate",
         _handle_account_activate,
         is_mutating=True,
         result_kind="operation",
-        required_services=frozenset({"account"}),
+        required_services=frozenset({"account", "audit_logger"}),
+        account_id_policy="required",
+        audit_action="account.activate",
     )
     # bot.* — bot 객체 entity 반환, audit_action은 start/stop/update만.
     registry.register(

--- a/tests/unit/ipc/test_dispatch_wrapper_audit.py
+++ b/tests/unit/ipc/test_dispatch_wrapper_audit.py
@@ -407,6 +407,220 @@ async def test_audit_detail_partial_fields_filled_with_defaults(
 # ── audit_action + audit_logger 부재 (lifecycle ordering 보조) ─────────────
 
 
+# ── account.suspend / account.activate wrapper migration (#1852) ──────────
+
+
+@pytest.mark.asyncio
+async def test_account_suspend_audit_action_fires(socket_path: str) -> None:
+    """Refs #1852: ``account.suspend`` 가 wrapper 자동 audit 발화한다.
+
+    register_all_handlers 가 ``audit_action="account.suspend"`` 를 부여하므로
+    handler 정상 종료 후 wrapper 가 ``audit_logger.log`` 를 1회 호출하고
+    ``_audit_detail`` 의 ``resource``/``detail`` 을 전달한다.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_account = MagicMock()
+    fake_account.suspend = AsyncMock(return_value=None)
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, account=fake_account
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "account.suspend",
+                "args": {"account_id": "acc-1", "reason": "ops halt"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "ok"
+        audit_logger.log.assert_awaited_once_with(
+            member_id="alice",
+            action="account.suspend",
+            resource="account:acc-1",
+            detail="reason=ops halt",
+            ip="",
+        )
+        fake_account.suspend.assert_awaited_once_with(
+            "acc-1", reason="ops halt", suspended_by="alice"
+        )
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_account_activate_audit_action_fires(socket_path: str) -> None:
+    """Refs #1852: ``account.activate`` 가 wrapper 자동 audit 발화한다."""
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_account = MagicMock()
+    fake_account.activate = AsyncMock(return_value=None)
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, account=fake_account
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "account.activate",
+                "args": {"account_id": "acc-1"},
+                "actor": "bob",
+            }
+        )
+        assert response["status"] == "ok"
+        audit_logger.log.assert_awaited_once_with(
+            member_id="bob",
+            action="account.activate",
+            resource="account:acc-1",
+            detail="",
+            ip="",
+        )
+        fake_account.activate.assert_awaited_once_with("acc-1", activated_by="bob")
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_account_suspend_audit_detail_stripped_from_envelope(
+    socket_path: str,
+) -> None:
+    """Refs #1852: ``account.suspend`` public envelope 에 ``_audit_detail``
+    이 절대 노출되지 않는다 (reserved key strip invariant)."""
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_account = MagicMock()
+    fake_account.suspend = AsyncMock(return_value=None)
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, account=fake_account
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "account.suspend",
+                "args": {"account_id": "acc-1", "reason": "ops"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "ok"
+        assert "_audit_detail" not in response["result"]
+        assert response["result"] == {
+            "account_id": "acc-1",
+            "status": "suspended",
+        }
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_account_suspend_account_id_policy_required_preflight(
+    socket_path: str,
+) -> None:
+    """Refs #1852: ``account.suspend`` 는 ``account_id_policy="required"`` 로
+    invalid/missing ``account_id`` 를 ``VALIDATION_ERROR`` envelope 으로
+    handler 호출 전에 거부한다.
+
+    ``require_account_id`` 가 wrapper preflight 단계에서 raise 되면 dispatch
+    의 generic except 가 ``getattr(e, "code", ...)`` 로 ``VALIDATION_ERROR``
+    envelope 을 만들어 반환한다(#1850 동형). ``account.suspend`` 실제 서비스
+    호출은 절대 일어나지 않는다.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_account = MagicMock()
+    fake_account.suspend = AsyncMock(return_value=None)
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, account=fake_account
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        # missing account_id
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "account.suspend",
+                "args": {"reason": "x"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR"
+
+        # empty string
+        response = await server._dispatch(
+            {
+                "id": "2",
+                "command": "account.suspend",
+                "args": {"account_id": ""},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR"
+
+        # reserved 'default'
+        response = await server._dispatch(
+            {
+                "id": "3",
+                "command": "account.suspend",
+                "args": {"account_id": "default"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR"
+
+        # pattern violation
+        response = await server._dispatch(
+            {
+                "id": "4",
+                "command": "account.suspend",
+                "args": {"account_id": "bad_id!"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "VALIDATION_ERROR"
+
+        # service 호출 / audit 발화는 0회 (preflight 차단)
+        fake_account.suspend.assert_not_awaited()
+        assert audit_logger.log.await_count == 0
+    finally:
+        await server.stop()
+
+
 @pytest.mark.asyncio
 async def test_audit_action_without_audit_logger_no_crash(socket_path: str) -> None:
     """방어 케이스 — audit_action 부여되었지만 audit_logger 가 None.

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -826,10 +826,15 @@ class TestRegisteredCommandsMetadataCompleteness:
         """``audit_action`` 값들이 실제 handler ``audit_logger.log(action=...)``
         호출과 정합한다(#1849 plan B step).
 
-        본 단언은 registry 내 audit_logger 호출 grep 결과(7개)와 1:1로 lock 한다.
+        본 단언은 registry 내 audit_logger 호출 grep 결과와 1:1로 lock 한다.
         호출 추가/삭제 시 양쪽을 동기화하지 않으면 본 테스트가 회귀를 잡는다.
+
+        Refs #1852 (#1819 epic): account.suspend / account.activate 가 wrapper
+        migration 으로 audit_action 부여(7→9 commands).
         """
         expected_actions = {
+            "account.suspend",
+            "account.activate",
             "bot.start",
             "bot.stop",
             "bot.update",

--- a/tests/unit/test_account_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_account_cli_ipc_error_equivalence.py
@@ -354,6 +354,11 @@ class TestAccountAlreadySuspendedEquivalence:
         account_svc.suspend = AsyncMock(
             side_effect=AccountAlreadySuspendedError("이미 정지됨")
         )
+        # Refs #1852: account.suspend handler 가 required_services 에
+        # ``audit_logger`` 를 보유하므로 wrapper preflight (SERVICE_NOT_CONFIGURED)
+        # 를 피하려면 ServiceRegistry 에 ``audit_logger`` 를 주입해야 한다.
+        audit_logger = MagicMock()
+        audit_logger.log = AsyncMock(return_value=None)
         svc_registry = ServiceRegistry(
             account=account_svc,
             bot_manager=MagicMock(),
@@ -362,6 +367,7 @@ class TestAccountAlreadySuspendedEquivalence:
             approval=MagicMock(),
             reconciler=MagicMock(),
             eventbus=MagicMock(),
+            audit_logger=audit_logger,
         )
         cmd_registry = CommandRegistry()
         register_all_handlers(cmd_registry)


### PR DESCRIPTION
Closes #1852

## Summary

`account.suspend` / `account.activate` IPC handler 본문이 wrapper 자동 처리 경로 (`account_id_policy` preflight + `audit_action` auto-fire) 를 따르도록 metadata 와 `_audit_detail` 반환을 정렬한다. business behavior 와 envelope shape 는 보존한다.

- `register_all_handlers`: `account.suspend` / `account.activate` 등록에 `account_id_policy="required"`, `audit_action`, `required_services={"account","audit_logger"}` 부여. invalid/missing `account_id` 는 wrapper preflight 에서 `InvalidAccountIdError` → `VALIDATION_ERROR` envelope 으로 거부된다.
- `_handle_account_suspend` / `_handle_account_activate`: return dict 에 `_audit_detail` (resource/detail/ip) 추가. wrapper 가 `audit_logger.log` 1회 발화 후 envelope 진입 전 `pop` 으로 strip.
- `test_audit_actions_match_known_set`: known audit_action 집합 7 → 9 commands.
- `test_dispatch_wrapper_audit`: account.suspend/activate audit 발화 / `_audit_detail` strip / `account_id_policy` preflight 회귀 lock 4 건 신규.
- `test_account_cli_ipc_error_equivalence`: 실제 handler 로 검증하는 `ACCOUNT_ALREADY_SUSPENDED` fixture 에 `audit_logger` 주입 (`required_services` 추가로 인한 `SERVICE_NOT_CONFIGURED` preflight 우회).

## Codex Plan Review (v2) 반영

| BLOCKER | 반영 |
|---|---|
| 1. `account.suspend/activate` metadata (audit_action, account_id_policy, audit_logger) 누락 | `register_all_handlers` 항목 갱신 |
| 2. handler 본문은 "제거"가 아니라 "metadata 추가 + `_audit_detail` 반환" | handler 2건 본문 정렬 |
| 3. `test_audit_actions_match_known_set` 7 → 9 + account-specific wrapper tests 4건 | tests 갱신 + 신규 |

## Metadata 변경 표

| Command | account_id_policy | audit_action | required_services |
|---|---|---|---|
| account.suspend | `none` → `required` | (none) → `account.suspend` | `{account}` → `{account, audit_logger}` |
| account.activate | `none` → `required` | (none) → `account.activate` | `{account}` → `{account, audit_logger}` |

## Test plan

- [x] `pytest tests/unit/ipc -v` — 82 passed (신규 4건 포함)
- [x] `pytest tests/unit/test_account_cli_ipc_error_equivalence.py tests/unit/test_cli_ipc_commands.py tests/unit/test_cli_account_id_construction_lifecycle.py tests/unit/test_cli_group_q_state_conflict_sweep.py` — 85 passed
- [x] `pytest` (IPC + account 회귀 grab) — 240 passed
- [x] `mypy src/` — Success: 223 files
- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check` — formatted
- [x] `project-structure.md` regen — diff 없음 (변경 없음)
- [x] main HEAD 불변 확인: `a54c3972a43ce2f48be982fa7ff509abf6549283`

🤖 Generated with [Claude Code](https://claude.com/claude-code)