### PR TITLE
fix(test): #1897 follow-up — mock.patch.stopall() autouse cleanup (cross-test contamination)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import importlib.util
 import os
 import sys
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -58,6 +59,14 @@ async def _cleanup_tasks():
     ``sqlite3.Connection`` 가 같은 테스트 경계 안에서 GC 되도록 한다. 다음
     테스트로 누수 attribution 이 전이되어 ``PytestUnraisableExceptionWarning``
     / ``ResourceWarning`` 이 무관 테스트에 표시되는 회귀를 방지한다.
+
+    Refs #1904 follow-up: 매 테스트 종료 직후 ``mock.patch.stopall()`` 을
+    호출해 ``patch.start()`` 후 ``stop()`` 누락(예: ``try`` 진입 전 예외)으로
+    인해 module attribute (``ante.cli.commands.*._create_*``,
+    ``ante.cli.main.authenticate_member`` 등) 가 mock 으로 영구 leak 되는
+    cross-test contamination 을 차단한다. xdist 환경에서 worker 별 random
+    fail (assert exit_code==0 인데 1, ``WARNING ante.config.config`` 가
+    captured log 에 잡히는 패턴) 의 baseline 누수원이다.
     """
     yield
     loop = asyncio.get_event_loop()
@@ -72,3 +81,7 @@ async def _cleanup_tasks():
         await asyncio.gather(*pending, return_exceptions=True)
     # Refs #1897: 남은 transport / DB Connection 객체를 결정적으로 정리한다.
     gc.collect()
+    # Refs #1904: stop-orphaned patch leak 방어. 정상 패스의 with-block /
+    # try-finally 는 already stop 했으므로 idempotent. start() 직후
+    # stop() 호출 전 예외가 발생한 leak 만 정리한다.
+    mock.patch.stopall()


### PR DESCRIPTION
Refs #1897 (follow-up), unblocks #1896/#1904

## Summary

`tests/conftest.py`의 `_cleanup_tasks` autouse fixture에 `mock.patch.stopall()` 한 줄 추가. PR #1900 sweep 이후 다수 CLI 테스트가 `patch(...).start()`만 호출하고 `try` 진입 전 예외 발생 시 `stop()` 누락 → module attribute (`ante.cli.commands.*._create_*` 등)가 mock으로 영구 leak되어 후속 테스트의 `with patch(...)` 블록 내에서도 real factory 실행됨.

## Root cause 증거

CI fail 로그에서 `test_register_format_after` fail과 함께 등장하는 captured log `WARNING ante.config.config:config.py:20 TOML 설정 파일 없음` → mock된 `_create_service`가 무효화되어 real factory가 호출됐다는 직접 증거.

## Verification (xdist `-n auto` 풀패스 5회)

- `test_register_format_after`: **5/5 PASS** (regression 차단)
- 전체 fail 카운트: 9 / 16 / 9 / **0** / 11 (평균 9)
  - baseline (PR #1897 직후) 14/45/32/1/18 (평균 22) 대비 **60% 감소**
  - **0-fail run 등장** → CI rerun 통과 확률 상승
- 단독 실행: PASS 유지
- ruff check / format: 통과
- Codex 브랜치 리뷰: PASS

## Follow-up (본 PR 범위 외)

남은 random fail은 broader cross-test contamination이며 별도 issue로 분리 정리 필요:
- `for p in patches: p.start()` 패턴의 leak 가능성 (첫 patch 실패 시)
- xdist worker 격리를 위한 module attribute snapshot/restore 메커니즘