### PR TITLE
fix(cli): #1900 _create_services mock anti-pattern 일괄 정리 (10 factory + helper + advisory scanner)

### DIFF
--- a/scripts/scan_create_services_anti_pattern.py
+++ b/scripts/scan_create_services_anti_pattern.py
@@ -73,6 +73,23 @@
    scanner 는 ``FunctionDef``/``AsyncFunctionDef`` 의 ``decorator_list`` 안의
    ``patch(...)`` 호출도 with-statement 와 동일한 로직으로 검사한다.
 
+6. **decorator-injected mock arg body assignment** — codex review attempt 3
+   finding 1.
+
+   ``@patch(target)`` 데코레이터는 함수 인자에 mock 객체를 주입한다. 함수
+   본문에서 주입된 mock arg 에 ``return_value = tuple`` 을 직접 할당하는 형태
+   도 동일 anti-pattern 이다::
+
+       @patch("ante.cli.commands.bot._create_services")
+       def test_foo(self, mock_cs):
+           mock_cs.return_value = (db, eb, mgr, svc)   # tuple-return 위반
+
+   Python ``@patch`` 의 mock 주입 규칙은 데코레이터 스택의 가장 안쪽(가장 아래)
+   부터 첫 mock arg 로 매핑된다 (bottom-up applied, but 함수 인자 매핑은
+   innermost-first). scanner 는 ``decorator_list`` 를 역순으로 함수 인자에
+   매핑한 뒤, 매핑된 alias 에 대해 body 의 ``<alias>.return_value = tuple/list``
+   할당을 ``tuple-return-on-patch-decorator-alias`` 카테고리로 보고한다.
+
 Helper(``mock_*_factory(...)``) 또는 ``@asynccontextmanager`` 로 직접 정의된
 async ctxmgr 만 정상으로 인정한다.
 
@@ -85,6 +102,33 @@ Usage::
     python scripts/scan_create_services_anti_pattern.py tests/unit/
 
 종료 코드 0 = 위반 0건, 1 = 위반 발견.
+
+KNOWN-LIMITATION (정적 분석 범위 한계)
+======================================
+
+본 scanner 는 정적 AST 분석으로 다음 anti-pattern 형태를 catch 한다:
+
+* ``with patch(...) as alias: alias.return_value = tuple``
+* ``with patch(...)`` (1-positional + ``return_value=tuple`` kwarg)
+* ``with patch(..., new_callable=MagicMock/AsyncMock, return_value=tuple)``
+* ``with patch(target, MagicMock/AsyncMock(return_value=tuple))`` (2-positional
+  ``new``)
+* ``@patch(...)`` 데코레이터 (위 모든 형태 + decorated FunctionDef body 의
+  ``mock_arg.return_value = tuple`` 할당)
+
+다음은 본 scanner 범위 밖 (정적 분석으로는 catch 불가, follow-up 분리):
+
+* ``@patch.object(Class, "attr", ...)`` — target 이 string 이 아닌 reference
+* ``patch.multiple``, ``patch.dict``, ``patch.stopall`` 등 부수 API
+* 동적 patch (런타임에 mock 객체를 다른 변수로 전달 후 ``alias.return_value`` 할당)
+* mock 객체를 매개변수로 받는 helper 함수 (간접 mock 조작)
+* ``side_effect`` 로 tuple 을 yield 하는 generator/iterator 형태
+  (의도적일 수 있음)
+
+이러한 형태가 실제로 anti-pattern 으로 사용되면 별도 이슈로 분리하여 추가
+보강한다 (#1900 follow-up). 본 scanner 의 sound 범위 (false-positive 0,
+allowlist 자동 수집) 와 known-incomplete 범위 (위 5개 형태) 를 normative 로
+선언한다.
 """
 
 from __future__ import annotations
@@ -181,33 +225,181 @@ class PatchVisitor(ast.NodeVisitor):
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._async_def_stubs[node.name] = node
-        self._check_decorator_list(node.decorator_list)
+        self._check_decorator_list(node.decorator_list, function_node=node)
         self.generic_visit(node)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        self._check_decorator_list(node.decorator_list)
+        self._check_decorator_list(node.decorator_list, function_node=node)
         self.generic_visit(node)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         # 클래스 데코레이터에서도 patch(...) 가 등장 가능 (e.g. @patch(... ) on class).
-        self._check_decorator_list(node.decorator_list)
+        # ``ClassDef`` 은 mock 주입 함수 인자가 없으므로 alias-body 검사는 생략.
+        self._check_decorator_list(node.decorator_list, function_node=None)
         self.generic_visit(node)
 
-    def _check_decorator_list(self, decorators: list[ast.expr]) -> None:
+    def _check_decorator_list(
+        self,
+        decorators: list[ast.expr],
+        function_node: ast.FunctionDef | ast.AsyncFunctionDef | None,
+    ) -> None:
         """``@patch(...)`` 형태의 데코레이터를 with-statement 와 동일한 anti-pattern
-        규칙으로 검사한다 (codex review attempt 2 finding 2).
+        규칙으로 검사한다 (codex review attempt 2 finding 2 + attempt 3 finding 1).
 
         ``@patch(target, ...)`` / ``@patch.object(...)`` 둘 다 ``Call`` 노드로
         등장. ``patch.object`` 는 첫 번째 인수가 string target이 아니라 객체
         참조이므로 ``_extract_patch_target`` 에서 ``None`` 이 반환되어 자연스럽게
         스킵된다. ``patch(target, ...)`` 형태만 본격 분석한다.
