### PR TITLE
ci: #1896 ci-gate job을 fail-fast로 강제하여 skip 우회 차단

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
       - lint
       - test
       - docker-build
+    if: always()
     steps:
-      - name: CI gate passed
-        run: echo "ci passed"
+      - name: CI gate
+        run: |
+          for r in "${{ needs.lint.result }}" "${{ needs.test.result }}" "${{ needs.docker-build.result }}"; do
+            [ "$r" = "success" ] || { echo "Upstream job failed: $r"; exit 1; }
+          done


### PR DESCRIPTION
Closes #1896

## Summary

`.github/workflows/ci.yml`의 `ci` job이 `needs` 중 하나라도 실패하면 GitHub Actions가 자동 SKIPPED로 처리하고, GitHub은 SKIPPED required check를 통과로 평가 → required status check 우회 발생. `if: always()` + 명시적 `needs.<job>.result` 검사로 fail-fast 강제.

## 변경

- `.github/workflows/ci.yml` `ci` job
  - `if: always()` 추가
  - step: `lint`/`test`/`docker-build` 각각의 `.result`가 `success`가 아니면 `exit 1`로 종료

## Test Plan

- [x] YAML syntax check (PyYAML safe_load): PASS
- [x] Codex 브랜치 리뷰: PASS (기존 동작 영향 없음 확인)
- 본 PR 자체의 lint/test/docker-build가 모두 success여야 ci job success → 자기 검증

## Plan Preflight

- iteration 1 (2026-05-27 04:25): finding 1 (self-blocking) → #1900 머지로 해소, finding 2 (post-merge dispatch) → #1899 분리
- iteration 2 (autopilot 자율): approve-implement