### PR TITLE
refactor: #1870 bot/config text-mode prefix UX — allowlist intended_no_code 영구 이동

### DIFF
--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -27,7 +27,36 @@
 #       module = dotted module path (예: ante.account.errors).
 #       class_anchor = class 이름.
 
-intended_no_code: []
+# bot.py 931/967/1001 (구 882/918/952) 와 config.py 214/217 (구 176/179) 의
+# ``ipc_send`` ClickException text-mode 분기는 ``text = f"{code}: {message}"``
+# prefix 패턴이 의도된 영구 UX 계약이다. 회귀 lock
+# ``test_bot_start_error_text_mode_carries_code_prefix`` 와
+# ``test_config_set_server_error`` 의 ``"STATIC_CONFIG" in result.output`` 가
+# text 모드에서 ``code: message`` prefix 톤을 명시 요구하므로 단순
+# ``fmt.error(message, code=code)`` 정렬이 UX 회귀가 된다. 따라서
+# ``known_drift`` deferred 가 아닌 ``intended_no_code`` 영구 면제로 분류한다
+# (#1870 옵션 3).
+intended_no_code:
+  - path: src/ante/cli/commands/bot.py
+    line: 931
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
+  - path: src/ante/cli/commands/bot.py
+    line: 967
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
+  - path: src/ante/cli/commands/bot.py
+    line: 1001
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
+  - path: src/ante/cli/commands/config.py
+    line: 214
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
+  - path: src/ante/cli/commands/config.py
+    line: 217
+    snippet_sha1: "1b05e8ebf6bd"
+    reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
 
 known_drift_fmt_error_no_code:
   # #1842: account.py line 762/804 entries 제거 — emit_cli_error 정렬 완료
@@ -38,25 +67,10 @@ known_drift_fmt_error_no_code:
   # line 499 (non-table-missing OperationalError fallback) 는 emit_cli_error
   # 로 ``EXECUTION_ERROR`` (registry miss fallback) surface 로 정렬.
   #
