### PR TITLE
docs(spec): #1917 instrument invalid exchange enforcement #1577 완료 시제 정합

### DIFF
--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -714,8 +714,8 @@ ante instrument import <filepath> [--dry-run] [--db-path <경로>]  # CSV/JSON �
 
 > canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
 > instrument는 canonical-only(`*` 거부) 주 신규 입력 표면이다. `list`/`sync`/`import`의
-> non-canonical `--exchange` / import payload는 non-zero exit + 구조화 error payload로 거부되어야
-> 한다(`ORACLE_INVALID_EXCHANGE` 출처). enforcement 정렬은 #1577에서 다룬다(현재 코드/스펙 drift).
+> non-canonical `--exchange` / import payload는 `INSTRUMENT_INVALID_EXCHANGE` 코드 + non-zero exit
+> + 구조화 error payload로 거부된다 (#1577 완료). `ORACLE_INVALID_EXCHANGE`는 oracle host probe 측 source label이고 구현 코드는 `INSTRUMENT_INVALID_EXCHANGE`다.
 
 ### `ante notification` — 알림 관리
 

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -149,7 +149,7 @@ surface 운영/소스/핸들러 디테일은 후속 이슈 정렬 사안으로 �
 
 | 표면 | canonical | `*` | non-canonical 신규 입력 거부 계약 | 비고 |
 |------|-----------|-----|-----------------------------------|------|
-| Instrument CLI `list`/`import` | 허용 | 거부 | non-zero exit + 구조화 error payload (`{status:"error", code, message}`) | #1577 enforcement. **주 신규 입력 표면** (oracle `ORACLE_INVALID_EXCHANGE` 출처) |
+| Instrument CLI `list`/`import` | 허용 | 거부 | non-zero exit + 구조화 error payload (`{status:"error", code, message}`) | #1577 완료 (`INSTRUMENT_INVALID_EXCHANGE`). **주 신규 입력 표면** (oracle source label은 `ORACLE_INVALID_EXCHANGE`; 구현 코드는 `INSTRUMENT_INVALID_EXCHANGE`) |
 | Instrument CLI `sync` | 허용 (vocabulary 측면은 동일: canonical 5종만 유효, non-canonical 거부) | 거부 | non-zero exit + 구조화 error payload | **source-bound 표면.** `sync`는 KIS API(KRX 도메인)에서만 마스터를 가져와 전달 `exchange`를 저장 라벨로 쓴다(`src/ante/cli/commands/instrument.py`의 `sync`→`KISAdapter.get_instruments`, `docs/specs/instrument/` source 계약). 따라서 canonical이지만 source 미지원 exchange(`NYSE/NASDAQ/AMEX` 등 비-KRX)에 대한 sync 동작·에러 계약은 **source-supported-exchange 정렬 사안으로 #1577에 위임**(backtest `--exchange`처럼 spec-vs-implementation gap). 본 SSOT는 "sync는 source-bound이며 source 미지원 canonical 값 처리 계약은 #1577" 까지만 명시하고 완전 명세하지 않는다 |
 | Account CLI preset (`account create` 등) | canonical 5종은 invalid-exchange로 거부되지 않음 (축 A); preset 미제공 canonical 값은 축 B 제약 | 거부 | non-zero exit | 축 A: `*`/non-canonical은 거부. 축 B: canonical이지만 1.0 preset 미제공 값(`NYSE/NASDAQ/AMEX`)은 **preset/broker 가용성 제약**이지 invalid-exchange 거부가 아니다(별개 차원). 구체적 preset wiring(어떤 preset이 어떤 exchange를 자동 구성하는가)은 축 B canonical-known 표·축 B 정의를 상위 기준으로 삼아 **#1578에서 정렬**한다 — 본 행은 vocabulary 계약(축 A 비거부 / `*`·non-canonical 거부)만 명시한다 |
 | AccountService (생성/검증) | canonical 5종 허용 (축 A: non-canonical만 서비스 검증 에러) | 거부 | 서비스 검증 에러 | `exchange`는 identity 필드(`docs/specs/account/03-data-model.md:96`). canonical 5종은 서비스 exchange 검증에서 거부되지 않는다. 1.0 account preset이 `NYSE/NASDAQ/AMEX`를 미제공하는 것은 **축 B(preset/broker 가용성) 제약**이며 "invalid exchange 거부"가 아니다(별개 차원) |
@@ -195,7 +195,7 @@ surface 운영/소스/핸들러 디테일은 후속 이슈 정렬 사안으로 �
 | 소비자 / 작업 | 후속 이슈 |
 |---------------|-----------|
 | 코드 레벨 SSOT 도입(canonical 상수 단일화) | #1576 |
-| Instrument CLI enforcement(주 신규 입력 표면) | #1577 |
+| Instrument CLI enforcement(주 신규 입력 표면) | #1577 완료 (`INSTRUMENT_INVALID_EXCHANGE`) |
 | account / data / backtest / strategy 경계면 정렬 + backtest `--exchange` 옵션 신설 | #1578 |
 | 회귀 테스트 고정 | #1579 |
 | 에픽 | #1561 |

--- a/docs/specs/instrument/instrument.md
+++ b/docs/specs/instrument/instrument.md
@@ -35,7 +35,8 @@ Instrument 모듈은 **종목 마스터 데이터를 중앙 관리하는 모듈*
 
 > canonical exchange 허용값·검증 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
 > Instrument는 canonical-only(`*` 거부) 표면이며, instrument CLI `list`/`sync`/`import`의
-> non-canonical 신규 입력 거부 enforcement는 #1577에서 정렬한다(현재 코드/스펙 drift).
+> non-canonical 신규 입력은 `INSTRUMENT_INVALID_EXCHANGE` 코드 + non-zero exit + 구조화 error
+> payload로 거부된다 (#1577 완료).
 
 ## Instrument 모델
 


### PR DESCRIPTION
Closes #1917

## Summary
- `INSTRUMENT_INVALID_EXCHANGE` enforcement(`src/ante/cli/commands/instrument.py:16,63-66,133-136,376-382`)는 #1577에서 완료되었으나 docs 4 site가 여전히 미해결 drift로 표기. 시제 정합.
- `docs/specs/instrument/instrument.md:36-39` — drift note → `INSTRUMENT_INVALID_EXCHANGE`로 거부됨 (#1577 완료)
- `docs/specs/cli/03-commands.md:715-718` — drift note → `INSTRUMENT_INVALID_EXCHANGE`로 거부됨 (#1577 완료). `ORACLE_INVALID_EXCHANGE`는 oracle source label로 disambiguation 보존
- `docs/specs/core/core.md:152` — `#1577 enforcement` row → `#1577 완료 (INSTRUMENT_INVALID_EXCHANGE)` + oracle/구현 코드 명시
- `docs/specs/core/core.md:198` — `#1577` row → `#1577 완료 (INSTRUMENT_INVALID_EXCHANGE)`

### 범위 분리
- core.md narrative 6 lines(70, 145, 146, 153, 172, 174)와 `docs/decisions/D-016-canonical-exchange-vocabulary.md:61`은 narrative/sub-axis로 follow-up #1926에 분리

## Spec
- 구현 SSOT: `src/ante/cli/commands/instrument.py` `_INVALID_EXCHANGE_CODE = "INSTRUMENT_INVALID_EXCHANGE"`
- cross-ref: `docs/specs/core/core.md` `## Canonical Exchange Vocabulary`

## Test Plan
- `rg -n '코드/스펙 drift' docs/specs/instrument/instrument.md docs/specs/cli/03-commands.md` → 0건
- `rg -n 'INSTRUMENT_INVALID_EXCHANGE' docs/` → 4건 (instrument.md + 03-commands.md + core.md:152,198)
- `git diff --stat origin/main` → 3 files
- 자동 생성 산출물 변경 없음

## Review
- Plan Preflight v1→v2: Codex REVISE→approve-implement (v1 core.md 8 lines 추가 발견 → v2에서 2 progress marker는 본 PR scope, narrative 6+D-016은 #1926으로 split)
- Codex 브랜치 review PASS