### PR TITLE
test: #1848 CLI registry ↔ docs drift + guide/cli.md regen idempotent (closes #1815)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -602,7 +602,10 @@ tests/
 │   │   ├── test_cli_registry_leaf_coverage.py
 │   │   ├── test_cli_registry_shell.py
 │   │   ├── test_cli_registry_auth_drift.py
-│   │   └── factory_drift_allowlist.yaml
+│   │   ├── factory_drift_allowlist.yaml
+│   │   ├── docs_drift_allowlist.yaml
+│   │   ├── test_cli_registry_docs_drift.py
+│   │   └── test_cli_registry_guide_sync.py
 │   ├── test_account_cli_ipc_error_equivalence.py
 │   ├── test_member_cli_ipc_error_equivalence.py
 │   ├── test_approval_cli_ipc_error_equivalence.py

--- a/tests/unit/contracts/docs_drift_allowlist.yaml
+++ b/tests/unit/contracts/docs_drift_allowlist.yaml
@@ -1,0 +1,59 @@
+# CLI registry ↔ docs command table drift baseline allowlist (#1848 Family A).
+#
+# `src/ante/contracts/cli_registry.py` 의 ``CLI_COMMAND_REGISTRY`` (94 entries)
+# 와 ``docs/specs/cli/03-commands.md`` 의 ``| ante ... |`` 표 행에서 추출한
+# command path 집합의 차집합을 baseline 으로 등록한다.
+#
+# 본 baseline 의 의도는 다음과 같다 (#1815 epic / #1844 leaf coverage 결과):
+#
+# - registry 94 entries 는 docs 표에 모두 등장한다 (registry → docs drift 0).
+# - docs 표에는 registry 가 의도적으로 다루지 않는 group 또는 leaf path 가
+#   추가로 존재한다. 본 PR 시점에 식별된 잔여는 다음 3 카테고리.
+#
+#   (a) `feed` 도메인 — #1815 1차 PR scope 에서 제외 (registry 미등록 11
+#       leaves 중 9 leaves). docs 표는 일부 leaf 를 직접 행으로, 일부는
+#       group aggregated row (예: ``feed run ...``, ``feed config/...``) 로
+#       다룬다.
+#
+#   (b) `init` / `update` — bootstrap / external-process 단일 leaf. #1815
+#       epic 본문이 명시한 leaf coverage 잔여 11 leaves 중 2 leaves.
+#
+#   (c) `notification` — docs 표가 "public leaf command 없음" 으로 명시한
+#       group level 행. registry 에 leaf 가 없는 게 정상.
+#
+# 본 baseline 은 *drift 가 아니라 의도된 carry-over* 다. 새 leaf 가 docs 표에
+# 추가되었는데 registry 미등록이면 본 YAML 갱신 없이 drift test 가 FAIL 해야
+# 한다 (구조적 invariant).
+#
+# 항목 추가/제거 규칙:
+# - registry 등록이 완료된 path 는 본 YAML 에서 entry 를 삭제한다.
+# - docs 가 새로 다루는 path 가 baseline 이상으로 늘어나면 본 YAML 에 추가
+#   *전*에 #1815 epic 후속 이슈로 spec 정렬을 결정한다.
+# - reason 은 사람이 읽는 자유 문자열. drift test 는 path tuple 만 참조한다.
+
+# docs/specs/cli/03-commands.md 에 등장하지만 CLI_COMMAND_REGISTRY 에는 등록되지
+# 않은 path. tuple 은 root-to-leaf segment (예: ["feed", "init"]).
+docs_only_paths:
+  # (a) feed 도메인 — #1815 1차 PR scope 제외 (registry 미등록 leaves)
+  - path: ["feed", "init"]
+    reason: "#1844 leaf coverage 잔여 — feed domain bootstrap leaf (registry out-of-scope)"
+  - path: ["feed", "inject"]
+    reason: "#1844 leaf coverage 잔여 — feed domain manual injection leaf"
+  - path: ["feed", "start"]
+    reason: "#1844 leaf coverage 잔여 — feed scheduler external process leaf"
+  - path: ["feed", "status"]
+    reason: "#1844 leaf coverage 잔여 — feed domain status leaf"
+  - path: ["feed", "config"]
+    reason: "docs aggregated group row (config/check/list/set sub-leaves are documented at group level only)"
+  - path: ["feed", "run"]
+    reason: "docs aggregated group row (run/backfill/daily sub-leaves are documented at group level only)"
+
+  # (b) init / update — single-leaf bootstrap / external-process
+  - path: ["init"]
+    reason: "#1844 leaf coverage 잔여 — ante init bootstrap (auth-exempt, fresh DB creation)"
+  - path: ["update"]
+    reason: "#1844 leaf coverage 잔여 — ante update external process (pip self-upgrade)"
+
+  # (c) notification — group level row, no public leaf
+  - path: ["notification"]
+    reason: "docs explicitly records '— public leaf command 없음' (group has no leaves)"

--- a/tests/unit/contracts/helpers.py
+++ b/tests/unit/contracts/helpers.py
@@ -40,6 +40,7 @@ test 가 repository root 를 고정하는 책임을 진다.
 from __future__ import annotations
 
 import ast
