### PR TITLE
refactor: #1855 CLI DB lifecycle async context manager (open_cli_db)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -252,7 +252,8 @@ src/ante/
 │   │   └── update.py
 │   ├── __init__.py
 │   ├── cold_path.py
-│   └── _validators.py
+│   ├── _validators.py
+│   └── db_context.py
 ├── account/
 │   ├── __init__.py
 │   ├── crypto.py
@@ -394,7 +395,8 @@ tests/
 │   │   ├── test_bot_create_exit_code.py
 │   │   ├── test_broker_missing_account.py
 │   │   ├── test_usage_error_json.py
-│   │   └── test_instrument_exchange_validation.py
+│   │   ├── test_instrument_exchange_validation.py
+│   │   └── test_db_context_manager.py
 │   ├── ipc/
 │   │   ├── __init__.py
 │   │   ├── test_protocol.py

--- a/src/ante/cli/db_context.py
+++ b/src/ante/cli/db_context.py
@@ -1,0 +1,88 @@
+"""CLI offline command DB lifecycle async context manager.
+
+Spec / SSOT:
+- 부모 에픽: #1818 (CLI offline command factory)
+- 선행 contract: docs/specs/contracts/offline-factory.md (#1854)
+- DB path resolver: :func:`ante.cli.main.get_db_path`
+- Database lifecycle: :class:`ante.core.database.Database`
+- cleanup 패턴 선례: #1722 ``_create_account_service`` + #1755 ``except BaseException``
+
+본 helper는 반복되는 ``Database(get_db_path(...))`` + manual ``close()`` 패턴을
+async context manager로 캡슐화한다. 후속 callsite migration은 #1856/#1857
+에서 다룬다 — 본 PR scope는 helper 추가만이다.
+
+Codex Plan Review v2 lock:
+1. ``ctx``는 mandatory (None 명시 거부, legacy ``get_db_path()`` fallback 의존 안 함).
+2. cleanup은 ``except BaseException``으로 ``asyncio.CancelledError``까지 catch한다.
+3. ``Database.close()``가 실패해도 원래 body 예외를 가린다거나 chain되지 않도록
+   inner try/except로 ``close()`` 실패를 무시하고 원래 예외만 surface한다.
+4. ``read_only``는 caller hint metadata일 뿐, ``Database`` 생성자에는 전달하지
+   않는다 (#1854 contract 옵션 B — Database API 변경 금지).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import click
+
+from ante.cli.main import get_db_path
+from ante.core.database import Database
+
+__all__ = ["open_cli_db"]
+
+
+@asynccontextmanager
+async def open_cli_db(
+    ctx: click.Context,
+    *,
+    read_only: bool = False,
+) -> AsyncIterator[Database]:
+    """CLI offline command DB lifecycle context manager.
+
+    Args:
+        ctx: Click 컨텍스트 (mandatory). ``--config-dir`` / ``ANTE_CONFIG_DIR``
+            를 통해 결정된 DB 경로를 ``get_db_path(ctx)``로 해석한다.
+            ``None``을 전달하면 ``ValueError``를 발생시킨다 — legacy 암시
+            fallback에 의존하지 않는다.
+        read_only: caller hint. ``Database`` 생성자에는 전달되지 않으며,
+            현재는 메타데이터로만 유지된다 (#1854 contract 옵션 B). 후속
+            이슈에서 read-only enforcement가 필요하면 이 플래그를 통해
+            확장한다.
+
+    Yields:
+        ``connect()``가 완료된 :class:`Database` 인스턴스.
+
+    Cleanup invariant:
+        - normal exit / exception / cancellation (BaseException) 모든 경로에서
+          ``Database.close()``를 호출한다.
+        - ``close()`` 자체가 예외를 던져도 body의 원래 예외를 가리지 않는다.
+
+    Raises:
+        ValueError: ``ctx is None``.
+    """
+    if ctx is None:
+        raise ValueError(
+            "open_cli_db requires explicit Click context (legacy fallback deprecated)"
+        )
+    # ``read_only`` is a caller hint only; it is intentionally not forwarded
+    # to ``Database.__init__`` per #1854 contract option B (no Database API
+    # signature change in this PR scope).
+    _ = read_only
+    db_path = get_db_path(ctx)
+    db = Database(db_path)
+    await db.connect()
+    try:
+        yield db
+    except BaseException:
+        # ``close()`` 실패가 원래 예외(BaseException 포함, CancelledError 등)를
+        # 가리지 않도록 inner try/except로 swallow한다. close 실패는 lifecycle
+        # leak이지만 caller에게 surface해야 할 것은 body의 원래 예외다.
+        try:
+            await db.close()
+        except Exception:
+            pass
+        raise
+    else:
+        await db.close()

--- a/tests/unit/cli/test_db_context_manager.py
+++ b/tests/unit/cli/test_db_context_manager.py
@@ -1,0 +1,187 @@
+"""Tests for :func:`ante.cli.db_context.open_cli_db` lifecycle context manager.
+
+Plan v2 SSOT — 8 시나리오:
+1. ``open_cli_db``가 connect된 :class:`Database`를 yield 한다.
+2. normal exit에서 ``close()``가 호출된다.
+3. body 예외가 발생해도 ``close()``가 호출된다.
+4. ``asyncio.CancelledError`` cancellation 경로에서도 ``close()``가 호출된다.
+5. ``get_db_path(ctx)``가 ctx로부터 명시적으로 resolve된다 (``--config-dir``).
+6. ``read_only=True``는 ``Database.__init__``에 전달되지 않는다 (#1854 옵션 B).
+7. ``ctx=None``은 ``ValueError``로 명시적으로 거부된다 (legacy fallback 의존 안 함).
+8. body 예외와 ``db.close()`` 실패가 함께 발생할 때 body 예외만 surface한다.
+
+본 테스트는 ``open_cli_db`` helper 자체의 lifecycle invariant만 검증한다.
+기존 22 callsite 변경/migration은 #1856/#1857에서 다룬다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import click
+import pytest
+
+from ante.cli.db_context import open_cli_db
+from ante.cli.main import cli
+
+
+def _make_ctx_with_config_dir(config_dir: Path) -> click.Context:
+    """root ``cli`` group을 사용해 ``--config-dir``가 반영된 ctx를 만든다."""
+    ctx = click.Context(cli, obj={"config_dir": config_dir})
+    return ctx
+
+
+def _bootstrap_config_dir(tmp_path: Path) -> Path:
+    """`ante init` 결과와 동등한 최소 config_dir 구조를 만든다.
+
+    ``get_db_path``는 system.toml 부재 시 default ``<config_dir>/db/ante.db``로
+    폴백하므로 (Config.load 기본값) 별도 system.toml 작성은 불필요하다.
+    db 디렉토리만 미리 만들어 ``Database.connect``가 실패하지 않도록 한다.
+    """
+    cfg_dir = tmp_path / "cfg"
+    (cfg_dir / "db").mkdir(parents=True, exist_ok=True)
+    return cfg_dir
+
+
+@pytest.mark.asyncio
+async def test_open_cli_db_yields_connected_database(tmp_path: Path) -> None:
+    """1) ``open_cli_db``가 yield하는 객체는 connect된 Database 인스턴스다."""
+    cfg_dir = _bootstrap_config_dir(tmp_path)
+    ctx = _make_ctx_with_config_dir(cfg_dir)
+    async with open_cli_db(ctx) as db:
+        # writer/reader 연결이 살아 있어 fetch 가능해야 한다.
+        row = await db.fetch_one("SELECT 1 AS one")
+        assert row == {"one": 1}
+
+
+@pytest.mark.asyncio
+async def test_open_cli_db_closes_on_normal_exit(tmp_path: Path) -> None:
+    """2) normal exit path에서 ``Database.close()``가 호출된다."""
+    cfg_dir = _bootstrap_config_dir(tmp_path)
+    ctx = _make_ctx_with_config_dir(cfg_dir)
+    captured: dict[str, Any] = {}
+    with patch("ante.cli.db_context.Database") as db_cls:
+        instance = db_cls.return_value
+        instance.connect = AsyncMock()
+        instance.close = AsyncMock()
+        captured["instance"] = instance
+        async with open_cli_db(ctx) as db:
+            assert db is instance
+    captured["instance"].connect.assert_awaited_once()
+    captured["instance"].close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_open_cli_db_closes_on_exception(tmp_path: Path) -> None:
+    """3) body에서 일반 예외가 발생해도 ``close()``가 호출된다."""
+    cfg_dir = _bootstrap_config_dir(tmp_path)
+    ctx = _make_ctx_with_config_dir(cfg_dir)
+    with patch("ante.cli.db_context.Database") as db_cls:
+        instance = db_cls.return_value
+        instance.connect = AsyncMock()
+        instance.close = AsyncMock()
+
+        class _BodyError(RuntimeError):
+            pass
+
+        with pytest.raises(_BodyError):
+            async with open_cli_db(ctx):
+                raise _BodyError("boom")
+        instance.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_open_cli_db_closes_on_cancellation(tmp_path: Path) -> None:
+    """4) ``asyncio.CancelledError`` (BaseException 계열)도 close를 보장한다."""
+    cfg_dir = _bootstrap_config_dir(tmp_path)
+    ctx = _make_ctx_with_config_dir(cfg_dir)
+    with patch("ante.cli.db_context.Database") as db_cls:
+        instance = db_cls.return_value
+        instance.connect = AsyncMock()
+        instance.close = AsyncMock()
+
+        with pytest.raises(asyncio.CancelledError):
+            async with open_cli_db(ctx):
+                raise asyncio.CancelledError()
+        instance.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_open_cli_db_uses_ctx_db_path(tmp_path: Path) -> None:
+    """5) ``get_db_path(ctx)``가 ctx로부터 resolve되어 Database에 전달된다."""
+    cfg_dir = _bootstrap_config_dir(tmp_path)
+    ctx = _make_ctx_with_config_dir(cfg_dir)
+    expected_db_path = str(cfg_dir / "db" / "ante.db")
+    with patch("ante.cli.db_context.Database") as db_cls:
+        instance = db_cls.return_value
+        instance.connect = AsyncMock()
+        instance.close = AsyncMock()
+        async with open_cli_db(ctx):
+            pass
+    db_cls.assert_called_once_with(expected_db_path)
+
+
+@pytest.mark.asyncio
+async def test_open_cli_db_read_only_not_passed_to_database_init(
+    tmp_path: Path,
+) -> None:
+    """6) ``read_only=True``는 hint일 뿐 ``Database.__init__``에 전달되지 않는다.
+
+    #1854 contract 옵션 B — Database API 시그니처 변경 금지.
+    """
+    cfg_dir = _bootstrap_config_dir(tmp_path)
+    ctx = _make_ctx_with_config_dir(cfg_dir)
+    expected_db_path = str(cfg_dir / "db" / "ante.db")
+    with patch("ante.cli.db_context.Database") as db_cls:
+        instance = db_cls.return_value
+        instance.connect = AsyncMock()
+        instance.close = AsyncMock()
+        async with open_cli_db(ctx, read_only=True):
+            pass
+    # 위치 인자 1개(db_path)만 전달, read_only는 kwargs에 없어야 한다.
+    db_cls.assert_called_once_with(expected_db_path)
+    call = db_cls.call_args
+    assert "read_only" not in call.kwargs
+
+
+@pytest.mark.asyncio
+async def test_open_cli_db_rejects_none_ctx() -> None:
+    """7) ``ctx=None``은 ``ValueError``로 명시 거부된다 (legacy fallback 의존 안 함)."""
+    with pytest.raises(ValueError, match="explicit Click context"):
+        async with open_cli_db(None):  # type: ignore[arg-type]
+            pass
+
+
+@pytest.mark.asyncio
+async def test_open_cli_db_preserves_original_exception_when_close_fails(
+    tmp_path: Path,
+) -> None:
+    """8) body 예외 + ``close()`` 실패가 함께 발생해도 body의 원래 예외만 surface한다.
+
+    ``close()`` 실패가 caller의 traceback을 가리거나 chain하지 않아야 한다.
+    """
+    cfg_dir = _bootstrap_config_dir(tmp_path)
+    ctx = _make_ctx_with_config_dir(cfg_dir)
+
+    class _BodyError(RuntimeError):
+        pass
+
+    class _CloseError(RuntimeError):
+        pass
+
+    with patch("ante.cli.db_context.Database") as db_cls:
+        instance = db_cls.return_value
+        instance.connect = AsyncMock()
+        instance.close = AsyncMock(side_effect=_CloseError("close-failed"))
+
+        with pytest.raises(_BodyError) as excinfo:
+            async with open_cli_db(ctx):
+                raise _BodyError("body-failed")
+        # surface된 예외는 body의 _BodyError여야 한다.
+        assert "body-failed" in str(excinfo.value)
+        # close 실패는 swallow되었으므로 __context__/cause로 노출되지 않아야 한다
+        # (inner try/except가 close 예외를 삼킨다).
+        assert not isinstance(excinfo.value.__cause__, _CloseError)


### PR DESCRIPTION
## Summary

- `src/ante/cli/db_context.py` 신규: `open_cli_db(ctx, *, read_only=False)` asynccontextmanager
- 반복되는 `Database(get_db_path(...))` + manual `close()` 패턴을 단일 helper로 캡슐화
- 본 PR scope는 helper 추가만 — 기존 22 callsite migration은 후속 #1856/#1857

Closes #1855

## Codex Plan Review v2 lock (구현 반영)

1. **`ctx` mandatory**: `None`은 `ValueError("explicit Click context")`로 명시 거부. legacy 암시 `get_db_path()` fallback에 의존하지 않는다.
2. **cleanup BaseException**: `except BaseException`으로 `asyncio.CancelledError`까지 catch하여 `Database.close()`를 보장 호출한다.
3. **`close()` 실패 보존**: `close()` 자체가 예외를 던져도 body의 원래 예외를 가리거나 chain하지 않도록 inner `try/except`로 swallow한다.
4. **`read_only` hint-only**: caller hint metadata로만 유지하고 `Database.__init__`에는 전달하지 않는다 (#1854 contract 옵션 B — Database API 시그니처 변경 금지).

## 시그니처

```python
@asynccontextmanager
async def open_cli_db(
    ctx: click.Context,
    *,
    read_only: bool = False,
) -> AsyncIterator[Database]:
    if ctx is None:
        raise ValueError("open_cli_db requires explicit Click context (legacy fallback deprecated)")
    db_path = get_db_path(ctx)
    db = Database(db_path)
    await db.connect()
    try:
        yield db
    except BaseException:
        try:
            await db.close()
        except Exception:
            pass
        raise
    else:
        await db.close()
```

## Tests (8 시나리오, 모두 PASS)

- `test_open_cli_db_yields_connected_database` — yield된 객체가 connect된 Database
- `test_open_cli_db_closes_on_normal_exit` — normal path close 호출
- `test_open_cli_db_closes_on_exception` — body 예외 시 close 호출
- `test_open_cli_db_closes_on_cancellation` — `asyncio.CancelledError` (BaseException) close
- `test_open_cli_db_uses_ctx_db_path` — `--config-dir` 기반 path resolve 확인
- `test_open_cli_db_read_only_not_passed_to_database_init` — Database 생성자 kwargs에 read_only 없음
- `test_open_cli_db_rejects_none_ctx` — None ctx → ValueError
- `test_open_cli_db_preserves_original_exception_when_close_fails` — body 예외만 surface

## Non-goals (후속 이슈)

- CLI 22 callsite migration → #1856 / #1857
- `Database` API 변경 (read_only enforcement 등)
- service factory 통합
- runtime composition root (`src/ante/main.py`) 변경
- IPC fallback logic 통합

## Test plan

- [x] `pytest tests/unit/cli/test_db_context_manager.py -v` — 8 PASS
- [x] `pytest tests/unit/` 회귀 — 본 PR 영향 0 (217 failures는 origin/main에서도 동일하게 발생하는 pre-existing batch-only flake; isolation 시 PASS, 새 db_context 테스트는 영향 없음)
- [x] `mypy src/ante` — clean (224 source files)
- [x] `ruff check src/ante/cli tests/unit/cli` — All checks passed
- [x] `ruff format --check src/ante/cli tests/unit/cli` — 39 files already formatted
- [x] `python scripts/generate_project_structure.py` — regen 반영
- [x] main HEAD `a54c3972` 불변 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)