### PR TITLE
fix(cli): #1911 non-auth JSON envelope code SCREAMING_SNAKE 정합

### DIFF
--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -569,7 +569,7 @@ def init(
             "default test account(account_id='test')가 비활성 상태입니다. "
             "`ante account activate test`로 활성화하거나 해당 row를 정리한 "
             "뒤 재시도하세요.",
-            code="test_account_inactive",
+            code="ACCOUNT_TEST_INACTIVE",
         )
 
     # state 1: 모든 상태 완료 → 거부

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -614,7 +614,7 @@ def init(
                 _bootstrap_master(str(db_path), member_id, name, password)
             )
         except ValueError as e:
-            _fail(fmt, str(e), code="bootstrap_failed")
+            _fail(fmt, str(e), code="ACCOUNT_MASTER_BOOTSTRAP_FAILED")
         # text 모드는 여기서 비밀값을 1회 노출 (completion 블록은 재출력 금지).
         # JSON 성공 경로는 stdout payload로 1회 노출되므로 여기서 stderr 이벤트를
         # 내보내지 않는다 (중복 노출 방지). JSON 실패 경로만 아래 except에서
@@ -640,10 +640,14 @@ def init(
                     f"테스트 계좌 생성 실패: {e}. "
                     "master는 위에 출력된 비밀값으로 접근 가능. "
                     "원인 해결 후 재실행 시 test account만 생성됨.",
-                    code="test_account_failed",
+                    code="ACCOUNT_TEST_CREATE_FAILED",
                 )
             else:
-                _fail(fmt, f"테스트 계좌 생성 실패: {e}", code="test_account_failed")
+                _fail(
+                    fmt,
+                    f"테스트 계좌 생성 실패: {e}",
+                    code="ACCOUNT_TEST_CREATE_FAILED",
+                )
 
     if fmt.is_json:
         payload: dict = {"config_dir": str(config_path)}

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -110,7 +110,7 @@ def config_set(ctx: click.Context, key: str, value: str, data_path: str) -> None
         supported = ", ".join(API_KEYS)
         fmt.error(
             f"지원하지 않는 키입니다: {key}\n지원 키: {supported}",
-            code="unsupported_key",
+            code="CONFIG_UNSUPPORTED_KEY",
         )
         raise SystemExit(1)
 

--- a/tests/unit/feed/test_cli_config_set.py
+++ b/tests/unit/feed/test_cli_config_set.py
@@ -82,7 +82,7 @@ class TestFeedConfigSetUnsupportedKey:
         )
         payload = json.loads(result.stdout.strip())
         assert payload["status"] == "error"
-        assert payload["code"] == "unsupported_key"
+        assert payload["code"] == "CONFIG_UNSUPPORTED_KEY"
         assert payload["message"].startswith("지원하지 않는 키입니다: unsupported_key")
         assert "지원 키:" in payload["message"]
 

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -405,7 +405,7 @@ class TestInitFiveStateGuard:
         assert _MOCK_TOKEN in combined
         assert _MOCK_RECOVERY_KEY in combined
         assert "패스워드" in combined
