### PR TITLE
refactor: #1857 remaining offline/cold-path CLI domain factory migration (broker/signal 제외)

### DIFF
--- a/src/ante/cli/commands/audit.py
+++ b/src/ante/cli/commands/audit.py
@@ -7,6 +7,7 @@ import asyncio
 import click
 
 from ante.cli._validators import reject_inverted_date_range, validate_iso_date
+from ante.cli.db_context import open_cli_db
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 
@@ -63,13 +64,13 @@ def audit_list(
     )
 
     async def _run_list() -> list[dict]:
+        # #1857: ``open_cli_db`` 헬퍼가 ``AuditLogger.initialize()`` /
+        # ``query()`` 의 예외 / cancellation 까지 ``Database.close()`` 1회 호출을
+        # 보장한다 (#1722 cleanup invariant). ``AuditLogger.initialize()`` 는
+        # #1854 §4.2 명시 예외 (read-only) — 그대로 보존한다.
         from ante.audit import AuditLogger
-        from ante.cli.main import get_db_path
-        from ante.core.database import Database
 
-        db = Database(get_db_path())
-        await db.connect()
-        try:
+        async with open_cli_db(ctx) as db:
             audit_logger = AuditLogger(db)
             await audit_logger.initialize()
             return await audit_logger.query(
@@ -80,8 +81,6 @@ def audit_list(
                 limit=limit,
                 offset=offset,
             )
-        finally:
-            await db.close()
 
     result = _run(_run_list())
 

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import UTC, date, datetime, time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
@@ -15,10 +18,17 @@ from ante.cli._validators import (
     validate_positive_finite_amount,
 )
 from ante.cli.cold_path import is_active_runtime
+from ante.cli.db_context import open_cli_db
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 from ante.contracts import emit_cli_error
+
+if TYPE_CHECKING:
+    from ante.account.service import AccountService
+    from ante.bot.manager import BotManager
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
 
 logger = logging.getLogger(__name__)
 
@@ -32,21 +42,60 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
-async def _create_services():  # noqa: ANN202
+@asynccontextmanager
+async def _create_services(
+    ctx: click.Context | None = None,
+) -> AsyncIterator[tuple[Database, EventBus, BotManager, AccountService]]:
+    """CLI 에서 ``Database``/``EventBus``/``BotManager``/``AccountService`` 를
+    함께 구성하는 async context manager (#1857).
+
+    이전 시그니처(``async def`` → ``tuple[Database, EventBus, BotManager,
+    AccountService]``)에서 ``open_cli_db`` 기반 async context manager 로 전환
+    했다 (#1855 factory composition, #1856 account.py 패턴 1:1 미러). 호출
+    패턴:
+
+        async with _create_services(ctx=ctx) as (db, eventbus, mgr, account_service):
+            ...
+
+    ``open_cli_db`` 가 normal/exception/cancellation 모든 경로에서
+    ``Database.close()`` 를 보장하므로 (#1722/#1755 cleanup invariant),
+    callsite 의 ``try/finally: await db.close()`` 패턴이 제거된다 (#1799
+    회귀 lock 재미러).
+
+    Args:
+        ctx: Click 컨텍스트. ``None`` 이면 ``click.get_current_context``
+            (silent=True) 로 fallback 해 ctx-less call sites 와의 하위 호환을
+            유지한다. 신규 호출은 항상 ctx 명시 전달이 권장된다
+            (offline-factory.md §3.1).
+
+    Yields:
+        ``initialize()`` 가 완료된 ``(db, eventbus, manager, account_service)``
+        4-tuple. ``BotManager``/``AccountService`` 의 ``initialize()`` 호출은
+        그대로 보존된다 (#1854 §4.2 명시 예외는 ``AuditLogger`` /
+        ``DynamicConfigService`` 만; 본 helper 는 read-only skip 적용 안 함).
+
+    Cleanup invariant:
+        - ``open_cli_db`` 가 ``BaseException`` 까지 catch 하므로 service
+          ``initialize()`` 가 raise 해도 ``Database.close()`` 가 1회 호출된다.
+    """
     from ante.account.service import AccountService
     from ante.bot.manager import BotManager
-    from ante.cli.main import get_db_path
-    from ante.core.database import Database
     from ante.eventbus.bus import EventBus
 
-    db = Database(get_db_path())
-    await db.connect()
-    eventbus = EventBus()
-    account_service = AccountService(db=db, eventbus=eventbus)
-    await account_service.initialize()
-    manager = BotManager(eventbus=eventbus, db=db)
-    await manager.initialize()
-    return db, eventbus, manager, account_service
+    resolved_ctx = ctx if ctx is not None else click.get_current_context(silent=True)
+    if resolved_ctx is None:
+        raise ValueError(
+            "_create_services requires a Click context "
+            "(explicit ctx or active click.get_current_context)"
+        )
+
+    async with open_cli_db(resolved_ctx) as db:
+        eventbus = EventBus()
+        account_service = AccountService(db=db, eventbus=eventbus)
+        await account_service.initialize()
+        manager = BotManager(eventbus=eventbus, db=db)
+        await manager.initialize()
+        yield db, eventbus, manager, account_service
 
 
 async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
@@ -61,16 +110,26 @@ async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
         logger.warning("감사 로그 기록 실패: %s", e)
 
 
-async def _run_bot_remove_cold_path(bot_id: str) -> dict:
-    """서버 정지 상태에서 BotManager 없이 봇을 soft-delete한다."""
-    from ante.bot.cold_path import cold_path_remove_bot
-    from ante.cli.main import get_config_dir, get_db_path
-    from ante.config import Config
-    from ante.core.database import Database
+async def _run_bot_remove_cold_path(
+    bot_id: str, ctx: click.Context | None = None
+) -> dict:
+    """서버 정지 상태에서 BotManager 없이 봇을 soft-delete한다.
 
-    db = Database(get_db_path())
-    await db.connect()
-    try:
+    #1857: ``open_cli_db`` 기반 lifecycle 로 전환했다. ``ctx`` 가 ``None`` 이면
+    ``click.get_current_context`` 로 fallback 한다 (callsite 하위 호환).
+    """
+    from ante.bot.cold_path import cold_path_remove_bot
+    from ante.cli.main import get_config_dir
+    from ante.config import Config
+
+    resolved_ctx = ctx if ctx is not None else click.get_current_context(silent=True)
+    if resolved_ctx is None:
+        raise ValueError(
+            "_run_bot_remove_cold_path requires a Click context "
+            "(explicit ctx or active click.get_current_context)"
+        )
+
+    async with open_cli_db(resolved_ctx) as db:
         config = Config.load(config_dir=get_config_dir())
         strategies_dir = Path(str(config.get("strategy.dir", "strategies")))
         return await cold_path_remove_bot(
@@ -78,8 +137,6 @@ async def _run_bot_remove_cold_path(bot_id: str) -> dict:
             bot_id,
             strategies_dir=strategies_dir,
         )
-    finally:
-        await db.close()
 
 
 @bot.command("list")
@@ -105,8 +162,10 @@ def bot_list(ctx: click.Context, account_id: str | None) -> None:
         account_id = reject_invalid_account_id(account_id, fmt, context="cli.bot.list")
 
     async def _run_list() -> list[dict]:
-        db, _, _, _ = await _create_services()
-        try:
+        # #1857: ``_create_services`` 를 async context manager 로 변환했다.
+        # ``open_cli_db`` 가 normal/exception/cancellation 모든 경로에서
+        # ``Database.close()`` 를 보장한다 (#1799 회귀 lock 재미러).
+        async with _create_services(ctx=ctx) as (db, _, _, _):
             if account_id is not None:
                 rows = await db.fetch_all(
                     "SELECT bot_id, name, strategy_id, account_id, status, created_at"
@@ -119,8 +178,6 @@ def bot_list(ctx: click.Context, account_id: str | None) -> None:
                     " FROM bots WHERE status != 'deleted'"
                 )
             return [dict(r) for r in rows]
-        finally:
-            await db.close()
 
     result = _run(_run_list())
 
@@ -147,12 +204,10 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_info() -> dict | None:
-        db, _, _, _ = await _create_services()
-        try:
+        # #1857: ``_create_services`` async context manager 전환.
+        async with _create_services(ctx=ctx) as (db, _, _, _):
             row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = ?", (bot_id,))
             return dict(row) if row else None
-        finally:
-            await db.close()
 
     result = _run(_run_info())
 
@@ -294,11 +349,12 @@ def bot_create(
         # 가 항상 보장된다. JSON envelope code (``BOT_MISSING_REQUIRED_ACCOUNT``)
         # 는 종전 동작 그대로다 (이슈 본질은 process termination 보장).
         async def _list_accounts() -> list:
-            db, _, _, account_service = await _create_services()
-            try:
+            # #1857: ``_create_services`` async context manager 전환. #1799
+            # cleanup invariant (resolver SystemExit 이후에도 db 가 close 되어
+            # process termination 보장) 는 ``open_cli_db`` body close 가 그대로
+            # 유지한다.
+            async with _create_services(ctx=ctx) as (_, _, _, account_service):
                 return await account_service.list(status=AccountStatus.ACTIVE)
-            finally:
-                await db.close()
 
         accounts = _run(_list_accounts())
         account_id = _resolve_account_non_interactive(accounts, fmt)
@@ -370,7 +426,7 @@ def bot_remove(ctx: click.Context, bot_id: str, yes: bool) -> None:
 
         if is_active_runtime():
             return await ipc_send("bot.remove", {"bot_id": bot_id}, actor=actor)
-        return await _run_bot_remove_cold_path(bot_id)
+        return await _run_bot_remove_cold_path(bot_id, ctx=ctx)
 
     try:
         result = _run(_run_remove())
@@ -404,10 +460,10 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_signal_key() -> dict:
+        # #1857: ``_create_services`` async context manager 전환.
         from ante.bot.signal_key import SignalKeyManager
 
-        db, _, _, _ = await _create_services()
-        try:
+        async with _create_services(ctx=ctx) as (db, _, _, _):
             skm = SignalKeyManager(db)
             await skm.initialize()
 
@@ -492,8 +548,6 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
             if not key:
                 return {"bot_id": bot_id, "signal_key": None}
             return {"bot_id": bot_id, "signal_key": key}
-        finally:
-            await db.close()
 
     try:
         result = _run(_run_signal_key())
@@ -557,16 +611,17 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_positions() -> list[dict] | None:
-        from ante.cli.main import get_db_path
-        from ante.core.database import Database
+        # #1857: ``open_cli_db`` 헬퍼가 service ``initialize()`` /
+        # ``get_positions()`` 예외 / cancellation 모든 경로에서
+        # ``Database.close()`` 1회 호출을 보장한다 (#1722/#1799 cleanup
+        # invariant). ``--db-path`` override 는 ctx 의 ``get_db_path(ctx)``
+        # resolution 으로 흡수된다.
         from ante.trade.performance import PerformanceTracker
         from ante.trade.position import PositionHistory
         from ante.trade.recorder import TradeRecorder
         from ante.trade.service import TradeService
 
-        db = Database(get_db_path())
-        await db.connect()
-        try:
+        async with open_cli_db(ctx) as db:
             # 미존재 bot 을 "실재 bot 의 0 포지션" 과 구분하기 위해 포지션 조회
             # 전에 bot 존재를 먼저 확인한다. 미존재면 sentinel ``None`` 을
             # 반환하고, 실재 bot 이면 (0개 포함) list 를 반환한다 (#1558).
@@ -606,8 +661,6 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
                 }
                 for p in positions
             ]
-        finally:
-            await db.close()
 
     result = _run(_run_positions())
 
@@ -779,13 +832,11 @@ def bot_logs(
         raise SystemExit(1)
 
     async def _run_logs() -> dict:
-        from ante.cli.main import get_db_path
-        from ante.core.database import Database
+        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799). ``--config-dir``
+        # / ``ANTE_CONFIG_DIR`` 를 통한 ``get_db_path(ctx)`` resolution 동일.
         from ante.eventbus.history import EventHistoryStore
 
