### PR TITLE
refactor: #1853 IPC metadata drift + remaining handler migration (closes #1819)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -404,7 +404,9 @@ tests/
 │   │   ├── test_server_client.py
 │   │   ├── test_service_registry.py
 │   │   ├── test_dispatch_wrapper_preflight.py
-│   │   └── test_dispatch_wrapper_audit.py
+│   │   ├── test_dispatch_wrapper_audit.py
+│   │   ├── test_cli_registry_ipc_cross_ref.py
+│   │   └── test_docs_taxonomy_drift.py
 │   ├── specs/
 │   │   ├── __init__.py
 │   │   ├── test_cold_path_terminology.py

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -575,20 +575,38 @@ async def _handle_treasury_set_balance(
 async def _handle_rule_update(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    from ante.account.scoping import require_account_id
+    """계좌 룰 업데이트 IPC handler.
+
+    Refs #1853 (#1819 부모 epic): account_id 검증은 ``_dispatch`` wrapper 가
+    ``CommandSpec.account_id_policy="required"`` 기반으로 사전 수행한다. audit
+    호출은 wrapper 가 ``CommandSpec.audit_action="account.rule.update"`` 기반
+    으로 자동 발화하며, handler 는 helper 에 ``audit_logger=None`` 을 전달하여
+    helper 내부 audit 발화를 끈다(CLI offline path 는 ``audit_logger`` 를
+    그대로 전달하여 기존 동작 유지). handler 는 helper 결과에
+    ``_audit_detail`` reserved key 를 덧붙여 wrapper 가 ``pop`` 으로 strip
+    한다.
+    """
     from ante.rule.config_update import update_account_rule_config
 
-    account_id = require_account_id(args.get("account_id"), context="ipc.rule.update")
-    return await update_account_rule_config(
+    account_id = args["account_id"]
+    rule_type = args["rule_type"]
+    enabled = bool(args.get("enabled", True))
+    result = await update_account_rule_config(
         account_service=svc.account,
         dynamic_config=svc.dynamic_config,
         account_id=account_id,
-        rule_type=args["rule_type"],
-        enabled=bool(args.get("enabled", True)),
+        rule_type=rule_type,
+        enabled=enabled,
         params=dict(args.get("params") or {}),
         changed_by=actor,
-        audit_logger=getattr(svc, "audit_logger", None),
+        audit_logger=None,
     )
+    result["_audit_detail"] = {
+        "resource": f"account:{account_id}:rule:{rule_type}",
+        "detail": f"rule update: {rule_type} enabled={enabled}",
+        "ip": "",
+    }
+    return result
 
 
 async def _handle_strategy_set_status(
@@ -847,6 +865,15 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     실제 ``audit_logger.log`` 호출이 있는 명령만 값을 가진다(#1819 본문 /
     Codex v2 condition 3). ``cross_validators``/``shutdown_behavior``는 본
     이슈에서 default(빈 tuple / None=derive)로 유지한다.
+
+    Refs #1853 (#1819 epic 종결): ``rule.update`` 의 audit 호출을 wrapper 로
+    이전한다(helper 의 ``audit_logger`` 인자를 IPC handler 에서 ``None`` 으로
+    전달, wrapper 가 ``audit_action="account.rule.update"`` 자동 발화). 현재
+    ``audit_action`` 부여 commands 는 10개:
+    ``account.suspend`` / ``account.activate`` / ``bot.start`` /
+    ``bot.stop`` / ``bot.update`` / ``treasury.set_balance`` /
+    ``strategy.set_status`` / ``member.update_scopes`` /
+    ``approval.cancel_invalid`` / ``rule.update``.
     """
     # ── mutating (23개): 서버 상태/DB를 변경 ──────────
     # system.* — account_service의 suspend_all/activate_all (collective ops).
@@ -959,7 +986,12 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         account_id_policy="required",
     )
     # rule.update — update_account_rule_config helper 응답을 그대로 통과
-    # (envelope shape이 helper 내부 결정이므로 raw).
+    # (envelope shape이 helper 내부 결정이므로 raw). Refs #1853 (#1819 epic):
+    # audit 호출을 wrapper 로 이전. handler 가 helper 에 ``audit_logger=None``
+    # 을 전달해 helper 내부 audit 발화를 끄고, wrapper 가
+    # ``audit_action="account.rule.update"`` (helper 의 기존 action 이름과 동일)
+    # 으로 자동 발화한다. CLI offline path 는 helper 의 audit_logger 인자를
+    # 그대로 사용해 기존 동작 보존.
     registry.register(
         "rule.update",
         _handle_rule_update,
@@ -967,6 +999,7 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         result_kind="raw",
         required_services=frozenset({"account", "dynamic_config", "audit_logger"}),
         account_id_policy="required",
+        audit_action="account.rule.update",
     )
     registry.register(
         "strategy.set_status",

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -332,9 +332,9 @@ class IPCServer:
         에 전달할 수 있으며, public envelope 으로 새 나가지 않도록 wrapper 가
         ``pop`` 으로 strip 한 뒤 envelope ``result`` 에 담는다. handler 가
         예외로 종료되면 audit 호출은 일어나지 않는다(실패 시 audit invariant).
-        ``audit_action`` 이 부여된 7 commands 는 ``required_services`` 에
-        ``audit_logger`` 가 명시되어 있어 preflight 단계에서 부재가 차단된다
-        (#1849 등록 시 동형 lock).
+        ``audit_action`` 이 부여된 commands(현재 10개 — #1852 / #1853 포함)는
+        ``required_services`` 에 ``audit_logger`` 가 명시되어 있어 preflight
+        단계에서 부재가 차단된다 (#1849 등록 시 동형 lock).
         """
         request_id = request.get("id", str(uuid.uuid4()))
         command = request.get("command", "")
@@ -402,11 +402,12 @@ class IPCServer:
             # Refs #1851: handler 정상 종료 후 audit_action 자동 발화.
             # ``_audit_detail`` reserved key 는 ``pop`` 으로 envelope 노출
             # 전에 strip 된다 (public payload 누출 invariant).
-            # ``audit_action`` 부여 7 commands 는 ``required_services`` 에
-            # ``audit_logger`` 가 포함되어 있어 preflight 단계에서 부재가
-            # 이미 차단됨 — 여기서는 ``getattr`` safe-access 로 한 번 더
-            # 방어한다 (handler 가 dict 가 아닌 다른 shape 을 반환하는
-            # 경우에도 strip 시도가 실패하지 않도록 isinstance 가드).
+            # ``audit_action`` 부여 commands(현재 10개 — #1852 / #1853 포함)는
+            # ``required_services`` 에 ``audit_logger`` 가 포함되어 있어
+            # preflight 단계에서 부재가 이미 차단됨 — 여기서는 ``getattr``
+            # safe-access 로 한 번 더 방어한다 (handler 가 dict 가 아닌 다른
+            # shape 을 반환하는 경우에도 strip 시도가 실패하지 않도록
+            # isinstance 가드).
             audit_detail: dict | None = None
             if isinstance(result, dict):
                 audit_detail = result.pop("_audit_detail", None)

--- a/tests/unit/ipc/test_cli_registry_ipc_cross_ref.py
+++ b/tests/unit/ipc/test_cli_registry_ipc_cross_ref.py
@@ -1,0 +1,137 @@
+"""CLI registry ``runtime_ipc`` ↔ IPC ``CommandRegistry`` drift 가드.
+
+Refs #1853 (#1819 epic 종결): ``src/ante/contracts/cli_registry.py`` 의
+``execution="runtime_ipc"`` entries 가 가리키는 ``ipc_command`` 가 실제로
+``ante.ipc.registry.register_all_handlers()`` 에 등록된 27 commands 중
+하나이거나, ``EXPECTED_MISSING_IPC_COMMANDS`` baseline (후속 wiring stub —
+docs/specs/ipc/ipc.md:273-276 명시) 중 하나여야 한다.
+
+baseline 밖의 미존재 (예: 오타, 명칭 변경 누락) → 즉시 FAIL.
+
+baseline 12 entries 의 후속 wiring 은 별도 child issue 에서 점진 제거되며,
+removal 시 본 모듈의 ``EXPECTED_MISSING_IPC_COMMANDS`` 도 함께 갱신해야 한다
+(SSOT 한쪽만 갱신되는 회귀를 본 test 가 차단).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.contracts.cli_registry import all_contracts
+from ante.ipc.registry import CommandRegistry, register_all_handlers
+
+# ``docs/specs/ipc/ipc.md:273-276`` 명시 — ``register_all_handlers()`` 에
+# 아직 wiring 되지 않은 12 commands. CLI registry 의 ``ipc_command`` stub
+# 값은 후속 wiring 이슈로 점진 제거된다.
+#
+# member.* 8: ipc.md:160-168 표 stub. ``member.update_scopes`` 만 현재 등록.
+# bot.* 4: ipc.md:97-103 / 274 — ``bot.list`` / ``bot.info`` / ``bot.positions`` /
+#   ``bot.signal_key`` 의 live 조회/회수 IPC 후속 wiring.
+EXPECTED_MISSING_IPC_COMMANDS: frozenset[str] = frozenset(
+    {
+        # member runtime IPC stub (8)
+        "member.register",
+        "member.set_emoji",
+        "member.suspend",
+        "member.reactivate",
+        "member.revoke",
+        "member.rotate_token",
+        "member.reset_password",
+        "member.regenerate_recovery_key",
+        # bot query 계열 후속 wiring (4)
+        "bot.list",
+        "bot.info",
+        "bot.positions",
+        "bot.signal_key",
+    }
+)
+
+
+@pytest.fixture
+def loaded_registry() -> CommandRegistry:
+    registry = CommandRegistry()
+    register_all_handlers(registry)
+    return registry
+
+
+def test_baseline_size_locked() -> None:
+    """baseline 크기를 12 로 lock — 후속 wiring 이슈가 줄여나갈 때 본 lock 도
+    함께 갱신해야 한다 (SSOT 동기화 강제)."""
+    assert len(EXPECTED_MISSING_IPC_COMMANDS) == 12, (
+        f"baseline size={len(EXPECTED_MISSING_IPC_COMMANDS)}; "
+        "후속 wiring 이슈에서 baseline 항목을 제거했다면 본 lock 도 함께 갱신."
+    )
+
+
+def test_cli_runtime_ipc_entries_reference_registered_or_baseline(
+    loaded_registry: CommandRegistry,
+) -> None:
+    """CLI ``execution="runtime_ipc"`` entries 의 ``ipc_command`` 값은
+    ``CommandRegistry`` 에 등록되어 있거나 ``EXPECTED_MISSING_IPC_COMMANDS``
+    baseline 에 등록되어 있어야 한다.
+
+    drift 시나리오: CLI registry 에 새 runtime_ipc entry 가 추가되었으나
+    IPC ``register_all_handlers()`` 에 wiring 되지 않았고 baseline 에도 없는
+    경우 → FAIL. baseline 추가는 후속 wiring 이슈와 동기화된 의도적 결정만
+    허용한다.
+    """
+    registered = set(loaded_registry.commands)
+    failures: list[str] = []
+    for contract in all_contracts():
+        if contract.execution != "runtime_ipc":
+            continue
+        ipc_cmd = contract.ipc_command
+        if ipc_cmd is None:
+            failures.append(
+                f"CLI {'.'.join(contract.path)!r} execution=runtime_ipc 인데 "
+                "ipc_command=None — runtime IPC entries 는 반드시 IPC "
+                "command name 을 stub 으로라도 보유해야 합니다."
+            )
+            continue
+        if ipc_cmd in registered:
+            continue
+        if ipc_cmd in EXPECTED_MISSING_IPC_COMMANDS:
+            continue
+        failures.append(
+            f"CLI {'.'.join(contract.path)!r} → ipc_command={ipc_cmd!r} "
+            "이 IPC CommandRegistry 에도 EXPECTED_MISSING_IPC_COMMANDS "
+            "baseline 에도 없습니다. ``register_all_handlers()`` 에 wiring "
+            "하거나 baseline 에 등록하세요."
+        )
+    assert not failures, "CLI runtime_ipc cross-ref drift:\n" + "\n".join(failures)
+
+
+def test_baseline_does_not_overlap_registered(
+    loaded_registry: CommandRegistry,
+) -> None:
+    """baseline 항목이 실제 registered command 와 겹치지 않는다.
+
+    drift 시나리오: 후속 wiring 으로 IPC handler 가 등록되었는데 baseline 에서
+    제거하지 않은 경우 → FAIL. baseline 은 "아직 wiring 안 됨" 의미이므로
+    registered 와 disjoint 해야 한다.
+    """
+    registered = set(loaded_registry.commands)
+    overlap = EXPECTED_MISSING_IPC_COMMANDS & registered
+    assert not overlap, (
+        f"baseline 항목이 이미 IPC CommandRegistry 에 등록되어 있습니다: "
+        f"{sorted(overlap)!r}. wiring 이 완료된 항목은 baseline 에서 제거해야 "
+        "합니다."
+    )
+
+
+def test_baseline_entries_have_cli_runtime_ipc_reference() -> None:
+    """baseline 의 모든 항목은 CLI registry 에 ``runtime_ipc`` entry 로 실제로
+    참조되어야 한다 (dead baseline 방지).
+
+    drift 시나리오: CLI 에서 entry 가 제거되었거나 ``execution`` 이 변경되어
+    더 이상 baseline 이 의미 없게 된 경우 → FAIL.
+    """
+    cli_ipc_refs: set[str] = set()
+    for contract in all_contracts():
+        if contract.execution == "runtime_ipc" and contract.ipc_command:
+            cli_ipc_refs.add(contract.ipc_command)
+    dead = EXPECTED_MISSING_IPC_COMMANDS - cli_ipc_refs
+    assert not dead, (
+        f"baseline 에 있으나 CLI runtime_ipc 참조가 없는 항목 (dead baseline): "
+        f"{sorted(dead)!r}. CLI registry 변경에 맞춰 baseline 도 정리하세요."
+    )

--- a/tests/unit/ipc/test_docs_taxonomy_drift.py
+++ b/tests/unit/ipc/test_docs_taxonomy_drift.py
@@ -1,0 +1,226 @@
+"""docs/specs/ipc/ipc.md ↔ IPC ``CommandRegistry`` drift 가드.
+
+Refs #1853 (#1819 epic 종결): ``docs/specs/ipc/ipc.md`` 의 IPC commands
+taxonomy 두 표(런타임 커맨드 전수 목록 / Handler taxonomy)와
+``register_all_handlers()`` 등록 결과를 cross-ref 한다. drift 가 생기면 즉시
+실패시켜, 코드/스펙 한쪽만 갱신되는 회귀를 차단한다.
+
+검출 대상:
+
+1. docs 표에 있는 IPC command name 이 모두 registry 에 존재한다(스펙→코드).
+2. registry 에 있는 27 commands 가 모두 docs 표(Handler taxonomy)에 등장한다
+   (코드→스펙).
+3. docs Handler taxonomy 의 ``mutating`` / ``read-only`` 분류가 registry 의
+   ``is_mutating`` 값과 정확히 일치한다.
+
+본 테스트는 IPC envelope shape 이나 args schema 를 검증하지 않는다. 그 책임은
+``tests/unit/ipc/test_registry.py`` 와 contracts 모듈 테스트에 있다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from ante.ipc.registry import CommandRegistry, register_all_handlers
+
+# ``docs/specs/ipc/ipc.md`` 절대 경로 — repo root 기반 resolve.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_IPC_SPEC_PATH = _REPO_ROOT / "docs" / "specs" / "ipc" / "ipc.md"
+
+
+# 도메인 prefix 화이트리스트. docs 표의 ``IPC 커맨드`` 컬럼에 나오는 백틱
+# inline literal 중 이 prefix 로 시작하는 토큰만 IPC command name 후보로
+# 수집한다(``ipc.bot.create`` context 문자열, ``BotManager.create_bot()`` 같은
+# 호출 표기는 제외).
+_IPC_COMMAND_PREFIXES = (
+    "system.",
+    "account.",
+    "bot.",
+    "treasury.",
+    "rule.",
+    "strategy.",
+    "member.",
+    "config.",
+    "approval.",
+    "broker.",
+)
+
+# docs 표에는 등장하지만 IPC ``CommandRegistry`` 등록 대상이 아닌 토큰.
+# ipc.md:97-103 / 273-276 명시: 후속 wiring 대상, cold-path 전용, 또는 표
+# 본문 prose 에서 언급된 contextual command name.
+_DOCS_NON_REGISTRY_TOKENS = frozenset(
+    {
+        # member.* runtime IPC stub (CLI 표 surface, 실제 wiring 후속) — ipc.md:160-168
+        "member.register",
+        "member.set_emoji",
+        "member.suspend",
+        "member.reactivate",
+        "member.revoke",
+        "member.rotate_token",
+        "member.reset_password",
+        "member.regenerate_recovery_key",
+        # bot.signal_key.rotate 후속 wiring — ipc.md:86 / 274
+        "bot.signal_key.rotate",
+        # bot.query 계열 후속 wiring — ipc.md:98 / 274
+        "bot.query",
+        # cold-path 전용 — ipc.md:70-74 / 193 / 273
+        "account.delete",
+        "account.create",
+        "account.set_credentials",
+    }
+)
+
+
+def _parse_docs_taxonomy_table() -> dict[str, str]:
+    """``docs/specs/ipc/ipc.md`` Handler taxonomy 표를 ``{command: taxonomy}``
+    매핑으로 파싱한다.
+
+    표 형식: ``| `<command>` | mutating/read-only | <근거> |``. 표 헤더 라인
+    ``| IPC 커맨드 | taxonomy | 근거 |`` 등장 이후의 ``|`` 시작 라인만 수집한다.
+    """
+    text = _IPC_SPEC_PATH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    # 표 시작 헤더 찾기.
+    header_idx: int | None = None
+    for idx, line in enumerate(lines):
+        if (
+            line.startswith("|")
+            and "IPC 커맨드" in line
+            and "taxonomy" in line
+            and "근거" in line
+        ):
+            header_idx = idx
+            break
+    assert header_idx is not None, (
+        "docs/specs/ipc/ipc.md Handler taxonomy 표 헤더를 찾지 못했습니다 — "
+        "스펙 구조가 변경된 경우 본 파서를 동기화해야 합니다."
+    )
+
+    result: dict[str, str] = {}
+    # 헤더 다음 줄은 alignment row (``| --- | --- | --- |``). 본문은 그 다음.
+    for line in lines[header_idx + 2 :]:
+        if not line.startswith("|"):
+            break  # 표 종료
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        cmd_cell, tax_cell = cells[0], cells[1]
+        match = re.match(r"`([^`]+)`", cmd_cell)
+        if not match:
+            continue
+        cmd = match.group(1)
+        if not any(cmd.startswith(p) for p in _IPC_COMMAND_PREFIXES):
+            continue
+        taxonomy = tax_cell.strip().lower()
+        if taxonomy in {"mutating", "read-only"}:
+            result[cmd] = taxonomy
+    return result
+
+
+def _parse_docs_runtime_commands() -> set[str]:
+    """docs ``런타임 커맨드 전수 목록`` 영역(``## CLI 커맨드 분류`` 아래)에서
+    백틱으로 감싼 IPC command name 을 수집한다.
+
+    ``## IPCServer lifecycle state`` 절 이전까지를 범위로 본다. Handler
+    taxonomy 영역은 별도 파서(``_parse_docs_taxonomy_table``)가 담당한다.
+    """
+    text = _IPC_SPEC_PATH.read_text(encoding="utf-8")
+    start_match = re.search(r"^## CLI 커맨드 분류", text, flags=re.MULTILINE)
+    end_match = re.search(r"^## IPCServer lifecycle state", text, flags=re.MULTILINE)
+    assert start_match is not None and end_match is not None, (
+        "docs/specs/ipc/ipc.md 의 런타임 커맨드 분류 절 경계를 찾지 못했습니다."
+    )
+    section = text[start_match.end() : end_match.start()]
+    tokens = re.findall(r"`([^`]+)`", section)
+    found: set[str] = set()
+    for tok in tokens:
+        if not any(tok.startswith(p) for p in _IPC_COMMAND_PREFIXES):
+            continue
+        # ``ipc.bot.create`` 같은 context 문자열 제외 (앞에 ``ipc.`` 가 붙음).
+        if tok.startswith("ipc."):
+            continue
+        # python attribute/index 표기는 IPC command name 아님
+        # (예: ``account.credentials["app_key"]``).
+        if any(ch in tok for ch in '[]()" '):
+            continue
+        found.add(tok)
+    return found
+
+
+@pytest.fixture
+def loaded_registry() -> CommandRegistry:
+    registry = CommandRegistry()
+    register_all_handlers(registry)
+    return registry
+
+
+def test_docs_runtime_section_commands_exist_in_registry(
+    loaded_registry: CommandRegistry,
+) -> None:
+    """docs 런타임 커맨드 표의 모든 IPC command (후속 wiring stub 제외) 이
+    registry 에 등록되어 있다.
+
+    drift 시나리오: docs 에 새 command 가 추가되었으나 ``register_all_handlers``
+    가 갱신되지 않은 경우 → FAIL.
+    """
+    docs_cmds = _parse_docs_runtime_commands()
+    registry_cmds = set(loaded_registry.commands)
+    # docs 에 명시된 후속 wiring stub 은 검증에서 제외.
+    docs_expected = docs_cmds - _DOCS_NON_REGISTRY_TOKENS
+    missing = docs_expected - registry_cmds
+    assert not missing, (
+        f"docs 런타임 커맨드 절에 명시된 IPC commands 가 registry 에 없습니다: "
+        f"{sorted(missing)!r}. ``register_all_handlers()`` 또는 docs/specs/ipc/"
+        f"ipc.md 중 한쪽이 누락된 drift 입니다."
+    )
+
+
+def test_registry_commands_all_present_in_docs_taxonomy(
+    loaded_registry: CommandRegistry,
+) -> None:
+    """registry 27 commands 가 모두 docs Handler taxonomy 표에 등장한다.
+
+    drift 시나리오: registry 에 새 handler 가 등록되었으나 docs Handler
+    taxonomy 표가 갱신되지 않은 경우 → FAIL.
+    """
+    docs_taxonomy = _parse_docs_taxonomy_table()
+    registry_cmds = set(loaded_registry.commands)
+    missing = registry_cmds - set(docs_taxonomy.keys())
+    assert not missing, (
+        f"registry 등록 IPC commands 가 docs Handler taxonomy 표에 없습니다: "
+        f"{sorted(missing)!r}. docs/specs/ipc/ipc.md Handler taxonomy 섹션을 "
+        f"갱신하세요."
+    )
+
+
+def test_docs_taxonomy_is_mutating_matches_registry(
+    loaded_registry: CommandRegistry,
+) -> None:
+    """docs Handler taxonomy 의 ``mutating`` / ``read-only`` 분류가 registry
+    ``is_mutating`` 값과 일치한다.
+
+    drift 시나리오: 코드의 ``is_mutating=True/False`` 와 docs 분류가 어긋난
+    경우 → FAIL. ``SHUTTING_DOWN`` lifecycle gate(#1184)와 직접 연관된
+    invariant 이므로 강한 lock.
+    """
+    docs_taxonomy = _parse_docs_taxonomy_table()
+    mismatches: list[str] = []
+    for spec in loaded_registry.iter_specs():
+        docs_label = docs_taxonomy.get(spec.name)
+        if docs_label is None:
+            # 부재는 위 test 가 별도로 잡는다 — 본 test 는 분류 일치만 검사.
+            continue
+        expected = "mutating" if spec.is_mutating else "read-only"
+        if docs_label != expected:
+            mismatches.append(
+                f"{spec.name}: docs={docs_label!r} but registry "
+                f"is_mutating={spec.is_mutating}"
+            )
+    assert not mismatches, (
+        "docs Handler taxonomy 와 registry is_mutating 분류 drift: "
+        + "; ".join(mismatches)
+    )

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -831,6 +831,10 @@ class TestRegisteredCommandsMetadataCompleteness:
 
         Refs #1852 (#1819 epic): account.suspend / account.activate 가 wrapper
         migration 으로 audit_action 부여(7→9 commands).
+
+        Refs #1853 (#1819 epic 종결): rule.update 의 audit 호출을 wrapper 로
+        이전(action="account.rule.update", helper 의 기존 action 이름 보존)
+        (9→10 commands).
         """
         expected_actions = {
             "account.suspend",
@@ -842,6 +846,7 @@ class TestRegisteredCommandsMetadataCompleteness:
             "strategy.set_status",
             "member.update_scopes",
             "approval.cancel_invalid",
+            "account.rule.update",
         }
         actual = {
             spec.audit_action


### PR DESCRIPTION
Closes #1853
Closes #1819

## 요약

#1819 epic 종결 PR. 잔여 IPC handler audit migration (rule.update) + 3축
drift guard (docs taxonomy / CLI runtime_ipc cross-ref / audit known-set).

## 변경 사항

### Step 1 — rule.update audit handler wrapper migration (commit 701e161b)

- `src/ante/ipc/registry.py:_handle_rule_update`: helper
  `update_account_rule_config` 에 `audit_logger=None` 전달하여 helper 내부
  audit 발화를 끄고, handler 가 `_audit_detail` reserved key
  (resource=`account:<id>:rule:<type>`, detail=`rule update: <type>
  enabled=<bool>`) 를 반환. CLI offline path 는 helper 의 `audit_logger`
  인자를 그대로 사용하여 기존 동작 보존.
- `CommandSpec` rule.update: `audit_action="account.rule.update"` 부여 —
  helper 의 기존 action 이름과 동일 (audit log shape 보존).
- `tests/unit/ipc/test_registry.py:test_audit_actions_match_known_set`:
  known audit action set 을 9 → 10 commands 로 확장.
- `src/ante/ipc/server.py` docstring: audit_action 보유 commands count
  표기를 7 → "현재 10개 (#1852 / #1853 포함)" 으로 동기화.

### Step 2 — Drift guards (commit 30e93dda)

- `tests/unit/ipc/test_docs_taxonomy_drift.py` 신규 (3 시나리오):
  - docs `docs/specs/ipc/ipc.md` 런타임 커맨드 표의 IPC commands 가
    registry 에 등록되어 있다 (후속 wiring stub 제외).
  - registry 27 commands 가 모두 docs Handler taxonomy 표에 등장한다.
  - docs Handler taxonomy 의 mutating/read-only 분류가 registry
    `is_mutating` 값과 일치한다.
- `tests/unit/ipc/test_cli_registry_ipc_cross_ref.py` 신규 (4 시나리오):
  - CLI `execution="runtime_ipc"` entries 의 `ipc_command` 가 registry
    에 등록되어 있거나 `EXPECTED_MISSING_IPC_COMMANDS` baseline 에
    등록되어 있어야 한다.
  - baseline size = 12 lock.
  - baseline 항목이 registered commands 와 disjoint 하다.
  - baseline 항목이 CLI runtime_ipc 참조와 일치한다 (dead baseline 차단).

### EXPECTED_MISSING_IPC_COMMANDS baseline (12 entries)

`docs/specs/ipc/ipc.md:273-276` 명시 — 후속 wiring stub:

| 도메인 | command | 후속 wiring |
| --- | --- | --- |
| member | `member.register` | ipc.md:160 |
| member | `member.set_emoji` | ipc.md:161 |
| member | `member.suspend` | ipc.md:162 |
| member | `member.reactivate` | ipc.md:163 |
| member | `member.revoke` | ipc.md:164 |
| member | `member.rotate_token` | ipc.md:165 |
| member | `member.reset_password` | ipc.md:167 |
| member | `member.regenerate_recovery_key` | ipc.md:168 |
| bot | `bot.list` | ipc.md:98 / 274 |
| bot | `bot.info` | ipc.md:98 / 274 |
| bot | `bot.positions` | ipc.md:98 / 274 |
| bot | `bot.signal_key` | ipc.md:86 / 274 |

후속 wiring 이슈가 baseline 항목을 줄여나갈 때 본 모듈의
`EXPECTED_MISSING_IPC_COMMANDS` 도 함께 갱신해야 하며, 그렇지 않으면
no-overlap / no-dead-baseline 가드가 즉시 회귀를 잡는다.

### 신규 audit_action commands

본 PR 에서 추가된 audit_action: `account.rule.update` (rule.update). 기존 9
commands + 1 = 총 10 commands 가 wrapper-managed audit 사용.

### 보존된 invariant

- IPC envelope shape: 무변경 (`_audit_detail` 은 wrapper pop 으로 strip).
- handler business logic: rule.update 본문은 helper 호출 결과 통과 — 검증
  로직 / event 발행 / DynamicConfig 갱신 경로 무변경.
- CLI offline path (rule.py:386): helper 의 `audit_logger=AuditLogger`
  인자 그대로 — IPC 미경유 시 audit 동작 동일.

## Test plan

- [x] `PYTHONPATH=src pytest tests/unit/ipc -q` — 89 passed (기존 + 신규
  드리프트 가드 8 시나리오).
- [x] `pytest tests/unit/test_rule_*` — 288 passed (rule 도메인 회귀
  없음).
- [x] `pytest tests/unit/ipc tests/unit/contracts` — 205 passed.
- [x] `ruff check src tests` — All checks passed.
- [x] `ruff format --check src tests` — 545 files already formatted.
- [x] `mypy src/ante` — Success: no issues found in 224 source files.
- [x] `python scripts/generate_project_structure.py` regen — 신규 테스트
  2 파일 반영.

main HEAD = `2a638ebb` 불변 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)