### PR TITLE
fix(core): #1923 Database.transaction이 BaseException 경로에서도 ROLLBACK

### DIFF
--- a/src/ante/core/database.py
+++ b/src/ante/core/database.py
@@ -76,7 +76,15 @@ class Database:
 
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator["Database"]:
-        """트랜잭션 컨텍스트 매니저. 실패 시 자동 ROLLBACK."""
+        """트랜잭션 컨텍스트 매니저.
+
+        asyncio.CancelledError / KeyboardInterrupt / SystemExit 포함 모든
+        BaseException 경로에서 ROLLBACK을 시도한 뒤 원본 예외를 재전파한다.
+        ROLLBACK 자체 실패는 swallow하여 원본 예외(특히 CancelledError) 보존을
+        우선한다.
+
+        nested transaction은 지원하지 않는다. savepoint는 본 구현 범위 외.
+        """
         if self._in_transaction:
             raise RuntimeError("중첩 트랜잭션은 지원하지 않습니다")
         conn = self._get_writer()
@@ -85,8 +93,12 @@ class Database:
             await conn.execute("BEGIN")
             yield self
             await conn.execute("COMMIT")
-        except Exception:
-            await conn.execute("ROLLBACK")
+        except BaseException:
+            try:
+                await conn.execute("ROLLBACK")
+            except BaseException:
+                # rollback 실패도 swallow — 원본 예외 보존이 우선
+                pass
             raise
         finally:
             self._in_transaction = False

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,5 +1,8 @@
 """Database 래퍼 단위 테스트."""
 
+import asyncio
+from unittest.mock import patch
+
 import pytest
 
 from ante.core import Database
@@ -113,3 +116,61 @@ async def test_transaction_ddl(db):
     assert row is not None
     assert row["col_b"] == "b"
     assert row["col_c"] == "c"
+
+
+# --- BaseException(CancelledError 등) 경로 ROLLBACK 회귀 (#1923) ---
+
+
+async def test_transaction_rollback_on_cancelled_error(db):
+    """asyncio.CancelledError 경로에서도 INSERT가 롤백되고 원본 예외가 재전파된다."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    with pytest.raises(asyncio.CancelledError):
+        async with db.transaction():
+            await db.execute("INSERT INTO t (val) VALUES (?)", ("cancelled",))
+            raise asyncio.CancelledError()
+
+    rows = await db.fetch_all("SELECT * FROM t")
+    assert rows == []
+
+
+async def test_transaction_state_allows_new_transaction_after_cancelled_error(db):
+    """CancelledError 후 _in_transaction이 해제되어 새 트랜잭션이 가능하다."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    with pytest.raises(asyncio.CancelledError):
+        async with db.transaction():
+            await db.execute("INSERT INTO t (val) VALUES (?)", ("first",))
+            raise asyncio.CancelledError()
+
+    # 동일 Database 인스턴스에서 새 트랜잭션이 정상 시작/COMMIT 가능해야 한다.
+    async with db.transaction():
+        await db.execute("INSERT INTO t (val) VALUES (?)", ("second",))
+
+    rows = await db.fetch_all("SELECT val FROM t")
+    assert [row["val"] for row in rows] == ["second"]
+
+
+async def test_transaction_rollback_failure_preserves_original_exception(db):
+    """ROLLBACK 자체가 실패해도 원본 예외(CancelledError)가 호출자에게 전달된다."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    real_execute = db._get_writer().execute
+
+    async def execute_with_rollback_failure(sql, *args, **kwargs):
+        if sql.strip().upper().startswith("ROLLBACK"):
+            raise RuntimeError("rollback boom")
+        return await real_execute(sql, *args, **kwargs)
+
+    with patch.object(
+        db._get_writer(),
+        "execute",
+        side_effect=execute_with_rollback_failure,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            async with db.transaction():
+                await db.execute("INSERT INTO t (val) VALUES (?)", ("x",))
+                raise asyncio.CancelledError()
+
+    # _in_transaction 플래그도 finally에서 해제되어야 한다.
+    assert db._in_transaction is False


### PR DESCRIPTION
Closes #1923

## Summary
`Database.transaction()`이 `asyncio.CancelledError` / `KeyboardInterrupt` / `SystemExit` 포함 `BaseException` 경로에서도 ROLLBACK 시도 후 원본 예외 재전파. ROLLBACK 자체 실패는 swallow.

- `src/ante/core/database.py:77-95`: `except Exception` → `except BaseException` + nested try/except 보호
- `tests/unit/test_database.py` +3 회귀: CancelledError rollback, 후속 transaction 정상, rollback 실패 시 원본 예외 보존

## Test Plan
- `pytest tests/unit/test_database.py -q` 12 PASS
- `pytest tests/unit/test_signal_key_rotate_transaction.py -q` 7 PASS (회귀 없음)
- ruff/mypy clean

## Review
- Codex Plan Review: approve-implement
- Codex 브랜치 review: PASS