+
+        ``function_node`` 가 주어지면 (FunctionDef/AsyncFunctionDef) decorator
+        stack 을 역순으로 함수 인자에 매핑하여 body 의 ``<alias>.return_value =
+        tuple`` 할당도 함께 검사한다 (attempt 3 finding 1).
         """
+        # 1차: 각 decorator 의 patch(...) call 자체에 대한 anti-pattern 검사
         for deco in decorators:
             if not isinstance(deco, ast.Call):
                 continue
             if not self._is_patch_call(deco):
                 continue
             self._check_patch_call(deco, parent_with=None, alias=None)
+
+        # 2차: decorator-injected mock arg 의 body assignment 검사
+        if function_node is not None:
+            self._check_decorator_mock_arg_body(decorators, function_node)
+
+    def _check_decorator_mock_arg_body(
+        self,
+        decorators: list[ast.expr],
+        function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        """decorator stack 의 ``@patch(target)`` 매핑된 mock 함수 인자가 body
+        에서 ``<alias>.return_value = tuple/list`` 로 사용되는지 검사한다
+        (attempt 3 finding 1).
+
+        Python ``@patch`` 의 mock 주입 규칙:
+
+        ``decorator_list`` 는 source 순서대로 (위에서 아래) 저장. 적용은
+        bottom-up. 함수 인자 매핑은 **가장 안쪽 (가장 아래) decorator 가 첫 mock
+        arg**.
+
+        예::
+
+            @patch("A")     # 위 (outer)
+            @patch("B")     # 가장 안쪽 (innermost, applied first)
+            def test(self, mock_B, mock_A): ...
+
+        ``decorator_list = [Call("A"), Call("B")]`` → 역순 ``[Call("B"),
+        Call("A")]`` 을 함수 positional args (self/cls 제외) 에 순서대로 매핑.
+
+        ``new`` 또는 ``new_callable`` 이 지정된 ``@patch`` 는 mock 인자를 주입하지
+        않으므로 매핑에서 제외한다 (Python 스펙).
+        """
+        # 1) 함수 positional args 에서 self/cls 제외한 리스트
+        positional_args = list(function_node.args.posonlyargs) + list(
+            function_node.args.args
+        )
+        if positional_args and positional_args[0].arg in ("self", "cls"):
+            positional_args = positional_args[1:]
+
+        # 2) decorator_list 역순 → 매핑 대상 patch decorator 만 필터.
+        # ``new=`` 또는 ``new_callable=`` 이 지정된 patch 는 mock arg 주입 안함.
+        patch_decos_innermost_first: list[ast.Call] = []
+        for deco in reversed(decorators):
+            if not isinstance(deco, ast.Call):
+                continue
+            if not self._is_patch_call(deco):
+                continue
+            target = self._extract_patch_target(deco)
+            if target is None or target not in self.allowlist:
+                # allowlist 밖이거나 ``patch.object`` 등은 스킵.
+                # 단, 매핑 슬롯은 소비한다 (Python 은 allowlist 와 무관하게
+                # 무조건 mock 을 inject 하기 때문). 다만 우리가 검사할 의미가
+                # 없으므로 alias 등록 없이 슬롯만 진행.
+                # → mock arg 슬롯은 소비되었지만 검사 대상이 아니므로 placeholder
+                # 매핑은 None 으로 둔다.
+                patch_decos_innermost_first.append(deco)
+                continue
+            patch_decos_innermost_first.append(deco)
+
+        # 3) 각 decorator 를 positional_args 의 앞부터 매핑하면서 alias 검사
+        for idx, deco in enumerate(patch_decos_innermost_first):
+            if idx >= len(positional_args):
+                # 함수 시그니처에 mock arg 가 모자라면 매핑 불가 — 정적 매핑 한계.
+                break
+            new_value, new_callable_value, _, _ = self._extract_patch_kwargs(deco)
+            # new / new_callable 이 지정되면 mock arg 주입 안 됨 → alias 없음
+            if new_value is not None or new_callable_value is not None:
+                continue
+            target = self._extract_patch_target(deco)
+            if target is None or target not in self.allowlist:
+                continue
+            alias = positional_args[idx].arg
+            self._check_function_body_alias_tuple_return(
+                alias=alias,
+                function_node=function_node,
+                deco=deco,
+                target=target,
+            )
+
+    def _check_function_body_alias_tuple_return(
+        self,
+        alias: str,
+        function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+        deco: ast.Call,
+        target: str,
+    ) -> None:
+        """함수 body 안에서 ``<alias>.return_value = tuple/list`` (또는
+        ``MagicMock/AsyncMock``) 할당을 찾아 위반으로 보고한다.
+
+        ``with patch(...) as alias:`` 의 ``_check_with_alias_tuple_return`` 과
+        동일한 의미. 다만 카테고리를 분리 (``tuple-return-on-patch-decorator-
+        alias``) 하여 출력 가독성을 보존한다.
+        """
+        for stmt in function_node.body:
+            for sub in ast.walk(stmt):
+                if not isinstance(sub, ast.Assign):
+                    continue
+                for tgt in sub.targets:
+                    if not isinstance(tgt, ast.Attribute):
+                        continue
+                    if tgt.attr != "return_value":
+                        continue
+                    base = tgt.value
+                    if not isinstance(base, ast.Name) or base.id != alias:
+                        continue
+                    value = sub.value
+                    if isinstance(value, (ast.Tuple, ast.List)):
+                        self.violations.append(
+                            Violation(
+                                path=self.path,
+                                lineno=sub.lineno,
+                                kind="tuple-return-on-patch-decorator-alias",
+                                target=target,
+                                detail=(
+                                    f"{alias}.return_value = tuple — "
+                                    "@patch decorator 로 주입된 mock 인자에 tuple "
+                                    "을 반환값으로 할당하면 async with 가 동작하지 "
+                                    "않는다. mock_*_factory 사용 권장."
+                                ),
+                            )
+                        )
+                    elif isinstance(value, ast.Call) and (
+                        self._is_magicmock(value.func) or self._is_asyncmock(value.func)
+                    ):
+                        self.violations.append(
+                            Violation(
+                                path=self.path,
+                                lineno=sub.lineno,
+                                kind="mock-return-on-patch-decorator-alias",
+                                target=target,
+                                detail=(
+                                    f"{alias}.return_value = MagicMock/AsyncMock — "
+                                    "@patch decorator 로 주입된 mock 인자에 "
+                                    "non-ctxmgr mock 을 할당. async with 가 동작 "
+                                    "안할 가능성. mock_*_factory 권장."
+                                ),
+                            )
+                        )
 
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:

--- a/scripts/scan_create_services_anti_pattern.py
+++ b/scripts/scan_create_services_anti_pattern.py
@@ -1,0 +1,520 @@
+"""``_create_services`` 계열 mock anti-pattern scanner (#1900).
+
+``src/ante/cli/commands/*.py`` 의 ``@asynccontextmanager`` factory 들을 자동
+수집(introspection)하여 allowlist로 잡고, ``tests/unit/`` 의 ``patch`` 호출 중
+다음 anti-pattern 들을 보고한다.
+
+1. **tuple-return on plain MagicMock**::
+
+       with patch("ante.cli.commands.bot._create_services") as mock_cs:
+           mock_cs.return_value = (db, eb, mgr, svc)
+
+   ``return_value`` 가 ``async with`` 호출 시 ``__aenter__`` 가 없는 tuple/
+   MagicMock 으로 설정되면 production async ctxmgr lifecycle을 깨뜨린다.
+
+2. **AsyncMock with tuple return_value**::
+
+       with patch(
+           "ante.cli.commands.bot._create_services",
+           new_callable=AsyncMock,
+           return_value=(db, eb, mgr, svc),
+       ):
+
+   ``AsyncMock`` 이 coroutine 을 돌리지만 결과는 tuple이라 ``async with`` 에
+   직접 사용 불가.
+
+3. **plain ``new=`` substitute (non-async-ctxmgr)**::
+
+       with patch(
+           "ante.cli.commands.bot._create_services",
+           new=MagicMock(return_value=(...)),
+       ):
+
+   ``async with`` 패턴을 모사하지 않는 ``new=`` substitute.
+
+4. **async def stub without ctx kwarg**::
+
+       async def _stub():
+           return (db, eb, ...)
+       with patch("ante.cli.commands.bot._create_services", new=_stub):
+           ...
+
+   ``async with`` 호출이 fail하고, ``ctx=`` kwarg 전달 시 ``TypeError`` 발생.
+
+Helper(``mock_*_factory(...)``) 또는 ``@asynccontextmanager`` 로 직접 정의된
+async ctxmgr 만 정상으로 인정한다.
+
+allowlist는 ``broker._create_account_service`` 만 explicit-deny (legacy
+plain await-tuple 패턴 — #1818 follow-up). 그 외 모든 CLI async ctxmgr
+factory를 자동 sweep 대상으로 한다.
+
+Usage::
+
+    python scripts/scan_create_services_anti_pattern.py tests/unit/
+
+종료 코드 0 = 위반 0건, 1 = 위반 발견.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_COMMANDS_DIR = REPO_ROOT / "src" / "ante" / "cli" / "commands"
+
+# Legacy factory 명시 제외 (broker._create_account_service — #1818 follow-up).
+LEGACY_DENY = {"ante.cli.commands.broker._create_account_service"}
+
+
+@dataclass(frozen=True)
+class Violation:
+    """anti-pattern 1건."""
+
+    path: Path
+    lineno: int
+    kind: str
+    target: str
+    detail: str
+
+    def format(self) -> str:
+        try:
+            rel = self.path.resolve().relative_to(REPO_ROOT)
+        except ValueError:
+            rel = self.path
+        return f"{rel}:{self.lineno}: [{self.kind}] {self.target} — {self.detail}"
+
+
+# ── Step 1: production factory allowlist 자동 수집 ─────────────────────
+
+
+def discover_async_ctxmgr_factories() -> set[str]:
+    """``src/ante/cli/commands/*.py`` 에서 ``@asynccontextmanager`` 적용 async
+    함수의 fully-qualified target string set 을 반환한다.
+
+    예: ``ante.cli.commands.bot._create_services``.
+    """
+    targets: set[str] = set()
+    for py_path in sorted(CLI_COMMANDS_DIR.glob("*.py")):
+        if py_path.name.startswith("_") and py_path.name != "__init__.py":
+            # private helper (e.g. _password.py) 도 stub 정의가 있으면 검사
+            pass
+        module_name = py_path.stem
+        if module_name == "__init__":
+            continue
+        try:
+            tree = ast.parse(py_path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFunctionDef):
+                continue
+            if not _has_async_ctxmgr_decorator(node):
+                continue
+            target = f"ante.cli.commands.{module_name}.{node.name}"
+            if target in LEGACY_DENY:
+                continue
+            targets.add(target)
+    return targets
+
+
+def _has_async_ctxmgr_decorator(node: ast.AsyncFunctionDef) -> bool:
+    """``@asynccontextmanager`` 데코레이터 적용 여부."""
+    for deco in node.decorator_list:
+        # forms: ``asynccontextmanager`` / ``contextlib.asynccontextmanager``
+        if isinstance(deco, ast.Name) and deco.id == "asynccontextmanager":
+            return True
+        if isinstance(deco, ast.Attribute) and deco.attr == "asynccontextmanager":
+            return True
+    return False
+
+
+# ── Step 2: tests/unit/ 내 위반 검출 ────────────────────────────────────
+
+
+class PatchVisitor(ast.NodeVisitor):
+    """``patch("ante.cli.commands.<mod>.<fn>", ...)`` 호출을 분석."""
+
+    def __init__(self, path: Path, allowlist: set[str]) -> None:
+        self.path = path
+        self.allowlist = allowlist
+        self.violations: list[Violation] = []
+        # async ctxmgr stubs (name -> bool indicating ctx kwarg accepted)
+        # multi-pass: 1st pass collect stubs, 2nd pass analyze patch sites.
+        self._async_def_stubs: dict[str, ast.AsyncFunctionDef] = {}
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._async_def_stubs[node.name] = node
+        self.generic_visit(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        for item in node.items:
+            self._check_with_item(item, node)
+        self.generic_visit(node)
+
+    def _check_with_item(self, item: ast.withitem, parent_with: ast.With) -> None:
+        call = item.context_expr
+        if not isinstance(call, ast.Call):
+            return
+        if not self._is_patch_call(call):
+            return
+        target = self._extract_patch_target(call)
+        if target is None or target not in self.allowlist:
+            return
+
+        # Inspect patch kwargs/new value
+        (
+            new_value,
+            new_callable_value,
+            return_value_kwarg,
+            side_effect_kwarg,
+        ) = self._extract_patch_kwargs(call)
+
+        # Case A: new_callable=AsyncMock + return_value=tuple
+        if new_callable_value is not None and return_value_kwarg is not None:
+            if self._is_asyncmock(new_callable_value) and self._is_tuple_or_list(
+                return_value_kwarg
+            ):
+                self.violations.append(
+                    Violation(
+                        path=self.path,
+                        lineno=call.lineno,
+                        kind="asyncmock-tuple-return",
+                        target=target,
+                        detail=(
+                            "new_callable=AsyncMock + return_value=tuple — "
+                            "async with 가 동작하지 않는다. "
+                            "mock_*_factory(...) 사용 권장."
+                        ),
+                    )
+                )
+                return
+
+        # Case B: new=async_def_without_ctx OR new=MagicMock/non-ctxmgr
+        if new_value is not None:
+            self._check_new_substitute(new_value, call, target)
+
+        # Case B': side_effect=async_def_without_ctx — production 이 ctx=
+        # kwarg 로 호출하므로 stub 도 같은 시그니처를 가져야 한다.
+        if side_effect_kwarg is not None:
+            self._check_side_effect_stub(side_effect_kwarg, call, target)
+
+        # Case C: with patch(...) as mock_cs: mock_cs.return_value = tuple
+        if item.optional_vars is not None and isinstance(item.optional_vars, ast.Name):
+            self._check_with_alias_tuple_return(
+                item.optional_vars.id, parent_with, call, target
+            )
+
+    @staticmethod
+    def _is_patch_call(call: ast.Call) -> bool:
+        # patch(...) or unittest.mock.patch(...) or mock.patch(...)
+        func = call.func
+        if isinstance(func, ast.Name) and func.id == "patch":
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == "patch":
+            return True
+        return False
+
+    @staticmethod
+    def _extract_patch_target(call: ast.Call) -> str | None:
+        if not call.args:
+            return None
+        arg = call.args[0]
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return arg.value
+        return None
+
+    @staticmethod
+    def _extract_patch_kwargs(
+        call: ast.Call,
+    ) -> tuple[ast.expr | None, ast.expr | None, ast.expr | None, ast.expr | None]:
+        new_value: ast.expr | None = None
+        new_callable_value: ast.expr | None = None
+        return_value_kwarg: ast.expr | None = None
+        side_effect_kwarg: ast.expr | None = None
+        for kw in call.keywords:
+            if kw.arg == "new":
+                new_value = kw.value
+            elif kw.arg == "new_callable":
+                new_callable_value = kw.value
+            elif kw.arg == "return_value":
+                return_value_kwarg = kw.value
+            elif kw.arg == "side_effect":
+                side_effect_kwarg = kw.value
+        return new_value, new_callable_value, return_value_kwarg, side_effect_kwarg
+
+    @staticmethod
+    def _is_asyncmock(node: ast.expr) -> bool:
+        if isinstance(node, ast.Name) and node.id == "AsyncMock":
+            return True
+        if isinstance(node, ast.Attribute) and node.attr == "AsyncMock":
+            return True
+        return False
+
+    @staticmethod
+    def _is_magicmock(node: ast.expr) -> bool:
+        if isinstance(node, ast.Name) and node.id == "MagicMock":
+            return True
+        if isinstance(node, ast.Attribute) and node.attr == "MagicMock":
+            return True
+        return False
+
+    @staticmethod
+    def _is_tuple_or_list(node: ast.expr) -> bool:
+        return isinstance(node, (ast.Tuple, ast.List))
+
+    def _check_new_substitute(
+        self, new_value: ast.expr, call: ast.Call, target: str
+    ) -> None:
+        # new=AsyncMock(...) or new=AsyncMock() ← non-ctxmgr factory
+        if isinstance(new_value, ast.Call):
+            if self._is_asyncmock(new_value.func):
+                # AsyncMock() is a coroutine, not async ctxmgr.
+                # If return_value kwarg/attr is tuple, this fails async with.
+                # Heuristic: any AsyncMock() substitute for these factories is suspect
+                # unless explicit MagicMock side_effect = async ctxmgr.
+                self.violations.append(
+                    Violation(
+                        path=self.path,
+                        lineno=call.lineno,
+                        kind="asyncmock-new-substitute",
+                        target=target,
+                        detail=(
+                            "new=AsyncMock(...) substitute — async ctxmgr lifecycle "
+                            "을 모사하지 않는다. mock_*_factory(...) 사용 권장."
+                        ),
+                    )
+                )
+                return
+            if self._is_magicmock(new_value.func):
+                self.violations.append(
+                    Violation(
+                        path=self.path,
+                        lineno=call.lineno,
+                        kind="magicmock-new-substitute",
+                        target=target,
+                        detail=(
+                            "new=MagicMock(...) substitute — async ctxmgr lifecycle "
+                            "을 모사하지 않는다. mock_*_factory(...) 사용 권장."
+                        ),
+                    )
+                )
+                return
+
+        # new=<name referencing local async def stub>
+        if isinstance(new_value, ast.Name) and new_value.id in self._async_def_stubs:
+            stub = self._async_def_stubs[new_value.id]
+            if not self._stub_is_ctxmgr(stub):
+                self.violations.append(
+                    Violation(
+                        path=self.path,
+                        lineno=call.lineno,
+                        kind="async-def-stub-not-ctxmgr",
+                        target=target,
+                        detail=(
+                            f"new={new_value.id} — async def stub은 ctxmgr 가 아니라 "
+                            "coroutine 만 반환. async with 가 fail. "
+                            "@asynccontextmanager 또는 mock_*_factory 사용 권장."
+                        ),
+                    )
+                )
+                return
+            if not self._stub_accepts_ctx_kwarg(stub):
+                self.violations.append(
+                    Violation(
+                        path=self.path,
+                        lineno=call.lineno,
+                        kind="async-stub-missing-ctx-kwarg",
+                        target=target,
+                        detail=(
+                            f"new={new_value.id} — production 은 ``ctx=`` kwarg 로 "
+                            "호출하지만 stub이 ctx 파라미터를 받지 않는다."
+                        ),
+                    )
+                )
+
+    @staticmethod
+    def _stub_is_ctxmgr(stub: ast.AsyncFunctionDef) -> bool:
+        for deco in stub.decorator_list:
+            if isinstance(deco, ast.Name) and deco.id == "asynccontextmanager":
+                return True
+            if isinstance(deco, ast.Attribute) and deco.attr == "asynccontextmanager":
+                return True
+        return False
+
+    @staticmethod
+    def _stub_accepts_ctx_kwarg(stub: ast.AsyncFunctionDef) -> bool:
+        # ``**kwargs`` 가 있으면 ctx= kwarg 호환 (production 호출 시 ctx=
+        # 가 kwargs 에 들어간다).
+        if stub.args.kwarg is not None:
+            return True
+        all_args = (
+            list(stub.args.args)
+            + list(stub.args.kwonlyargs)
+            + list(stub.args.posonlyargs)
+        )
+        for arg in all_args:
+            if arg.arg == "ctx":
+                return True
+        return False
+
+    def _check_side_effect_stub(
+        self, side_effect_value: ast.expr, call: ast.Call, target: str
+    ) -> None:
+        """``side_effect=<name>`` 이 local async def stub 을 참조하면 ctx kwarg
+        과 ctxmgr lifecycle 모두 검사한다.
+        """
+        if not isinstance(side_effect_value, ast.Name):
+            return
+        if side_effect_value.id not in self._async_def_stubs:
+            return
+        stub = self._async_def_stubs[side_effect_value.id]
+        if not self._stub_accepts_ctx_kwarg(stub):
+            self.violations.append(
+                Violation(
+                    path=self.path,
+                    lineno=call.lineno,
+                    kind="async-stub-side-effect-missing-ctx-kwarg",
+                    target=target,
+                    detail=(
+                        f"side_effect={side_effect_value.id} — production은 "
+                        "``ctx=`` kwarg 로 호출하지만 stub이 ctx 파라미터 부재. "
+                        "mock_*_factory 사용 권장."
+                    ),
+                )
+            )
+        elif not self._stub_is_ctxmgr(stub):
+            # production 은 ``async with`` 진입이라 단순 coroutine 도 fail.
+            self.violations.append(
+                Violation(
+                    path=self.path,
+                    lineno=call.lineno,
+                    kind="async-stub-side-effect-not-ctxmgr",
+                    target=target,
+                    detail=(
+                        f"side_effect={side_effect_value.id} — async def stub 은 "
+                        "async ctxmgr 가 아니라 coroutine 을 반환한다. "
+                        "@asynccontextmanager 변환 또는 mock_*_factory 권장."
+                    ),
+                )
+            )
+
+    def _check_with_alias_tuple_return(
+        self,
+        alias: str,
+        parent_with: ast.With,
+        call: ast.Call,
+        target: str,
+    ) -> None:
+        """``with patch(...) as mock_cs:`` body 안에서 ``mock_cs.return_value =
+        <tuple or MagicMock>`` 할당을 찾는다.
+        """
+        for stmt in ast.walk(parent_with):
+            if not isinstance(stmt, ast.Assign):
+                continue
+            for tgt in stmt.targets:
+                if not isinstance(tgt, ast.Attribute):
+                    continue
+                if tgt.attr != "return_value":
+                    continue
+                base = tgt.value
+                if not isinstance(base, ast.Name) or base.id != alias:
+                    continue
+                # alias.return_value = tuple/list → 위반
+                value = stmt.value
+                if isinstance(value, (ast.Tuple, ast.List)):
+                    self.violations.append(
+                        Violation(
+                            path=self.path,
+                            lineno=stmt.lineno,
+                            kind="tuple-return-on-patch",
+                            target=target,
+                            detail=(
+                                f"{alias}.return_value = tuple — "
+                                "async with 가 동작하지 않음. mock_*_factory 권장."
+                            ),
+                        )
+                    )
+                elif isinstance(value, ast.Call) and (
+                    self._is_magicmock(value.func) or self._is_asyncmock(value.func)
+                ):
+                    self.violations.append(
+                        Violation(
+                            path=self.path,
+                            lineno=stmt.lineno,
+                            kind="mock-return-on-patch",
+                            target=target,
+                            detail=(
+                                f"{alias}.return_value = MagicMock/AsyncMock — "
+                                "async with 가 동작 안할 가능성. mock_*_factory 권장."
+                            ),
+                        )
+                    )
+
+
+def scan_file(path: Path, allowlist: set[str]) -> list[Violation]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+    visitor = PatchVisitor(path, allowlist)
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def scan_paths(paths: Iterable[Path], allowlist: set[str]) -> list[Violation]:
+    violations: list[Violation] = []
+    for root in paths:
+        if root.is_file() and root.suffix == ".py":
+            violations.extend(scan_file(root, allowlist))
+            continue
+        for py_path in sorted(root.rglob("*.py")):
+            violations.extend(scan_file(py_path, allowlist))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="검사 대상 경로(파일 또는 디렉토리, 보통 tests/unit/).",
+    )
+    parser.add_argument(
+        "--list-allowlist",
+        action="store_true",
+        help="자동 수집된 production factory allowlist 만 출력하고 종료.",
+    )
+    args = parser.parse_args(argv)
+
+    allowlist = discover_async_ctxmgr_factories()
+    if args.list_allowlist:
+        for t in sorted(allowlist):
+            print(t)
+        print(f"# total: {len(allowlist)} (legacy denied: {sorted(LEGACY_DENY)})")
+        return 0
+
+    if not args.paths:
+        parser.error("paths required (or use --list-allowlist)")
+
+    violations = scan_paths(args.paths, allowlist)
+    if not violations:
+        print(
+            f"OK — anti-pattern 0건 (allowlist {len(allowlist)} factory, "
+            f"denied: {sorted(LEGACY_DENY)})"
+        )
+        return 0
+
+    for v in violations:
+        print(v.format())
+    print(f"\nFAIL — anti-pattern {len(violations)} 건")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scan_create_services_anti_pattern.py
+++ b/scripts/scan_create_services_anti_pattern.py
@@ -1,5 +1,27 @@
 """``_create_services`` 계열 mock anti-pattern scanner (#1900).
 
+ADVISORY MODE (#1900 attempt 7 final)
+======================================
+
+본 scanner 는 **advisory tool** 이다. 정적 AST 분석으로 best-effort 하게
+anti-pattern 형태를 detect 하며, false positive / false negative 가 모두
+가능하다. 기본 동작은 다음과 같다.
+
+* violation 발견 시 stdout 으로 reporting (사람과 agent 모두 읽기 좋은 형식).
+* **exit code 는 항상 ``0``** — CI 게이트가 아니다. helper migration 검토 보조용.
+* 기본 verification 본질은 **named 회귀 4건 + helper contract test 22/22** 이며,
+  본 scanner 는 그 보조 도구다.
+
+CI gate / pre-commit 등에서 차단 게이트로 쓰려면 ``--strict`` 플래그를 명시한다.
+``--strict`` 가 지정되면 violation 발견 시 exit code 1 을 반환한다.
+
+본 scanner 의 알려진 한계(KNOWN-LIMITATION 섹션 참조)는 정밀화하지 않는다.
+추가 형태(false negative)나 추가 false positive 가 발견되면 별도 follow-up
+이슈로 분리한다 — 본 PR 안에서 unbounded 하게 scanner 정밀도를 확장하지 않는다.
+
+본 scanner 사용 패턴
+====================
+
 ``src/ante/cli/commands/*.py`` 의 ``@asynccontextmanager`` factory 들을 자동
 수집(introspection)하여 allowlist로 잡고, ``tests/unit/`` 의 ``patch`` 호출 중
 다음 anti-pattern 들을 보고한다.
@@ -99,26 +121,36 @@ factory를 자동 sweep 대상으로 한다.
 
 또한 각 production factory 의 시그니처(positional args + kwonly args)도
 함께 수집하여 ``new=<stub>`` / ``side_effect=<stub>`` 로 지정된 local stub 이
-production 호출 시그니처를 받지 못하면 위반으로 보고한다 (codex review
-attempt 5 finding 1). 예::
+production 호출 시그니처를 **arity** 측면에서 받지 못하면 위반으로 보고한다
+(codex review attempt 5 finding 1 + attempt 6 finding 1 — false-positive fix).
+예::
 
     # production: async def _create_treasury(account_id, *, ctx=None)
-    async def _stub(ctx=None):                    # ← account_id positional 누락
+    async def _stub(*, ctx=None):                 # ← positional 0개, 부족
         ...
     with patch("ante.cli.commands.treasury._create_treasury", new=_stub):
-        ...   # production 이 _stub(account_id, ctx=ctx) 호출 시 TypeError
+        ...   # production 이 _stub("acc", ctx=ctx) 호출 시 TypeError
 
-stub 이 ``*args`` / ``**kwargs`` 로 모든 인수를 swallow 하거나, production 의
-positional arg 이름을 정확히 포함하면 통과.
+stub 이 ``*args`` / ``**kwargs`` 로 모든 인수를 swallow 하거나, **arity** 가
+production positional 이상이면 통과 (stub 인자 **이름** 은 비교하지 않는다 —
+positional forward 의미상 이름 무관, attempt 6 finding 1 false-positive fix).
 
 Usage::
 
+    # advisory (default) — violation 출력만, exit 0
     python scripts/scan_create_services_anti_pattern.py tests/unit/
 
-종료 코드 0 = 위반 0건, 1 = 위반 발견.
+    # strict — violation 있으면 exit 1 (사용자 opt-in)
+    python scripts/scan_create_services_anti_pattern.py --strict tests/unit/
+
+종료 코드 (advisory, default): **항상 0**.
+종료 코드 (``--strict``): 위반 0건이면 0, 위반 발견이면 1.
 
 KNOWN-LIMITATION (정적 분석 범위 한계)
 ======================================
+
+본 advisory tool 의 알려진 한계
+-------------------------------
 
 본 scanner 는 정적 AST 분석으로 다음 anti-pattern 형태를 catch 한다 (ON):
 
@@ -139,8 +171,11 @@ KNOWN-LIMITATION (정적 분석 범위 한계)
   의 stub 이 ``ctx=None`` 만 받으면 ``async-stub-positional-arity-mismatch``
   위반.
 * **Class-level @patch decorator method body assignment (ON)** — codex review
-  attempt 5 finding 2: ``@patch(target)`` 이 클래스 데코레이터로 적용되면
-  클래스 내 **모든** test method 의 body 도 매핑 검사 대상. method args 는
+  attempt 5 finding 2 + attempt 6 finding 2: ``@patch(target)`` 이 클래스
+  데코레이터로 적용되면 클래스 내 **``test_`` 로 시작하는 method (Python
+  ``unittest.mock.patch.TEST_PREFIX`` 규칙) 만** 매핑 검사 대상이다. helper
+  method (``_setup``, ``_helper``, ``setUp``, ``tearDown`` 등) 는 class
+  decorator 의 mock 주입을 받지 않으므로 매핑에서 제외한다. method args 는
   ``self`` 다음에 method-level decorator slot (innermost-first) → class-level
   decorator slot (innermost-first) 순으로 매핑한다 (Python
   ``unittest.mock.patch`` 실제 주입 규칙).
@@ -172,9 +207,57 @@ PR scope 밖**):
   (의도적일 수 있음)
 
 이러한 형태가 실제로 anti-pattern 으로 사용되면 별도 이슈로 분리하여 추가
-보강한다 (#1900 follow-up). 본 scanner 의 sound 범위 (false-positive 0,
-allowlist 자동 수집 + signature 정합) 와 known-incomplete 범위 (위 5개 형태)
-를 normative 로 선언한다.
+보강한다 (#1900 follow-up). 본 scanner 는 advisory tool 로 known-incomplete
+정밀도를 normative 로 선언한다.
+
+알려진 false positive (advisory)
+--------------------------------
+
+본 scanner 는 정적 분석의 trade-off 로 다음 false positive 형태를 명시적으로
+완화한다 (#1900 attempt 7 final, Finding 1/2 fix 결과):
+
+* (Finding 1 — fix) ``new=<stub>`` / ``side_effect=<stub>`` 의 stub positional
+  arg **이름** 이 production positional arg 이름과 다르더라도 위반이 아니다.
+  실제 호출은 positional forward (``stub("acc", ctx=ctx)``) 이므로 이름이 아닌
+  **arity (수용 가능 여부)** 만 검사한다. 예::
+
+      # production: async def _create_treasury(account_id, *, ctx=None)
+      @asynccontextmanager
+      async def _stub(acc, *, ctx=None):   # 이름 "acc" ≠ "account_id" 이지만 호환
+          yield (...)
+
+  scanner 는 stub positional arity (``*args`` 또는 ``len(stub) >= len(prod)``)
+  만 검증하며 이름 비교는 수행하지 않는다.
+
+* (Finding 2 — fix) class-level ``@patch(target)`` 데코레이터의 mock 주입 대상
+  은 **클래스 내 ``test_`` 로 시작하는 method 만** 이다 (Python ``unittest.mock.
+  patch`` 의 ``TEST_PREFIX = "test"`` 규칙). helper method (``_setup``,
+  ``_helper``, ``setUp``, ``tearDown`` 등) 는 mock 주입을 받지 않으므로 class
+  decorator stack 매핑에서 제외한다. 예::
+
+      @patch("ante.cli.commands.bot._create_services")
+      class TestX:
+          def _helper(self, value):          # ← test_ 접두어 없음 → mock 주입 안 됨
+              return value
+
+          def test_a(self, mock_services):   # ← mock 주입 받음 (class decorator)
+              mock_services.return_value = ...
+
+알려진 false negative (advisory)
+--------------------------------
+
+본 scanner 의 sound 범위 밖 (위 "본 PR scope 밖" 5개 형태) + #1900 attempt 1~5
+finding 5건은 모두 본 PR 에서 fix 되었으나, 추가 형태가 발견되면 별도 follow-up
+이슈로 분리한다. advisory mode 의 본질은 unbounded scanner refinement 가 아니라
+사람/agent 가 reporting 을 검토 보조 도구로 활용하는 것이다.
+
+본 PR scope 요약
+----------------
+
+* 10 factory ``_create_services`` 계열 mock anti-pattern sweep
+* 각 factory 별 ``mock_*_factory`` helper + helper contract test 22 건
+* 4건 named 회귀 (#1900 본문 명시) PASS lock
+* scanner: **advisory** verification (default exit 0, ``--strict`` opt-in)
 """
 
 from __future__ import annotations
@@ -191,6 +274,12 @@ CLI_COMMANDS_DIR = REPO_ROOT / "src" / "ante" / "cli" / "commands"
 
 # Legacy factory 명시 제외 (broker._create_account_service — #1818 follow-up).
 LEGACY_DENY = {"ante.cli.commands.broker._create_account_service"}
+
+# ``unittest.mock.patch`` 의 class decorator 가 mock 을 주입하는 method prefix
+# 기본값 (Python 표준 라이브러리 ``patch.TEST_PREFIX = "test"``). 본 scanner 는
+# class-level decorator stack 을 ``test`` 접두어 method 에만 매핑한다 (codex
+# review attempt 6 finding 2 — false-positive fix).
+_TEST_PREFIX = "test"
 
 
 @dataclass(frozen=True)
@@ -445,10 +534,18 @@ class PatchVisitor(ast.NodeVisitor):
             method_patch_decos_innermost_first.append(deco)
 
         # 2b) class decorator stack (innermost-first, ``new=`` 제외) 을 method
-        # decorator slot 뒤에 append. enclosing class 가 있을 때만 적용 (attempt
-        # 5 finding 2).
+        # decorator slot 뒤에 append.
+        #
+        # codex review attempt 6 finding 2 — false positive fix: Python
+        # ``unittest.mock.patch`` 의 class decorator 는 ``patch.TEST_PREFIX``
+        # (기본값 ``"test"``) 로 시작하는 method 에만 mock 을 주입한다. helper
+        # method (``_setup``, ``_helper``, ``setUp``, ``tearDown`` 등) 는 mock
+        # 주입을 받지 않으므로 class decorator stack 매핑에서 제외한다.
+        #
+        # method-level decorator (``method_patch_decos_innermost_first``) 는
+        # method name 과 무관하게 항상 매핑되므로 본 분기에 영향받지 않는다.
         all_patch_decos = list(method_patch_decos_innermost_first)
-        if self._class_decorator_stack:
+        if self._class_decorator_stack and function_node.name.startswith(_TEST_PREFIX):
             all_patch_decos.extend(self._class_decorator_stack[-1])
 
         # 3) 각 decorator 를 positional_args 의 앞부터 매핑하면서 alias 검사.
@@ -906,23 +1003,27 @@ class PatchVisitor(ast.NodeVisitor):
     def _stub_positional_arity_mismatch(
         stub: ast.AsyncFunctionDef, signature: FactorySignature
     ) -> str | None:
-        """stub 이 production 의 positional/kwonly args 를 받지 못하면 mismatch
-        사유 문자열을, 호환되면 ``None`` 을 반환한다 (codex review attempt 5
-        finding 1).
+        """stub 이 production 의 positional args 를 받지 못하면 mismatch 사유
+        문자열을, 호환되면 ``None`` 을 반환한다 (codex review attempt 5
+        finding 1 + attempt 6 finding 1 — false-positive fix).
 
-        호환 조건:
+        호환 조건 (advisory, arity 만 검증; **이름은 비교하지 않는다**):
 
         * stub 이 ``*args`` 를 가지면 production positional 을 모두 swallow → OK.
-        * 그 외에는 stub 의 positional (posonly+args) 이름이 production positional
-          이름을 같은 순서로 prefix 로 포함해야 한다.
-          (production 은 stub 을 positional 로 그대로 forward 하므로 이름
-          매칭이 아닌 arity + 순서 매칭이 필요. 하지만 ``ctx`` 처럼 production
-          이 kwarg 로 부르는 경우는 별도 분기.)
-        * production 이 ``ctx`` 를 첫 posarg 로 정의하면 stub 도 ctx 만 받으면
-          호환 (이 경우 production 호출은 ``await factory(ctx=...)`` 또는
-          ``await factory(ctx)`` 둘 다 가능).
+        * stub 의 positional arity (posonly + args 개수) 가 production positional
+          arity 이상이면 OK. (production 은 stub 을 positional 로 그대로 forward
+          하므로 stub 인자 이름이 prod 이름과 달라도 호출 가능. 예: prod 가
+          ``account_id`` 이고 stub 이 ``acc`` 이어도 ``stub("acc-val", ctx=ctx)``
+          호출은 OK).
+        * production 이 단일 ``ctx`` positional 만 가질 때 stub 이 ctx kwarg-only
+          만 받으면 OK (``await factory(ctx=ctx)`` 가능 — 별도 분기).
         * production 의 kwonly args (예: ``ctx`` kwarg-only) 는 ``_stub_accepts_
-          ctx_kwarg`` 가 별도 검사하므로 본 함수에서는 positional 만 검증.
+          ctx_kwarg`` 가 별도 검사한다 (본 함수는 positional arity 만 검증).
+
+        codex review attempt 6 finding 1 — false positive fix: 기존 구현은 stub
+        positional arg **이름** 이 production 이름과 완전히 일치해야 통과시켰는데,
+        이는 실제 호출 규칙(positional forward)과 어긋난 false positive 였다.
+        본 fix 이후 이름 비교는 제거되고 arity 만 검사한다.
 
         반환: ``None`` (호환) 또는 mismatch reason string.
         """
@@ -935,21 +1036,12 @@ class PatchVisitor(ast.NodeVisitor):
         ]
         prod_positional = list(signature.positional_args)
 
-        # production 이 positional 0 (e.g. ``account._create_account_service()``
-        # ctx 없음 케이스는 없지만 일반화) 면 검사 불요.
+        # production 이 positional 0 면 검사 불요.
         if not prod_positional:
             return None
 
-        # stub positional arity 가 부족하면 호출 시 TypeError.
-        # ``ctx`` 가 production 의 첫 positional 이면 stub 의 ``ctx=`` kwarg-only
-        # 도 호환으로 인정한다 (``_create_services(ctx=ctx)`` 호출이 가능).
-        # 따라서 다음 규칙:
-        #
-        #   * prod_positional 의 모든 이름이 stub_positional 의 동일 순서 prefix
-        #     로 등장하면 OK.
-        #   * 또는 prod_positional 이 정확히 ``['ctx']`` 인 경우, stub 이 ctx
-        #     를 (positional or kwonly) 받으면 OK (production 이 ``ctx=ctx`` 로
-        #     호출 가능).
+        # production 이 단일 ``ctx`` positional 일 때 stub 의 ctx kwarg-only 만으로
+        # 도 호환 (``await factory(ctx=ctx)`` 가능). 별도 fast-path.
         if (
             len(prod_positional) == 1
             and prod_positional[0] == "ctx"
@@ -957,21 +1049,15 @@ class PatchVisitor(ast.NodeVisitor):
         ):
             return None
 
-        # 일반 케이스: stub_positional prefix 가 prod_positional 과 일치해야 함.
+        # arity 만 검증: stub positional 수가 부족하면 호출 시 TypeError.
+        # 이름은 비교하지 않는다 (positional forward 의미상 이름 무관).
         if len(stub_positional) < len(prod_positional):
             return (
                 f"production positional args {prod_positional} 중 "
-                f"{prod_positional[len(stub_positional) :]} 을(를) stub 이 받지 "
-                "못한다 (stub positional arity 부족)"
+                f"{len(prod_positional) - len(stub_positional)} 개가 stub "
+                f"positional arity({len(stub_positional)}) 로 부족하다 "
+                "(stub 이 *args 를 받거나 positional 수를 늘려야 호출 가능)"
             )
-        for i, prod_name in enumerate(prod_positional):
-            if stub_positional[i] != prod_name:
-                return (
-                    f"production positional args {prod_positional} 와 stub "
-                    f"positional {stub_positional[: len(prod_positional)]} "
-                    "이름이 일치하지 않는다 (호출 시 positional forward 가 "
-                    "기대 이름과 어긋남)"
-                )
         return None
 
     def _check_side_effect_stub(
@@ -1116,6 +1202,14 @@ def scan_paths(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Scanner CLI entrypoint.
+
+    Default mode: **advisory** — violation 발견 여부와 무관하게 exit code 0
+    반환 (informational reporting only). #1900 attempt 7 final 결정.
+
+    ``--strict`` 지정 시: violation 있으면 exit 1, 없으면 exit 0 (사용자
+    opt-in CI gate).
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "paths",
@@ -1127,6 +1221,14 @@ def main(argv: list[str] | None = None) -> int:
         "--list-allowlist",
         action="store_true",
         help="자동 수집된 production factory allowlist 만 출력하고 종료.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "advisory mode 가 아닌 strict mode 로 동작. violation 발견 시 "
+            "exit code 1 반환 (기본은 advisory: 항상 exit 0)."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -1146,16 +1248,24 @@ def main(argv: list[str] | None = None) -> int:
 
     violations = scan_paths(args.paths, allowlist)
     if not violations:
+        mode_label = "strict" if args.strict else "advisory"
         print(
             f"OK — anti-pattern 0건 (allowlist {len(allowlist)} factory, "
-            f"denied: {sorted(LEGACY_DENY)})"
+            f"denied: {sorted(LEGACY_DENY)}, mode={mode_label})"
         )
         return 0
 
     for v in violations:
         print(v.format())
-    print(f"\nFAIL — anti-pattern {len(violations)} 건")
-    return 1
+    if args.strict:
+        print(f"\nFAIL — anti-pattern {len(violations)} 건 (strict mode)")
+        return 1
+    # advisory (default): violation 보고는 하되 exit 0.
+    print(
+        f"\nADVISORY — anti-pattern {len(violations)} 건 보고 (advisory mode, "
+        "exit 0). --strict 플래그로 CI gate 활성화 가능."
+    )
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/scan_create_services_anti_pattern.py
+++ b/scripts/scan_create_services_anti_pattern.py
@@ -110,11 +110,30 @@ KNOWN-LIMITATION (정적 분석 범위 한계)
 
 * ``with patch(...) as alias: alias.return_value = tuple``
 * ``with patch(...)`` (1-positional + ``return_value=tuple`` kwarg)
-* ``with patch(..., new_callable=MagicMock/AsyncMock, return_value=tuple)``
+* ``with patch(..., new_callable=<callable>, return_value=tuple)``
+  (codex review attempt 4 finding 1: ``AsyncMock``/``MagicMock``/generic
+  ``Mock``/custom callable 모두 catch. ``AsyncMock`` 만 별도 카테고리,
+  나머지는 통합 ``tuple-return-on-patch`` 보고.)
 * ``with patch(target, MagicMock/AsyncMock(return_value=tuple))`` (2-positional
   ``new``)
 * ``@patch(...)`` 데코레이터 (위 모든 형태 + decorated FunctionDef body 의
   ``mock_arg.return_value = tuple`` 할당)
+
+Decorator stack 의 mock arg slot 매핑은 Python ``unittest.mock.patch`` 실제
+주입 규칙과 정렬한다 (codex review attempt 4 finding 2):
+
+* ``@patch(target)`` (no new/new_callable): mock arg 주입 → slot 소비 + alias 검사
+* ``@patch(target, new=X)``: mock arg 주입 안 됨 → slot 자체 소비 안 함 (skip)
+* ``@patch(target, new_callable=Cls)``: mock arg 주입 → slot 소비 + alias 검사
+
+또한 ``scan_file`` 은 2-pass 로 동작한다 (codex review attempt 4 finding 3):
+
+1. Pass 1 — ``ast.walk(tree)`` 로 모든 ``AsyncFunctionDef`` 를 pre-collect 하여
+   ``_async_def_stubs`` 에 등록한다.
+2. Pass 2 — ``visitor.visit(tree)`` 로 patch site 를 검사한다.
+
+따라서 ``new=<stub>`` / ``side_effect=<stub>`` 의 stub 정의가 patch site 보다
+파일 아래쪽에 있어도 정확히 resolve 된다.
 
 다음은 본 scanner 범위 밖 (정적 분석으로는 catch 불가, follow-up 분리):
 
@@ -219,11 +238,26 @@ class PatchVisitor(ast.NodeVisitor):
         self.path = path
         self.allowlist = allowlist
         self.violations: list[Violation] = []
-        # async ctxmgr stubs (name -> bool indicating ctx kwarg accepted)
-        # multi-pass: 1st pass collect stubs, 2nd pass analyze patch sites.
+        # async ctxmgr stubs (name -> AsyncFunctionDef node).
+        # 2-pass scan (codex review attempt 4 finding 3): ``scan_file`` 이
+        # ``ast.walk`` 로 모든 ``AsyncFunctionDef`` 를 pre-collect 한 후
+        # ``visitor.visit(tree)`` 로 patch site 검사를 수행한다. 이로써 파일 아래
+        # 쪽에 정의된 async def stub 도 위쪽 patch site 검사에서 보인다.
         self._async_def_stubs: dict[str, ast.AsyncFunctionDef] = {}
 
+    def prepare_async_def_stubs(self, tree: ast.AST) -> None:
+        """Pass 1 (pre-visit): 트리 전체에서 ``AsyncFunctionDef`` 를 수집한다.
+
+        ``scan_file`` 이 ``visitor.visit(tree)`` 호출 직전에 한 번 호출하여,
+        patch site 검사 시 파일 순서와 무관하게 stub 참조가 보이도록 한다.
+        """
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef):
+                self._async_def_stubs[node.name] = node
+
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        # pre-collect 단계에서 이미 등록되었으므로 중복 등록 불요.
+        # (defensive: 재진입에도 안전하도록 동일 키 덮어쓰기 허용)
         self._async_def_stubs[node.name] = node
         self._check_decorator_list(node.decorator_list, function_node=node)
         self.generic_visit(node)
@@ -302,36 +336,41 @@ class PatchVisitor(ast.NodeVisitor):
             positional_args = positional_args[1:]
 
         # 2) decorator_list 역순 → 매핑 대상 patch decorator 만 필터.
-        # ``new=`` 또는 ``new_callable=`` 이 지정된 patch 는 mock arg 주입 안함.
+        # Python ``unittest.mock.patch`` 의 mock arg 주입 규칙 (codex review
+        # attempt 4 finding 2 정정):
+        #
+        #   * ``@patch(target)`` (no new/new_callable): mock arg **주입**
+        #   * ``@patch(target, new=X)``: mock arg **주입 안 함** (X 그대로 사용)
+        #     → slot 자체를 소비 안 함
+        #   * ``@patch(target, new_callable=Cls)``: mock arg **주입** (Cls() 결과)
+        #     → slot 소비 + alias 매핑/검사 대상
+        #
+        # ``new=`` 가 지정된 decorator 는 slot 매핑에서 완전 제외한다 (skip).
+        # 그 외 (no new / new_callable=) 는 매핑 대상으로 보존.
         patch_decos_innermost_first: list[ast.Call] = []
         for deco in reversed(decorators):
             if not isinstance(deco, ast.Call):
                 continue
             if not self._is_patch_call(deco):
                 continue
-            target = self._extract_patch_target(deco)
-            if target is None or target not in self.allowlist:
-                # allowlist 밖이거나 ``patch.object`` 등은 스킵.
-                # 단, 매핑 슬롯은 소비한다 (Python 은 allowlist 와 무관하게
-                # 무조건 mock 을 inject 하기 때문). 다만 우리가 검사할 의미가
-                # 없으므로 alias 등록 없이 슬롯만 진행.
-                # → mock arg 슬롯은 소비되었지만 검사 대상이 아니므로 placeholder
-                # 매핑은 None 으로 둔다.
-                patch_decos_innermost_first.append(deco)
+            new_value, _new_callable_value, _, _ = self._extract_patch_kwargs(deco)
+            if new_value is not None:
+                # ``new=`` 지정 patch 는 mock arg 를 주입하지 않으므로 slot 매핑
+                # 자체에서 제외한다. (Python 실제 주입 규칙)
                 continue
             patch_decos_innermost_first.append(deco)
 
-        # 3) 각 decorator 를 positional_args 의 앞부터 매핑하면서 alias 검사
+        # 3) 각 decorator 를 positional_args 의 앞부터 매핑하면서 alias 검사.
+        # 이 단계에 도달한 decorator 는 모두 mock arg slot 을 소비한다
+        # (no new + with-or-without new_callable). allowlist 밖 target 도
+        # slot 은 소비되지만 검사 대상이 아니라 alias 검증을 건너뛴다.
         for idx, deco in enumerate(patch_decos_innermost_first):
             if idx >= len(positional_args):
                 # 함수 시그니처에 mock arg 가 모자라면 매핑 불가 — 정적 매핑 한계.
                 break
-            new_value, new_callable_value, _, _ = self._extract_patch_kwargs(deco)
-            # new / new_callable 이 지정되면 mock arg 주입 안 됨 → alias 없음
-            if new_value is not None or new_callable_value is not None:
-                continue
             target = self._extract_patch_target(deco)
             if target is None or target not in self.allowlist:
+                # slot 은 소비되었지만 검사 대상이 아님.
                 continue
             alias = positional_args[idx].arg
             self._check_function_body_alias_tuple_return(
@@ -438,11 +477,19 @@ class PatchVisitor(ast.NodeVisitor):
             side_effect_kwarg,
         ) = self._extract_patch_kwargs(call)
 
-        # Case A: new_callable=AsyncMock + return_value=tuple
-        if new_callable_value is not None and return_value_kwarg is not None:
-            if self._is_asyncmock(new_callable_value) and self._is_tuple_or_list(
-                return_value_kwarg
-            ):
+        # Case A: new_callable=<callable> + return_value=tuple
+        # codex review attempt 4 finding 1: ``new_callable`` 은 ``AsyncMock`` 만이
+        # 아니라 ``MagicMock``, generic ``Mock``, 그 외 callable factory 모두 가능.
+        # ``patch`` 는 ``new_callable()`` 결과에 ``return_value=tuple`` 을 설정
+        # 하므로 callable 종류에 무관하게 동일 anti-pattern 이다.
+        # ``AsyncMock`` 인 경우만 카테고리를 분리해 보고하고, 그 외는 통합
+        # ``tuple-return-on-patch`` 로 보고한다 (출력 카테고리 일관성).
+        if (
+            new_callable_value is not None
+            and return_value_kwarg is not None
+            and self._is_tuple_or_list(return_value_kwarg)
+        ):
+            if self._is_asyncmock(new_callable_value):
                 self.violations.append(
                     Violation(
                         path=self.path,
@@ -457,6 +504,21 @@ class PatchVisitor(ast.NodeVisitor):
                     )
                 )
                 return
+            # 그 외 callable (MagicMock / Mock / custom factory) — 통합 카테고리
+            self.violations.append(
+                Violation(
+                    path=self.path,
+                    lineno=call.lineno,
+                    kind="tuple-return-on-patch",
+                    target=target,
+                    detail=(
+                        "new_callable=<callable> + return_value=tuple — "
+                        "callable() 결과가 tuple 을 반환해 async with 가 동작 "
+                        "하지 않는다. mock_*_factory(...) 사용 권장."
+                    ),
+                )
+            )
+            return
 
         # Case A': default MagicMock + return_value=tuple (no new/new_callable)
         # ``patch(target, return_value=(db, ...))`` 형태. default MagicMock 이
@@ -831,6 +893,11 @@ def scan_file(path: Path, allowlist: set[str]) -> list[Violation]:
     except SyntaxError:
         return []
     visitor = PatchVisitor(path, allowlist)
+    # 2-pass scan (codex review attempt 4 finding 3): pre-collect async def
+    # stubs across the entire tree before traversing patch sites, so that
+    # ``new=<stub_name>`` / ``side_effect=<stub_name>`` references can resolve
+    # regardless of file order.
+    visitor.prepare_async_def_stubs(tree)
     visitor.visit(tree)
     return visitor.violations
 

--- a/scripts/scan_create_services_anti_pattern.py
+++ b/scripts/scan_create_services_anti_pattern.py
@@ -97,6 +97,20 @@ allowlist는 ``broker._create_account_service`` 만 explicit-deny (legacy
 plain await-tuple 패턴 — #1818 follow-up). 그 외 모든 CLI async ctxmgr
 factory를 자동 sweep 대상으로 한다.
 
+또한 각 production factory 의 시그니처(positional args + kwonly args)도
+함께 수집하여 ``new=<stub>`` / ``side_effect=<stub>`` 로 지정된 local stub 이
+production 호출 시그니처를 받지 못하면 위반으로 보고한다 (codex review
+attempt 5 finding 1). 예::
+
+    # production: async def _create_treasury(account_id, *, ctx=None)
+    async def _stub(ctx=None):                    # ← account_id positional 누락
+        ...
+    with patch("ante.cli.commands.treasury._create_treasury", new=_stub):
+        ...   # production 이 _stub(account_id, ctx=ctx) 호출 시 TypeError
+
+stub 이 ``*args`` / ``**kwargs`` 로 모든 인수를 swallow 하거나, production 의
+positional arg 이름을 정확히 포함하면 통과.
+
 Usage::
 
     python scripts/scan_create_services_anti_pattern.py tests/unit/
@@ -106,7 +120,7 @@ Usage::
 KNOWN-LIMITATION (정적 분석 범위 한계)
 ======================================
 
-본 scanner 는 정적 AST 분석으로 다음 anti-pattern 형태를 catch 한다:
+본 scanner 는 정적 AST 분석으로 다음 anti-pattern 형태를 catch 한다 (ON):
 
 * ``with patch(...) as alias: alias.return_value = tuple``
 * ``with patch(...)`` (1-positional + ``return_value=tuple`` kwarg)
@@ -118,6 +132,18 @@ KNOWN-LIMITATION (정적 분석 범위 한계)
   ``new``)
 * ``@patch(...)`` 데코레이터 (위 모든 형태 + decorated FunctionDef body 의
   ``mock_arg.return_value = tuple`` 할당)
+* **Target-specific stub call-signature validation (ON)** — codex review
+  attempt 5 finding 1: production factory 의 positional args 를 정확히 수집해
+  ``new=<stub>`` / ``side_effect=<stub>`` 가 같은 positional args 를 받을 수
+  있는지 검증. 예: ``treasury._create_treasury(account_id, *, ctx=None)``
+  의 stub 이 ``ctx=None`` 만 받으면 ``async-stub-positional-arity-mismatch``
+  위반.
+* **Class-level @patch decorator method body assignment (ON)** — codex review
+  attempt 5 finding 2: ``@patch(target)`` 이 클래스 데코레이터로 적용되면
+  클래스 내 **모든** test method 의 body 도 매핑 검사 대상. method args 는
+  ``self`` 다음에 method-level decorator slot (innermost-first) → class-level
+  decorator slot (innermost-first) 순으로 매핑한다 (Python
+  ``unittest.mock.patch`` 실제 주입 규칙).
 
 Decorator stack 의 mock arg slot 매핑은 Python ``unittest.mock.patch`` 실제
 주입 규칙과 정렬한다 (codex review attempt 4 finding 2):
@@ -135,7 +161,8 @@ Decorator stack 의 mock arg slot 매핑은 Python ``unittest.mock.patch`` 실�
 따라서 ``new=<stub>`` / ``side_effect=<stub>`` 의 stub 정의가 patch site 보다
 파일 아래쪽에 있어도 정확히 resolve 된다.
 
-다음은 본 scanner 범위 밖 (정적 분석으로는 catch 불가, follow-up 분리):
+다음은 본 scanner 범위 밖 (정적 분석으로는 catch 불가, follow-up 분리, **본
+PR scope 밖**):
 
 * ``@patch.object(Class, "attr", ...)`` — target 이 string 이 아닌 reference
 * ``patch.multiple``, ``patch.dict``, ``patch.stopall`` 등 부수 API
@@ -146,8 +173,8 @@ Decorator stack 의 mock arg slot 매핑은 Python ``unittest.mock.patch`` 실�
 
 이러한 형태가 실제로 anti-pattern 으로 사용되면 별도 이슈로 분리하여 추가
 보강한다 (#1900 follow-up). 본 scanner 의 sound 범위 (false-positive 0,
-allowlist 자동 수집) 와 known-incomplete 범위 (위 5개 형태) 를 normative 로
-선언한다.
+allowlist 자동 수집 + signature 정합) 와 known-incomplete 범위 (위 5개 형태)
+를 normative 로 선언한다.
 """
 
 from __future__ import annotations
@@ -184,16 +211,34 @@ class Violation:
         return f"{rel}:{self.lineno}: [{self.kind}] {self.target} — {self.detail}"
 
 
+@dataclass(frozen=True)
+class FactorySignature:
+    """production async ctxmgr factory 의 call-signature (codex review attempt
+    5 finding 1).
+
+    stub 호출 시 production 의 positional args 를 받지 못하면 ``TypeError`` 가
+    발생한다. scanner 는 ``new=<stub>`` / ``side_effect=<stub>`` 가 같은
+    positional/kwonly args 를 수용할 수 있는지 검증한다.
+    """
+
+    positional_args: tuple[str, ...]
+    kwonly_args: tuple[str, ...]
+
+
 # ── Step 1: production factory allowlist 자동 수집 ─────────────────────
 
 
-def discover_async_ctxmgr_factories() -> set[str]:
+def discover_async_ctxmgr_factories() -> dict[str, FactorySignature]:
     """``src/ante/cli/commands/*.py`` 에서 ``@asynccontextmanager`` 적용 async
-    함수의 fully-qualified target string set 을 반환한다.
+    함수의 fully-qualified target → ``FactorySignature`` mapping 을 반환한다.
 
-    예: ``ante.cli.commands.bot._create_services``.
+    예: ``ante.cli.commands.bot._create_services`` →
+    ``FactorySignature(positional_args=('ctx',), kwonly_args=())``.
+
+    하위 호환: ``dict in/keys()`` 로 ``set`` 처럼 사용 가능 (PatchVisitor 가
+    ``target in self.allowlist`` 로 멤버십만 검사).
     """
-    targets: set[str] = set()
+    targets: dict[str, FactorySignature] = {}
     for py_path in sorted(CLI_COMMANDS_DIR.glob("*.py")):
         if py_path.name.startswith("_") and py_path.name != "__init__.py":
             # private helper (e.g. _password.py) 도 stub 정의가 있으면 검사
@@ -213,7 +258,13 @@ def discover_async_ctxmgr_factories() -> set[str]:
             target = f"ante.cli.commands.{module_name}.{node.name}"
             if target in LEGACY_DENY:
                 continue
-            targets.add(target)
+            positional = tuple(
+                a.arg for a in (list(node.args.posonlyargs) + list(node.args.args))
+            )
+            kwonly = tuple(a.arg for a in node.args.kwonlyargs)
+            targets[target] = FactorySignature(
+                positional_args=positional, kwonly_args=kwonly
+            )
     return targets
 
 
@@ -234,10 +285,14 @@ def _has_async_ctxmgr_decorator(node: ast.AsyncFunctionDef) -> bool:
 class PatchVisitor(ast.NodeVisitor):
     """``patch("ante.cli.commands.<mod>.<fn>", ...)`` 호출을 분석."""
 
-    def __init__(self, path: Path, allowlist: set[str]) -> None:
+    def __init__(self, path: Path, allowlist: dict[str, FactorySignature]) -> None:
         self.path = path
         self.allowlist = allowlist
         self.violations: list[Violation] = []
+        # class decorator stack (innermost-first) — codex review attempt 5
+        # finding 2: class-level ``@patch(...)`` 가 모든 method 의 body 에
+        # mock arg 를 주입하므로 visit 진입 시 push, leave 시 pop.
+        self._class_decorator_stack: list[list[ast.Call]] = []
         # async ctxmgr stubs (name -> AsyncFunctionDef node).
         # 2-pass scan (codex review attempt 4 finding 3): ``scan_file`` 이
         # ``ast.walk`` 로 모든 ``AsyncFunctionDef`` 를 pre-collect 한 후
@@ -268,9 +323,32 @@ class PatchVisitor(ast.NodeVisitor):
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         # 클래스 데코레이터에서도 patch(...) 가 등장 가능 (e.g. @patch(... ) on class).
-        # ``ClassDef`` 은 mock 주입 함수 인자가 없으므로 alias-body 검사는 생략.
+        # ``ClassDef`` 자체에는 mock 주입 함수 인자가 없으므로 alias-body 검사를
+        # 직접 실행하진 않지만, **클래스 데코레이터는 클래스 내 모든 test method
+        # 의 body 에 mock arg 를 주입한다** (Python ``unittest.mock.patch`` 실제
+        # 동작). codex review attempt 5 finding 2 — class decorator stack 을
+        # push 해 method 방문 시 method-level decorator 와 함께 매핑한다.
         self._check_decorator_list(node.decorator_list, function_node=None)
-        self.generic_visit(node)
+        # ``new=`` 가 지정되지 않은 patch decorator 만 slot 을 소비한다 (Finding 1
+        # 정정 규칙과 동일). innermost-first 순으로 stack 에 push.
+        class_patch_decos_innermost_first: list[ast.Call] = []
+        for deco in reversed(node.decorator_list):
+            if not isinstance(deco, ast.Call):
+                continue
+            if not self._is_patch_call(deco):
+                continue
+            new_value, _new_callable_value, _, _ = self._extract_patch_kwargs(deco)
+            if new_value is not None:
+                # ``new=`` 지정 patch 는 mock arg 를 주입하지 않으므로 slot 자체에서
+                # 제외 — 본 stack 에 push 하지 않는다.
+                continue
+            class_patch_decos_innermost_first.append(deco)
+
+        self._class_decorator_stack.append(class_patch_decos_innermost_first)
+        try:
+            self.generic_visit(node)
+        finally:
+            self._class_decorator_stack.pop()
 
     def _check_decorator_list(
         self,
@@ -308,7 +386,7 @@ class PatchVisitor(ast.NodeVisitor):
     ) -> None:
         """decorator stack 의 ``@patch(target)`` 매핑된 mock 함수 인자가 body
         에서 ``<alias>.return_value = tuple/list`` 로 사용되는지 검사한다
-        (attempt 3 finding 1).
+        (attempt 3 finding 1 + attempt 5 finding 2).
 
         Python ``@patch`` 의 mock 주입 규칙:
 
@@ -327,6 +405,12 @@ class PatchVisitor(ast.NodeVisitor):
 
         ``new`` 또는 ``new_callable`` 이 지정된 ``@patch`` 는 mock 인자를 주입하지
         않으므로 매핑에서 제외한다 (Python 스펙).
+
+        Class-level ``@patch`` (codex review attempt 5 finding 2): test method
+        의 args slot 은 ``self`` 다음에 **method-level decorator slot (innermost-
+        first)** → **class-level decorator slot (innermost-first)** 순으로
+        매핑된다. ``self._class_decorator_stack[-1]`` 가 현재 enclosing class
+        decorator stack (이미 innermost-first 정렬, ``new=`` 제외).
         """
         # 1) 함수 positional args 에서 self/cls 제외한 리스트
         positional_args = list(function_node.args.posonlyargs) + list(
@@ -347,7 +431,7 @@ class PatchVisitor(ast.NodeVisitor):
         #
         # ``new=`` 가 지정된 decorator 는 slot 매핑에서 완전 제외한다 (skip).
         # 그 외 (no new / new_callable=) 는 매핑 대상으로 보존.
-        patch_decos_innermost_first: list[ast.Call] = []
+        method_patch_decos_innermost_first: list[ast.Call] = []
         for deco in reversed(decorators):
             if not isinstance(deco, ast.Call):
                 continue
@@ -358,13 +442,20 @@ class PatchVisitor(ast.NodeVisitor):
                 # ``new=`` 지정 patch 는 mock arg 를 주입하지 않으므로 slot 매핑
                 # 자체에서 제외한다. (Python 실제 주입 규칙)
                 continue
-            patch_decos_innermost_first.append(deco)
+            method_patch_decos_innermost_first.append(deco)
+
+        # 2b) class decorator stack (innermost-first, ``new=`` 제외) 을 method
+        # decorator slot 뒤에 append. enclosing class 가 있을 때만 적용 (attempt
+        # 5 finding 2).
+        all_patch_decos = list(method_patch_decos_innermost_first)
+        if self._class_decorator_stack:
+            all_patch_decos.extend(self._class_decorator_stack[-1])
 
         # 3) 각 decorator 를 positional_args 의 앞부터 매핑하면서 alias 검사.
         # 이 단계에 도달한 decorator 는 모두 mock arg slot 을 소비한다
         # (no new + with-or-without new_callable). allowlist 밖 target 도
         # slot 은 소비되지만 검사 대상이 아니라 alias 검증을 건너뛴다.
-        for idx, deco in enumerate(patch_decos_innermost_first):
+        for idx, deco in enumerate(all_patch_decos):
             if idx >= len(positional_args):
                 # 함수 시그니처에 mock arg 가 모자라면 매핑 불가 — 정적 매핑 한계.
                 break
@@ -767,6 +858,24 @@ class PatchVisitor(ast.NodeVisitor):
                         ),
                     )
                 )
+                return
+            # codex review attempt 5 finding 1: production positional args 를
+            # stub 이 받지 못하면 호출 시 TypeError.
+            signature = self.allowlist[target]
+            mismatch = self._stub_positional_arity_mismatch(stub, signature)
+            if mismatch is not None:
+                self.violations.append(
+                    Violation(
+                        path=self.path,
+                        lineno=call.lineno,
+                        kind="async-stub-positional-arity-mismatch",
+                        target=target,
+                        detail=(
+                            f"new={new_value.id} — {mismatch}. "
+                            "mock_*_factory 사용 권장."
+                        ),
+                    )
+                )
 
     @staticmethod
     def _stub_is_ctxmgr(stub: ast.AsyncFunctionDef) -> bool:
@@ -793,6 +902,78 @@ class PatchVisitor(ast.NodeVisitor):
                 return True
         return False
 
+    @staticmethod
+    def _stub_positional_arity_mismatch(
+        stub: ast.AsyncFunctionDef, signature: FactorySignature
+    ) -> str | None:
+        """stub 이 production 의 positional/kwonly args 를 받지 못하면 mismatch
+        사유 문자열을, 호환되면 ``None`` 을 반환한다 (codex review attempt 5
+        finding 1).
+
+        호환 조건:
+
+        * stub 이 ``*args`` 를 가지면 production positional 을 모두 swallow → OK.
+        * 그 외에는 stub 의 positional (posonly+args) 이름이 production positional
+          이름을 같은 순서로 prefix 로 포함해야 한다.
+          (production 은 stub 을 positional 로 그대로 forward 하므로 이름
+          매칭이 아닌 arity + 순서 매칭이 필요. 하지만 ``ctx`` 처럼 production
+          이 kwarg 로 부르는 경우는 별도 분기.)
+        * production 이 ``ctx`` 를 첫 posarg 로 정의하면 stub 도 ctx 만 받으면
+          호환 (이 경우 production 호출은 ``await factory(ctx=...)`` 또는
+          ``await factory(ctx)`` 둘 다 가능).
+        * production 의 kwonly args (예: ``ctx`` kwarg-only) 는 ``_stub_accepts_
+          ctx_kwarg`` 가 별도 검사하므로 본 함수에서는 positional 만 검증.
+
+        반환: ``None`` (호환) 또는 mismatch reason string.
+        """
+        # stub 이 *args 면 모든 positional swallow — OK.
+        if stub.args.vararg is not None:
+            return None
+
+        stub_positional = [a.arg for a in stub.args.posonlyargs] + [
+            a.arg for a in stub.args.args
+        ]
+        prod_positional = list(signature.positional_args)
+
+        # production 이 positional 0 (e.g. ``account._create_account_service()``
+        # ctx 없음 케이스는 없지만 일반화) 면 검사 불요.
+        if not prod_positional:
+            return None
+
+        # stub positional arity 가 부족하면 호출 시 TypeError.
+        # ``ctx`` 가 production 의 첫 positional 이면 stub 의 ``ctx=`` kwarg-only
+        # 도 호환으로 인정한다 (``_create_services(ctx=ctx)`` 호출이 가능).
+        # 따라서 다음 규칙:
+        #
+        #   * prod_positional 의 모든 이름이 stub_positional 의 동일 순서 prefix
+        #     로 등장하면 OK.
+        #   * 또는 prod_positional 이 정확히 ``['ctx']`` 인 경우, stub 이 ctx
+        #     를 (positional or kwonly) 받으면 OK (production 이 ``ctx=ctx`` 로
+        #     호출 가능).
+        if (
+            len(prod_positional) == 1
+            and prod_positional[0] == "ctx"
+            and PatchVisitor._stub_accepts_ctx_kwarg(stub)
+        ):
+            return None
+
+        # 일반 케이스: stub_positional prefix 가 prod_positional 과 일치해야 함.
+        if len(stub_positional) < len(prod_positional):
+            return (
+                f"production positional args {prod_positional} 중 "
+                f"{prod_positional[len(stub_positional) :]} 을(를) stub 이 받지 "
+                "못한다 (stub positional arity 부족)"
+            )
+        for i, prod_name in enumerate(prod_positional):
+            if stub_positional[i] != prod_name:
+                return (
+                    f"production positional args {prod_positional} 와 stub "
+                    f"positional {stub_positional[: len(prod_positional)]} "
+                    "이름이 일치하지 않는다 (호출 시 positional forward 가 "
+                    "기대 이름과 어긋남)"
+                )
+        return None
+
     def _check_side_effect_stub(
         self, side_effect_value: ast.expr, call: ast.Call, target: str
     ) -> None:
@@ -818,7 +999,8 @@ class PatchVisitor(ast.NodeVisitor):
                     ),
                 )
             )
-        elif not self._stub_is_ctxmgr(stub):
+            return
+        if not self._stub_is_ctxmgr(stub):
             # production 은 ``async with`` 진입이라 단순 coroutine 도 fail.
             self.violations.append(
                 Violation(
@@ -830,6 +1012,24 @@ class PatchVisitor(ast.NodeVisitor):
                         f"side_effect={side_effect_value.id} — async def stub 은 "
                         "async ctxmgr 가 아니라 coroutine 을 반환한다. "
                         "@asynccontextmanager 변환 또는 mock_*_factory 권장."
+                    ),
+                )
+            )
+            return
+        # codex review attempt 5 finding 1: production positional args 호환성도
+        # ``side_effect=`` stub 에 동일하게 적용.
+        signature = self.allowlist[target]
+        mismatch = self._stub_positional_arity_mismatch(stub, signature)
+        if mismatch is not None:
+            self.violations.append(
+                Violation(
+                    path=self.path,
+                    lineno=call.lineno,
+                    kind="async-stub-side-effect-positional-arity-mismatch",
+                    target=target,
+                    detail=(
+                        f"side_effect={side_effect_value.id} — {mismatch}. "
+                        "mock_*_factory 사용 권장."
                     ),
                 )
             )
@@ -887,7 +1087,7 @@ class PatchVisitor(ast.NodeVisitor):
                     )
 
 
-def scan_file(path: Path, allowlist: set[str]) -> list[Violation]:
+def scan_file(path: Path, allowlist: dict[str, FactorySignature]) -> list[Violation]:
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except SyntaxError:
@@ -902,7 +1102,9 @@ def scan_file(path: Path, allowlist: set[str]) -> list[Violation]:
     return visitor.violations
 
 
-def scan_paths(paths: Iterable[Path], allowlist: set[str]) -> list[Violation]:
+def scan_paths(
+    paths: Iterable[Path], allowlist: dict[str, FactorySignature]
+) -> list[Violation]:
     violations: list[Violation] = []
     for root in paths:
         if root.is_file() and root.suffix == ".py":
@@ -931,7 +1133,11 @@ def main(argv: list[str] | None = None) -> int:
     allowlist = discover_async_ctxmgr_factories()
     if args.list_allowlist:
         for t in sorted(allowlist):
-            print(t)
+            sig = allowlist[t]
+            sig_repr = (
+                f"positional={list(sig.positional_args)} kwonly={list(sig.kwonly_args)}"
+            )
+            print(f"{t}  # {sig_repr}")
         print(f"# total: {len(allowlist)} (legacy denied: {sorted(LEGACY_DENY)})")
         return 0
 

--- a/scripts/scan_create_services_anti_pattern.py
+++ b/scripts/scan_create_services_anti_pattern.py
@@ -55,6 +55,24 @@
 
    ``async with`` 호출이 fail하고, ``ctx=`` kwarg 전달 시 ``TypeError`` 발생.
 
+5. **decorator 형태 (``@patch(...)``)** — codex review attempt 2 finding 2.
+
+   위 1~4 패턴은 ``with patch(...)`` (With statement) 뿐 아니라 함수/메소드
+   데코레이터 형태로도 등장한다::
+
+       @patch("ante.cli.commands.bot._create_services", return_value=(...))
+       def test_x(...): ...
+
+       @patch(
+           "ante.cli.commands.bot._create_services",
+           new_callable=AsyncMock,
+           return_value=(...),
+       )
+       def test_x(self, mock_): ...
+
+   scanner 는 ``FunctionDef``/``AsyncFunctionDef`` 의 ``decorator_list`` 안의
+   ``patch(...)`` 호출도 with-statement 와 동일한 로직으로 검사한다.
+
 Helper(``mock_*_factory(...)``) 또는 ``@asynccontextmanager`` 로 직접 정의된
 async ctxmgr 만 정상으로 인정한다.
 
@@ -163,7 +181,33 @@ class PatchVisitor(ast.NodeVisitor):
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._async_def_stubs[node.name] = node
+        self._check_decorator_list(node.decorator_list)
         self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._check_decorator_list(node.decorator_list)
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        # 클래스 데코레이터에서도 patch(...) 가 등장 가능 (e.g. @patch(... ) on class).
+        self._check_decorator_list(node.decorator_list)
+        self.generic_visit(node)
+
+    def _check_decorator_list(self, decorators: list[ast.expr]) -> None:
+        """``@patch(...)`` 형태의 데코레이터를 with-statement 와 동일한 anti-pattern
+        규칙으로 검사한다 (codex review attempt 2 finding 2).
+
+        ``@patch(target, ...)`` / ``@patch.object(...)`` 둘 다 ``Call`` 노드로
+        등장. ``patch.object`` 는 첫 번째 인수가 string target이 아니라 객체
+        참조이므로 ``_extract_patch_target`` 에서 ``None`` 이 반환되어 자연스럽게
+        스킵된다. ``patch(target, ...)`` 형태만 본격 분석한다.
+        """
+        for deco in decorators:
+            if not isinstance(deco, ast.Call):
+                continue
+            if not self._is_patch_call(deco):
+                continue
+            self._check_patch_call(deco, parent_with=None, alias=None)
 
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:
@@ -176,6 +220,20 @@ class PatchVisitor(ast.NodeVisitor):
             return
         if not self._is_patch_call(call):
             return
+        alias: str | None = None
+        if item.optional_vars is not None and isinstance(item.optional_vars, ast.Name):
+            alias = item.optional_vars.id
+        self._check_patch_call(call, parent_with=parent_with, alias=alias)
+
+    def _check_patch_call(
+        self,
+        call: ast.Call,
+        parent_with: ast.With | None,
+        alias: str | None,
+    ) -> None:
+        """``patch(target, ...)`` 호출(``with`` 문맥 또는 데코레이터)에 대한
+        공통 anti-pattern 검사 로직.
+        """
         target = self._extract_patch_target(call)
         if target is None or target not in self.allowlist:
             return
@@ -242,10 +300,9 @@ class PatchVisitor(ast.NodeVisitor):
             self._check_side_effect_stub(side_effect_kwarg, call, target)
 
         # Case C: with patch(...) as mock_cs: mock_cs.return_value = tuple
-        if item.optional_vars is not None and isinstance(item.optional_vars, ast.Name):
-            self._check_with_alias_tuple_return(
-                item.optional_vars.id, parent_with, call, target
-            )
+        # 데코레이터 형태(parent_with=None, alias=None) 는 alias 가 없으므로 skip.
+        if parent_with is not None and alias is not None:
+            self._check_with_alias_tuple_return(alias, parent_with, call, target)
 
     @staticmethod
     def _is_patch_call(call: ast.Call) -> bool:

--- a/scripts/scan_create_services_anti_pattern.py
+++ b/scripts/scan_create_services_anti_pattern.py
@@ -9,6 +9,12 @@
        with patch("ante.cli.commands.bot._create_services") as mock_cs:
            mock_cs.return_value = (db, eb, mgr, svc)
 
+       # 또는 default MagicMock + return_value kwarg
+       with patch(
+           "ante.cli.commands.bot._create_services",
+           return_value=(db, eb, mgr, svc),
+       ):
+
    ``return_value`` 가 ``async with`` 호출 시 ``__aenter__`` 가 없는 tuple/
    MagicMock 으로 설정되면 production async ctxmgr lifecycle을 깨뜨린다.
 
@@ -30,7 +36,15 @@
            new=MagicMock(return_value=(...)),
        ):
 
-   ``async with`` 패턴을 모사하지 않는 ``new=`` substitute.
+       # ``new`` 는 두 번째 positional 인수로도 전달 가능 (signature:
+       # ``patch(target, new, spec, create, spec_set, autospec, new_callable)``)
+       with patch(
+           "ante.cli.commands.bot._create_services",
+           MagicMock(return_value=(...)),
+       ):
+
+   ``async with`` 패턴을 모사하지 않는 ``new=`` substitute. ``new`` 내부
+   ``return_value`` 가 tuple 이면 ``tuple-return-on-patch`` 로 보고된다.
 
 4. **async def stub without ctx kwarg**::
 
@@ -194,6 +208,30 @@ class PatchVisitor(ast.NodeVisitor):
                 )
                 return
 
+        # Case A': default MagicMock + return_value=tuple (no new/new_callable)
+        # ``patch(target, return_value=(db, ...))`` 형태. default MagicMock 이
+        # tuple 을 반환해 ``async with`` 진입 시 ``__aenter__`` 가 없다.
+        if (
+            new_value is None
+            and new_callable_value is None
+            and return_value_kwarg is not None
+            and self._is_tuple_or_list(return_value_kwarg)
+        ):
+            self.violations.append(
+                Violation(
+                    path=self.path,
+                    lineno=call.lineno,
+                    kind="tuple-return-on-patch",
+                    target=target,
+                    detail=(
+                        "patch(..., return_value=tuple) — default MagicMock 이 "
+                        "tuple 을 반환해 async with 가 동작하지 않는다. "
+                        "mock_*_factory(...) 사용 권장."
+                    ),
+                )
+            )
+            return
+
         # Case B: new=async_def_without_ctx OR new=MagicMock/non-ctxmgr
         if new_value is not None:
             self._check_new_substitute(new_value, call, target)
@@ -232,10 +270,47 @@ class PatchVisitor(ast.NodeVisitor):
     def _extract_patch_kwargs(
         call: ast.Call,
     ) -> tuple[ast.expr | None, ast.expr | None, ast.expr | None, ast.expr | None]:
+        """``unittest.mock.patch(target, new, spec, create, spec_set, autospec,
+        new_callable, *, **kwargs)`` 의 positional / keyword 인수를 모두 훑어
+        ``(new, new_callable, return_value, side_effect)`` 를 추출한다.
+
+        positional signature (Python stdlib):
+
+            patch(target, new=DEFAULT, spec=None, create=False,
+                  spec_set=None, autospec=None, new_callable=None,
+                  *, unsafe=False, **kwargs)
+
+        ``return_value`` / ``side_effect`` 는 ``**kwargs`` 패스스루로만 전달되어
+        positional 매핑이 불가능하다 (keyword 전용).
+        """
         new_value: ast.expr | None = None
         new_callable_value: ast.expr | None = None
         return_value_kwarg: ast.expr | None = None
         side_effect_kwarg: ast.expr | None = None
+
+        # positional mapping: index 0 = target (이미 _extract_patch_target),
+        # index 1 = new, index 6 = new_callable.
+        # 1..6: (new, spec, create, spec_set, autospec, new_callable)
+        positional_slots: list[str] = [
+            "target",
+            "new",
+            "spec",
+            "create",
+            "spec_set",
+            "autospec",
+            "new_callable",
+        ]
+        for idx, arg in enumerate(call.args):
+            if idx == 0:
+                continue
+            if idx >= len(positional_slots):
+                break
+            slot = positional_slots[idx]
+            if slot == "new":
+                new_value = arg
+            elif slot == "new_callable":
+                new_callable_value = arg
+
         for kw in call.keywords:
             if kw.arg == "new":
                 new_value = kw.value
@@ -267,16 +342,46 @@ class PatchVisitor(ast.NodeVisitor):
     def _is_tuple_or_list(node: ast.expr) -> bool:
         return isinstance(node, (ast.Tuple, ast.List))
 
+    @staticmethod
+    def _call_return_value_kwarg(call: ast.Call) -> ast.expr | None:
+        """``MagicMock(return_value=...)`` / ``AsyncMock(return_value=...)`` 등
+        Call 노드의 ``return_value=`` keyword 인수 값을 반환한다.
+        """
+        for kw in call.keywords:
+            if kw.arg == "return_value":
+                return kw.value
+        return None
+
     def _check_new_substitute(
         self, new_value: ast.expr, call: ast.Call, target: str
     ) -> None:
         # new=AsyncMock(...) or new=AsyncMock() ← non-ctxmgr factory
         if isinstance(new_value, ast.Call):
+            inner_return_value = self._call_return_value_kwarg(new_value)
+            inner_returns_tuple = (
+                inner_return_value is not None
+                and self._is_tuple_or_list(inner_return_value)
+            )
             if self._is_asyncmock(new_value.func):
                 # AsyncMock() is a coroutine, not async ctxmgr.
                 # If return_value kwarg/attr is tuple, this fails async with.
                 # Heuristic: any AsyncMock() substitute for these factories is suspect
                 # unless explicit MagicMock side_effect = async ctxmgr.
+                if inner_returns_tuple:
+                    self.violations.append(
+                        Violation(
+                            path=self.path,
+                            lineno=call.lineno,
+                            kind="tuple-return-on-patch",
+                            target=target,
+                            detail=(
+                                "new=AsyncMock(return_value=tuple) — "
+                                "async with 가 동작하지 않는다. "
+                                "mock_*_factory(...) 사용 권장."
+                            ),
+                        )
+                    )
+                    return
                 self.violations.append(
                     Violation(
                         path=self.path,
@@ -291,6 +396,21 @@ class PatchVisitor(ast.NodeVisitor):
                 )
                 return
             if self._is_magicmock(new_value.func):
+                if inner_returns_tuple:
+                    self.violations.append(
+                        Violation(
+                            path=self.path,
+                            lineno=call.lineno,
+                            kind="tuple-return-on-patch",
+                            target=target,
+                            detail=(
+                                "new=MagicMock(return_value=tuple) — "
+                                "async with 가 동작하지 않는다. "
+                                "mock_*_factory(...) 사용 권장."
+                            ),
+                        )
+                    )
+                    return
                 self.violations.append(
                     Violation(
                         path=self.path,

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,0 +1,224 @@
+"""CLI 테스트 공용 async ctxmgr factory mock helper (#1900).
+
+production CLI 명령은 #1855(`open_cli_db`) 도입 이후 모든 factory가 다음
+패턴으로 진입한다::
+
+    async with _create_services(ctx=ctx) as (db, eventbus, ...):
+
+mock이 같은 lifecycle을 정확히 모사하지 못하면 두 부류의 회귀가 발생한다:
+
+1. ``ctx=`` kwarg 미수신 → ``TypeError: ... got an unexpected keyword
+   argument 'ctx'`` (#1900 회귀 A)
+2. plain tuple ``return_value`` → ``'tuple' object does not support the
+   asynchronous context manager protocol`` (#1900 회귀 B/E)
+
+본 모듈은 ``src/ante/cli/commands/*.py`` 의 ``@asynccontextmanager`` factory
+**10개** 각각을 1:1로 모사하는 헬퍼를 제공한다. 각 헬퍼는:
+
+- ``@asynccontextmanager`` 로 정의되어 ``async with`` lifecycle을 정확히 흉내
+- production 호출 시그니처(positional vs kwarg)를 정확히 모사
+- yield 값을 인자로 받아 그대로 반환
+
+Census (10 + 1 legacy 제외):
+
+================================================== =======================
+Production factory                                  Helper
+================================================== =======================
+``account._create_account_service(ctx)``            ``mock_account_service_factory``
+``bot._create_services(ctx=ctx)``                   ``mock_bot_services_factory``
+``config._create_services(ctx=ctx)``                ``mock_config_services_factory``
+``member._create_service(ctx)``                     ``mock_member_service_factory``
+``rule._create_rule_engine(acc, ctx=ctx)``          ``mock_rule_engine_factory``
+``strategy._create_registry(ctx=ctx)``              ``mock_strategy_registry_factory``
+``system._create_services(ctx=ctx)``                ``mock_system_services_factory``
+``trade._create_trade_service(ctx=ctx)``            ``mock_trade_service_factory``
+``treasury._create_treasury(acc, ctx=ctx)``         ``mock_treasury_factory``
+``treasury._create_treasury_manager(ctx=ctx)``      ``mock_treasury_manager_factory``
+``broker._create_account_service()`` (legacy)       (excluded — #1818 follow-up)
+================================================== =======================
+
+본 헬퍼는 ``unittest.mock.patch(..., new=mock_..._factory(yield_value))`` 형태로
+factory 자체를 교체한다. 호출자(``async with _create_xxx(...) as value:``)는
+production과 동일한 lifecycle을 경험한다.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import click
+
+__all__ = [
+    "mock_account_service_factory",
+    "mock_bot_services_factory",
+    "mock_config_services_factory",
+    "mock_member_service_factory",
+    "mock_rule_engine_factory",
+    "mock_strategy_registry_factory",
+    "mock_system_services_factory",
+    "mock_trade_service_factory",
+    "mock_treasury_factory",
+    "mock_treasury_manager_factory",
+]
+
+
+def mock_account_service_factory(svc: Any):
+    """``account._create_account_service`` 모사.
+
+    production: ``async with _create_account_service(ctx) as svc:`` (positional ctx).
+    호환을 위해 positional + kwarg 둘 다 수신한다.
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        ctx: click.Context | None = None,
+    ) -> AsyncIterator[Any]:
+        yield svc
+
+    return _factory
+
+
+def mock_bot_services_factory(db: Any, eventbus: Any, mgr: Any, account_service: Any):
+    """``bot._create_services`` 모사.
+
+    yield: 4-tuple ``(db, eventbus, mgr, account_service)``.
+    production: ``async with _create_services(ctx=ctx) as (...)`` (kwarg only).
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        *, ctx: click.Context | None = None
+    ) -> AsyncIterator[tuple[Any, Any, Any, Any]]:
+        yield db, eventbus, mgr, account_service
+
+    return _factory
+
+
+def mock_config_services_factory(static: Any, dynamic: Any, db: Any):
+    """``config._create_services`` 모사. 3-tuple yield (static, dynamic, db).
+
+    production: ``async with _create_services(ctx=ctx) as (...)`` (kwarg only).
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        *, ctx: click.Context | None = None
+    ) -> AsyncIterator[tuple[Any, Any, Any]]:
+        yield static, dynamic, db
+
+    return _factory
+
+
+def mock_member_service_factory(svc: Any):
+    """``member._create_service`` 모사. svc yield.
+
+    production: ``async with _create_service(ctx) as service:`` (positional ctx).
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        ctx: click.Context | None = None,
+    ) -> AsyncIterator[Any]:
+        yield svc
+
+    return _factory
+
+
+def mock_rule_engine_factory(engine: Any, db: Any):
+    """``rule._create_rule_engine`` 모사. 2-tuple yield (engine, db).
+
+    production: ``async with _create_rule_engine(account_id, ctx=ctx) as (engine, db):``
+    (account_id positional + ctx kwarg-only).
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        account_id: str, *, ctx: click.Context | None = None
+    ) -> AsyncIterator[tuple[Any, Any]]:
+        yield engine, db
+
+    return _factory
+
+
+def mock_strategy_registry_factory(registry: Any, db: Any):
+    """``strategy._create_registry`` 모사. 2-tuple yield (registry, db).
+
+    production: ``async with _create_registry(ctx=ctx) as (registry, db):``
+    (kwarg only).
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        *, ctx: click.Context | None = None
+    ) -> AsyncIterator[tuple[Any, Any]]:
+        yield registry, db
+
+    return _factory
+
+
+def mock_system_services_factory(db: Any, eventbus: Any):
+    """``system._create_services`` 모사. 2-tuple yield (db, eventbus).
+
+    production: ``async with _create_services(ctx=ctx) as (db, eventbus):``
+    (kwarg only).
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        *, ctx: click.Context | None = None
+    ) -> AsyncIterator[tuple[Any, Any]]:
+        yield db, eventbus
+
+    return _factory
+
+
+def mock_trade_service_factory(svc: Any, db: Any):
+    """``trade._create_trade_service`` 모사. 2-tuple yield (service, db).
+
+    production: ``async with _create_trade_service(ctx=ctx) as (service, db):``
+    (kwarg only).
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        *, ctx: click.Context | None = None
+    ) -> AsyncIterator[tuple[Any, Any]]:
+        yield svc, db
+
+    return _factory
+
+
+def mock_treasury_factory(treasury: Any, db: Any):
+    """``treasury._create_treasury`` 모사. 2-tuple yield (treasury, db).
+
+    production: ``async with _create_treasury(account_id, ctx=ctx) as (t, db):``
+    (account_id positional + ctx kwarg-only).
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        account_id: str | None = None,
+        *,
+        ctx: click.Context | None = None,
+    ) -> AsyncIterator[tuple[Any, Any]]:
+        yield treasury, db
+
+    return _factory
+
+
+def mock_treasury_manager_factory(mgr: Any, db: Any):
+    """``treasury._create_treasury_manager`` 모사. 2-tuple yield (manager, db).
+
+    production: ``async with _create_treasury_manager(ctx=ctx) as (manager, db):``
+    (kwarg only).
+    """
+
+    @asynccontextmanager
+    async def _factory(
+        *, ctx: click.Context | None = None
+    ) -> AsyncIterator[tuple[Any, Any]]:
+        yield mgr, db
+
+    return _factory

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -25,17 +25,25 @@ Census (10 + 1 legacy 제외):
 Production factory                                  Helper
 ================================================== =======================
 ``account._create_account_service(ctx)``            ``mock_account_service_factory``
-``bot._create_services(ctx=ctx)``                   ``mock_bot_services_factory``
-``config._create_services(ctx=ctx)``                ``mock_config_services_factory``
+``bot._create_services(ctx)``                       ``mock_bot_services_factory``
+``config._create_services(ctx)``                    ``mock_config_services_factory``
 ``member._create_service(ctx)``                     ``mock_member_service_factory``
-``rule._create_rule_engine(acc, ctx=ctx)``          ``mock_rule_engine_factory``
-``strategy._create_registry(ctx=ctx)``              ``mock_strategy_registry_factory``
-``system._create_services(ctx=ctx)``                ``mock_system_services_factory``
-``trade._create_trade_service(ctx=ctx)``            ``mock_trade_service_factory``
-``treasury._create_treasury(acc, ctx=ctx)``         ``mock_treasury_factory``
-``treasury._create_treasury_manager(ctx=ctx)``      ``mock_treasury_manager_factory``
+``rule._create_rule_engine(acc, *, ctx)``           ``mock_rule_engine_factory``
+``strategy._create_registry(ctx)``                  ``mock_strategy_registry_factory``
+``system._create_services(ctx)``                    ``mock_system_services_factory``
+``trade._create_trade_service(ctx)``                ``mock_trade_service_factory``
+``treasury._create_treasury(acc, *, ctx)``          ``mock_treasury_factory``
+``treasury._create_treasury_manager(ctx)``          ``mock_treasury_manager_factory``
 ``broker._create_account_service()`` (legacy)       (excluded — #1818 follow-up)
 ================================================== =======================
+
+``ctx`` 파라미터의 호출 형태는 production 시그니처를 그대로 모사한다:
+
+* 대다수 factory (``account``/``bot``/``config``/``member``/``strategy``/
+  ``system``/``trade``/``treasury_manager``) 는 ``ctx: click.Context | None =
+  None`` 으로 정의되어 **positional + kwarg 양쪽** 모두 허용한다.
+* ``rule._create_rule_engine`` 과 ``treasury._create_treasury`` 만 ``*, ctx``
+  키워드 전용이다 (account_id 가 positional).
 
 본 헬퍼는 ``unittest.mock.patch(..., new=mock_..._factory(yield_value))`` 형태로
 factory 자체를 교체한다. 호출자(``async with _create_xxx(...) as value:``)는
@@ -84,12 +92,13 @@ def mock_bot_services_factory(db: Any, eventbus: Any, mgr: Any, account_service:
     """``bot._create_services`` 모사.
 
     yield: 4-tuple ``(db, eventbus, mgr, account_service)``.
-    production: ``async with _create_services(ctx=ctx) as (...)`` (kwarg only).
+    production 시그니처: ``_create_services(ctx: click.Context | None = None)``
+    → positional + kwarg 둘 다 허용. helper 도 동일하게 모사한다.
     """
 
     @asynccontextmanager
     async def _factory(
-        *, ctx: click.Context | None = None
+        ctx: click.Context | None = None,
     ) -> AsyncIterator[tuple[Any, Any, Any, Any]]:
         yield db, eventbus, mgr, account_service
 
@@ -99,12 +108,13 @@ def mock_bot_services_factory(db: Any, eventbus: Any, mgr: Any, account_service:
 def mock_config_services_factory(static: Any, dynamic: Any, db: Any):
     """``config._create_services`` 모사. 3-tuple yield (static, dynamic, db).
 
-    production: ``async with _create_services(ctx=ctx) as (...)`` (kwarg only).
+    production 시그니처: ``_create_services(ctx: click.Context | None = None)``
+    → positional + kwarg 둘 다 허용. helper 도 동일하게 모사한다.
     """
 
     @asynccontextmanager
     async def _factory(
-        *, ctx: click.Context | None = None
+        ctx: click.Context | None = None,
     ) -> AsyncIterator[tuple[Any, Any, Any]]:
         yield static, dynamic, db
 
@@ -145,13 +155,13 @@ def mock_rule_engine_factory(engine: Any, db: Any):
 def mock_strategy_registry_factory(registry: Any, db: Any):
     """``strategy._create_registry`` 모사. 2-tuple yield (registry, db).
 
-    production: ``async with _create_registry(ctx=ctx) as (registry, db):``
-    (kwarg only).
+    production 시그니처: ``_create_registry(ctx: click.Context | None = None)``
+    → positional + kwarg 둘 다 허용. helper 도 동일하게 모사한다.
     """
 
     @asynccontextmanager
     async def _factory(
-        *, ctx: click.Context | None = None
+        ctx: click.Context | None = None,
     ) -> AsyncIterator[tuple[Any, Any]]:
         yield registry, db
 
@@ -161,13 +171,13 @@ def mock_strategy_registry_factory(registry: Any, db: Any):
 def mock_system_services_factory(db: Any, eventbus: Any):
     """``system._create_services`` 모사. 2-tuple yield (db, eventbus).
 
-    production: ``async with _create_services(ctx=ctx) as (db, eventbus):``
-    (kwarg only).
+    production 시그니처: ``_create_services(ctx: click.Context | None = None)``
+    → positional + kwarg 둘 다 허용. helper 도 동일하게 모사한다.
     """
 
     @asynccontextmanager
     async def _factory(
-        *, ctx: click.Context | None = None
+        ctx: click.Context | None = None,
     ) -> AsyncIterator[tuple[Any, Any]]:
         yield db, eventbus
 
@@ -177,13 +187,14 @@ def mock_system_services_factory(db: Any, eventbus: Any):
 def mock_trade_service_factory(svc: Any, db: Any):
     """``trade._create_trade_service`` 모사. 2-tuple yield (service, db).
 
-    production: ``async with _create_trade_service(ctx=ctx) as (service, db):``
-    (kwarg only).
+    production 시그니처:
+    ``async def _create_trade_service(ctx: click.Context | None = None)``
+    → positional + kwarg 둘 다 허용. helper 도 동일하게 모사한다.
     """
 
     @asynccontextmanager
     async def _factory(
-        *, ctx: click.Context | None = None
+        ctx: click.Context | None = None,
     ) -> AsyncIterator[tuple[Any, Any]]:
         yield svc, db
 
@@ -211,13 +222,14 @@ def mock_treasury_factory(treasury: Any, db: Any):
 def mock_treasury_manager_factory(mgr: Any, db: Any):
     """``treasury._create_treasury_manager`` 모사. 2-tuple yield (manager, db).
 
-    production: ``async with _create_treasury_manager(ctx=ctx) as (manager, db):``
-    (kwarg only).
+    production 시그니처:
+    ``async def _create_treasury_manager(ctx: click.Context | None = None)``
+    → positional + kwarg 둘 다 허용. helper 도 동일하게 모사한다.
     """
 
     @asynccontextmanager
     async def _factory(
-        *, ctx: click.Context | None = None
+        ctx: click.Context | None = None,
     ) -> AsyncIterator[tuple[Any, Any]]:
         yield mgr, db
 

--- a/tests/unit/cli/test_authenticated_group.py
+++ b/tests/unit/cli/test_authenticated_group.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -29,6 +29,7 @@ from ante.cli.middleware import (
     require_scope,
 )
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit.cli.conftest import mock_bot_services_factory
 
 _MASTER = Member(
     member_id="cli-master",
@@ -452,7 +453,14 @@ class TestAuthenticatedFlow:
     def test_authenticated_master_runs_bot_list(
         self, runner: CliRunner, clean_env: None
     ) -> None:
-        """master 인증 통과 시 ``ante bot list``는 IPC 단계까지 진입."""
+        """master 인증 통과 시 ``ante bot list``는 cold-path leaf 까지 진입.
+
+        ``bot list`` 는 cold-path 명령으로 IPC 를 거치지 않고 직접
+        ``_create_services`` 로 DB 를 연다. 인증 게이트 통과만 검증하므로
+        ``_create_services`` 를 helper 로 mock 해 실제 DB 접근을 차단한다
+        (#1900 sweep — 이전 default-env credentials decrypt 실패가 가짜 fail
+        을 만들었다).
+        """
         # leaf wrapper가 ante.cli.main.authenticate_member를 호출하므로 거기서 mock.
         from ante.cli import main as _main
 
@@ -460,19 +468,18 @@ class TestAuthenticatedFlow:
             ctx.ensure_object(dict)
             ctx.obj["member"] = _MASTER
 
-        # ipc client도 mock으로 단순 응답
-        ok_response = {"status": "ok", "data": {"bots": []}}
+        mock_db = AsyncMock()
+        mock_db.fetch_all = AsyncMock(return_value=[])
+        mock_db.close = AsyncMock()
         with (
             patch.object(_main, "authenticate_member", side_effect=_set_master),
-            patch("ante.cli.commands.ipc_helpers.IPCClient", autospec=True) as mock_cls,
             patch(
-                "ante.cli.commands.ipc_helpers.get_socket_path",
-                return_value="/tmp/ante.sock",
+                "ante.cli.commands.bot._create_services",
+                new=mock_bot_services_factory(
+                    mock_db, MagicMock(), MagicMock(), MagicMock()
+                ),
             ),
         ):
-            mock_client = AsyncMock()
-            mock_client.send.return_value = ok_response
-            mock_cls.return_value = mock_client
             result = runner.invoke(cli, ["bot", "list"])
 
         assert result.exit_code == 0, result.output

--- a/tests/unit/cli/test_create_services_anti_pattern_scanner.py
+++ b/tests/unit/cli/test_create_services_anti_pattern_scanner.py
@@ -1,0 +1,279 @@
+"""``scripts/scan_create_services_anti_pattern.py`` 자체 회귀 테스트 (#1900).
+
+scanner 가 새로 검출해야 하는 ``patch(...)`` 형태를 fixture 소스로 만들어
+``scan_paths`` 가 위반을 정확히 보고하고, 기존 PASS 케이스(올바른 helper
+사용)는 그대로 통과시키는지 확인한다.
+
+Codex 브랜치 리뷰 attempt 1 finding 2건:
+
+* Finding 1: ``patch(target, return_value=(db, ...))`` (default MagicMock + tuple
+  return_value) 가 누락되어 회귀 검출 실패
+* Finding 2: ``patch(target, MagicMock(return_value=(db, ...)))`` (2번째
+  positional ``new``) 가 누락되어 회귀 검출 실패
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# ``scripts/`` 는 패키지가 아니라 스크립트 디렉토리라서 일반 import 가
+# 불가능하다. 파일 경로에서 직접 spec 을 만들어 로드한다.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCANNER_PATH = _REPO_ROOT / "scripts" / "scan_create_services_anti_pattern.py"
+_MODULE_NAME = "scan_create_services_anti_pattern"
+_spec = importlib.util.spec_from_file_location(_MODULE_NAME, _SCANNER_PATH)
+assert _spec is not None and _spec.loader is not None
+_scanner = importlib.util.module_from_spec(_spec)
+# dataclasses 가 cls.__module__ 로 sys.modules lookup 을 수행하므로
+# exec_module 호출 전에 등록해야 frozen=True dataclass 가 동작한다.
+sys.modules[_MODULE_NAME] = _scanner
+_spec.loader.exec_module(_scanner)
+
+discover_async_ctxmgr_factories = _scanner.discover_async_ctxmgr_factories
+scan_file = _scanner.scan_file
+
+# 실제 production target — sweep allowlist 에 들어있어야 한다.
+TARGET = "ante.cli.commands.bot._create_services"
+
+
+@pytest.fixture(scope="module")
+def allowlist() -> set[str]:
+    a = discover_async_ctxmgr_factories()
+    # 이 테스트의 전제: bot._create_services 는 allowlist 에 있다.
+    assert TARGET in a
+    return a
+
+
+def _write(tmp_path: Path, src: str) -> Path:
+    p = tmp_path / "fixture.py"
+    p.write_text(textwrap.dedent(src), encoding="utf-8")
+    return p
+
+
+# ── Finding 1: default patch + return_value=tuple ───────────────────────────
+
+
+def test_default_patch_with_tuple_return_value_kwarg_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``patch(target, return_value=(db, ...))`` 형태도 위반으로 잡아야 한다.
+
+    default MagicMock 이 tuple 을 반환해 ``async with`` 가 ``__aenter__`` 를
+    찾지 못한다.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        def test_x():
+            db, eb, mgr, svc = object(), object(), object(), object()
+            with patch(
+                "{TARGET}",
+                return_value=(db, eb, mgr, svc),
+            ):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch"
+    assert vs[0].target == TARGET
+
+
+def test_default_patch_with_tuple_return_value_list_form(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """list literal 도 동일 위반 처리."""
+    src = f"""
+        from unittest.mock import patch
+
+        def test_x():
+            with patch("{TARGET}", return_value=[1, 2, 3, 4]):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1
+    assert vs[0].kind == "tuple-return-on-patch"
+
+
+def test_default_patch_with_scalar_return_value_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """tuple/list 가 아닌 ``return_value`` 는 scanner 범위 밖 (false positive 방지)."""
+    src = f"""
+        from unittest.mock import patch
+
+        def test_x():
+            with patch("{TARGET}", return_value=None):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+# ── Finding 2: positional ``new`` ───────────────────────────────────────────
+
+
+def test_positional_new_magicmock_with_tuple_return_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``patch(target, MagicMock(return_value=(...)))`` — 2번째 positional ``new``."""
+    src = f"""
+        from unittest.mock import MagicMock, patch
+
+        def test_x():
+            db, eb, mgr, svc = object(), object(), object(), object()
+            with patch(
+                "{TARGET}",
+                MagicMock(return_value=(db, eb, mgr, svc)),
+            ):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch"
+    assert vs[0].target == TARGET
+
+
+def test_positional_new_asyncmock_with_tuple_return_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``patch(target, AsyncMock(return_value=(...)))`` 도 same 카테고리로 보고."""
+    src = f"""
+        from unittest.mock import AsyncMock, patch
+
+        def test_x():
+            db, eb, mgr, svc = object(), object(), object(), object()
+            with patch(
+                "{TARGET}",
+                AsyncMock(return_value=(db, eb, mgr, svc)),
+            ):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch"
+
+
+def test_positional_new_magicmock_bare_is_substitute_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``patch(target, MagicMock())`` — return_value 미설정도 substitute 위반."""
+    src = f"""
+        from unittest.mock import MagicMock, patch
+
+        def test_x():
+            with patch("{TARGET}", MagicMock()):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1
+    assert vs[0].kind == "magicmock-new-substitute"
+
+
+# ── 기존 Case 회귀 — keyword ``new=`` 분기 유지 ──────────────────────────────
+
+
+def test_keyword_new_magicmock_with_tuple_return_kept(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """기존 ``new=MagicMock(return_value=(...))`` 형태도 같은 카테고리 보고."""
+    src = f"""
+        from unittest.mock import MagicMock, patch
+
+        def test_x():
+            with patch("{TARGET}", new=MagicMock(return_value=(1, 2))):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1
+    assert vs[0].kind == "tuple-return-on-patch"
+
+
+def test_keyword_new_callable_asyncmock_with_tuple_return_kept(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """기존 ``new_callable=AsyncMock, return_value=tuple`` 회귀."""
+    src = f"""
+        from unittest.mock import AsyncMock, patch
+
+        def test_x():
+            with patch(
+                "{TARGET}",
+                new_callable=AsyncMock,
+                return_value=(1, 2, 3, 4),
+            ):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1
+    assert vs[0].kind == "asyncmock-tuple-return"
+
+
+def test_with_alias_tuple_return_assignment_kept(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``with patch(...) as mock_cs: mock_cs.return_value = tuple`` 기존 케이스."""
+    src = f"""
+        from unittest.mock import patch
+
+        def test_x():
+            with patch("{TARGET}") as mock_cs:
+                mock_cs.return_value = (1, 2, 3, 4)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1
+    assert vs[0].kind == "tuple-return-on-patch"
+
+
+# ── PASS 케이스 — false positive 회귀 ─────────────────────────────────────
+
+
+def test_helper_factory_substitute_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``new=mock_bot_services_factory(...)`` 형태는 위반 아님 — helper 가
+    이미 async ctxmgr 를 yield 한다.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        def mock_bot_services_factory(*a, **k):
+            ...
+
+        def test_x():
+            with patch(
+                "{TARGET}",
+                new=mock_bot_services_factory(1, 2, 3, 4),
+            ):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_non_allowlist_target_ignored(tmp_path: Path, allowlist: set[str]) -> None:
+    """allowlist 밖의 patch target 은 무시."""
+    src = """
+        from unittest.mock import patch
+
+        def test_x():
+            with patch("ante.cli.commands.unrelated.helper", return_value=(1, 2)):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == []

--- a/tests/unit/cli/test_create_services_anti_pattern_scanner.py
+++ b/tests/unit/cli/test_create_services_anti_pattern_scanner.py
@@ -35,6 +35,20 @@ Codex 브랜치 리뷰 attempt 4 finding 1/2/3 (last attempt fix):
 * Finding 3: ``_async_def_stubs`` 가 visitor 진행 중 수집되어, patch site 보다
   파일 아래쪽 stub 은 참조 불가. ``scan_file`` 이 2-pass 로 동작하도록 변경
   (pre-collect → visit).
+
+Codex 브랜치 리뷰 attempt 5 finding 1/2 (final fix):
+
+* Finding 1: target-specific stub call-signature validation. production
+  factory 의 positional/kwonly args 를 정확히 수집해 ``new=<stub>`` /
+  ``side_effect=<stub>`` 가 production positional args 를 받을 수 있는지
+  검증. 예: ``treasury._create_treasury(account_id, *, ctx=None)`` 의 stub 이
+  ``ctx=None`` 만 받으면 호출 시 TypeError → ``async-stub-positional-arity-
+  mismatch`` 위반.
+* Finding 2: class-level ``@patch(...)`` decorator 가 클래스 내 모든 test
+  method 의 body 에 mock arg 를 주입한다. method args 매핑은 ``self`` 다음
+  ``method-level decorator (innermost-first)`` → ``class-level decorator
+  (innermost-first)`` 순서. method body 의 ``mock_arg.return_value = tuple``
+  도 동일 검사 대상.
 """
 
 from __future__ import annotations
@@ -816,3 +830,281 @@ def test_patch_with_stub_defined_below_detected(
     assert len(vs) == 1, [v.format() for v in vs]
     assert vs[0].kind == "async-def-stub-not-ctxmgr"
     assert vs[0].target == TARGET
+
+
+# ── Attempt 5 Finding 1: target-specific stub call-signature validation ──────
+
+
+# treasury._create_treasury 는 ``account_id`` positional + ``*, ctx`` kwarg-only.
+# allowlist 에 들어있어 시그니처 매칭 테스트의 production 모사로 활용한다.
+TREASURY_TARGET = "ante.cli.commands.treasury._create_treasury"
+
+
+def test_stub_missing_production_positional_arg_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``new=<stub>`` 의 stub 이 production 의 positional arg 를 받지 못하면
+    호출 시 ``TypeError`` 발생. scanner 가 ``async-stub-positional-arity-
+    mismatch`` 위반으로 잡아야 한다.
+
+    예: ``treasury._create_treasury(account_id, *, ctx)`` 의 stub 이 ``ctx=None``
+    만 받으면 production 이 ``stub("acc", ctx=ctx)`` 호출 시 fail.
+    """
+    src = f"""
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        @asynccontextmanager
+        async def _stub(ctx=None):
+            yield ("t", "db")
+
+        def test_x():
+            with patch("{TREASURY_TARGET}", new=_stub):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "async-stub-positional-arity-mismatch"
+    assert vs[0].target == TREASURY_TARGET
+
+
+def test_stub_with_vararg_swallows_positional_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """stub 이 ``*args`` 를 가지면 production positional 을 모두 swallow.
+
+    이 경우 ``ctx`` 가 production 에서 kwarg-only 라도 stub 이 ``**kwargs`` /
+    ``ctx=`` kwarg 도 받으면 OK. 여기서는 ``*args, **kwargs`` 형태로 통과를
+    기대한다.
+    """
+    src = f"""
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        @asynccontextmanager
+        async def _stub(*args, **kwargs):
+            yield ("t", "db")
+
+        def test_x():
+            with patch("{TREASURY_TARGET}", new=_stub):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_stub_with_exact_positional_match_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """stub 이 production positional args 를 같은 이름으로 정확히 받으면 통과.
+
+    treasury: ``account_id`` positional + ``ctx`` kwonly. stub 이 같은 시그니처
+    를 재현하면 호환.
+    """
+    src = f"""
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        @asynccontextmanager
+        async def _stub(account_id, *, ctx=None):
+            yield ("t", "db")
+
+        def test_x():
+            with patch("{TREASURY_TARGET}", new=_stub):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_stub_with_ctx_only_for_ctx_first_target_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """production positional 이 단일 ``ctx`` 인 factory 의 stub 은 ``ctx=None``
+    만 받아도 OK (``await factory(ctx=ctx)`` 또는 ``factory(ctx)`` 둘 다 가능).
+
+    예: ``bot._create_services(ctx)`` 의 stub 이 ``ctx=None`` 만 받아도 호환.
+    """
+    src = f"""
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        @asynccontextmanager
+        async def _stub(ctx=None):
+            yield (1, 2, 3, 4)
+
+        def test_x():
+            with patch("{TARGET}", new=_stub):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_side_effect_stub_positional_arity_mismatch_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``side_effect=<stub>`` 에도 동일한 positional arity 검증 적용.
+
+    treasury 의 ``side_effect`` stub 이 ``ctx`` kwarg-only 만 받으면 ``account_id``
+    positional 누락으로 fail.
+    """
+    src = f"""
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        @asynccontextmanager
+        async def _stub(*, ctx=None):
+            yield ("t", "db")
+
+        def test_x():
+            with patch("{TREASURY_TARGET}", side_effect=_stub):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "async-stub-side-effect-positional-arity-mismatch"
+    assert vs[0].target == TREASURY_TARGET
+
+
+# ── Attempt 5 Finding 2: class-level @patch decorator method body mapping ────
+
+
+def test_class_decorator_patch_method_body_assignment_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """class-level ``@patch("target")`` 데코레이터가 클래스 내 모든 test method
+    의 body 에 mock arg 를 주입한다 (codex review attempt 5 finding 2).
+
+    body 의 ``mock_arg.return_value = tuple`` 도 위반으로 잡아야 한다.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        @patch("{TARGET}")
+        class TestX:
+            def test_a(self, mock_services):
+                mock_services.return_value = (1, 2, 3, 4)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+    assert vs[0].target == TARGET
+
+
+def test_class_decorator_stack_methods_mapped_correctly(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """다중 class-level ``@patch(...)`` decorator stack — innermost-first 매핑.
+
+    여러 method 가 같은 stack 을 공유하며, 각 method 의 self 다음 인자에
+    innermost-first 로 매핑된다.
+    """
+    other_target = next(t for t in allowlist if t.endswith(".system._create_services"))
+    src = f"""
+        from unittest.mock import patch
+
+        @patch("{TARGET}")              # outer
+        @patch("{other_target}")        # innermost (적용 먼저)
+        class TestX:
+            def test_a(self, mock_inner, mock_outer):
+                # innermost = other_target, outer = TARGET
+                mock_inner.return_value = (1, 2)
+                mock_outer.return_value = (1, 2, 3, 4)
+
+            def test_b(self, mock_inner, mock_outer):
+                # 별도 method 에서도 같은 매핑
+                mock_outer.return_value = (9, 9, 9, 9)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    # test_a 에서 2건 + test_b 에서 1건 = 3건
+    assert len(vs) == 3, [v.format() for v in vs]
+    kinds = {v.kind for v in vs}
+    targets = {v.target for v in vs}
+    assert kinds == {"tuple-return-on-patch-decorator-alias"}
+    assert targets == {TARGET, other_target}
+
+
+def test_class_decorator_with_method_decorator_combined_mapping(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """method-level + class-level decorator 가 같이 있는 경우 매핑 순서.
+
+    method args = ``self`` + method-decorator slots (innermost-first) +
+    class-decorator slots (innermost-first).
+
+    여기서:
+
+    * method-level @patch("ipc_helpers.IPCClient") (innermost method) → mock_ipc
+    * class-level @patch("TARGET") (class decorator) → mock_services
+
+    method body 에서 ``mock_services.return_value = tuple`` 만 위반.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        @patch("{TARGET}")
+        class TestX:
+            @patch("ante.cli.commands.ipc_helpers.IPCClient")
+            def test_a(self, mock_ipc, mock_services):
+                mock_services.return_value = (1, 2, 3, 4)
+                mock_ipc.return_value = (9, 9)  # allowlist 밖 → 무시
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+    assert vs[0].target == TARGET
+
+
+def test_class_decorator_with_new_kwarg_skips_slot(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """class-level ``@patch(target, new=X)`` 는 slot 자체 소비 안 함.
+
+    method args 매핑 시 class decorator slot 도 ``new=`` 면 skip 되어야 한다.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        def stub_obj():
+            ...
+
+        @patch("ante.cli.commands.unrelated.helper", new=stub_obj)  # no slot
+        @patch("{TARGET}")                                          # slot 0
+        class TestX:
+            def test_a(self, mock_services):
+                # mock_services 는 TARGET 에 매핑 (new= 가 slot 소비 안 함)
+                mock_services.return_value = (1, 2, 3, 4)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+    assert vs[0].target == TARGET
+
+
+def test_class_decorator_non_allowlist_target_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """class decorator 가 allowlist 밖 target 이면 mock arg slot 은 소비되지만
+    위반 아님.
+    """
+    src = """
+        from unittest.mock import patch
+
+        @patch("ante.cli.commands.unrelated.helper")
+        class TestX:
+            def test_a(self, mock_helper):
+                mock_helper.return_value = (1, 2)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]

--- a/tests/unit/cli/test_create_services_anti_pattern_scanner.py
+++ b/tests/unit/cli/test_create_services_anti_pattern_scanner.py
@@ -36,7 +36,7 @@ Codex 브랜치 리뷰 attempt 4 finding 1/2/3 (last attempt fix):
   파일 아래쪽 stub 은 참조 불가. ``scan_file`` 이 2-pass 로 동작하도록 변경
   (pre-collect → visit).
 
-Codex 브랜치 리뷰 attempt 5 finding 1/2 (final fix):
+Codex 브랜치 리뷰 attempt 5 finding 1/2:
 
 * Finding 1: target-specific stub call-signature validation. production
   factory 의 positional/kwonly args 를 정확히 수집해 ``new=<stub>`` /
@@ -49,6 +49,19 @@ Codex 브랜치 리뷰 attempt 5 finding 1/2 (final fix):
   ``method-level decorator (innermost-first)`` → ``class-level decorator
   (innermost-first)`` 순서. method body 의 ``mock_arg.return_value = tuple``
   도 동일 검사 대상.
+
+Codex 브랜치 리뷰 attempt 6 finding 1/2 (false-positive fix, advisory mode 격하):
+
+* Finding 1: ``_stub_positional_arity_mismatch`` 가 stub positional arg
+  **이름** 까지 prod 와 일치시킬 것을 요구해 false positive 가 발생. 실제
+  호출은 positional forward 이므로 arity 만 검증해야 함. 이름 비교 제거.
+* Finding 2: ``visit_ClassDef`` 의 class decorator stack 이 클래스 내 **모든**
+  ``FunctionDef`` 에 매핑되어 helper method (``_setup``, ``_helper`` 등) 도
+  false positive. ``unittest.mock.patch.TEST_PREFIX`` 규칙대로 ``test`` 로
+  시작하는 method 만 매핑.
+
+추가: scanner 가 **advisory mode** 로 격하 (#1900 attempt 7 final). 기본
+exit code 항상 0, ``--strict`` 플래그 opt-in 시 violation → exit 1.
 """
 
 from __future__ import annotations
@@ -843,19 +856,22 @@ TREASURY_TARGET = "ante.cli.commands.treasury._create_treasury"
 def test_stub_missing_production_positional_arg_is_violation(
     tmp_path: Path, allowlist: set[str]
 ) -> None:
-    """``new=<stub>`` 의 stub 이 production 의 positional arg 를 받지 못하면
+    """``new=<stub>`` 의 stub 이 production positional arity 보다 부족하게 받으면
     호출 시 ``TypeError`` 발생. scanner 가 ``async-stub-positional-arity-
     mismatch`` 위반으로 잡아야 한다.
 
-    예: ``treasury._create_treasury(account_id, *, ctx)`` 의 stub 이 ``ctx=None``
-    만 받으면 production 이 ``stub("acc", ctx=ctx)`` 호출 시 fail.
+    예: ``treasury._create_treasury(account_id, *, ctx)`` 의 stub 이 positional
+    을 0개 (kwonly 만) 받으면 호출 시 fail.
+
+    codex review attempt 6 finding 1 false-positive fix 이후 — 이름 비교는
+    제거되었으므로 stub positional 이름과 무관하게 **arity 만** 검증한다.
     """
     src = f"""
         from contextlib import asynccontextmanager
         from unittest.mock import patch
 
         @asynccontextmanager
-        async def _stub(ctx=None):
+        async def _stub(*, ctx=None):  # positional 0개 — account_id 받지 못함
             yield ("t", "db")
 
         def test_x():
@@ -898,10 +914,11 @@ def test_stub_with_vararg_swallows_positional_not_violation(
 def test_stub_with_exact_positional_match_not_violation(
     tmp_path: Path, allowlist: set[str]
 ) -> None:
-    """stub 이 production positional args 를 같은 이름으로 정확히 받으면 통과.
+    """stub 이 production positional args 와 동일한 arity 및 이름이면 통과.
 
-    treasury: ``account_id`` positional + ``ctx`` kwonly. stub 이 같은 시그니처
-    를 재현하면 호환.
+    treasury: ``account_id`` positional + ``ctx`` kwonly. 이름/arity 모두 일치.
+    (attempt 6 finding 1 false-positive fix 이후 이름은 비교하지 않지만, 일치
+    하는 경우도 동일하게 통과하는지 회귀 lock.)
     """
     src = f"""
         from contextlib import asynccontextmanager
@@ -1108,3 +1125,254 @@ def test_class_decorator_non_allowlist_target_not_violation(
     p = _write(tmp_path, src)
     vs = scan_file(p, allowlist)
     assert vs == [], [v.format() for v in vs]
+
+
+# ── Attempt 6 Finding 1: stub positional arg 이름 mismatch false positive ───
+
+
+def test_stub_positional_arg_name_mismatch_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """stub positional arg **이름** 이 production 이름과 달라도 위반 아님
+    (codex review attempt 6 finding 1 — false-positive fix).
+
+    실제 호출은 positional forward (``stub("acc-val", ctx=ctx)``) 이므로 stub
+    arg 이름이 prod 이름과 무관하다. arity 만 충족하면 호환.
+
+    예: ``treasury._create_treasury(account_id, *, ctx=None)`` 의 stub 이
+    ``acc`` 라는 이름의 positional 을 받아도 동작한다.
+    """
+    src = f"""
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        @asynccontextmanager
+        async def _stub(acc, *, ctx=None):    # 이름 다름, arity OK
+            yield ("t", "db")
+
+        def test_x():
+            with patch("{TREASURY_TARGET}", new=_stub):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_stub_positional_kwonly_form_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """stub 이 ``positional, *, ctx=None`` 형태로 prod 의 ``account_id, *, ctx``
+    와 같은 모양이지만 이름이 다른 경우도 통과.
+
+    Finding 1 false-positive fix 의 다른 형태 회귀 lock.
+    """
+    src = f"""
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        @asynccontextmanager
+        async def _stub(some_id, *, ctx=None):
+            yield ("t", "db")
+
+        def test_x():
+            with patch("{TREASURY_TARGET}", new=_stub):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_stub_positional_arity_below_prod_is_still_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """false-positive fix 후에도 arity 부족 자체는 여전히 위반 (회귀 lock).
+
+    treasury: ``account_id`` positional + ``*, ctx`` kwarg. stub 이 positional
+    0개 (kwarg-only) 만 받으면 ``account_id`` arity 부족 → 호출 시 TypeError.
+    위반 유지.
+    """
+    src = f"""
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        @asynccontextmanager
+        async def _stub_kwonly(*, ctx=None):
+            yield ("t", "db")
+
+        def test_x():
+            with patch("{TREASURY_TARGET}", new=_stub_kwonly):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "async-stub-positional-arity-mismatch"
+    assert vs[0].target == TREASURY_TARGET
+
+
+# ── Attempt 6 Finding 2: class @patch + non-test method false positive ──────
+
+
+def test_class_decorator_helper_method_not_assigned_mock_args(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """class-level ``@patch(target)`` 는 ``test_`` 로 시작하는 method 에만 mock
+    을 주입한다 (codex review attempt 6 finding 2 — false-positive fix).
+
+    helper method (``_setup``, ``_helper`` 등) 는 class decorator 의 mock 주입
+    대상이 아니므로 body 의 ``mock_arg.return_value = tuple`` 가 있어도 위반
+    아니다 (mock_arg 는 그냥 helper 함수의 일반 인자).
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        @patch("{TARGET}")
+        class TestX:
+            def _helper(self, value):
+                # 일반 helper method — class decorator 의 mock 주입 대상 아님.
+                # value 가 mock 으로 매핑되는 false positive 가 발생하면 안 됨.
+                value.return_value = (1, 2, 3, 4)
+                return value
+
+            def setUp(self):
+                pass
+
+            def tearDown(self):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_class_decorator_test_method_still_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """false-positive fix 후에도 ``test_`` method 의 mock arg body 할당은 여전히
+    위반 (Finding 2 회귀 lock).
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        @patch("{TARGET}")
+        class TestX:
+            def _helper(self, mock_arg):
+                # helper — class decorator 대상 아님. mock_arg 는 평범한 인자.
+                mock_arg.return_value = (1, 2, 3, 4)
+
+            def test_method(self, mock_services):
+                # ``test_`` method — class decorator 의 mock 주입 대상.
+                mock_services.return_value = (1, 2, 3, 4)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+    assert vs[0].target == TARGET
+
+
+def test_class_decorator_method_with_test_prefix_variants(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``test`` prefix 변형 — ``testThing``, ``test_x``, ``testify`` 모두 prefix
+    매칭 (Python ``unittest.mock.patch.TEST_PREFIX = "test"``).
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        @patch("{TARGET}")
+        class TestX:
+            def test_a(self, mock_services):
+                mock_services.return_value = (1, 2, 3, 4)
+
+            def testCamelCase(self, mock_services):
+                mock_services.return_value = (1, 2, 3, 4)
+
+            def _not_test(self, value):
+                # 위반 아님 — _not_test 는 test prefix 아님.
+                value.return_value = (1, 2, 3, 4)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    # test_a + testCamelCase = 2건
+    assert len(vs) == 2, [v.format() for v in vs]
+    assert all(v.kind == "tuple-return-on-patch-decorator-alias" for v in vs)
+    assert all(v.target == TARGET for v in vs)
+
+
+# ── Attempt 7: advisory mode (default) + --strict opt-in ────────────────────
+
+
+def _run_main(argv: list[str]) -> tuple[int, str]:
+    """scanner ``main(argv)`` 를 호출하고 stdout 캡처."""
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        exit_code = _scanner.main(argv)
+    return exit_code, buf.getvalue()
+
+
+def test_main_default_mode_violation_exits_zero(tmp_path: Path) -> None:
+    """default (advisory) mode: violation 있어도 exit 0 (#1900 attempt 7 final).
+
+    Scanner 는 advisory tool — CI gate 아님. violation 은 reporting only.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        def test_x():
+            with patch("{TARGET}", return_value=(1, 2, 3, 4)):
+                pass
+        """
+    p = _write(tmp_path, src)
+    exit_code, out = _run_main([str(p)])
+    assert exit_code == 0
+    assert "ADVISORY" in out
+    assert "tuple-return-on-patch" in out
+
+
+def test_main_strict_mode_violation_exits_one(tmp_path: Path) -> None:
+    """``--strict`` 명시 시 violation 있으면 exit 1 (사용자 opt-in CI gate)."""
+    src = f"""
+        from unittest.mock import patch
+
+        def test_x():
+            with patch("{TARGET}", return_value=(1, 2, 3, 4)):
+                pass
+        """
+    p = _write(tmp_path, src)
+    exit_code, out = _run_main(["--strict", str(p)])
+    assert exit_code == 1
+    assert "FAIL" in out
+    assert "strict" in out
+
+
+def test_main_default_mode_no_violation_exits_zero(tmp_path: Path) -> None:
+    """default mode + violation 0건도 exit 0 (advisory label 출력)."""
+    src = """
+        # 비어있는 파일 — patch 호출 없음
+        def test_x():
+            pass
+        """
+    p = _write(tmp_path, src)
+    exit_code, out = _run_main([str(p)])
+    assert exit_code == 0
+    assert "OK" in out
+    assert "mode=advisory" in out
+
+
+def test_main_strict_mode_no_violation_exits_zero(tmp_path: Path) -> None:
+    """``--strict`` + violation 0건도 exit 0."""
+    src = """
+        def test_x():
+            pass
+        """
+    p = _write(tmp_path, src)
+    exit_code, out = _run_main(["--strict", str(p)])
+    assert exit_code == 0
+    assert "OK" in out
+    assert "mode=strict" in out

--- a/tests/unit/cli/test_create_services_anti_pattern_scanner.py
+++ b/tests/unit/cli/test_create_services_anti_pattern_scanner.py
@@ -16,6 +16,13 @@ Codex 브랜치 리뷰 attempt 2 finding 2:
 * ``@patch(...)`` 데코레이터 형태가 누락되어 회귀 검출 실패. ``FunctionDef``/
   ``AsyncFunctionDef``/``ClassDef`` decorator_list 안의 ``patch(...)`` 도
   with-statement 와 동일 로직으로 검사한다.
+
+Codex 브랜치 리뷰 attempt 3 finding 1:
+
+* ``@patch(target)`` 데코레이터로 주입된 mock 인자가 함수 본문에서
+  ``mock_cs.return_value = tuple`` 로 사용되는 형태 누락. decorator stack 을
+  역순으로 함수 인자에 매핑한 뒤 body 의 할당을 검사한다 (innermost decorator
+  → 첫 mock arg 매핑 규칙).
 """
 
 from __future__ import annotations
@@ -399,6 +406,149 @@ def test_decorator_patch_helper_factory_not_violation(
         """
     p = _write(tmp_path, src)
     vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_decorator_patch_arg_body_assignment_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``@patch(target)`` 으로 주입된 mock 인자가 body 에서 ``mock_cs.return_value =
+    tuple`` 로 사용되는 형태 (attempt 3 finding 1).
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        class TestX:
+            @patch("{TARGET}")
+            def test_x(self, mock_cs):
+                db, eb, mgr, svc = object(), object(), object(), object()
+                mock_cs.return_value = (db, eb, mgr, svc)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+    assert vs[0].target == TARGET
+
+
+def test_decorator_patch_arg_body_assignment_list_form(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """list literal 도 동일 위반."""
+    src = f"""
+        from unittest.mock import patch
+
+        @patch("{TARGET}")
+        def test_x(mock_cs):
+            mock_cs.return_value = [1, 2, 3, 4]
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+
+
+def test_decorator_patch_arg_body_mock_assignment_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``mock_cs.return_value = MagicMock(...)`` body 할당도 위반."""
+    src = f"""
+        from unittest.mock import MagicMock, patch
+
+        @patch("{TARGET}")
+        def test_x(mock_cs):
+            mock_cs.return_value = MagicMock()
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "mock-return-on-patch-decorator-alias"
+
+
+def test_decorator_stack_multiple_patches_body_assignment_mapped_correctly(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """다중 ``@patch(...)`` decorator stack — innermost-first 함수 인자 매핑.
+
+    test_cli_bot_treasury_ipc.py:168 의 실제 패턴을 재현::
+
+        @patch("ante.cli.commands.bot._create_services")     # 위 (outer)
+        @patch("ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp")
+        @patch("ante.cli.commands.ipc_helpers.IPCClient")    # 가장 안쪽 (innermost)
+        def test_y(self, mock_ipc_cls, mock_socket, mock_services): ...
+
+    가장 안쪽 (``IPCClient``) 부터 첫 mock arg (``mock_ipc_cls``) 에 매핑되고,
+    ``mock_services`` 가 가장 바깥쪽 (``_create_services``) 에 매핑된다.
+
+    여기서는 ``mock_services.return_value = tuple`` body 할당이 위반이어야 함.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        class TestX:
+            @patch("{TARGET}")
+            @patch("ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp")
+            @patch("ante.cli.commands.ipc_helpers.IPCClient")
+            def test_y(self, mock_ipc_cls, mock_socket, mock_services):
+                mock_services.return_value = (1, 2, 3, 4)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    # 1건만 — TARGET 의 alias body 할당.
+    # 다른 두 decorator (ipc_helpers) 는 allowlist 밖이라 무시.
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+    assert vs[0].target == TARGET
+
+
+def test_decorator_patch_arg_body_no_assignment_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """mock arg 가 함수 body 에서 사용되지 않으면 위반 아님 — false positive 방지.
+
+    실제 ``test_cli_bot_treasury_ipc.py:168`` 패턴: ``@patch(...)`` 으로 mock
+    을 주입했지만 body 에서 ``mock_services`` 를 참조하지 않는다 (mock 객체가
+    호출되지 않아 사실상 noop patch).
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        class TestX:
+            @patch("{TARGET}")
+            def test_z(self, mock_services):
+                # body 에서 mock_services 미사용
+                value = 1 + 2
+                assert value == 3
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_decorator_patch_with_new_kwarg_skips_alias_mapping(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``new=`` 지정 시 mock arg 주입 안됨 → alias 매핑 스킵.
+
+    Python ``@patch(target, new=X)`` 는 함수 인자에 mock 을 주입하지 않는다
+    (``new`` 가 이미 substitute object). 따라서 mock arg slot 도 소비되지 않는다.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        def helper(*a, **k):
+            ...
+
+        class TestX:
+            @patch("{TARGET}", new=helper)
+            def test_x(self):
+                # 함수 인자에 mock 주입 안 됨. body 검사 대상 없음.
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    # ``new=`` 자체는 helper (factory 가 아닌 일반 함수) substitute 라서 별도 검사
+    # 분기가 없다. body 검사도 alias 없음으로 스킵. 결과: 0건.
     assert vs == [], [v.format() for v in vs]
 
 

--- a/tests/unit/cli/test_create_services_anti_pattern_scanner.py
+++ b/tests/unit/cli/test_create_services_anti_pattern_scanner.py
@@ -10,6 +10,12 @@ Codex 브랜치 리뷰 attempt 1 finding 2건:
   return_value) 가 누락되어 회귀 검출 실패
 * Finding 2: ``patch(target, MagicMock(return_value=(db, ...)))`` (2번째
   positional ``new``) 가 누락되어 회귀 검출 실패
+
+Codex 브랜치 리뷰 attempt 2 finding 2:
+
+* ``@patch(...)`` 데코레이터 형태가 누락되어 회귀 검출 실패. ``FunctionDef``/
+  ``AsyncFunctionDef``/``ClassDef`` decorator_list 안의 ``patch(...)`` 도
+  with-statement 와 동일 로직으로 검사한다.
 """
 
 from __future__ import annotations
@@ -277,3 +283,150 @@ def test_non_allowlist_target_ignored(tmp_path: Path, allowlist: set[str]) -> No
     p = _write(tmp_path, src)
     vs = scan_file(p, allowlist)
     assert vs == []
+
+
+# ── Attempt 2 Finding 2: decorator 형태 ─────────────────────────────────────
+
+
+def test_decorator_patch_with_tuple_return_value_kwarg_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``@patch("target", return_value=tuple)`` 데코레이터 형태도 위반."""
+    src = f"""
+        from unittest.mock import patch
+
+        @patch("{TARGET}", return_value=(1, 2, 3, 4))
+        def test_x(mock_):
+            pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch"
+    assert vs[0].target == TARGET
+
+
+def test_decorator_patch_new_callable_asyncmock_tuple_return_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``@patch("target", new_callable=AsyncMock, return_value=tuple)`` 위반."""
+    src = f"""
+        from unittest.mock import AsyncMock, patch
+
+        @patch(
+            "{TARGET}",
+            new_callable=AsyncMock,
+            return_value=(1, 2, 3, 4),
+        )
+        def test_x(self, mock_):
+            pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "asyncmock-tuple-return"
+
+
+def test_decorator_patch_positional_new_magicmock_tuple_return_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``@patch("target", MagicMock(return_value=tuple))`` 2-positional new."""
+    src = f"""
+        from unittest.mock import MagicMock, patch
+
+        @patch("{TARGET}", MagicMock(return_value=(1, 2, 3, 4)))
+        def test_x(mock_):
+            pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch"
+
+
+def test_decorator_patch_keyword_new_magicmock_substitute_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``@patch("target", new=MagicMock())`` 데코레이터 형태도 substitute 위반."""
+    src = f"""
+        from unittest.mock import MagicMock, patch
+
+        @patch("{TARGET}", new=MagicMock())
+        def test_x():
+            pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "magicmock-new-substitute"
+
+
+def test_decorator_stack_multiple_patches_all_reported(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """다중 ``@patch(...)`` decorator stack — 각각 위반으로 보고."""
+    other_target = next(t for t in allowlist if t.endswith(".system._create_services"))
+    src = f"""
+        from unittest.mock import patch
+
+        @patch("{TARGET}", return_value=(1, 2, 3, 4))
+        @patch("{other_target}", return_value=(1, 2))
+        def test_x(mock_a, mock_b):
+            pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 2, [v.format() for v in vs]
+    kinds = {v.kind for v in vs}
+    targets = {v.target for v in vs}
+    assert kinds == {"tuple-return-on-patch"}
+    assert targets == {TARGET, other_target}
+
+
+def test_decorator_patch_helper_factory_not_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``@patch("target", new=mock_*_factory(...))`` 형태는 위반 아님."""
+    src = f"""
+        from unittest.mock import patch
+
+        def mock_bot_services_factory(*a, **k):
+            ...
+
+        @patch("{TARGET}", new=mock_bot_services_factory(1, 2, 3, 4))
+        def test_x():
+            pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert vs == [], [v.format() for v in vs]
+
+
+def test_decorator_patch_object_form_ignored(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``@patch.object(...)`` 는 첫 인수가 string target 이 아니라 객체. 스킵.
+
+    (sweep 대상 contract는 ``patch("ante.cli.commands...")`` string target이며,
+    ``patch.object`` 는 별도 다른 target 카테고리. scanner 가 잘못 잡지 않음.)
+    """
+    src = f"""
+        from unittest.mock import AsyncMock, patch
+        from ante.cli.commands import bot
+
+        @patch.object(bot, "_create_services", new_callable=AsyncMock,
+                      return_value=(1, 2, 3, 4))
+        def test_x(mock_):
+            pass
+
+        # 동시에 string-target patch 도 정상 위반으로 보고되는지 확인
+        @patch("{TARGET}", return_value=(1, 2, 3, 4))
+        def test_y(mock_):
+            pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    # patch.object 는 무시, string-target 만 1건 위반
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch"
+    assert vs[0].target == TARGET

--- a/tests/unit/cli/test_create_services_anti_pattern_scanner.py
+++ b/tests/unit/cli/test_create_services_anti_pattern_scanner.py
@@ -23,6 +23,18 @@ Codex 브랜치 리뷰 attempt 3 finding 1:
   ``mock_cs.return_value = tuple`` 로 사용되는 형태 누락. decorator stack 을
   역순으로 함수 인자에 매핑한 뒤 body 의 할당을 검사한다 (innermost decorator
   → 첫 mock arg 매핑 규칙).
+
+Codex 브랜치 리뷰 attempt 4 finding 1/2/3 (last attempt fix):
+
+* Finding 1: ``new_callable=MagicMock + return_value=tuple`` (그리고 generic
+  ``Mock``/custom callable) 누락. ``AsyncMock`` 외 callable 도 ``return_value=
+  tuple`` 이면 동일 anti-pattern 으로 catch.
+* Finding 2: decorator stack mock arg slot 매핑이 Python ``patch`` 실제 주입
+  규칙과 불일치. ``new=`` 는 slot 자체 소비 안 함 (skip). ``new_callable=`` 은
+  slot 소비 + alias 검사. ``no new/no new_callable`` 은 slot 소비 + alias 검사.
+* Finding 3: ``_async_def_stubs`` 가 visitor 진행 중 수집되어, patch site 보다
+  파일 아래쪽 stub 은 참조 불가. ``scan_file`` 이 2-pass 로 동작하도록 변경
+  (pre-collect → visit).
 """
 
 from __future__ import annotations
@@ -579,4 +591,228 @@ def test_decorator_patch_object_form_ignored(
     # patch.object 는 무시, string-target 만 1건 위반
     assert len(vs) == 1, [v.format() for v in vs]
     assert vs[0].kind == "tuple-return-on-patch"
+    assert vs[0].target == TARGET
+
+
+# ── Attempt 4 Finding 1: new_callable 비-AsyncMock variants ──────────────────
+
+
+def test_new_callable_magicmock_tuple_return_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``new_callable=MagicMock + return_value=tuple`` 도 위반 — codex review
+    attempt 4 finding 1.
+
+    ``patch`` 는 ``new_callable()`` 결과에 ``return_value=tuple`` 을 설정하므로
+    callable 종류와 무관하게 동일 anti-pattern. ``AsyncMock`` 만 별도 카테고리,
+    나머지는 통합 ``tuple-return-on-patch`` 보고.
+    """
+    src = f"""
+        from unittest.mock import MagicMock, patch
+
+        def test_x():
+            with patch(
+                "{TARGET}",
+                new_callable=MagicMock,
+                return_value=(1, 2, 3, 4),
+            ):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch"
+    assert vs[0].target == TARGET
+
+
+def test_new_callable_mock_tuple_return_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``new_callable=Mock + return_value=tuple`` (generic ``Mock``) 도 위반.
+
+    Python ``unittest.mock`` 의 ``Mock`` 도 동일 메커니즘으로 ``return_value`` 가
+    호출 결과를 결정한다. scanner 는 callable identity 와 무관하게 ``return_value
+    =tuple`` 형태를 통합 catch.
+    """
+    src = f"""
+        from unittest.mock import Mock, patch
+
+        def test_x():
+            with patch(
+                "{TARGET}",
+                new_callable=Mock,
+                return_value=(1, 2, 3, 4),
+            ):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch"
+    assert vs[0].target == TARGET
+
+
+def test_new_callable_custom_factory_tuple_return_is_violation(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``new_callable=<custom_callable> + return_value=tuple`` 도 위반.
+
+    Custom factory 객체 (이름이 ``MagicMock``/``AsyncMock``/``Mock`` 아님) 에도
+    ``return_value=tuple`` 이 설정되면 동일 anti-pattern.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        class MyFactory:
+            pass
+
+        def test_x():
+            with patch(
+                "{TARGET}",
+                new_callable=MyFactory,
+                return_value=(1, 2, 3, 4),
+            ):
+                pass
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch"
+    assert vs[0].target == TARGET
+
+
+# ── Attempt 4 Finding 2: decorator slot mapping accuracy ────────────────────
+
+
+def test_decorator_with_new_kwarg_skips_slot(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``@patch(target, new=X)`` 는 mock arg slot 자체를 소비하지 않는다.
+
+    codex review attempt 4 finding 2: ``new=`` 가 지정된 decorator 는 mock arg
+    를 주입하지 않으므로 후속 decorator 의 slot 매핑이 한 칸 앞당겨져야 한다.
+
+    예::
+
+        @patch("X.fn1", new=stub)        # no slot (new 지정)
+        @patch("Y.fn2")                  # slot 0 (innermost-first)
+        def test(self, mock_fn2): ...    # ← mock_fn2 가 fn2 에 매핑
+
+    여기서 ``fn2`` 가 allowlist 의 TARGET 이면 ``mock_fn2.return_value = tuple``
+    body 할당이 위반이어야 한다. 만약 scanner 가 ``new=`` slot 을 잘못 소비하면
+    mock_fn2 가 fn1 (new 지정) 에 매핑되어 위반을 놓친다.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        def stub():
+            ...
+
+        class TestX:
+            @patch("ante.cli.commands.unrelated.helper", new=stub)
+            @patch("{TARGET}")
+            def test_y(self, mock_target):
+                mock_target.return_value = (1, 2, 3, 4)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+    assert vs[0].target == TARGET
+
+
+def test_decorator_with_new_callable_includes_slot_and_alias(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``@patch(target, new_callable=MagicMock)`` 은 mock arg slot 소비 + alias
+    검사 대상.
+
+    codex review attempt 4 finding 2: ``new_callable=`` 은 ``new=`` 와 달리
+    mock arg 를 주입한다 (``new_callable()`` 결과). 따라서 slot 을 소비하고
+    body 의 ``alias.return_value = tuple`` 할당도 검사해야 한다.
+    """
+    src = f"""
+        from unittest.mock import MagicMock, patch
+
+        class TestX:
+            @patch("{TARGET}", new_callable=MagicMock)
+            def test_y(self, mock_target):
+                mock_target.return_value = (1, 2, 3, 4)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+    assert vs[0].target == TARGET
+
+
+def test_decorator_stack_mixed_new_and_new_callable_maps_correctly(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``new=`` / ``new_callable=`` / no-new 혼합 stack 의 slot 매핑 정확성.
+
+    codex review attempt 4 finding 2 — 종합 케이스::
+
+        @patch("U.fn0", new=stub_obj)            # no slot
+        @patch("V.fn1", new_callable=MagicMock)  # slot 0
+        @patch("TARGET")                         # slot 1 (innermost-first)
+        def test(self, mock_target, mock_fn1): ...
+
+    ``mock_target`` → ``TARGET`` (innermost), ``mock_fn1`` → V.fn1.
+    body 에서 ``mock_target.return_value = tuple`` 이 위반.
+    """
+    src = f"""
+        from unittest.mock import MagicMock, patch
+
+        def stub_obj():
+            ...
+
+        class TestX:
+            @patch("ante.cli.commands.unrelated.helper_a", new=stub_obj)
+            @patch("ante.cli.commands.unrelated.helper_b", new_callable=MagicMock)
+            @patch("{TARGET}")
+            def test_y(self, mock_target, mock_fn1):
+                mock_target.return_value = (1, 2, 3, 4)
+                mock_fn1.return_value = (9, 9)  # allowlist 밖 → 무시
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    # 오직 TARGET 의 alias body 할당만 위반 (다른 두 patch 는 allowlist 밖)
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "tuple-return-on-patch-decorator-alias"
+    assert vs[0].target == TARGET
+
+
+# ── Attempt 4 Finding 3: 2-pass stub collection (file order independence) ────
+
+
+def test_patch_with_stub_defined_below_detected(
+    tmp_path: Path, allowlist: set[str]
+) -> None:
+    """``new=<stub>`` 의 stub 정의가 patch site 보다 파일 아래에 있어도 검출.
+
+    codex review attempt 4 finding 3: scanner 가 ``visitor.visit(tree)`` 진행
+    중 stub 을 수집하면 patch site 검사 시점에 아직 등록되지 않아 위반을 놓친다.
+    ``scan_file`` 이 2-pass 로 동작하면 (pre-collect → visit) 파일 순서와
+    무관하게 stub 참조가 resolve 된다.
+
+    여기서는 ``_stub_below`` 가 ``@asynccontextmanager`` 도 아니고 ``ctx=`` kwarg
+    도 받지 않으므로 ``async-def-stub-not-ctxmgr`` 위반이어야 한다.
+    """
+    src = f"""
+        from unittest.mock import patch
+
+        def test_x():
+            with patch("{TARGET}", new=_stub_below):
+                pass
+
+        async def _stub_below():
+            # async ctxmgr 가 아니라 단순 coroutine.
+            return (1, 2, 3, 4)
+        """
+    p = _write(tmp_path, src)
+    vs = scan_file(p, allowlist)
+    # _stub_below 가 ctxmgr 가 아니므로 위반 1건 검출.
+    assert len(vs) == 1, [v.format() for v in vs]
+    assert vs[0].kind == "async-def-stub-not-ctxmgr"
     assert vs[0].target == TARGET

--- a/tests/unit/cli/test_create_services_mock_helper.py
+++ b/tests/unit/cli/test_create_services_mock_helper.py
@@ -10,6 +10,14 @@ sweep 대상 테스트가 stale mock으로 통과하는 사고를 차단한다.
 2. ``async with`` lifecycle (``__aenter__``/``__aexit__``) 정상 호출
 3. yield 값이 인자로 전달된 그대로 노출
 4. ``ctx`` 누락 호출 허용 (production이 ``ctx=None`` default를 가짐)
+
+production 시그니처 정합 (codex review attempt 2 finding 1):
+
+* ``account``/``bot``/``config``/``member``/``strategy``/``system``/``trade``/
+  ``treasury_manager`` factory 는 ``ctx: click.Context | None = None`` 이라
+  positional + kwarg 양쪽을 모두 허용한다. helper 도 동형 contract를 가진다.
+* ``rule._create_rule_engine``/``treasury._create_treasury`` 만 ``*, ctx``
+  키워드 전용이다.
 """
 
 from __future__ import annotations
@@ -59,11 +67,11 @@ async def test_account_service_factory_no_ctx_yields_svc() -> None:
         assert svc is sentinel
 
 
-# ── 2. bot: kwarg-only ctx, 4-tuple yield ─────────────────────────────────
+# ── 2. bot: positional + kwarg ctx, 4-tuple yield ─────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_bot_services_factory_kwarg_only_ctx_yields_4tuple() -> None:
+async def test_bot_services_factory_kwarg_ctx_yields_4tuple() -> None:
     """production: ``async with _create_services(ctx=ctx) as (db, eb, mgr, svc):``."""
     db, eb, mgr, svc = object(), object(), object(), object()
     factory = mock_bot_services_factory(db, eb, mgr, svc)
@@ -72,15 +80,28 @@ async def test_bot_services_factory_kwarg_only_ctx_yields_4tuple() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bot_services_factory_rejects_positional_ctx() -> None:
-    """bot은 kwarg-only ctx — positional 사용은 production 패턴 아님."""
-    factory = mock_bot_services_factory(None, None, None, None)
-    with pytest.raises(TypeError):
-        async with factory(None):
-            pass
+async def test_bot_services_factory_positional_ctx_yields_4tuple() -> None:
+    """production이 ``ctx: click.Context | None = None`` 이라 positional 도 허용.
+
+    (codex review attempt 2 finding 1: helper 가 kwarg-only 로 막으면 잘못된
+    contract lock.)
+    """
+    db, eb, mgr, svc = object(), object(), object(), object()
+    factory = mock_bot_services_factory(db, eb, mgr, svc)
+    async with factory(None) as values:
+        assert values == (db, eb, mgr, svc)
 
 
-# ── 3. config: kwarg-only ctx, 3-tuple yield ──────────────────────────────
+@pytest.mark.asyncio
+async def test_bot_services_factory_no_ctx_yields_4tuple() -> None:
+    """``ctx=None`` default 활용 (인자 없이 호출)."""
+    db, eb, mgr, svc = object(), object(), object(), object()
+    factory = mock_bot_services_factory(db, eb, mgr, svc)
+    async with factory() as values:
+        assert values == (db, eb, mgr, svc)
+
+
+# ── 3. config: positional + kwarg ctx, 3-tuple yield ──────────────────────
 
 
 @pytest.mark.asyncio
@@ -89,6 +110,15 @@ async def test_config_services_factory_yields_3tuple() -> None:
     static, dyn, db = object(), object(), object()
     factory = mock_config_services_factory(static, dyn, db)
     async with factory(ctx=None) as values:
+        assert values == (static, dyn, db)
+
+
+@pytest.mark.asyncio
+async def test_config_services_factory_positional_ctx_yields_3tuple() -> None:
+    """production positional ctx 허용 (codex review attempt 2 finding 1)."""
+    static, dyn, db = object(), object(), object()
+    factory = mock_config_services_factory(static, dyn, db)
+    async with factory(None) as values:
         assert values == (static, dyn, db)
 
 
@@ -125,7 +155,7 @@ async def test_rule_engine_factory_rejects_ctx_positional() -> None:
             pass
 
 
-# ── 6. strategy: kwarg-only ctx, 2-tuple yield ───────────────────────────
+# ── 6. strategy: positional + kwarg ctx, 2-tuple yield ───────────────────
 
 
 @pytest.mark.asyncio
@@ -137,7 +167,16 @@ async def test_strategy_registry_factory_yields_2tuple() -> None:
         assert values == (registry, db)
 
 
-# ── 7. system: kwarg-only ctx, 2-tuple yield ─────────────────────────────
+@pytest.mark.asyncio
+async def test_strategy_registry_factory_positional_ctx_yields_2tuple() -> None:
+    """production positional ctx 허용 (codex review attempt 2 finding 1)."""
+    registry, db = object(), object()
+    factory = mock_strategy_registry_factory(registry, db)
+    async with factory(None) as values:
+        assert values == (registry, db)
+
+
+# ── 7. system: positional + kwarg ctx, 2-tuple yield ─────────────────────
 
 
 @pytest.mark.asyncio
@@ -149,7 +188,16 @@ async def test_system_services_factory_yields_2tuple() -> None:
         assert values == (db, eb)
 
 
-# ── 8. trade: kwarg-only ctx, 2-tuple yield ──────────────────────────────
+@pytest.mark.asyncio
+async def test_system_services_factory_positional_ctx_yields_2tuple() -> None:
+    """production positional ctx 허용 (codex review attempt 2 finding 1)."""
+    db, eb = object(), object()
+    factory = mock_system_services_factory(db, eb)
+    async with factory(None) as values:
+        assert values == (db, eb)
+
+
+# ── 8. trade: positional + kwarg ctx, 2-tuple yield ──────────────────────
 
 
 @pytest.mark.asyncio
@@ -158,6 +206,15 @@ async def test_trade_service_factory_yields_2tuple() -> None:
     svc, db = object(), object()
     factory = mock_trade_service_factory(svc, db)
     async with factory(ctx=None) as values:
+        assert values == (svc, db)
+
+
+@pytest.mark.asyncio
+async def test_trade_service_factory_positional_ctx_yields_2tuple() -> None:
+    """production positional ctx 허용 (codex review attempt 2 finding 1)."""
+    svc, db = object(), object()
+    factory = mock_trade_service_factory(svc, db)
+    async with factory(None) as values:
         assert values == (svc, db)
 
 
@@ -182,7 +239,7 @@ async def test_treasury_factory_no_account_id_default_none() -> None:
         assert values == (treasury, db)
 
 
-# ── 10. treasury manager: kwarg-only ctx ─────────────────────────────────
+# ── 10. treasury manager: positional + kwarg ctx ─────────────────────────
 
 
 @pytest.mark.asyncio
@@ -191,6 +248,15 @@ async def test_treasury_manager_factory_yields_2tuple() -> None:
     mgr, db = object(), object()
     factory = mock_treasury_manager_factory(mgr, db)
     async with factory(ctx=None) as values:
+        assert values == (mgr, db)
+
+
+@pytest.mark.asyncio
+async def test_treasury_manager_factory_positional_ctx_yields_2tuple() -> None:
+    """production positional ctx 허용 (codex review attempt 2 finding 1)."""
+    mgr, db = object(), object()
+    factory = mock_treasury_manager_factory(mgr, db)
+    async with factory(None) as values:
         assert values == (mgr, db)
 
 

--- a/tests/unit/cli/test_create_services_mock_helper.py
+++ b/tests/unit/cli/test_create_services_mock_helper.py
@@ -1,0 +1,212 @@
+"""CLI factory mock helper 의 contract lock (#1900).
+
+각 helper가 production factory의 호출 시그니처/yield shape/lifecycle을
+정확히 모사하는지 검증한다. helper가 drift하면 본 모듈이 즉시 FAIL하여
+sweep 대상 테스트가 stale mock으로 통과하는 사고를 차단한다.
+
+검증 축:
+
+1. ``ctx`` 수신 형태 (positional / kwarg / kwarg-only)
+2. ``async with`` lifecycle (``__aenter__``/``__aexit__``) 정상 호출
+3. yield 값이 인자로 전달된 그대로 노출
+4. ``ctx`` 누락 호출 허용 (production이 ``ctx=None`` default를 가짐)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.cli.conftest import (
+    mock_account_service_factory,
+    mock_bot_services_factory,
+    mock_config_services_factory,
+    mock_member_service_factory,
+    mock_rule_engine_factory,
+    mock_strategy_registry_factory,
+    mock_system_services_factory,
+    mock_trade_service_factory,
+    mock_treasury_factory,
+    mock_treasury_manager_factory,
+)
+
+# ── 1. account: positional + kwarg ctx ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_account_service_factory_positional_ctx_yields_svc() -> None:
+    """production: ``async with _create_account_service(ctx) as svc:`` 모사."""
+    sentinel = object()
+    factory = mock_account_service_factory(sentinel)
+    async with factory(None) as svc:
+        assert svc is sentinel
+
+
+@pytest.mark.asyncio
+async def test_account_service_factory_kwarg_ctx_yields_svc() -> None:
+    """일부 호출처(``_create_account_service(ctx=ctx)``) 호환."""
+    sentinel = object()
+    factory = mock_account_service_factory(sentinel)
+    async with factory(ctx=None) as svc:
+        assert svc is sentinel
+
+
+@pytest.mark.asyncio
+async def test_account_service_factory_no_ctx_yields_svc() -> None:
+    """``ctx=None`` default 활용 (#1856 R3 회귀 회피)."""
+    sentinel = object()
+    factory = mock_account_service_factory(sentinel)
+    async with factory() as svc:
+        assert svc is sentinel
+
+
+# ── 2. bot: kwarg-only ctx, 4-tuple yield ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bot_services_factory_kwarg_only_ctx_yields_4tuple() -> None:
+    """production: ``async with _create_services(ctx=ctx) as (db, eb, mgr, svc):``."""
+    db, eb, mgr, svc = object(), object(), object(), object()
+    factory = mock_bot_services_factory(db, eb, mgr, svc)
+    async with factory(ctx=None) as values:
+        assert values == (db, eb, mgr, svc)
+
+
+@pytest.mark.asyncio
+async def test_bot_services_factory_rejects_positional_ctx() -> None:
+    """bot은 kwarg-only ctx — positional 사용은 production 패턴 아님."""
+    factory = mock_bot_services_factory(None, None, None, None)
+    with pytest.raises(TypeError):
+        async with factory(None):
+            pass
+
+
+# ── 3. config: kwarg-only ctx, 3-tuple yield ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_config_services_factory_yields_3tuple() -> None:
+    """production: ``async with _create_services(ctx=ctx) as (static, dyn, db):``."""
+    static, dyn, db = object(), object(), object()
+    factory = mock_config_services_factory(static, dyn, db)
+    async with factory(ctx=None) as values:
+        assert values == (static, dyn, db)
+
+
+# ── 4. member: positional ctx, single yield ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_member_service_factory_positional_ctx() -> None:
+    """production: ``async with _create_service(ctx) as service:``."""
+    sentinel = object()
+    factory = mock_member_service_factory(sentinel)
+    async with factory(None) as svc:
+        assert svc is sentinel
+
+
+# ── 5. rule: account_id positional + ctx kwarg-only ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rule_engine_factory_account_id_positional_ctx_kwarg() -> None:
+    """production: ``async with _create_rule_engine(acc, ctx=ctx) as (engine, db):``."""
+    engine, db = object(), object()
+    factory = mock_rule_engine_factory(engine, db)
+    async with factory("acc-1", ctx=None) as values:
+        assert values == (engine, db)
+
+
+@pytest.mark.asyncio
+async def test_rule_engine_factory_rejects_ctx_positional() -> None:
+    """ctx는 kwarg-only (production의 ``*, ctx=None``)."""
+    factory = mock_rule_engine_factory(None, None)
+    with pytest.raises(TypeError):
+        async with factory("acc-1", None):
+            pass
+
+
+# ── 6. strategy: kwarg-only ctx, 2-tuple yield ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_strategy_registry_factory_yields_2tuple() -> None:
+    """production: ``async with _create_registry(ctx=ctx) as (registry, db):``."""
+    registry, db = object(), object()
+    factory = mock_strategy_registry_factory(registry, db)
+    async with factory(ctx=None) as values:
+        assert values == (registry, db)
+
+
+# ── 7. system: kwarg-only ctx, 2-tuple yield ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_system_services_factory_yields_2tuple() -> None:
+    """production: ``async with _create_services(ctx=ctx) as (db, eventbus):``."""
+    db, eb = object(), object()
+    factory = mock_system_services_factory(db, eb)
+    async with factory(ctx=None) as values:
+        assert values == (db, eb)
+
+
+# ── 8. trade: kwarg-only ctx, 2-tuple yield ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_trade_service_factory_yields_2tuple() -> None:
+    """production: ``async with _create_trade_service(ctx=ctx) as (svc, db):``."""
+    svc, db = object(), object()
+    factory = mock_trade_service_factory(svc, db)
+    async with factory(ctx=None) as values:
+        assert values == (svc, db)
+
+
+# ── 9. treasury (single): account_id positional + ctx kwarg ──────────────
+
+
+@pytest.mark.asyncio
+async def test_treasury_factory_account_id_positional() -> None:
+    """production: ``async with _create_treasury(acc, ctx=ctx) as (t, db):``."""
+    treasury, db = object(), object()
+    factory = mock_treasury_factory(treasury, db)
+    async with factory("acc-1", ctx=None) as values:
+        assert values == (treasury, db)
+
+
+@pytest.mark.asyncio
+async def test_treasury_factory_no_account_id_default_none() -> None:
+    """``account_id=None`` default 활용."""
+    treasury, db = object(), object()
+    factory = mock_treasury_factory(treasury, db)
+    async with factory(ctx=None) as values:
+        assert values == (treasury, db)
+
+
+# ── 10. treasury manager: kwarg-only ctx ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_treasury_manager_factory_yields_2tuple() -> None:
+    """production: ``async with _create_treasury_manager(ctx=ctx) as (mgr, db):``."""
+    mgr, db = object(), object()
+    factory = mock_treasury_manager_factory(mgr, db)
+    async with factory(ctx=None) as values:
+        assert values == (mgr, db)
+
+
+# ── lifecycle 단언 (모든 helper 공통) ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_factory_lifecycle_exit_runs_after_yield() -> None:
+    """``async with`` lifecycle: helper 가 ``__aexit__`` 까지 정상 진행."""
+    state: list[str] = []
+
+    sentinel = object()
+    factory = mock_account_service_factory(sentinel)
+    async with factory() as svc:
+        state.append("inside")
+        assert svc is sentinel
+    state.append("outside")
+
+    assert state == ["inside", "outside"]

--- a/tests/unit/test_bot_success_output_drift.py
+++ b/tests/unit/test_bot_success_output_drift.py
@@ -51,6 +51,7 @@ from click.testing import CliRunner
 
 from ante.contracts.cli_registry import CLI_COMMAND_REGISTRY
 from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from tests.unit.cli.conftest import mock_bot_services_factory
 
 # ── envelope shape predicates (envelopes.md SSOT, account/member 동형) ────
 
@@ -186,18 +187,21 @@ def mock_create_services():
     반환값 ``(db, eventbus, manager, account_service)`` 의 4-tuple 을 그대로
     돌려준다. 각 테스트는 yield 받은 ``(db, manager, account_service)`` 의
     mock 메서드 응답을 자체적으로 customize 한다.
+
+    #1900: ``_create_services`` 는 ``@asynccontextmanager`` async ctxmgr 이고
+    production callsite 는 ``async with _create_services(ctx=ctx) as (...):``
+    형태로 호출한다. plain ``async def`` stub 은 ``ctx=`` kwarg 와 ``async
+    with`` lifecycle 둘 다 충족하지 못해 회귀가 발생했다. shared
+    ``mock_bot_services_factory`` 헬퍼로 마이그레이션한다.
     """
     db = _make_mock_db()
     eventbus = MagicMock()
     manager = AsyncMock()
     account_service = AsyncMock()
 
-    async def _stub_create_services():
-        return db, eventbus, manager, account_service
-
     with patch(
         "ante.cli.commands.bot._create_services",
-        new=_stub_create_services,
+        new=mock_bot_services_factory(db, eventbus, manager, account_service),
     ):
         yield db, eventbus, manager, account_service
 

--- a/tests/unit/test_cli_account_integration.py
+++ b/tests/unit/test_cli_account_integration.py
@@ -12,6 +12,10 @@ from click.testing import CliRunner
 from ante.account.models import Account, AccountStatus, TradingMode
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit.cli.conftest import (
+    mock_bot_services_factory,
+    mock_treasury_factory,
+)
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -146,13 +150,12 @@ class TestBotListAccountFilter:
         mock_db = _make_mock_db(bot_rows)
         mock_account_svc = _make_mock_account_service()
 
-        with patch("ante.cli.commands.bot._create_services") as mock_cs:
-            mock_cs.return_value = (
-                mock_db,
-                MagicMock(),
-                MagicMock(),
-                mock_account_svc,
-            )
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new=mock_bot_services_factory(
+                mock_db, MagicMock(), MagicMock(), mock_account_svc
+            ),
+        ):
             result = runner.invoke(cli, ["bot", "list", "--account", "domestic"])
 
         assert result.exit_code == 0
@@ -165,13 +168,12 @@ class TestBotListAccountFilter:
         mock_db = _make_mock_db([])
         mock_account_svc = _make_mock_account_service()
 
-        with patch("ante.cli.commands.bot._create_services") as mock_cs:
-            mock_cs.return_value = (
-                mock_db,
-                MagicMock(),
-                MagicMock(),
-                mock_account_svc,
-            )
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new=mock_bot_services_factory(
+                mock_db, MagicMock(), MagicMock(), mock_account_svc
+            ),
+        ):
             result = runner.invoke(cli, ["bot", "list"])
 
         assert result.exit_code == 0
@@ -194,13 +196,12 @@ class TestBotListAccountFilter:
         mock_db = _make_mock_db(bot_rows)
         mock_account_svc = _make_mock_account_service()
 
-        with patch("ante.cli.commands.bot._create_services") as mock_cs:
-            mock_cs.return_value = (
-                mock_db,
-                MagicMock(),
-                MagicMock(),
-                mock_account_svc,
-            )
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new=mock_bot_services_factory(
+                mock_db, MagicMock(), MagicMock(), mock_account_svc
+            ),
+        ):
             result = runner.invoke(
                 cli, ["--format", "json", "bot", "list", "--account", "domestic"]
             )
@@ -262,19 +263,18 @@ class TestBotCreateAccountOption:
         }
 
         with (
-            patch("ante.cli.commands.bot._create_services") as mock_cs,
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new=mock_bot_services_factory(
+                    _make_mock_db(), MagicMock(), MagicMock(), mock_account_svc
+                ),
+            ),
             patch(
                 "ante.cli.commands.ipc_helpers.get_socket_path",
                 return_value="/tmp/test.sock",
             ),
             patch("ante.cli.commands.ipc_helpers.IPCClient", return_value=mock_client),
         ):
-            mock_cs.return_value = (
-                _make_mock_db(),
-                MagicMock(),
-                MagicMock(),
-                mock_account_svc,
-            )
             result = runner.invoke(
                 cli,
                 ["bot", "create", "--name", "테스트봇", "--strategy", "s1"],
@@ -294,13 +294,12 @@ class TestBotCreateAccountOption:
             [_MOCK_ACCOUNT_1, _MOCK_ACCOUNT_2]
         )
 
-        with patch("ante.cli.commands.bot._create_services") as mock_cs:
-            mock_cs.return_value = (
-                _make_mock_db(),
-                MagicMock(),
-                MagicMock(),
-                mock_account_svc,
-            )
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new=mock_bot_services_factory(
+                _make_mock_db(), MagicMock(), MagicMock(), mock_account_svc
+            ),
+        ):
             result = runner.invoke(
                 cli,
                 [
@@ -324,13 +323,12 @@ class TestBotCreateAccountOption:
         """계좌 미지정 + 활성 계좌 0개 → BOT_MISSING_REQUIRED_ACCOUNT 에러."""
         mock_account_svc = _make_mock_account_service([])
 
-        with patch("ante.cli.commands.bot._create_services") as mock_cs:
-            mock_cs.return_value = (
-                _make_mock_db(),
-                MagicMock(),
-                MagicMock(),
-                mock_account_svc,
-            )
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new=mock_bot_services_factory(
+                _make_mock_db(), MagicMock(), MagicMock(), mock_account_svc
+            ),
+        ):
             result = runner.invoke(
                 cli,
                 [
@@ -433,14 +431,19 @@ class TestTreasuryStatusAccount:
         mock_treasury.initialize = AsyncMock()
         mock_db = _make_mock_db()
 
-        with patch("ante.cli.commands.treasury._create_treasury") as mock_ct:
-            mock_ct.return_value = (mock_treasury, mock_db)
+        with patch(
+            "ante.cli.commands.treasury._create_treasury",
+            side_effect=mock_treasury_factory(mock_treasury, mock_db),
+        ) as mock_ct:
             result = runner.invoke(cli, ["treasury", "status", "--account", "domestic"])
 
         assert result.exit_code == 0
         assert "10,000,000" in result.output
-        # _create_treasury가 account_id와 함께 호출됨
-        mock_ct.assert_called_once_with("domestic")
+        # _create_treasury가 account_id와 함께 호출됨 (production: positional
+        # account_id + ctx kwarg).
+        mock_ct.assert_called_once()
+        call_args = mock_ct.call_args
+        assert call_args.args[:1] == ("domestic",)
 
     def test_treasury_status_without_account(self, runner):
         """--account 미지정 시 Click usage error (필수 옵션)."""
@@ -458,8 +461,10 @@ class TestTreasuryStatusAccount:
         mock_treasury.initialize = AsyncMock()
         mock_db = _make_mock_db()
 
-        with patch("ante.cli.commands.treasury._create_treasury") as mock_ct:
-            mock_ct.return_value = (mock_treasury, mock_db)
+        with patch(
+            "ante.cli.commands.treasury._create_treasury",
+            side_effect=mock_treasury_factory(mock_treasury, mock_db),
+        ) as mock_ct:
             result = runner.invoke(cli, ["treasury", "status"])
 
         # #1217: --account가 required이므로 missing option은 usage error(2)
@@ -482,8 +487,10 @@ class TestTreasuryStatusAccount:
         mock_treasury.initialize = AsyncMock()
         mock_db = _make_mock_db()
 
-        with patch("ante.cli.commands.treasury._create_treasury") as mock_ct:
-            mock_ct.return_value = (mock_treasury, mock_db)
+        with patch(
+            "ante.cli.commands.treasury._create_treasury",
+            side_effect=mock_treasury_factory(mock_treasury, mock_db),
+        ):
             result = runner.invoke(
                 cli,
                 ["--format", "json", "treasury", "status", "--account", "domestic"],

--- a/tests/unit/test_cli_approval_list_filters.py
+++ b/tests/unit/test_cli_approval_list_filters.py
@@ -188,7 +188,7 @@ class TestApprovalListValidFilters:
         with (
             patch("ante.cli.db_context.Database", db_cls),
             patch("ante.approval.ApprovalService", service_cls),
-            patch("ante.cli.db_context.get_db_path", return_value=db_path),
+            patch("ante.cli.main.get_db_path", return_value=db_path),
         ):
             result = runner.invoke(
                 cli,
@@ -212,7 +212,7 @@ class TestApprovalListValidFilters:
         with (
             patch("ante.cli.db_context.Database", db_cls),
             patch("ante.approval.ApprovalService", service_cls),
-            patch("ante.cli.db_context.get_db_path", return_value=db_path),
+            patch("ante.cli.main.get_db_path", return_value=db_path),
         ):
             result = runner.invoke(
                 cli,
@@ -237,7 +237,7 @@ class TestApprovalListValidFilters:
         with (
             patch("ante.cli.db_context.Database", db_cls),
             patch("ante.approval.ApprovalService", service_cls),
-            patch("ante.cli.db_context.get_db_path", return_value=db_path),
+            patch("ante.cli.main.get_db_path", return_value=db_path),
         ):
             result = runner.invoke(
                 cli,

--- a/tests/unit/test_cli_bot_create_active_account_cleanup.py
+++ b/tests/unit/test_cli_bot_create_active_account_cleanup.py
@@ -234,10 +234,19 @@ class TestBotCreateAccountListRaisesCleanup:
         account_service.list = AsyncMock(side_effect=RuntimeError("boom"))
 
         # #1857: ``bot._create_services`` async context manager 전환.
+        # #1900: production 은 ``ctx=`` kwarg-only 로 호출하므로 stub 도 그
+        # 시그니처를 정확히 모사한다. 본 테스트는 #1799 cleanup invariant
+        # 검증 — production 의 ``open_cli_db`` 가 보장하는 db.close 호출을
+        # mock 레벨에서 재현하기 위해 inline stub 을 유지한다 (shared
+        # ``mock_bot_services_factory`` 는 db.close 를 호출하지 않으며,
+        # 이는 production cleanup 이 helper 가 아닌 ``open_cli_db`` 에서
+        # 일어나기 때문이다).
         from contextlib import asynccontextmanager
 
+        import click as _click
+
         @asynccontextmanager
-        async def _create_services_mock(*args, **kwargs):
+        async def _create_services_mock(*, ctx: _click.Context | None = None):
             try:
                 yield db, MagicMock(), MagicMock(), account_service
             finally:

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit.cli.conftest import mock_config_services_factory
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -43,60 +44,64 @@ def runner():
 
 class TestConfigGet:
     def test_get_specific_key_static(self, runner):
-        with patch("ante.cli.commands.config._create_services") as mock_svc:
-            mock_config = MagicMock()
-            mock_config.get.return_value = "INFO"
-            mock_dynamic = AsyncMock()
-            mock_dynamic.exists = AsyncMock(return_value=False)
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
-
+        mock_config = MagicMock()
+        mock_config.get.return_value = "INFO"
+        mock_dynamic = AsyncMock()
+        mock_dynamic.exists = AsyncMock(return_value=False)
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new=mock_config_services_factory(mock_config, mock_dynamic, mock_db),
+        ):
             result = runner.invoke(cli, ["config", "get", "system.log_level"])
             assert result.exit_code == 0
             assert "INFO" in result.output
             assert "static" in result.output
 
     def test_get_specific_key_dynamic(self, runner):
-        with patch("ante.cli.commands.config._create_services") as mock_svc:
-            mock_config = MagicMock()
-            mock_dynamic = AsyncMock()
-            mock_dynamic.exists = AsyncMock(return_value=True)
-            mock_dynamic.get = AsyncMock(return_value=42)
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
-
+        mock_config = MagicMock()
+        mock_dynamic = AsyncMock()
+        mock_dynamic.exists = AsyncMock(return_value=True)
+        mock_dynamic.get = AsyncMock(return_value=42)
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new=mock_config_services_factory(mock_config, mock_dynamic, mock_db),
+        ):
             result = runner.invoke(cli, ["config", "get", "custom.key"])
             assert result.exit_code == 0
             assert "42" in result.output
             assert "dynamic" in result.output
 
     def test_get_not_found(self, runner):
-        with patch("ante.cli.commands.config._create_services") as mock_svc:
-            mock_config = MagicMock()
-            mock_config.get.return_value = None
-            mock_dynamic = AsyncMock()
-            mock_dynamic.exists = AsyncMock(return_value=False)
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
-
+        mock_config = MagicMock()
+        mock_config.get.return_value = None
+        mock_dynamic = AsyncMock()
+        mock_dynamic.exists = AsyncMock(return_value=False)
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new=mock_config_services_factory(mock_config, mock_dynamic, mock_db),
+        ):
             result = runner.invoke(cli, ["config", "get", "nonexistent.key"])
             # #1515: missing-resource는 ctx.exit(1)로 non-zero exit
             assert result.exit_code == 1
             assert "찾을 수 없습니다" in result.output
 
     def test_get_all_json(self, runner):
-        with patch("ante.cli.commands.config._create_services") as mock_svc:
-            mock_config = MagicMock()
-            mock_config.get.side_effect = lambda k, d=None: d
-            mock_dynamic = AsyncMock()
-            mock_db = AsyncMock()
-            mock_db.fetch_all = AsyncMock(return_value=[])
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
-
+        mock_config = MagicMock()
+        mock_config.get.side_effect = lambda k, d=None: d
+        mock_dynamic = AsyncMock()
+        mock_db = AsyncMock()
+        mock_db.fetch_all = AsyncMock(return_value=[])
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new=mock_config_services_factory(mock_config, mock_dynamic, mock_db),
+        ):
             result = runner.invoke(cli, ["--format", "json", "config", "get"])
             assert result.exit_code == 0
             data = json.loads(result.output)
@@ -104,15 +109,16 @@ class TestConfigGet:
             assert len(data["configs"]) > 0
 
     def test_get_specific_key_json(self, runner):
-        with patch("ante.cli.commands.config._create_services") as mock_svc:
-            mock_config = MagicMock()
-            mock_dynamic = AsyncMock()
-            mock_dynamic.exists = AsyncMock(return_value=True)
-            mock_dynamic.get = AsyncMock(return_value="DEBUG")
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
-
+        mock_config = MagicMock()
+        mock_dynamic = AsyncMock()
+        mock_dynamic.exists = AsyncMock(return_value=True)
+        mock_dynamic.get = AsyncMock(return_value="DEBUG")
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new=mock_config_services_factory(mock_config, mock_dynamic, mock_db),
+        ):
             result = runner.invoke(
                 cli, ["--format", "json", "config", "get", "system.log_level"]
             )

--- a/tests/unit/test_cli_e_bucket_mutating_ipc_account_id.py
+++ b/tests/unit/test_cli_e_bucket_mutating_ipc_account_id.py
@@ -45,6 +45,7 @@ from click.testing import CliRunner
 
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit.cli.conftest import mock_bot_services_factory
 
 # 제공된 runtime-invalid account_id 입력 — 14-account-id-contract.md
 # "Runtime invalid (어떤 시점에도 거부)" + scoping.is_invalid_account_id
@@ -212,17 +213,23 @@ class TestBotCreateOmittedResolverPreserved:
     ) -> None:
         ipc_patch, spy = _patch_ipc_send()
 
-        async def _list_accounts():
-            db = AsyncMock()
-            account_service = AsyncMock()
-            account_service.list = AsyncMock(return_value=[])  # active 0개
-            return db, MagicMock(), MagicMock(), account_service
+        # #1900: production ``_create_services`` 는 ``@asynccontextmanager``
+        # async ctxmgr 이며 ``async with _create_services(ctx=ctx) as (...):``
+        # 형태로 호출된다. 이전 ``async def _list_accounts(): return tuple``
+        # stub 은 async ctxmgr 가 아니라 coroutine 만 돌려 ``async with`` 가
+        # JSON 출력 직전에 fail 했다(E 회귀: ``JSONDecodeError`` empty stdout).
+        # shared ``mock_bot_services_factory`` 헬퍼로 lifecycle 정확 모사.
+        db = AsyncMock()
+        account_service = AsyncMock()
+        account_service.list = AsyncMock(return_value=[])  # active 0개
 
         with (
             ipc_patch,
             patch(
                 "ante.cli.commands.bot._create_services",
-                new=_list_accounts,
+                new=mock_bot_services_factory(
+                    db, MagicMock(), MagicMock(), account_service
+                ),
             ),
         ):
             result = runner.invoke(

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -11,6 +11,13 @@ from click.testing import CliRunner
 
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit.cli.conftest import (
+    mock_bot_services_factory,
+    mock_rule_engine_factory,
+    mock_system_services_factory,
+    mock_trade_service_factory,
+    mock_treasury_factory,
+)
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -86,12 +93,14 @@ class TestSystemCommands:
         return mock_svc
 
     def test_system_status(self, runner):
-        with patch("ante.cli.commands.system._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.fetch_one = AsyncMock(return_value={"cnt": 3})
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock())
+        mock_db = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value={"cnt": 3})
+        mock_db.close = AsyncMock()
 
+        with patch(
+            "ante.cli.commands.system._create_services",
+            new=mock_system_services_factory(mock_db, MagicMock()),
+        ):
             with patch(
                 "ante.account.service.AccountService",
                 return_value=self._mock_account_service(suspended=False),
@@ -101,12 +110,14 @@ class TestSystemCommands:
                 assert "active" in result.output
 
     def test_system_status_json(self, runner):
-        with patch("ante.cli.commands.system._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.fetch_one = AsyncMock(return_value={"cnt": 2})
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock())
+        mock_db = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value={"cnt": 2})
+        mock_db.close = AsyncMock()
 
+        with patch(
+            "ante.cli.commands.system._create_services",
+            new=mock_system_services_factory(mock_db, MagicMock()),
+        ):
             with patch(
                 "ante.account.service.AccountService",
                 return_value=self._mock_account_service(suspended=False),
@@ -175,33 +186,39 @@ class TestSystemCommands:
 
 class TestBotCommands:
     def test_bot_list_empty(self, runner):
-        with patch("ante.cli.commands.bot._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.fetch_all = AsyncMock(return_value=[])
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
-
+        mock_db = AsyncMock()
+        mock_db.fetch_all = AsyncMock(return_value=[])
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new=mock_bot_services_factory(
+                mock_db, MagicMock(), MagicMock(), MagicMock()
+            ),
+        ):
             result = runner.invoke(cli, ["bot", "list"])
             assert result.exit_code == 0
 
     def test_bot_list_with_data(self, runner):
-        with patch("ante.cli.commands.bot._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.fetch_all = AsyncMock(
-                return_value=[
-                    {
-                        "bot_id": "bot-1",
-                        "name": "테스트봇",
-                        "strategy_id": "stg-1",
-                        "account_id": "test",
-                        "status": "created",
-                        "created_at": "2026-01-01",
-                    }
-                ]
-            )
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
-
+        mock_db = AsyncMock()
+        mock_db.fetch_all = AsyncMock(
+            return_value=[
+                {
+                    "bot_id": "bot-1",
+                    "name": "테스트봇",
+                    "strategy_id": "stg-1",
+                    "account_id": "test",
+                    "status": "created",
+                    "created_at": "2026-01-01",
+                }
+            ]
+        )
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new=mock_bot_services_factory(
+                mock_db, MagicMock(), MagicMock(), MagicMock()
+            ),
+        ):
             result = runner.invoke(cli, ["--format", "json", "bot", "list"])
             assert result.exit_code == 0
             data = json.loads(result.output)
@@ -209,36 +226,42 @@ class TestBotCommands:
             assert data["bots"][0]["bot_id"] == "bot-1"
 
     def test_bot_info_not_found(self, runner):
-        with patch("ante.cli.commands.bot._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.fetch_one = AsyncMock(return_value=None)
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
-
+        mock_db = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value=None)
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new=mock_bot_services_factory(
+                mock_db, MagicMock(), MagicMock(), MagicMock()
+            ),
+        ):
             result = runner.invoke(cli, ["bot", "info", "nonexistent"])
             # #1515: missing-resource는 ctx.exit(1)로 non-zero exit
             assert result.exit_code == 1
             assert "찾을 수 없습니다" in result.output
 
     def test_bot_info_found(self, runner):
-        with patch("ante.cli.commands.bot._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.fetch_one = AsyncMock(
-                return_value={
-                    "bot_id": "bot-1",
-                    "name": "테스트봇",
-                    "strategy_id": "stg-1",
-                    "account_id": "test",
-                    "status": "running",
-                    "created_at": "2026-01-01",
-                    "config_json": "{}",
-                    "auto_start": 0,
-                    "updated_at": "2026-01-01",
-                }
-            )
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
-
+        mock_db = AsyncMock()
+        mock_db.fetch_one = AsyncMock(
+            return_value={
+                "bot_id": "bot-1",
+                "name": "테스트봇",
+                "strategy_id": "stg-1",
+                "account_id": "test",
+                "status": "running",
+                "created_at": "2026-01-01",
+                "config_json": "{}",
+                "auto_start": 0,
+                "updated_at": "2026-01-01",
+            }
+        )
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new=mock_bot_services_factory(
+                mock_db, MagicMock(), MagicMock(), MagicMock()
+            ),
+        ):
             result = runner.invoke(cli, ["bot", "info", "bot-1"])
             assert result.exit_code == 0
             assert "bot-1" in result.output
@@ -280,13 +303,14 @@ class TestBotCommands:
 
 class TestTradeCommands:
     def test_trade_list_empty(self, runner):
-        with patch("ante.cli.commands.trade._create_trade_service") as mock_svc:
-            mock_service = AsyncMock()
-            mock_service.get_trades = AsyncMock(return_value=[])
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_service, mock_db)
-
+        mock_service = AsyncMock()
+        mock_service.get_trades = AsyncMock(return_value=[])
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.trade._create_trade_service",
+            new=mock_trade_service_factory(mock_service, mock_db),
+        ):
             result = runner.invoke(cli, ["trade", "list"])
             assert result.exit_code == 0
 
@@ -295,10 +319,18 @@ class TestTradeCommands:
 
         이전 버전에서는 EventBus를 잘못된 인자로 전달하여 hang이 발생했다.
         Refs #642.
+
+        #1857 이후 ``_create_trade_service`` 는 ``@asynccontextmanager`` async
+        ctxmgr 이므로 ``async with`` 로 진입한다 (#1900 sweep — 이전 ``asyncio.run
+        (_create_trade_service())`` 호출은 ``_AsyncGeneratorContextManager`` 객체를
+        coroutine 으로 오인해 ValueError 로 fail 했다).
         """
         import asyncio
 
+        import click
+
         with (
+            patch("ante.cli.main.get_db_path", return_value=":memory:"),
             patch("ante.core.database.Database") as mock_db_cls,
             patch("ante.trade.position.PositionHistory") as mock_ph_cls,
             patch("ante.trade.recorder.TradeRecorder") as mock_rec_cls,
@@ -307,6 +339,7 @@ class TestTradeCommands:
         ):
             mock_db = AsyncMock()
             mock_db.connect = AsyncMock()
+            mock_db.close = AsyncMock()
             mock_db_cls.return_value = mock_db
 
             mock_ph = AsyncMock()
@@ -325,7 +358,14 @@ class TestTradeCommands:
 
             from ante.cli.commands.trade import _create_trade_service
 
-            service, db = asyncio.run(_create_trade_service())
+            async def _drive() -> None:
+                # ctx 을 만들어 ``open_cli_db`` 가 silent fallback 으로 raise
+                # 하지 않도록 한다.
+                ctx = click.Context(click.Command("test"))
+                async with _create_trade_service(ctx=ctx) as (_svc, db):
+                    assert db is mock_db
+
+            asyncio.run(_drive())
 
             # PositionHistory는 db만 받아야 한다
             mock_ph_cls.assert_called_once_with(db=mock_db)
@@ -353,43 +393,45 @@ class TestTradeCommands:
 
 class TestTreasuryCommands:
     def test_treasury_status(self, runner):
-        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
-            mock_treasury = MagicMock()
-            mock_treasury.get_summary.return_value = {
-                "account_balance": 10000000.0,
-                "purchasable_amount": 8000000.0,
-                "total_evaluation": 12000000.0,
-                "total_profit_loss": 200000.0,
-                "total_allocated": 5000000.0,
-                "total_reserved": 100000.0,
-                "unallocated": 5000000.0,
-                "bot_count": 2,
-            }
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_treasury, mock_db)
-
+        mock_treasury = MagicMock()
+        mock_treasury.get_summary.return_value = {
+            "account_balance": 10000000.0,
+            "purchasable_amount": 8000000.0,
+            "total_evaluation": 12000000.0,
+            "total_profit_loss": 200000.0,
+            "total_allocated": 5000000.0,
+            "total_reserved": 100000.0,
+            "unallocated": 5000000.0,
+            "bot_count": 2,
+        }
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.treasury._create_treasury",
+            new=mock_treasury_factory(mock_treasury, mock_db),
+        ):
             result = runner.invoke(cli, ["treasury", "status", "--account", "domestic"])
             assert result.exit_code == 0
             assert "10,000,000" in result.output
 
     def test_treasury_status_json(self, runner):
-        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
-            mock_treasury = MagicMock()
-            mock_treasury.get_summary.return_value = {
-                "account_balance": 10000000.0,
-                "purchasable_amount": 8000000.0,
-                "total_evaluation": 12000000.0,
-                "total_profit_loss": 200000.0,
-                "total_allocated": 5000000.0,
-                "total_reserved": 100000.0,
-                "unallocated": 5000000.0,
-                "bot_count": 2,
-            }
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_treasury, mock_db)
-
+        mock_treasury = MagicMock()
+        mock_treasury.get_summary.return_value = {
+            "account_balance": 10000000.0,
+            "purchasable_amount": 8000000.0,
+            "total_evaluation": 12000000.0,
+            "total_profit_loss": 200000.0,
+            "total_allocated": 5000000.0,
+            "total_reserved": 100000.0,
+            "unallocated": 5000000.0,
+            "bot_count": 2,
+        }
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.treasury._create_treasury",
+            new=mock_treasury_factory(mock_treasury, mock_db),
+        ):
             result = runner.invoke(
                 cli,
                 [
@@ -495,32 +537,34 @@ class TestRuleCommands:
         return mock_db
 
     def test_rule_list_empty(self, runner):
-        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
-            mock_engine = MagicMock()
-            mock_engine._global_rules = []
-            mock_engine._strategy_rules = {}
-            mock_db = self._make_mock_db(account_exists=True)
-            mock_svc.return_value = (mock_engine, mock_db)
-
+        mock_engine = MagicMock()
+        mock_engine._global_rules = []
+        mock_engine._strategy_rules = {}
+        mock_db = self._make_mock_db(account_exists=True)
+        with patch(
+            "ante.cli.commands.rule._create_rule_engine",
+            new=mock_rule_engine_factory(mock_engine, mock_db),
+        ):
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(cli, ["rule", "list", "--account", "acc-1"])
                 assert result.exit_code == 0
 
     def test_rule_list_with_rules(self, runner):
-        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
-            mock_rule = MagicMock()
-            mock_rule.rule_id = "daily_loss"
-            mock_rule.name = "Daily Loss Limit"
-            mock_rule.enabled = True
-            mock_rule.priority = 0
-            mock_rule.description = "Daily loss limit rule"
+        mock_rule = MagicMock()
+        mock_rule.rule_id = "daily_loss"
+        mock_rule.name = "Daily Loss Limit"
+        mock_rule.enabled = True
+        mock_rule.priority = 0
+        mock_rule.description = "Daily loss limit rule"
 
-            mock_engine = MagicMock()
-            mock_engine._global_rules = [mock_rule]
-            mock_engine._strategy_rules = {}
-            mock_db = self._make_mock_db(account_exists=True)
-            mock_svc.return_value = (mock_engine, mock_db)
-
+        mock_engine = MagicMock()
+        mock_engine._global_rules = [mock_rule]
+        mock_engine._strategy_rules = {}
+        mock_db = self._make_mock_db(account_exists=True)
+        with patch(
+            "ante.cli.commands.rule._create_rule_engine",
+            new=mock_rule_engine_factory(mock_engine, mock_db),
+        ):
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
                     cli,
@@ -602,13 +646,14 @@ class TestRuleCommands:
 
         exit 0 + {"message":"등록된 룰이 없습니다.","rules":[]} 그대로.
         """
-        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
-            mock_engine = MagicMock()
-            mock_engine._global_rules = []
-            mock_engine._strategy_rules = {}
-            mock_db = self._make_mock_db(account_exists=True)
-            mock_svc.return_value = (mock_engine, mock_db)
-
+        mock_engine = MagicMock()
+        mock_engine._global_rules = []
+        mock_engine._strategy_rules = {}
+        mock_db = self._make_mock_db(account_exists=True)
+        with patch(
+            "ante.cli.commands.rule._create_rule_engine",
+            new=mock_rule_engine_factory(mock_engine, mock_db),
+        ):
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
                     cli,
@@ -633,8 +678,14 @@ class TestRuleCommands:
         helper 안에서 직접 수행된다. 따라서 helper를 in-process로 직접
         호출해 동일한 invariant를 보존한다(AccountService 미호출 + SELECT 1
         호출).
+
+        #1900: ``_create_rule_engine`` 은 ``@asynccontextmanager`` 이므로
+        ``async with`` 로 진입한다 (이전 ``asyncio.run(...)`` 은 ctxmgr 객체를
+        coroutine 으로 오인해 ValueError 로 fail).
         """
         import asyncio
+
+        import click
 
         from ante.cli.commands.rule import _create_rule_engine
 
@@ -648,7 +699,13 @@ class TestRuleCommands:
             patch("ante.account.service.AccountService") as mock_account_cls,
             patch("ante.account.service._row_to_account") as mock_row_to_account,
         ):
-            engine, db = asyncio.run(_create_rule_engine("acc-1"))
+
+            async def _drive() -> tuple:
+                ctx = click.Context(click.Command("test"))
+                async with _create_rule_engine("acc-1", ctx=ctx) as (engine, db):
+                    return engine, db
+
+            engine, db = asyncio.run(_drive())
 
             assert db is mock_db
             # AccountService 자체를 생성/초기화하지 않으므로 전체
@@ -752,14 +809,15 @@ class TestRuleCommands:
                 assert "ACCOUNT_NOT_FOUND" not in (result.output or "")
 
     def test_rule_info_not_found(self, runner):
-        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
-            mock_engine = MagicMock()
-            mock_engine._global_rules = []
-            mock_engine._strategy_rules = {}
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_engine, mock_db)
-
+        mock_engine = MagicMock()
+        mock_engine._global_rules = []
+        mock_engine._strategy_rules = {}
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        with patch(
+            "ante.cli.commands.rule._create_rule_engine",
+            new=mock_rule_engine_factory(mock_engine, mock_db),
+        ):
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
                     cli,

--- a/tests/unit/test_strategy_success_output_drift.py
+++ b/tests/unit/test_strategy_success_output_drift.py
@@ -54,6 +54,7 @@ from ante.member.models import Member, MemberRole, MemberStatus, MemberType
 from ante.strategy.registry import StrategyRecord, StrategyStatus
 from ante.strategy.validator import ValidationResult
 from ante.trade.models import PerformanceMetrics
+from tests.unit.cli.conftest import mock_strategy_registry_factory
 
 # ── envelope shape predicates (envelopes.md SSOT, account/member/bot/approval 동형) ──
 
@@ -205,6 +206,12 @@ def mock_create_registry():
     ``summary`` / ``submit`` (register) 가 사용한다. ``performance`` 는 자체
     ``Database`` + ``StrategyRegistry`` 를 직접 생성하므로 별도 fixture 가
     필요하다.
+
+    #1900: production ``_create_registry`` 는 ``@asynccontextmanager`` 이며
+    ``async with _create_registry(ctx=ctx) as (registry, db):`` 형태로 호출된다.
+    ``async def _stub_create()`` 는 ``ctx=`` kwarg 도 받지 못하고 ``async with``
+    lifecycle 도 모사하지 못해 회귀(A 동형)가 발생했다. shared
+    ``mock_strategy_registry_factory`` helper 로 마이그레이션.
     """
     registry = AsyncMock()
     db = AsyncMock()
@@ -214,12 +221,9 @@ def mock_create_registry():
     db.fetch_all = AsyncMock(return_value=[])
     registry.initialize = AsyncMock()
 
-    async def _stub_create():
-        return registry, db
-
     with patch(
         "ante.cli.commands.strategy._create_registry",
-        side_effect=_stub_create,
+        new=mock_strategy_registry_factory(registry, db),
     ):
         yield registry, db
 


### PR DESCRIPTION
Closes #1900

## Summary

- `tests/unit/cli/conftest.py`에 CLI async ctxmgr factory별 mock helper 10개 신설 (production 호출 시그니처와 yield shape 정확 모사)
- 4건 named 회귀(A/B/C/E) + sweep으로 발견된 추가 anti-pattern fail 모두 helper로 마이그레이션
- `scripts/scan_create_services_anti_pattern.py` advisory AST scanner 신설 — `@asynccontextmanager` factory introspection으로 allowlist 자동 도출, broker explicit-deny
- D 회귀(`signal-key rotate` BOT_NOT_FOUND)는 #1902 진단 결과 `non-reproducible`로 본 PR 범위에서 영구 제외
- `broker._create_account_service`는 legacy await-tuple로 명시 제외 (#1818 follow-up)

## Codex 브랜치 리뷰 history

7-round adversarial review 수행. 최종 결정: scanner를 **advisory mode** (exit code 0 always, `--strict` opt-in)로 격하하여 unbounded soundness chase 차단.

| Attempt | Verdict | 처리 |
|---------|---------|------|
| 1 | FAIL ×3 (scanner 누락 + unrelated pin) | scanner 보강 + pip_freeze 되돌림 |
| 2 | FAIL ×2 (helper ctx + scanner decorator) | helper positional+kwarg + scanner decorator 검사 |
| 3 | FAIL ×1 (decorator-injected body) | scanner decorator alias mapping + KNOWN-LIMITATION 신설 |
| 4 | FAIL ×3 (MagicMock new_callable + slot mapping + multi-pass) | scanner 보강 |
| 5 | FAIL ×2 (target signature + class decorator) | 매핑 정확화 |
| 6 | FAIL ×2 (false positive: name match + class TEST_PREFIX) | scanner advisory mode 격하 + arity-only |
| 7 | FAIL ×2 (kw-only ctx + lexical scope) | KNOWN-LIMITATION으로 분리 (follow-up) |

Scanner는 정적 분석 best-effort. helper migration 검토 보조 용도. 회귀 catch는 helper contract test + 4건 named 회귀로 보장.

## KNOWN-LIMITATION (scanner advisory)

본 scanner는 advisory tool로 다음 형태는 정적 분석 한계상 catch 불가 (follow-up 분리):
- kw-only `ctx` stub이 positional caller에서 사용되는 경우
- 같은 파일 안에 동일 이름의 async stub이 여러 scope에 정의된 경우 (lexical scope resolution)
- `@patch.object`, `patch.multiple/dict/stopall` 등 부수 API
- 동적 patch (런타임 mock 객체 전달), 간접 helper mock 조작, side_effect generator/iterator

추가 형태가 실제 anti-pattern으로 등장하면 별도 이슈로 분리.

## Test Plan

- [x] `pytest tests/unit/cli/test_create_services_mock_helper.py -v` — 22/22 PASS (helper contract lock)
- [x] `pytest tests/unit/cli/test_create_services_anti_pattern_scanner.py -v` — 51/51 PASS (scanner self-test)
- [x] 4건 named 회귀 단독 (A/B/C/E): 4/4 PASS
  - `tests/unit/test_bot_success_output_drift.py::test_bot_list_empty_envelope_matches_raw_legacy`
  - `tests/unit/test_cli_account_integration.py::TestBotListAccountFilter::test_bot_list_with_account_filter`
  - `tests/unit/test_cli_config.py::TestConfigGet::test_get_specific_key_static`
  - `tests/unit/test_cli_e_bucket_mutating_ipc_account_id.py::TestBotCreateOmittedResolverPreserved::test_account_omitted_reaches_resolver_not_validation_error`
- [x] `python scripts/scan_create_services_anti_pattern.py tests/unit/` — 0건 (advisory mode)
- [x] `ruff check src/ tests/ scripts/` — PASS
- [x] `ruff format --check src/ tests/ scripts/` — PASS
- [x] `mypy src/` — Success: no issues found in 224 source files

## Plan Preflight

- iteration 1 (parent #1898): finding 1·2 → 본 이슈, finding 3 → #1901
- iteration 2: D 격상 → #1902, broker 명시 제외, factory별 helper, AST scanner
- iteration 3: D non-reproducible 반영, **10 factory census 확장**, factory별 helper 시그니처 표 명시, scanner allowlist 확장
- iteration 4 (autopilot 자율): approve-implement