### PR TITLE
fix(cli): #1914 --data-path default을 config-resolved data root로 정합

### DIFF
--- a/guide/cli.md
+++ b/guide/cli.md
@@ -2,7 +2,7 @@
 
 Ante가 제공하는 모든 CLI 명령어를 정리한 문서입니다. 각 명령어의 사용법, 옵션, 필수 권한(scope)을 확인할 수 있습니다.
 
-> 마지막 갱신: 2026-05-22
+> 마지막 갱신: 2026-05-29
 
 ## 목차
 
@@ -293,7 +293,7 @@ ante account create [OPTIONS]
 | `--credential-env` | - | TEXT | — | credential을 환경변수에서 읽는다 (권장 채널) |
 | `--credential-file` | - | TEXT | — | credential을 파일에서 읽는다 (권장 채널) |
 | `--broker-config` | - | TEXT | — | broker-specific 설정 (free-form pass-through, 예: is_paper=true) |
-| `--market-order-reserve-buffer-rate` | - | FLOAT | — | 시장가 매수 reserve buffer 비율 (예: 0.005=0.5%). omit 시 BrokerPreset 기본값을 사용한다 (#1333). |
+| `--market-order-reserve-buffer-rate` | - | FLOAT | — | 시장가 매수 reserve buffer 비율 (예: 0.005=0.5%). omit 시 BrokerPreset 기본값을 사용한다 (#1333). NaN/Infinity/음수는 거부된다 (#1723). |
 | `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
@@ -1432,7 +1432,7 @@ ante data list [OPTIONS]
 | `--type` | - | ohlcv / fundamental | — | 데이터 유형 필터 |
 | `--offset` | - | INT (0~) | 0 | 조회 offset |
 | `--limit` | - | INT (1~) | 50 | 조회 개수 |
-| `--data-path` | - | TEXT | data/ | 데이터 디렉토리 경로 |
+| `--data-path` | - | TEXT | — | 데이터 디렉토리 경로 (미지정 시 config_dir 기반) |
 | `--db-path` | - | TEXT | — | DB 경로 (미지정 시 config_dir 기반) |
 | `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
@@ -1458,7 +1458,7 @@ ante data info <DATASET_ID> [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 디렉토리 경로 |
+| `--data-path` | - | TEXT | — | 데이터 디렉토리 경로 (미지정 시 config_dir 기반) |
 | `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
@@ -1485,7 +1485,7 @@ ante data delete <DATASET_ID> [OPTIONS]
 |------|------|------|--------|------|
 | `--type` | - | ohlcv / fundamental | — | dataset_id 파생 유형과 일치해야 하는 데이터 유형 |
 | `--yes` | - | BOOLEAN | false | 삭제를 확인 (위험 명령). 누락 시 prompt 없이 에러로 실패 |
-| `--data-path` | - | TEXT | data/ | 데이터 디렉토리 경로 |
+| `--data-path` | - | TEXT | — | 데이터 디렉토리 경로 (미지정 시 config_dir 기반) |
 | `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
@@ -1504,7 +1504,7 @@ ante data schema [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 디렉토리 경로 |
+| `--data-path` | - | TEXT | — | 데이터 디렉토리 경로 (미지정 시 config_dir 기반) |
 
 
 ### ante data storage
@@ -1522,7 +1522,7 @@ ante data storage [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 디렉토리 경로 |
+| `--data-path` | - | TEXT | — | 데이터 디렉토리 경로 (미지정 시 config_dir 기반) |
 
 
 ### ante data validate
@@ -1543,7 +1543,7 @@ ante data validate [OPTIONS]
 | `--symbol` | - | TEXT | — | 검증할 종목 코드 (미지정 시 전체) |
 | `--timeframe` | - | TEXT | 1d | 타임프레임 |
 | `--fix` | - | BOOLEAN | false | 손상 파일을 .corrupted로 이동 |
-| `--data-path` | - | TEXT | data/ | 데이터 디렉토리 경로 |
+| `--data-path` | - | TEXT | — | 데이터 디렉토리 경로 (미지정 시 config_dir 기반) |
 
 
 ---
@@ -1577,7 +1577,7 @@ ante backtest run <STRATEGY_PATH> --start <START> --end <END> [OPTIONS]
 | `--balance` | - | FLOAT | 10000000 | 초기 자금 |
 | `--timeframe` | - | TEXT | 1d | 타임프레임 |
 | `--exchange` | - | TEXT | KRX | 거래소 (기본: KRX) |
-| `--data-path` | - | TEXT | data/ | 데이터 디렉토리 경로 |
+| `--data-path` | - | TEXT | — | 데이터 디렉토리 경로 (미지정 시 config_dir 기반) |
 | `--db-path` | - | TEXT | — | DB 경로 (미지정 시 config_dir 기반) |
 
 
@@ -2595,7 +2595,7 @@ ante feed config set <KEY> <VALUE> [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 저장소 경로 |
+| `--data-path` | - | TEXT | — | 데이터 저장소 경로 (미지정 시 config_dir 기반) |
 
 
 ### ante feed config list
@@ -2613,7 +2613,7 @@ ante feed config list [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 저장소 경로 |
+| `--data-path` | - | TEXT | — | 데이터 저장소 경로 (미지정 시 config_dir 기반) |
 
 
 ### ante feed config check
@@ -2631,7 +2631,7 @@ ante feed config check [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 저장소 경로 |
+| `--data-path` | - | TEXT | — | 데이터 저장소 경로 (미지정 시 config_dir 기반) |
 
 
 ### ante feed run backfill
@@ -2649,7 +2649,7 @@ ante feed run backfill [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 저장소 경로 |
+| `--data-path` | - | TEXT | — | 데이터 저장소 경로 (미지정 시 config_dir 기반) |
 | `--since` | - | TEXT | — | 수집 시작일 (YYYY-MM-DD, config 기본값 오버라이드) |
 
 
@@ -2668,7 +2668,7 @@ ante feed run daily [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 저장소 경로 |
+| `--data-path` | - | TEXT | — | 데이터 저장소 경로 (미지정 시 config_dir 기반) |
 | `--date` | - | TEXT | — | 수집 대상일 (YYYY-MM-DD, 기본값: 어제) |
 
 
@@ -2687,7 +2687,7 @@ ante feed start [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 저장소 경로 |
+| `--data-path` | - | TEXT | — | 데이터 저장소 경로 (미지정 시 config_dir 기반) |
 
 
 ### ante feed init
@@ -2723,7 +2723,7 @@ ante feed status [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--data-path` | - | TEXT | data/ | 데이터 저장소 경로 |
+| `--data-path` | - | TEXT | — | 데이터 저장소 경로 (미지정 시 config_dir 기반) |
 
 
 ### ante feed inject
@@ -2750,7 +2750,7 @@ ante feed inject <PATH> --symbol <SYMBOL> [OPTIONS]
 | `--symbol` | O | TEXT | — | 종목 코드 (6자리) |
 | `--timeframe` | - | TEXT | 1d | 타임프레임 (기본값: 1d) |
 | `--source` | - | TEXT | external | 데이터 소스 식별자 |
-| `--data-path` | - | TEXT | data/ | 데이터 저장소 경로 |
+| `--data-path` | - | TEXT | — | 데이터 저장소 경로 (미지정 시 config_dir 기반) |
 
 
 ---

--- a/src/ante/cli/_data_path.py
+++ b/src/ante/cli/_data_path.py
@@ -1,0 +1,52 @@
+"""CLI `--data-path` resolver helper.
+
+Spec: docs/specs/config/03-design-decisions.md `Ante instance/path contract`
+(특히 `data.path` SSOT 행과 "명시적 CLI override는 작업 대상만 바꾸며 인스턴스
+경계 불변" 규약).
+
+이 helper는 CLI 커맨드들이 `--data-path` 옵션을 처리할 때 단일 경로 해석
+지점을 갖도록 한다:
+
+  * override 가 명시적으로 주어지면(``None`` 도 ``""`` 도 아님) 그 값을 그대로
+    반환한다. `resolve()`/`absolute()` 등으로 변형하지 않는다. 이는 사용자가
+    상대 경로를 의도적으로 넘겼을 때 그대로 사용할 수 있게 하고, 테스트가
+    임시 디렉토리 등을 그대로 주입할 수 있게 한다.
+  * override 가 없으면 ``Config.resolve_path("data.path", "data")`` 로
+    ``config_dir`` 기준 절대 경로를 만든 뒤, ``Path.resolve()`` 로 정규화하여
+    문자열로 반환한다. CWD 와 무관하게 server runtime / CLI 가 동일한
+    canonical data root 를 본다.
+
+helper 자체는 ``Config`` 로딩이 부수효과(예: secrets.env 의 fernet key 검증)를
+일으킬 수 있으므로, override 가 있을 때는 ``Config`` 로딩을 건너뛰어 불필요한
+부수효과를 피한다.
+"""
+
+from __future__ import annotations
+
+import click
+
+from ante.config.config import Config
+
+
+def resolve_data_path(ctx: click.Context | None, override: str | None) -> str:
+    """`--data-path` 옵션 값을 config-resolved data root 로 정합한다.
+
+    Args:
+        ctx: Click 컨텍스트. ``None`` 이면 현재 컨텍스트를 자동 조회한다
+            (`get_config_dir` 가 내부에서 처리).
+        override: 사용자가 명시한 `--data-path` 값. ``None`` 또는 빈 문자열이면
+            config-resolved default 로 폴백한다.
+
+    Returns:
+        - override 가 명시되면 그 값을 변형 없이 그대로 반환.
+        - 미명시이면 ``Config.resolve_path("data.path", "data").resolve()`` 의
+          문자열(절대 경로).
+    """
+    if override is not None and override != "":
+        return override
+    # Lazy import: ante.cli.main 은 본 모듈을 사용하는 commands 모듈을
+    # import 하므로 top-level import 로 두면 순환 import 가 된다.
+    from ante.cli.main import get_config_dir
+
+    cfg = Config.load(config_dir=get_config_dir(ctx))
+    return str(cfg.resolve_path("data.path", "data").resolve())

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from ante.cli._data_path import resolve_data_path
 from ante.cli._validators import validate_positive_finite_amount
 from ante.cli.main import get_formatter
 
@@ -34,7 +35,11 @@ def backtest() -> None:
 )
 @click.option("--timeframe", default="1d", help="타임프레임")
 @click.option("--exchange", default="KRX", help="거래소 (기본: KRX)")
-@click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.option(
+    "--data-path",
+    default=None,
+    help="데이터 디렉토리 경로 (미지정 시 config_dir 기반)",
+)
 @click.option("--db-path", default=None, help="DB 경로 (미지정 시 config_dir 기반)")
 @click.pass_context
 @require_auth
@@ -48,7 +53,7 @@ def run(
     balance: float,
     timeframe: str,
     exchange: str,
-    data_path: str,
+    data_path: str | None,
     db_path: str | None,
 ) -> None:
     """백테스트 실행."""
@@ -63,6 +68,7 @@ def run(
         is_valid_timeframe,
     )
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     resolved_db_path = db_path or get_db_path(ctx)
 

--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import click
 
+from ante.cli._data_path import resolve_data_path
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
@@ -26,7 +27,11 @@ def data() -> None:
 )
 @click.option("--offset", default=0, type=click.IntRange(min=0), help="조회 offset")
 @click.option("--limit", default=50, type=click.IntRange(min=1), help="조회 개수")
-@click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.option(
+    "--data-path",
+    default=None,
+    help="데이터 디렉토리 경로 (미지정 시 config_dir 기반)",
+)
 @click.option("--db-path", default=None, help="DB 경로 (미지정 시 config_dir 기반)")
 @format_option
 @click.pass_context
@@ -39,7 +44,7 @@ def data_list(
     data_type: str | None,
     offset: int,
     limit: int,
-    data_path: str,
+    data_path: str | None,
     db_path: str | None,
 ) -> None:
     """보유 데이터셋 목록."""
@@ -49,6 +54,7 @@ def data_list(
     from ante.data.datasets import list_datasets, validate_dataset_filters
     from ante.data.store import ParquetStore
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     store = ParquetStore(base_path=data_path)
     resolved_db_path = db_path or get_db_path(ctx)
@@ -110,16 +116,21 @@ def data_list(
 
 @data.command("info")
 @click.argument("dataset_id")
-@click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.option(
+    "--data-path",
+    default=None,
+    help="데이터 디렉토리 경로 (미지정 시 config_dir 기반)",
+)
 @format_option
 @click.pass_context
 @require_auth
 @require_scope("data:read")
-def data_info(ctx: click.Context, dataset_id: str, data_path: str) -> None:
+def data_info(ctx: click.Context, dataset_id: str, data_path: str | None) -> None:
     """데이터셋 상세 조회."""
     from ante.data.datasets import get_dataset_detail
     from ante.data.store import ParquetStore
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     store = ParquetStore(base_path=data_path)
     try:
@@ -169,7 +180,11 @@ def data_info(ctx: click.Context, dataset_id: str, data_path: str) -> None:
     default=False,
     help="삭제를 확인 (위험 명령). 누락 시 prompt 없이 에러로 실패",
 )
-@click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.option(
+    "--data-path",
+    default=None,
+    help="데이터 디렉토리 경로 (미지정 시 config_dir 기반)",
+)
 @format_option
 @click.pass_context
 @require_auth
@@ -179,12 +194,13 @@ def data_delete(
     dataset_id: str,
     data_type: str | None,
     yes: bool,
-    data_path: str,
+    data_path: str | None,
 ) -> None:
     """데이터셋 삭제."""
     from ante.data.datasets import delete_dataset, validate_dataset_filters
     from ante.data.store import ParquetStore
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     if not yes:
         fmt.error(
@@ -211,27 +227,37 @@ def data_delete(
 
 
 @data.command()
-@click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.option(
+    "--data-path",
+    default=None,
+    help="데이터 디렉토리 경로 (미지정 시 config_dir 기반)",
+)
 @click.pass_context
 @require_auth
 @require_scope("data:read")
-def schema(ctx: click.Context, data_path: str) -> None:
+def schema(ctx: click.Context, data_path: str | None) -> None:
     """데이터 스키마 조회."""
     from ante.data.schemas import OHLCV_SCHEMA
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     fmt.output({k: str(v) for k, v in OHLCV_SCHEMA.items()})
 
 
 @data.command()
-@click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.option(
+    "--data-path",
+    default=None,
+    help="데이터 디렉토리 경로 (미지정 시 config_dir 기반)",
+)
 @click.pass_context
 @require_auth
 @require_scope("data:read")
-def storage(ctx: click.Context, data_path: str) -> None:
+def storage(ctx: click.Context, data_path: str | None) -> None:
     """저장 용량 현황."""
     from ante.data.store import ParquetStore
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     store = ParquetStore(base_path=data_path)
     usage = store.get_storage_usage()
@@ -256,7 +282,11 @@ def storage(ctx: click.Context, data_path: str) -> None:
 @click.option(
     "--fix", is_flag=True, default=False, help="손상 파일을 .corrupted로 이동"
 )
-@click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.option(
+    "--data-path",
+    default=None,
+    help="데이터 디렉토리 경로 (미지정 시 config_dir 기반)",
+)
 @click.pass_context
 @require_auth
 @require_scope("data:read")
@@ -265,7 +295,7 @@ def validate(
     symbol: str | None,
     timeframe: str,
     fix: bool,
-    data_path: str,
+    data_path: str | None,
 ) -> None:
     """Parquet 파일 무결성 검증."""
 
@@ -276,6 +306,7 @@ def validate(
     )
     from ante.data.store import ParquetStore
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
 
     # 타임프레임/심볼 검증 (CLI 경계 단일 지점, #1613 SSOT helper 위임).

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -217,4 +217,4 @@ cli.add_command(system)  # type: ignore[has-type]
 cli.add_command(trade)  # type: ignore[has-type]
 cli.add_command(treasury)  # type: ignore[has-type]
 cli.add_command(update)  # type: ignore[has-type]
-cli.add_command(feed)
+cli.add_command(feed)  # type: ignore[has-type]

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import click
 
+from ante.cli._data_path import resolve_data_path
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 
@@ -50,8 +51,7 @@ def _validate_iso_date(value: str, option: str, fmt: object) -> None:
         raise SystemExit(1)
 
 
-_DEFAULT_DATA_PATH = "data/"
-_DATA_PATH_HELP = "데이터 저장소 경로"
+_DATA_PATH_HELP = "데이터 저장소 경로 (미지정 시 config_dir 기반)"
 _SCOPE_DATA_WRITE = "data:write"
 _SCOPE_DATA_READ = "data:read"
 _SEPARATOR = "──────────────────────────────────────────────────"
@@ -96,14 +96,15 @@ def feed_config() -> None:
 @feed_config.command("set")
 @click.argument("key")
 @click.argument("value")
-@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
+@click.option("--data-path", default=None, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
 @require_scope(_SCOPE_DATA_WRITE)
-def config_set(ctx: click.Context, key: str, value: str, data_path: str) -> None:
+def config_set(ctx: click.Context, key: str, value: str, data_path: str | None) -> None:
     """API 키를 .feed/.env 파일에 저장한다."""
     from ante.feed.config import API_KEYS, FeedConfig
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
 
     if key not in API_KEYS:
@@ -124,14 +125,15 @@ def config_set(ctx: click.Context, key: str, value: str, data_path: str) -> None
 
 
 @feed_config.command("list")
-@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
+@click.option("--data-path", default=None, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
 @require_scope(_SCOPE_DATA_READ)
-def config_list(ctx: click.Context, data_path: str) -> None:
+def config_list(ctx: click.Context, data_path: str | None) -> None:
     """등록된 API 키 목록을 마스킹하여 표시한다."""
     from ante.feed.config import FeedConfig
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
     keys = cfg.list_api_keys()
@@ -147,14 +149,15 @@ def config_list(ctx: click.Context, data_path: str) -> None:
 
 
 @feed_config.command("check")
-@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
+@click.option("--data-path", default=None, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
 @require_scope(_SCOPE_DATA_READ)
-def config_check(ctx: click.Context, data_path: str) -> None:
+def config_check(ctx: click.Context, data_path: str | None) -> None:
     """API 키 존재 여부를 확인한다."""
     from ante.feed.config import FeedConfig
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
     statuses = cfg.check_api_keys()
@@ -230,7 +233,7 @@ def _ensure_initialized(  # noqa: ANN001, ANN201
 
 
 @feed_run.command("backfill")
-@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
+@click.option("--data-path", default=None, help=_DATA_PATH_HELP)
 @click.option(
     "--since", default=None, help="수집 시작일 (YYYY-MM-DD, config 기본값 오버라이드)"
 )
@@ -239,7 +242,7 @@ def _ensure_initialized(  # noqa: ANN001, ANN201
 @require_scope(_SCOPE_DATA_WRITE)
 def run_backfill(
     ctx: click.Context,
-    data_path: str,
+    data_path: str | None,
     since: str | None,
 ) -> None:
     """과거 데이터를 1회 수집한다 (backfill)."""
@@ -254,6 +257,7 @@ def run_backfill(
         validate_backfill_since,
     )
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
 
@@ -311,7 +315,7 @@ def run_backfill(
 
 
 @feed_run.command("daily")
-@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
+@click.option("--data-path", default=None, help=_DATA_PATH_HELP)
 @click.option(
     "--date", "target_date", default=None, help="수집 대상일 (YYYY-MM-DD, 기본값: 어제)"
 )
@@ -320,7 +324,7 @@ def run_backfill(
 @require_scope(_SCOPE_DATA_WRITE)
 def run_daily(
     ctx: click.Context,
-    data_path: str,
+    data_path: str | None,
     target_date: str | None,
 ) -> None:
     """어제(또는 지정일) 데이터를 1회 수집한다 (daily)."""
@@ -330,6 +334,7 @@ def run_daily(
     from ante.feed.cli_output import format_daily_result
     from ante.feed.config import FeedConfig
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
 
@@ -377,17 +382,18 @@ def run_daily(
 
 
 @feed.command("start")
-@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
+@click.option("--data-path", default=None, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
 @require_scope(_SCOPE_DATA_WRITE)
-def feed_start(ctx: click.Context, data_path: str) -> None:
+def feed_start(ctx: click.Context, data_path: str | None) -> None:
     """내장 스케줄러로 backfill/daily를 자동 실행하는 상주 프로세스를 시작한다."""
     import asyncio
 
     from ante.feed.cli_scheduler import run_scheduler_loop
     from ante.feed.config import FeedConfig
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
 
@@ -423,14 +429,15 @@ def feed_start(ctx: click.Context, data_path: str) -> None:
 
 
 @feed.command("init")
-@click.argument("data_path", default=_DEFAULT_DATA_PATH)
+@click.argument("data_path", required=False, default=None)
 @click.pass_context
 @require_auth
 @require_scope(_SCOPE_DATA_WRITE)
-def feed_init(ctx: click.Context, data_path: str) -> None:
+def feed_init(ctx: click.Context, data_path: str | None) -> None:
     """DataFeed 운영 디렉토리를 초기화한다."""
     from ante.feed.config import FeedConfig
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
     created = cfg.init()
@@ -449,16 +456,17 @@ def feed_init(ctx: click.Context, data_path: str) -> None:
 
 
 @feed.command("status")
-@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
+@click.option("--data-path", default=None, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
 @require_scope(_SCOPE_DATA_READ)
-def feed_status(ctx: click.Context, data_path: str) -> None:
+def feed_status(ctx: click.Context, data_path: str | None) -> None:
     """수집 상태를 조회한다."""
 
     from ante.feed.config import FeedConfig
     from ante.feed.report.generator import ReportGenerator
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
 
@@ -612,7 +620,7 @@ def _load_latest_report(
 @click.option("--symbol", required=True, help="종목 코드 (6자리)")
 @click.option("--timeframe", default="1d", help="타임프레임 (기본값: 1d)")
 @click.option("--source", default="external", help="데이터 소스 식별자")
-@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
+@click.option("--data-path", default=None, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
 @require_scope(_SCOPE_DATA_WRITE)
@@ -622,7 +630,7 @@ def feed_inject(
     symbol: str,
     timeframe: str,
     source: str,
-    data_path: str,
+    data_path: str | None,
 ) -> None:
     """외부 CSV 파일에서 과거 데이터를 수동 주입한다."""
     from pathlib import Path as _Path
@@ -636,6 +644,7 @@ def feed_inject(
     from ante.data.store import ParquetStore
     from ante.feed.injector import FeedInjector
 
+    data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     filepath = _Path(path)
 

--- a/tests/unit/cli/test_data_path_callsites.py
+++ b/tests/unit/cli/test_data_path_callsites.py
@@ -1,0 +1,293 @@
+"""CLI `--data-path` 16 callsite 정합 회귀 테스트 (#1914).
+
+본 모듈은 다음 invariant 를 락한다:
+
+1. **config-resolved default**: ``--data-path`` 미지정 시 16 callsite 모두
+   ``resolve_data_path(ctx, None)`` 을 호출하여 ``Config.resolve_path(
+   "data.path", "data").resolve()`` 의 절대 경로를 사용해야 한다.
+2. **override invariant**: ``--data-path`` 명시 시 그 값이 변형 없이
+   downstream 까지 흘러야 한다 (option + positional).
+3. **positional 무인자**: ``ante feed init`` (positional 생략) 가 Click
+   error 없이 helper 로 fall through 되어 config-resolved default 를
+   사용해야 한다.
+
+Spec: docs/specs/config/03-design-decisions.md `Ante instance/path contract`
+(`data.path` SSOT 행).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """auth bypass 된 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx: object) -> None:
+                import click
+
+                ctx = click.get_current_context()
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """`[data] path = "canonical-data"` 가 설정된 config_dir.
+
+    ``ANTE_CONFIG_DIR`` 로 노출하여 모든 CLI 가 같은 config_dir 를 본다.
+    """
+    cfg_dir = tmp_path / "ante-cfg"
+    cfg_dir.mkdir()
+    (cfg_dir / "system.toml").write_text(
+        '[data]\npath = "canonical-data"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(cfg_dir))
+    return cfg_dir
+
+
+@pytest.fixture
+def expected_default_path(config_dir: Path) -> str:
+    """config-resolved default 의 기대값 (절대 경로 문자열)."""
+    return str((config_dir / "canonical-data").resolve())
+
+
+# ── ① 16 callsite census ─────────────────────────────────────────────────────
+
+
+# (cli_args, has_data_path_option, positional_supports_data_path)
+#
+# 16 callsite census:
+#   feed/cli.py        : 8 option + 1 positional (feed init) = 9
+#   cli/commands/data.py : 6 option = 6
+#   cli/commands/backtest.py : 1 option = 1
+#
+# 합계 = 16
+#
+# 각 callsite 가 ``resolve_data_path(ctx, override)`` 를 호출하는지 확인하기
+# 위해 helper 자체를 spy 로 patch 한 뒤 실제 호출 횟수와 인자를 검증한다.
+# CLI 가 helper 미호출 시 helper.call_count == 0 으로 즉시 발견된다.
+
+_OPTION_CALLSITES_DEFAULT = [
+    # feed/cli.py
+    pytest.param(
+        ["feed", "config", "set", "ANTE_DART_API_KEY", "xxx"],
+        id="feed_config_set",
+    ),
+    pytest.param(["feed", "config", "list"], id="feed_config_list"),
+    pytest.param(["feed", "config", "check"], id="feed_config_check"),
+    # cli/commands/data.py
+    pytest.param(["data", "list"], id="data_list"),
+    pytest.param(["data", "schema"], id="data_schema"),
+    pytest.param(["data", "storage"], id="data_storage"),
+]
+
+
+def _spy_helper(
+    captured: list[tuple[object, object]],
+    fallback_path: str,
+) -> object:
+    """`resolve_data_path` 호출 인자를 기록하는 spy.
+
+    실제 helper 가 ``Config.load`` 까지 들어가면 secrets/system.toml 부수효과가
+    생기므로, spy 는 helper 의 contract 와 동일하게 동작하되 ``Config.load`` 는
+    건너뛰는 stub 으로 대체한다. fallback_path 는 호출 측이 fs 작업을
+    수행하더라도 안전하도록 tmp 안의 유효한 절대 경로를 받는다.
+    """
+
+    def _spy(ctx, override):  # type: ignore[no-untyped-def]
+        captured.append((ctx, override))
+        if override is not None and override != "":
+            return override
+        return fallback_path
+
+    return _spy
+
+
+# ── ② config-resolved default: helper 가 None 으로 호출되는지 ────────────────
+
+
+class TestConfigResolvedDefault:
+    """``--data-path`` 미지정 시 모든 callsite 가 helper(ctx, None) 호출."""
+
+    @pytest.mark.parametrize("cli_args", _OPTION_CALLSITES_DEFAULT)
+    def test_option_callsite_uses_helper_for_default(
+        self,
+        runner: CliRunner,
+        config_dir: Path,
+        tmp_path: Path,
+        cli_args: list[str],
+    ) -> None:
+        captured: list[tuple[object, object]] = []
+        fallback = str(tmp_path / "fallback-data")
+        # callsite 별로 import 위치가 다르므로 source module 에 patch.
+        with (
+            patch(
+                "ante.feed.cli.resolve_data_path",
+                side_effect=_spy_helper(captured, fallback),
+            ),
+            patch(
+                "ante.cli.commands.data.resolve_data_path",
+                side_effect=_spy_helper(captured, fallback),
+            ),
+            patch(
+                "ante.cli.commands.backtest.resolve_data_path",
+                side_effect=_spy_helper(captured, fallback),
+            ),
+        ):
+            runner.invoke(cli, cli_args, catch_exceptions=False)
+        # callsite 가 helper 를 한 번 이상 호출했어야 한다.
+        assert len(captured) >= 1, f"helper 미호출. cli_args={cli_args}"
+        # 첫 호출은 ``--data-path`` 미지정이므로 override 가 None 이어야 한다.
+        _, override = captured[0]
+        assert override is None, (
+            f"callsite 가 helper 에 override=None 을 전달해야 한다. got: {override!r}"
+        )
+
+    def test_feed_init_positional_omitted_uses_helper(
+        self, runner: CliRunner, config_dir: Path, tmp_path: Path
+    ) -> None:
+        """`ante feed init` (positional 생략) 는 Click error 없이 helper 호출."""
+        captured: list[tuple[object, object]] = []
+        fallback = str(tmp_path / "fallback-data")
+        with patch(
+            "ante.feed.cli.resolve_data_path",
+            side_effect=_spy_helper(captured, fallback),
+        ):
+            result = runner.invoke(cli, ["feed", "init"], catch_exceptions=False)
+        # Click 이 ``Missing argument`` 로 reject 하면 exit_code == 2.
+        assert result.exit_code != 2, (
+            f"`feed init` 무인자 호출이 Click 에러로 거부됨. output={result.output}"
+        )
+        assert len(captured) >= 1, "helper 미호출."
+        _, override = captured[0]
+        assert override is None
+
+
+# ── ③ override invariant: option + positional ────────────────────────────────
+
+
+class TestOverrideInvariant:
+    """``--data-path /custom`` (option) 과 ``feed init /custom`` (positional)
+    모두 override 값을 그대로 helper 에 넘겨야 한다.
+    """
+
+    def test_feed_config_check_data_path_option_preserved(
+        self,
+        runner: CliRunner,
+        config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        captured: list[tuple[object, object]] = []
+        custom = str(tmp_path / "my-custom-data")
+        fallback = str(tmp_path / "unused-fallback")
+        with patch(
+            "ante.feed.cli.resolve_data_path",
+            side_effect=_spy_helper(captured, fallback),
+        ):
+            runner.invoke(
+                cli,
+                ["feed", "config", "check", "--data-path", custom],
+                catch_exceptions=False,
+            )
+        assert len(captured) >= 1
+        _, override = captured[0]
+        assert override == custom, (
+            f"--data-path override 가 helper 에 그대로 전달되어야 한다. "
+            f"got={override!r}"
+        )
+
+    def test_data_list_data_path_option_preserved(
+        self,
+        runner: CliRunner,
+        config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        captured: list[tuple[object, object]] = []
+        custom = str(tmp_path / "my-custom-data")
+        fallback = str(tmp_path / "unused-fallback")
+        with patch(
+            "ante.cli.commands.data.resolve_data_path",
+            side_effect=_spy_helper(captured, fallback),
+        ):
+            runner.invoke(
+                cli,
+                ["data", "list", "--data-path", custom],
+                catch_exceptions=False,
+            )
+        assert len(captured) >= 1
+        _, override = captured[0]
+        assert override == custom
+
+    def test_feed_init_positional_preserved(
+        self,
+        runner: CliRunner,
+        config_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        """`ante feed init /custom/path` positional 값이 그대로 흐른다."""
+        captured: list[tuple[object, object]] = []
+        custom = str(tmp_path / "my-positional-data")
+        fallback = str(tmp_path / "unused-fallback")
+        with patch(
+            "ante.feed.cli.resolve_data_path",
+            side_effect=_spy_helper(captured, fallback),
+        ):
+            runner.invoke(cli, ["feed", "init", custom], catch_exceptions=False)
+        assert len(captured) >= 1
+        _, override = captured[0]
+        assert override == custom
+
+
+# ── ④ 통합: ANTE_CONFIG_DIR 기반 실제 helper 동작 ────────────────────────────
+
+
+class TestRealHelperWithConfigDir:
+    """spy 없이 실제 helper 가 ``ANTE_CONFIG_DIR`` 기반 절대 경로를 반환."""
+
+    def test_data_schema_with_real_config_dir(
+        self,
+        runner: CliRunner,
+        config_dir: Path,
+        expected_default_path: str,
+    ) -> None:
+        """``data schema`` 는 data_path 를 사용하진 않지만 helper resolve 후
+        절대 경로를 통과시키는지 통합 확인.
+        """
+        # 본 테스트의 핵심은 helper 가 ANTE_CONFIG_DIR 을 읽어 절대 경로를
+        # 반환하는지이다. ``ante.cli._data_path.resolve_data_path`` 를 직접
+        # 호출하여 확인한다.
+        from ante.cli._data_path import resolve_data_path
+
+        result = resolve_data_path(None, None)
+        assert result == expected_default_path

--- a/tests/unit/cli/test_data_path_helper.py
+++ b/tests/unit/cli/test_data_path_helper.py
@@ -1,0 +1,168 @@
+"""`ante.cli._data_path.resolve_data_path` helper 단위 테스트 (#1914).
+
+Spec: docs/specs/config/03-design-decisions.md `Ante instance/path contract`
+(특히 `data.path` SSOT 행과 "명시적 CLI override는 작업 대상만 바꾸며 인스턴스
+경계 불변" 규약).
+
+본 helper 가 보장해야 하는 invariant:
+
+1. override 가 명시되면 반환값은 override 와 1:1 동일 (변형 금지).
+2. override 가 ``None`` 또는 ``""`` 이면 ``Config.resolve_path("data.path",
+   "data").resolve()`` 의 문자열을 반환.
+3. config_dir 이 cwd-상대(예: ``./config``) 여도 반환값은 항상 절대 경로.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from ante.cli._data_path import resolve_data_path
+
+
+@pytest.fixture
+def config_dir_with_data(tmp_path: Path) -> Path:
+    """`[data] path = "canonical-data"` 가 적힌 `system.toml` 을 가진 config_dir."""
+    cfg_dir = tmp_path / "ante-cfg"
+    cfg_dir.mkdir()
+    (cfg_dir / "system.toml").write_text(
+        '[data]\npath = "canonical-data"\n',
+        encoding="utf-8",
+    )
+    return cfg_dir
+
+
+@pytest.fixture
+def config_dir_default(tmp_path: Path) -> Path:
+    """`data.path` 가 명시되지 않은 빈 config_dir.
+
+    이 경우 helper 는 default fallback ``"data"`` 를 사용해야 한다.
+    """
+    cfg_dir = tmp_path / "ante-cfg-empty"
+    cfg_dir.mkdir()
+    (cfg_dir / "system.toml").write_text("", encoding="utf-8")
+    return cfg_dir
+
+
+@pytest.fixture
+def env_config_dir(monkeypatch: pytest.MonkeyPatch) -> object:
+    """`ANTE_CONFIG_DIR` 를 monkeypatch 로 설정하는 callable fixture."""
+
+    def _set(p: Path) -> None:
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(p))
+
+    return _set
+
+
+# ── override invariant ───────────────────────────────────────────────────────
+
+
+class TestOverrideInvariant:
+    """override 가 명시되면 그 값을 변형 없이 그대로 반환해야 한다."""
+
+    def test_relative_override_preserved(self) -> None:
+        # 상대 경로를 그대로 반환해야 한다 (절대화 금지).
+        result = resolve_data_path(None, "./custom-data")
+        assert result == "./custom-data"
+
+    def test_absolute_override_preserved(self, tmp_path: Path) -> None:
+        target = str(tmp_path / "custom" / "data")
+        result = resolve_data_path(None, target)
+        assert result == target
+
+    def test_override_with_trailing_slash_preserved(self) -> None:
+        # `data/` 같은 trailing slash 도 유지되어야 한다.
+        result = resolve_data_path(None, "custom-data/")
+        assert result == "custom-data/"
+
+
+# ── config-resolved default ──────────────────────────────────────────────────
+
+
+class TestConfigResolvedDefault:
+    """override 미명시 시 ``Config.resolve_path("data.path", "data")`` 사용."""
+
+    def test_uses_data_path_from_system_toml(
+        self,
+        config_dir_with_data: Path,
+        env_config_dir: object,
+    ) -> None:
+        env_config_dir(config_dir_with_data)  # type: ignore[operator]
+        result = resolve_data_path(None, None)
+        expected = (config_dir_with_data / "canonical-data").resolve()
+        assert result == str(expected)
+
+    def test_empty_string_override_falls_back_to_config(
+        self,
+        config_dir_with_data: Path,
+        env_config_dir: object,
+    ) -> None:
+        env_config_dir(config_dir_with_data)  # type: ignore[operator]
+        # 빈 문자열은 명시적 override 가 아니라 미지정과 동일하게 처리.
+        result = resolve_data_path(None, "")
+        expected = (config_dir_with_data / "canonical-data").resolve()
+        assert result == str(expected)
+
+    def test_default_fallback_when_data_path_missing(
+        self,
+        config_dir_default: Path,
+        env_config_dir: object,
+    ) -> None:
+        # `[data] path` 가 system.toml 에 없으면 ``"data"`` fallback.
+        env_config_dir(config_dir_default)  # type: ignore[operator]
+        result = resolve_data_path(None, None)
+        expected = (config_dir_default / "data").resolve()
+        assert result == str(expected)
+
+
+# ── 절대경로 보장 ────────────────────────────────────────────────────────────
+
+
+class TestAbsoluteResolve:
+    """``.resolve()`` 가 항상 적용되어 cwd 와 무관하게 절대 경로를 반환한다."""
+
+    def test_returns_absolute_path(
+        self,
+        config_dir_with_data: Path,
+        env_config_dir: object,
+    ) -> None:
+        env_config_dir(config_dir_with_data)  # type: ignore[operator]
+        result = resolve_data_path(None, None)
+        assert Path(result).is_absolute(), (
+            f"helper 반환값은 절대 경로여야 한다. got: {result}"
+        )
+
+    def test_resolved_path_independent_of_cwd(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """config_dir 이 cwd-상대 ``"."`` 인 케이스에서도 결과는 절대.
+
+        Config(`config_dir=Path(".")`) 처럼 직접 생성된 객체는 `_config_dir`
+        이 cwd 상대일 수 있다. helper 는 `.resolve()` 로 정규화해야 한다.
+        """
+        from ante.config.config import Config
+
+        # 임시 cwd 안에서 동작.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "system.toml").write_text(
+            '[data]\npath = "rel-data"\n',
+            encoding="utf-8",
+        )
+        cfg = Config.load(config_dir=Path("."))
+        resolved = cfg.resolve_path("data.path", "data").resolve()
+        # `.resolve()` 결과는 항상 절대.
+        assert resolved.is_absolute()
+        assert str(resolved) == str((tmp_path / "rel-data").resolve())
+        # cwd 가 바뀌어도 동일 instance 의 resolved 는 같은 절대 경로를 유지해야
+        # 한다 (sanity).
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        os.chdir(sub)
+        try:
+            assert resolved.is_absolute()
+        finally:
+            os.chdir(tmp_path)

--- a/tests/unit/contracts/factory_drift_allowlist.yaml
+++ b/tests/unit/contracts/factory_drift_allowlist.yaml
@@ -54,15 +54,15 @@ direct_database_construction:
   # bar 와 함께 장시간 작업) 이고, `backtest history` 는 `offline` 이지만
   # #1857 잔여로 본 사이클에서 마이그레이션 보류.
   - path: src/ante/cli/commands/backtest.py
-    line: 206
+    line: 212
     reason: "backtest run — long_running (progress-bar driven, deferred migration)"
   - path: src/ante/cli/commands/backtest.py
-    line: 249
+    line: 255
     reason: "backtest history — offline (deferred migration, post-#1818 follow-up)"
 
   # data domain — `data list` callsite. #1857 잔여로 본 사이클에서 보류.
   - path: src/ante/cli/commands/data.py
-    line: 82
+    line: 88
     reason: "data list — offline (deferred migration, post-#1818 follow-up)"
 
   # init — root-level `ante init` bootstrap command. CLI registry 의


### PR DESCRIPTION
Closes #1914

## Summary
`--data-path`를 생략한 CLI 호출이 cwd 기준 `data/` 대신 SSOT인 config-resolved `data.path`를 사용하도록 정합. `system.toml` `[data] path = "canonical-data"`로 설정하면 `<config_dir>/canonical-data`가 자동 사용됨.

### Helper (single chokepoint)
- `src/ante/cli/_data_path.py:resolve_data_path(ctx, override)`:
  - override 있으면 그대로 반환 (CLI override invariant)
  - 없으면 `Config.load(get_config_dir(ctx)).resolve_path("data.path", "data").resolve()` 반환 (절대 경로 보장)

### 16 callsite 정합
- `src/ante/feed/cli.py` 9곳 (8 option + 1 positional `feed init`)
  - positional은 `@click.argument("data_path", required=False, default=None)` (무인자 `ante feed init` 호출 보존)
- `src/ante/cli/commands/data.py` 6곳
- `src/ante/cli/commands/backtest.py` 1곳

### 부수 변경
- `_DEFAULT_DATA_PATH = "data/"` 상수 제거
- `src/ante/cli/main.py:220` `cli.add_command(feed)`에 `# type: ignore[has-type]` 추가 (순환 import 회피 — sibling 패턴과 정합)
- `tests/unit/contracts/factory_drift_allowlist.yaml` 라인 번호 시프트
- `guide/cli.md` 재생성 (15 `--data-path` default 표시 `data/` → `—`)

## Bounded Scope (Non-Goals)
- `--db-path` 등 다른 path option
- `parquet.base_path` legacy alias 제거
- 서버 lifecycle 경로
- `data.path`를 DEFAULTS에 등록

## Test Plan
- `tests/unit/cli/test_data_path_helper.py`: 8 helper 단위테스트 (override invariant, config-resolved default, .resolve() 절대경로)
- `tests/unit/cli/test_data_path_callsites.py`: 11 callsite spy 검증 (default·override·positional 무인자)
- 전체 회귀: `pytest tests/unit/ -x -q` 5611 passed
- ruff/mypy clean

## Review
- Plan Preflight v1→v4: Codex revise-plan 3회 (v1 .resolve()/positional/16번째 callsite → v2 internal inconsistency → v3 positional default=None required 추론 → v4 approve)
- Codex 브랜치 review r1 FAIL (pre-#1913 base false positive) → rebase 후 r2 PASS