### PR TITLE
refactor(bot): #1924 2차 — src/ante/bot/ invariant 중심 주석 정리

### DIFF
--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -320,10 +320,10 @@ class Bot:
                 "reason": event.error_message,
             }
         elif isinstance(event, OrderModifyRejectedEvent):
-            # #1331: 정정 거부 (rule reject / rule exception / gateway
-            # not-implemented) 통보를 전략에 전달. status는 신규 키
-            # ``"modify_rejected"``로 분리하여 기존 ``"rejected"``(신규
-            # 주문 거부)와 충돌하지 않도록 한다.
+            # 정정 거부 (rule reject / rule exception / gateway
+            # not-implemented) 통보를 전략에 전달. status 는 신규 키
+            # ``"modify_rejected"`` 로 분리하여 기존 ``"rejected"`` (신규
+            # 주문 거부) 와 충돌하지 않도록 한다.
             update = {
                 "order_id": event.order_id,
                 "status": "modify_rejected",
@@ -332,8 +332,8 @@ class Bot:
                 "reason": event.reason,
             }
         elif isinstance(event, StopOrderRegisteredEvent):
-            # #1336: stop / stop_limit 주문 등록 통보. 기존 ``order_id``
-            # 키와의 호환을 위해 ``stop_order_id`` 를 그대로 ``order_id`` 에도
+            # stop / stop_limit 주문 등록 통보. 기존 ``order_id`` 키와의
+            # 호환을 위해 ``stop_order_id`` 를 그대로 ``order_id`` 에도
             # 채운다 (전략이 후속 ``cancel/modify`` 에 그대로 사용 가능).
             # ``stop_order_id`` 키는 명시 식별자로 별도 노출.
             update = {
@@ -347,7 +347,7 @@ class Bot:
                 "limit_price": event.limit_price,
             }
         elif isinstance(event, StopOrderTriggeredEvent):
-            # #1336: stop 트리거 통보. 변환된 일반 주문은 자체
+            # stop 트리거 통보. 변환된 일반 주문은 자체
             # ``OrderSubmittedEvent`` 로 별도 통보되며, 본 dict 는 stop
             # 식별 단위 (stop_order_id, trigger_price) 를 보존한다.
             update = {
@@ -361,10 +361,10 @@ class Bot:
                 "converted_order_type": event.converted_order_type,
             }
         elif isinstance(event, StopOrderExpiredEvent):