+import re
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -783,6 +784,138 @@ def load_drift_allowlist(path: Path | None = None) -> DriftAllowlist:
     )
 
 
+# ── docs/specs/cli/03-commands.md table parser (#1848) ────────────────────
+
+
+@dataclass(frozen=True)
+class DocsCommandRow:
+    """``docs/specs/cli/03-commands.md`` 의 ``| ante ... |`` 표 행 메타데이터.
+
+    Attributes:
+        lineno: 표 행이 등장한 줄 (1-based).
+        raw_first_cell: 표의 첫 cell 원문 ("ante" 접두 뒤의 raw 텍스트, 끝
+            backtick / 공백은 제거됨). 디버깅용.
+        paths: 본 행에서 추출된 root-to-leaf path tuple. 슬래시 alternation
+            (예: ``data list/schema/storage/...``) 은 카테시안 곱으로 확장된다.
+    """
+
+    lineno: int
+    raw_first_cell: str
+    paths: tuple[tuple[str, ...], ...]
+
+
+_DOCS_ROW_RE = re.compile(r"^\|\s*`?ante\s+([^|`]*)", re.MULTILINE)
+
+
+def _extract_docs_command_paths(first_cell: str) -> tuple[tuple[str, ...], ...]:
+    """표 행의 첫 cell 텍스트에서 command path 후보를 추출한다.
+
+    Heuristic:
+
+    * "ante" 접두는 정규식이 이미 제거. 남은 토큰을 공백 분리.
+    * 다음 중 하나로 시작하는 토큰을 만나면 끊는다 (option/argument 경계):
+
+      - ``-`` (e.g., ``--status``)
+      - ``<`` (e.g., ``<account_id>``)
+      - ``[`` / ``(`` (optional group / alternation in usage)
+      - ``...`` (variadic)
+
+    * 토큰 안의 ``/`` 는 alternative leaf alias 로 간주 (예:
+      ``list/schema/storage`` → ``list``, ``schema``, ``storage`` 각각 leaf).
+      여러 슬래시 토큰이 같은 행에 있으면 카테시안 곱으로 확장한다.
+
+    빈 결과 (``([],)``) 는 빈 tuple 로 변환해 ``return ()``.
+    """
+    raw = first_cell.strip().rstrip(" `")
+    tokens: list[str] = []
+    for tok in raw.split():
+        if not tok:
+            break
+        if tok.startswith("-") or tok.startswith("<") or tok.startswith("["):
+            break
+        if tok.startswith("("):
+            break
+        if tok == "...":
+            break
+        tok = tok.strip("`")
+        if not tok:
+            break
+        tokens.append(tok)
+    if not tokens:
+        return ()
+    paths: list[list[str]] = [[]]
+    for tok in tokens:
+        if "/" in tok:
+            alts = [a for a in tok.split("/") if a]
+            paths = [p + [a] for p in paths for a in alts]
+        else:
+            paths = [p + [tok] for p in paths]
+    return tuple(tuple(p) for p in paths if p)
+
+
+def iter_docs_command_rows(
+    path: Path | None = None,
+) -> Iterator[DocsCommandRow]:
+    """``docs/specs/cli/03-commands.md`` 의 ``| ante ... |`` 표 행을 yield.
+
+    AST 가 아니라 텍스트 정규식 기반이다. 문서 SSOT 구조가 markdown 표라는
+    invariant 를 그대로 따른다 — 표 구조가 깨지면 본 helper 도 함께 갱신
+    되어야 한다.
+
+    Args:
+        path: 로드할 markdown 경로. ``None`` 이면 repo 의
+            ``docs/specs/cli/03-commands.md`` 를 호출자 cwd 기준으로 읽는다.
+
+    Yields:
+        :class:`DocsCommandRow`: 각 표 행의 메타데이터. 슬래시 alternation 은
+        ``paths`` 에 카테시안 확장된 형태로 담긴다.
+
+    Note:
+        ``--version`` 만으로 끝나는 메타 경로 행은 ``paths`` 가
+        ``(("--version",),)`` 가 되는데, 본 helper 는 raw 추출만 책임지고
+        meta path 제외는 호출자가 결정한다 — 테스트가 명시적으로
+        ``--version`` 같은 dash 시작 segment 를 거른다.
+    """
+    if path is None:
+        path = Path("docs/specs/cli/03-commands.md")
+    text = path.read_text(encoding="utf-8")
+    for m in _DOCS_ROW_RE.finditer(text):
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        lineno = text.count("\n", 0, line_start) + 1
+        first_cell = m.group(1)
+        paths = _extract_docs_command_paths(first_cell)
+        yield DocsCommandRow(
+            lineno=lineno,
+            raw_first_cell=first_cell.strip().rstrip(" `"),
+            paths=paths,
+        )
+
+
+def collect_docs_command_paths(
+    path: Path | None = None,
+) -> frozenset[tuple[str, ...]]:
+    """``docs/specs/cli/03-commands.md`` 의 모든 명령 path 를 frozenset 으로.
+
+    :func:`iter_docs_command_rows` 의 각 row 의 paths 를 합친 결과. dash 로
+    시작하는 segment (``--version`` 같은 메타 옵션 행) 는 제외한다 — 본
+    helper 의 결과는 leaf 또는 그룹 command path 만 포함하는 invariant 를
+    유지한다.
+
+    Args:
+        path: :func:`iter_docs_command_rows` 와 동일.
+
+    Returns:
+        모든 명령 path tuple 의 frozenset (그룹 + leaf 혼합 가능).
+    """
+    result: set[tuple[str, ...]] = set()
+    for row in iter_docs_command_rows(path):
+        for p in row.paths:
+            if p and p[0].startswith("-"):
+                continue
+            result.add(p)
+    return frozenset(result)
+
+
 # ── public surface ────────────────────────────────────────────────────────
 
 
