### PR TITLE
fix(member): #1915 emoji/master-protect 오류를 typed exception으로 정합

### DIFF
--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -54,6 +54,20 @@ Non-Goals).
 - ``MemberInvalidRecoveryCredentialError`` →
   ``MEMBER_INVALID_RECOVERY_CREDENTIAL`` / ``auth`` (#1826)
 
+#1915 member domain 2 sub-class 추가 (실측 ``.code`` mirror, #1843 sub-PR 1
+1:1 미러):
+
+- ``MemberInvalidEmojiError`` → ``MEMBER_INVALID_EMOJI`` / ``validation``
+  (#1915; ``_validate_emoji_format`` 형식 거부 — CLI ``set-emoji`` /
+  ``register`` / master bootstrap 표면. ``ValueError`` 다중상속으로 기존
+  generic fallback 회귀 없음.)
+- ``MemberMasterProtectedError`` → ``MEMBER_MASTER_PROTECTED`` /
+  ``permission`` (#1915; ``_assert_not_master`` 호출 — CLI ``suspend`` /
+  ``revoke`` 표면. ``PermissionDeniedError`` (비-master 의 master-only
+  operation 시도) 와 의미 분리 — master 본인을 대상으로 한 파괴적
+  operation 거부. ``PermissionError`` 다중상속으로 기존 generic fallback
+  회귀 없음.)
+
 ``MemberError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
 ``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
 ``AccountError`` 와 동일 패턴, #1843 sub-PR 1 Non-Goals).
@@ -225,7 +239,9 @@ from ante.config.exceptions import ConfigValidationError
 from ante.contracts.errors import ErrorSpec
 from ante.member.errors import (
     MemberAlreadyExistsError,
+    MemberInvalidEmojiError,
     MemberInvalidRecoveryCredentialError,
+    MemberMasterProtectedError,
     MemberNotFoundError,
     MemberStateConflictError,
     PermissionDeniedError,
@@ -380,6 +396,28 @@ _MEMBER_ALREADY_EXISTS_SPEC: Final[ErrorSpec] = ErrorSpec(
 _MEMBER_INVALID_RECOVERY_CREDENTIAL_SPEC: Final[ErrorSpec] = ErrorSpec(
     code="MEMBER_INVALID_RECOVERY_CREDENTIAL",
     category="auth",
+)
+
+
+# ── member #1915: emoji 형식 / master 보호 typed exception lock ──────────────
+
+# emoji 형식 거부 (``_validate_emoji_format`` — 단일 이모지 외 입력)
+# 는 입력 계약 위반이므로 taxonomy ``validation`` 카테고리. CLI
+# ``set-emoji`` / ``register`` / master bootstrap 표면이 동일 안정 코드
+# ``MEMBER_INVALID_EMOJI`` 를 surface 한다.
+_MEMBER_INVALID_EMOJI_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="MEMBER_INVALID_EMOJI",
+    category="validation",
+)
+
+# master 보호 위반 (``_assert_not_master`` — master 본인을 대상으로 한
+# suspend / revoke 거부) 는 권한 정책 거부이므로 taxonomy ``permission``
+# 카테고리. ``PERMISSION_DENIED`` (비-master 의 master-only operation 시도)
+# 와 의미 분리 — 본 코드는 master 본인을 대상으로 한 파괴적 operation
+# 거부를 의미한다.
+_MEMBER_MASTER_PROTECTED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="MEMBER_MASTER_PROTECTED",
+    category="permission",
 )
 
 
@@ -707,6 +745,9 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     MemberStateConflictError: _MEMBER_STATE_CONFLICT_SPEC,
     MemberAlreadyExistsError: _MEMBER_ALREADY_EXISTS_SPEC,
     MemberInvalidRecoveryCredentialError: _MEMBER_INVALID_RECOVERY_CREDENTIAL_SPEC,