-        # 에러 메시지에서 test_account_failed 코드 확인
+        # 에러 메시지에서 ACCOUNT_TEST_CREATE_FAILED 코드 확인
         assert "테스트 계좌 생성 실패" in combined
 
     def test_master_credentials_json_mode_stderr_event_on_test_account_failure(
@@ -812,7 +812,7 @@ class TestInitJsonErrorContract:
         data = self._parse_error_json(result.output)
         assert data["status"] == "error"
         assert "패스워드 정책 위반" in data["message"]
-        assert data.get("code") == "bootstrap_failed"
+        assert data.get("code") == "ACCOUNT_MASTER_BOOTSTRAP_FAILED"
 
     def test_init_test_account_failure_json_output(self, runner, tmp_path):
         """_create_test_account가 Exception을 던지면 JSON 에러 + exit 1."""
@@ -847,7 +847,7 @@ class TestInitJsonErrorContract:
         assert data["status"] == "error"
         assert "테스트 계좌 생성 실패" in data["message"]
         assert "DB lock" in data["message"]
-        assert data.get("code") == "test_account_failed"
+        assert data.get("code") == "ACCOUNT_TEST_CREATE_FAILED"
 
     def test_init_already_initialized_text_mode_preserves_message(
         self, runner, tmp_path

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -1033,7 +1033,7 @@ class TestInitTestAccountDetectionNarrowed:
         했지만 `AccountService.create_default_test_account()`는 `account_id='test'`
         중복 검사에 걸려 예외를 던진다 → init 자체가 실패하면서 사용자에게는
         원인이 불명확하다. 이제는 3-state (active/inactive/missing) 판정으로
-        inactive를 만나면 `test_account_inactive` 에러 코드로 안내한다.
+        inactive를 만나면 `ACCOUNT_TEST_INACTIVE` 에러 코드로 안내한다.
         """
         target = tmp_path / "config"
         target.mkdir()
@@ -1084,6 +1084,50 @@ class TestInitTestAccountDetectionNarrowed:
 
         assert result.exit_code == 1, result.output
         assert "비활성 상태" in result.output
+        create_acc_mock.assert_not_called()
+        bootstrap_mock.assert_not_called()
+
+
+class TestInitTestAccountInactiveJsonEnvelope:
+    """#1911 — inactive test account 경로의 JSON envelope code SSOT 정합 회귀.
+
+    `docs/specs/contracts/error-taxonomy.md` §명명 규칙 1·2는 envelope `code`를
+    SCREAMING_SNAKE_CASE + 허용 prefix로 lock한다(legacy alias는 auth-3에 한정).
+    inactive test account 경로의 code는 `ACCOUNT_TEST_INACTIVE`여야 한다.
+    """
+
+    def test_json_mode_inactive_emits_uppercase_code(self, runner, tmp_path):
+        """--format json: stdout JSON envelope, status='error',
+        code='ACCOUNT_TEST_INACTIVE', exit 1.
+
+        기존 text 모드 회귀(`test_test_account_suspended_raises_clear_error`)와
+        동일 setup(suspended status)을 재사용하되 JSON 출력 envelope을 검증한다.
+        """
+        target = tmp_path / "config"
+        target.mkdir()
+        db_path = target / "db" / "ante.db"
+        _create_db_with_master_row(db_path)
+        _create_db_with_test_account_row(
+            db_path, account_id="test", broker_type="test", status="suspended"
+        )
+
+        bootstrap_mock = AsyncMock(side_effect=_mock_bootstrap)
+        create_acc_mock = AsyncMock(side_effect=_mock_create_test_account)
+
+        with (
+            patch("ante.cli.commands.init._bootstrap_master", new=bootstrap_mock),
+            patch("ante.cli.commands.init._create_test_account", new=create_acc_mock),
+            patch("ante.cli.main.authenticate_member"),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "init", "--dir", str(target)]
+            )
+
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout.strip())
+        assert payload["status"] == "error"
+        assert payload["code"] == "ACCOUNT_TEST_INACTIVE"
+        # 묵시적 재생성/bootstrap 시도 금지 (회귀 락)
         create_acc_mock.assert_not_called()
         bootstrap_mock.assert_not_called()
 

--- a/tests/unit/test_cli_init_secret_leak.py
+++ b/tests/unit/test_cli_init_secret_leak.py
@@ -7,7 +7,7 @@
 4. stderr JSON mode recovery event
 5. caplog records (level=DEBUG, propagation 강제 on)
 6. Click ``result.exception`` chain message
-7. ``test_account_failed`` 실패 메시지 본문
+7. ``ACCOUNT_TEST_CREATE_FAILED`` 실패 메시지 본문
 
 성공 경로 + 실패 경로(``_create_test_account`` 가 raise) 둘 다 검증한다.
 
@@ -211,13 +211,13 @@ class TestInitR13EncryptionKeyNoLeak:
         exc_json = "" if result_json.exception is None else repr(result_json.exception)
         _assert_key_not_in(json_key, where="json exception", blob=exc_json)
 
-    def test_failure_path_no_leak_in_test_account_failed_message(
+    def test_failure_path_no_leak_in_account_test_create_failed_message(
         self,
         tmp_path: Path,
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """실패 경로 — ``test_account_failed`` 에러 메시지 본문에 키 부재.
+        """실패 경로 — ``ACCOUNT_TEST_CREATE_FAILED`` 에러 메시지 본문에 키 부재.
 
         7번째 채널 (실패 메시지 본문) 검증. ``_create_test_account``가 raise한
         ``RuntimeError`` 메시지가 ``OutputFormatter.error``로 직렬화될 때 키가
@@ -246,12 +246,12 @@ class TestInitR13EncryptionKeyNoLeak:
         )
         stderr_blob = result_text.stderr if result_text.stderr_bytes else ""
         _assert_key_not_in(text_key, where="fail text stderr", blob=stderr_blob)
-        # test_account_failed 메시지 본문 검증 (stdout 또는 stderr 어느 한 쪽에 있음)
+        # ACCOUNT_TEST_CREATE_FAILED 본문 검증 (stdout 또는 stderr 어느 한 쪽)
         combined = (result_text.stdout or "") + stderr_blob
         assert "테스트 계좌 생성 실패" in combined
         _assert_key_not_in(
             text_key,
-            where="fail text test_account_failed message",
+            where="fail text ACCOUNT_TEST_CREATE_FAILED message",
             blob=combined,
         )
         log_blob = "\n".join(r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Closes #1911

## Summary
- `feed config set` / `ante init`의 non-auth JSON envelope `code` 5개를 SSOT(`docs/specs/contracts/error-taxonomy.md`)의 SCREAMING_SNAKE + 도메인 prefix 규칙에 맞춰 정렬:
  - `feed/cli.py:113` `unsupported_key` → `CONFIG_UNSUPPORTED_KEY`
  - `init.py:572` `test_account_inactive` → `ACCOUNT_TEST_INACTIVE`
  - `init.py:617` `bootstrap_failed` → `ACCOUNT_MASTER_BOOTSTRAP_FAILED`
  - `init.py:643,649` `test_account_failed` → `ACCOUNT_TEST_CREATE_FAILED`
- 기존 lowercase code를 assert하던 단위테스트 갱신 + JSON-mode inactive 회귀 테스트 신규 추가.
- `secret-leak` 테스트의 docstring·라벨도 새 SCREAMING_SNAKE로 정리(사용자 메시지 본문은 보존).
- `update.py:280,290`의 잔여 lowercase 2건(`migration_failed`/`rollback_failed`)은 동일 SSOT invariant이지만 다른 surface(`ante update`)이므로 follow-up #1921로 분리.

## Spec
- SSOT: `docs/specs/contracts/error-taxonomy.md` §명명 규칙 1·2(SCREAMING_SNAKE + 허용 prefix `ACCOUNT_*`/`CONFIG_*`/…), §Legacy alias(auth-3 폐쇄 — 본 PR은 alias 추가 없음). 본 PR은 신규 taxonomy 확장이 아니라 기존 lowercase callsite의 prefix-conforming rename.

## Test Plan
- `pytest tests/unit/feed/test_cli_config_set.py tests/unit/test_cli_init.py tests/unit/test_cli_init_secret_leak.py -q` → 56 passed
- `ruff check` / `ruff format --check` → PASS
- `mypy src/ante/feed/cli.py src/ante/cli/commands/init.py` → 변경 파일 clean
- literal sweep `rg -n 'code="[a-z_]+"' src/` → 본 PR scope 0건, `update.py:280,290`만 남음(#1921 분리됨)
- 동적 propagation sweep `rg -n 'code\s*=\s*(code|e\.code|getattr\(|.*\.get\("code")' src/ante` → 43행 전수 propagator로 분류, 신규 lowercase literal 0건. 분류 결과는 이슈 #1911 코멘트에 첨부.
- identifier sweep `rg -n "unsupported_key|test_account_inactive|bootstrap_failed|test_account_failed" src/ tests/ docs/` → 남은 occurrence는 모두 사용자 입력 키 literal(`unsupported_key`)로 분류.

## Review
- Plan Preflight v1→v5: Codex Plan Review 5회(v2 approve → r1 FAIL로 scope 확장 → v3/v4 verification 강화 → v5 approve).
- Codex 브랜치 review r2 PASS (r1 FAIL 3건 모두 해소: init.py rename, test 갱신, update.py 분리).