### PR TITLE
fix(test): #1909 contracts shell test를 subprocess isolation으로 변환 (sys.modules pollution → CI 결정적 fail 해소)

### DIFF
--- a/docs/runbooks/05-testing.md
+++ b/docs/runbooks/05-testing.md
@@ -100,6 +100,27 @@ async def test_order_request_to_fill():
 - 헬퍼 `_run_isolated_import`는 메타-테스트
   `test_isolation_helper_detects_planted_heavy_import`로 자체 회귀를 검증한다.
 
+### 3.5 Test isolation invariants
+
+- 같은 pytest 프로세스 안에서 `del sys.modules[...]`를 **호출하지 않는다**.
+  module re-import는 closure-bound reference (예: Click callback의
+  `__globals__`)와 `sys.modules` 사이 inconsistency를 만들어, 같은 worker의
+  다른 test가 `patch("ante.cli.commands.member._create_service", ...)` 등
+  module-level attribute를 mock할 때 wrong module instance를 target하게
+  된다. 그러면 real factory가 실행되어 결정적 fail로 이어진다 (#1909).
+- import side-effect 자체를 검증해야 한다면 별도 Python subprocess
+  (`subprocess.run([sys.executable, "-c", ...], env={..., "PYTHONPATH": ...})`)
+  에서 실행한다. 본 패턴 예시는 §3.4의
+  `tests/unit/test_cli_dependency_isolation.py`와 `#1909` fix 후의
+  `tests/unit/contracts/test_cli_registry_shell.py::
+  test_cli_registry_import_does_not_load_cli_main`를 참고한다.
+- module-level monkey-patch (autouse fixture 외)는 금지. 필요 시 pytest
+  fixture로 감싸 시점·범위를 명시한다.
+- `mock.patch(...).start()` 호출은 반드시 동일 scope의 `stop()` 또는
+  `addCleanup` / `with` context로 동반한다. `tests/conftest.py`의
+  `mock.patch.stopall()` autouse cleanup은 안전망일 뿐 idiomatic 패턴이
+  아니다 — start/stop은 test 본문에서 짝을 맞춰 작성한다.
+
 ## 4. Fixture 전략
 
 ```python

--- a/tests/unit/contracts/test_cli_registry_shell.py
+++ b/tests/unit/contracts/test_cli_registry_shell.py
@@ -29,7 +29,11 @@ scope 외 (deliberately not asserted): 실제 command entry 등록 여부는
 from __future__ import annotations
 
 import dataclasses
+import os
+import pathlib
+import subprocess
 import sys
+import textwrap
 import typing
 
 import pytest
@@ -631,61 +635,68 @@ def test_package_reexports_registry_symbols() -> None:
 # ── import side effect lock ───────────────────────────────────────────────
 
 
+def _repo_root() -> pathlib.Path:
+    """현재 test 파일 기준 repo root (=src 부모)."""
+    # tests/unit/contracts/test_cli_registry_shell.py → parents[3] = repo root.
+    return pathlib.Path(__file__).resolve().parents[3]
+
+
+def _run_import_probe(target_import: str) -> subprocess.CompletedProcess[str]:
+    """별도 Python subprocess 에서 ``target_import`` 를 수행하고
+    ``ante.cli`` 트리 leak 여부를 검증하는 probe 를 실행한다.
+
+    Refs #1909: 본 probe 를 in-process 로 수행하면 ``del sys.modules[...]`` →
+    module re-import 가 Click callback 의 ``__globals__`` 와 ``sys.modules``
+    사이 inconsistency 를 만들어 같은 worker 의 후속 CLI test (``patch(...)``
+    target) 를 self-block 한다. process boundary 로 봉인하여 sys.modules
+    pollution 을 차단한다.
+    """
+    script = textwrap.dedent(f"""
+        import sys
+        import {target_import}  # noqa: F401  -- side effect probe
+
+        loaded = sorted(
+            n for n in sys.modules
+            if n == "ante.cli" or n.startswith("ante.cli.")
+        )
+        if loaded:
+            print("LEAKED:", loaded)
+            sys.exit(1)
+    """)
+    src_path = str(_repo_root() / "src")
+    env = {**os.environ, "PYTHONPATH": src_path}
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
 def test_cli_registry_import_does_not_load_cli_main() -> None:
     """registry import 만으로 ``ante.cli.main`` (Click root) 이 import 되지 않는다.
 
     Click root import 는 모든 command module 의 ``import`` 및 그에 따른 IO /
     env access / configuration 로딩을 트리거할 수 있다. registry shell 은
     순수 dataclass + 빈 dict 이므로 어떤 CLI 모듈도 끌어오면 안 된다.
+
+    Refs #1909: subprocess isolation 으로 sys.modules pollution 을 차단한다.
     """
-    # 본 test 실행 시점에 이전 test 가 ``ante.cli.main`` 을 import 했을 수
-    # 있으므로 sys.modules 를 정리한 뒤 isolated import 한다.
-    cli_modules = [
-        name
-        for name in list(sys.modules)
-        if name == "ante.cli" or name.startswith("ante.cli.")
-    ]
-    for name in cli_modules:
-        del sys.modules[name]
-    # cli_registry / contracts package 도 다시 import 해서 import 그래프를
-    # 재현한다.
-    for name in ("ante.contracts.cli_registry", "ante.contracts"):
-        if name in sys.modules:
-            del sys.modules[name]
-
-    import ante.contracts.cli_registry  # noqa: F401  -- side effect probe
-
-    loaded_cli = [
-        name
-        for name in sys.modules
-        if name == "ante.cli" or name.startswith("ante.cli.")
-    ]
-    assert loaded_cli == [], (
-        "ante.contracts.cli_registry import 가 ante.cli 트리를 끌어왔다: "
-        f"{sorted(loaded_cli)}"
+    result = _run_import_probe("ante.contracts.cli_registry")
+    assert result.returncode == 0, (
+        "ante.contracts.cli_registry import 가 ante.cli 트리를 끌어왔다.\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
     )
 
 
 def test_contracts_package_import_does_not_load_cli_main() -> None:
-    """``from ante import contracts`` 만으로 ``ante.cli.main`` 이 import 되지 않는다."""
-    cli_modules = [
-        name
-        for name in list(sys.modules)
-        if name == "ante.cli" or name.startswith("ante.cli.")
-    ]
-    for name in cli_modules:
-        del sys.modules[name]
-    for name in ("ante.contracts", "ante.contracts.cli_registry"):
-        if name in sys.modules:
-            del sys.modules[name]
+    """``from ante import contracts`` 만으로 ``ante.cli.main`` 이 import 되지 않는다.
 
-    import ante.contracts  # noqa: F401
-
-    loaded_cli = [
-        name
-        for name in sys.modules
-        if name == "ante.cli" or name.startswith("ante.cli.")
-    ]
-    assert loaded_cli == [], (
-        f"ante.contracts import 가 ante.cli 트리를 끌어왔다: {sorted(loaded_cli)}"
+    Refs #1909: subprocess isolation 으로 sys.modules pollution 을 차단한다.
+    """
+    result = _run_import_probe("ante.contracts")
+    assert result.returncode == 0, (
+        "ante.contracts import 가 ante.cli 트리를 끌어왔다.\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
     )


### PR DESCRIPTION
Closes #1909

## Summary

`tests/unit/contracts/test_cli_registry_shell.py:634-691`의 2건 test가 `del sys.modules[...]` 후 module restore 없이 종료 → 같은 worker의 후속 `patch()` test가 wrong module을 target하여 real factory 실행 → CI에서 결정적 fail. Option A subprocess isolation으로 root cause 봉인.

지난 6/6 PR run에서 `test_register_format_after`가 동일 패턴으로 100% fail. 본 fix가 직접 해소.

## 변경

- `tests/unit/contracts/test_cli_registry_shell.py`: 두 test를 subprocess script로 변환. 공통 헬퍼 `_run_import_probe(target_import)` + `_repo_root()` 도입. import 추가 (`os`, `pathlib`, `subprocess`, `textwrap`).
- `docs/runbooks/05-testing.md`: §3.5 "Test isolation invariants" 추가 — `del sys.modules` 금지, subprocess probe normative, module-level monkey-patch 금지, `patch.start/stop` 짝 명시.

## Test Plan

- [x] 재현 명령 (이슈 §재현 절차): **PASS** (이전엔 결정적 FAIL이던 조합)
- [x] `tests/unit/contracts/test_cli_registry_shell.py` 단독: 38건 PASS (contract invariant 보존)
- [x] `pytest tests/unit/ -x -n auto` **5회 반복 모두 5591 passed, fail 0** (이전 평균 9-22 fail에서 0으로)
- [x] `ruff check tests/` + `ruff format --check tests/` PASS
- [x] `mypy src/` Success (224 files)
- [x] Codex 브랜치 리뷰: PASS

## Plan Preflight

- iteration 1 (autopilot 자율): approve-implement (이슈 본문에 deep dive 결과 포함됨, root cause + Option A 채택 사유 명시)

## 관련

- 진단 결과 deep dive: 이슈 #1909 본문 (mechanism, Python repro id divergence 증거 포함)
- 잠재 follow-up: `for p in patches: p.start()` 패턴 sweep (`tests/unit/test_cli_init.py` 23건 등) — 본 PR 후 random fail 0이면 우선순위 낮음