-        db = Database(get_db_path(ctx))
-        await db.connect()
-        try:
+        async with open_cli_db(ctx) as db:
             try:
                 bot_row = await db.fetch_one(
                     "SELECT 1 FROM bots WHERE bot_id = ? AND status != 'deleted'",
@@ -826,8 +877,6 @@ def bot_logs(
                 for row in rows
             ]
             return {"bot_id": bot_id, "logs": logs, "total": total}
-        finally:
-            await db.close()
 
     result = _run(_run_logs())
     if result.get("missing"):

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -22,6 +22,10 @@ def _run(coro):  # noqa: ANN001, ANN202
 
 
 async def _create_account_service():  # noqa: ANN202
+    # #1857: broker live-state 경로 (adapter.connect 동반) 는 본 PR scope
+    # 외다. live broker state 와 ``Database`` lifecycle 이 같은 try/except 로
+    # 엮여 있어 단순 ``open_cli_db`` wrap 으로 동치 변환이 불가능하다.
+    # 별도 spec 정렬 PR (부모 epic #1818 follow-up) 에서 다룬다.
     from ante.account.service import AccountService
     from ante.cli.main import get_db_path
     from ante.core.database import Database
@@ -337,7 +341,10 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
 
             result = _run(_run_ipc_reconcile())
         except click.ClickException:
-            # 서버 미실행 — 기존 오프라인 방식 폴백
+            # 서버 미실행 — 기존 오프라인 방식 폴백.
+            # #1857: broker live-state (adapter + DB) 경로는 본 PR scope 외다
+            # — 별도 spec 정렬 PR (#1818 follow-up) 에서 ``open_cli_db`` 와
+            # adapter lifecycle 의 동치 변환 contract 를 정합한다.
             async def _run_reconcile() -> dict:
                 from ante.cli.main import get_db_path
                 from ante.core.database import Database

--- a/src/ante/cli/commands/config.py
+++ b/src/ante/cli/commands/config.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
 import click
 
+from ante.cli.db_context import open_cli_db
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+if TYPE_CHECKING:
+    from ante.config.config import Config
+    from ante.config.dynamic import DynamicConfigService
+    from ante.core.database import Database
 
 
 @click.group()
@@ -21,20 +30,51 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
-async def _create_services():  # noqa: ANN202
-    from ante.cli.main import get_config_dir, get_db_path
+@asynccontextmanager
+async def _create_services(
+    ctx: click.Context | None = None,
+) -> AsyncIterator[tuple[Config, DynamicConfigService, Database]]:
+    """CLI 에서 ``Config`` / ``DynamicConfigService`` / ``Database`` 를 함께
+    구성하는 async context manager (#1857).
+
+    이전 시그니처(``async def`` → ``tuple[Config, DynamicConfigService,
+    Database]``)에서 ``open_cli_db`` 기반 async context manager 로 전환했다
+    (#1855 factory composition, #1856 account.py 패턴 1:1 미러). 호출 패턴:
+
+        async with _create_services(ctx=ctx) as (static_config, dynamic, db):
+            ...
+
+    Args:
+        ctx: Click 컨텍스트. ``None`` 이면 ``click.get_current_context``
+            (silent=True) 로 fallback. 신규 호출은 ctx 명시 전달 권장.
+
+    Yields:
+        ``DynamicConfigService.initialize()`` 가 완료된 3-tuple. #1854 §4.2
+        명시 예외에 따라 ``DynamicConfigService.initialize()`` 호출을 보존한다
+        (read-only operation 의 read-only 검증을 위한 schema bootstrap).
+
+    Cleanup invariant:
+        - ``open_cli_db`` 가 ``BaseException`` 까지 catch — service init 실패
+          시에도 ``Database.close()`` 보장 (#1722 회귀 lock).
+    """
+    from ante.cli.main import get_config_dir
     from ante.config.config import Config
     from ante.config.dynamic import DynamicConfigService
-    from ante.core.database import Database
     from ante.eventbus.bus import EventBus
 
-    db = Database(get_db_path())
-    await db.connect()
-    eventbus = EventBus()
-    static_config = Config.load(config_dir=get_config_dir())
-    dynamic = DynamicConfigService(db, eventbus)
-    await dynamic.initialize()
-    return static_config, dynamic, db
+    resolved_ctx = ctx if ctx is not None else click.get_current_context(silent=True)
+    if resolved_ctx is None:
+        raise ValueError(
+            "_create_services requires a Click context "
+            "(explicit ctx or active click.get_current_context)"
+        )
+
+    async with open_cli_db(resolved_ctx) as db:
+        eventbus = EventBus()
+        static_config = Config.load(config_dir=get_config_dir())
+        dynamic = DynamicConfigService(db, eventbus)
+        await dynamic.initialize()
+        yield static_config, dynamic, db
 
 
 async def _resolve_single(key, static_config, dynamic) -> dict:  # noqa: ANN001
@@ -108,13 +148,11 @@ def config_get(ctx: click.Context, key: str | None) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_get() -> dict | list[dict]:
-        static_config, dynamic, db = await _create_services()
-        try:
+        # #1857: ``_create_services`` async context manager 전환.
+        async with _create_services(ctx=ctx) as (static_config, dynamic, db):
             if key is not None:
                 return await _resolve_single(key, static_config, dynamic)
             return await _resolve_all(static_config, db)
-        finally:
-            await db.close()
 
     result = _run(_run_get())
 
@@ -207,11 +245,9 @@ def config_history(ctx: click.Context, key: str, limit: int) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_history() -> list[dict]:
-        _, dynamic, db = await _create_services()
-        try:
+        # #1857: ``_create_services`` async context manager 전환.
+        async with _create_services(ctx=ctx) as (_, dynamic, _):
             return await dynamic.get_history(key, limit=limit)
-        finally:
-            await db.close()
 
     rows = _run(_run_history())
 

--- a/src/ante/cli/commands/instrument.py
+++ b/src/ante/cli/commands/instrument.py
@@ -6,6 +6,7 @@ import asyncio
 
 import click
 
+from ante.cli.db_context import open_cli_db
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 from ante.core.exchange import CANONICAL_EXCHANGES, is_canonical
@@ -53,12 +54,9 @@ def instrument_list(
     db_path: str | None,
 ) -> None:
     """등록된 종목 목록 조회."""
-    from ante.cli.main import get_db_path
-    from ante.core.database import Database
     from ante.instrument.service import InstrumentService
 
     fmt = get_formatter(ctx)
-    resolved_db_path = db_path or get_db_path(ctx)
 
     # Axis 1 — ingress 옵션 검증: exchange 사용 전 canonical 검증.
     # `*` 도 비-canonical이라 거부됨 (StrategyMeta 전용 wildcard).
@@ -70,9 +68,10 @@ def instrument_list(
         ctx.exit(1)
 
     async def _run() -> list[dict]:
-        db = Database(resolved_db_path)
-        await db.connect()
-        try:
+        # #1857: ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
+        # ``db_path_override`` 로 전달 — offline-factory.md §1.1 caller 산출
+        # 경로 패턴.
+        async with open_cli_db(ctx, db_path_override=db_path) as db:
             svc = InstrumentService(db)
             await svc.initialize()
 
@@ -98,8 +97,6 @@ def instrument_list(
                 }
                 for r in rows
             ]
-        finally:
-            await db.close()
 
     results = asyncio.run(_run())
 
@@ -123,14 +120,12 @@ def sync(
 ) -> None:
     """KIS API에서 종목 마스터 데이터를 동기화."""
     from ante.broker.kis import KISAdapter
-    from ante.cli.main import get_config_dir, get_db_path
+    from ante.cli.main import get_config_dir
     from ante.config import Config
-    from ante.core.database import Database
     from ante.instrument.models import Instrument
     from ante.instrument.service import InstrumentService
 
     fmt = get_formatter(ctx)
-    resolved_db_path = db_path or get_db_path(ctx)
     resolved_config_dir = get_config_dir(ctx)
 
     # Axis 1 — ingress 옵션 검증: 비-canonical exchange 거부 (KISAdapter
@@ -158,14 +153,14 @@ def sync(
         ctx.exit(1)
 
     async def _run() -> dict:
+        # #1857: ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
+        # ``db_path_override`` 로 전달.
         config = Config.load(config_dir=resolved_config_dir)
         broker_config = config.get("broker", {})
         if not broker_config.get("app_key"):
             return {"error": "브로커 설정이 없습니다."}
 
-        db = Database(resolved_db_path)
-        await db.connect()
-        try:
+        async with open_cli_db(ctx, db_path_override=db_path) as db:
             svc = InstrumentService(db)
             await svc.initialize()
 
@@ -221,8 +216,6 @@ def sync(
                 "updated": updated_count,
                 "delisted": len(delisted),
             }
-        finally:
-            await db.close()
 
     result = asyncio.run(_run())
 
@@ -259,17 +252,14 @@ def search(
     db_path: str | None,
 ) -> None:
     """키워드로 종목 검색 (종목코드, 한글명, 영문명)."""
-    from ante.cli.main import get_db_path
-    from ante.core.database import Database
     from ante.instrument.service import InstrumentService
 
     fmt = get_formatter(ctx)
-    resolved_db_path = db_path or get_db_path(ctx)
 
     async def _run() -> list[dict]:
-        db = Database(resolved_db_path)
-        await db.connect()
-        try:
+        # #1857: ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
+        # ``db_path_override`` 로 전달.
+        async with open_cli_db(ctx, db_path_override=db_path) as db:
             svc = InstrumentService(db)
             await svc.initialize()
             instruments = await svc.search(
@@ -287,8 +277,6 @@ def search(
                 }
                 for inst in instruments
             ]
-        finally:
-            await db.close()
 
     results = asyncio.run(_run())
 
@@ -316,13 +304,11 @@ def instrument_import(
     import json
     from pathlib import Path
 
-    from ante.cli.main import get_db_path
     from ante.instrument.models import Instrument
 
     fmt = get_formatter(ctx)
     path = Path(file_path)
     ext = path.suffix.lower()
-    resolved_db_path = db_path or get_db_path(ctx)
 
     # 파일 형식 확인 (try 블록 밖에서 분기 — ctx.exit(1)이 같은 try의
     # except Exception에 잡혀 swallow되는 것을 방지)
@@ -455,17 +441,14 @@ def instrument_import(
         return
 
     async def _import() -> int:
-        from ante.core.database import Database
+        # #1857: ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
+        # ``db_path_override`` 로 전달.
         from ante.instrument.service import InstrumentService
 
-        db = Database(resolved_db_path)
-        await db.connect()
-        try:
+        async with open_cli_db(ctx, db_path_override=db_path) as db:
             svc = InstrumentService(db)
             await svc.initialize()
             return await svc.bulk_upsert(instruments)
-        finally:
-            await db.close()
 
     count = asyncio.run(_import())
     fmt.success(

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -10,6 +10,7 @@ import click
 from pydantic import ValidationError
 
 from ante.cli._validators import reject_inverted_date_range, validate_iso_date
+from ante.cli.db_context import open_cli_db
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
@@ -345,13 +346,10 @@ def report_performance(
     )
 
     async def _run_performance() -> list[dict]:
-        from ante.cli.main import get_db_path
-        from ante.core.database import Database
+        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799 cleanup invariant).
         from ante.trade.performance import PerformanceTracker
 
-        db = Database(get_db_path())
-        await db.connect()
-        try:
+        async with open_cli_db(ctx) as db:
             tracker = PerformanceTracker(db)
             if period == "daily":
                 daily_summaries = await tracker.get_daily_summary(
@@ -366,8 +364,6 @@ def report_performance(
                     year=year,
                 )
                 return [asdict(s) for s in monthly_summaries]
-        finally:
-            await db.close()
 
     result = asyncio.run(_run_performance())
 

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -6,14 +6,22 @@ import asyncio
 import json
 import logging
 import sqlite3
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
 import click
 
 from ante.account.errors import AccountNotFoundError
 from ante.cli._validators import reject_invalid_account_id
+from ante.cli.db_context import open_cli_db
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.rule.engine import RuleEngine
 
 logger = logging.getLogger(__name__)
 
@@ -27,44 +35,50 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
-async def _create_rule_engine(account_id: str):  # noqa: ANN202
-    """CLI용 RuleEngine 생성.
+@asynccontextmanager
+async def _create_rule_engine(
+    account_id: str, *, ctx: click.Context | None = None
+) -> AsyncIterator[tuple[RuleEngine, Database]]:
+    """CLI용 RuleEngine async context manager (#1857).
+
+    이전 시그니처(``async def`` → ``tuple[RuleEngine, Database]``)에서
+    ``open_cli_db`` 기반 async context manager 로 전환했다 (#1855 factory
+    composition, #1856 account.py 패턴 1:1 미러). 호출 패턴:
+
+        async with _create_rule_engine(account_id, ctx=ctx) as (engine, db):
+            ...
 
     호출자가 ``--account`` 옵션으로 검증된 ``account_id`` 를 반드시 전달
     해야 한다. fallback 정책상 첫 번째 계좌를 임의로 선택해선 안 된다
     (#1217). ``RuleEngine`` 생성자가 내부에서 ``require_account_id`` 로
     재검증한다.
 
-    invalid ``account_id`` 검증은 ``db.connect()`` **이전**에 수행한다
-    (#1635 Split B Layer 2 — ``treasury.py:37`` ``_create_treasury`` 패턴
-    1:1 미러). 기존 구조는 ``db.connect()`` 후 ``RuleEngine(account_id=...)``
-    내부 ``require_account_id`` 가 raise하여 ``(engine, db)`` 가 미반환 →
-    호출자 ``finally: db.close()`` 미도달 → aiosqlite connection 누수
-    (#1623 Codex finding, lifecycle). resource acquisition 이전에 검증·raise
-    하면 획득 자원이 0이라 정리 대상도 0 — 누수 구조 자체를 제거한다.
-    ``RuleEngine.__init__`` 내부 ``require_account_id``(``engine.py:270``)는
-    defense-in-depth로 그대로 유지한다(무변경).
+    invalid ``account_id`` 검증은 ``open_cli_db`` (==``db.connect()``)
+    **이전**에 수행한다(#1635 Split B Layer 2 — ``treasury.py:37``
+    ``_create_treasury`` 패턴 1:1 미러). resource acquisition 이전에
+    검증·raise 하면 획득 자원이 0이라 정리 대상도 0 — 누수 구조 자체를
+    제거한다 (#1623 lifecycle invariant). ``RuleEngine.__init__`` 내부
+    ``require_account_id`` 는 defense-in-depth 그대로 유지.
 
-    valid-format이지만 DB에 없는 ``account_id`` (예: ``acc-9999``)는
+    valid-format 이지만 DB에 없는 ``account_id`` (예: ``acc-9999``)는
     ``RuleEngine`` 생성 **이전**에 lightweight ``SELECT 1`` 로 존재를
-    검증해 ``AccountNotFoundError`` 로 분기한다(#1726, ``rule list`` 의
-    기존 inline 블록을 SSOT consolidation으로 helper로 이동). 이 검증을
-    helper에 두면 ``rule list`` 외에도 ``info`` 등 다른 rule 명령에
-    동일하게 적용되며, rule lookup 보다 account existence가 먼저 보고된다.
-    실패 시 ``except BaseException`` 블록으로 ``db.close()`` 를 보장한다
-    (``_create_treasury`` (#1722) 동형 cleanup).
+    검증해 ``AccountNotFoundError`` 로 분기한다(#1726). ``open_cli_db`` 가
+    ``BaseException`` 까지 catch 하므로 cleanup 보장된다 (#1722 동형).
     """
     from ante.account.scoping import require_account_id
-    from ante.cli.main import get_db_path
-    from ante.core.database import Database
     from ante.eventbus.bus import EventBus
     from ante.rule.engine import RuleEngine
 
     validated_account_id = require_account_id(account_id, context="cli.rule")
 
-    db = Database(get_db_path())
-    try:
-        await db.connect()
+    resolved_ctx = ctx if ctx is not None else click.get_current_context(silent=True)
+    if resolved_ctx is None:
+        raise ValueError(
+            "_create_rule_engine requires a Click context "
+            "(explicit ctx or active click.get_current_context)"
+        )
+
+    async with open_cli_db(resolved_ctx) as db:
         # account existence pre-check. ``rule_list`` 의 기존 inline 블록을
         # 그대로 옮긴 형태이며, ``_create_treasury`` 동형 (#1725).
         #
@@ -104,16 +118,7 @@ async def _create_rule_engine(account_id: str):  # noqa: ANN202
             )
         eventbus = EventBus()
         engine = RuleEngine(eventbus=eventbus, account_id=validated_account_id)
-    except BaseException:
-        try:
-            await db.close()
-        except Exception:
-            logger.debug(
-                "db.close() after rule engine init failure raised — ignored",
-                exc_info=True,
-            )
-        raise
-    return engine, db
+        yield engine, db
 
 
 def _load_rules_from_config(engine) -> None:  # noqa: ANN001
@@ -191,8 +196,8 @@ def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> 
         # 검증한다(#1726 SSOT consolidation — 기존 여기 inline 블록을 helper
         # 로 이동). 미존재 account는 ``AccountNotFoundError`` 로 raise되며
         # 아래 호출 표면의 ``except AccountNotFoundError`` 분기가 받는다.
-        engine, db = await _create_rule_engine(account_id)
-        try:
+        # #1857: ``_create_rule_engine`` async context manager 전환.
+        async with _create_rule_engine(account_id, ctx=ctx) as (engine, _):
             try:
                 _load_rules_from_config(engine)
             except Exception as e:
@@ -209,8 +214,6 @@ def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> 
                     )
                 ]
             return rules
-        finally:
-            await db.close()
 
     try:
         result = _run(_run_list())
@@ -251,16 +254,14 @@ def rule_info(ctx: click.Context, rule_id: str, account_id: str) -> None:
     reject_invalid_account_id(account_id, fmt, context="cli.rule")
 
     async def _run_info() -> dict | None:
-        engine, db = await _create_rule_engine(account_id)
-        try:
+        # #1857: ``_create_rule_engine`` async context manager 전환.
+        async with _create_rule_engine(account_id, ctx=ctx) as (engine, _):
             try:
                 _load_rules_from_config(engine)
             except Exception as e:
                 logger.warning("룰 설정 로드 실패: %s", e)
             rules = _collect_rules(engine)
             return next((r for r in rules if r["rule_id"] == rule_id), None)
-        finally:
-            await db.close()
 
     try:
         result = _run(_run_info())
@@ -364,17 +365,19 @@ def rule_update(
                 actor=actor,
             )
 
+        # #1857: cold-path ``rule update`` lifecycle 을 ``open_cli_db`` 로
+        # 전환했다. ``AccountService``/``DynamicConfigService``/``AuditLogger``
+        # ``initialize()`` 호출은 그대로 유지된다 — #1854 §4.2 명시 예외는
+        # AuditLogger/DynamicConfigService만이고, 본 callsite 는 audit 기록을
+        # 동반하는 cold-path mutation 이라 안전성을 위해 모두 보존한다.
         from ante.account.service import AccountService
         from ante.audit import AuditLogger
-        from ante.cli.main import get_config_dir, get_db_path
+        from ante.cli.main import get_config_dir
         from ante.config import Config, DynamicConfigService
-        from ante.core.database import Database
         from ante.eventbus.bus import EventBus
         from ante.rule.config_update import update_account_rule_config
 
-        db = Database(get_db_path(ctx))
-        await db.connect()
-        try:
+        async with open_cli_db(ctx) as db:
             eventbus = EventBus()
             account_service = AccountService(db=db, eventbus=eventbus)
             await account_service.initialize()
@@ -394,8 +397,6 @@ def rule_update(
                 config=config,
                 audit_logger=audit_logger,
             )
-        finally:
-            await db.close()
 
     try:
         result = _run(_run_update())

--- a/src/ante/cli/commands/signal.py
+++ b/src/ante/cli/commands/signal.py
@@ -29,7 +29,13 @@ def signal_connect(ctx: click.Context, key: str) -> None:
 
 
 async def _run_connect(ctx: click.Context, key: str) -> None:
-    """시그널 채널 연결 및 실행."""
+    """시그널 채널 연결 및 실행.
+
+    #1857: 본 명령은 ``SignalChannel`` 을 통해 외부 시그널 소스 (HTTP/WS 등)
+    와 long-lived loop 를 형성한다. ``Database`` lifecycle 이 external process
+    runtime 과 엮여 있어 단순 ``open_cli_db`` async-context wrap 으로 동치
+    변환이 불가능하다 — 별도 spec 정렬 PR (#1818 follow-up) 에서 다룬다.
+    """
     from ante.bot.config import BotStatus
     from ante.bot.manager import BotManager
     from ante.bot.signal_channel import SignalChannel

--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -4,18 +4,26 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import asdict
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
 from ante.account.errors import AccountNotFoundError
 from ante.cli._validators import reject_invalid_account_id
+from ante.cli.db_context import open_cli_db
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 from ante.contracts import emit_cli_error
 from ante.strategy.registry import StrategyStatus
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.strategy.registry import StrategyRegistry
 
 # `StrategyStatus` enum이 단일 SSOT이며 (#1463에서 임시 frozenset 복사본 제거),
 # `ante.strategy.__init__`의 lazy ``__getattr__`` 정리로 본 import가 heavy
@@ -32,20 +40,38 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
-async def _create_registry():  # noqa: ANN202
-    from ante.cli.main import get_db_path
-    from ante.core.database import Database
+@asynccontextmanager
+async def _create_registry(
+    ctx: click.Context | None = None,
+) -> AsyncIterator[tuple[StrategyRegistry, Database]]:
+    """CLI 에서 ``StrategyRegistry`` async context manager (#1857).
+
+    이전 시그니처(``async def`` → ``tuple[StrategyRegistry, Database]``)에서
+    ``open_cli_db`` 기반 async context manager 로 전환했다 (#1855 factory
+    composition, #1856 account.py 패턴 1:1 미러). 호출 패턴:
+
+        async with _create_registry(ctx=ctx) as (registry, db):
+            ...
+
+    fresh DB에서도 strategies 테이블이 존재하도록 helper 차원에서
+    보장한다. ``register/get_by_name/list_strategies`` 등 모든 caller 에
+    자동 적용되며, idempotent하므로 기존 명시 ``await registry.initialize()``
+    호출은 회귀 안전을 위해 보존한다 (#1753 — #1854 §4.2 도 read-only 명시
+    예외 대상이지만 본 helper 는 안전성을 위해 호출을 그대로 보존한다).
+    """
     from ante.strategy.registry import StrategyRegistry
 
-    db = Database(get_db_path())
-    await db.connect()
-    registry = StrategyRegistry(db)
-    # fresh DB에서도 strategies 테이블이 존재하도록 helper 차원에서
-    # 보장한다. `register/get_by_name/list_strategies` 등 모든 caller에
-    # 자동 적용되며, idempotent하므로 기존의 명시 `await registry.initialize()`
-    # 호출은 회귀 안전을 위해 보존한다 (#1753).
-    await registry.initialize()
-    return registry, db
+    resolved_ctx = ctx if ctx is not None else click.get_current_context(silent=True)
+    if resolved_ctx is None:
+        raise ValueError(
+            "_create_registry requires a Click context "
+            "(explicit ctx or active click.get_current_context)"
+        )
+
+    async with open_cli_db(resolved_ctx) as db:
+        registry = StrategyRegistry(db)
+        await registry.initialize()
+        yield registry, db
 
 
 async def _find_bot_id_for_strategy(db, strategy_id: str) -> str | None:  # noqa: ANN001
@@ -223,8 +249,8 @@ def submit(ctx: click.Context, path: str) -> None:
 
     # 4. Registry 등록
     async def _register() -> dict:
-        registry, db = await _create_registry()
-        try:
+        # #1857: ``_create_registry`` async context manager 전환.
+        async with _create_registry(ctx=ctx) as (registry, _):
             await registry.initialize()
             record = await registry.register(
                 filepath=filepath,
@@ -245,8 +271,6 @@ def submit(ctx: click.Context, path: str) -> None:
                 "registered_at": record.registered_at.isoformat(),
                 "validation_warnings": record.validation_warnings,
             }
-        finally:
-            await db.close()
 
     try:
         result = _run(_register())
@@ -305,8 +329,8 @@ def strategy_list(ctx: click.Context, status: str | None) -> None:
         raise SystemExit(1)
 
     async def _list() -> list[dict]:
-        registry, db = await _create_registry()
-        try:
+        # #1857: ``_create_registry`` async context manager 전환.
+        async with _create_registry(ctx=ctx) as (registry, _):
             filter_status = StrategyStatus(status) if status else None
             records = await registry.list_strategies(status=filter_status)
             return [
@@ -322,8 +346,6 @@ def strategy_list(ctx: click.Context, status: str | None) -> None:
                 }
                 for r in records
             ]
-        finally:
-            await db.close()
 
     # account.py:683-687 패턴: click.ClickException은 그대로 전파해 click의
     # 표준 출력 경로를 보존하고, 나머지 일반 Exception은 STRATEGY_ERROR로
@@ -390,8 +412,8 @@ def strategy_set_status(ctx: click.Context, strategy_id: str, status: str) -> No
                 actor=actor,
             )
 
-        registry, db = await _create_registry()
-        try:
+        # #1857: ``_create_registry`` async context manager 전환.
+        async with _create_registry(ctx=ctx) as (registry, _):
             await registry.initialize()
             await registry.update_status(strategy_id, target_status)
             record = await registry.get(strategy_id)
@@ -401,8 +423,6 @@ def strategy_set_status(ctx: click.Context, strategy_id: str, status: str) -> No
                 "name": record.name if record else "",
                 "version": record.version if record else "",
             }
-        finally:
-            await db.close()
 
     try:
         result = _run(_set_status())
@@ -439,8 +459,8 @@ def strategy_info(ctx: click.Context, name: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _info() -> dict | None:
-        registry, db = await _create_registry()
-        try:
+        # #1857: ``_create_registry`` async context manager 전환.
+        async with _create_registry(ctx=ctx) as (registry, _):
             records = await registry.get_by_name(name)
             if not records:
                 return None
@@ -483,8 +503,6 @@ def strategy_info(ctx: click.Context, name: str) -> None:
                 ]
 
             return result
-        finally:
-            await db.close()
 
     # 호출 표면 try/except: fresh DB 또는 race 상황의
     # `sqlite3.OperationalError: no such table: strategies` 는 not-found 로
@@ -617,10 +635,10 @@ def strategy_summary(ctx: click.Context, strategy_id: str, period: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _summary() -> dict | None:
+        # #1857: ``_create_registry`` async context manager 전환.
         from ante.trade.performance import PerformanceTracker
 
-        registry, db = await _create_registry()
-        try:
+        async with _create_registry(ctx=ctx) as (registry, db):
             await registry.initialize()
             record = await registry.get(strategy_id)
             if record is None:
@@ -646,8 +664,6 @@ def strategy_summary(ctx: click.Context, strategy_id: str, period: str) -> None:
                 "bot_id": bot_id,
                 "items": items,
             }
-        finally:
-            await db.close()
 
     try:
         result = _run(_summary())
@@ -711,14 +727,11 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
     )
 
     async def _perf() -> dict | None:
-        from ante.cli.main import get_db_path
-        from ante.core.database import Database
+        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799 cleanup invariant).
         from ante.strategy.registry import StrategyRegistry
         from ante.trade.performance import PerformanceTracker
 
-        db = Database(get_db_path())
-        await db.connect()
-        try:
+        async with open_cli_db(ctx) as db:
             registry = StrategyRegistry(db)
             # fresh DB에서도 strategies 테이블이 존재하도록 정규화한다
             # (#1753 Codex Plan v2 must-fix 1: `_create_registry` 경로와
@@ -775,8 +788,6 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
                 "strategy_id": record.strategy_id,
                 "metrics": asdict(metrics),
             }
-        finally:
-            await db.close()
 
     try:
         result = _run(_perf())

--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -8,12 +8,20 @@ import os
 import signal
 import subprocess
 import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
 import click
 
+from ante.cli.db_context import open_cli_db
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
 
 logger = logging.getLogger(__name__)
 
@@ -152,16 +160,30 @@ def stop(ctx: click.Context) -> None:
     fmt.success("종료 시그널 전송 완료", {"pid": pid})
 
 
-async def _create_services():  # noqa: ANN202
-    """오프라인 커맨드용 DB/EventBus 생성 헬퍼."""
-    from ante.cli.main import get_db_path
-    from ante.core.database import Database
+@asynccontextmanager
+async def _create_services(
+    ctx: click.Context | None = None,
+) -> AsyncIterator[tuple[Database, EventBus]]:
+    """오프라인/bootstrap 커맨드용 DB/EventBus async context manager (#1857).
+
+    ``open_cli_db`` 기반 lifecycle 로 전환했다 (#1855 factory composition,
+    #1856 account.py 패턴 1:1 미러). 호출 패턴:
+
+        async with _create_services(ctx=ctx) as (db, eventbus):
+            ...
+    """
     from ante.eventbus.bus import EventBus
 
-    db = Database(get_db_path())
-    await db.connect()
-    eventbus = EventBus()
-    return db, eventbus
+    resolved_ctx = ctx if ctx is not None else click.get_current_context(silent=True)
+    if resolved_ctx is None:
+        raise ValueError(
+            "_create_services requires a Click context "
+            "(explicit ctx or active click.get_current_context)"
+        )
+
+    async with open_cli_db(resolved_ctx) as db:
+        eventbus = EventBus()
+        yield db, eventbus
 
 
 @system.command()
@@ -174,10 +196,10 @@ def status(ctx: click.Context) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_status() -> dict:
+        # #1857: ``_create_services`` async context manager 전환.
         from ante.account.service import AccountService
 
-        db, eventbus = await _create_services()
-        try:
+        async with _create_services(ctx=ctx) as (db, eventbus):
             account_service = AccountService(db=db, eventbus=eventbus)
             await account_service.initialize()
 
@@ -194,8 +216,6 @@ def status(ctx: click.Context) -> None:
                 "trading_state": "suspended" if suspended else "active",
                 "bot_count": bot_count,
             }
-        finally:
-            await db.close()
 
     result = _run(_run_status())
 

--- a/src/ante/cli/commands/trade.py
+++ b/src/ante/cli/commands/trade.py
@@ -4,14 +4,22 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import click
 
 from ante.cli._validators import reject_inverted_date_range, validate_iso_date
+from ante.cli.db_context import open_cli_db
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.trade.service import TradeService
 
 
 @click.group()
@@ -23,23 +31,42 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
-async def _create_trade_service():  # noqa: ANN202
-    from ante.cli.main import get_db_path
-    from ante.core.database import Database
+@asynccontextmanager
+async def _create_trade_service(
+    ctx: click.Context | None = None,
+) -> AsyncIterator[tuple[TradeService, Database]]:
+    """CLI 에서 ``TradeService`` async context manager (#1857).
+
+    ``open_cli_db`` 기반 lifecycle 로 전환했다 (#1855 factory composition,
+    #1856 account.py 패턴 1:1 미러). 호출 패턴:
+
+        async with _create_trade_service(ctx=ctx) as (service, db):
+            ...
+
+    ``PositionHistory``/``TradeRecorder`` ``initialize()`` 는 표 생성용으로
+    그대로 보존한다 (#1854 §4.2 예외는 AuditLogger/DynamicConfigService 만;
+    본 helper 는 안전성을 위해 호출 유지).
+    """
     from ante.trade.performance import PerformanceTracker
     from ante.trade.position import PositionHistory
     from ante.trade.recorder import TradeRecorder
     from ante.trade.service import TradeService
 
-    db = Database(get_db_path())
-    await db.connect()
-    position_history = PositionHistory(db=db)
-    await position_history.initialize()
-    recorder = TradeRecorder(db=db, position_history=position_history)
-    await recorder.initialize()
-    performance = PerformanceTracker(db=db)
-    service = TradeService(recorder, position_history, performance)
-    return service, db
+    resolved_ctx = ctx if ctx is not None else click.get_current_context(silent=True)
+    if resolved_ctx is None:
+        raise ValueError(
+            "_create_trade_service requires a Click context "
+            "(explicit ctx or active click.get_current_context)"
+        )
+
+    async with open_cli_db(resolved_ctx) as db:
+        position_history = PositionHistory(db=db)
+        await position_history.initialize()
+        recorder = TradeRecorder(db=db, position_history=position_history)
+        await recorder.initialize()
+        performance = PerformanceTracker(db=db)
+        service = TradeService(recorder, position_history, performance)
+        yield service, db
 
 
 @trade.command("list")
@@ -87,8 +114,8 @@ def trade_list(
     )
 
     async def _run_list() -> list[dict]:
-        service, db = await _create_trade_service()
-        try:
+        # #1857: ``_create_trade_service`` async context manager 전환.
+        async with _create_trade_service(ctx=ctx) as (service, _):
             fd = datetime.fromisoformat(from_date) if from_date else None
             td = datetime.fromisoformat(to_date) if to_date else None
             trades = await service.get_trades(
@@ -112,8 +139,6 @@ def trade_list(
                 }
                 for t in trades
             ]
-        finally:
-            await db.close()
 
     result = _run(_run_list())
 
@@ -150,12 +175,8 @@ def trade_info(ctx: click.Context, trade_id: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_info() -> dict | None:
-        from ante.cli.main import get_db_path
-        from ante.core.database import Database
-
-        db = Database(get_db_path())
-        await db.connect()
-        try:
+        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799 cleanup invariant).
+        async with open_cli_db(ctx) as db:
             # fresh DB 에서는 `trades` 테이블이 아직 생성되지 않은 상태일 수
             # 있다. (`_create_trade_service` 경로와 달리 `trade info` 는
             # raw db 핸들만 쓰고 `TradeRecorder.initialize` 를 거치지 않는다.)
@@ -171,8 +192,6 @@ def trade_info(ctx: click.Context, trade_id: str) -> None:
                     return None
                 raise
             return dict(row) if row else None
-        finally:
-            await db.close()
 
     # 호출 표면 try/except: 위 _run_info 에서 흡수하지 못한 비정상 예외는
     # TRADE_ERROR 로 분류해 raw traceback 노출을 차단한다 (#1753).

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
 
 import click
 
@@ -17,11 +20,17 @@ from ante.cli._validators import (
     validate_nonnegative_finite_amount,
     validate_positive_finite_amount,
 )
+from ante.cli.db_context import open_cli_db
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id as _get_member_id
 from ante.cli.middleware import require_auth, require_scope
 from ante.contracts import emit_cli_error
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.treasury.manager import TreasuryManager
+    from ante.treasury.treasury import Treasury
 
 logger = logging.getLogger(__name__)
 
@@ -35,30 +44,44 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
-async def _create_treasury(account_id: str | None = None):  # noqa: ANN202
-    """CLI에서 Treasury를 생성하는 헬퍼.
+@asynccontextmanager
+async def _create_treasury(
+    account_id: str | None = None,
+    *,
+    ctx: click.Context | None = None,
+) -> AsyncIterator[tuple[Treasury, Database]]:
+    """CLI 에서 ``Treasury`` async context manager (#1857).
 
-    ``db.connect()`` 이후의 모든 라이프사이클(``AccountService.initialize`` /
-    ``AccountService.get`` / ``Treasury.initialize`` 포함)을 ``except
-    BaseException`` 블록으로 감싸 실패 시 ``db.close()``를 보장한다.
-    valid-but-missing account_id(예: ``acc-9999``)가 들어오면
-    ``account_service.get``이 :class:`AccountNotFoundError`를 raise하는데,
-    이 때 aiosqlite 연결이 leak되어 asyncio 종료 시 busy_timeout 대기로 CLI
-    프로세스가 6초 이상 hang하는 회귀를 차단한다(#1725). 본 패턴은
-    ``_create_account_service`` (#1722) byte-for-byte 동형이다.
+    이전 시그니처(``async def`` → ``tuple[Treasury, Database]``)에서
+    ``open_cli_db`` 기반 async context manager 로 전환했다 (#1855 factory
+    composition, #1856 account.py 패턴 1:1 미러). 호출 패턴:
+
+        async with _create_treasury(account_id, ctx=ctx) as (t, db):
+            ...
+
+    ``open_cli_db`` 가 ``BaseException`` 까지 catch 하므로
+    ``AccountService.initialize`` / ``AccountService.get`` / ``Treasury.
+    initialize`` 라이프사이클 실패 시에도 ``db.close()`` 가 보장된다.
+    valid-but-missing account_id(예: ``acc-9999``) 가 들어오면
+    ``account_service.get`` 이 :class:`AccountNotFoundError` 를 raise 하는데,
+    이전 inline 패턴(#1725) 에서 aiosqlite 연결이 leak 되어 6초 hang 회귀가
+    있었고 본 helper 가 동일 cleanup 을 보장한다.
     """
     from ante.account.scoping import require_account_id
     from ante.account.service import AccountService
-    from ante.cli.main import get_db_path
-    from ante.core.database import Database
     from ante.eventbus.bus import EventBus
     from ante.treasury.treasury import Treasury
 
     validated_account_id = require_account_id(account_id, context="cli.treasury")
 
-    db = Database(get_db_path())
-    try:
-        await db.connect()
+    resolved_ctx = ctx if ctx is not None else click.get_current_context(silent=True)
+    if resolved_ctx is None:
+        raise ValueError(
+            "_create_treasury requires a Click context "
+            "(explicit ctx or active click.get_current_context)"
+        )
+
+    async with open_cli_db(resolved_ctx) as db:
         eventbus = EventBus()
         account_service = AccountService(db=db, eventbus=eventbus)
         await account_service.initialize()
@@ -72,48 +95,37 @@ async def _create_treasury(account_id: str | None = None):  # noqa: ANN202
             sell_commission_rate=float(account.sell_commission_rate),
         )
         await t.initialize()
-    except BaseException:
-        try:
-            await db.close()
-        except Exception:
-            logger.debug(
-                "db.close() after init failure raised — ignored", exc_info=True
-            )
-        raise
-    return t, db
+        yield t, db
 
 
-async def _create_treasury_manager():  # noqa: ANN202
-    """CLI에서 TreasuryManager를 생성하는 헬퍼.
+@asynccontextmanager
+async def _create_treasury_manager(
+    ctx: click.Context | None = None,
+) -> AsyncIterator[tuple[TreasuryManager, Database]]:
+    """CLI 에서 ``TreasuryManager`` async context manager (#1857).
 
-    ``_create_treasury`` 동형 cleanup 패턴(#1722). 현재 사용처
-    (``budgets``/``portfolio value`` no-account 분기)는 valid-but-missing
-    account_id를 직접 처리하지 않지만, defense-in-depth로 ``initialize_all``
-    / ``account_service.list`` 등 lifecycle 실패 시에도 db.close를 보장한다.
+    ``_create_treasury`` 동형 패턴. ``open_cli_db`` 가 ``initialize_all`` /
+    ``account_service.list`` 등 lifecycle 실패 시에도 ``db.close()`` 를
+    보장한다.
     """
     from ante.account.service import AccountService
-    from ante.cli.main import get_db_path
-    from ante.core.database import Database
     from ante.eventbus.bus import EventBus
     from ante.treasury.manager import TreasuryManager
 
-    db = Database(get_db_path())
-    try:
-        await db.connect()
+    resolved_ctx = ctx if ctx is not None else click.get_current_context(silent=True)
+    if resolved_ctx is None:
+        raise ValueError(
+            "_create_treasury_manager requires a Click context "
+            "(explicit ctx or active click.get_current_context)"
+        )
+
+    async with open_cli_db(resolved_ctx) as db:
         eventbus = EventBus()
         account_service = AccountService(db=db, eventbus=eventbus)
         await account_service.initialize()
         manager = TreasuryManager(db=db, eventbus=eventbus)
         await manager.initialize_all(await account_service.list())
-    except BaseException:
-        try:
-            await db.close()
-        except Exception:
-            logger.debug(
-                "db.close() after init failure raised — ignored", exc_info=True
-            )
-        raise
-    return manager, db
+        yield manager, db
 
 
 @treasury.command()
@@ -135,11 +147,9 @@ def status(ctx: click.Context, account_id: str) -> None:
     reject_invalid_account_id(account_id, fmt, context="cli.treasury")
 
     async def _run_status() -> dict:
-        t, db = await _create_treasury(account_id)
-        try:
+        # #1857: ``_create_treasury`` async context manager 전환.
+        async with _create_treasury(account_id, ctx=ctx) as (t, _):
             return t.get_summary()
-        finally:
-            await db.close()
 
     # valid-but-missing account_id(예: `acc-9999`)는 `account_service.get`에서
     # `AccountNotFoundError`로 raise된다. Click 기본 핸들러가 typed exception을
@@ -203,12 +213,8 @@ def transactions(
     reject_inverted_date_range(from_date, to_date, fmt)
 
     async def _run_transactions() -> dict:
-        from ante.cli.main import get_db_path
-        from ante.core.database import Database
-
-        db = Database(get_db_path(ctx))
-        await db.connect()
-        try:
+        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799 cleanup invariant).
+        async with open_cli_db(ctx) as db:
             where: list[str] = []
             params: list[str | int] = []
             if account_id:
@@ -254,8 +260,6 @@ def transactions(
                 for r in rows
             ]
             return {"items": items, "total": int(count_row["cnt"]) if count_row else 0}
-        finally:
-            await db.close()
 
     result = _run(_run_transactions())
     if fmt.is_json:
@@ -282,13 +286,10 @@ def budgets(ctx: click.Context, account_id: str | None) -> None:
         )
 
     async def _run_budgets() -> dict:
-        if account_id is not None:
-            t, db = await _create_treasury(account_id)
-            treasuries = [t]
-        else:
-            manager, db = await _create_treasury_manager()
-            treasuries = manager.list_all()
-        try:
+        # #1857: ``_create_treasury`` / ``_create_treasury_manager`` async
+        # context manager 전환. 두 분기 모두 ``open_cli_db`` 가 normal/
+        # exception/cancellation 모든 경로에서 ``db.close()`` 를 보장한다.
+        async def _collect_items(treasuries: list) -> dict:
             items = []
             for treasury_obj in treasuries:
                 for budget in treasury_obj.list_budgets():
@@ -297,8 +298,12 @@ def budgets(ctx: click.Context, account_id: str | None) -> None:
                         data["last_updated"] = budget.last_updated.isoformat()
                     items.append(data)
             return {"budgets": items}
-        finally:
-            await db.close()
+
+        if account_id is not None:
+            async with _create_treasury(account_id, ctx=ctx) as (t, _):
+                return await _collect_items([t])
+        async with _create_treasury_manager(ctx=ctx) as (manager, _):
+            return await _collect_items(manager.list_all())
 
     # valid-but-missing account_id(예: `acc-9999`)는 `_create_treasury` 내부의
     # `account_service.get`에서 `AccountNotFoundError`로 raise된다. Click 기본
@@ -352,16 +357,14 @@ def set_balance(ctx: click.Context, amount: float, account_id: str) -> None:
                 {"account_id": account_id, "balance": amount},
                 actor=actor,
             )
-        t, db = await _create_treasury(account_id)
-        try:
+        # #1857: ``_create_treasury`` async context manager 전환.
+        async with _create_treasury(account_id, ctx=ctx) as (t, _):
             await t.set_account_balance(amount)
             return {
                 "account_id": account_id,
                 "total_balance": t.account_balance,
                 "updated_at": datetime.now(UTC).isoformat(),
             }
-        finally:
-            await db.close()
 
     # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다
     # (#1758, #1725). Click/Exception fallback은 기존(#1722 IPC 분기)을 보존한다.
@@ -590,8 +593,8 @@ def snapshot(
     )
 
     async def _run_snapshot() -> dict | list[dict] | None:
-        t, db = await _create_treasury(account_id)
-        try:
+        # #1857: ``_create_treasury`` async context manager 전환.
+        async with _create_treasury(account_id, ctx=ctx) as (t, _):
             if date_str:
                 return await t.get_daily_snapshot(date_str)
             if from_date or to_date:
@@ -602,8 +605,6 @@ def snapshot(
             # 기본: 오늘 스냅샷
             today = datetime.now(UTC).strftime("%Y-%m-%d")
             return await t.get_daily_snapshot(today)
-        finally:
-            await db.close()
 
     # valid-but-missing account_id 매핑은 status와 동형이다 (#1725).
     try:
@@ -674,13 +675,11 @@ def portfolio_value(ctx: click.Context, account_id: str | None) -> None:
         )
 
     async def _run_value() -> dict:
-        if account_id is not None:
-            t, db = await _create_treasury(account_id)
-            treasuries = [t]
-        else:
-            manager, db = await _create_treasury_manager()
-            treasuries = manager.list_all()
-        try:
+        # #1857: ``_create_treasury`` / ``_create_treasury_manager`` async
+        # context manager 전환. 분기별로 별도 with 블록을 열어 두 분기 모두
+        # ``open_cli_db`` 가 normal/exception/cancellation 경로에서
+        # ``db.close()`` 를 보장한다.
+        async def _collect_values(treasuries: list) -> dict:
             values = []
             for treasury_obj in treasuries:
                 snapshot = await treasury_obj.get_latest_snapshot()
@@ -720,8 +719,12 @@ def portfolio_value(ctx: click.Context, account_id: str | None) -> None:
                 "accounts": values,
                 "updated_at": datetime.now(UTC).isoformat(),
             }
-        finally:
-            await db.close()
+
+        if account_id is not None:
+            async with _create_treasury(account_id, ctx=ctx) as (t, _):
+                return await _collect_values([t])
+        async with _create_treasury_manager(ctx=ctx) as (manager, _):
+            return await _collect_values(manager.list_all())
 
     # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다
     # (#1758, #1725). outer try는 `_create_treasury`(line ~612)와
@@ -776,13 +779,9 @@ def portfolio_history(
     )
 
     async def _run_history() -> dict:
-        if account_id is not None:
-            t, db = await _create_treasury(account_id)
-            treasuries = [t]
-        else:
-            manager, db = await _create_treasury_manager()
-            treasuries = manager.list_all()
-        try:
+        # #1857: ``_create_treasury`` / ``_create_treasury_manager`` async
+        # context manager 전환. budgets/portfolio.value 와 동형 분기 패턴.
+        async def _collect_history(treasuries: list) -> dict:
             by_date: dict[str, dict[str, float | str]] = {}
             for treasury_obj in treasuries:
                 for snapshot in await treasury_obj.get_snapshots(start_date, end_date):
@@ -812,8 +811,12 @@ def portfolio_history(
                 row["daily_return"] = daily_pnl / total_asset if total_asset else 0.0
                 data.append(row)
             return {"data": data, "start_date": start_date, "end_date": end_date}
-        finally:
-            await db.close()
+
+        if account_id is not None:
+            async with _create_treasury(account_id, ctx=ctx) as (t, _):
+                return await _collect_history([t])
+        async with _create_treasury_manager(ctx=ctx) as (manager, _):
+            return await _collect_history(manager.list_all())
 
     # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다
     # (#1758, #1725). outer try는 `_create_treasury`(line ~699)와

--- a/src/ante/cli/db_context.py
+++ b/src/ante/cli/db_context.py
@@ -27,10 +27,17 @@ from contextlib import asynccontextmanager
 
 import click
 
-from ante.cli.main import get_db_path
+# ``Database`` 는 ``open_cli_db`` 내부에서 lazy import 되며, 동시에 본 모듈에
+# 속성으로 노출되어야 한다 (#1856 ``patch("ante.cli.db_context.Database")``
+# 테스트 호환). lazy lookup 은 ``open_cli_db`` 가 매 호출마다
+# ``ante.core.database.Database`` 를 다시 가져오도록 한다.
 from ante.core.database import Database
 
-__all__ = ["open_cli_db"]
+# import-time binding 사본. lazy lookup 에서 ``globals()['Database']`` 가
+# 원본인지 patch 된 mock 인지 식별하는 reference 다.
+_ORIGINAL_DATABASE = Database
+
+__all__ = ["open_cli_db", "Database"]
 
 
 @asynccontextmanager
@@ -78,8 +85,32 @@ async def open_cli_db(
     # to ``Database.__init__`` per #1854 contract option B (no Database API
     # signature change in this PR scope).
     _ = read_only
-    db_path = db_path_override if db_path_override is not None else get_db_path(ctx)
-    db = Database(db_path)
+    # #1857: lazy module-attribute access for ``get_db_path`` /
+    # ``Database`` to honor test patches of either:
+    #   - ``ante.cli.main.get_db_path`` (callsite import binding)
+    #   - ``ante.cli.db_context.Database`` (#1856 db_path_override 테스트)
+    #   - ``ante.core.database.Database`` (constructor patch — #1857 호환)
+    from ante.cli import main as _cli_main
+    from ante.core import database as _core_db
+
+    db_path = (
+        db_path_override if db_path_override is not None else _cli_main.get_db_path(ctx)
+    )
+    # patch 우선순위 (둘 다 동시에 patch 되는 경우는 없다고 가정):
+    #   1) ``ante.cli.db_context.Database`` 가 patch 된 경우 (#1856 테스트):
+    #      ``globals()['Database']`` 가 ``_ORIGINAL_DATABASE`` 와 다른 객체.
+    #   2) ``ante.core.database.Database`` 가 patch 된 경우 (#1857 회귀
+    #      테스트): ``_core_db.Database`` 가 ``_ORIGINAL_DATABASE`` 와 다름.
+    #   3) 둘 다 미patch: 원본 ``Database`` 사용.
+    _local_db_cls = globals().get("Database", _ORIGINAL_DATABASE)
+    _module_db_cls = _core_db.Database
+    if _local_db_cls is not _ORIGINAL_DATABASE:
+        _db_cls = _local_db_cls
+    elif _module_db_cls is not _ORIGINAL_DATABASE:
+        _db_cls = _module_db_cls
+    else:
+        _db_cls = _ORIGINAL_DATABASE
+    db = _db_cls(db_path)
     await db.connect()
     try:
         yield db

--- a/tests/unit/cli/test_cli_factory_migration_cleanup.py
+++ b/tests/unit/cli/test_cli_factory_migration_cleanup.py
@@ -483,3 +483,407 @@ class TestFactoryPathPreservesBusinessBehavior:
             f"factory 경로에서 AccountService.initialize 는 1회 호출되어야 한다 "
             f"(실제={len(init_calls)})"
         )
+
+
+# ════════════════════════════════════════════════════════════════════════
+# #1857 추가 — 9 domain × cleanup invariant + business behavior parity.
+#
+# 11~25) bot/config/strategy/system/rule/trade/treasury 7 domain helper +
+# audit/report inline 의 ``open_cli_db`` 기반 lifecycle 회귀 lock.
+# ════════════════════════════════════════════════════════════════════════
+
+
+class TestBotServicesFactoryClosesDb:
+    """11) ``bot._create_services`` 가 normal exit 에서 ``Database.close`` 호출."""
+
+    @pytest.mark.asyncio
+    async def test_bot_services_normal_exit_closes_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from ante.account.service import AccountService
+        from ante.bot.manager import BotManager
+        from ante.cli.commands.bot import _create_services
+
+        async def noop(*a, **k):  # noqa: ANN001, ANN202
+            return None
+
+        monkeypatch.setattr(Database, "connect", noop)
+        monkeypatch.setattr(AccountService, "initialize", noop)
+        monkeypatch.setattr(BotManager, "initialize", noop)
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            async with _create_services(ctx=ctx) as (db, eventbus, manager, svc):
+                assert isinstance(svc, AccountService)
+                assert isinstance(manager, BotManager)
+
+        assert close_mock.await_count == 1
+
+
+class TestBotServicesFactoryExceptionCloses:
+    """12) ``bot._create_services`` 가 service init 실패 시에도 close 호출."""
+
+    @pytest.mark.asyncio
+    async def test_bot_services_exception_closes_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from ante.account.service import AccountService
+        from ante.bot.manager import BotManager
+        from ante.cli.commands.bot import _create_services
+
+        async def noop(*a, **k):  # noqa: ANN001, ANN202
+            return None
+
+        async def raising_initialize(self: BotManager) -> None:
+            raise RuntimeError("bot init failed")
+
+        monkeypatch.setattr(Database, "connect", noop)
+        monkeypatch.setattr(AccountService, "initialize", noop)
+        monkeypatch.setattr(BotManager, "initialize", raising_initialize)
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            with pytest.raises(RuntimeError, match="bot init failed"):
+                async with _create_services(ctx=ctx):
+                    pass
+
+        assert close_mock.await_count == 1
+
+
+class TestConfigServicesFactoryClosesDb:
+    """13) ``config._create_services`` 가 normal exit 에서 ``Database.close`` 호출."""
+
+    @pytest.mark.asyncio
+    async def test_config_services_normal_exit_closes_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from ante.cli.commands.config import _create_services
+        from ante.config.dynamic import DynamicConfigService
+
+        async def noop(*a, **k):  # noqa: ANN001, ANN202
+            return None
+
+        monkeypatch.setattr(Database, "connect", noop)
+        monkeypatch.setattr(DynamicConfigService, "initialize", noop)
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            async with _create_services(ctx=ctx) as (static_cfg, dynamic, db):
+                assert isinstance(dynamic, DynamicConfigService)
+
+        assert close_mock.await_count == 1
+
+
+class TestStrategyRegistryFactoryClosesDb:
+    """14) ``strategy._create_registry`` 가 normal exit 에서 ``Database.close`` 호출."""
+
+    @pytest.mark.asyncio
+    async def test_strategy_registry_normal_exit_closes_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from ante.cli.commands.strategy import _create_registry
+        from ante.strategy.registry import StrategyRegistry
+
+        async def noop(*a, **k):  # noqa: ANN001, ANN202
+            return None
+
+        monkeypatch.setattr(Database, "connect", noop)
+        monkeypatch.setattr(StrategyRegistry, "initialize", noop)
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            async with _create_registry(ctx=ctx) as (registry, db):
+                assert isinstance(registry, StrategyRegistry)
+
+        assert close_mock.await_count == 1
+
+
+class TestSystemServicesFactoryClosesDb:
+    """15) ``system._create_services`` (bootstrap) 가 normal exit 에서 close."""
+
+    @pytest.mark.asyncio
+    async def test_system_services_normal_exit_closes_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from ante.cli.commands.system import _create_services
+
+        async def noop_connect(self: Database) -> None:
+            return None
+
+        monkeypatch.setattr(Database, "connect", noop_connect)
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            async with _create_services(ctx=ctx) as (db, eventbus):
+                assert db is not None
+
+        assert close_mock.await_count == 1
+
+
+class TestRuleEngineFactoryClosesDb:
+    """16) ``rule._create_rule_engine`` 가 normal exit 에서 ``Database.close`` 호출."""
+
+    @pytest.mark.asyncio
+    async def test_rule_engine_normal_exit_closes_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from ante.cli.commands.rule import _create_rule_engine
+        from ante.rule.engine import RuleEngine
+
+        async def noop_connect(self: Database) -> None:
+            return None
+
+        async def existing_account_row(self: Database, sql: str, params: tuple = ()):
+            return {"1": 1}
+
+        monkeypatch.setattr(Database, "connect", noop_connect)
+        monkeypatch.setattr(Database, "fetch_one", existing_account_row)
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            async with _create_rule_engine("acc-1", ctx=ctx) as (engine, db):
+                assert isinstance(engine, RuleEngine)
+
+        assert close_mock.await_count == 1
+
+
+class TestTradeServiceFactoryClosesDb:
+    """17) ``trade._create_trade_service`` 가 normal exit 에서 close."""
+
+    @pytest.mark.asyncio
+    async def test_trade_service_normal_exit_closes_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from ante.cli.commands.trade import _create_trade_service
+        from ante.trade.position import PositionHistory
+        from ante.trade.recorder import TradeRecorder
+        from ante.trade.service import TradeService
+
+        async def noop(*a, **k):  # noqa: ANN001, ANN202
+            return None
+
+        monkeypatch.setattr(Database, "connect", noop)
+        monkeypatch.setattr(PositionHistory, "initialize", noop)
+        monkeypatch.setattr(TradeRecorder, "initialize", noop)
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            async with _create_trade_service(ctx=ctx) as (svc, db):
+                assert isinstance(svc, TradeService)
+
+        assert close_mock.await_count == 1
+
+
+class TestTreasuryFactoryClosesDb:
+    """18) ``treasury._create_treasury`` 가 normal exit 에서 ``Database.close`` 호출."""
+
+    @pytest.mark.asyncio
+    async def test_treasury_normal_exit_closes_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from unittest.mock import MagicMock
+
+        from ante.account.service import AccountService
+        from ante.cli.commands.treasury import _create_treasury
+        from ante.treasury.treasury import Treasury
+
+        async def noop(*a, **k):  # noqa: ANN001, ANN202
+            return None
+
+        async def passing_initialize(self: AccountService) -> None:
+            return None
+
+        async def returning_account(self: AccountService, account_id: str):
+            fake = MagicMock()
+            fake.account_id = account_id
+            fake.currency = "KRW"
+            from decimal import Decimal
+
+            fake.buy_commission_rate = Decimal("0.00015")
+            fake.sell_commission_rate = Decimal("0.00015")
+            return fake
+
+        monkeypatch.setattr(Database, "connect", noop)
+        monkeypatch.setattr(AccountService, "initialize", passing_initialize)
+        monkeypatch.setattr(AccountService, "get", returning_account)
+        monkeypatch.setattr(Treasury, "initialize", noop)
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            async with _create_treasury("acc-1", ctx=ctx) as (t, db):
+                assert isinstance(t, Treasury)
+
+        assert close_mock.await_count == 1
+
+
+class TestTreasuryManagerFactoryClosesDb:
+    """19) ``treasury._create_treasury_manager`` 가 normal exit 에서 close."""
+
+    @pytest.mark.asyncio
+    async def test_treasury_manager_normal_exit_closes_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from ante.account.service import AccountService
+        from ante.cli.commands.treasury import _create_treasury_manager
+        from ante.treasury.manager import TreasuryManager
+
+        async def noop(*a, **k):  # noqa: ANN001, ANN202
+            return None
+
+        async def empty_accounts(self: AccountService, status=None):  # noqa: ANN001
+            return []
+
+        monkeypatch.setattr(Database, "connect", noop)
+        monkeypatch.setattr(AccountService, "initialize", noop)
+        monkeypatch.setattr(AccountService, "list", empty_accounts)
+        monkeypatch.setattr(TreasuryManager, "initialize_all", noop)
+
+        with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+            async with _create_treasury_manager(ctx=ctx) as (manager, db):
+                assert isinstance(manager, TreasuryManager)
+
+        assert close_mock.await_count == 1
+
+
+class TestOpenCliDbDbPathOverride:
+    """20) ``open_cli_db`` 가 ``db_path_override`` 를 ``Database`` 에 전달한다.
+
+    instrument list/sync/search/import 의 ``--db-path`` Click option 보존
+    (offline-factory.md §1.1).
+    """
+
+    @pytest.mark.asyncio
+    async def test_db_path_override_forwarded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ante.cli.db_context import open_cli_db
+
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        override_path = str(tmp_path / "override-instrument.db")
+
+        with patch("ante.cli.db_context.Database") as db_cls:
+            instance = db_cls.return_value
+            instance.connect = AsyncMock()
+            instance.close = AsyncMock()
+            async with open_cli_db(ctx, db_path_override=override_path):
+                pass
+
+        db_cls.assert_called_once_with(override_path)
+
+
+class TestOpenCliDbCtxResolution:
+    """21) ``open_cli_db`` 가 ``db_path_override=None`` 일 때 ctx-기반
+    ``get_db_path`` 로 resolution 한다 (기본 경로).
+    """
+
+    @pytest.mark.asyncio
+    async def test_db_path_default_uses_get_db_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ante.cli.db_context import open_cli_db
+
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        expected_default_db_path = str(config_dir / "db" / "ante.db")
+
+        with patch("ante.cli.db_context.Database") as db_cls:
+            instance = db_cls.return_value
+            instance.connect = AsyncMock()
+            instance.close = AsyncMock()
+            async with open_cli_db(ctx):
+                pass
+
+        db_cls.assert_called_once_with(expected_default_db_path)
+
+
+class TestBotServicesBusinessBehaviorParity:
+    """22) ``bot._create_services`` 변환 전후 동일 ``initialize()`` 호출 sequence
+    + 동일 service 인스턴스 yield (Codex v1 condition 5 business behavior
+    parity).
+    """
+
+    @pytest.mark.asyncio
+    async def test_bot_services_business_behavior_parity(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        from ante.account.service import AccountService
+        from ante.bot.manager import BotManager
+        from ante.cli.commands.bot import _create_services
+
+        async def noop_connect(self: Database) -> None:
+            return None
+
+        init_calls: list[str] = []
+
+        async def acc_init(self: AccountService) -> None:
+            init_calls.append("account")
+
+        async def mgr_init(self: BotManager) -> None:
+            init_calls.append("bot")
+
+        monkeypatch.setattr(Database, "connect", noop_connect)
+        monkeypatch.setattr(AccountService, "initialize", acc_init)
+        monkeypatch.setattr(BotManager, "initialize", mgr_init)
+
+        captured: tuple | None = None
+        with patch.object(Database, "close", new_callable=AsyncMock):
+            async with _create_services(ctx=ctx) as composed:
+                captured = composed
+
+        assert captured is not None
+        db, eventbus, manager, svc = captured
+        # 변환 전후 동일 호출 sequence (account 가 먼저 init, 그 다음 bot manager).
+        assert init_calls == ["account", "bot"], init_calls
+        assert isinstance(svc, AccountService)
+        assert isinstance(manager, BotManager)
+
+
+class TestTreasuryFactoryRejectsInvalidAccountId:
+    """23) ``treasury._create_treasury`` 가 ``invalid account_id`` 를
+    ``open_cli_db`` 진입 이전에 거부한다 (resource 미획득).
+    """
+
+    @pytest.mark.asyncio
+    async def test_invalid_account_id_no_resource(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ante.account.errors import InvalidAccountIdError
+        from ante.cli.commands.treasury import _create_treasury
+
+        config_dir = _bootstrap_config_dir(tmp_path, monkeypatch)
+        ctx = _make_ctx(config_dir)
+
+        with patch.object(Database, "connect", new_callable=AsyncMock) as connect_mock:
+            with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
+                with pytest.raises(InvalidAccountIdError):
+                    async with _create_treasury("default", ctx=ctx):
+                        pass
+
+        # invalid 거부 시점에 db.connect 자체가 호출되지 않는다.
+        connect_mock.assert_not_awaited()
+        close_mock.assert_not_awaited()

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -46,17 +46,17 @@ known_drift_fmt_error_no_code:
   # ``fmt.error(message, code=code)`` 정렬이 UX 회귀가 된다. config.py 의
   # 동형 deferred 정리와 함께 별도 follow-up 에서 책임진다.
   - path: src/ante/cli/commands/bot.py
-    line: 882
+    line: 931
     snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock"
+    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (line shifted by #1857 _create_services factory migration)"
   - path: src/ante/cli/commands/bot.py
-    line: 918
+    line: 967
     snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock"
+    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (line shifted by #1857 _create_services factory migration)"
   - path: src/ante/cli/commands/bot.py
-    line: 952
+    line: 1001
     snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock"
+    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (line shifted by #1857 _create_services factory migration)"
   # #1843 sub-PR 5: broker.py line 211/266/318 entries 제거 — emit_cli_error
   # 정렬 완료 (broker typed exception 5 sub-class 가 ``BROKER_*`` 안정 코드를
   # registry MRO lookup 으로 surface, 미분류 fault 는 ``EXECUTION_ERROR``
@@ -79,13 +79,13 @@ known_drift_fmt_error_no_code:
   # 의 ``"STATIC_CONFIG" in result.output`` 회귀 lock 이 깨진다.
   # bot.py 882/918/952 와 묶어 별도 follow-up issue 가 책임진다.
   - path: src/ante/cli/commands/config.py
-    line: 176
+    line: 214
     snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (bot.py 동형)"
+    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (bot.py 동형, line shifted by #1857 _create_services factory migration)"
   - path: src/ante/cli/commands/config.py
-    line: 179
+    line: 217
     snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (bot.py 동형)"
+    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (bot.py 동형, line shifted by #1857 _create_services factory migration)"
   # #1843 sub-PR 1: member.py entries 15건 제거 — emit_cli_error 정렬 완료
   # (CLI direct path 가 IPC envelope 와 동일 public code surface).
   # _MASTER_REQUIRED_MESSAGE override 보존하는 typed except 는 code 인자

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -12,6 +12,22 @@ from ante.cli.formatter import OutputFormatter
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -294,8 +310,7 @@ class TestStrategyCommands:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["strategy", "list"])
             assert result.exit_code == 0

--- a/tests/unit/test_cli_account_id_construction_lifecycle.py
+++ b/tests/unit/test_cli_account_id_construction_lifecycle.py
@@ -78,6 +78,7 @@ import json
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -162,13 +163,17 @@ def _make_mock_treasury(summary=None, snapshot=None):
 
     create_calls: list[str] = []
 
-    async def _create(account_id=None):
+    # #1857: ``_create_treasury`` 는 async context manager 로 변환됨.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _create(account_id=None, *, ctx=None):
         create_calls.append(account_id)
-        return mock_t, mock_db
+        yield mock_t, mock_db
 
     ctx_patch = patch(
         "ante.cli.commands.treasury._create_treasury",
-        side_effect=_create,
+        new=_create,
     )
     return ctx_patch, mock_t, mock_db, create_calls
 
@@ -202,13 +207,17 @@ def _make_mock_rule_engine():
 
     create_calls: list[str] = []
 
-    async def _create(account_id):
+    # #1857: ``_create_rule_engine`` 는 async context manager 로 변환됨.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _create(account_id, *, ctx=None):
         create_calls.append(account_id)
-        return mock_engine, mock_db
+        yield mock_engine, mock_db
 
     ctx_patch = patch(
         "ante.cli.commands.rule._create_rule_engine",
-        side_effect=_create,
+        new=_create,
     )
     return ctx_patch, mock_engine, mock_db, create_calls
 
@@ -336,6 +345,9 @@ class TestCreateRuleEngineLifecycleRegression:
 
     @pytest.mark.parametrize("invalid", _INVALID_INPUTS)
     def test_invalid_raises_before_db_connect_no_resource(self, invalid: str) -> None:
+        # #1857: ``_create_rule_engine`` 는 async context manager 로 변환됨.
+        # invalid account_id 는 ``open_cli_db`` (==db.connect) 진입 이전에
+        # raise 한다. test 는 async with 진입 시점에 raise 함을 직접 검증.
         import asyncio
 
         from ante.account.errors import InvalidAccountIdError
@@ -345,6 +357,11 @@ class TestCreateRuleEngineLifecycleRegression:
         mock_db_instance.connect = AsyncMock()
         mock_db_instance.close = AsyncMock()
 
+        async def _enter():
+            ctx = click.Context(click.Command("dummy"))
+            async with _create_rule_engine(invalid, ctx=ctx):
+                pass
+
         with (
             patch(
                 "ante.core.database.Database",
@@ -353,7 +370,7 @@ class TestCreateRuleEngineLifecycleRegression:
             patch("ante.cli.main.get_db_path", return_value=":memory:"),
         ):
             with pytest.raises(InvalidAccountIdError) as exc_info:
-                asyncio.run(_create_rule_engine(invalid))
+                asyncio.run(_enter())
 
         # #1633 SSOT 코드 보존.
         assert exc_info.value.code == "VALIDATION_ERROR"
@@ -372,6 +389,12 @@ class TestCreateRuleEngineLifecycleRegression:
         mock_db_instance = AsyncMock()
         mock_db_instance.connect = AsyncMock()
         mock_db_instance.close = AsyncMock()
+        mock_db_instance.fetch_one = AsyncMock(return_value={"1": 1})
+
+        async def _enter():
+            ctx = click.Context(click.Command("dummy"))
+            async with _create_rule_engine(_VALID_PRESENT, ctx=ctx) as (engine, db):
+                return engine, db
 
         with (
             patch(
@@ -380,7 +403,7 @@ class TestCreateRuleEngineLifecycleRegression:
             ),
             patch("ante.cli.main.get_db_path", return_value=":memory:"),
         ):
-            engine, db = asyncio.run(_create_rule_engine(_VALID_PRESENT))
+            engine, db = asyncio.run(_enter())
 
         assert db is mock_db_instance
         mock_db_instance.connect.assert_awaited_once()
@@ -477,13 +500,18 @@ class TestValidButAbsentNotMisclassified:
 
         create_calls: list[str] = []
 
-        async def _create(account_id=None):
+        # #1857: ``_create_treasury`` async context manager 변환.
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _create(account_id=None, *, ctx=None):
             create_calls.append(account_id)
             raise AccountNotFoundError("계좌를 찾을 수 없습니다")
+            yield  # unreachable but required for asynccontextmanager  # noqa
 
         with patch(
             "ante.cli.commands.treasury._create_treasury",
-            side_effect=_create,
+            new=_create,
         ):
             result = runner.invoke(
                 cli,

--- a/tests/unit/test_cli_account_id_invalid_contract.py
+++ b/tests/unit/test_cli_account_id_invalid_contract.py
@@ -131,8 +131,12 @@ def _patch_account_service(svc: AsyncMock, db: AsyncMock):
 
 
 def _patch_bot_services(db: AsyncMock):
-    async def _create_services():
-        return db, MagicMock(), MagicMock(), AsyncMock()
+    """#1857: ``bot._create_services`` async context manager fake factory."""
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _create_services(*args, **kwargs):
+        yield db, MagicMock(), MagicMock(), AsyncMock()
 
     return patch(
         "ante.cli.commands.bot._create_services",

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -11,6 +11,22 @@ from click.testing import CliRunner
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -116,8 +132,7 @@ def _mock_strategy_registry():
     registry.list_strategies = AsyncMock(return_value=[])
     return patch(
         "ante.cli.commands.strategy._create_registry",
-        new_callable=AsyncMock,
-        return_value=(registry, db),
+        new=_acm_factory((registry, db)),
     )
 
 

--- a/tests/unit/test_cli_bot_create_active_account_cleanup.py
+++ b/tests/unit/test_cli_bot_create_active_account_cleanup.py
@@ -75,8 +75,17 @@ def _build_create_services_mock(
     account_service = AsyncMock()
     account_service.list = AsyncMock(return_value=active_accounts)
 
-    async def _create_services_mock():
-        return db, MagicMock(), MagicMock(), account_service
+    # #1857: ``bot._create_services`` 는 async context manager 로 변환됨.
+    # fake factory 는 open_cli_db lifecycle 을 그대로 재현하기 위해 __aexit__
+    # 시 ``db.close()`` 를 호출한다 (#1799 회귀 lock invariant 보존).
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _create_services_mock(*args, **kwargs):
+        try:
+            yield db, MagicMock(), MagicMock(), account_service
+        finally:
+            await db.close()
 
     return _create_services_mock, db, account_service
 
@@ -224,8 +233,15 @@ class TestBotCreateAccountListRaisesCleanup:
         account_service = AsyncMock()
         account_service.list = AsyncMock(side_effect=RuntimeError("boom"))
 
-        async def _create_services_mock():
-            return db, MagicMock(), MagicMock(), account_service
+        # #1857: ``bot._create_services`` async context manager 전환.
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _create_services_mock(*args, **kwargs):
+            try:
+                yield db, MagicMock(), MagicMock(), account_service
+            finally:
+                await db.close()
 
         ipc_patch, ipc_spy = _patch_ipc_send()
         with (

--- a/tests/unit/test_cli_bot_signal_key_rotate_external_gate.py
+++ b/tests/unit/test_cli_bot_signal_key_rotate_external_gate.py
@@ -55,6 +55,22 @@ from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 from ante.strategy.base import Signal, Strategy, StrategyMeta
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -166,8 +182,7 @@ class TestRotateExternalStrategyAllowed:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -230,8 +245,7 @@ class TestRotateNonExternalStrategyRejected:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -275,8 +289,7 @@ class TestRotateNonExternalStrategyRejected:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -319,8 +332,7 @@ class TestNonRotateGetUnaffectedByGate:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",

--- a/tests/unit/test_cli_bot_treasury_ipc.py
+++ b/tests/unit/test_cli_bot_treasury_ipc.py
@@ -311,7 +311,12 @@ class TestBotRemoveIpc:
 
         assert result.exit_code == 0
         assert "봇 삭제 완료(cold-path)" in result.output
-        mock_cold_path.assert_awaited_once_with("bot-abc")
+        # #1857: ``_run_bot_remove_cold_path`` 는 ctx 인자를 받는다.
+        mock_cold_path.assert_awaited_once()
+        call_args = mock_cold_path.await_args
+        assert call_args.args == ("bot-abc",) or (
+            call_args.args and call_args.args[0] == "bot-abc"
+        )
 
     @patch("ante.cli.commands.bot.is_active_runtime", return_value=False)
     @patch("ante.cli.commands.bot._run_bot_remove_cold_path")
@@ -335,6 +340,12 @@ class TestBotRemoveIpc:
         fake_config = MagicMock()
         fake_config.get.return_value = "strategies"
 
+        # #1857: ``_run_bot_remove_cold_path`` 는 ctx 를 받는 async 함수가
+        # 되었고, 내부 ``open_cli_db`` 가 ``Database`` lifecycle 을 소유한다.
+        # ``ante.cli.main.get_db_path`` / ``ante.core.database.Database`` 는
+        # ``open_cli_db`` 가 lazy import 하므로 그대로 patch 된다.
+        import click
+
         with (
             patch("ante.cli.main.get_db_path", return_value="/tmp/ante-test.db"),
             patch("ante.cli.main.get_config_dir", return_value=None),
@@ -345,8 +356,9 @@ class TestBotRemoveIpc:
                 side_effect=RuntimeError("boom"),
             ),
         ):
+            ctx = click.Context(click.Command("dummy"))
             with pytest.raises(RuntimeError, match="boom"):
-                await _run_bot_remove_cold_path("bot-abc")
+                await _run_bot_remove_cold_path("bot-abc", ctx=ctx)
 
         fake_db.connect.assert_awaited_once()
         fake_db.close.assert_awaited_once()

--- a/tests/unit/test_cli_date_validation.py
+++ b/tests/unit/test_cli_date_validation.py
@@ -53,6 +53,22 @@ from click.testing import CliRunner
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -336,8 +352,7 @@ class TestTreasurySnapshotOmitDates:
 
         with patch(
             "ante.cli.commands.treasury._create_treasury",
-            new_callable=AsyncMock,
-            return_value=(mock_treasury, mock_db),
+            new=_acm_factory((mock_treasury, mock_db)),
         ):
             result = runner.invoke(cli, ["treasury", "snapshot", "--account", "test"])
         combined = (result.output or "") + (getattr(result, "stderr", "") or "")

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -27,6 +27,21 @@ from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 
 
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 def _patch_account_factory(svc, db):  # noqa: ANN001, ANN202
     """#1856: ``_create_account_service`` 가 async context manager 로 전환된 후
     fake factory 가 ``ctx`` 인자를 받아 ``svc`` 만 yield 하도록 한다.
@@ -292,8 +307,7 @@ class TestTreasuryStatusFormatOption:
 
         with patch(
             "ante.cli.commands.treasury._create_treasury",
-            new_callable=AsyncMock,
-            return_value=(mock_treasury, db),
+            new=_acm_factory((mock_treasury, db)),
         ):
             result = runner.invoke(
                 cli,
@@ -325,8 +339,7 @@ class TestStrategyListFormatOption:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["strategy", "list", "--format", "json"])
             assert result.exit_code == 0
@@ -364,8 +377,7 @@ class TestStrategyInfoFormatOption:
         with (
             patch(
                 "ante.cli.commands.strategy._create_registry",
-                new_callable=AsyncMock,
-                return_value=(registry, db),
+                new=_acm_factory((registry, db)),
             ),
             patch(
                 "ante.cli.commands.strategy._load_strategy_params",
@@ -396,8 +408,7 @@ class TestConfigGetFormatOption:
 
         with patch(
             "ante.cli.commands.config._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_config, mock_dynamic, mock_db),
+            new=_acm_factory((mock_config, mock_dynamic, mock_db)),
         ):
             result = runner.invoke(cli, ["config", "get", "--format", "json"])
             assert result.exit_code == 0
@@ -452,8 +463,7 @@ class TestConfigHistoryFormatOption:
 
         with patch(
             "ante.cli.commands.config._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_config, mock_dynamic, mock_db),
+            new=_acm_factory((mock_config, mock_dynamic, mock_db)),
         ):
             result = runner.invoke(
                 cli,
@@ -478,8 +488,7 @@ class TestTradeListFormatOption:
 
         with patch(
             "ante.cli.commands.trade._create_trade_service",
-            new_callable=AsyncMock,
-            return_value=(svc, db),
+            new=_acm_factory((svc, db)),
         ):
             result = runner.invoke(cli, ["trade", "list", "--format", "json"])
             assert result.exit_code == 0
@@ -671,8 +680,7 @@ class TestBotListFormatOption1701:
 
         with patch(
             "ante.cli.commands.bot._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_db, None, None, None),
+            new=_acm_factory((mock_db, None, None, None)),
         ):
             result = runner.invoke(cli, ["bot", "list", "--format", "json"])
 

--- a/tests/unit/test_cli_group_p_missing_resource_sweep.py
+++ b/tests/unit/test_cli_group_p_missing_resource_sweep.py
@@ -36,6 +36,22 @@ import pytest
 from click.testing import CliRunner
 from cryptography.fernet import Fernet
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 # subprocess timeout: hang 회귀를 5초 마진으로 차단한다.
 _SUBPROCESS_TIMEOUT_S = 10.0
 
@@ -227,8 +243,7 @@ class TestBotSignalKeyNotSetTypedCode:
             patch("ante.cli.main.authenticate_member", side_effect=_auth_set),
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",

--- a/tests/unit/test_cli_missing_resource_exit.py
+++ b/tests/unit/test_cli_missing_resource_exit.py
@@ -61,6 +61,22 @@ from click.testing import CliRunner
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -200,8 +216,7 @@ class TestConfigGetMissingExit:
 
         with patch(
             "ante.cli.commands.config._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_config, mock_dynamic, mock_db),
+            new=_acm_factory((mock_config, mock_dynamic, mock_db)),
         ):
             result = runner.invoke(
                 cli, ["config", "get", "nonexistent.key", "--format", "json"]
@@ -222,8 +237,7 @@ class TestConfigGetMissingExit:
 
         with patch(
             "ante.cli.commands.config._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_config, mock_dynamic, mock_db),
+            new=_acm_factory((mock_config, mock_dynamic, mock_db)),
         ):
             result = runner.invoke(cli, ["config", "get", "nonexistent.key"])
 
@@ -241,8 +255,7 @@ class TestConfigGetMissingExit:
 
         with patch(
             "ante.cli.commands.config._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_config, mock_dynamic, mock_db),
+            new=_acm_factory((mock_config, mock_dynamic, mock_db)),
         ):
             result = runner.invoke(
                 cli, ["config", "get", "some.key", "--format", "json"]
@@ -271,8 +284,7 @@ class TestBotInfoMissingExit:
 
         with patch(
             "ante.cli.commands.bot._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_db, None, None, None),
+            new=_acm_factory((mock_db, None, None, None)),
         ):
             result = runner.invoke(
                 cli, ["--format", "json", "bot", "info", "nonexistent-bot"]
@@ -290,8 +302,7 @@ class TestBotInfoMissingExit:
 
         with patch(
             "ante.cli.commands.bot._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_db, None, None, None),
+            new=_acm_factory((mock_db, None, None, None)),
         ):
             result = runner.invoke(cli, ["bot", "info", "nonexistent-bot"])
 
@@ -315,8 +326,7 @@ class TestBotInfoMissingExit:
 
         with patch(
             "ante.cli.commands.bot._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_db, None, None, None),
+            new=_acm_factory((mock_db, None, None, None)),
         ):
             result = runner.invoke(cli, ["bot", "info", "b-1"])
 
@@ -347,8 +357,7 @@ class TestBotSignalKeyMissingExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -382,8 +391,7 @@ class TestBotSignalKeyMissingExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -409,8 +417,7 @@ class TestBotSignalKeyMissingExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -459,8 +466,7 @@ class TestBotSignalKeyMissingExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -527,8 +533,7 @@ class TestBotSignalKeyMissingBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -569,8 +574,7 @@ class TestBotSignalKeyMissingBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -596,8 +600,7 @@ class TestBotSignalKeyMissingBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -628,8 +631,7 @@ class TestBotSignalKeyMissingBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -661,8 +663,7 @@ class TestBotSignalKeyMissingBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -702,8 +703,7 @@ class TestBotSignalKeyMissingBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -746,8 +746,7 @@ class TestBotSignalKeyMissingBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -783,8 +782,7 @@ class TestBotSignalKeyMissingBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -865,8 +863,7 @@ class TestBotSignalKeySoftDeletedBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -905,8 +902,7 @@ class TestBotSignalKeySoftDeletedBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -932,8 +928,7 @@ class TestBotSignalKeySoftDeletedBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
@@ -964,8 +959,7 @@ class TestBotSignalKeySoftDeletedBotExit:
         with (
             patch(
                 "ante.cli.commands.bot._create_services",
-                new_callable=AsyncMock,
-                return_value=(mock_db, None, None, None),
+                new=_acm_factory((mock_db, None, None, None)),
             ),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",

--- a/tests/unit/test_cli_pagination_validation.py
+++ b/tests/unit/test_cli_pagination_validation.py
@@ -34,6 +34,22 @@ from click.testing import CliRunner
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -202,8 +218,7 @@ class TestTradeListLimitValid:
 
         with patch(
             "ante.cli.commands.trade._create_trade_service",
-            new_callable=AsyncMock,
-            return_value=(svc, db),
+            new=_acm_factory((svc, db)),
         ):
             result = runner.invoke(cli, ["trade", "list", "--limit", "50"])
 
@@ -262,8 +277,7 @@ class TestConfigHistoryLimitValid:
 
         with patch(
             "ante.cli.commands.config._create_services",
-            new_callable=AsyncMock,
-            return_value=(mock_config, mock_dynamic, mock_db),
+            new=_acm_factory((mock_config, mock_dynamic, mock_db)),
         ):
             result = runner.invoke(
                 cli, ["config", "history", "risk.some_key", "--limit", "20"]

--- a/tests/unit/test_cli_rule_account_not_found.py
+++ b/tests/unit/test_cli_rule_account_not_found.py
@@ -217,12 +217,17 @@ class TestCreateRuleEngineCleanup:
         ) -> object:
             raise AccountNotFoundError("계좌 'acc-9999'를 찾을 수 없습니다.")
 
+        # #1857: ``_create_rule_engine`` 는 async context manager 로 변환됨.
+        import click
+
         with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
             monkeypatch.setattr(Database, "connect", passing_connect)
             monkeypatch.setattr(Database, "fetch_one", raising_fetch_one)
 
             with pytest.raises(AccountNotFoundError):
-                await _create_rule_engine("acc-9999")
+                ctx = click.Context(click.Command("dummy"))
+                async with _create_rule_engine("acc-9999", ctx=ctx):
+                    pass
 
         assert close_mock.await_count == 1, (
             f"Database.close 가 정확히 1회 await되어야 한다 "

--- a/tests/unit/test_cli_strategy.py
+++ b/tests/unit/test_cli_strategy.py
@@ -15,6 +15,22 @@ from ante.member.models import Member, MemberRole, MemberType
 from ante.strategy.registry import StrategyRecord, StrategyStatus
 from ante.trade.models import PerformanceMetrics
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -117,8 +133,7 @@ class TestStrategyList:
         with (
             patch(
                 "ante.cli.commands.strategy._create_registry",
-                new_callable=AsyncMock,
-                return_value=(registry, db),
+                new=_acm_factory((registry, db)),
             ),
         ):
             result = runner.invoke(cli, ["strategy", "list"])
@@ -132,8 +147,7 @@ class TestStrategyList:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["--format", "json", "strategy", "list"])
             assert result.exit_code == 0
@@ -147,8 +161,7 @@ class TestStrategyList:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["strategy", "list"])
             assert result.exit_code == 0
@@ -161,8 +174,7 @@ class TestStrategyList:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["--format", "json", "strategy", "list"])
             assert result.exit_code == 0
@@ -178,8 +190,7 @@ class TestStrategyList:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["strategy", "list", "--status", "adopted"])
             assert result.exit_code == 0
@@ -196,8 +207,7 @@ class TestStrategyInfo:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["strategy", "info", "nonexistent"])
             assert result.exit_code == 1
@@ -209,8 +219,7 @@ class TestStrategyInfo:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(
                 cli, ["--format", "json", "strategy", "info", "nonexistent"]
@@ -225,8 +234,7 @@ class TestStrategyInfo:
         with (
             patch(
                 "ante.cli.commands.strategy._create_registry",
-                new_callable=AsyncMock,
-                return_value=(registry, db),
+                new=_acm_factory((registry, db)),
             ),
             patch(
                 "ante.cli.commands.strategy._load_strategy_params",
@@ -251,8 +259,7 @@ class TestStrategyInfo:
         with (
             patch(
                 "ante.cli.commands.strategy._create_registry",
-                new_callable=AsyncMock,
-                return_value=(registry, db),
+                new=_acm_factory((registry, db)),
             ),
             patch(
                 "ante.cli.commands.strategy._load_strategy_params",
@@ -283,8 +290,7 @@ class TestStrategyInfo:
         with (
             patch(
                 "ante.cli.commands.strategy._create_registry",
-                new_callable=AsyncMock,
-                return_value=(registry, db),
+                new=_acm_factory((registry, db)),
             ),
             patch(
                 "ante.cli.commands.strategy._load_strategy_params",
@@ -308,8 +314,7 @@ class TestStrategyInfo:
         with (
             patch(
                 "ante.cli.commands.strategy._create_registry",
-                new_callable=AsyncMock,
-                return_value=(registry, db),
+                new=_acm_factory((registry, db)),
             ),
             patch(
                 "ante.cli.commands.strategy._load_strategy_params",
@@ -411,8 +416,7 @@ class TestStrategyPerformance:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(
                 cli, ["--format", "json", "strategy", "performance", "momentum"]
@@ -428,8 +432,7 @@ class TestStrategyPerformance:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["strategy", "performance", "momentum"])
             assert result.exit_code == 1
@@ -697,8 +700,7 @@ class TestStrategyPerformance:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(
                 cli,
@@ -767,8 +769,7 @@ class TestStrategyPerformance:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(
                 cli, ["--format", "json", "strategy", "performance", "momentum"]
@@ -864,8 +865,7 @@ class TestStrategySubmit:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["strategy", "submit", strategy_file])
             assert result.exit_code == 0
@@ -893,8 +893,7 @@ class TestStrategySubmit:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(
                 cli, ["--format", "json", "strategy", "submit", strategy_file]
@@ -970,8 +969,7 @@ class TestStrategySubmit:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["strategy", "submit", strategy_file])
             assert result.exit_code == 1
@@ -990,8 +988,7 @@ class TestStrategySubmit:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(
                 cli,

--- a/tests/unit/test_cli_strategy_list_invalid_status.py
+++ b/tests/unit/test_cli_strategy_list_invalid_status.py
@@ -20,6 +20,22 @@ from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 from ante.strategy.registry import StrategyRecord, StrategyStatus
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -175,8 +191,7 @@ class TestStrategyListInvalidStatus:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(cli, ["--format", "json", "strategy", "list"])
             assert result.exit_code == 0
@@ -189,8 +204,7 @@ class TestStrategyListInvalidStatus:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(
                 cli,
@@ -213,8 +227,7 @@ class TestStrategyListInvalidStatus:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(
                 cli,
@@ -253,8 +266,7 @@ class TestStrategyListInvalidStatus:
 
         with patch(
             "ante.cli.commands.strategy._create_registry",
-            new_callable=AsyncMock,
-            return_value=(registry, db),
+            new=_acm_factory((registry, db)),
         ):
             result = runner.invoke(
                 cli,

--- a/tests/unit/test_cli_strategy_submit_meta_shape.py
+++ b/tests/unit/test_cli_strategy_submit_meta_shape.py
@@ -46,6 +46,22 @@ from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 from ante.strategy.base import Signal, Strategy, StrategyMeta
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -220,8 +236,7 @@ class TestSubmitValidMetaSanity:
             patch("ante.strategy.loader.StrategyLoader") as mock_loader,
             patch(
                 "ante.cli.commands.strategy._create_registry",
-                new_callable=AsyncMock,
-                return_value=(registry, db),
+                new=_acm_factory((registry, db)),
             ),
         ):
             mock_validator_cls.return_value.validate.return_value = validation

--- a/tests/unit/test_cli_system_status.py
+++ b/tests/unit/test_cli_system_status.py
@@ -14,6 +14,22 @@ from click.testing import CliRunner
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -73,8 +89,7 @@ class TestSystemStatusFormatJson:
         with (
             patch(
                 "ante.cli.commands.system._create_services",
-                new_callable=AsyncMock,
-                return_value=(db, eventbus),
+                new=_acm_factory((db, eventbus)),
             ),
             patch(
                 "ante.account.service.AccountService",
@@ -106,8 +121,7 @@ class TestSystemStatusFormatJson:
         with (
             patch(
                 "ante.cli.commands.system._create_services",
-                new_callable=AsyncMock,
-                return_value=(db, eventbus),
+                new=_acm_factory((db, eventbus)),
             ),
             patch(
                 "ante.account.service.AccountService",
@@ -136,8 +150,7 @@ class TestSystemStatusFormatJson:
         with (
             patch(
                 "ante.cli.commands.system._create_services",
-                new_callable=AsyncMock,
-                return_value=(db, eventbus),
+                new=_acm_factory((db, eventbus)),
             ),
             patch(
                 "ante.account.service.AccountService",

--- a/tests/unit/test_cli_treasury_account_not_found.py
+++ b/tests/unit/test_cli_treasury_account_not_found.py
@@ -229,12 +229,21 @@ class TestCreateTreasuryCleanup:
         # Database.close 를 AsyncMock으로 주입하고 await_count == 1로 검증한다.
         # cleanup 호출 사실만 검증하면 충분하므로 실제 close 본체는 위임하지
         # 않는다 (process 종료 시 임시 자원은 OS가 회수).
+        #
+        # #1857: ``_create_treasury`` 는 async context manager 로 변환됨.
+        # ``async with`` 진입 시점에 ``AccountService.get`` raise 가 발생해야
+        # ``open_cli_db`` 의 ``except BaseException`` cleanup 이 ``db.close()``
+        # 를 호출한다. ctx 없이 호출하기 위해 click context 를 만든다.
+        import click
+
         with patch.object(Database, "close", new_callable=AsyncMock) as close_mock:
             monkeypatch.setattr(AccountService, "initialize", passing_initialize)
             monkeypatch.setattr(AccountService, "get", raising_get)
 
             with pytest.raises(AccountNotFoundError):
-                await _create_treasury("acc-9999")
+                ctx = click.Context(click.Command("dummy"))
+                async with _create_treasury("acc-9999", ctx=ctx):
+                    pass
 
         assert close_mock.await_count == 1, (
             f"Database.close 가 정확히 1회 await되어야 한다 "

--- a/tests/unit/test_cli_treasury_snapshot.py
+++ b/tests/unit/test_cli_treasury_snapshot.py
@@ -84,12 +84,24 @@ def _make_mock_treasury(get_daily_return=None, get_range_return=None):
     mock_db = AsyncMock()
     mock_db.close = AsyncMock()
 
-    async def _fake_create(account_id=None):
-        return mock_treasury, mock_db
+    # #1857: ``_create_treasury`` 는 async context manager 로 변환됨.
+    # MagicMock 으로 wrap 해 ``assert_called_with`` 검증 호환을 유지하면서,
+    # ``__call__`` 결과를 async context manager 가 반환하도록 한다.
+    from contextlib import asynccontextmanager
+    from unittest.mock import MagicMock
+
+    @asynccontextmanager
+    async def _yield_impl():
+        yield mock_treasury, mock_db
+
+    def _fake_create(account_id=None, *, ctx=None):
+        return _yield_impl()
+
+    spy = MagicMock(side_effect=_fake_create)
 
     return patch(
         "ante.cli.commands.treasury._create_treasury",
-        side_effect=_fake_create,
+        new=spy,
     ), mock_treasury
 
 
@@ -463,5 +475,7 @@ class TestSnapshotAccount:
             )
 
         assert result.exit_code == 0
-        # _create_treasury가 account_id="domestic"으로 호출되었는지 확인
-        p.assert_called_with("domestic")
+        # _create_treasury가 account_id="domestic"으로 호출되었는지 확인.
+        # #1857: 호출자가 ctx 도 keyword 인자로 전달한다.
+        assert p.call_args.args == ("domestic",), p.call_args
+        assert "ctx" in p.call_args.kwargs, p.call_args

--- a/tests/unit/test_strategy_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_strategy_cli_ipc_error_equivalence.py
@@ -118,8 +118,12 @@ def _patch_strategy_set_status_raises(exc: BaseException):  # noqa: ANN202
     mock_db = MagicMock()
     mock_db.close = AsyncMock(return_value=None)
 
-    async def _fake_create_registry():  # noqa: ANN202
-        return mock_registry, mock_db
+    # #1857: ``_create_registry`` 는 async context manager 로 변환됨.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _fake_create_registry(*args, **kwargs):  # noqa: ANN202
+        yield mock_registry, mock_db
 
     return (
         patch.object(strategy_cmd, "_create_registry", new=_fake_create_registry),

--- a/tests/unit/test_strategy_submit.py
+++ b/tests/unit/test_strategy_submit.py
@@ -12,6 +12,22 @@ from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 from ante.strategy.base import Signal, Strategy, StrategyMeta
 
+
+def _acm_factory(value):  # noqa: ANN001, ANN202
+    """#1857: helper async context manager 전환에 맞춰 fake factory 를
+    생성한다. 기존 ``new_callable=AsyncMock, return_value=(...)`` 패턴을
+    ``new=_acm_factory((...))`` 로 대체해 ``async with helper(ctx) as
+    (...):`` 호출이 yield 한 값을 그대로 받도록 한다.
+    """
+    from contextlib import asynccontextmanager as _acm
+
+    @_acm
+    async def _fake_factory(*args, **kwargs):
+        yield value
+
+    return _fake_factory
+
+
 _MOCK_MASTER = Member(
     member_id="test-master",
     type=MemberType.HUMAN,
@@ -175,8 +191,7 @@ class TestSubmitRationaleRisks:
             patch("ante.strategy.loader.StrategyLoader") as mock_loader,
             patch(
                 "ante.cli.commands.strategy._create_registry",
-                new_callable=AsyncMock,
-                return_value=(registry, db),
+                new=_acm_factory((registry, db)),
             ),
         ):
             mock_validator_cls.return_value.validate.return_value = validation_result
@@ -208,8 +223,7 @@ class TestSubmitRationaleRisks:
             patch("ante.strategy.loader.StrategyLoader") as mock_loader,
             patch(
                 "ante.cli.commands.strategy._create_registry",
-                new_callable=AsyncMock,
-                return_value=(registry, db),
+                new=_acm_factory((registry, db)),
             ),
         ):
             mock_validator_cls.return_value.validate.return_value = validation_result

--- a/tests/unit/test_treasury_success_output_drift.py
+++ b/tests/unit/test_treasury_success_output_drift.py
@@ -243,20 +243,21 @@ def _make_mock_treasury(
 def mock_create_treasury():
     """``treasury._create_treasury`` 를 patch — ``(treasury_mock, db_mock)`` 반환.
 
-    treasury.py 의 ``status`` / ``set-balance`` (cold_path 분기) / ``snapshot``
-    / ``portfolio value`` (with --account) / ``portfolio history`` (with
-    --account) / ``budgets`` (with --account) 가 사용한다.
+    #1857: ``_create_treasury`` 는 async context manager 로 변환되었다.
     """
+    from contextlib import asynccontextmanager
+
     t = _make_mock_treasury()
     db = AsyncMock()
     db.close = AsyncMock()
 
-    async def _stub_create(account_id=None):  # noqa: ANN001, ANN202
-        return t, db
+    @asynccontextmanager
+    async def _stub_create(account_id=None, *, ctx=None):  # noqa: ANN001, ANN202
+        yield t, db
 
     with patch(
         "ante.cli.commands.treasury._create_treasury",
-        side_effect=_stub_create,
+        new=_stub_create,
     ):
         yield t, db
 


### PR DESCRIPTION
Closes #1857

## Summary

#1855 `open_cli_db` 헬퍼 기반으로 audit/bot/config/instrument/report/rule/strategy/system/trade/treasury **9 domain × 21 callsite** 의 offline/cold-path/bootstrap CLI commands 를 async context manager 패턴으로 전환한다 (#1818 remaining migration target, #1856 account/member/approval 패턴 1:1 미러). broker (live state) + signal (external process) 는 본 PR scope **외** 이며 별도 spec 정렬 PR (#1818 follow-up) 에서 다룬다.

## Codex Plan Review v2 narrow-scope 흡수

- v1 verdict: split (HIGH risk, 5 conditions)
- v2 narrow-scope (단일 PR 유지):
  1. 21 callsite re-inventory: instrument 4 추가 (누락 발견), 5축 분류
  2. broker/signal scope 제외 (live/external 경로, 별도 spec 정렬 필요)
  3. instrument 4 callsite 추가
  4. read-only initialize §4.2 예외 재검증: AuditLogger/DynamicConfigService 만 명시 예외, 기타는 initialize() 보존
  5. business behavior parity test 추가 (변환 전/후 동일 결과)
- scope decision: **approve-implement** (v2 narrow-scope, 9 domain × 21 callsite)

## 21 callsite 변환 (5축 분류)

| 축 | 파일 | line | 변환 |
| --- | --- | --- | --- |
| offline | audit.py | 70 | inline → `open_cli_db(ctx)` |
| offline | bot.py | 42 | `_create_services` async ctx mgr |
| offline | bot.py | 71 | `_run_bot_remove_cold_path` async ctx mgr |
| offline | bot.py | 567 | `bot positions` inline → `open_cli_db(ctx)` |
| offline | bot.py | 786 | `bot logs` inline → `open_cli_db(ctx)` |
| offline | config.py | 31 | `_create_services` async ctx mgr |
| offline | instrument.py | 73 | `instrument list` (db_path_override) |
| offline | instrument.py | 166 | `instrument sync` (db_path_override) |
| offline | instrument.py | 270 | `instrument search` (db_path_override) |
| offline | instrument.py | 461 | `instrument import` (db_path_override) |
| offline | report.py | 352 | `report performance` |
| offline | rule.py | 65 | `_create_rule_engine` async ctx mgr |
| offline | strategy.py | 40 | `_create_registry` async ctx mgr |
| offline | strategy.py | 719 | `strategy performance` inline |
| offline | trade.py | 34 | `_create_trade_service` async ctx mgr |
| offline | trade.py | 156 | `trade info` inline |
| offline | treasury.py | 59 | `_create_treasury` async ctx mgr |
| offline | treasury.py | 100 | `_create_treasury_manager` async ctx mgr |
| offline | treasury.py | 209 | `treasury transactions` inline |
| cold-path | rule.py | 375 | `rule update` (audit_logger 동반 mutation) |
| bootstrap | system.py | 161 | `_create_services` async ctx mgr |

## broker/signal 제외 사유 (scope 외)

- **broker.py:30/347** — live broker state (`adapter.connect` 동반). live broker state 와 `Database` lifecycle 이 같은 try/except 로 엮여 있어 단순 `open_cli_db` wrap 으로 동치 변환이 불가능. 별도 spec 정렬 PR (#1818 follow-up) 에서 다룬다.
- **signal.py:42** — external signal process (`SignalChannel` long-lived loop). `Database` lifecycle 이 external process runtime 과 엮여 있어 동치 변환 불가능.

각 파일에 코멘트로 scope-외 사유 명시.

## Read-only initialize 예외 (Codex v2)

#1854 §4.2 명시 예외인 `AuditLogger` + `DynamicConfigService` 의 `initialize()` 호출은 보존된다. 기타 service (`BotManager` / `TradeService` / `StrategyRegistry` / `Treasury` / `AccountService`) 도 안전성을 위해 `initialize()` 호출을 그대로 유지한다 (skip 적용 안 함, 안전성).

## `open_cli_db` lazy lookup (#1857 회귀 보호)

`ante.cli.db_context.open_cli_db` 가 `get_db_path` / `Database` 를 함수-내 lookup 으로 사용해 다음 test patch 패턴을 모두 호환:

- `patch("ante.cli.main.get_db_path", ...)`
- `patch("ante.cli.db_context.Database", ...)` (#1856)
- `patch("ante.core.database.Database", ...)` (#1857 회귀 테스트)

## Tests — 13 신규 시나리오 + 15 파일 마이그레이션

- `tests/unit/cli/test_cli_factory_migration_cleanup.py` (#1856 패턴 확장): 13 신규 시나리오 (#1857 11~23 — bot/config/strategy/system/rule/trade/treasury normal-exit close + open_cli_db db_path_override + business behavior parity + invalid account_id reject)
- 15 영향 test 파일: helper async context manager 전환에 따라 `new_callable=AsyncMock, return_value=(...)` → `new=_acm_factory((...))` 일괄 변환 (각 파일에 `_acm_factory` helper 추가)
- `tests/unit/contracts/error_drift_allowlist.yaml`: bot.py 882/918/952 + config.py 176/179 anchor 를 helper migration 으로 line shift 된 새 위치로 갱신

## Test plan

- [x] `pytest tests/unit/cli/test_cli_factory_migration_cleanup.py -v` — 23 PASS
- [x] `pytest tests/unit/contracts/test_error_drift.py -v` — 7 PASS
- [x] `pytest tests/unit/cli/ tests/unit/contracts/ tests/unit/ipc/ tests/unit/strategy/ tests/unit/specs/ tests/unit/feed/` — 744 PASS, 1 pre-existing fail (encryption key env, baseline 동일 — #1857 무관)
- [x] `mypy src/ante` — clean (224 files)
- [x] `ruff check src/ tests/` + `ruff format --check` — clean (546 files)
- [x] `python scripts/generate_project_structure.py` — regen 완료

## 변경 금지 보존

- service business logic 무변경
- broker/signal CLI commands 보존 (scope 외, 코멘트 명시)
- runtime composition root (`src/ante/main.py`) 무변경
- command output contract (#1815) 무변경
- error code SSOT (#1816) 무변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)