-  # bot.py line 882/918/952 (구 872/908/942) 는 ``ipc_send`` ClickException
-  # text-mode 분기의 ``text = f"{code}: {message}"`` 패턴 — config.py 와
-  # 동형의 #1673 ``config set`` 선례 deferred 유지. 회귀 lock
-  # ``test_bot_start_error_text_mode_carries_code_prefix`` 가 text 모드의
-  # ``code: message`` prefix 톤을 명시 요구하므로 단순
-  # ``fmt.error(message, code=code)`` 정렬이 UX 회귀가 된다. config.py 의
-  # 동형 deferred 정리와 함께 별도 follow-up 에서 책임진다.
-  - path: src/ante/cli/commands/bot.py
-    line: 931
-    snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (line shifted by #1857 _create_services factory migration)"
-  - path: src/ante/cli/commands/bot.py
-    line: 967
-    snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (line shifted by #1857 _create_services factory migration)"
-  - path: src/ante/cli/commands/bot.py
-    line: 1001
-    snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (line shifted by #1857 _create_services factory migration)"
+  # #1870 옵션 3: bot.py 931/967/1001 + config.py 214/217 entries 를
+  # ``intended_no_code`` 로 영구 이동 — text-mode ``{code}: {message}``
+  # prefix UX lock 은 의도된 계약이며 deferred 가 아니다.
+  #
   # #1843 sub-PR 5: broker.py line 211/266/318 entries 제거 — emit_cli_error
   # 정렬 완료 (broker typed exception 5 sub-class 가 ``BROKER_*`` 안정 코드를
   # registry MRO lookup 으로 surface, 미분류 fault 는 ``EXECUTION_ERROR``
@@ -71,25 +85,15 @@ known_drift_fmt_error_no_code:
   # ``code="UPDATE_INSTALL_FAILED"`` 명시 부여 (typed exception 없는
   # bool 반환 함수의 실패 surface).
   #
-  # config.py 176/179 는 bot.py 882/918/952 와 동일 snippet_sha1
-  # (``3dc4008c3fb0``) 의 ``ipc_send`` ClickException text-mode
-  # ``text = f"{code}: {message}"`` prefix 패턴이다. helper
-  # ``emit_cli_error`` 는 ``OutputFormatter.error`` 가 text 모드에서 code
-  # 를 출력하지 않으므로 prefix 가 사라져 ``test_config_set_server_error``
-  # 의 ``"STATIC_CONFIG" in result.output`` 회귀 lock 이 깨진다.
-  # bot.py 882/918/952 와 묶어 별도 follow-up issue 가 책임진다.
-  - path: src/ante/cli/commands/config.py
-    line: 214
-    snippet_sha1: "3dc4008c3fb0"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (bot.py 동형, line shifted by #1857 _create_services factory migration)"
-  - path: src/ante/cli/commands/config.py
-    line: 217
-    snippet_sha1: "1b05e8ebf6bd"
-    reason: "baseline (#1841); deferred — text-mode {code}: {message} prefix lock (bot.py 동형, line shifted by #1857 _create_services factory migration)"
   # #1843 sub-PR 1: member.py entries 15건 제거 — emit_cli_error 정렬 완료
   # (CLI direct path 가 IPC envelope 와 동일 public code surface).
   # _MASTER_REQUIRED_MESSAGE override 보존하는 typed except 는 code 인자
   # 명시 (``code="PERMISSION_DENIED"``) 로 정렬했다.
+  #
+  # 본 section 은 현재 비어 있다 — #1870 이 마지막 5건 (bot.py 931/967/1001
+  # + config.py 214/217) 을 ``intended_no_code`` 로 영구 이동하면서 baseline
+  # 잔여분이 모두 해소되었다. 향후 신규 deferred drift 가 등장하면 본 section
+  # 에 재등록한다.
 
 pending_migration:
   - module: ante.account.errors


### PR DESCRIPTION
Closes #1870

## Summary

- `tests/unit/contracts/error_drift_allowlist.yaml` 의 5 entries 를
  `known_drift_fmt_error_no_code` → `intended_no_code` 로 영구 이동.
  - `src/ante/cli/commands/bot.py:931` (snippet_sha1=`3dc4008c3fb0`)
  - `src/ante/cli/commands/bot.py:967` (snippet_sha1=`3dc4008c3fb0`)
  - `src/ante/cli/commands/bot.py:1001` (snippet_sha1=`3dc4008c3fb0`)
  - `src/ante/cli/commands/config.py:214` (snippet_sha1=`3dc4008c3fb0`)
  - `src/ante/cli/commands/config.py:217` (snippet_sha1=`1b05e8ebf6bd`)
- 각 entry 의 `reason` 을 `"text-mode {code}: {message} prefix UX lock —
  intended permanent (resolves #1870)"` 로 갱신.
- `known_drift` section 헤더 및 `intended_no_code` section 헤더에 #1870
  옵션 3 결정 설명 주석 추가.

## 의도된 영구 분류 근거

`bot.py` / `config.py` 의 `ipc_send` ClickException text-mode 분기는
`text = f"{code}: {message}"` 패턴으로 사용자가 즉시 코드를 식별할 수
있게 한다. 회귀 lock 두 개가 이 톤을 명시 요구한다:

- `test_bot_start_error_text_mode_carries_code_prefix`
- `test_config_set_server_error` 의 `"STATIC_CONFIG" in result.output`

`emit_cli_error` / `fmt.error(message, code=code)` 로 단순 정렬하면 text
모드에서 `OutputFormatter.error` 가 code 를 출력하지 않아 prefix 가
사라지고 두 lock 이 깨진다. 따라서 `known_drift` deferred (= 후속 PR 이
fmt.error 정렬로 제거) 분류는 잘못된 의미이며, `intended_no_code` 영구
면제로 정정한다.

## 변경 범위 (의도적 비-범위)

- `src/ante/cli/commands/bot.py` 본문 — 변경 없음 (UX 패턴 보존).
- `src/ante/cli/commands/config.py` 본문 — 변경 없음 (UX 패턴 보존).
- `src/ante/cli/formatter.py` 시그니처 — 변경 없음.
- 다른 allowlist entries — 변경 없음.

## Test plan

- [x] `pytest tests/unit/contracts/test_error_drift.py -v` — 7 passed
  (intended_no_code section union 면제로 drift 안 잡힘).
- [x] `pytest tests/unit/test_cli_bot_lifecycle.py tests/unit/test_cli_config_approval_broker_ipc.py -q`
  — text-mode `{code}: {message}` prefix 회귀 lock 두 개 보존.
- [x] `pytest tests/unit/` (bot_start/config 카테고리 76 passed) — 회귀 없음.
- [x] `ruff check` clean / `ruff format --check` clean / `mypy src/`
  Success: no issues found in 224 source files.
- [x] `python scripts/generate_project_structure.py` — 변경 없음 (allowlist
  YAML 만 수정, project-structure 영향 없음).

Note: 전체 `tests/unit/` 233 failed 가 보일 수 있으나 origin/main
HEAD (a8bb2345) 에서도 동일 233 failed 가 재현되는 사전 환경 회귀이며 본 PR
변경과 무관함을 baseline run 으로 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)