-            # #1336: stop 만료 통보. ``reason`` 은
-            # ``"session_ended"`` | ``"manager_stopped"``.
-            # ``StopOrderExpiredEvent`` 자체에 side/quantity/stop_price 가
-            # 없으므로 dict 도 누락한 채 노출한다.
+            # stop 만료 통보. ``reason`` 은 ``"session_ended"`` |
+            # ``"manager_stopped"``. ``StopOrderExpiredEvent`` 자체에
+            # side/quantity/stop_price 가 없으므로 dict 도 누락한 채
+            # 노출한다.
             update = {
                 "order_id": event.stop_order_id,
                 "stop_order_id": event.stop_order_id,
@@ -436,10 +436,10 @@ class Bot:
 
         for action in actions:
             if action.action == "cancel":
-                # #1331: ``strategy_id`` 보강. 기존에는 비워서 발행되어 룰
-                # 평가/리포팅/외부 채널이 strategy 단위로 식별하지 못했다.
-                # symbol/side는 ``OrderAction`` 입력에 없고 ``OrderView``가
-                # 보장하지 않으므로 본 PR 범위 밖.
+                # ``strategy_id`` 보강 — 룰 평가/리포팅/외부 채널이 strategy
+                # 단위로 식별할 수 있도록 한다. symbol/side 는 ``OrderAction``
+                # 입력에 없고 ``OrderView`` 가 보장하지 않으므로 본 이벤트에는
+                # 포함하지 않는다.
                 await self._eventbus.publish(
                     OrderCancelEvent(
                         bot_id=self.bot_id,
@@ -450,7 +450,7 @@ class Bot:
                     )
                 )
             elif action.action == "modify":
-                # #1331: ``strategy_id`` 보강. 동일 사유.
+                # ``strategy_id`` 보강. 동일 사유.
                 await self._eventbus.publish(
                     OrderModifyEvent(
                         bot_id=self.bot_id,
@@ -467,11 +467,11 @@ class Bot:
         """봇 상태 정보 반환.
 
         ``config`` nested object 는 ``BotConfig`` 의 runtime control 6 필드
-        (#1458 — runtime control 6필드 SSOT: ``src/ante/bot/config.py``) 를
-        상세 조회 prefill 용도로 노출한다. top-level ``interval_seconds``
-        는 backward compatibility 용으로 유지된다(기존 list/detail 호출자의
-        flat key 의존성). 다른 runtime control 필드는 top-level 에 추가하지
-        않는다 (계약 중복 방지, #1458 Stop Conditions).
+        (SSOT: ``src/ante/bot/config.py``) 를 상세 조회 prefill 용도로
+        노출한다. top-level ``interval_seconds`` 는 backward compatibility
+        용으로 유지된다 (기존 list/detail 호출자의 flat key 의존성). 다른
+        runtime control 필드는 top-level 에 추가하지 않는다 (계약 중복
+        방지).
         """
         return {
             "bot_id": self.bot_id,

--- a/src/ante/bot/cold_path.py
+++ b/src/ante/bot/cold_path.py
@@ -30,7 +30,7 @@ async def _release_treasury_budget(
 
     Mirrors ``BotManager.delete_bot``: try the bot's account first, then scan
     all persisted budget account ids because legacy or cross-account rows may
-    not match ``bots.account_id`` (Refs #982/#1161).
+    not match ``bots.account_id``.
     """
     from ante.eventbus.bus import EventBus
     from ante.treasury.treasury import Treasury
@@ -104,9 +104,9 @@ async def cold_path_remove_bot(
     if row is None:
         raise BotNotFoundError(bot_id)
 
-    # Refs #1217 → #1241 SPLIT-2: account_id fallback (`or "test"`) 제거.
-    # invalid 값은 ``InvalidAccountIdError`` 로 즉시 거부되어 잘못된 account 의
-    # Treasury 환수 / 잘못된 계좌 cleanup 경로가 실행되지 않는다.
+    # account_id fallback (`or "test"`) 금지. invalid 값은
+    # ``InvalidAccountIdError`` 로 즉시 거부되어 잘못된 account 의 Treasury
+    # 환수 / 잘못된 계좌 cleanup 경로가 실행되지 않는다.
     account_id = require_account_id(
         row.get("account_id"), context="cold_path_remove_bot"
     )

--- a/src/ante/bot/config.py
+++ b/src/ante/bot/config.py
@@ -23,9 +23,8 @@ class BotStatus(StrEnum):
 MIN_INTERVAL_SECONDS = 10
 MAX_INTERVAL_SECONDS = 3600
 
-# Runtime control 허용 범위 (#1456 — 본 파일의 ``MIN_*``/``MAX_*`` 상수가
-# SSOT). 범위 밖 값은 ``BotConfig`` 직접 생성 단계에서 ``ValueError`` 로
-# 거부된다.
+# Runtime control 허용 범위 (본 파일의 ``MIN_*``/``MAX_*`` 상수가 SSOT).
+# 범위 밖 값은 ``BotConfig`` 직접 생성 단계에서 ``ValueError`` 로 거부된다.
 MIN_MAX_RESTART_ATTEMPTS = 1
 MAX_MAX_RESTART_ATTEMPTS = 10
 MIN_RESTART_COOLDOWN_SECONDS = 10
@@ -40,15 +39,15 @@ MAX_MAX_SIGNALS_PER_STEP = 200
 class BotConfig:
     """봇 설정.
 
-    ``account_id`` 는 봇 생성 진입점에서 검증된다 (#1217 → #1241 SPLIT-2).
-    fallback (`""`, ``None``, ``"default"``) 또는 형식 위반 값은 거부된다.
+    ``account_id`` 는 봇 생성 진입점에서 검증된다. fallback (`""`, ``None``,
+    ``"default"``) 또는 형식 위반 값은 거부된다.
 
     runtime control 4개 필드 (``max_restart_attempts``,
     ``restart_cooldown_seconds``, ``step_timeout_seconds``,
-    ``max_signals_per_step``) 는 #1456 허용 범위 내에서만 허용된다
-    (코드 SSOT: 본 파일의 ``MIN_*``/``MAX_*`` 상수). 범위 밖 값은
-    ``ValueError`` 로 거부되어 ``update_bot`` (manager.py:340) 의 재구성
-    경로에서도 동일하게 차단된다.
+    ``max_signals_per_step``) 는 허용 범위 내에서만 허용된다 (코드 SSOT: 본
+    파일의 ``MIN_*``/``MAX_*`` 상수). 범위 밖 값은 ``ValueError`` 로 거부
+    되어 ``update_bot`` (manager.py:340) 의 재구성 경로에서도 동일하게
+    차단된다.
     """
 
     bot_id: str
@@ -92,7 +91,7 @@ def validate_runtime_controls(
     step_timeout_seconds: int,
     max_signals_per_step: int,
 ) -> None:
-    """Runtime control 4개 필드 범위 검증. 범위 밖이면 ``ValueError`` (#1456).
+    """Runtime control 4개 필드 범위 검증. 범위 밖이면 ``ValueError``.
 
     코드 SSOT: 본 파일의 ``MIN_*``/``MAX_*`` 상수 + Pydantic Field +
     manual OpenAPI schema bounds.

--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -35,12 +35,12 @@ class StrategyContextFactory:
 
     main.py에서 생성되어 BotManager에 주입된다.
 
-    SPLIT-3 (#1242): live mode 에서는 봇별로 ``LiveDataProvider`` 인스턴스
-    를 새로 생성해 ``account_id`` 를 closure 방식으로 격리한다. strategy
-    인터페이스 (``StrategyContext.get_ohlcv``) 는 변경되지 않는다.
-    ``api_gateway`` / ``parquet_store`` 가 모두 주입되어 있을 때만 봇별
-    인스턴스를 만들고, 미주입이면 fallback ``data_provider`` 를 사용한다
-    (virtual-only 환경 호환).
+    live mode 에서는 봇별로 ``LiveDataProvider`` 인스턴스를 새로 생성해
+    ``account_id`` 를 closure 방식으로 격리한다. strategy 인터페이스
+    (``StrategyContext.get_ohlcv``) 는 변경되지 않는다. ``api_gateway`` /
+    ``parquet_store`` 가 모두 주입되어 있을 때만 봇별 인스턴스를 만들고,
+    미주입이면 fallback ``data_provider`` 를 사용한다 (virtual-only 환경
+    호환).
     """
 
     def __init__(
@@ -116,10 +116,9 @@ class StrategyContextFactory:
     def _create_live_context(self, config: BotConfig) -> StrategyContext:
         """Live 봇용 StrategyContext 생성.
 
-        SPLIT-3 (#1242): ``APIGateway`` 가 주입돼 있으면 봇별로 새
-        ``LiveDataProvider`` 인스턴스를 만들어 ``config.account_id`` 를
-        closure 로 binding 한다. 그 외 환경에서는 공유 ``self._data_provider``
-        를 그대로 사용한다.
+        ``APIGateway`` 가 주입돼 있으면 봇별로 새 ``LiveDataProvider``
+        인스턴스를 만들어 ``config.account_id`` 를 closure 로 binding 한다.
+        그 외 환경에서는 공유 ``self._data_provider`` 를 그대로 사용한다.
         """
         portfolio = self._get_live_portfolio(config)
 
@@ -150,8 +149,8 @@ class StrategyContextFactory:
     def _create_virtual_context(self, config: BotConfig) -> StrategyContext:
         """Virtual 계좌 봇용 StrategyContext 생성.
 
-        SPLIT-3 (#1242): virtual 계좌 봇이라도 OHLCV / price 조회는 봇의 account_id
-        로 APIGateway 를 호출해야 한다 (broker routing). live 와 동일하게
+        virtual 계좌 봇이라도 OHLCV / price 조회는 봇의 account_id 로
+        APIGateway 를 호출해야 한다 (broker routing). live 와 동일하게
         ``api_gateway`` 가 있으면 봇별 LiveDataProvider 를 생성한다.
         """
         initial_balance = self._resolve_virtual_balance(config)

--- a/src/ante/bot/exceptions.py
+++ b/src/ante/bot/exceptions.py
@@ -1,7 +1,7 @@
 """Bot 모듈 예외.
 
-Refs #1712: ``bot.start``/``bot.stop`` IPC handler 가 stable coded exception을
-반환하도록 두 개를 추가했다 — ``BotAccountCredentialsNotConfigured``
+``bot.start``/``bot.stop`` IPC handler 는 stable coded exception 을
+반환한다 — ``BotAccountCredentialsNotConfigured``
 (``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED``, app_key 부재 preflight 실패) /
 ``BotStateConflict`` (``BOT_STATE_CONFLICT``, 상태머신 거부). IPC server.py
 의 ``getattr(e, "code", ...)`` envelope 정렬 패턴(``BOT_NOT_FOUND_CODE`` 와
@@ -35,10 +35,10 @@ class BotNotFoundError(BotError):
 class BotAccountCredentialsNotConfigured(BotError):  # noqa: N818
     """봇 시작 시 account 의 ``app_key`` 가 부재.
 
-    Refs #1712: 봇 시작 전 ``app_key`` preflight 거부
-    (``계좌에 인증정보(app_key)가 설정되지 않았습니다``)를 표현하는 IPC
-    오류. IPC ``server.py`` 의 ``getattr(e, "code", ...)`` 가
-    ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` envelope 으로 변환한다.
+    봇 시작 전 ``app_key`` preflight 거부 (``계좌에 인증정보(app_key)가
+    설정되지 않았습니다``) 를 표현하는 IPC 오류. IPC ``server.py`` 의
+    ``getattr(e, "code", ...)`` 가 ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED``
+    envelope 으로 변환한다.
     """
 
     code: str = BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE
@@ -47,9 +47,9 @@ class BotAccountCredentialsNotConfigured(BotError):  # noqa: N818
 class BotStateConflict(BotError):  # noqa: N818
     """봇 상태머신 충돌 (start_bot/stop_bot 가 ``BotError`` 로 거부).
 
-    Refs #1712: ``BotError`` 상태머신 거부를 표현하는 IPC 오류. IPC
-    ``server.py`` 의 ``getattr(e, "code", ...)`` 가 ``BOT_STATE_CONFLICT``
-    envelope 으로 변환한다.
+    ``BotError`` 상태머신 거부를 표현하는 IPC 오류. IPC ``server.py`` 의
+    ``getattr(e, "code", ...)`` 가 ``BOT_STATE_CONFLICT`` envelope 으로
+    변환한다.
     """
 
     code: str = BOT_STATE_CONFLICT_CODE
@@ -58,10 +58,10 @@ class BotStateConflict(BotError):  # noqa: N818
 class BotNotAcceptingSignals(BotError):  # noqa: N818
     """봇의 전략이 외부 시그널을 받지 않음 (``accepts_external_signals=False``).
 
-    Refs #1761: ``bot signal-key --rotate`` 가 ``accepts_external_signals=False``
-    전략에도 키를 발급해 orphan credential 이 생기던 회귀를 막는다.
-    ``signal connect`` 가 동일 조건을 이미 ``BOT_NOT_ACCEPTING_SIGNALS`` 로
-    거부(``ante/cli/commands/signal.py:70-75``)하고 있어 같은 코드를 재사용해
+    ``bot signal-key --rotate`` 가 ``accepts_external_signals=False`` 전략에
+    키를 발급해 orphan credential 이 생기는 경로를 막는다. ``signal connect``
+    가 동일 조건을 이미 ``BOT_NOT_ACCEPTING_SIGNALS`` 로 거부
+    (``ante/cli/commands/signal.py:70-75``) 하고 있어 같은 코드를 재사용해
     IPC/CLI 표면 간 envelope 코드 일관성을 유지한다.
     """
 
@@ -69,7 +69,7 @@ class BotNotAcceptingSignals(BotError):  # noqa: N818
 
 
 class BotAlreadyExistsError(BotError):
-    """동일 ``bot_id`` 가 이미 존재함 (#1800).
+    """동일 ``bot_id`` 가 이미 존재함.
 
     ``BotManager.create_bot`` 가 동일 bot_id 중복 등록을 거부할 때 raise
     한다. IPC ``server.py`` 의 ``getattr(e, "code", ...)`` envelope 이
@@ -81,7 +81,7 @@ class BotAlreadyExistsError(BotError):
 
 
 class BotStrategyAlreadyRunningError(BotError):
-    """동일 ``strategy_id`` 가 이미 실행 중인 다른 봇에 의해 사용 중 (#1800).
+    """동일 ``strategy_id`` 가 이미 실행 중인 다른 봇에 의해 사용 중.
 
     "1전략 1봇" 정책에 따른 거부. IPC envelope 이
     ``BOT_STRATEGY_ALREADY_RUNNING`` 으로 변환되어 자동화/사용자가 동일

--- a/src/ante/bot/info.py
+++ b/src/ante/bot/info.py
@@ -1,7 +1,7 @@
 """Bot info enrichment helper — IPC 공유.
 
-Refs #1712: IPC ``bot.status`` 가 ``bot`` info 보강 로직
-(strategy/budget/positions 조인)을 공유하기 위한 extraction.
+IPC ``bot.status`` 가 ``bot`` info 보강 로직 (strategy/budget/positions
+조인) 을 공유하기 위한 extraction.
 
 설계 원칙:
 - 본 helper 는 순수 도메인 dict 변환만 수행하며, IPC 표면 매핑은 handler가
@@ -9,9 +9,9 @@ Refs #1712: IPC ``bot.status`` 가 ``bot`` info 보강 로직
 - 의존성은 모두 keyword-only optional — 보유한 객체만 보강에 기여한다. None
   이면 해당 섹션은 skip 되며 dict 에 키가 추가되지 않는다(누락 vs. 빈 값
   의미 구분).
-- ``trade_service`` 는 #1712 에서 ``ServiceRegistry`` 에 optional 로 도입
-  되었다. legacy / cold-path 환경에서 None 이면 ``positions`` 키 자체가
-  부재한다(회귀 lock).
+- ``trade_service`` 는 ``ServiceRegistry`` 에 optional 로 주입된다.
+  legacy / cold-path 환경에서 None 이면 ``positions`` 키 자체가 부재한다
+  (회귀 lock).
 """
 
 from __future__ import annotations
@@ -28,8 +28,8 @@ async def enrich_bot_info(
 ) -> dict[str, Any]:
     """``bot.get_info()`` 결과에 strategy/budget/positions 정보를 보강한다.
 
-    Refs #1712: 응답 shape/field/key 순서를 변경하지 않으며, 의존성 None 시
-    해당 섹션 키 자체가 부재한다.
+    응답 shape/field/key 순서를 변경하지 않으며, 의존성 None 시 해당 섹션
+    키 자체가 부재한다.
 
     Args:
         bot: ``get_info()`` 메서드를 가진 Bot 인스턴스. info 의 ``strategy_id``
@@ -43,7 +43,7 @@ async def enrich_bot_info(
             로 미리 resolve 한 뒤 전달한다.
         trade_service: ``TradeService`` (또는 ``get_positions(bot_id=...,
             include_closed=...)`` await coroutine 을 노출하는 stub). None
-            이면 ``positions`` 키가 추가되지 않는다(회귀 lock — #1712 cold-path
+            이면 ``positions`` 키가 추가되지 않는다 (회귀 lock — cold-path
             / legacy 환경 호환).
 
     Returns:

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -56,10 +56,9 @@ CREATE TABLE IF NOT EXISTS bots (
 CREATE INDEX IF NOT EXISTS idx_bots_account_id ON bots(account_id);
 """
 
-# Refs #1457: ``BotConfig`` 직렬화 / 복원 라운드트립 대상 필드.
-# ``interval_seconds`` 는 기존부터 직렬화되던 필드이고, 나머지 5개는 #1456 으로
-# ``BotConfig`` 에 도입된 runtime control. 모두 ``BotConfig`` dataclass field
-# default 가 SSOT 다 (하드코딩 금지).
+# ``BotConfig`` 직렬화 / 복원 라운드트립 대상 필드. ``interval_seconds`` 와
+# runtime control 5개. ``BotConfig`` dataclass field default 가 SSOT
+# (하드코딩 금지).
 _PERSISTED_BOT_CONFIG_FIELDS: tuple[str, ...] = (
     "interval_seconds",
     "auto_restart",
@@ -71,7 +70,7 @@ _PERSISTED_BOT_CONFIG_FIELDS: tuple[str, ...] = (
 
 
 def _runtime_control_default(name: str) -> Any:
-    """``BotConfig`` dataclass field default 를 조회한다 (Refs #1457).
+    """``BotConfig`` dataclass field default 를 조회한다.
 
     SSOT 는 :class:`BotConfig` 의 dataclass field default. manager 가 default
     를 독립적으로 재정의하지 않도록 항상 ``dataclasses.fields`` 를 통해
@@ -96,12 +95,10 @@ def _runtime_control_default(name: str) -> Any:
 def _pick_persisted_runtime_control(config_data: dict[str, Any], name: str) -> Any:
     """``config_json`` payload 에서 runtime control 값을 안전하게 꺼낸다.
 
-    Refs #1457:
-
     - key 가 없으면 :func:`_runtime_control_default` 로 dataclass default 복원
       (missing legacy row 호환).
     - key 가 있지만 값이 ``None`` 이면 ``ValueError`` 로 거부 — explicit null
-      은 데이터 손상으로 간주하고 ``load_from_db`` 의 새 ``except ValueError``
+      은 데이터 손상으로 간주하고 ``load_from_db`` 의 ``except ValueError``
       가 row 자체를 skip + warning 처리한다.
 
     ``auto_restart`` (bool) 와 숫자 필드 모두 동일 경로로 처리한다.
@@ -157,14 +154,14 @@ class BotManager:
         self._restart_counts: dict[str, int] = {}
         self._restart_tasks: dict[str, asyncio.Task[None]] = {}
         self._restart_reset_tasks: dict[str, asyncio.Task[None]] = {}
-        # Refs #1460: 같은 ``bot_id`` 에 대한 ``update_bot`` 동시 호출을
-        # 직렬화하기 위한 per-bot asyncio.Lock 저장소. lazy init helper
+        # 같은 ``bot_id`` 에 대한 ``update_bot`` 동시 호출을 직렬화하기
+        # 위한 per-bot asyncio.Lock 저장소. lazy init helper
         # ``_get_update_lock`` 으로만 노출하여 외부에서 직접 dict 를 만지지
         # 않도록 한다.
         self._bot_update_locks: dict[str, asyncio.Lock] = {}
 
     def _get_update_lock(self, bot_id: str) -> asyncio.Lock:
-        """``update_bot`` 직렬화용 per-bot lock 을 lazy 로 발급한다 (Refs #1460).
+        """``update_bot`` 직렬화용 per-bot lock 을 lazy 로 발급한다.
 
         같은 ``bot_id`` 에 대한 ``update_bot`` 호출이 동시에 들어왔을 때
         runtime control 재생성 → ``_save_bot_config`` → ``treasury.update_budget``
@@ -191,11 +188,10 @@ class BotManager:
         deleted 상태가 아닌 모든 봇을 읽어 stub Bot 인스턴스를 생성한다.
         기존 메모리 상태는 초기화된다. 반환값은 로드된 봇 수.
 
-        Refs #1217 → #1241 SPLIT-2: ``account_id`` 가 invalid (``""``,
-        ``"default"``, 형식 위반) 인 row 는 warning 후 skip 한다 (SPLIT-1
-        패턴). ``BotConfig.__post_init__`` 의 ``require_account_id`` 가
-        :class:`InvalidAccountIdError` 를 raise 하므로 read 경로가 실패하지
-        않도록 본 단계에서 가지치기한다.
+        ``account_id`` 가 invalid (``""``, ``"default"``, 형식 위반) 인 row
+        는 warning 후 skip 한다. ``BotConfig.__post_init__`` 의
+        ``require_account_id`` 가 :class:`InvalidAccountIdError` 를 raise
+        하므로 read 경로가 실패하지 않도록 본 단계에서 가지치기한다.
         """
         from ante.account.errors import InvalidAccountIdError
         from ante.strategy.base import Signal, Strategy, StrategyMeta
@@ -220,21 +216,22 @@ class BotManager:
         )
 
         for row in rows:
-            # NOTE(Refs #1457): ``json.loads`` 는 try 블록 밖에서 실행한다.
-            # ``JSONDecodeError`` 는 ``ValueError`` 의 서브클래스이므로 try 안에
-            # 들어가면 새로 도입한 ``except ValueError`` 가 이를 silent 하게
-            # 흡수해 다른 종류의 corruption 까지 묻혀버린다. JSON 파싱 실패는
-            # 별도 이슈로 다루어야 하므로 의도적으로 try 범위에 포함하지 않는다.
+            # ``json.loads`` 는 try 블록 밖에서 실행한다.
+            # ``JSONDecodeError`` 는 ``ValueError`` 의 서브클래스이므로 try
+            # 안에 들어가면 아래 ``except ValueError`` 가 이를 silent 하게
+            # 흡수해 다른 종류의 corruption 까지 묻혀버린다. JSON 파싱
+            # 실패는 별도 issue 로 다루어야 하므로 의도적으로 try 범위에
+            # 포함하지 않는다.
             config_data = json.loads(row["config_json"]) if row["config_json"] else {}
             # bot_type, exchange 키는 무시 (BotConfig에서 제거됨)
             config_data.pop("bot_type", None)
             config_data.pop("exchange", None)
             account_id = row.get("account_id") or ""
             try:
-                # Refs #1457: ``interval_seconds`` 와 4 runtime control +
-                # ``auto_restart`` 를 helper 로 복원한다. helper 는 missing key
-                # 일 때 ``BotConfig`` dataclass default 로 fallback 하고,
-                # explicit null 일 때 ``ValueError`` 를 raise 한다.
+                # ``interval_seconds`` 와 4 runtime control + ``auto_restart``
+                # 를 helper 로 복원한다. helper 는 missing key 일 때
+                # ``BotConfig`` dataclass default 로 fallback 하고, explicit
+                # null 일 때 ``ValueError`` 를 raise 한다.
                 config = BotConfig(
                     bot_id=row["bot_id"],
                     strategy_id=row["strategy_id"],
@@ -260,8 +257,8 @@ class BotManager:
                     ),
                 )
             except InvalidAccountIdError as e:
-                # SPLIT-1 패턴: invalid account_id row 는 skip + warning.
-                # legacy 마이그레이션(#1219)이 완료되기 전까지 read 경로 안전망.
+                # invalid account_id row 는 skip + warning. legacy
+                # 마이그레이션이 완료되기 전까지 read 경로 안전망.
                 logger.warning(
                     "BotManager.load_from_db: invalid account_id row skip"
                     " (legacy migration 필요): bot_id=%s account_id=%r — %s",
@@ -271,8 +268,8 @@ class BotManager:
                 )
                 continue
             except ValueError as e:
-                # Refs #1457: invalid runtime control / invalid interval_seconds
-                # / explicit null persisted row 는 raise 없이 skip + warning.
+                # invalid runtime control / invalid interval_seconds /
+                # explicit null persisted row 는 raise 없이 skip + warning.
                 # ``BotConfig.__post_init__`` (validate_interval /
                 # validate_runtime_controls) 와 ``_pick_persisted_runtime_control``
                 # 의 explicit-null guard 가 ``ValueError`` 를 raise 한다.
@@ -333,10 +330,11 @@ class BotManager:
         ctx가 주입되면 그대로 사용하고, None이면 context_factory로 자동 생성한다.
         source_path가 주어지면 전략 파일을 스냅샷으로 복사하여 보호한다.
         """
-        # Defense-in-depth: BotConfig.__post_init__의 invariant를 service boundary에서
-        # mirror. attribute mutation으로 invariant를 우회한 객체가 들어와도 여기서
-        # 차단한다 (#1459). 호출 순서는 BotConfig.__post_init__과 동일하게
-        # account_id → interval → runtime controls.
+        # Defense-in-depth: BotConfig.__post_init__의 invariant를 service
+        # boundary 에서 mirror. attribute mutation 으로 invariant 를 우회한
+        # 객체가 들어와도 여기서 차단한다. 호출 순서는
+        # BotConfig.__post_init__ 과 동일하게 account_id → interval →
+        # runtime controls.
         config.account_id = require_account_id(
             config.account_id, context="BotManager.create_bot"
         )
@@ -349,9 +347,9 @@ class BotManager:
         )
 
         if config.bot_id in self._bots:
-            # #1800: 동일 bot_id 중복 등록은 ``BotAlreadyExistsError``
-            # (code=``"BOT_ALREADY_EXISTS"``) 로 typed raise — IPC envelope
-            # 이 일반 ``EXECUTION_ERROR`` 가 아닌 안정 코드를 surface 한다.
+            # 동일 bot_id 중복 등록은 ``BotAlreadyExistsError`` (code=
+            # ``"BOT_ALREADY_EXISTS"``) 로 typed raise — IPC envelope 이
+            # 일반 ``EXECUTION_ERROR`` 가 아닌 안정 코드를 surface 한다.
             raise BotAlreadyExistsError(f"Bot already exists: {config.bot_id}")
 
         # 1전략 1봇 정책: 실행 중인 봇이 사용 중인 전략 중복 차단
@@ -361,9 +359,8 @@ class BotManager:
                 existing_bot.config.strategy_id == config.strategy_id
                 and existing_bot.status in active_statuses
             ):
-                # #1800: 1전략 1봇 정책 위반은
-                # ``BotStrategyAlreadyRunningError`` (code=
-                # ``"BOT_STRATEGY_ALREADY_RUNNING"``) 로 typed raise.
+                # 1전략 1봇 정책 위반은 ``BotStrategyAlreadyRunningError``
+                # (code=``"BOT_STRATEGY_ALREADY_RUNNING"``) 로 typed raise.
                 raise BotStrategyAlreadyRunningError(
                     f"전략 '{config.strategy_id}'은(는) 이미 봇 "
                     f"'{existing_bot.bot_id}'에서 사용 중입니다. "
@@ -468,12 +465,12 @@ class BotManager:
         Raises:
             BotError: 봇이 중지 상태가 아닌 경우.
         """
-        # Refs #1460: 같은 bot_id 에 대한 update_bot 동시 호출을 직렬화한다.
-        # lock 획득 전에는 ``bot.config`` 가 다른 update_bot 에 의해 임의로
-        # 교체될 수 있으므로 존재 확인과 상태 검증, ``old_config`` 캡처,
-        # ``new_config`` 재생성, save, budget 처리, rollback 모두 lock 안에서
-        # 수행한다. 기존 rollback 의 conditional skip 가드는 lock 이 race 를
-        # 차단하더라도 안전망으로 그대로 유지한다.
+        # 같은 bot_id 에 대한 update_bot 동시 호출을 직렬화한다. lock 획득
+        # 전에는 ``bot.config`` 가 다른 update_bot 에 의해 임의로 교체될 수
+        # 있으므로 존재 확인과 상태 검증, ``old_config`` 캡처, ``new_config``
+        # 재생성, save, budget 처리, rollback 모두 lock 안에서 수행한다.
+        # rollback 의 conditional skip 가드는 lock 이 race 를 차단하더라도
+        # 안전망으로 그대로 유지한다.
         async with self._get_update_lock(bot_id):
             # bot 존재/상태 검증을 lock 안에서 (재)수행. lock 획득 전 다른
             # 코루틴이 봇을 삭제했을 수도 있다.
@@ -516,36 +513,35 @@ class BotManager:
             new_config = BotConfig(**config_fields)  # type: ignore[arg-type]
             bot.config = new_config
 
-            # Refs #1460 (attempt 4): rollback eq 가드용 commit-time snapshot.
-            # ``bot.config`` 와 ``new_config`` 는 같은 객체이므로 같은 lock 을
-            # 쓰지 않는 다른 mutator (예: ``change_strategy``) 가
-            # ``bot.config.<field> = ...`` in-place mutation 을 하면 ``new_config``
-            # 의 필드도 함께 바뀌어 ``bot.config == new_config`` 는 자명하게
-            # True 가 된다. 따라서 commit 시점의 필드값을 별도 객체로 떠두고
-            # rollback 가드에서 그 snapshot 과 ``bot.config`` 를 비교한다.
-            # ``dataclasses.replace`` 는 shallow copy 라서 raise 가능성이 거의
-            # 없는 단순 작업이다 (``BotConfig.__post_init__`` 의 검증은 동일
-            # 필드 값으로 재호출되므로 통과한다).
+            # rollback eq 가드용 commit-time snapshot. ``bot.config`` 와
+            # ``new_config`` 는 같은 객체이므로 같은 lock 을 쓰지 않는 다른
+            # mutator (예: ``change_strategy``) 가 ``bot.config.<field> = ...``
+            # in-place mutation 을 하면 ``new_config`` 의 필드도 함께 바뀌어
+            # ``bot.config == new_config`` 는 자명하게 True 가 된다. 따라서
+            # commit 시점의 필드값을 별도 객체로 떠두고 rollback 가드에서
+            # 그 snapshot 과 ``bot.config`` 를 비교한다. ``dataclasses.replace``
+            # 는 shallow copy 라서 raise 가능성이 거의 없는 단순 작업이다
+            # (``BotConfig.__post_init__`` 의 검증은 동일 필드 값으로
+            # 재호출되므로 통과한다).
             committed_snapshot = dataclasses.replace(new_config)
 
             # DB 갱신
             await self._save_bot_config(new_config)
 
             # budget 변경 시 Treasury 연동.
-            # Refs #1335: 과거에는 ``new_budget is not None`` 인 경로에서도
-            # ``TreasuryManager`` 부재 / account 미등록을 silent 하게 흘려보내
-            # 호출자가 budget 배정 실패를 감지하지 못했다.
-            # 이제 budget 배정 의도가 있는 경우(``new_budget is not None``)에는
-            # ``TreasuryNotConfiguredError`` 를 raise 하여 라우트 계층이 422 로
-            # 매핑할 수 있도록 한다. ``new_budget is None`` 인 단순 update
-            # 경로는 기존과 동일하게 무영향(no-op)이다.
+            # budget 배정 의도가 있는 경우(``new_budget is not None``)에는
+            # ``TreasuryManager`` 부재 / account 미등록을 silent 하게 흘려
+            # 보내지 않고 ``TreasuryNotConfiguredError`` 를 raise 하여 라우트
+            # 계층이 422 로 매핑할 수 있도록 한다. ``new_budget is None`` 인
+            # 단순 update 경로는 무영향(no-op)이다.
             #
-            # Refs #1460: budget 처리 실패 시 update_bot 전체가 atomic 하도록
-            # runtime control 변경(memory + DB) 을 ``old_config`` 로 rollback
-            # 한다. TreasuryManager 미주입, account 미등록, treasury.update_budget
-            # 내부 예외, asyncio.CancelledError(요청 취소) 모두 동일하게 rollback
-            # 경로를 탄다. ``treasury.update_budget`` 내부 allocate/deallocate
-            # side effect(예산 부분 commit) 까지는 atomic 보장하지 않는다.
+            # budget 처리 실패 시 update_bot 전체가 atomic 하도록 runtime
+            # control 변경(memory + DB) 을 ``old_config`` 로 rollback 한다.
+            # TreasuryManager 미주입, account 미등록, treasury.update_budget
+            # 내부 예외, asyncio.CancelledError(요청 취소) 모두 동일하게
+            # rollback 경로를 탄다. ``treasury.update_budget`` 내부 allocate/
+            # deallocate side effect(예산 부분 commit) 까지는 atomic 보장
+            # 하지 않는다.
             if new_budget is not None:
                 try:
                     from ante.treasury.exceptions import TreasuryNotConfiguredError
@@ -569,13 +565,13 @@ class BotManager:
                     # DB rollback 실패와 무관하게 최소한 메모리 상태는
                     # 일관되게 만든다.
                     #
-                    # Atomicity scope (Refs #1460): 본 rollback 은 같은
-                    # ``update_bot`` 호출 내부의 budget 실패 시 ``BotConfig``
-                    # memory/DB 를 원자적으로 되돌린다. 다른 mutator
-                    # (``change_strategy`` / ``assign_strategy`` / ``delete_bot``
-                    # / ``create_bot``) 와의 직렬화는 본 이슈 범위 밖이며,
-                    # 별도 BotManager 동시성 모델 이슈에서 다룬다. 본 가드는
-                    # 다중 safety net 으로 구성된다:
+                    # Atomicity scope: 본 rollback 은 같은 ``update_bot``
+                    # 호출 내부의 budget 실패 시 ``BotConfig`` memory/DB 를
+                    # 원자적으로 되돌린다. 다른 mutator (``change_strategy``
+                    # / ``assign_strategy`` / ``delete_bot`` / ``create_bot``)
+                    # 와의 직렬화는 본 가드 범위 밖이며, 별도 BotManager
+                    # 동시성 모델 이슈에서 다룬다. 본 가드는 다중 safety net
+                    # 으로 구성된다:
                     # - per-bot Lock: 같은 ``update_bot`` 호출들의 직렬화.
                     # - identity check (``bot.config is new_config``): 다른
                     #   ``update_bot`` 이 끼어들어 ``bot.config`` 를 다른 객체로
@@ -594,10 +590,10 @@ class BotManager:
                     #   dataclass eq 로 모든 필드가 동등할 때만 rollback 한다.
                     if bot.config is new_config and bot.config == committed_snapshot:
                         bot.config = old_config
-                        # Refs #1460 (attempt 3): DB rollback save 직전에
-                        # manager 의 ``_bots`` 메모리 맵에 이 ``bot_id`` 가
-                        # 여전히 우리가 잡고 있는 같은 ``bot`` 인스턴스로 등록되어
-                        # 있는지 한 번 더 확인한다. ``update_bot`` 의 per-bot
+                        # DB rollback save 직전에 manager 의 ``_bots`` 메모리
+                        # 맵에 이 ``bot_id`` 가 여전히 우리가 잡고 있는 같은
+                        # ``bot`` 인스턴스로 등록되어 있는지 한 번 더 확인
+                        # 한다. ``update_bot`` 의 per-bot
                         # lock 은 ``update_bot`` 들 사이에서만 직렬화하므로,
                         # ``treasury.update_budget`` await 동안 같은 ``bot_id``
                         # 에 대해 ``delete_bot`` (hard delete 포함) 이나
@@ -733,12 +729,12 @@ class BotManager:
     async def start_bot(self, bot_id: str) -> None:
         """봇 시작. 전략별 룰이 설정되어 있으면 RuleEngine에 로드.
 
-        Refs #1759: 이미 ``RUNNING`` 상태인 봇에 대한 중복 호출은
-        ``BotStateConflict`` 로 거부한다 (IPC envelope:
-        ``BOT_STATE_CONFLICT``). ``resume_bot`` 의 status 체크 + raise
-        패턴과 동형이며, ``BotStateConflict`` 는 ``BotError`` 서브클래스
-        이므로 기존 ``except BotError`` 호출자 (IPC handler) 는 자연스럽게
-        ``BOT_STATE_CONFLICT`` envelope 으로 매핑된다.
+        이미 ``RUNNING`` 상태인 봇에 대한 중복 호출은 ``BotStateConflict`` 로
+        거부한다 (IPC envelope: ``BOT_STATE_CONFLICT``). ``resume_bot`` 의
+        status 체크 + raise 패턴과 동형이며, ``BotStateConflict`` 는
+        ``BotError`` 서브클래스이므로 기존 ``except BotError`` 호출자 (IPC
+        handler) 는 자연스럽게 ``BOT_STATE_CONFLICT`` envelope 으로 매핑
+        된다.
         """
         bot = self._get_bot(bot_id)
         if bot.status == BotStatus.RUNNING:
@@ -756,7 +752,7 @@ class BotManager:
         suppress_notification이 True이면 BotStoppedEvent에 의한
         NotificationEvent 발행을 1회 억제한다.
 
-        Refs #1759: ``RUNNING`` / ``ERROR`` 가 아닌 상태에서의 중복 호출은
+        ``RUNNING`` / ``ERROR`` 가 아닌 상태에서의 중복 호출은
         ``BotStateConflict`` 로 거부한다. 허용 범위는 ``Bot.stop()`` 이
         실제로 처리하는 상태 집합 (``RUNNING``/``ERROR``) 과 정합시킨다.
         ``BotStateConflict`` 는 ``BotError`` 서브클래스이므로 기존
@@ -790,14 +786,13 @@ class BotManager:
                 기본 ``False`` 는 기존 soft delete 거동 (``status='deleted'``)
                 을 유지한다.
 
-                Refs #1335: budget 배정 실패 후 rollback 경로에서는 같은
-                ``bot_id`` 로의 재시도가 가능해야 한다.
-                soft delete 만 수행하면 row 가 ``status='deleted'`` 로
-                남아 ``_save_bot_config()`` UPSERT 가 status 를 복구하지
-                않으므로, 재시도가 ``201`` 을 반환해도 봇은 메모리에만
-                존재하고 재시작 후 ``load_from_db()`` 에서 제외된다.
-                rollback 경로에서는 ``hard=True`` 로 row 자체를 제거해
-                재시도 의미를 보존한다.
+                budget 배정 실패 후 rollback 경로에서는 같은 ``bot_id`` 로의
+                재시도가 가능해야 한다. soft delete 만 수행하면 row 가
+                ``status='deleted'`` 로 남아 ``_save_bot_config()`` UPSERT 가
+                status 를 복구하지 않으므로, 재시도가 ``201`` 을 반환해도
+                봇은 메모리에만 존재하고 재시작 후 ``load_from_db()`` 에서
+                제외된다. rollback 경로에서는 ``hard=True`` 로 row 자체를
+                제거해 재시도 의미를 보존한다.
         """
         if handle_positions not in ("keep", "liquidate"):
             raise BotError(
@@ -836,8 +831,8 @@ class BotManager:
             except KeyError:
                 pass
             if released == 0.0:
-                # 봇 account_id와 예산의 account_id가 다를 수 있음 (Refs #982)
-                # 모든 Treasury에서 해당 봇의 budget을 찾아 환수
+                # 봇 account_id 와 예산의 account_id 가 다를 수 있음 — 모든
+                # Treasury 에서 해당 봇의 budget 을 찾아 환수.
                 for t in self._treasury_manager.list_all():
                     released = await t.release_budget(bot_id)
                     if released > 0:
@@ -978,11 +973,11 @@ class BotManager:
     async def _on_bot_stop_request(self, event: object) -> None:
         """BotStopEvent 수신 시 해당 봇 중지.
 
-        Refs #1759: ``BotManager.stop_bot`` 이 strict state machine 으로
-        전환된 이후에도 EventBus 경로의 ``BotStopEvent`` 핸들러는
-        idempotent 의미를 보존한다 (rule engine 이 한도 위반으로 발행한
-        이벤트가 중복 수신되거나 봇이 이미 중지되어 있을 수 있음).
-        state machine 거부는 silent ignore 한다.
+        ``BotManager.stop_bot`` 이 strict state machine 으로 동작하더라도
+        EventBus 경로의 ``BotStopEvent`` 핸들러는 idempotent 의미를 보존
+        한다 (rule engine 이 한도 위반으로 발행한 이벤트가 중복 수신되거나
+        봇이 이미 중지되어 있을 수 있음). state machine 거부는 silent
+        ignore 한다.
         """
         from ante.eventbus.events import BotStopEvent
 
@@ -1197,17 +1192,17 @@ class BotManager:
     async def rotate_signal_key(self, bot_id: str) -> str:
         """시그널 키 재발급.
 
-        Refs #1761: ``accepts_external_signals=False`` 전략의 봇에 rotate 가
-        새 키를 발급해 orphan credential 이 생기던 회귀를 막는다.
-        ``create_bot`` 의 자동 발급 분기 (``manager.py`` 의
-        ``getattr(strategy_cls.meta, "accepts_external_signals", False)``)와
-        동일한 조건을 사용해 일관성을 유지한다.
+        ``accepts_external_signals=False`` 전략의 봇에 rotate 가 새 키를
+        발급해 orphan credential 이 생기지 않도록 막는다. ``create_bot`` 의
+        자동 발급 분기 (``manager.py`` 의 ``getattr(strategy_cls.meta,
+        "accepts_external_signals", False)``) 와 동일한 조건을 사용해
+        일관성을 유지한다.
         """
         if not self._signal_key_manager:
             raise BotError("SignalKeyManager가 설정되지 않았습니다")
         bot = self._get_bot(bot_id)  # 존재 확인
 
-        # accepts_external_signals 게이트 (#1761).
+        # accepts_external_signals 게이트.
         # ``Bot.__init__`` 가 ``_strategy_cls`` 를 보관하므로 ``start()``
         # 이전(``bot.strategy is None``)에도 메타를 조회할 수 있다. fallback
         # 으로는 registry+loader 를 사용해 cold-path 호출자에서도 동작한다.
@@ -1263,12 +1258,12 @@ class BotManager:
 
         self._eventbus.subscribe(OrderFilledEvent, bot.on_order_filled)
         self._eventbus.subscribe(ExternalSignalEvent, bot.on_external_signal)
-        # #1331: ``OrderModifyRejectedEvent`` 추가 — rule reject / rule
-        # exception / gateway not-implemented 통보가 ``Bot.on_order_update``
-        # 를 거쳐 ``strategy.on_order_update``까지 전달되도록 한다.
-        # #1336: ``StopOrderRegistered/Triggered/ExpiredEvent`` 추가 —
-        # stop / stop_limit 주문 등록·발동·만료 통보를 일반 주문 통보 채널과
-        # 동일한 ``on_order_update`` 로 변환한다 (별도 콜백 신설 금지 정책).
+        # ``OrderModifyRejectedEvent`` — rule reject / rule exception /
+        # gateway not-implemented 통보가 ``Bot.on_order_update`` 를 거쳐
+        # ``strategy.on_order_update`` 까지 전달되도록 한다.
+        # ``StopOrderRegistered/Triggered/ExpiredEvent`` — stop / stop_limit
+        # 주문 등록·발동·만료 통보를 일반 주문 통보 채널과 동일한
+        # ``on_order_update`` 로 변환한다 (별도 콜백 신설 금지 정책).
         for event_type in (
             OrderSubmittedEvent,
             OrderRejectedEvent,
@@ -1300,8 +1295,8 @@ class BotManager:
 
         self._eventbus.unsubscribe(OrderFilledEvent, bot.on_order_filled)
         self._eventbus.unsubscribe(ExternalSignalEvent, bot.on_external_signal)
-        # #1331: 등록과 동일하게 ``OrderModifyRejectedEvent`` 해지 추가.
-        # #1336: stop 이벤트 3종 해지 추가.
+        # 등록과 동일하게 ``OrderModifyRejectedEvent`` 와 stop 이벤트 3종
+        # 해지.
         for event_type in (
             OrderSubmittedEvent,
             OrderRejectedEvent,
@@ -1328,10 +1323,10 @@ class BotManager:
     async def _save_bot_config(self, config: BotConfig) -> None:
         """봇 설정 DB 저장.
 
-        Refs #1457: ``interval_seconds`` 외에 runtime control 4개 필드와
-        ``auto_restart`` 도 함께 직렬화한다. 누락 시 ``load_from_db`` 에서
-        dataclass default 로 복원되어 사용자가 PUT 으로 변경한 값이 silent
-        하게 default 로 되돌아가는 회귀(#1413)가 발생한다.
+        ``interval_seconds`` 외에 runtime control 4개 필드와 ``auto_restart``
+        도 함께 직렬화한다. 누락 시 ``load_from_db`` 에서 dataclass default
+        로 복원되어 사용자가 PUT 으로 변경한 값이 silent 하게 default 로
+        되돌아가는 회귀가 발생한다.
         """
         config_dict = {
             "bot_id": config.bot_id,

--- a/src/ante/bot/providers/virtual.py
+++ b/src/ante/bot/providers/virtual.py
@@ -171,7 +171,7 @@ class VirtualExecutor:
         if not isinstance(event, OrderApprovedEvent):
             return
 
-        # 등록 단계의 stop / stop_limit 주문은 가상 체결하지 않는다 (#1337).
+        # 등록 단계의 stop / stop_limit 주문은 가상 체결하지 않는다.
         # StopOrderManager가 trigger 시 변환된 OrderRequestEvent를 발행하면
         # 그 변환 주문이 일반 limit/market로 다시 RuleEngine → Treasury →
         # OrderApprovedEvent 경로를 타고 들어와 정상 체결된다.
@@ -194,8 +194,8 @@ class VirtualExecutor:
             fill_price = event.price
         else:
             # market 주문: 현재가 기반 + 슬리피지
-            # SPLIT-3 (#1242): APIGateway.get_current_price 가 account_id 를
-            # required 로 받으므로 OrderApprovedEvent.account_id 를 명시 전달.
+            # APIGateway.get_current_price 가 account_id 를 required 로 받으
+            # 므로 OrderApprovedEvent.account_id 를 명시 전달.
             if self._gateway:
                 try:
                     current_price = await self._gateway.get_current_price(

--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -169,11 +169,11 @@ class SignalChannel:
         )
 
         self._eventbus.subscribe(OrderFilledEvent, self._on_fill)
-        # #1331: ``OrderModifyRejectedEvent`` 추가 — 외부 채널 구독자에게도
-        # 정정 거부/미구현 통보를 ``order_update`` 메시지로 전달한다.
-        # #1336: stop 주문 등록·발동·만료를 외부 채널에도 동일한
-        # ``{type:"order_update", ...}`` shape 로 전달한다 (외부 소비자
-        # 파싱 분기 추가 부담 회피).
+        # ``OrderModifyRejectedEvent`` — 외부 채널 구독자에게도 정정 거부/
+        # 미구현 통보를 ``order_update`` 메시지로 전달한다.
+        # stop 주문 등록·발동·만료도 외부 채널에 동일한 ``{type:
+        # "order_update", ...}`` shape 로 전달한다 (외부 소비자 파싱 분기
+        # 추가 부담 회피).
         for evt in (
             OrderSubmittedEvent,
             OrderRejectedEvent,
@@ -203,8 +203,8 @@ class SignalChannel:
         )
 
         self._eventbus.unsubscribe(OrderFilledEvent, self._on_fill)
-        # #1331: 등록과 동일하게 ``OrderModifyRejectedEvent`` 해지 추가.
-        # #1336: stop 이벤트 3종 해지 추가.
+        # 등록과 동일하게 ``OrderModifyRejectedEvent`` 와 stop 이벤트 3종
+        # 해지.
         for evt in (
             OrderSubmittedEvent,
             OrderRejectedEvent,
@@ -284,26 +284,26 @@ class SignalChannel:
             status = "cancel_failed"
             reason = event.error_message
         elif isinstance(event, OrderModifyRejectedEvent):
-            # #1331: 정정 거부/미구현 통보를 status로 잠그고, 외부 dict
-            # shape는 기존 ``{type:"order_update", ...}`` 패턴을 그대로
-            # 유지한다. ``type``을 ``"modify_rejected"`` 같은 새 형태로
-            # 바꾸면 외부 소비자(stdin/stdout 기반 에이전트)가 파싱
-            # 분기를 추가해야 하므로 의도적으로 잠갔다.
+            # 정정 거부/미구현 통보를 status 로 잠그고, 외부 dict shape 는
+            # 기존 ``{type:"order_update", ...}`` 패턴을 그대로 유지한다.
+            # ``type`` 을 ``"modify_rejected"`` 같은 새 형태로 바꾸면 외부
+            # 소비자(stdin/stdout 기반 에이전트) 가 파싱 분기를 추가해야
+            # 하므로 의도적으로 잠갔다.
             status = "modify_rejected"
             reason = event.reason
         elif isinstance(event, StopOrderRegisteredEvent):
-            # #1336: stop 등록 통보. 외부 채널에는 식별 핵심인 stop_order_id
-            # 만 ``order_id`` 키로 전달하고, dict shape 는 기존
-            # ``{type:"order_update", order_id, status, reason}`` 그대로 유지.
+            # stop 등록 통보. 외부 채널에는 식별 핵심인 stop_order_id 만
+            # ``order_id`` 키로 전달하고, dict shape 는 기존 ``{type:
+            # "order_update", order_id, status, reason}`` 그대로 유지.
             status = "stop_registered"
             order_id = event.stop_order_id
         elif isinstance(event, StopOrderTriggeredEvent):
-            # #1336: stop 트리거 통보.
+            # stop 트리거 통보.
             status = "stop_triggered"
             order_id = event.stop_order_id
         elif isinstance(event, StopOrderExpiredEvent):
-            # #1336: stop 만료 통보. ``reason`` 은
-            # ``"session_ended"`` | ``"manager_stopped"``.
+            # stop 만료 통보. ``reason`` 은 ``"session_ended"`` |
+            # ``"manager_stopped"``.
             status = "stop_expired"
             order_id = event.stop_order_id
             reason = event.reason

--- a/src/ante/bot/signal_key.py
+++ b/src/ante/bot/signal_key.py
@@ -59,8 +59,8 @@ class SignalKeyManager:
     async def rotate(self, bot_id: str) -> str:
         """기존 키 폐기 + 새 키 발급.
 
-        Refs #1901: DELETE 와 INSERT 를 단일 트랜잭션으로 묶어 부분 실패(예:
-        INSERT UNIQUE 위반, 연결 단절) 시 기존 키가 영구 폐기되어 자격 증명이
+        DELETE 와 INSERT 를 단일 트랜잭션으로 묶어 부분 실패(예: INSERT
+        UNIQUE 위반, 연결 단절) 시 기존 키가 영구 폐기되어 자격 증명이
         사라지는 상태(orphan revoke)를 차단한다. 트랜잭션 내부 예외는
         ``Database.transaction()`` 컨텍스트 매니저가 자동 ROLLBACK 후 재전파
         한다.


### PR DESCRIPTION
Re-addresses #1924 (2차 chunk).

## Summary
`src/ante/bot/` 10 files, 71건 이슈번호/리뷰 히스토리 인용을 runbook §10 정책에 따라 정리.

- 유지: 현재 invariant, 호출 계약, 보안 이유, SSOT 인용(`src/ante/bot/config.py`, `manager.py:340`, `Database.transaction()`), envelope code (`BOT_NOT_FOUND` 등)
- 축약: `Refs #N`/`(#NNNN)` prefix 제거, invariant 본문 유지

| file | 건수 |
|------|-----|
| manager.py | 33 |
| signal_channel.py | 8 |
| bot.py | 8 |
| exceptions.py | 6 |
| info.py / config.py | 각 4 |
| context_factory.py | 3 |
| providers/virtual.py / cold_path.py | 각 2 |
| signal_key.py | 1 |

## Scope (#1924 시리즈)
- 1차: `src/ante/cli/middleware.py` (#1939 merged)
- 2차 (본 PR): `src/ante/bot/` 모듈
- 3차 후속: `src/ante/cli/commands/` 약 ~360건 — 별도 follow-up 이슈로 chunked

## Test Plan
- `pytest tests/unit/test_bot*.py tests/unit/test_signal_key*.py` 330 PASS
- `pytest tests/unit/test_cli_bot_signal_key_rotate_external_gate.py` 6 PASS
- `ruff check` / `mypy src/ante/bot/` clean
- runtime/contract/identifier 그대로

## Review
- Codex 브랜치 review PASS