+    # ── #1915 member 2 sub-class (emoji 형식 / master 보호) ───────────────
+    MemberInvalidEmojiError: _MEMBER_INVALID_EMOJI_SPEC,
+    MemberMasterProtectedError: _MEMBER_MASTER_PROTECTED_SPEC,
     # ── #1843 sub-PR 2 approval 2 sub-class (실측 .code mirror) ───────────
     ApprovalStatusConflictError: _APPROVAL_STATUS_CONFLICT_SPEC,
     ApprovalValidationError: _APPROVAL_VALIDATION_ERROR_SPEC,

--- a/src/ante/member/errors.py
+++ b/src/ante/member/errors.py
@@ -21,6 +21,19 @@ credential validation 거부를 typed exception 으로 좁힌다. CLI envelope
 안정 코드를 surface 한다. ``ValueError`` 다중상속으로 #1805 패턴 1:1
 미러 — 기존 ``except (ValueError, PermissionError)`` fallback 분기가
 회귀 없이 동일하게 잡히도록 한다.
+
+Refs #1915: ``MemberInvalidEmojiError`` 와 ``MemberMasterProtectedError`` 를
+신규 도입해 emoji 형식 검증 거부 (``_validate_emoji_format``) 와 master
+보호 위반 (``_assert_not_master``) 을 typed exception 으로 좁힌다. CLI
+envelope 이 각각 ``"MEMBER_INVALID_EMOJI"`` / ``"MEMBER_MASTER_PROTECTED"``
+안정 코드를 surface 한다. ``ValueError`` / ``PermissionError`` 다중상속
+으로 #1805/#1807 패턴 1:1 미러 — 기존 ``except (ValueError,
+PermissionError)`` generic fallback 분기 (CLI ``set-emoji`` /
+``suspend`` / ``revoke``) 가 회귀 없이 동일하게 잡히도록 한다.
+emoji 중복 (``_validate_emoji_unique``) 와 타입-역할 invariant
+(``_assert_type_role``) 는 본 PR scope 외로 보존된다 — 이슈 #1915
+본문은 ``MEMBER_INVALID_EMOJI`` (형식 거부) / ``MEMBER_MASTER_PROTECTED``
+(master 보호) 두 표면만 명시한다.
 """
 
 
@@ -177,3 +190,60 @@ class MemberInvalidRecoveryCredentialError(MemberError, ValueError, PermissionEr
 
     def __init__(self, message: str) -> None:
         super().__init__(message)
+
+
+class MemberInvalidEmojiError(MemberError, ValueError):
+    """emoji 형식 검증 거부 (#1915).
+
+    ``MemberService._validate_emoji_format`` 이 단일 이모지가 아닌 입력을
+    받았을 때 raise 한다. 빈 문자열은 허용되며, 그 외 입력은 ``emoji_pkg``
+    (``_is_single_emoji``) 가 단일 이모지로 인식하는 문자열만 통과한다.
+
+    ``MemberError`` 와 ``ValueError`` 다중상속으로 둔다 — #1807
+    ``MemberAlreadyExistsError`` 패턴 1:1 미러. 기존 caller (CLI
+    ``set-emoji`` 의 ``except ValueError`` generic fallback, ``test_member.py:
+    602/606`` 의 ``pytest.raises(ValueError, match="단일 이모지만")`` 단언)
+    가 회귀 없이 동일하게 잡히도록 한다. ``emit_cli_error`` registry-first
+    lookup 이 본 typed exception 을 받아 안정 코드를 surface 한다 (Python
+    MRO 보장).
+
+    ``_validate_emoji_unique`` (emoji 중복 거부) 는 본 PR scope 외 — 이슈
+    #1915 본문은 형식 거부 표면만 명시. ``register`` / ``bootstrap_master``
+    가 호출하는 형식 검증도 동일 typed exception 으로 자동 정렬된다.
+
+    클래스 레벨 ``code`` 속성은 CLI/IPC envelope 이 안정 코드
+    ``"MEMBER_INVALID_EMOJI"`` 로 surface 하도록 한다.
+    """
+
+    code: str = "MEMBER_INVALID_EMOJI"
+
+
+class MemberMasterProtectedError(MemberError, PermissionError):
+    """master 보호 위반 (#1915).
+
+    ``MemberService._assert_not_master`` 가 master role 멤버에 대한
+    ``suspend`` / ``revoke`` 요청을 거부할 때 raise 한다. master 보호 동작
+    자체는 그대로 유지되며, raise 타입만 typed exception 으로 좁힌다.
+
+    ``MemberError`` 와 ``PermissionError`` 다중상속으로 둔다 — 기존 caller
+    (CLI ``suspend`` / ``revoke`` 의 ``except (ValueError, PermissionError)``
+    generic fallback, ``test_member_service_master_guard.py:239/245`` 의
+    ``pytest.raises(PermissionError, match="master는 ...")`` 단언) 가 회귀
+    없이 동일하게 잡히도록 한다. ``emit_cli_error`` registry-first lookup
+    이 본 typed exception 을 받아 안정 코드를 surface 한다 (Python MRO 보장).
+
+    ``_assert_type_role`` (타입-역할 invariant 거부) 는 본 PR scope 외 —
+    이슈 #1915 본문은 master 보호 표면만 명시.
+
+    ``PermissionDeniedError`` 와의 분리: ``PermissionDeniedError`` 는 비-master
+    호출자의 master-only operation 시도 (``@require_master`` decorator) 를 의미
+    하는 반면, 본 ``MemberMasterProtectedError`` 는 master 본인을 대상으로 한
+    파괴적 operation (suspend / revoke) 거부를 의미한다. 두 fault 의 의미적
+    분리를 envelope 안정 코드로도 분리한다 (``PERMISSION_DENIED`` vs
+    ``MEMBER_MASTER_PROTECTED``).
+
+    클래스 레벨 ``code`` 속성은 CLI/IPC envelope 이 안정 코드
+    ``"MEMBER_MASTER_PROTECTED"`` 로 surface 하도록 한다.
+    """
+
+    code: str = "MEMBER_MASTER_PROTECTED"

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -255,8 +255,16 @@ class MemberService:
         if not emoji:
             return
         if not _is_single_emoji(emoji):
+            # #1915: emoji 형식 거부는 typed ``MemberInvalidEmojiError``
+            # (.code=MEMBER_INVALID_EMOJI) 로 raise 해 CLI envelope 에 안정
+            # 코드 surface. ``ValueError`` 다중상속이라 기존 ``except
+            # ValueError`` (CLI ``set-emoji`` generic fallback, ``test_member.
+            # py:602/606`` 의 ``pytest.raises(ValueError, match=...)``) 가
+            # 회귀 없이 동일하게 잡힌다.
+            from ante.member.errors import MemberInvalidEmojiError
+
             msg = "emoji는 단일 이모지만 허용됩니다"
-            raise ValueError(msg)
+            raise MemberInvalidEmojiError(msg)
 
     async def update_emoji(
         self, member_id: str, emoji: str, updated_by: str = ""
@@ -876,8 +884,17 @@ class MemberService:
     def _assert_not_master(member: Member, action: str) -> None:
         """master 보호."""
         if member.role == MemberRole.MASTER:
+            # #1915: master 보호 위반은 typed ``MemberMasterProtectedError``
+            # (.code=MEMBER_MASTER_PROTECTED) 로 raise 해 CLI envelope 에
+            # 안정 코드 surface. ``PermissionError`` 다중상속이라 기존
+            # ``except PermissionError`` (CLI ``suspend``/``revoke`` generic
+            # fallback, ``test_member_service_master_guard.py:239/245`` 의
+            # ``pytest.raises(PermissionError, match="master는 ...")``) 가
+            # 회귀 없이 동일하게 잡힌다.
+            from ante.member.errors import MemberMasterProtectedError
+
             msg = f"master는 {action}할 수 없습니다"
-            raise PermissionError(msg)
+            raise MemberMasterProtectedError(msg)
 
     @staticmethod
     def _assert_active(member: Member, action: str) -> None:

--- a/tests/unit/test_member_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_member_cli_ipc_error_equivalence.py
@@ -49,7 +49,9 @@ from ante.ipc.registry import CommandRegistry, register_all_handlers
 from ante.ipc.server import IPCServer
 from ante.member.errors import (
     MemberAlreadyExistsError,
+    MemberInvalidEmojiError,
     MemberInvalidRecoveryCredentialError,
+    MemberMasterProtectedError,
     MemberNotFoundError,
     MemberStateConflictError,
     PermissionDeniedError,
@@ -481,3 +483,131 @@ class TestMemberPermissionDeniedEquivalence:
         # server.py:322 ``getattr(e, "code", ...)`` 와 helper ``ipc_error_payload``
         # 가 동일 코드를 produce 함을 verify (CLI/IPC contract 동등성).
         assert _ipc_envelope_code(exc) == "PERMISSION_DENIED"
+
+
+# ── (7) MemberInvalidEmojiError ↔ MEMBER_INVALID_EMOJI (#1915 set-emoji) ────
+
+
+class TestMemberInvalidEmojiEquivalence:
+    """``MemberInvalidEmojiError`` 는 양쪽에서 ``MEMBER_INVALID_EMOJI``.
+
+    CLI direct path: ``member set-emoji`` 표면 — ``except ValueError as e:
+    emit_cli_error(fmt, e)`` generic fallback 이 ``error_spec_for_exception``
+    의 registry-first lookup 으로 typed code 를 surface 한다. typed exception
+    이 ``ValueError`` 다중상속이라 기존 caller (test_member.py:602/606 의
+    ``pytest.raises(ValueError, match=...)``) 도 회귀 없이 동일하게 잡힌다.
+
+    이전 (#1915 이전): ``_validate_emoji_format`` 이 단순 ``ValueError`` 를
+    raise → ``emit_cli_error`` 가 ``.code`` 속성 부재로 ``EXECUTION_ERROR``
+    로 fallback → envelope code 가 ``EXECUTION_ERROR`` 로 surface 되었다.
+    #1915 가 typed exception 도입으로 안정 코드를 surface 한다.
+    """
+
+    def test_cli_direct_invalid_emoji_via_set_emoji(self, runner: CliRunner) -> None:
+        exc = MemberInvalidEmojiError("emoji는 단일 이모지만 허용됩니다")
+        svc = AsyncMock()
+        svc.update_emoji.side_effect = exc
+
+        @asynccontextmanager
+        async def _create_service(ctx=None):  # noqa: ANN202
+            yield svc
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "member", "set-emoji", "owner", "x"],
+            )
+
+        assert result.exit_code != 0, result.output
+        # traceback 누설 금지 — CLI exit 1 + JSON envelope 만 surface.
+        assert "Traceback" not in result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "MEMBER_INVALID_EMOJI"
+
+    def test_ipc_envelope_invalid_emoji(self) -> None:
+        exc = MemberInvalidEmojiError("emoji는 단일 이모지만 허용됩니다")
+        assert _ipc_envelope_code(exc) == "MEMBER_INVALID_EMOJI"
+
+
+# ── (8) MemberMasterProtectedError ↔ MEMBER_MASTER_PROTECTED (#1915 suspend/revoke)
+
+
+class TestMemberMasterProtectedEquivalence:
+    """``MemberMasterProtectedError`` 는 양쪽에서 ``MEMBER_MASTER_PROTECTED``.
+
+    CLI direct path: ``member suspend`` / ``member revoke`` 표면 — ``except
+    (ValueError, PermissionError) as e: emit_cli_error(fmt, e)`` generic
+    fallback 이 ``error_spec_for_exception`` 의 registry-first lookup 으로
+    typed code 를 surface 한다. typed exception 이 ``PermissionError``
+    다중상속이라 기존 caller (test_member_service_master_guard.py:239/245
+    의 ``pytest.raises(PermissionError, match="master는 ...")``) 도 회귀
+    없이 동일하게 잡힌다.
+
+    ``PermissionDeniedError`` (#1843 sub-PR 1) 와 의미 분리:
+
+    - ``PermissionDeniedError`` (``PERMISSION_DENIED``): 비-master 호출자의
+      master-only operation 시도 (``@require_master`` decorator surface).
+    - ``MemberMasterProtectedError`` (``MEMBER_MASTER_PROTECTED``): master
+      본인을 대상으로 한 파괴적 operation (suspend / revoke) 거부 — 호출자
+      권한이 master 라도 거부된다.
+
+    이전 (#1915 이전): ``_assert_not_master`` 가 단순 ``PermissionError`` 를
+    raise → ``emit_cli_error`` 가 ``.code`` 속성 부재로 ``EXECUTION_ERROR``
+    fallback. #1915 가 typed exception 도입으로 안정 코드 surface.
+    """
+
+    def test_cli_direct_master_protected_via_suspend(self, runner: CliRunner) -> None:
+        exc = MemberMasterProtectedError("master는 suspend할 수 없습니다")
+        svc = AsyncMock()
+        svc.suspend.side_effect = exc
+
+        @asynccontextmanager
+        async def _create_service(ctx=None):  # noqa: ANN202
+            yield svc
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "member", "suspend", "owner"],
+            )
+
+        assert result.exit_code != 0, result.output
+        assert "Traceback" not in result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "MEMBER_MASTER_PROTECTED"
+
+    def test_cli_direct_master_protected_via_revoke(self, runner: CliRunner) -> None:
+        exc = MemberMasterProtectedError("master는 revoke할 수 없습니다")
+        svc = AsyncMock()
+        svc.revoke.side_effect = exc
+
+        @asynccontextmanager
+        async def _create_service(ctx=None):  # noqa: ANN202
+            yield svc
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=_create_service,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "member", "revoke", "owner", "--yes"],
+            )
+
+        assert result.exit_code != 0, result.output
+        assert "Traceback" not in result.output
+        payload = _cli_envelope_payload(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "MEMBER_MASTER_PROTECTED"
+
+    def test_ipc_envelope_master_protected(self) -> None:
+        exc = MemberMasterProtectedError("master는 suspend할 수 없습니다")
+        assert _ipc_envelope_code(exc) == "MEMBER_MASTER_PROTECTED"

--- a/tests/unit/test_member_service_master_guard.py
+++ b/tests/unit/test_member_service_master_guard.py
@@ -15,7 +15,11 @@ import pytest
 
 from ante.core.database import Database
 from ante.eventbus import EventBus
-from ante.member.errors import PermissionDeniedError
+from ante.member.errors import (
+    MemberInvalidEmojiError,
+    MemberMasterProtectedError,
+    PermissionDeniedError,
+)
 from ante.member.models import MemberStatus, MemberType
 from ante.member.service import MemberService
 
@@ -244,3 +248,69 @@ class TestMasterCallerOnMasterTarget:
     ) -> None:
         with pytest.raises(PermissionError, match="master는 revoke"):
             await populated_service.revoke("owner", revoked_by="owner")
+
+
+# ── #1915 typed exception lock ────────────────────────────────────────────
+
+
+class TestMemberMasterProtectedTypedException:
+    """#1915: master 보호 위반은 typed ``MemberMasterProtectedError`` raise.
+
+    이전 (#1915 이전): ``_assert_not_master`` 가 단순 ``PermissionError`` 를
+    raise → CLI envelope 이 ``EXECUTION_ERROR`` 로 fallback.
+    #1915 가 typed exception 으로 좁혀 안정 코드
+    ``MEMBER_MASTER_PROTECTED`` 를 surface 한다.
+
+    ``PermissionError`` 다중상속이라 기존 ``pytest.raises(PermissionError)``
+    회귀 lock (상기 ``TestMasterCallerOnMasterTarget``) 은 그대로 통과한다.
+    """
+
+    async def test_suspend_master_raises_typed_exception(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(MemberMasterProtectedError, match="master는 suspend"):
+            await populated_service.suspend("owner", suspended_by="owner")
+
+    async def test_revoke_master_raises_typed_exception(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(MemberMasterProtectedError, match="master는 revoke"):
+            await populated_service.revoke("owner", revoked_by="owner")
+
+    async def test_typed_exception_has_stable_code(
+        self, populated_service: MemberService
+    ) -> None:
+        """typed exception 의 class-level ``.code`` 는 안정 코드 그대로."""
+        with pytest.raises(MemberMasterProtectedError) as excinfo:
+            await populated_service.suspend("owner", suspended_by="owner")
+        assert excinfo.value.code == "MEMBER_MASTER_PROTECTED"
+
+
+class TestMemberInvalidEmojiTypedException:
+    """#1915: emoji 형식 검증 거부는 typed ``MemberInvalidEmojiError`` raise.
+
+    이전 (#1915 이전): ``_validate_emoji_format`` 이 단순 ``ValueError`` 를
+    raise → CLI envelope 이 ``EXECUTION_ERROR`` fallback.
+    #1915 가 typed exception 으로 좁혀 안정 코드 ``MEMBER_INVALID_EMOJI``
+    를 surface 한다.
+
+    ``ValueError`` 다중상속이라 기존 ``pytest.raises(ValueError, match=...)``
+    회귀 lock (``test_member.py::TestEmojiValidation``) 은 그대로 통과한다.
+    """
+
+    async def test_update_emoji_invalid_format_raises_typed_exception(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(MemberInvalidEmojiError, match="단일 이모지만"):
+            await populated_service.update_emoji(
+                "agent-active", "abc", updated_by="owner"
+            )
+
+    async def test_typed_exception_has_stable_code(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(MemberInvalidEmojiError) as excinfo:
+            await populated_service.update_emoji(
+                "agent-active", "xyz", updated_by="owner"
+            )
+        assert excinfo.value.code == "MEMBER_INVALID_EMOJI"


### PR DESCRIPTION
Closes #1915

## Summary
3 oracle 관찰 케이스의 generic exception을 typed exception으로 좁혀 `EXECUTION_ERROR` 노출을 안정 도메인 code로 정합.

| case | before | after |
| --- | --- | --- |
| `member set-emoji owner x` (invalid emoji) | exit 1 + `EXECUTION_ERROR` | exit 1 + `MEMBER_INVALID_EMOJI` |
| `member suspend owner` (master) | exit 1 + `EXECUTION_ERROR` | exit 1 + `MEMBER_MASTER_PROTECTED` |
| `member revoke owner --yes` (master) | exit 1 + `EXECUTION_ERROR` | exit 1 + `MEMBER_MASTER_PROTECTED` |

### 핵심 변경
- 새 typed exceptions (`src/ante/member/errors.py`):
  - `MemberInvalidEmojiError(MemberError, ValueError)` — code `MEMBER_INVALID_EMOJI`, category `validation`
  - `MemberMasterProtectedError(MemberError, PermissionError)` — code `MEMBER_MASTER_PROTECTED`, category `permission`
- `service.py:259` `_validate_emoji_format` → `MemberInvalidEmojiError`
- `service.py:880` `_assert_not_master` → `MemberMasterProtectedError`
- 메시지 한국어 본문 보존
- `error_registry.py`에 2 SPEC + 2 EXCEPTION_TO_SPEC 매핑 추가 (#1843 sub-PR 1 mirror)

## Bounded Scope (Non-Goals)
- 다른 raise 사이트 (emoji 중복 `ValueError`, type-role `PermissionError`) — 별도 표면
- IPC server-side 정합 — 본 PR 외 (registry-first lookup으로 기능 동등)
- error-taxonomy.md SSOT 갱신 (prefix `MEMBER_*` + category enumerate는 이미 normative)
- master 보호 동작 자체 변경

## Test Plan
- `tests/unit/test_member_cli_ipc_error_equivalence.py` 신규 5건: 3 oracle case + 2 IPC envelope code equivalence
- `tests/unit/test_member_service_master_guard.py` service 레벨 typed raise 5건
- 회귀: 기존 `pytest.raises(ValueError)` / `pytest.raises(PermissionError)` 모두 MRO 다중상속으로 통과
- pytest 광역 PASS, ruff/mypy clean

## Review
- Plan Preflight v1 Codex approve-implement (#1843 mirror pattern)
- Codex 브랜치 review PASS