### PR TITLE
docs(spec): #1918 master-only CLI guard #1543 완료 시제 정합

### DIFF
--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -230,9 +230,11 @@ exit 1로 종료한다. CLI 표면 가드(`@require_scope`)는 `member:admin` sc
 수단이 recovery key 또는 현재 패스워드 자체이므로 위 master-only 정책과 별도로
 공개 명령 allowlist 경로([03-commands.md — 공개 명령 allowlist](03-commands.md#공개-명령-allowlist--인증-면제))를 따른다.
 
-> 후속 implementation 정렬: #1543 (CLI 표면 가드 master-only로 일치),
-> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
-> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
+> #1542 (결정 SSOT) 기준의 CLI 표면 가드 master-only 정렬은 #1543 완료
+> (`require_master`가 `src/ante/cli/middleware.py`에 정의되고 member admin
+> mutation CLI에 적용). oracle host probe scope 기대값 정렬은 #1544(별도,
+> ante-oracle)에서 진행. 부모 #1511(oracle host probe scope drift)에서
+> 시작된 정합 작업이다.
 
 ### default-deny CLI 인증 게이트
 

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -683,9 +683,11 @@ ante member reset-password --recovery-key <key> (--new-password-env ENV_NAME | -
 ante member regenerate-recovery-key (--password-env ENV_NAME | --password-file PATH)  # 복구 키 재발급 (공개 명령 allowlist — 현재 패스워드가 인증 수단)
 ```
 
-> 후속 implementation 정렬: #1543 (CLI 표면 가드 master-only로 일치),
-> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
-> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
+> #1542 (결정 SSOT) 기준의 CLI 표면 가드 master-only 정렬은 #1543 완료
+> (`require_master`가 `src/ante/cli/middleware.py`에 정의되고 member admin
+> mutation CLI에 적용). oracle host probe scope 기대값 정렬은 #1544(별도,
+> ante-oracle)에서 진행. 부모 #1511(oracle host probe scope drift)에서
+> 시작된 정합 작업이다.
 
 `member list/info`와 `member list-invalid-roles`는 오프라인 조회가 가능하다. 단,
 `member list-invalid-roles`는 `MemberService.initialize()`로 schema migration DDL을

--- a/docs/specs/member/02-design-decisions.md
+++ b/docs/specs/member/02-design-decisions.md
@@ -214,9 +214,11 @@ master 외 호출자를 `PermissionError`로 거부하며, 표면 계약(CLI com
 이 invariant에 정합한다. `member:admin`
 agent token으로의 접근은 1.0에서 허용되지 않는다.
 
-> 후속 implementation 정렬: #1543 (CLI 표면 가드 master-only로 일치),
-> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
-> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
+> #1542 (결정 SSOT) 기준의 CLI 표면 가드 master-only 정렬은 #1543 완료
+> (`require_master`가 `src/ante/cli/middleware.py`에 정의되고 member admin
+> mutation CLI에 적용). oracle host probe scope 기대값 정렬은 #1544(별도,
+> ante-oracle)에서 진행. 부모 #1511(oracle host probe scope drift)에서
+> 시작된 정합 작업이다.
 
 ### Member command runtime boundary
 

--- a/docs/specs/member/05-member-service.md
+++ b/docs/specs/member/05-member-service.md
@@ -86,6 +86,8 @@ def _assert_invariants(self, member: Member, action: str) -> None:
   패스워드 자체이므로 master 토큰을 요구하지 않는 공개 명령 allowlist 경로다
   ([cli/03-commands.md — 공개 명령 allowlist](../cli/03-commands.md#공개-명령-allowlist--인증-면제) 참조).
 
-> 후속 implementation 정렬: #1543 (CLI 표면 가드 master-only로 일치),
-> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
-> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
+> #1542 (결정 SSOT) 기준의 CLI 표면 가드 master-only 정렬은 #1543 완료
+> (`require_master`가 `src/ante/cli/middleware.py`에 정의되고 member admin
+> mutation CLI에 적용). oracle host probe scope 기대값 정렬은 #1544(별도,
+> ante-oracle)에서 진행. 부모 #1511(oracle host probe scope drift)에서
+> 시작된 정합 작업이다.

--- a/docs/specs/member/06-cli.md
+++ b/docs/specs/member/06-cli.md
@@ -41,9 +41,11 @@ master-only 정책의 적용 대상이 아니다. `member reset-password`와
 자체이므로 별도 공개 명령 allowlist 경로를 따른다
 ([cli/03-commands.md — 공개 명령 allowlist](../cli/03-commands.md#공개-명령-allowlist--인증-면제) 참조).
 
-> 후속 implementation 정렬: #1543 (CLI 표면 가드 master-only로 일치),
-> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
-> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
+> #1542 (결정 SSOT) 기준의 CLI 표면 가드 master-only 정렬은 #1543 완료
+> (`require_master`가 `src/ante/cli/middleware.py`에 정의되고 member admin
+> mutation CLI에 적용). oracle host probe scope 기대값 정렬은 #1544(별도,
+> ante-oracle)에서 진행. 부모 #1511(oracle host probe scope drift)에서
+> 시작된 정합 작업이다.
 
 ### `ante member list`
 


### PR DESCRIPTION
Closes #1918

## Summary
- master-only CLI guard(`require_master` in `src/ante/cli/middleware.py:192-258` + `@require_master` at `src/ante/cli/commands/member.py:500,571,607,666,706,753,797`)는 #1543에서 완료되었으나 5 docs가 미해결 후속작업으로 표기. 시제 정합.
- 5 곳 모두 동일 phrasing(byte-identical block, sha256 `67a51edf…`):
  - `docs/specs/member/02-design-decisions.md:217`
  - `docs/specs/member/05-member-service.md:89`
  - `docs/specs/member/06-cli.md:44`
  - `docs/specs/cli/02-design-decisions.md:233`
  - `docs/specs/cli/03-commands.md:686`

새 phrasing은 #1542 결정 SSOT + #1543 완료(`require_master`) + #1544 분리(ante-oracle) + #1511 부모 작업으로 정합.

## Spec
- 구현 SSOT: `src/ante/cli/middleware.py:192-258` + `src/ante/cli/commands/member.py` 7곳 `@require_master`
- 결정 SSOT: `docs/specs/member/02-design-decisions.md` 본문(보존)

## Test Plan
- `rg -n '후속 implementation 정렬: #1543' docs/` → 0건
- `rg -n '#1543 완료' docs/` → 5건
- `rg -n 'require_master' docs/` → 5건 (본 PR 정합 phrasing)
- `git diff --stat origin/main` → 5 files
- 5 블록 sha256 동일 확인

## Review
- Plan Preflight v1→v3: Codex PASS-with-fixes (line 686 정정 + member.py 데코레이터 라인 7곳 정확화) → Codex FAIL (verification 충돌) → v3 PASS
- Codex 브랜치 review PASS