### PR TITLE
docs(cli): #1916 strategy performance --account-id semantic-required 표기 정합

### DIFF
--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -106,7 +106,7 @@ allowlist 후보에서 제거한다.
 | `ante strategy submit <path>` | `offline` | 검증 + 로드 테스트 + StrategyRegistry 등록 |
 | `ante strategy list` | `offline` | StrategyRegistry 조회 |
 | `ante strategy info <name>` | `offline` | StrategyRegistry 조회 |
-| `ante strategy performance <name> [--account-id <account_id>]` | `offline` | 성과 DB 집계 |
+| `ante strategy performance <name> --account-id <account_id>` | `offline` | 성과 DB 집계 (account-scoped, semantic-required) |
 | `ante strategy set-status <strategy_id> --status adopted\|archived` | `runtime IPC` | 전략 상태 변경 |
 | `ante strategy summary <strategy_id> --period daily\|weekly\|monthly` | `offline` | 성과 기간 집계 |
 | `ante treasury status --account <account_id>` | `offline` | persisted treasury 상태 조회 (`--account` 필수) |
@@ -402,7 +402,7 @@ ante strategy submit <path>        # 검증 + 로드 테스트 + 전략 등록
 ante strategy list                 # 등록된 전략 목록
 ante strategy info <name>          # 전략 상세 (메타데이터, 파라미터)
 ante strategy set-status <strategy_id> --status adopted|archived  # 전략 상태 변경
-ante strategy performance <name> [--account-id <account_id>]  # 전략 전체 성과 (모든 봇 집계, Agent 피드백용)
+ante strategy performance <name> --account-id <account_id>  # 전략 전체 성과 (계좌별, 모든 봇 집계, Agent 피드백용)
 ante strategy summary <strategy_id> --period daily|weekly|monthly  # 전략 기간별 성과 집계
 ```
 

--- a/docs/specs/cli/04-agent-workflows.md
+++ b/docs/specs/cli/04-agent-workflows.md
@@ -29,7 +29,7 @@ ante --format json report submit report_draft.json
 # 5. (채택 후) 실전 성과 확인 — Agent 피드백 루프
 ante trade list --bot bot_001 --from 2026-03-01 --to 2026-03-31 --format json
 ante --format json bot positions bot_001
-ante --format json strategy performance my_strategy
+ante --format json strategy performance my_strategy --account-id domestic
 ```
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조

--- a/docs/specs/strategy/03-14-performance-scoping.md
+++ b/docs/specs/strategy/03-14-performance-scoping.md
@@ -4,15 +4,12 @@
 
 # 성과 추적의 scoping
 
-전략 정의는 글로벌이지만, 성과·거래 기록은 계좌별로 분리 추적된다.
+전략 정의는 글로벌이지만, 성과·거래 기록은 계좌별로 분리 추적된다. `ante strategy performance` 는 `--account-id` 를 semantic-required 로 받으며 (미지정 시 `STRATEGY_MISSING_REQUIRED_ACCOUNT` 에러, SSOT: `src/ante/cli/commands/strategy.py`), 지정 계좌에서의 모든 봇 성과를 집계한다.
 
 ```bash
-# 계좌별 성과 조회
+# 계좌별 성과 조회 (semantic-required)
 ante strategy performance momentum_breakout --account-id domestic
-# → domestic 계좌에서의 성과만
-
-ante strategy performance momentum_breakout
-# → 전 계좌 합산 (각 계좌별 통화로 개별 표시)
+# → domestic 계좌에서의 성과만 (해당 계좌에서 이 전략을 사용한 모든 봇 집계)
 ```
 
-성과 집계 시 `account_id`로 그룹핑하여 계좌별 수익률, MDD 등을 독립 산출한다. 통화가 다른 계좌 간 성과를 단순 합산하지 않는다.
+성과 집계는 항상 단일 계좌 scope 에서 수행하여 통화 차이로 인한 합산 오류를 차단한다. 통화가 다른 계좌 간 성과를 단순 합산하지 않으며, 여러 계좌의 성과를 비교하려면 호출자가 각 계좌별로 명령을 반복 호출한다.

--- a/guide/strategy.md
+++ b/guide/strategy.md
@@ -487,6 +487,6 @@ ante strategy list --status active
 # 전략 상세 정보
 ante strategy info momentum_breakout
 
-# 전략 성과 조회 (모든 봇 합산)
-ante strategy performance momentum_breakout
+# 전략 성과 조회 (지정 계좌의 모든 봇 합산)
+ante strategy performance momentum_breakout --account-id domestic
 ```


### PR DESCRIPTION
Closes #1916

## Summary
`ante strategy performance`의 `--account-id`는 구현상 semantic-required(`src/ante/cli/commands/strategy.py:718-721` — `account_id is None` → `STRATEGY_MISSING_REQUIRED_ACCOUNT`)인데 docs 4-5곳이 생략/optional 표기로 drift. docs를 SSOT인 구현에 맞춰 정합.

### 변경
- `docs/specs/cli/03-commands.md:109` table entry-row — `[--account-id ...]` 대괄호 제거 + 비고 보강
- `docs/specs/cli/03-commands.md:405` bash example — 대괄호 제거 + 주석 정합
- `docs/specs/cli/04-agent-workflows.md:32` — 생략 호출 예시 → `--account-id` 포함
- `docs/specs/strategy/03-14-performance-scoping.md:12` — 전 계좌 합산 생략 예시 제거 + narrative 정합
- `guide/strategy.md:490` — `--account-id domestic` example로 교정

`#1662` follow-up의 semantic-required 표면 정합으로, runtime 코드 미변경.

## Spec
- SSOT: `src/ante/cli/commands/strategy.py:718-721`. cross-ref: `docs/specs/account/14-account-id-contract.md`.

## Test Plan
- `rg -n 'ante strategy performance momentum_breakout$' docs/ guide/` → 0건
- `rg -n 'ante --format json strategy performance my_strategy$' docs/specs/cli/04-agent-workflows.md` → 0건
- `git diff --stat origin/main` → 4 files
- 자동 생성 산출물(`guide/cli.md`) 변경 없음 (Click decorator 미변경)

## Review
- Plan Preflight v1→v2: Codex Plan Review FAIL→approve-implement (v1 04-agent-workflows.md:32 누락 → v2에서 4번째 site 추가)
- Codex 브랜치 review PASS (narrow scope diff 확인)