@@ -790,15 +923,18 @@ __all__ = [
     "AuthMetadata",
     "CliLeafCommand",
     "DatabaseConstructionSite",
+    "DocsCommandRow",
     "DriftAllowlist",
     "ExceptionAllowlistEntry",
     "ExceptionClassInfo",
     "FmtErrorAllowlistEntry",
     "FmtErrorCallsite",
     "GetDbPathCall",
+    "collect_docs_command_paths",
     "iter_click_leaf_commands",
     "iter_command_auth_metadata",
     "iter_database_constructions",
+    "iter_docs_command_rows",
     "iter_exception_classes",
     "iter_fmt_error_calls",
     "iter_get_db_path_calls",

--- a/tests/unit/contracts/test_cli_registry_docs_drift.py
+++ b/tests/unit/contracts/test_cli_registry_docs_drift.py
@@ -1,0 +1,171 @@
+"""CLI registry ↔ docs command table drift tests (#1848 Family A).
+
+#1815 epic 의 마지막 sub. ``src/ante/contracts/cli_registry.py`` 의
+``CLI_COMMAND_REGISTRY`` 와 ``docs/specs/cli/03-commands.md`` 의 ``| ante ... |``
+표 행에서 추출한 command path 집합을 양방향 비교한다.
+
+두 invariant 를 강제한다:
+
+* **registry → docs**: registry 의 모든 leaf path 는 docs 표에 반드시 등장한다.
+  registry 가 새 leaf 를 등록했는데 docs 표에 누락되면 본 테스트가 FAIL 한다
+  (allowlist 우회 없음 — 본 방향은 baseline 0 invariant).
+* **docs → registry**: docs 표에 등장하는 path 중 registry 미등록인 path 는
+  ``docs_drift_allowlist.yaml`` 에 baseline 으로 등록된 set 과 일치해야 한다.
+  새 docs row 가 추가되었는데 registry 미등록이면 본 테스트가 FAIL 한다.
+
+본 PR (#1848) 시점에 baseline 등록된 9 path 는 #1815 epic 본문이 명시한
+leaf coverage 잔여 11 leaves + docs aggregated group row + notification group
+의 carry-over 다. 본 baseline 의 *사유* 는 ``docs_drift_allowlist.yaml`` 의
+inline 주석을 참조한다.
+
+본 테스트는 docs 본문이나 registry entries 를 *수정* 하지 않는다. drift 검출만
+한다 — 보정은 별도 PR 에서 처리한다는 #1848 stop condition 을 따른다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
+from tests.unit.contracts.helpers import collect_docs_command_paths
+
+# ── fixtures / paths ────────────────────────────────────────────────────────
+
+
+def _repo_root() -> Path:
+    """본 test file 기준 repo root 를 절대 경로로 반환한다.
+
+    ``tests/unit/contracts/test_cli_registry_docs_drift.py`` → 3 단계 위.
+    """
+    return Path(__file__).resolve().parent.parent.parent.parent
+
+
+def _docs_path() -> Path:
+    return _repo_root() / "docs" / "specs" / "cli" / "03-commands.md"
+
+
+def _allowlist_path() -> Path:
+    return Path(__file__).resolve().parent / "docs_drift_allowlist.yaml"
+
+
+# ── allowlist loader ────────────────────────────────────────────────────────
+
+
+def _load_docs_only_allowlist() -> frozenset[tuple[str, ...]]:
+    """``docs_drift_allowlist.yaml`` 의 ``docs_only_paths`` section 을 로드한다.
+
+    YAML 의 ``path`` 필드는 list[str] 로 저장되며, 본 helper 가 tuple 로 정규화
+    한다. ``reason`` 은 test 가 참조하지 않는다 (사람 리뷰 근거 용).
+    """
+    data = yaml.safe_load(_allowlist_path().read_text(encoding="utf-8")) or {}
+    raw = data.get("docs_only_paths") or []
+    return frozenset(tuple(item["path"]) for item in raw)
+
+
+# ── tests ───────────────────────────────────────────────────────────────────
+
+
+def test_registry_paths_are_subset_of_docs() -> None:
+    """registry 의 모든 leaf path 는 docs 표에 등장해야 한다 (baseline 0).
+
+    allowlist 우회 없음. registry 가 새 leaf 를 등록했는데 docs 표에 누락된
+    경우 본 테스트가 FAIL 한다. drift 발견 시 docs 표를 갱신해야 한다.
+
+    본 방향의 baseline 이 0 인 이유는 #1815 epic 본문이 명시했듯 registry 가
+    docs SSOT 의 *부분집합* 이어야 하기 때문이다 — docs 는 group aggregated
+    row 같은 추가 entry 를 가질 수 있지만, registry 의 모든 leaf 는 반드시
+    docs 표에 등장해야 한다.
+    """
+    docs_paths = collect_docs_command_paths(_docs_path())
+    registry_paths = frozenset(CLI_COMMAND_REGISTRY.keys())
+
+    missing = registry_paths - docs_paths
+    assert not missing, (
+        "CLI_COMMAND_REGISTRY 에 등록된 leaf 가 docs/specs/cli/03-commands.md "
+        f"표에 누락됨 (count={len(missing)}): {sorted(missing)}. "
+        "docs 표를 갱신하거나 registry entry 를 제거할 것."
+    )
+
+
+def test_docs_only_paths_match_baseline() -> None:
+    """docs 표에 등장하지만 registry 미등록인 path 는 baseline 과 일치해야 한다.
+
+    새 docs row 가 추가되었는데 registry 미등록이면 본 테스트가 FAIL 한다.
+    drift 발견 시 두 선택지가 있다:
+
+    * registry 에 해당 leaf 를 등록 (선호) — docs 가 SSOT.
+    * 의도적 carry-over 면 ``docs_drift_allowlist.yaml`` 에 sustained rationale
+      과 함께 등록하고 본 baseline 을 갱신.
+
+    본 테스트는 양방향 동치를 강제한다: baseline 에 있지만 docs 에서 사라진
+    path 도 FAIL — stale entry 가 누적되지 않도록 sanity 한다.
+    """
+    docs_paths = collect_docs_command_paths(_docs_path())
+    registry_paths = frozenset(CLI_COMMAND_REGISTRY.keys())
+    baseline = _load_docs_only_allowlist()
+
+    actual_docs_only = docs_paths - registry_paths
+
+    unexpected_new = actual_docs_only - baseline
+    assert not unexpected_new, (
+        "docs/specs/cli/03-commands.md 표에 등장하지만 registry 미등록이고 "
+        f"baseline 에도 없는 path (count={len(unexpected_new)}): "
+        f"{sorted(unexpected_new)}. "
+        "registry 에 등록하거나 docs_drift_allowlist.yaml 의 docs_only_paths "
+        "section 에 사유와 함께 추가할 것."
+    )
+
+    stale_baseline = baseline - actual_docs_only
+    assert not stale_baseline, (
+        "docs_drift_allowlist.yaml 의 docs_only_paths 에 등록되어 있지만 "
+        f"실제 docs 표 - registry 차집합에는 없는 stale entry "
+        f"(count={len(stale_baseline)}): {sorted(stale_baseline)}. "
+        "registry 에 새로 등록되어 더 이상 carry-over 가 아니거나 docs 에서 "
+        "행이 삭제되었다면 baseline 에서도 entry 를 제거할 것."
+    )
+
+
+def test_docs_command_paths_extraction_smoke() -> None:
+    """parser smoke test — docs 표가 최소 한 자릿수 이상의 path 를 생성한다.
+
+    구조적 회귀 (예: 정규식이 zero-match 가 되거나 file path 가 잘못 변경되어
+    텍스트가 empty 가 되는 경우) 를 빠르게 잡는다.
+    """
+    docs_paths = collect_docs_command_paths(_docs_path())
+    # 본 PR 시점 docs 표는 약 100 개 distinct command path 를 가지므로 50 을
+    # 최소선으로 잡는다 — 향후 docs 가 크게 축소되어도 50 이하면 invariant 위반.
+    assert len(docs_paths) >= 50, (
+        f"docs/specs/cli/03-commands.md 에서 추출된 command path 가 너무 적음 "
+        f"({len(docs_paths)} < 50). 표 parser 또는 docs 파일 자체에 회귀 의심."
+    )
+
+
+@pytest.mark.parametrize(
+    "expected_known_path",
+    [
+        ("init",),
+        ("update",),
+        ("feed", "init"),
+        ("notification",),
+    ],
+)
+def test_known_docs_only_paths_present_in_baseline(
+    expected_known_path: tuple[str, ...],
+) -> None:
+    """#1815 epic 본문이 명시한 known carry-over 가 baseline 에 등록되어 있다.
+
+    Smoke regression — baseline 파일이 의도치 않게 빈 list 로 회귀하거나
+    epic 문서가 명시한 carry-over set 이 누락되면 즉시 FAIL 한다. 본 테스트
+    자체는 baseline 의 *완전성* 을 강제하지 않는다 (full 동치는
+    :func:`test_docs_only_paths_match_baseline` 가 본다). 본 테스트는 epic 의
+    핵심 4 carry-over 가 사라지지 않는지만 본다.
+    """
+    baseline = _load_docs_only_allowlist()
+    assert expected_known_path in baseline, (
+        f"#1815 epic 본문이 명시한 carry-over path {expected_known_path!r} 가 "
+        "docs_drift_allowlist.yaml 의 docs_only_paths 에 누락됨. "
+        "epic 본문과 baseline 의 정합성을 확인할 것."
+    )

--- a/tests/unit/contracts/test_cli_registry_guide_sync.py
+++ b/tests/unit/contracts/test_cli_registry_guide_sync.py
@@ -1,0 +1,173 @@
+"""CLI registry ↔ ``guide/cli.md`` generated reference sync tests (#1848 Family B).
+
+#1815 epic 의 마지막 sub. ``scripts/generate_cli_reference.py`` 의
+:func:`generate_cli_reference` 가 Click introspection 결과를 markdown 으로
+출력한다. 본 generator 는 ``guide/cli.md`` 의 SSOT 다.
+
+본 모듈은 두 invariant 를 강제한다:
+
+* **Idempotency**: generator 를 같은 process / 같은 input 으로 두 번 실행하면
+  output 이 byte-equal 해야 한다. 비결정적 ordering (dict iteration, set
+  iteration, scope 출력) 회귀를 잡는다.
+
+* **Determinism modulo timestamp**: 동일 process 안에서 두 번 호출하면
+  ``> 마지막 갱신: YYYY-MM-DD`` 줄을 포함한 전체 output 이 동일하다 (같은
+  process 의 ``datetime.now()`` 가 ms 단위까지 같지는 않지만 day precision
+  만 출력하므로). 본 invariant 는 generator 의 timestamp emission 패턴에
+  의존하지 않도록 timestamp 줄을 정규화한 비교도 함께 둔다.
+
+본 PR (#1848) 는 ``guide/cli.md`` 의 *본문* 을 갱신하지 않는다 — committed
+markdown 과 freshly generated output 의 비교는 별도 dedicated PR 이 처리
+한다는 #1848 stop condition 을 따른다. 본 테스트는 generator 자신의 행동
+invariant 만 검증한다.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+# ── fixtures / setup ───────────────────────────────────────────────────────
+
+
+def _repo_root() -> Path:
+    """본 test file 기준 repo root 절대 경로."""
+    return Path(__file__).resolve().parent.parent.parent.parent
+
+
+@pytest.fixture(scope="module")
+def _scripts_on_path() -> None:
+    """``scripts/`` 디렉토리를 ``sys.path`` 에 일시적으로 추가.
+
+    ``generate_cli_reference`` 는 top-level script 라 package 가 아니다. test
+    process 가 import 할 수 있도록 ``scripts/`` 경로를 path 에 넣는다.
+    """
+    scripts_dir = str(_repo_root() / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+
+_TIMESTAMP_RE = re.compile(r"^> 마지막 갱신: \d{4}-\d{2}-\d{2}$", re.MULTILINE)
+
+
+def _normalize_timestamp(markdown: str) -> str:
+    """``> 마지막 갱신: YYYY-MM-DD`` 행을 ``<TIMESTAMP>`` 자리표시자로 치환.
+
+    generator 의 day-precision timestamp 를 정규화해 본문 결정성만 비교한다.
+    """
+    return _TIMESTAMP_RE.sub("> 마지막 갱신: <TIMESTAMP>", markdown)
+
+
+# ── tests ───────────────────────────────────────────────────────────────────
+
+
+def test_generate_cli_reference_is_byte_equal_on_repeat(
+    _scripts_on_path: None,
+) -> None:
+    """같은 process 에서 두 번 호출하면 output 이 byte-equal.
+
+    Click introspection 의 비결정적 ordering 회귀를 잡는다. dict / set /
+    scope ordering 변경, hidden command set 의 ordering 변화 같은 회귀가
+    있으면 본 테스트가 FAIL 한다.
+
+    timestamp 까지 포함해 완전 동치를 본다 — generator 가 same-day 안에서는
+    같은 timestamp 를 emit 한다는 invariant 도 함께 강제한다.
+    """
+    from generate_cli_reference import generate_cli_reference  # noqa: PLC0415
+
+    buf1 = io.StringIO()
+    count1 = generate_cli_reference(buf1)
+    buf2 = io.StringIO()
+    count2 = generate_cli_reference(buf2)
+
+    assert count1 == count2, (
+        f"subcommand count 가 두 번의 호출에서 다름: "
+        f"first={count1}, second={count2} (non-determinism 의심)"
+    )
+
+    output1 = buf1.getvalue()
+    output2 = buf2.getvalue()
+    assert output1 == output2, (
+        "generate_cli_reference 가 같은 process 에서 두 번 호출되었는데 "
+        f"output 이 다름 (lengths: first={len(output1)}, second={len(output2)}). "
+        "Click introspection 의 비결정적 ordering 회귀 의심."
+    )
+
+
+def test_generate_cli_reference_body_is_deterministic(
+    _scripts_on_path: None,
+) -> None:
+    """timestamp 를 정규화한 본문은 두 호출에서 byte-equal.
+
+    :func:`test_generate_cli_reference_is_byte_equal_on_repeat` 와 같은
+    invariant 를 timestamp 추출 후 다시 본다. timestamp regex 가 잡지 못
+    하는 또 다른 비결정 source 가 있으면 본 테스트도 FAIL 한다 (defense-in-depth).
+    """
+    from generate_cli_reference import generate_cli_reference  # noqa: PLC0415
+
+    buf1 = io.StringIO()
+    generate_cli_reference(buf1)
+    buf2 = io.StringIO()
+    generate_cli_reference(buf2)
+
+    norm1 = _normalize_timestamp(buf1.getvalue())
+    norm2 = _normalize_timestamp(buf2.getvalue())
+    assert norm1 == norm2, (
+        "generate_cli_reference 의 timestamp 외 본문이 두 호출에서 다름. "
+        "timestamp regex 가 잡지 못하는 추가 비결정성 의심."
+    )
+
+
+def test_generate_cli_reference_emits_expected_structural_anchors(
+    _scripts_on_path: None,
+) -> None:
+    """generator output 의 핵심 구조 anchor 가 항상 등장한다.
+
+    구조적 회귀 (예: 글로벌 옵션 섹션 누락, 명령어 요약 표 누락) 를 빠르게
+    잡는다. 본 테스트는 본문 byte-level diff 가 아니라 anchor 존재 여부만
+    본다 — committed ``guide/cli.md`` 본문과의 동기화는 별도 PR scope.
+    """
+    from generate_cli_reference import generate_cli_reference  # noqa: PLC0415
+
+    buf = io.StringIO()
+    count = generate_cli_reference(buf)
+    output = buf.getvalue()
+
+    # 최소한의 구조 anchor — generator 가 정상 동작하면 모두 등장한다.
+    assert "# Ante CLI Reference" in output
+    assert "## 글로벌 옵션" in output
+    assert "## 명령어 요약" in output
+    assert "> 마지막 갱신:" in output
+    # 본 PR 시점 Click 트리는 105 leaf — 향후 leaf 추가/제거가 정상이므로
+    # 정확한 수치보다 "두 자릿수 이상의 leaf 를 emit" 인지만 본다.
+    assert count >= 50, (
+        f"generate_cli_reference 가 expected 보다 적은 leaf 를 emit ({count} < 50). "
+        "Click 트리 또는 generator hidden filter 회귀 의심."
+    )
+
+
+def test_generate_cli_reference_timestamp_normalization_smoke() -> None:
+    """timestamp 정규화 regex 가 실제 generator output 패턴을 매치한다.
+
+    :func:`_normalize_timestamp` 는 본 모듈의 invariant 강제 helper 다.
+    regex 가 잘못 변경되어 매치하지 못하면 idempotency 검사가 false-pass
+    하므로 regex 자체를 smoke test 한다.
+    """
+    sample = "> 마지막 갱신: 2026-05-27"
+    normalized = _normalize_timestamp(sample)
+    assert normalized == "> 마지막 갱신: <TIMESTAMP>"
+
+    # multi-line 안에서도 정확히 timestamp 줄만 치환한다.
+    sample_multi = "Header\n> 마지막 갱신: 2026-05-27\nBody"
+    normalized_multi = _normalize_timestamp(sample_multi)
+    assert normalized_multi == "Header\n> 마지막 갱신: <TIMESTAMP>\nBody"
+
+    # timestamp 가 아닌 줄은 변하지 않는다.
+    sample_noop = "> 다른 인용\n  > 마지막 갱신: 2026-05-27"
+    # leading spaces 가 있으면 매치하지 않는다 (^ anchor + MULTILINE).
+    normalized_noop = _normalize_timestamp(sample_noop)
+    assert "  > 마지막 갱신: 2026-05-27" in normalized_noop

--- a/tests/unit/contracts/test_helpers.py
+++ b/tests/unit/contracts/test_helpers.py
@@ -17,12 +17,15 @@ from tests.unit.contracts.helpers import (
     AuthMetadata,
     CliLeafCommand,
     DatabaseConstructionSite,
+    DocsCommandRow,
     ExceptionClassInfo,
     FmtErrorCallsite,
     GetDbPathCall,
+    collect_docs_command_paths,
     iter_click_leaf_commands,
     iter_command_auth_metadata,
     iter_database_constructions,
+    iter_docs_command_rows,
     iter_exception_classes,
     iter_fmt_error_calls,
     iter_get_db_path_calls,
@@ -695,6 +698,153 @@ class TestIterGetDbPathCalls:
     def test_missing_root_returns_empty(self, tmp_path: Path) -> None:
         results = list(iter_get_db_path_calls(tmp_path / "nonexistent"))
         assert results == []
+
+
+# ── iter_docs_command_rows / collect_docs_command_paths (#1848) ───────────
+
+
+class TestIterDocsCommandRows:
+    """``docs/specs/cli/03-commands.md`` 표 행 파서 skeleton."""
+
+    def test_extracts_simple_leaf_row(self, tmp_path: Path) -> None:
+        """단일 leaf path 행을 그대로 추출한다."""
+        doc = tmp_path / "spec.md"
+        doc.write_text(
+            "| `ante account list` | offline | runtime-safe |\n",
+            encoding="utf-8",
+        )
+        rows = list(iter_docs_command_rows(doc))
+        assert len(rows) == 1
+        assert rows[0].paths == (("account", "list"),)
+
+    def test_extracts_row_with_argument_placeholder(self, tmp_path: Path) -> None:
+        """``<arg>`` 형태의 placeholder 토큰은 path 추출에서 끊긴다."""
+        doc = tmp_path / "spec.md"
+        doc.write_text(
+            "| `ante account info <account_id>` | offline | x |\n",
+            encoding="utf-8",
+        )
+        rows = list(iter_docs_command_rows(doc))
+        assert rows[0].paths == (("account", "info"),)
+
+    def test_extracts_row_with_option(self, tmp_path: Path) -> None:
+        """``--option`` 토큰은 path 추출에서 끊긴다."""
+        doc = tmp_path / "spec.md"
+        doc.write_text(
+            "| `ante account list [--status <status>]` | offline | x |\n",
+            encoding="utf-8",
+        )
+        rows = list(iter_docs_command_rows(doc))
+        assert rows[0].paths == (("account", "list"),)
+
+    def test_expands_slash_alternation(self, tmp_path: Path) -> None:
+        """슬래시로 구분된 토큰은 카테시안 곱으로 확장한다."""
+        doc = tmp_path / "spec.md"
+        doc.write_text(
+            "| `ante data list/schema/storage ...` | offline | x |\n",
+            encoding="utf-8",
+        )
+        rows = list(iter_docs_command_rows(doc))
+        assert set(rows[0].paths) == {
+            ("data", "list"),
+            ("data", "schema"),
+            ("data", "storage"),
+        }
+
+    def test_returns_typed_rows(self, tmp_path: Path) -> None:
+        """yield 되는 객체는 :class:`DocsCommandRow` 인스턴스다."""
+        doc = tmp_path / "spec.md"
+        doc.write_text(
+            "| `ante system status` | offline | x |\n",
+            encoding="utf-8",
+        )
+        rows = list(iter_docs_command_rows(doc))
+        assert isinstance(rows[0], DocsCommandRow)
+        assert rows[0].lineno == 1
+        assert "ante system status" in f"ante {rows[0].raw_first_cell}"
+
+    def test_ignores_non_ante_rows(self, tmp_path: Path) -> None:
+        """``| ante`` 로 시작하지 않는 행은 무시한다."""
+        doc = tmp_path / "spec.md"
+        doc.write_text(
+            textwrap.dedent(
+                """\
+                | 분류 | 의미 |
+                |------|------|
+                | `offline` | x |
+                | `ante system status` | offline | x |
+                """,
+            ),
+            encoding="utf-8",
+        )
+        rows = list(iter_docs_command_rows(doc))
+        assert len(rows) == 1
+        assert rows[0].paths == (("system", "status"),)
+
+
+class TestCollectDocsCommandPaths:
+    """``collect_docs_command_paths`` aggregation 동작."""
+
+    def test_collects_distinct_paths(self, tmp_path: Path) -> None:
+        """여러 행에서 중복된 path 는 한 번만 등장한다."""
+        doc = tmp_path / "spec.md"
+        doc.write_text(
+            textwrap.dedent(
+                """\
+                | `ante system status` | offline | x |
+                | `ante system status` | offline | duplicate row |
+                | `ante system halt` | runtime IPC | x |
+                """,
+            ),
+            encoding="utf-8",
+        )
+        paths = collect_docs_command_paths(doc)
+        assert paths == frozenset(
+            {
+                ("system", "status"),
+                ("system", "halt"),
+            },
+        )
+
+    def test_excludes_dash_meta_paths(self, tmp_path: Path) -> None:
+        """``--version`` 처럼 dash 로 시작하는 segment 는 결과에서 제외된다."""
+        doc = tmp_path / "spec.md"
+        doc.write_text(
+            "| `ante --version` | meta | meta row |\n"
+            "| `ante system status` | offline | x |\n",
+            encoding="utf-8",
+        )
+        paths = collect_docs_command_paths(doc)
+        # ``--version`` 토큰은 path extraction 단계에서 break 되어 paths=()
+        # 가 되지만, 만에 하나 row 가 ``--`` segment 로 추출되더라도 collect
+        # 단계가 dash-leading segment 를 거른다.
+        assert paths == frozenset({("system", "status")})
+
+    def test_returns_frozenset(self, tmp_path: Path) -> None:
+        """결과는 :class:`frozenset` 으로 immutable 하다."""
+        doc = tmp_path / "spec.md"
+        doc.write_text(
+            "| `ante system status` | offline | x |\n",
+            encoding="utf-8",
+        )
+        paths = collect_docs_command_paths(doc)
+        assert isinstance(paths, frozenset)
+
+    def test_runs_against_real_docs(self) -> None:
+        """실제 ``docs/specs/cli/03-commands.md`` 에 대해 파서가 깨지지 않는다.
+
+        본 테스트는 docs SSOT 변경 시 path extraction 이 zero-match 가 되거나
+        구조적 회귀가 생기는지를 sanity check 한다. 정확한 path set 동치는
+        :mod:`tests.unit.contracts.test_cli_registry_docs_drift` 의 책임.
+        """
+        repo_root = Path(__file__).resolve().parents[3]
+        spec_path = repo_root / "docs" / "specs" / "cli" / "03-commands.md"
+        if not spec_path.exists():
+            pytest.skip("docs/specs/cli/03-commands.md not present in this layout")
+        paths = collect_docs_command_paths(spec_path)
+        assert len(paths) >= 50, (
+            f"실제 docs 에서 추출된 path 수가 너무 적음 ({len(paths)} < 50)"
+        )
 
 
 # ── repository-wide sanity ────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1848
Closes #1815

## Summary

#1815 epic 의 마지막 sub. CLI command contract SSOT 정리의 docs/probe drift integration 과 generated guide sync 게이트를 추가한다. 본 PR 은 drift 검출만 도입하고 docs/registry 본문은 변경하지 않는다 (#1848 stop condition).

## 2 Family Tests

### Family A — registry ↔ docs command table (`test_cli_registry_docs_drift.py`)

`CLI_COMMAND_REGISTRY` (94 entries, #1844) 와 `docs/specs/cli/03-commands.md` 의 `| ante ... |` 표 행에서 추출한 command path 집합을 양방향 비교.

두 invariant:

* **registry → docs**: registry 의 모든 leaf path 는 docs 표에 등장. baseline 0 (allowlist 우회 없음).
* **docs → registry**: docs 표에는 있지만 registry 미등록인 path 는 baseline allowlist 와 정확히 일치. 새 docs row 추가 시 자동 FAIL. stale entry 도 함께 sanity 검출.

검증 결과:

* `registry - docs = ∅` (registry → docs 완전 부분집합, 0 drift).
* `docs - registry = 9 paths` → 모두 baseline 에 등록 (의도된 carry-over).

### Family B — `guide/cli.md` regen idempotent (`test_cli_registry_guide_sync.py`)

`scripts/generate_cli_reference.py:generate_cli_reference` 가 Click introspection 결과를 markdown 으로 emit. 본 generator 가 `guide/cli.md` 의 SSOT.

두 invariant:

* **Idempotency**: 같은 process 에서 두 번 호출 → byte-equal output. Click introspection 의 비결정적 ordering 회귀 검출.
* **Determinism modulo timestamp**: `> 마지막 갱신: YYYY-MM-DD` 줄을 정규화한 본문이 두 호출에서 byte-equal. defense-in-depth.

추가 sanity: 구조 anchor 존재 (Header / 글로벌 옵션 / 명령어 요약 / timestamp marker), leaf count ≥ 50, timestamp 정규화 regex 자체 smoke.

## Baseline Allowlist

`tests/unit/contracts/docs_drift_allowlist.yaml` `docs_only_paths` section (9 entries):

* `feed` 도메인 6 entries — #1844 leaf coverage 잔여 (feed init/inject/start/status) + docs aggregated group row (feed config, feed run).
* `init` / `update` 2 entries — #1815 epic 본문이 명시한 single-leaf bootstrap / external-process.
* `notification` 1 entry — docs 표가 "public leaf command 없음" 으로 명시한 group level row.

본 baseline 은 drift 가 아니라 의도된 carry-over. 새 docs row 가 baseline 외로 추가되거나 baseline entry 가 사라지면 자동 FAIL.

## helpers.py 확장

`tests/unit/contracts/helpers.py` 에 docs 표 파서 추가:

* `DocsCommandRow` dataclass (lineno + paths)
* `iter_docs_command_rows` — `| ante ... |` 표 행 순회
* `collect_docs_command_paths` — distinct path frozenset aggregator

self-test 11 cases (leaf row, argument placeholder, option boundary, slash alternation, distinct aggregation, dash exclusion, frozenset invariant, real docs smoke).

## Verification

* `pytest tests/unit/contracts/test_cli_registry_docs_drift.py -v` — 7 PASS
* `pytest tests/unit/contracts/test_cli_registry_guide_sync.py -v` — 4 PASS
* `pytest tests/unit/contracts/test_helpers.py -v` — 11 new PASS (62 total)
* `pytest tests/unit/contracts/` — 145 PASS
* `pytest tests/unit/` — 본 PR 회귀 0 (failed test set 이 main 과 byte-equal; +21 PASS 증가는 본 PR 신규 테스트)
* `mypy src/ante` — 224 source files clean
* `ruff check tests/unit/contracts/` — All checks passed
* `ruff format --check tests/unit/contracts/` — already formatted
* `scripts/generate_project_structure.py` — 3 new files 반영하여 regen

## 변경 금지 (스펙 stop condition 준수)

* CLI registry entries — 미변경
* CLI command 본문 — 미변경
* `docs/specs/cli/03-commands.md` 본문 — 미변경 (drift 검출만)
* `guide/cli.md` 본문 — 미변경 (idempotency invariant 만 강제)

## #1815 Epic Close

본 PR 머지 시 #1815 epic 의 sub checklist 마지막 항목 (`[ ] #1848 ...`) 이 완료된다. 의존성 그래프 `#1816 → #1844 → #1845 → #1846 → #1847 → #1848` 의 종착점 + `#1819 → #1848` 도 충족. 사용자가 #1815 의 epic 완료 처리 결정 가능.

## Test plan

- [x] Family A 7 tests PASS (registry-docs 양방향 + baseline 동치 + smoke + 4 parametrized known-path)
- [x] Family B 4 tests PASS (idempotency + body determinism + structural anchors + timestamp regex smoke)
- [x] helpers 자체 11 cases PASS
- [x] 전체 tests/unit/ 회귀 0 (failed test set main 과 동일)
- [x] mypy src/ante clean
- [x] ruff / ruff format clean
- [x] project-structure.md regen 반영
- [x] main HEAD `24a24d29` 불변 확인