### PR TITLE
refactor(cli): #1941 commands/ invariant 중심 주석 정리 (#1924 시리즈 3차)

### DIFF
--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -42,9 +42,9 @@ from ante.cli.middleware import get_member_id, require_auth, require_scope
 from ante.contracts import emit_cli_error
 
 # `AccountStatus` enum이 `--status` 필터의 SSOT다. `account list`는 DB 진입 전
-# preflight에서 invalid 값을 차단해야 하며 (#1462), 이를 위해 함수 내부 import
-# 대신 모듈 상단 import을 사용한다. `ante.account.models`은 dataclass + StrEnum
-# 만 노출하는 light 모듈이라 `tests/unit/test_cli_dependency_isolation.py`가
+# preflight에서 invalid 값을 차단해야 하며, 이를 위해 함수 내부 import 대신
+# 모듈 상단 import을 사용한다. `ante.account.models`은 dataclass + StrEnum 만
+# 노출하는 light 모듈이라 `tests/unit/test_cli_dependency_isolation.py`가
 # 회귀를 차단한다.
 
 if TYPE_CHECKING:
@@ -75,9 +75,9 @@ _COLD_PATH_BLOCKED_CODE = ACCOUNT_COLD_PATH_BLOCKED_CODE
 def _assert_no_active_runtime(fmt: OutputFormatter) -> None:
     """active Ante runtime이 있으면 cold-path 명령을 차단한다.
 
-    공유 헬퍼는 Refs #1157/#1160의 canonical config-dir, PID/socket, startup
-    marker 규칙을 사용한다. 이 래퍼는 기존 account 테스트와 import 경로를
-    유지하기 위한 호환 계층이다.
+    공유 헬퍼는 canonical config-dir, PID/socket, startup marker 규칙을
+    사용한다. 이 래퍼는 기존 account 테스트와 import 경로를 유지하기 위한
+    호환 계층이다.
     """
     # ``kill=os.kill``은 기존 테스트가 ``ante.cli.commands.account.os.kill``을
     # monkeypatch하던 계약을 유지하기 위한 호환 주입점이다.
@@ -96,18 +96,16 @@ def _assert_no_active_runtime(fmt: OutputFormatter) -> None:
 async def _create_account_service(
     ctx: click.Context | None = None,
 ) -> AsyncIterator[AccountService]:
-    """CLI에서 ``AccountService`` 를 생성하는 async context manager (#1856).
+    """CLI에서 ``AccountService`` 를 생성하는 async context manager.
 
-    이전 시그니처(``async def`` → ``tuple[AccountService, Database]``)에서
-    ``open_cli_db`` 기반 async context manager 로 전환했다 (#1855 factory
-    composition). 호출 패턴:
+    ``open_cli_db`` 기반 lifecycle (factory composition). 호출 패턴:
 
         async with _create_account_service(ctx) as svc:
             await svc.create(...)
 
     ``open_cli_db`` 가 normal/exception/cancellation 모든 경로에서
-    ``Database.close()`` 를 보장하므로 (#1722/#1755 cleanup invariant 와 동형),
-    callsite 의 ``try/finally: await db.close()`` 패턴이 제거된다.
+    ``Database.close()`` 를 보장하므로 (cleanup invariant), callsite 의
+    ``try/finally: await db.close()`` 패턴이 제거된다.
 
     Args:
         ctx: Click 컨텍스트. ``None`` 이면 ``click.get_current_context(silent=True)``
@@ -123,7 +121,7 @@ async def _create_account_service(
     Cleanup invariant:
         - ``open_cli_db`` 가 ``BaseException`` 까지 catch 하므로
           ``AccountService.initialize()`` 가 ``EncryptionKeyMissingError`` 등을
-          raise 해도 ``Database.close()`` 가 1회 호출된다 (#1722 회귀 lock).
+          raise 해도 ``Database.close()`` 가 1회 호출된다.
         - ``close()`` 실패는 ``open_cli_db`` 내부 try/except 가 swallow 한다.
     """
     from ante.account.service import AccountService
@@ -496,8 +494,8 @@ def _validate_broker_type(fmt: OutputFormatter, broker_type: str) -> None:
     callback=validate_nonnegative_finite_amount,
     help=(
         "시장가 매수 reserve buffer 비율 (예: 0.005=0.5%). "
-        "omit 시 BrokerPreset 기본값을 사용한다 (#1333). "
-        "NaN/Infinity/음수는 거부된다 (#1723)."
+        "omit 시 BrokerPreset 기본값을 사용한다. "
+        "NaN/Infinity/음수는 거부된다."
     ),
 )
 @format_option
@@ -551,10 +549,10 @@ def account_create(
     assert name_opt is not None
     assert trading_mode_opt is not None
 
-    # 1-b) account_id ingress 검증 (#1724, D follow-up — #1634 동형). invalid
-    # account_id(`default` RESTRICTED, pattern 위반 `bad_id`, ``""``)를
-    # ``AccountService.create`` SQL 진입 이전에 `VALIDATION_ERROR` + exit 1로
-    # 거부한다. 미적용 시 ``svc.create``가 `EXECUTION_ERROR`/empty로 떨어져
+    # 1-b) account_id ingress 검증 — invalid account_id (`default` RESTRICTED,
+    # pattern 위반 `bad_id`, ``""``) 를 ``AccountService.create`` SQL 진입
+    # 이전에 `VALIDATION_ERROR` + exit 1로 거부한다. 미적용 시 ``svc.create``
+    # 가 `EXECUTION_ERROR`/empty로 떨어져
     # invalid ingress가 not-found 의미와 구별되지 않는다.
     # ``validate_new_account_id``는 RESTRICTED-aware라 lookup-policy의
     # ``require_account_id``와 달리 ``test`` 같은 bootstrap seed id도 거부한다.
@@ -596,7 +594,7 @@ def account_create(
     )
 
     # market_order_reserve_buffer_rate: 옵션 omit 시 preset 기본값을 그대로
-    # 사용하고, 명시된 경우 ``Decimal(str(...))``로 정밀도를 보존한다 (#1333).
+    # 사용하고, 명시된 경우 ``Decimal(str(...))``로 정밀도를 보존한다.
     if market_order_reserve_buffer_rate_opt is None:
         market_order_buffer = preset.market_order_reserve_buffer_rate
     else:
@@ -627,7 +625,7 @@ def account_create(
     try:
         created = _run(_do_create())
     except Exception as e:
-        # #1842: emit_cli_error 가 registry-first → ``.code`` fallback →
+        # emit_cli_error 가 registry-first → ``.code`` fallback →
         # EXECUTION_ERROR 순서로 ErrorSpec 을 resolve해 IPC envelope 와 동일한
         # public code 를 surface 한다.
         emit_cli_error(fmt, e)
@@ -663,8 +661,8 @@ def account_list(ctx: click.Context, status_filter: str | None) -> None:
     fmt = get_formatter(ctx)
 
     # Preflight: invalid `--status`는 `_create_account_service()` (DB 접속) 전에
-    # 차단한다. `AccountStatus` enum이 SSOT이며 (#1462) inline 비교한다.
-    # strategy.py:204-210 패턴과 동형이다.
+    # 차단한다. `AccountStatus` enum이 SSOT이며 inline 비교한다.
+    # strategy.py 패턴과 동형이다.
     if status_filter is not None and status_filter not in {
         s.value for s in AccountStatus
     }:
@@ -684,7 +682,7 @@ def account_list(ctx: click.Context, status_filter: str | None) -> None:
     try:
         rows = _run(_do_list())
     except Exception as e:
-        # #1842: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     if not rows:
@@ -713,7 +711,7 @@ def account_info(ctx: click.Context, account_id: str) -> None:
     """계좌 상세 정보 조회."""
     fmt = get_formatter(ctx)
 
-    # `svc.get(account_id)` lookup **이전** ingress 검증 (#1634, Split A).
+    # `svc.get(account_id)` lookup **이전** ingress 검증.
     # invalid account_id(`default`/`""`/패턴 위반)를 not-found로 오분류하지
     # 않고 `VALIDATION_ERROR` + exit 1로 거부한다. positional required arg라
     # omitted가 없어 전 입력을 검증한다. helper가 `InvalidAccountIdError`를
@@ -731,8 +729,8 @@ def account_info(ctx: click.Context, account_id: str) -> None:
     try:
         detail = _run(_do_info())
     except Exception as e:
-        # #1842: emit_cli_error 정렬 — AccountNotFoundError 등 typed exception
-        # 의 IPC envelope code (ACCOUNT_NOT_FOUND) 와 동일하게 surface.
+        # emit_cli_error 로 AccountNotFoundError 등 typed exception 의 IPC
+        # envelope code (ACCOUNT_NOT_FOUND) 와 동일하게 surface.
         emit_cli_error(fmt, e)
 
     if fmt.is_json:
@@ -757,12 +755,12 @@ def account_suspend(ctx: click.Context, account_id: str, reason: str) -> None:
     fmt = get_formatter(ctx)
     member_id = get_member_id(ctx)
 
-    # IPC dispatch **이전** ingress 검증 (#1655, D follow-up — #1634
-    # `account_info` 1:1 동형 미러). invalid account_id(`default`/`""`/패턴
-    # 위반)를 service/IPC 진입 전 `VALIDATION_ERROR` + exit 1로 거부한다.
-    # positional required arg라 omitted가 없어 전 입력을 검증한다. helper가
-    # `InvalidAccountIdError`를 명시 catch하므로 아래 generic
-    # `except Exception`(code 없음 → traceback 누출)에 도달하지 않는다.
+    # IPC dispatch **이전** ingress 검증 (`account_info` 1:1 동형 미러).
+    # invalid account_id(`default`/`""`/패턴 위반)를 service/IPC 진입 전
+    # `VALIDATION_ERROR` + exit 1로 거부한다. positional required arg라
+    # omitted가 없어 전 입력을 검증한다. helper가 `InvalidAccountIdError`를
+    # 명시 catch하므로 아래 generic `except Exception` (code 없음 →
+    # traceback 누출) 에 도달하지 않는다.
     validated_account_id = reject_invalid_account_id(
         account_id, fmt, context="cli.account.suspend"
     )
@@ -778,9 +776,8 @@ def account_suspend(ctx: click.Context, account_id: str, reason: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        # #1842: emit_cli_error 정렬 — code-less fmt.error 를 taxonomy 정렬된
-        # public code (IPC envelope 와 동일) 으로 surface 한다. baseline
-        # allowlist entry 제거 대상.
+        # emit_cli_error 로 code-less fmt.error 를 taxonomy 정렬된 public
+        # code (IPC envelope 와 동일) 으로 surface 한다.
         emit_cli_error(fmt, e)
 
     fmt.success(f'계좌 "{validated_account_id}" 정지 완료')
@@ -801,12 +798,12 @@ def account_activate(ctx: click.Context, account_id: str) -> None:
     fmt = get_formatter(ctx)
     member_id = get_member_id(ctx)
 
-    # IPC dispatch **이전** ingress 검증 (#1655, D follow-up — #1634
-    # `account_info` 1:1 동형 미러). invalid account_id(`default`/`""`/패턴
-    # 위반)를 service/IPC 진입 전 `VALIDATION_ERROR` + exit 1로 거부한다.
-    # positional required arg라 omitted가 없어 전 입력을 검증한다. helper가
-    # `InvalidAccountIdError`를 명시 catch하므로 아래 generic
-    # `except Exception`(code 없음 → traceback 누출)에 도달하지 않는다.
+    # IPC dispatch **이전** ingress 검증 (`account_info` 1:1 동형 미러).
+    # invalid account_id(`default`/`""`/패턴 위반)를 service/IPC 진입 전
+    # `VALIDATION_ERROR` + exit 1로 거부한다. positional required arg라
+    # omitted가 없어 전 입력을 검증한다. helper가 `InvalidAccountIdError`를
+    # 명시 catch하므로 아래 generic `except Exception` (code 없음 →
+    # traceback 누출) 에 도달하지 않는다.
     validated_account_id = reject_invalid_account_id(
         account_id, fmt, context="cli.account.activate"
     )
@@ -822,9 +819,8 @@ def account_activate(ctx: click.Context, account_id: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        # #1842: emit_cli_error 정렬 — code-less fmt.error 를 taxonomy 정렬된
-        # public code (IPC envelope 와 동일) 으로 surface 한다. baseline
-        # allowlist entry 제거 대상.
+        # emit_cli_error 로 code-less fmt.error 를 taxonomy 정렬된 public
+        # code (IPC envelope 와 동일) 으로 surface 한다.
         emit_cli_error(fmt, e)
 
     fmt.success(f'계좌 "{validated_account_id}" 활성화 완료')
@@ -866,10 +862,10 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
     # cold-path: confirm 통과 직후 active runtime 차단
     _assert_no_active_runtime(fmt)
 
-    # ingress 검증 (#1724, D follow-up — #1634 동형). invalid account_id
-    # (`default`/패턴 위반)를 ``AccountService.delete`` SQL 진입 이전에
-    # `VALIDATION_ERROR` + exit 1로 거부한다. 미적용 시 ``svc.delete``가
-    # ``AccountNotFoundError``로 raise되어 invalid ingress가 not-found 의미와
+    # ingress 검증 — invalid account_id (`default`/패턴 위반) 를
+    # ``AccountService.delete`` SQL 진입 이전에 `VALIDATION_ERROR` + exit 1로
+    # 거부한다. 미적용 시 ``svc.delete``가 ``AccountNotFoundError``로
+    # raise되어 invalid ingress가 not-found 의미와
     # 구별되지 않는다. positional required arg라 omitted가 없어 전 입력을
     # 검증한다.
     validated_account_id = reject_invalid_account_id(
@@ -890,7 +886,7 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
         _run(_do_delete())
     except AccountHasActiveBotsError as e:
         # 메시지 본문은 errors.py에서 multi-step 복구 절차까지 포함해 빌드한다.
-        # (#1139 R-A) 별도 wording을 만들지 말고 그대로 출력한다.
+        # 별도 wording을 만들지 말고 그대로 출력한다.
         fmt.error(str(e), code="ACCOUNT_HAS_ACTIVE_BOTS")
         raise SystemExit(1) from e
     except AccountNotFoundError as e:
@@ -899,14 +895,14 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
     except AccountDeletedError as e:
         # CLI surface override (보존): registry default ACCOUNT_DELETED 대신
         # account delete UX 의 already-deleted 의미 (ACCOUNT_ALREADY_DELETED)
-        # 를 surface 한다 (#1812 / errors.py:96-100 NOTE / #1842 plan v2).
+        # 를 surface 한다 (errors.py NOTE).
         fmt.error(str(e), code="ACCOUNT_ALREADY_DELETED")
         raise SystemExit(1) from e
     except click.ClickException:
         raise
     except Exception as e:
-        # #1842: emit_cli_error 정렬 — generic fallback 도 registry-first 로
-        # IPC envelope 와 동일 public code 를 surface.
+        # emit_cli_error 로 generic fallback 도 registry-first 로 IPC envelope
+        # 와 동일 public code 를 surface.
         emit_cli_error(fmt, e)
 
     fmt.success(f'계좌 "{validated_account_id}" 삭제 완료')
@@ -926,7 +922,7 @@ def account_credentials(ctx: click.Context, account_id: str) -> None:
     fmt = get_formatter(ctx)
 
     # `account info`와 동형 — `svc.get(account_id)` lookup **이전** ingress
-    # 검증 (#1634, Split A). invalid account_id를 not-found로 오분류하지 않고
+    # 검증. invalid account_id를 not-found로 오분류하지 않고
     # `VALIDATION_ERROR` + exit 1로 거부한다.
     validated_account_id = reject_invalid_account_id(
         account_id, fmt, context="cli.account.credentials"
@@ -940,7 +936,7 @@ def account_credentials(ctx: click.Context, account_id: str) -> None:
     try:
         masked = _run(_do_credentials())
     except Exception as e:
-        # #1842: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     if not masked:
@@ -1006,10 +1002,10 @@ def account_set_credentials(
     # cold-path: active runtime이 있으면 진입 직후 차단
     _assert_no_active_runtime(fmt)
 
-    # ingress 검증 (#1724, D follow-up — #1634 동형). invalid account_id
-    # (`default`/패턴 위반)를 ``svc.get`` lookup 이전에 `VALIDATION_ERROR` +
-    # exit 1로 거부한다. 미적용 시 ``svc.get``이 ``AccountNotFoundError``로
-    # raise되어 invalid ingress가 not-found 의미와 구별되지 않는다. positional
+    # ingress 검증 — invalid account_id (`default`/패턴 위반) 를 ``svc.get``
+    # lookup 이전에 `VALIDATION_ERROR` + exit 1로 거부한다. 미적용 시
+    # ``svc.get``이 ``AccountNotFoundError``로 raise되어 invalid ingress가
+    # not-found 의미와 구별되지 않는다. positional
     # required arg라 omitted가 없어 전 입력을 검증한다.
     validated_account_id = reject_invalid_account_id(
         account_id, fmt, context="cli.account.set-credentials"
@@ -1069,7 +1065,7 @@ def account_set_credentials(
     except SystemExit:
         raise
     except Exception as e:
-        # #1842: emit_cli_error 정렬 — MissingCredentialsError /
+        # emit_cli_error 로 MissingCredentialsError /
         # BrokerReconnectFailedError 등 typed exception 도 registry-first 로
         # 정확한 public code (ACCOUNT_MISSING_CREDENTIALS / BROKER_RECONNECT_FAILED)
         # 를 surface 한다.
@@ -1089,7 +1085,7 @@ def account_set_credentials(
 def account_repair_timezone(
     ctx: click.Context, account_id: str, new_timezone: str
 ) -> None:
-    """legacy invalid IANA timezone 계좌를 복구한다 (cold-path 전용, #1474).
+    """legacy invalid IANA timezone 계좌를 복구한다 (cold-path 전용).
 
     ``_row_to_account`` 가 stored invalid timezone 을 보존하면서
     ``Account.timezone_invalid`` marker 를 노출한 row 를 운영자가 명시한
@@ -1112,10 +1108,10 @@ def account_repair_timezone(
     # ``_create_account_service`` 자체가 호출되지 않아야 한다.
     _assert_no_active_runtime(fmt)
 
-    # ingress 검증 (#1724, D follow-up — #1634 동형). invalid account_id
-    # (`default`/패턴 위반)를 ``svc.repair_timezone`` 진입 이전에
-    # `VALIDATION_ERROR` + exit 1로 거부한다. 미적용 시 service-layer가
-    # ``AccountNotFoundError``로 raise되어 invalid ingress가 not-found 의미와
+    # ingress 검증 — invalid account_id (`default`/패턴 위반) 를
+    # ``svc.repair_timezone`` 진입 이전에 `VALIDATION_ERROR` + exit 1로
+    # 거부한다. 미적용 시 service-layer가 ``AccountNotFoundError``로
+    # raise되어 invalid ingress가 not-found 의미와
     # 구별되지 않는다. positional required arg라 omitted가 없어 전 입력을
     # 검증한다.
     validated_account_id = reject_invalid_account_id(
@@ -1156,13 +1152,13 @@ def account_repair_timezone(
     except AccountDeletedError as e:
         # CLI surface override (보존): registry default ACCOUNT_DELETED 대신
         # repair-timezone 표면에서 already-deleted 의미 (ACCOUNT_ALREADY_DELETED)
-        # 를 surface 한다 (account_delete 와 동일 정책, #1842 plan v2).
+        # 를 surface 한다 (account_delete 와 동일 정책).
         fmt.error(str(e), code="ACCOUNT_ALREADY_DELETED")
         raise SystemExit(1) from e
     except click.ClickException:
         raise
     except Exception as e:
-        # #1842: emit_cli_error 정렬 — registry-first 로 IPC envelope 와 동일.
+        # emit_cli_error 로 registry-first IPC envelope 동일 surface.
         emit_cli_error(fmt, e)
 
     fmt.success(

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -16,8 +16,8 @@ from ante.cli.middleware import get_member_id, require_auth, require_scope
 from ante.contracts import emit_cli_error
 
 # `ApprovalStatus`/`ApprovalType` enum이 `--status`/`--type` 필터의 SSOT다.
-# `approval list`는 DB 진입 전 preflight에서 invalid 값을 차단해야 하며 (#1462),
-# 이를 위해 함수 내부 import 대신 모듈 상단 import을 사용한다.
+# `approval list`는 DB 진입 전 preflight에서 invalid 값을 차단해야 하며, 이를
+# 위해 함수 내부 import 대신 모듈 상단 import을 사용한다.
 # `ante.approval.models`은 dataclass + StrEnum 만 노출하는 light 모듈이라
 # `tests/unit/test_cli_dependency_isolation.py`가 회귀를 차단한다.
 
@@ -49,7 +49,7 @@ def request(
 ) -> None:
     """결재 요청 생성."""
     # ApprovalType SSOT 검증. `ante.approval.models`는 모듈 상단에서 import한다
-    # (#1462; #1469 lazy 패턴은 dependency-isolation smoke가 회귀 차단).
+    # (dependency-isolation smoke가 lazy 패턴 회귀를 차단).
 
     fmt = get_formatter(ctx)
     requester = get_member_id(ctx)
@@ -63,8 +63,8 @@ def request(
     # ``--params`` 는 service ``params.get()`` 호출의 SSOT 입력이므로 JSON
     # object (dict) 만 허용한다. string/list/number/bool/null 같은 non-dict
     # JSON value 가 통과하면 service 단에서 ``AttributeError`` traceback 이
-    # 노출된다 (#1519). 같은 함수 line 57-58 / 62-66 패턴과 동형.
-    # service/IPC defense-in-depth 는 본 PR Non-Goals (follow-up).
+    # 노출된다. 같은 함수 다른 분기와 동형.
+    # service/IPC defense-in-depth 는 본 모듈 범위 밖.
     if not isinstance(params, dict):
         params_type = type(params).__name__
         fmt.error(
@@ -89,7 +89,7 @@ def request(
             # 너무 큰 숫자 + h/d 입력 시 ``timedelta`` 에서 ``OverflowError``
             # 를 raise 한다. 둘 다 ingress validation 실패이므로 동일하게
             # ``APPROVAL_VALIDATION_ERROR`` 구조화 에러로 종료시켜 Python
-            # traceback 노출을 차단한다 (#1518; line 57-58 / 92-94 패턴과 동형).
+            # traceback 노출을 차단한다 (다른 분기 패턴과 동형).
             fmt.error(
                 f"잘못된 expires-in: {e}",
                 code="APPROVAL_VALIDATION_ERROR",
@@ -121,11 +121,10 @@ def request(
     except click.ClickException:
         raise
     except Exception as e:
-        # #1843 sub-PR 2: typed exception (.code) 또는 registry MRO lookup 으로
-        # IPC envelope 과 동일한 public code (APPROVAL_VALIDATION_ERROR /
+        # typed exception (.code) 또는 registry MRO lookup 으로 IPC envelope
+        # 과 동일한 public code (APPROVAL_VALIDATION_ERROR /
         # APPROVAL_STATUS_CONFLICT 등) 를 surface 한다. registry miss 시
-        # EXECUTION_ERROR fallback (기존 ad-hoc "APPROVAL_ERROR" 와 별개의
-        # taxonomy lock 코드).
+        # EXECUTION_ERROR fallback (taxonomy lock 코드).
         emit_cli_error(fmt, e)
 
 
@@ -147,8 +146,8 @@ def approval_list(
     fmt = get_formatter(ctx)
 
     # Preflight: invalid `--status`/`--type`는 `Database` 생성 전에 차단한다.
-    # `ApprovalStatus`/`ApprovalType` enum이 SSOT이며 (#1462) inline 비교한다.
-    # strategy.py:204-210 패턴과 동형이다.
+    # `ApprovalStatus`/`ApprovalType` enum이 SSOT이며 inline 비교한다.
+    # strategy.py 패턴과 동형이다.
     if status is not None and status not in {s.value for s in ApprovalStatus}:
         fmt.error(
             f"잘못된 status 값: {status!r}. "
@@ -171,17 +170,17 @@ def approval_list(
         from ante.approval import ApprovalService
         from ante.eventbus.bus import EventBus
 
-        # #1856: ``open_cli_db`` 헬퍼가 ``Database`` 생성/connect/close lifecycle
-        # 을 캡슐화한다 (#1855). 이전 ``except BaseException`` cleanup 패턴
-        # (#1755) 은 헬퍼 내부의 ``BaseException`` catch + close 실패 swallow 로
-        # 흡수됐다. ``--db-path`` Click option 은 ``db_path_override`` 로 명시
-        # 전달해 ctx 의 기본 ``get_db_path(ctx)`` resolution 을 override 한다
-        # (offline-factory.md §1.1).
+        # ``open_cli_db`` 헬퍼가 ``Database`` 생성/connect/close lifecycle 을
+        # 캡슐화한다. cleanup 패턴 (``BaseException`` catch + close 실패
+        # swallow) 도 헬퍼 내부에 흡수됐다. ``--db-path`` Click option 은
+        # ``db_path_override`` 로 명시 전달해 ctx 의 기본 ``get_db_path(ctx)``
+        # resolution 을 override 한다 (offline-factory.md §1.1).
         async with open_cli_db(ctx, db_path_override=db_path) as db:
             eventbus = EventBus()
             service = ApprovalService(db=db, eventbus=eventbus)
-            # #1854 §4.2 예외: ``ApprovalService.initialize`` 는 ``APPROVAL_SCHEMA``
-            # DDL 을 수반하므로 read-only ``list`` 경로에서도 호출이 필요하다.
+            # ``ApprovalService.initialize`` 는 ``APPROVAL_SCHEMA`` DDL 을
+            # 수반하므로 read-only ``list`` 경로에서도 호출이 필요하다
+            # (read-only 명시 예외).
             await service.initialize()
 
             requests = await service.list_approvals(status=status, type=approval_type)
@@ -201,8 +200,8 @@ def approval_list(
         rows = asyncio.run(_list())
         fmt.table(rows, ["id", "type", "status", "requester", "title", "created_at"])
     except Exception as e:
-        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
-        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        # helper 가 typed exception (.code) → registry → fallback 순서로
+        # public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
         emit_cli_error(fmt, e)
 
 
@@ -221,14 +220,15 @@ def info(ctx: click.Context, id: str, db_path: str | None) -> None:
         from ante.approval import ApprovalService
         from ante.eventbus.bus import EventBus
 
-        # #1856: ``open_cli_db`` 헬퍼가 ``_find_request`` 의 ``ValueError`` /
+        # ``open_cli_db`` 헬퍼가 ``_find_request`` 의 ``ValueError`` /
         # ``ApprovalNotFoundError`` raise 경로에서도 ``Database.close()`` 를
-        # 보장한다 (#1755 회귀 lock — 이전 구현은 close 미도달로 aiosqlite
+        # 보장한다 (cleanup invariant — 이전 구현은 close 미도달로 aiosqlite
         # worker thread leak → 8s busy_timeout 대기로 probe timeout exit 124).
         async with open_cli_db(ctx, db_path_override=db_path) as db:
             eventbus = EventBus()
             service = ApprovalService(db=db, eventbus=eventbus)
-            # #1854 §4.2 예외: schema DDL 수반 → read-only 경로에도 initialize 호출.
+            # schema DDL 수반 → read-only 경로에도 initialize 호출 (read-only
+            # 명시 예외).
             await service.initialize()
 
             req = await _find_request(service, id)
@@ -254,16 +254,15 @@ def info(ctx: click.Context, id: str, db_path: str | None) -> None:
         result = asyncio.run(_info())
         fmt.output(result)
     except ApprovalNotFoundError as e:
-        # #1811: missing approval 은 안정 코드 ``APPROVAL_NOT_FOUND`` 로
-        # surface 한다 (Group A ``ApprovalNotFoundError.code`` 와 동형).
-        # #1843 sub-PR 2: typed except 보존 — registry 등록된 동일 코드와
-        # surface 일치하지만, ``info``/``review`` 양쪽이 _find_request 의
-        # ValueError(multi-match) 분기와도 구분되어야 하므로 명시 매핑 유지.
+        # missing approval 은 안정 코드 ``APPROVAL_NOT_FOUND`` 로 surface
+        # 한다 (``ApprovalNotFoundError.code`` 와 동형). ``info``/``review``
+        # 양쪽이 _find_request 의 ValueError(multi-match) 분기와도 구분되어야
+        # 하므로 명시 매핑 유지.
         fmt.error(str(e), code="APPROVAL_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
-        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        # helper 가 typed exception (.code) → registry → fallback 순서로
+        # public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
         emit_cli_error(fmt, e)
 
 
@@ -297,9 +296,9 @@ def review(
         from ante.approval import ApprovalService
         from ante.eventbus.bus import EventBus
 
-        # #1856: ``open_cli_db`` 헬퍼가 ``service.add_review`` 의 not-found /
-        # invalid-id raise 경로에서도 ``Database.close()`` 를 보장한다 (#1755
-        # 회귀 lock — ``approval info`` 와 동형).
+        # ``open_cli_db`` 헬퍼가 ``service.add_review`` 의 not-found /
+        # invalid-id raise 경로에서도 ``Database.close()`` 를 보장한다
+        # (cleanup invariant — ``approval info`` 와 동형).
         async with open_cli_db(ctx, db_path_override=db_path) as db:
             eventbus = EventBus()
             service = ApprovalService(db=db, eventbus=eventbus)
@@ -322,14 +321,14 @@ def review(
         result = asyncio.run(_review())
         fmt.success(f"검토 의견 추가: {reviewer} → {review_result}", result)
     except ApprovalNotFoundError as e:
-        # #1811: missing approval 은 안정 코드 ``APPROVAL_NOT_FOUND`` 로
-        # surface 한다 (Group A ``ApprovalNotFoundError.code`` 와 동형,
-        # ``approval info`` 형제 패턴 미러). #1843 sub-PR 2: typed except 보존.
+        # missing approval 은 안정 코드 ``APPROVAL_NOT_FOUND`` 로 surface
+        # 한다 (``ApprovalNotFoundError.code`` 와 동형, ``approval info``
+        # 형제 패턴 미러).
         fmt.error(str(e), code="APPROVAL_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
-        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        # helper 가 typed exception (.code) → registry → fallback 순서로
+        # public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
         emit_cli_error(fmt, e)
 
 
@@ -364,7 +363,7 @@ def reopen(
             fmt.error(f"잘못된 JSON 형식: {e}", code="INVALID_JSON")
             raise SystemExit(1) from e
         # ``--params`` 는 service ``params.get()`` 의 SSOT 입력이므로 JSON
-        # object 만 허용한다 (#1519; ``request`` 사이트와 동형).
+        # object 만 허용한다 (``request`` 사이트와 동형).
         # ``--params`` 옵션 미지정 (``params_json is None``) 시에는 이 분기에
         # 진입하지 않아 ``params=None`` sentinel 이 보존되어 IPC payload 에
         # ``params`` 키가 빠지고 기존 값 유지 invariant 가 지켜진다.
@@ -383,8 +382,8 @@ def reopen(
 
         # IPC handler ``_handle_approval_reopen`` 가 ``args["id"]`` 를 기대한다
         # (src/ante/ipc/registry.py). 과거 ``"approval_id"`` 키는 handler 미스매치
-        # 로 ``KeyError`` 를 일으켰다 — Web API/IPC 계약과 동일한 ``"id"`` 로 정렬
-        # (#1794). ``approval.cancel_invalid`` 만 별도 계약으로 ``approval_id``
+        # 로 ``KeyError`` 를 일으켰다 — Web API/IPC 계약과 동일한 ``"id"`` 로
+        # 정렬. ``approval.cancel_invalid`` 만 별도 계약으로 ``approval_id``
         # 사용을 유지한다.
         args: dict = {"id": id}
         if body is not None:
@@ -399,8 +398,8 @@ def reopen(
     except click.ClickException:
         raise
     except Exception as e:
-        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
-        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        # helper 가 typed exception (.code) → registry → fallback 순서로
+        # public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
         emit_cli_error(fmt, e)
 
 
@@ -416,7 +415,7 @@ def audit_types(
     status: str | None,
     db_path: str | None,
 ) -> None:
-    """``ApprovalType`` enum 외 ``type`` 을 가진 legacy invalid row 식별 (#1472).
+    """``ApprovalType`` enum 외 ``type`` 을 가진 legacy invalid row 식별.
 
     분류는 ``offline`` (DB 직접 조회) 이며 ``approval list`` 와 동일하게
     ``ApprovalService.initialize()`` 가 수반된다. 정상 type row 는 enum SSOT
@@ -441,9 +440,9 @@ def audit_types(
         from ante.approval import ApprovalService
         from ante.eventbus.bus import EventBus
 
-        # #1856: ``open_cli_db`` 헬퍼가 ``ApprovalService(...)`` /
+        # ``open_cli_db`` 헬퍼가 ``ApprovalService(...)`` /
         # ``service.initialize()`` raise 경로에서도 ``Database.close()`` 를
-        # 보장한다 (#1755 회귀 lock; ``approval list`` 와 동형).
+        # 보장한다 (cleanup invariant; ``approval list`` 와 동형).
         async with open_cli_db(ctx, db_path_override=db_path) as db:
             eventbus = EventBus()
             service = ApprovalService(db=db, eventbus=eventbus)
@@ -468,8 +467,8 @@ def audit_types(
             ["id", "type", "status", "requester", "created_at", "expires_at"],
         )
     except Exception as e:
-        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
-        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        # helper 가 typed exception (.code) → registry → fallback 순서로
+        # public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
         emit_cli_error(fmt, e)
 
 
@@ -480,7 +479,7 @@ def audit_types(
 @require_auth
 @require_scope("approval:admin")
 def cancel_invalid(ctx: click.Context, id: str) -> None:
-    """legacy invalid-type approval row 의 administrative cancellation (#1472).
+    """legacy invalid-type approval row 의 administrative cancellation.
 
     일반 ``ante approval cancel`` 의 requester ownership rule 을 우회한다 —
     invalid-type row 의 requester 는 신뢰할 수 없거나 사라졌을 수 있다. 이
@@ -512,8 +511,8 @@ def cancel_invalid(ctx: click.Context, id: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
-        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        # helper 가 typed exception (.code) → registry → fallback 순서로
+        # public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
         emit_cli_error(fmt, e)
 
 
@@ -532,8 +531,7 @@ def cancel(ctx: click.Context, id: str) -> None:
         from ante.cli.commands.ipc_helpers import ipc_send
 
         # IPC handler ``_handle_approval_cancel`` 가 ``args["id"]`` 를 기대한다
-        # (#1794, registry.py:533 참조). cancel-invalid 와 키 계약이 다르므로
-        # 혼동에 주의.
+        # (registry.py 참조). cancel-invalid 와 키 계약이 다르므로 혼동에 주의.
         return await ipc_send("approval.cancel", {"id": id}, actor=requester)
 
     try:
@@ -542,8 +540,8 @@ def cancel(ctx: click.Context, id: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
-        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
+        # helper 가 typed exception (.code) → registry → fallback 순서로
+        # public code 를 resolve 한다. IPC envelope 과 동일 코드 surface.
         emit_cli_error(fmt, e)
 
 
@@ -561,8 +559,8 @@ def approve(ctx: click.Context, id: str) -> None:
     async def _approve() -> dict:
         from ante.cli.commands.ipc_helpers import ipc_send
 
-        # IPC handler ``_handle_approval_approve`` 가 ``args["id"]`` 를 기대한다
-        # (#1794, registry.py:515 참조).
+        # IPC handler ``_handle_approval_approve`` 가 ``args["id"]`` 를
+        # 기대한다 (registry.py 참조).
         return await ipc_send("approval.approve", {"id": id}, actor=actor)
 
     try:
@@ -571,8 +569,8 @@ def approve(ctx: click.Context, id: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
-        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface
+        # helper 가 typed exception (.code) → registry → fallback 순서로
+        # public code 를 resolve 한다. IPC envelope 과 동일 코드 surface
         # (ApprovalStatusConflictError → APPROVAL_STATUS_CONFLICT 등).
         emit_cli_error(fmt, e)
 
@@ -593,7 +591,7 @@ def reject(ctx: click.Context, id: str, reason: str) -> None:
         from ante.cli.commands.ipc_helpers import ipc_send
 
         # IPC handler ``_handle_approval_reject`` 가 ``args["id"]`` 를 기대한다
-        # (#1794, registry.py:523 참조).
+        # (registry.py 참조).
         return await ipc_send(
             "approval.reject",
             {"id": id, "reason": reason},
@@ -606,8 +604,8 @@ def reject(ctx: click.Context, id: str, reason: str) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        # #1843 sub-PR 2: helper 가 typed exception (.code) → registry → fallback
-        # 순서로 public code 를 resolve 한다. IPC envelope 과 동일 코드 surface
+        # helper 가 typed exception (.code) → registry → fallback 순서로
+        # public code 를 resolve 한다. IPC envelope 과 동일 코드 surface
         # (ApprovalStatusConflictError → APPROVAL_STATUS_CONFLICT 등).
         emit_cli_error(fmt, e)
 
@@ -617,10 +615,10 @@ async def _find_request(service, id: str):  # type: ignore[no-untyped-def]
 
     not-found 는 ``ApprovalNotFoundError`` 로 raise 해 CLI ``approval info``
     / ``approval review`` 가 typed envelope code ``APPROVAL_NOT_FOUND`` 로
-    surface 할 수 있도록 한다 (#1811). multi-match 는 ``ValueError`` 로
-    유지 — 별도 의미(``"여러 건이 일치"``)이며 #1843 sub-PR 2 정렬 이후
-    generic ``emit_cli_error(fmt, e)`` 핸들러가 helper resolver 의 fallback
-    ``EXECUTION_ERROR`` 코드로 surface 한다 (registry 미등록 / ``.code`` 부재).
+    surface 할 수 있도록 한다. multi-match 는 ``ValueError`` 로 유지 —
+    별도 의미(``"여러 건이 일치"``) 이며 generic ``emit_cli_error(fmt, e)``
+    핸들러가 helper resolver 의 fallback ``EXECUTION_ERROR`` 코드로 surface
+    한다 (registry 미등록 / ``.code`` 부재).
     """
     from ante.approval.errors import ApprovalNotFoundError
 

--- a/src/ante/cli/commands/audit.py
+++ b/src/ante/cli/commands/audit.py
@@ -64,10 +64,10 @@ def audit_list(
     )
 
     async def _run_list() -> list[dict]:
-        # #1857: ``open_cli_db`` 헬퍼가 ``AuditLogger.initialize()`` /
-        # ``query()`` 의 예외 / cancellation 까지 ``Database.close()`` 1회 호출을
-        # 보장한다 (#1722 cleanup invariant). ``AuditLogger.initialize()`` 는
-        # #1854 §4.2 명시 예외 (read-only) — 그대로 보존한다.
+        # ``open_cli_db`` 헬퍼가 ``AuditLogger.initialize()`` / ``query()`` 의
+        # 예외 / cancellation 까지 ``Database.close()`` 1회 호출을 보장한다
+        # (cleanup invariant). ``AuditLogger.initialize()`` 는 read-only 명시
+        # 예외(`docs/specs/audit/` §4.2) — 그대로 보존한다.
         from ante.audit import AuditLogger
 
         async with open_cli_db(ctx) as db:

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -96,7 +96,7 @@ def run(
         )
         raise SystemExit(1)
 
-    # 타임프레임/심볼 검증 (CLI 경계 단일 지점, #1613 SSOT helper 위임).
+    # 타임프레임/심볼 검증 (CLI 경계 단일 지점, SSOT helper 위임).
     # precedence: date/exchange 검증 이후 → ① timeframe → ② 빈 segment →
     # ③ KRX symbol shape. config build·BacktestService.run·_save_backtest_run
     # 이전이어야 invalid 입력 시 backtest_runs history가 생성되지 않는다.

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -47,20 +47,17 @@ async def _create_services(
     ctx: click.Context | None = None,
 ) -> AsyncIterator[tuple[Database, EventBus, BotManager, AccountService]]:
     """CLI 에서 ``Database``/``EventBus``/``BotManager``/``AccountService`` 를
-    함께 구성하는 async context manager (#1857).
+    함께 구성하는 async context manager.
 
-    이전 시그니처(``async def`` → ``tuple[Database, EventBus, BotManager,
-    AccountService]``)에서 ``open_cli_db`` 기반 async context manager 로 전환
-    했다 (#1855 factory composition, #1856 account.py 패턴 1:1 미러). 호출
-    패턴:
+    ``open_cli_db`` 기반 lifecycle (factory composition, account.py 패턴
+    1:1 미러). 호출 패턴:
 
         async with _create_services(ctx=ctx) as (db, eventbus, mgr, account_service):
             ...
 
     ``open_cli_db`` 가 normal/exception/cancellation 모든 경로에서
-    ``Database.close()`` 를 보장하므로 (#1722/#1755 cleanup invariant),
-    callsite 의 ``try/finally: await db.close()`` 패턴이 제거된다 (#1799
-    회귀 lock 재미러).
+    ``Database.close()`` 를 보장하므로 (cleanup invariant), callsite 의
+    ``try/finally: await db.close()`` 패턴이 제거된다.
 
     Args:
         ctx: Click 컨텍스트. ``None`` 이면 ``click.get_current_context``
@@ -71,7 +68,7 @@ async def _create_services(
     Yields:
         ``initialize()`` 가 완료된 ``(db, eventbus, manager, account_service)``
         4-tuple. ``BotManager``/``AccountService`` 의 ``initialize()`` 호출은
-        그대로 보존된다 (#1854 §4.2 명시 예외는 ``AuditLogger`` /
+        그대로 보존된다 (read-only 명시 예외는 ``AuditLogger`` /
         ``DynamicConfigService`` 만; 본 helper 는 read-only skip 적용 안 함).
 
     Cleanup invariant:
@@ -115,7 +112,7 @@ async def _run_bot_remove_cold_path(
 ) -> dict:
     """서버 정지 상태에서 BotManager 없이 봇을 soft-delete한다.
 
-    #1857: ``open_cli_db`` 기반 lifecycle 로 전환했다. ``ctx`` 가 ``None`` 이면
+    ``open_cli_db`` 기반 lifecycle. ``ctx`` 가 ``None`` 이면
     ``click.get_current_context`` 로 fallback 한다 (callsite 하위 호환).
     """
     from ante.bot.cold_path import cold_path_remove_bot
@@ -149,9 +146,9 @@ def bot_list(ctx: click.Context, account_id: str | None) -> None:
     """봇 목록 조회."""
     fmt = get_formatter(ctx)
 
-    # SQL filter **이전** ingress 검증 (#1634, Split A).
+    # SQL filter **이전** ingress 검증.
     #
-    # omitted-vs-provided 계약 (#1624 동형):
+    # omitted-vs-provided 계약:
     #   - `--account` 미지정(`account_id is None`) → 전체 봇 반환 동작 **보존**
     #     (omitted 분기는 검증하지 않는다; 이게 불변이다).
     #   - `--account` provided(`default`/패턴 위반/`""` 포함) → invalid면
@@ -162,9 +159,9 @@ def bot_list(ctx: click.Context, account_id: str | None) -> None:
         account_id = reject_invalid_account_id(account_id, fmt, context="cli.bot.list")
 
     async def _run_list() -> list[dict]:
-        # #1857: ``_create_services`` 를 async context manager 로 변환했다.
+        # ``_create_services`` async context manager lifecycle.
         # ``open_cli_db`` 가 normal/exception/cancellation 모든 경로에서
-        # ``Database.close()`` 를 보장한다 (#1799 회귀 lock 재미러).
+        # ``Database.close()`` 를 보장한다.
         async with _create_services(ctx=ctx) as (db, _, _, _):
             if account_id is not None:
                 rows = await db.fetch_all(
@@ -204,7 +201,7 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_info() -> dict | None:
-        # #1857: ``_create_services`` async context manager 전환.
+        # ``_create_services`` async context manager lifecycle.
         async with _create_services(ctx=ctx) as (db, _, _, _):
             row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = ?", (bot_id,))
             return dict(row) if row else None
@@ -212,9 +209,9 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
     result = _run(_run_info())
 
     if not result:
-        # #1784: missing bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 해
-        # 자동화가 메시지 파싱 없이 분류할 수 있도록 한다 (CLI/IPC
-        # 일관성: ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와 동형).
+        # missing bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 해 자동화가
+        # 메시지 파싱 없이 분류할 수 있도록 한다 (CLI/IPC 일관성:
+        # ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와 동형).
         fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         ctx.exit(1)
 
@@ -314,20 +311,20 @@ def bot_create(
             key, value = _parse_param(p)
             param_dict[key] = value
         except click.BadParameter as e:
-            # #1784: invalid --param 입력은 안정 코드
+            # invalid --param 입력은 안정 코드
             # ``BOT_INVALID_PARAM`` 으로 surface 한다. 자동화/오라클이
             # 메시지 텍스트 파싱 없이 invalid-input 분류를 할 수 있게 한다.
             fmt.error(str(e), code="BOT_INVALID_PARAM")
             raise SystemExit(1) from e
 
-    # #1656 E bucket defense-in-depth: provided invalid account_id
-    # (`default`/패턴 위반/`""`)를 omitted resolver / `ipc_send`
-    # (→`_handle_bot_create`) 이전에 거부한다. IPC handler가 1차
-    # 보증(handler-first require_account_id)하지만, CLI ingress 거부는 clean
+    # defense-in-depth: provided invalid account_id (`default`/패턴 위반/`""`)
+    # 를 omitted resolver / `ipc_send` (→`_handle_bot_create`) 이전에 거부한다.
+    # IPC handler가 1차 보증(handler-first require_account_id)하지만, CLI
+    # ingress 거부는 clean
     # early exit(traceback 부재)이다. **provided-only**(`account_id is not
     # None`)로만 검증해 `--account` 미지정(None) → 비대화형 resolver 분기를
-    # **보존**한다(omitted 불변, #1634 `bot_list`(L97) 동형, invalid-format ↔
-    # valid-absent/omitted 분리). 에러코드는 #1633 SSOT `VALIDATION_ERROR`.
+    # **보존**한다(omitted 불변, `bot_list` 동형, invalid-format ↔
+    # valid-absent/omitted 분리). 에러코드는 SSOT `VALIDATION_ERROR`.
     if account_id is not None:
         account_id = reject_invalid_account_id(
             account_id, fmt, context="cli.bot.create"
@@ -338,9 +335,9 @@ def bot_create(
     if account_id is None:
         from ante.account.models import AccountStatus
 
-        # #1799: ``_create_services()`` 가 연 aiosqlite db 연결을 명시적으로
-        # close 하지 않아 ``_resolve_account_non_interactive`` 가 SystemExit 을
-        # raise 한 뒤 (active account 0 / 2+) leaked connection 이 asyncio
+        # ``_create_services()`` 가 연 aiosqlite db 연결을 명시적으로
+        # close 하지 않으면 ``_resolve_account_non_interactive`` 가 SystemExit
+        # 을 raise 한 뒤 (active account 0 / 2+) leaked connection 이 asyncio
         # event loop 를 dangling 상태로 만들어 CLI 프로세스가 종료되지 않고
         # 외부 timeout (probe exit 124) 으로만 죽던 hang 회귀를 차단한다.
         # ``bot_list`` (L107-122) / ``bot_info`` (L149-154) 와 동형의 try/
@@ -349,7 +346,7 @@ def bot_create(
         # 가 항상 보장된다. JSON envelope code (``BOT_MISSING_REQUIRED_ACCOUNT``)
         # 는 종전 동작 그대로다 (이슈 본질은 process termination 보장).
         async def _list_accounts() -> list:
-            # #1857: ``_create_services`` async context manager 전환. #1799
+            # ``_create_services`` async context manager lifecycle.
             # cleanup invariant (resolver SystemExit 이후에도 db 가 close 되어
             # process termination 보장) 는 ``open_cli_db`` body close 가 그대로
             # 유지한다.
@@ -381,11 +378,10 @@ def bot_create(
     except click.ClickException:
         raise
     except Exception as e:
-        # #1843 sub-PR 3: emit_cli_error 가 registry-first (#1843 sub-PR 3 등록한
-        # BotAlreadyExistsError / BotStrategyAlreadyRunningError 등) → ``.code``
-        # fallback → ``EXECUTION_ERROR`` 순서로 public code 를 resolve 한다.
-        # IPC envelope (server.py:322 ``getattr(e, "code", ...)``) 와 동일 코드
-        # surface — #1800 ``BotAlreadyExistsError.code = "BOT_ALREADY_EXISTS"``
+        # emit_cli_error 가 registry-first (BotAlreadyExistsError /
+        # BotStrategyAlreadyRunningError 등) → ``.code`` fallback →
+        # ``EXECUTION_ERROR`` 순서로 public code 를 resolve 한다. IPC envelope
+        # 와 동일 코드 surface — ``BotAlreadyExistsError.code = "BOT_ALREADY_EXISTS"``
         # 등 typed 동작은 그대로 유지된다.
         emit_cli_error(fmt, e)
 
@@ -433,18 +429,18 @@ def bot_remove(ctx: click.Context, bot_id: str, yes: bool) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        # #1843 sub-PR 3: emit_cli_error 가 ``BotNotFoundError`` (cold-path
-        # 미존재 봇 거부) 의 등록 spec ``BOT_NOT_FOUND`` 를 우선 surface 한다.
-        # registry miss + ``.code`` 부재 시 ``EXECUTION_ERROR`` fallback.
+        # emit_cli_error 가 ``BotNotFoundError`` (cold-path 미존재 봇 거부)
+        # 의 등록 spec ``BOT_NOT_FOUND`` 를 우선 surface 한다. registry miss
+        # + ``.code`` 부재 시 ``EXECUTION_ERROR`` fallback.
         emit_cli_error(fmt, e)
 
     if result.get("removed"):
         suffix = "(cold-path)" if result.get("cold_path") else ""
         fmt.success(f"봇 삭제 완료{suffix}: {bot_id}", result)
     else:
-        # #1843 sub-PR 3: removed=False sentinel 도 미존재 봇 의미이므로
-        # ``BOT_NOT_FOUND`` 안정 코드를 명시 부여한다 (``bot info`` 형제
-        # 패턴 미러, IPC envelope 와 동일 public code surface).
+        # removed=False sentinel 도 미존재 봇 의미이므로 ``BOT_NOT_FOUND``
+        # 안정 코드를 명시 부여한다 (``bot info`` 형제 패턴 미러, IPC envelope
+        # 와 동일 public code surface).
         fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         raise SystemExit(1)
 
@@ -460,7 +456,7 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_signal_key() -> dict:
-        # #1857: ``_create_services`` async context manager 전환.
+        # ``_create_services`` async context manager lifecycle.
         from ante.bot.signal_key import SignalKeyManager
 
         async with _create_services(ctx=ctx) as (db, _, _, _):
@@ -470,8 +466,8 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
             # 미존재 bot 에 대한 signal key 발급/조회를 막기 위해
             # rotate/get_key 호출 전에 bot 존재를 먼저 확인한다. 미존재면
             # sentinel(``missing=True``)을 반환하여 orphan credential 발급을
-            # 차단한다. 형제 명령(`bot info`/`bot remove`/`bot positions`,
-            # #1558)과 동일하게 code 없는 에러 + exit 1 로 거부한다.
+            # 차단한다. 형제 명령(`bot info`/`bot remove`/`bot positions`)과
+            # 동일하게 code 없는 에러 + exit 1 로 거부한다.
             #
             # ``status != 'deleted'`` 조건은 ``BotManager.load_from_db``
             # (manager.py:212 ``FROM bots WHERE status != 'deleted'``)의
@@ -479,18 +475,17 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
             # soft-delete (manager.py:826 ``UPDATE bots SET status =
             # 'deleted'``) 하므로 row 가 남는다 — 이를 운영상 미존재로
             # 취급하지 않으면 soft-deleted bot 에 ``--rotate`` 가
-            # orphan credential 을 재발급한다 (#1596가 막으려는 버그류).
+            # orphan credential 을 재발급하는 버그류.
             #
             # ``bots`` 테이블은 ``BotManager.initialize()`` 에서 생성되며
             # 위 ``_create_services()`` 가 이를 보장하지만, 방어적으로
             # malformed db 외의 "no such table" 은 미존재 bot 으로 정규화
             # 한다 (malformed db 같은 다른 ``OperationalError`` 까지
-            # 삼키지 않도록 메시지로 좁힌다, #1558 동형).
+            # 삼키지 않도록 메시지로 좁힌다, 형제 패턴 동형).
             try:
-                # Refs #1761: ``--rotate`` 게이트가 ``strategy_id`` 를
-                # 필요로 하므로 존재 확인 쿼리에서 함께 SELECT 한다.
-                # row 의 truthiness 는 보존되어 기존 미존재/소프트삭제
-                # 거부 회귀(#1596)와 동일하게 동작한다.
+                # ``--rotate`` 게이트가 ``strategy_id`` 를 필요로 하므로
+                # 존재 확인 쿼리에서 함께 SELECT 한다. row 의 truthiness 는
+                # 보존되어 기존 미존재/소프트삭제 거부 회귀와 동일하게 동작한다.
                 bot_row = await db.fetch_one(
                     "SELECT strategy_id FROM bots "
                     "WHERE bot_id = ? AND status != 'deleted'",
@@ -505,7 +500,7 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
                 return {"bot_id": bot_id, "missing": True}
 
             if rotate:
-                # accepts_external_signals 게이트 (#1761).
+                # accepts_external_signals 게이트.
                 # ``BotManager.rotate_signal_key`` 가 적용하는 동일 invariant
                 # 를 CLI cold-path 에도 적용해 defense-in-depth 를 유지한다
                 # (CLI 는 BotManager 를 우회해 ``SignalKeyManager`` 를 직접
@@ -556,15 +551,14 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
         # (malformed/locked DB 등)가 재던져지면 여기로 떨어진다. JSON error를
         # 출력하면서도 exit 0 으로 끝나면 자동화 호출자가 실패를 감지하지
         # 못하므로, 형제 ``bot remove`` (raise SystemExit(1) from e)와 동일하게
-        # non-zero exit 로 종료한다 (#1596).
-        # #1843 sub-PR 3: emit_cli_error 가 ``EXECUTION_ERROR`` 안정 코드를
-        # surface (registry miss + ``.code`` 부재 fallback). 신규 도메인
-        # 에러코드 신설 없이 taxonomy 기본 fallback 으로 정렬 — Non-Goal
-        # (신규 에러코드 신설 금지) 보존.
+        # non-zero exit 로 종료한다.
+        # emit_cli_error 가 ``EXECUTION_ERROR`` 안정 코드를 surface (registry
+        # miss + ``.code`` 부재 fallback). 신규 도메인 에러코드 신설 없이
+        # taxonomy 기본 fallback 으로 정렬.
         emit_cli_error(fmt, e)
 
     if result.get("missing"):
-        # #1784: 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 한다
+        # 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 한다
         # (CLI/IPC 일관성: ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와
         # 동형). signal_key None 분기보다 먼저 처리하여 미존재 bot 이 "키
         # 없음" 으로 잘못 빠지지 않도록 한다.
@@ -572,18 +566,18 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
         ctx.exit(1)
 
     if result.get("external_signals_disabled"):
-        # Refs #1761: ``accepts_external_signals=False`` 전략 봇에 rotate
-        # 가 새 키를 발급해 orphan credential 이 생기던 회귀를 막는다.
-        # ``signal connect`` 의 동형 거부(``ante/cli/commands/signal.py:70-75``)
-        # 와 동일한 ``BOT_NOT_ACCEPTING_SIGNALS`` 코드를 stable 하게 노출한다.
+        # ``accepts_external_signals=False`` 전략 봇에 rotate 가 새 키를
+        # 발급해 orphan credential 이 생기던 회귀를 막는다. ``signal connect``
+        # 의 동형 거부 (``ante/cli/commands/signal.py``) 와 동일한
+        # ``BOT_NOT_ACCEPTING_SIGNALS`` 코드를 stable 하게 노출한다.
         fmt.error(result["error"], code=result.get("code", ""))
         raise SystemExit(1)
 
     if result.get("signal_key") is None:
-        # #1808: 시그널 키 미발급은 안정 코드 ``SIGNAL_KEY_NOT_SET`` 로
-        # surface 한다. 미존재 bot (``BOT_NOT_FOUND``) 분기보다 뒤에 둬서
-        # 두 의미를 envelope 코드로 분리한다. typed exception 신설 대신
-        # None gate + code 라벨로 단순화한다 (BOT_NOT_FOUND 동형 — 본
+        # 시그널 키 미발급은 안정 코드 ``SIGNAL_KEY_NOT_SET`` 로 surface 한다.
+        # 미존재 bot (``BOT_NOT_FOUND``) 분기보다 뒤에 둬서 두 의미를 envelope
+        # 코드로 분리한다. typed exception 신설 대신 None gate + code 라벨로
+        # 단순화한다 (BOT_NOT_FOUND 동형 — 본
         # surface 는 service exception 을 거치지 않는다).
         fmt.error(
             f"signal key가 설정되지 않았습니다: {bot_id}",
@@ -611,11 +605,11 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_positions() -> list[dict] | None:
-        # #1857: ``open_cli_db`` 헬퍼가 service ``initialize()`` /
+        # ``open_cli_db`` 헬퍼가 service ``initialize()`` /
         # ``get_positions()`` 예외 / cancellation 모든 경로에서
-        # ``Database.close()`` 1회 호출을 보장한다 (#1722/#1799 cleanup
-        # invariant). ``--db-path`` override 는 ctx 의 ``get_db_path(ctx)``
-        # resolution 으로 흡수된다.
+        # ``Database.close()`` 1회 호출을 보장한다 (cleanup invariant).
+        # ``--db-path`` override 는 ctx 의 ``get_db_path(ctx)`` resolution 으로
+        # 흡수된다.
         from ante.trade.performance import PerformanceTracker
         from ante.trade.position import PositionHistory
         from ante.trade.recorder import TradeRecorder
@@ -624,7 +618,7 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
         async with open_cli_db(ctx) as db:
             # 미존재 bot 을 "실재 bot 의 0 포지션" 과 구분하기 위해 포지션 조회
             # 전에 bot 존재를 먼저 확인한다. 미존재면 sentinel ``None`` 을
-            # 반환하고, 실재 bot 이면 (0개 포함) list 를 반환한다 (#1558).
+            # 반환하고, 실재 bot 이면 (0개 포함) list 를 반환한다.
             #
             # ``bots`` 테이블은 ``BotManager.initialize()`` 에서만 생성되는데,
             # 이 경로는 raw ``Database`` 만 쓰고 ``BotManager`` 를 초기화하지
@@ -632,7 +626,7 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
             # 해당 bot_id 는 존재할 수 없으므로 미존재 bot 과 동일하게
             # 정규화한다(=sentinel ``None``). 단, malformed db 같은 다른
             # ``OperationalError`` 까지 삼키지 않도록 "no such table" 메시지
-            # 일 때로만 좁힌다 (#1558).
+            # 일 때로만 좁힌다.
             try:
                 bot_row = await db.fetch_one(
                     "SELECT 1 FROM bots WHERE bot_id = ?", (bot_id,)
@@ -665,10 +659,9 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
     result = _run(_run_positions())
 
     if result is None:
-        # #1810: 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 한다
+        # 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 한다
         # (CLI/IPC 일관성: ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와
-        # 동형, ``bot info`` line 162 / ``bot remove`` line 814 형제 패턴
-        # 1:1 미러).
+        # 동형, ``bot info`` / ``bot remove`` 형제 패턴 1:1 미러).
         fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         ctx.exit(1)
 
@@ -832,7 +825,7 @@ def bot_logs(
         raise SystemExit(1)
 
     async def _run_logs() -> dict:
-        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799). ``--config-dir``
+        # ``open_cli_db`` 헬퍼 lifecycle (cleanup invariant). ``--config-dir``
         # / ``ANTE_CONFIG_DIR`` 를 통한 ``get_db_path(ctx)`` resolution 동일.
         from ante.eventbus.history import EventHistoryStore
 
@@ -890,15 +883,15 @@ def bot_logs(
         fmt.table(result["logs"], ["timestamp", "result", "message"])
 
 
-# ── 봇 생명주기 leaf (#1713) ─────────────────────────────────────────────
+# ── 봇 생명주기 leaf ─────────────────────────────────────────────────────
 #
-# Refs #1713/#1712: ``bot.start``/``bot.stop``/``bot.status`` IPC handler가
-# ``BOT_NOT_FOUND`` / ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` /
-# ``BOT_STATE_CONFLICT`` coded exception을 raise한다. CLI ingress는 IPC
-# 단일-chokepoint를 그대로 사용하며 별도 cold-path fallback을 제공하지 않는다.
-# 에러 envelope 안정성은 #1673 ``config set`` 패턴
-# (``ipc_send``가 ``ClickException``에 부착한 ``ipc_error_code``/
-# ``ipc_error_message``를 split 없이 복원) 1:1 미러로 보존한다.
+# ``bot.start``/``bot.stop``/``bot.status`` IPC handler가 ``BOT_NOT_FOUND`` /
+# ``BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED`` / ``BOT_STATE_CONFLICT`` coded
+# exception을 raise한다. CLI ingress는 IPC 단일-chokepoint를 그대로 사용하며
+# 별도 cold-path fallback을 제공하지 않는다. 에러 envelope 안정성은
+# ``config set`` 패턴 (``ipc_send``가 ``ClickException``에 부착한
+# ``ipc_error_code``/``ipc_error_message``를 split 없이 복원) 1:1 미러로
+# 보존한다.
 
 
 @bot.command("start")
@@ -920,8 +913,8 @@ def bot_start(ctx: click.Context, bot_id: str) -> None:
     try:
         result = _run(_run_start())
     except click.ClickException as e:
-        # #1673 미러: ipc_send가 부착한 원본 code/message를 split 없이
-        # 복원해 text/JSON 공용 envelope 안정성을 보존한다.
+        # ipc_send가 부착한 원본 code/message를 split 없이 복원해 text/JSON
+        # 공용 envelope 안정성을 보존한다.
         code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
         message = getattr(e, "ipc_error_message", None) or e.message
         if fmt.is_json:
@@ -1007,7 +1000,7 @@ def bot_status(ctx: click.Context, bot_id: str) -> None:
     #   포함된다.
     # - text 모드: ``bot info`` 스타일 detail + optional sections
     #   (strategy_name/budget/positions). 의존성 부재로 키가 없으면
-    #   해당 section을 생략한다(#1712 read-only 정렬).
+    #   해당 section을 생략한다(read-only 정렬).
     if fmt.is_json:
         fmt.output(result)
         return

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -22,10 +22,10 @@ def _run(coro):  # noqa: ANN001, ANN202
 
 
 async def _create_account_service():  # noqa: ANN202
-    # #1857: broker live-state 경로 (adapter.connect 동반) 는 본 PR scope
-    # 외다. live broker state 와 ``Database`` lifecycle 이 같은 try/except 로
-    # 엮여 있어 단순 ``open_cli_db`` wrap 으로 동치 변환이 불가능하다.
-    # 별도 spec 정렬 PR (부모 epic #1818 follow-up) 에서 다룬다.
+    # broker live-state 경로 (adapter.connect 동반) 는 별도 epic scope.
+    # live broker state 와 ``Database`` lifecycle 이 같은 try/except 로 엮여
+    # 있어 단순 ``open_cli_db`` wrap 으로 동치 변환이 불가능하다 — 별도 spec
+    # 정렬 PR (부모 epic #1818 follow-up) 에서 다룬다.
     from ante.account.service import AccountService
     from ante.cli.main import get_db_path
     from ante.core.database import Database
@@ -48,8 +48,8 @@ async def _get_broker(account_id: str | None = None):  # noqa: ANN202
     ``adapter.connect`` 가 raise 하면, 호출자에 ``db`` 핸들이 전달되지 않으므로
     여기서 ``db.close()`` 를 보장해야 한다. close 를 누락하면 aiosqlite
     백그라운드 스레드가 살아 있어 ``asyncio.run`` 종료 후에도 프로세스가
-    수 초간 hang 한다 (#1535). lifecycle 보장 — 정상 경로의 close 는
-    호출자(``_run_balance`` 등)가 계속 책임진다.
+    수 초간 hang 한다. lifecycle 보장 — 정상 경로의 close 는 호출자
+    (``_run_balance`` 등) 가 계속 책임진다.
     """
     if account_id:
         account_service, db = await _create_account_service()
@@ -92,8 +92,8 @@ async def _ipc_broker_command(command: str, account_id: str, actor: str) -> dict
     """IPC를 통해 서버 브로커 인스턴스에 위임한다.
 
     ``account_id``는 호출자(``--account`` required CLI 옵션 + helper 통과)
-    에서 이미 검증된 값이어야 한다. fallback 금지 정책(#1217 SPLIT-1)에 따라
-    빈 dict 를 IPC 로 보내지 않는다.
+    에서 이미 검증된 값이어야 한다. fallback 금지 정책에 따라 빈 dict 를
+    IPC 로 보내지 않는다.
 
     ServerNotRunningError, IPCTimeoutError 시 예외를 전파하여 호출자가 폴백 처리한다.
     """
@@ -116,7 +116,7 @@ def status(ctx: click.Context, account_id: str) -> None:
     fmt = get_formatter(ctx)
 
     # CLI ingress에서 invalid account_id를 IPC/_get_broker 이전에 명시 거부
-    # (fallback 금지, #1217 SPLIT-1 + #1623 Split C / #1634 helper 재사용).
+    # (fallback 금지, helper 재사용).
     # ``InvalidAccountIdError``는 non-Click ``AccountError``라 기존
     # ``except click.ClickException`` fallback이 잡지 못해 traceback이 났다.
     # helper가 ``InvalidAccountIdError``→``fmt.error(code=VALIDATION_ERROR)``+
@@ -185,7 +185,7 @@ def balance(ctx: click.Context, account_id: str) -> None:
     fmt = get_formatter(ctx)
 
     # CLI ingress에서 invalid account_id를 IPC/_get_broker 이전에 명시 거부
-    # (fallback 금지, #1217 SPLIT-1 + #1623 Split C / #1634 helper 재사용).
+    # (fallback 금지, helper 재사용).
     validated_account_id = reject_invalid_account_id(
         account_id, fmt, context="cli.broker.balance"
     )
@@ -213,8 +213,8 @@ def balance(ctx: click.Context, account_id: str) -> None:
             fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
             raise SystemExit(1) from e
         except Exception as e:
-            # #1843 sub-PR 5: emit_cli_error 정렬 — CLI/IPC 동일 public code
-            # surface. broker typed exception (APIError / AuthenticationError /
+            # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
+            # broker typed exception (APIError / AuthenticationError /
             # OrderNotFoundError / RateLimitError / CircuitOpenError) 은
             # registry MRO lookup 으로 ``BROKER_*`` 안정 코드를 surface 하며,
             # 미분류 fault 는 ``EXECUTION_ERROR`` fallback.
@@ -243,7 +243,7 @@ def positions(ctx: click.Context, account_id: str) -> None:
     fmt = get_formatter(ctx)
 
     # CLI ingress에서 invalid account_id를 IPC/_get_broker 이전에 명시 거부
-    # (fallback 금지, #1217 SPLIT-1 + #1623 Split C / #1634 helper 재사용).
+    # (fallback 금지, helper 재사용).
     validated_account_id = reject_invalid_account_id(
         account_id, fmt, context="cli.broker.positions"
     )
@@ -272,8 +272,8 @@ def positions(ctx: click.Context, account_id: str) -> None:
             fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
             raise SystemExit(1) from e
         except Exception as e:
-            # #1843 sub-PR 5: emit_cli_error 정렬 — broker typed exception 의
-            # 안정 코드 surface (positions 표면 동일 정책).
+            # emit_cli_error 로 broker typed exception 안정 코드 surface
+            # (positions 표면 동일 정책).
             emit_cli_error(fmt, e)
 
     pos_list = result.get("positions", [])
@@ -305,7 +305,7 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
     fmt = get_formatter(ctx)
 
     # CLI ingress에서 invalid account_id를 IPC/_get_broker 이전에 명시 거부
-    # (fallback 금지, #1217 SPLIT-1 + #1623 Split C / #1634 helper 재사용).
+    # (fallback 금지, helper 재사용).
     validated_account_id = reject_invalid_account_id(
         account_id, fmt, context="cli.broker.reconcile"
     )
@@ -325,8 +325,8 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
         except click.ClickException:
             raise
         except Exception as e:
-            # #1843 sub-PR 5: emit_cli_error 정렬 — broker typed exception
-            # 의 안정 코드 surface (reconcile --fix mutating path).
+            # emit_cli_error 로 broker typed exception 안정 코드 surface
+            # (reconcile --fix mutating path).
             emit_cli_error(fmt, e)
     else:
         # 읽기 전용: IPC 우선, 폴백으로 오프라인 방식
@@ -342,9 +342,9 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
             result = _run(_run_ipc_reconcile())
         except click.ClickException:
             # 서버 미실행 — 기존 오프라인 방식 폴백.
-            # #1857: broker live-state (adapter + DB) 경로는 본 PR scope 외다
-            # — 별도 spec 정렬 PR (#1818 follow-up) 에서 ``open_cli_db`` 와
-            # adapter lifecycle 의 동치 변환 contract 를 정합한다.
+            # broker live-state (adapter + DB) 경로는 별도 spec 정렬 PR
+            # (#1818 follow-up) 에서 ``open_cli_db`` 와 adapter lifecycle 의
+            # 동치 변환 contract 를 정합한다.
             async def _run_reconcile() -> dict:
                 from ante.cli.main import get_db_path
                 from ante.core.database import Database
@@ -359,9 +359,9 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
                     await position_history.initialize()
 
                     broker_positions = await adapter.get_account_positions()
-                    # Refs #1240 review (P2-2): 단일 계좌 reconcile은 해당 계좌
-                    # 포지션끼리만 비교해야 한다. account_id 필터를 빼면 다른
-                    # 계좌의 positions 가 false discrepancy 로 잡힌다.
+                    # 단일 계좌 reconcile은 해당 계좌 포지션끼리만 비교한다.
+                    # account_id 필터를 빼면 다른 계좌의 positions 가 false
+                    # discrepancy 로 잡힌다.
                     internal_positions = await position_history.get_all_positions(
                         account_id=validated_account_id
                     )
@@ -403,9 +403,8 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
                 fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
                 raise SystemExit(1) from e
             except Exception as e:
-                # #1843 sub-PR 5: emit_cli_error 정렬 — broker typed exception
-                # (APIError 등) 도 안정 코드 surface. 기존 ``code=""`` fallback
-                # 은 sweep 정신과 어긋나므로 helper 의 registry MRO lookup +
+                # emit_cli_error 로 broker typed exception (APIError 등)
+                # 안정 코드 surface. helper 의 registry MRO lookup +
                 # EXECUTION_ERROR fallback 으로 일관 정렬한다.
                 emit_cli_error(fmt, e)
 

--- a/src/ante/cli/commands/config.py
+++ b/src/ante/cli/commands/config.py
@@ -35,11 +35,10 @@ async def _create_services(
     ctx: click.Context | None = None,
 ) -> AsyncIterator[tuple[Config, DynamicConfigService, Database]]:
     """CLI 에서 ``Config`` / ``DynamicConfigService`` / ``Database`` 를 함께
-    구성하는 async context manager (#1857).
+    구성하는 async context manager.
 
-    이전 시그니처(``async def`` → ``tuple[Config, DynamicConfigService,
-    Database]``)에서 ``open_cli_db`` 기반 async context manager 로 전환했다
-    (#1855 factory composition, #1856 account.py 패턴 1:1 미러). 호출 패턴:
+    ``open_cli_db`` 기반 lifecycle (factory composition, account.py 패턴
+    1:1 미러). 호출 패턴:
 
         async with _create_services(ctx=ctx) as (static_config, dynamic, db):
             ...
@@ -49,13 +48,13 @@ async def _create_services(
             (silent=True) 로 fallback. 신규 호출은 ctx 명시 전달 권장.
 
     Yields:
-        ``DynamicConfigService.initialize()`` 가 완료된 3-tuple. #1854 §4.2
-        명시 예외에 따라 ``DynamicConfigService.initialize()`` 호출을 보존한다
-        (read-only operation 의 read-only 검증을 위한 schema bootstrap).
+        ``DynamicConfigService.initialize()`` 가 완료된 3-tuple.
+        ``DynamicConfigService.initialize()`` 는 read-only 명시 예외(schema
+        bootstrap) 로 호출을 보존한다.
 
     Cleanup invariant:
         - ``open_cli_db`` 가 ``BaseException`` 까지 catch — service init 실패
-          시에도 ``Database.close()`` 보장 (#1722 회귀 lock).
+          시에도 ``Database.close()`` 보장.
     """
     from ante.cli.main import get_config_dir
     from ante.config.config import Config
@@ -115,7 +114,7 @@ def _render_single(result: dict, fmt) -> None:  # noqa: ANN001
     """단일 설정 결과 출력 (missing은 caller에서 처리).
 
     note: missing-resource (`source == "not_found"`) 분기는 caller(`config_get`)가
-    `ctx.exit(1)`로 처리한다. helper는 pure rendering만 담당한다 (#1515).
+    `ctx.exit(1)`로 처리한다. helper는 pure rendering만 담당한다.
     """
     if fmt.is_json:
         fmt.output(result)
@@ -148,7 +147,7 @@ def config_get(ctx: click.Context, key: str | None) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_get() -> dict | list[dict]:
-        # #1857: ``_create_services`` async context manager 전환.
+        # ``_create_services`` async context manager lifecycle.
         async with _create_services(ctx=ctx) as (static_config, dynamic, db):
             if key is not None:
                 return await _resolve_single(key, static_config, dynamic)
@@ -188,13 +187,12 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
     try:
         result = _run(_run_set())
     except click.ClickException as e:
-        # #1673 oracle A7: invalid log_level 같은 서비스 경계 입력 오류는
-        # ipc_send 가 error envelope를 ClickException 으로 변환한다. bare
-        # 재raise 하면 Click 기본 처리가 ``Error: ...`` 를 stderr 로 출력하고
-        # exit 1 로 종료해 JSON 모드 stdout 이 비어 envelope 계약이 깨진다
-        # (probe stdout_status=None). #1655-1657 envelope discipline 미러:
-        # ipc_send 가 부착한 원본 code/message 를 split 없이 복원해
-        # text/JSON 공용으로 구조화된 에러를 출력하고 SystemExit(1) 한다
+        # invalid log_level 같은 서비스 경계 입력 오류는 ipc_send 가 error
+        # envelope 를 ClickException 으로 변환한다. bare 재raise 하면 Click
+        # 기본 처리가 ``Error: ...`` 를 stderr 로 출력하고 exit 1 로 종료해
+        # JSON 모드 stdout 이 비어 envelope 계약이 깨진다. envelope discipline:
+        # ipc_send 가 부착한 원본 code/message 를 split 없이 복원해 text/JSON
+        # 공용으로 구조화된 에러를 출력하고 SystemExit(1) 한다
         # (_validators.reject_invalid_account_id 패턴).
         code = getattr(e, "ipc_error_code", "")
         message = getattr(e, "ipc_error_message", None)
@@ -245,7 +243,7 @@ def config_history(ctx: click.Context, key: str, limit: int) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_history() -> list[dict]:
-        # #1857: ``_create_services`` async context manager 전환.
+        # ``_create_services`` async context manager lifecycle.
         async with _create_services(ctx=ctx) as (_, dynamic, _):
             return await dynamic.get_history(key, limit=limit)
 

--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -309,15 +309,14 @@ def validate(
     data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
 
-    # 타임프레임/심볼 검증 (CLI 경계 단일 지점, #1613 SSOT helper 위임).
+    # 타임프레임/심볼 검증 (CLI 경계 단일 지점, SSOT helper 위임).
     # precedence: ① timeframe → ② KRX symbol shape. ParquetStore 생성·
     # store.list_symbols·store.validate·`if not symbols:` exit-0 이전이어야
-    # invalid 입력이 "검증할 데이터 없음" fake-success(#1591 oracle 증상)로
-    # 처리되지 않는다. `data validate`는 --exchange 옵션 없는 KRX-domain
-    # local store 대상이라 symbol에 is_krx_symbol을 직접 적용한다
-    # (core.md `### KRX symbol shape` 정합 — 비-KRX 경로 부재).
-    # `--symbol` 미지정(symbol is None)은 기존 전체 validate 동작을
-    # 유지하며 거부하지 않는다.
+    # invalid 입력이 "검증할 데이터 없음" fake-success 로 처리되지 않는다.
+    # `data validate`는 --exchange 옵션 없는 KRX-domain local store 대상이라
+    # symbol에 is_krx_symbol을 직접 적용한다 (core.md `### KRX symbol shape`
+    # 정합 — 비-KRX 경로 부재). `--symbol` 미지정(symbol is None)은 기존 전체
+    # validate 동작을 유지하며 거부하지 않는다.
     if not is_valid_timeframe(timeframe):
         fmt.error(
             f"유효하지 않은 타임프레임: {timeframe!r}. "

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -46,8 +46,8 @@ timezone = "Asia/Seoul"
 path = "{db_path}"
 
 [runtime]
-# `config_dir` 기준 상대 경로. PID/IPC socket 위치 (Refs #1157,
-# docs/specs/config/03-design-decisions.md 200-202).
+# `config_dir` 기준 상대 경로. PID/IPC socket 위치
+# (docs/specs/config/03-design-decisions.md 200-202).
 pid_path = "run/ante.pid"
 socket_path = "run/ante.sock"
 """
@@ -85,7 +85,7 @@ def _resolve_effective_key(
 ) -> tuple[str, bool, bool]:
     """env/file의 키 분류 결과로부터 effective key와 파일 상태 플래그를 도출한다.
 
-    결정 행렬 (이슈 #1721 Implementation Plan v4):
+    결정 행렬:
 
     - valid env + valid file (동일 값): env 사용, file 보존, 백업 없음.
     - valid env + valid file (다른 값): env-wins. file을 env value로 교체하지만

--- a/src/ante/cli/commands/instrument.py
+++ b/src/ante/cli/commands/instrument.py
@@ -68,7 +68,7 @@ def instrument_list(
         ctx.exit(1)
 
     async def _run() -> list[dict]:
-        # #1857: ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
+        # ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
         # ``db_path_override`` 로 전달 — offline-factory.md §1.1 caller 산출
         # 경로 패턴.
         async with open_cli_db(ctx, db_path_override=db_path) as db:
@@ -153,7 +153,7 @@ def sync(
         ctx.exit(1)
 
     async def _run() -> dict:
-        # #1857: ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
+        # ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
         # ``db_path_override`` 로 전달.
         config = Config.load(config_dir=resolved_config_dir)
         broker_config = config.get("broker", {})
@@ -257,7 +257,7 @@ def search(
     fmt = get_formatter(ctx)
 
     async def _run() -> list[dict]:
-        # #1857: ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
+        # ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
         # ``db_path_override`` 로 전달.
         async with open_cli_db(ctx, db_path_override=db_path) as db:
             svc = InstrumentService(db)
@@ -331,9 +331,9 @@ def instrument_import(
             with open(path, encoding="utf-8") as f:
                 records = json.load(f)
     except Exception as e:
-        # #1784: 파일 읽기 I/O 실패(directory-with-csv-suffix, 권한 등)는
-        # 안정 코드 ``INSTRUMENT_IO_ERROR`` 로 surface 한다. 자동화/오라클이
-        # 메시지 텍스트 파싱 없이 I/O 실패를 분류할 수 있게 한다.
+        # 파일 읽기 I/O 실패(directory-with-csv-suffix, 권한 등)는 안정 코드
+        # ``INSTRUMENT_IO_ERROR`` 로 surface 한다. 자동화/오라클이 메시지
+        # 텍스트 파싱 없이 I/O 실패를 분류할 수 있게 한다.
         fmt.error(f"파일 읽기 실패: {e}", code="INSTRUMENT_IO_ERROR")
         ctx.exit(1)
 
@@ -351,10 +351,10 @@ def instrument_import(
     # 필수 컬럼 확인
     first = records[0]
     if "symbol" not in first or "exchange" not in first:
-        # #1784: 필수 컬럼 누락은 안정 코드
-        # ``INSTRUMENT_MISSING_COLUMNS`` 로 surface 한다. 형제 코드
-        # ``INSTRUMENT_INVALID_JSON_SHAPE`` / ``INSTRUMENT_EMPTY_FILE`` /
-        # ``INSTRUMENT_INVALID_FILE_FORMAT`` 와 동형 envelope 일관성.
+        # 필수 컬럼 누락은 안정 코드 ``INSTRUMENT_MISSING_COLUMNS`` 로
+        # surface 한다. 형제 코드 ``INSTRUMENT_INVALID_JSON_SHAPE`` /
+        # ``INSTRUMENT_EMPTY_FILE`` / ``INSTRUMENT_INVALID_FILE_FORMAT`` 와
+        # 동형 envelope 일관성.
         fmt.error(
             "필수 컬럼 누락: symbol, exchange가 필요합니다.",
             code="INSTRUMENT_MISSING_COLUMNS",
@@ -441,7 +441,7 @@ def instrument_import(
         return
 
     async def _import() -> int:
-        # #1857: ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
+        # ``open_cli_db`` 헬퍼 lifecycle. ``--db-path`` override 는
         # ``db_path_override`` 로 전달.
         from ante.instrument.service import InstrumentService
 

--- a/src/ante/cli/commands/ipc_helpers.py
+++ b/src/ante/cli/commands/ipc_helpers.py
@@ -16,9 +16,9 @@ from ante.ipc.exceptions import IPCTimeoutError, ServerNotRunningError
 def get_socket_path(config_dir: Path | None = None) -> str:
     """IPC 소켓 경로 반환.
 
-    Refs #1157: ``runtime.socket_path`` resolver를 통해 ``<config_dir>/run/
-    ante.sock``(default)을 산출한다. ``[runtime] socket_path`` override가
-    ``system.toml``에 있으면 사용자 값이 우선한다.
+    ``runtime.socket_path`` resolver를 통해 ``<config_dir>/run/ante.sock``
+    (default)을 산출한다. ``[runtime] socket_path`` override가 ``system.toml``
+    에 있으면 사용자 값이 우선한다.
 
     Args:
         config_dir: 선택적 설정 디렉토리. None이면 현재 Click 컨텍스트의
@@ -71,12 +71,12 @@ async def ipc_send(
         client = IPCClient(socket_path=get_socket_path(config_dir=config_dir))
         response = await client.send(command, args, actor)
     except ServerNotRunningError:
-        # #1754: middleware ClickException fallback 이 IPC 미기동/타임아웃
-        # 케이스를 stable code 로 매핑할 수 있도록 ``ipc_error_code`` /
+        # middleware ClickException fallback 이 IPC 미기동/타임아웃 케이스를
+        # stable code 로 매핑할 수 있도록 ``ipc_error_code`` /
         # ``ipc_error_message`` 속성을 부착한다. ``raise`` 시그니처와 메시지
         # 본문은 기존 호출자(__str__ 가 그대로 사용자 메시지를 반환)와의
-        # 호환을 위해 변경하지 않는다 (서버 error envelope 경로의 attrs
-        # 부착 #1673 과 동형 패턴).
+        # 호환을 위해 변경하지 않는다 (서버 error envelope 경로 attrs 부착과
+        # 동형 패턴).
         exc = click.ClickException(
             "서버가 실행 중이 아닙니다. 'ante system start'로 시작하세요."
         )
@@ -98,8 +98,8 @@ async def ipc_send(
         # ``"{code}: {message}"`` 를 반환한다(동작 불변, 순수 additive).
         # config set 처럼 JSON envelope를 직접 만들어야 하는 호출자가
         # 원본 code/message 를 split 없이 복원할 수 있도록 속성을
-        # 부착한다 (#1673 택A — ipc_send 변경이 다수 명령에 회귀를
-        # 유발하지 않도록 raise 문자열·시그니처는 그대로 둔다).
+        # 부착한다 (ipc_send 변경이 다수 명령에 회귀를 유발하지 않도록
+        # raise 문자열·시그니처는 그대로 둔다).
         exc = click.ClickException(f"{code}: {message}")
         exc.ipc_error_code = code  # type: ignore[attr-defined]
         exc.ipc_error_message = message  # type: ignore[attr-defined]

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -49,10 +49,10 @@ logger = logging.getLogger(__name__)
 
 # CLI 핸들러에서 master guard 위반을 사용자 친화 메시지로 종료하기 위한 메시지.
 # ``MemberService._assert_master``가 raise하는 ``PermissionDeniedError``는 Python
-# 내장 ``PermissionError``와 별개 계열(``MemberError`` → ``Exception``)이라 기존
-# ``except (ValueError, PermissionError)``로는 잡히지 않고 traceback이 노출된다
-# (이슈 #1351 1차 Codex review FAIL — Finding 2). suspend / reactivate / revoke /
-# rotate-token 등 master 검증이 추가된 모든 CLI 핸들러에서 동일 메시지로 종료한다.
+# 내장 ``PermissionError``와 별개 계열(``MemberError`` → ``Exception``)이라
+# ``except (ValueError, PermissionError)``로는 잡히지 않고 traceback이 노출된다.
+# suspend / reactivate / revoke / rotate-token 등 master 검증이 추가된 모든 CLI
+# 핸들러에서 동일 메시지로 종료한다.
 _MASTER_REQUIRED_MESSAGE = "권한이 없습니다: master만 수행할 수 있습니다."
 
 
@@ -136,12 +136,12 @@ def _resolve_secret_non_interactive(
 async def _create_service(
     ctx: click.Context | None = None,
 ) -> AsyncIterator[MemberService]:
-    """CLI용 ``MemberService`` async context manager (#1856).
+    """CLI용 ``MemberService`` async context manager.
 
-    #1855 의 ``open_cli_db`` 헬퍼 기반으로 변환했다. callsite 패턴은
+    ``open_cli_db`` 헬퍼 기반. callsite 패턴은
     ``async with _create_service(ctx) as service:`` 이며, ``open_cli_db`` 가
     normal/exception/cancellation 모든 경로에서 ``Database.close()`` 를
-    보장한다 (#1722/#1755 cleanup invariant).
+    보장한다 (cleanup invariant).
 
     Args:
         ctx: Click 컨텍스트. ``None`` 이면 ``click.get_current_context(silent=True)``
@@ -150,7 +150,7 @@ async def _create_service(
     Yields:
         ``initialize()`` 가 완료된 :class:`MemberService` 인스턴스.
 
-    #1854 §4.2 예외: ``MemberService.initialize`` 는 ``MEMBER_SCHEMA`` +
+    read-only 명시 예외: ``MemberService.initialize`` 는 ``MEMBER_SCHEMA`` +
     ``_EMOJI_MIGRATION`` + ``_TOKEN_EXPIRES_MIGRATION`` schema DDL 을
     수반하므로 ``member list``/``info`` 같은 read-only 명령에서도
     ``initialize()`` 를 계속 호출한다.
@@ -290,10 +290,10 @@ def _explicit_config_dir(ctx: click.Context) -> str | None:
     의미하게 한다.
 
     이 값은 ``revoke_command`` 생성 시 운영자가 입력한 ``--config-dir`` 을
-    payload 에 보존하기 위해 사용된다 (#1468 Codex review attempt 3, P2):
-    운영자가 ``ante --config-dir /custom member list-invalid-roles`` 로 다른
-    인스턴스를 스캔했을 때, payload 의 ``revoke_command`` 에 ``--config-dir`` 이
-    빠지면 default config_dir 의 DB 에 실행되어 엉뚱한 인스턴스를 건드릴 위험이
+    payload 에 보존하기 위해 사용된다: 운영자가
+    ``ante --config-dir /custom member list-invalid-roles`` 로 다른 인스턴스를
+    스캔했을 때, payload 의 ``revoke_command`` 에 ``--config-dir`` 이 빠지면
+    default config_dir 의 DB 에 실행되어 엉뚱한 인스턴스를 건드릴 위험이
     있다. 항상 ``ctx`` 의 override 를 같은 자리에 다시 채워 인스턴스 일관성을
     보장한다.
 
@@ -313,7 +313,7 @@ def _explicit_config_dir(ctx: click.Context) -> str | None:
     if raw is None:
         return None
     # 절대 경로로 정규화 — payload 를 다른 CWD 에서 실행해도 같은 인스턴스를
-    # 가리키도록 한다 (#1468 Codex review attempt 4, P2).
+    # 가리키도록 한다.
     return str(Path(raw).expanduser().resolve())
 
 
@@ -321,12 +321,11 @@ def _build_revoke_command(member_id: str, *, config_dir: str | None) -> str:
     """``ante member revoke`` payload 명령 문자열을 생성한다.
 
     - ``config_dir`` 이 주어지면 ``ante --config-dir <quoted>`` 를 앞에 붙여
-      동일 인스턴스(DB) 대상으로 명령이 실행되도록 보존한다 (#1468 attempt 3 P2).
-    - ``--yes`` 는 ``member revoke`` 비대화형 게이트를 통과하기 위해 항상 포함한다
-      (#1468 attempt 1 P2-B).
+      동일 인스턴스(DB) 대상으로 명령이 실행되도록 보존한다.
+    - ``--yes`` 는 ``member revoke`` 비대화형 게이트를 통과하기 위해 항상 포함한다.
     - ``--`` separator 와 ``shlex.quote`` 로 ``member_id`` 를 셸 안전 인용해
       빈 문자열·공백·셸 메타문자·``-``-prefix 가 포함된 id 도 인자 splitting /
-      옵션 파싱으로 오해석되지 않도록 한다 (#1468 attempt 2 P2-A).
+      옵션 파싱으로 오해석되지 않도록 한다.
     """
     parts = ["ante"]
     if config_dir is not None:
@@ -343,31 +342,28 @@ def _invalid_role_row_dict(
 ) -> dict:
     """``Member`` row 를 CLI 출력용 dict 로 변환.
 
-    ``token_hash`` 는 보안상 절대 노출하지 않는다 (#1468 secret-exposure). 토큰
-    존재 여부는 ``has_token: bool`` 로만 표현하고 만료시각은 그대로 표시한다.
+    ``token_hash`` 는 보안상 절대 노출하지 않는다 (secret-exposure). 토큰 존재
+    여부는 ``has_token: bool`` 로만 표현하고 만료시각은 그대로 표시한다.
     ``valid_roles`` 는 row-level 이 아니라 top-level scan summary 에만 노출한다.
 
     ``revoke_command`` 는 **actionable row 에서만** 노출한다. legacy_revoked row
     는 이미 ``status=revoked`` 상태이며 ``MemberService.revoke`` 가
     ``active``/``suspended`` 만 허용하므로 재실행 시 실패한다. 따라서 noop 명령을
-    payload 에 싣지 않고 키 자체를 누락해 "추가 조치 불요" 임을 명시한다
-    (#1468 Codex review attempt 2, P2-B).
+    payload 에 싣지 않고 키 자체를 누락해 "추가 조치 불요" 임을 명시한다.
 
     actionable row 의 ``revoke_command`` 는 ``shlex.quote`` 로 ``member_id`` 를
     셸 안전하게 인용하고, ``--`` separator 로 옵션/포지셔널 경계를 명시한다 — 빈
     문자열·공백·셸 메타문자·``-``-prefix 가 포함된 ``member_id`` 가 운영자 셸에서
-    인자 splitting 이나 옵션 파싱으로 오해석되는 위험을 차단한다 (#1468 Codex
-    review attempt 2, P2-A).
+    인자 splitting 이나 옵션 파싱으로 오해석되는 위험을 차단한다.
 
     ``config_dir`` 이 주어지면(루트 ``--config-dir`` 이 명시된 경우) 그 값을
     ``revoke_command`` 앞에 ``--config-dir <quoted>`` 로 보존해, 운영자가 payload
     를 그대로 복사 실행해도 같은 인스턴스(DB) 대상으로 동작하도록 보장한다
-    (#1468 attempt 3 P2 — config-dir 보존). default config_dir 일 때는 인자 자체
-    를 생략해 기존 표준 호출 형태를 유지한다. 값은
-    :func:`_explicit_config_dir` 에서 ``expanduser().resolve()`` 로 **절대 경로
-    화** 되어 들어오므로, 운영자가 상대 경로/``~`` 확장 형태로 호출했더라도
-    payload 는 다른 CWD 에서 실행해도 같은 인스턴스를 가리킨다 (#1468 attempt 4
-    P2).
+    (config-dir 보존). default config_dir 일 때는 인자 자체를 생략해 기존 표준
+    호출 형태를 유지한다. 값은 :func:`_explicit_config_dir` 에서
+    ``expanduser().resolve()`` 로 **절대 경로화** 되어 들어오므로, 운영자가
+    상대 경로/``~`` 확장 형태로 호출했더라도 payload 는 다른 CWD 에서 실행해도
+    같은 인스턴스를 가리킨다.
     """
     has_token = bool(m.token_hash)
     row: dict = {
@@ -395,7 +391,7 @@ def _invalid_role_row_dict(
 def member_list_invalid_roles(
     ctx: click.Context,
 ) -> None:
-    """``MemberRole`` enum 외 role 을 가진 legacy member row 식별 (#1468).
+    """``MemberRole`` enum 외 role 을 가진 legacy member row 식별.
 
     본 명령은 canonical config 의 ``db.path`` (``get_db_path()``) 단일 DB 에
     대해서만 invalid-role row 를 식별한다. 다른 DB 파일 대상 점검은 본 PR scope
@@ -415,8 +411,8 @@ def member_list_invalid_roles(
     fmt = get_formatter(ctx)
     valid_roles = [member.value for member in MemberRole]
     # 루트 ``--config-dir`` 이 명시되어 있으면 payload 의 revoke_command 에
-    # 동일 값을 보존한다 (#1468 attempt 3 P2). default 이면 None 이 돌아오고
-    # ``--config-dir`` 인자는 생략된다.
+    # 동일 값을 보존한다. default 이면 None 이 돌아오고 ``--config-dir`` 인자는
+    # 생략된다.
     config_dir_override = _explicit_config_dir(ctx)
 
     async def _run_scan() -> tuple[list[dict], list[dict]]:
@@ -532,27 +528,27 @@ def member_register(
     try:
         result, token = _run(_run_register())
     except PermissionDeniedError:
-        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 — master 검증 위반의
-        # 안정 코드. CLI surface override 보존: 사용자 친화 한국어 문구
+        # PERMISSION_DENIED code 명시 — master 검증 위반의 안정 코드.
+        # CLI surface override 보존: 사용자 친화 한국어 문구
         # (``_MASTER_REQUIRED_MESSAGE``) 를 envelope message 로 surface 한다.
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberAlreadyExistsError as e:
-        # #1807 (Group R sweep): duplicate member_id 는 안정 코드
-        # ``MEMBER_ALREADY_EXISTS`` 로 surface (typed.code 직접 사용).
-        # ValueError 다중상속이라 generic 분기보다 먼저 둬야 typed 분기를
-        # 우선 매칭한다 (Python except 순서 의존).
+        # duplicate member_id 는 안정 코드 ``MEMBER_ALREADY_EXISTS`` 로
+        # surface (typed.code 직접 사용). ValueError 다중상속이라 generic
+        # 분기보다 먼저 둬야 typed 분기를 우선 매칭한다 (Python except 순서
+        # 의존).
         fmt.error(str(e), code=MemberAlreadyExistsError.code)
         raise SystemExit(1) from None
     except InvalidScopeError as e:
-        # SCOPE_VOCABULARY (#1439) 위반은 ``ValueError`` 서브클래스이지만
-        # CLI direct path 회귀를 위해 비-0 exit code 로 명시 종료한다.
+        # SCOPE_VOCABULARY 위반은 ``ValueError`` 서브클래스이지만 CLI direct
+        # path 회귀를 위해 비-0 exit code 로 명시 종료한다.
         # 다음 분기의 ``except (ValueError, ...)`` 가 먼저 매칭되면 ``return``
         # 으로 빠져 exit code 0 이 되므로 별도 분기로 둔다.
         fmt.error(str(e), code="MEMBER_INVALID_SCOPE")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     if fmt.is_json:
@@ -582,13 +578,13 @@ def member_set_emoji(ctx: click.Context, member_id: str, emoji: str) -> None:
     try:
         result = _run(_run_set_emoji())
     except MemberNotFoundError:
-        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
-        # 한다 (CLI/IPC 일관성: ``MemberNotFoundError.code`` 와 동형, ``member
-        # info`` line 231 형제 패턴 1:1 미러).
+        # missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface 한다
+        # (CLI/IPC 일관성: ``MemberNotFoundError.code`` 와 동형, ``member
+        # info`` 형제 패턴 1:1 미러).
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except ValueError as e:
-        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     fmt.success(f"이모지 설정 완료: {member_id} → {result['emoji']}", result)
@@ -642,7 +638,7 @@ def member_update_scopes(ctx: click.Context, member_id: str, scopes: str) -> Non
         fmt.error(message, code=code)
         raise SystemExit(1) from e
     except PermissionDeniedError:
-        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 — master 검증 위반.
+        # PERMISSION_DENIED code 명시 — master 검증 위반.
         # CLI surface override 보존 (한국어 친화 문구).
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
@@ -650,7 +646,7 @@ def member_update_scopes(ctx: click.Context, member_id: str, scopes: str) -> Non
         fmt.error(str(e), code="MEMBER_INVALID_SCOPE")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     if fmt.is_json:
@@ -677,23 +673,23 @@ def member_suspend(ctx: click.Context, member_id: str) -> None:
     try:
         result = _run(_run_suspend())
     except PermissionDeniedError:
-        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 + CLI surface override.
+        # PERMISSION_DENIED code 명시 + CLI surface override (한국어 친화 문구).
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberNotFoundError:
-        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
-        # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
+        # missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface 한다
+        # (CLI/IPC 일관성: ``member info`` 형제 패턴 미러).
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except MemberStateConflictError as e:
-        # #1814 Group Q sweep: state-conflict (이미 SUSPENDED 등) 는 안정 코드
+        # state-conflict (이미 SUSPENDED 등) 는 안정 코드
         # ``MEMBER_STATE_CONFLICT`` 로 surface 한다. ``ValueError`` 다중상속
         # 이라 아래 ``except (ValueError, PermissionError)`` generic fallback
         # 보다 typed 분기를 먼저 매칭한다 (Python MRO 보장).
         fmt.error(str(e), code="MEMBER_STATE_CONFLICT")
         raise SystemExit(1) from e
     except (ValueError, PermissionError) as e:
-        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     fmt.success(f"멤버 정지 완료: {member_id}", result)
@@ -717,23 +713,23 @@ def member_reactivate(ctx: click.Context, member_id: str) -> None:
     try:
         result = _run(_run_reactivate())
     except PermissionDeniedError:
-        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 + CLI surface override.
+        # PERMISSION_DENIED code 명시 + CLI surface override (한국어 친화 문구).
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberNotFoundError:
-        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
-        # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
+        # missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface 한다
+        # (CLI/IPC 일관성: ``member info`` 형제 패턴 미러).
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except MemberStateConflictError as e:
-        # #1814 Group Q sweep: state-conflict (이미 ACTIVE 등) 는 안정 코드
+        # state-conflict (이미 ACTIVE 등) 는 안정 코드
         # ``MEMBER_STATE_CONFLICT`` 로 surface 한다 (``member suspend`` 1:1
         # 미러). ``ValueError`` 다중상속이라 아래 generic fallback 보다
         # typed 분기를 먼저 매칭한다.
         fmt.error(str(e), code="MEMBER_STATE_CONFLICT")
         raise SystemExit(1) from e
     except (ValueError, PermissionError) as e:
-        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     fmt.success(f"멤버 재활성화 완료: {member_id}", result)
@@ -775,16 +771,16 @@ def member_revoke(ctx: click.Context, member_id: str, yes: bool) -> None:
     try:
         result = _run(_run_revoke())
     except PermissionDeniedError:
-        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 + CLI surface override.
+        # PERMISSION_DENIED code 명시 + CLI surface override (한국어 친화 문구).
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberNotFoundError:
-        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
-        # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
+        # missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface 한다
+        # (CLI/IPC 일관성: ``member info`` 형제 패턴 미러).
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     fmt.success(f"멤버 폐기 완료: {member_id}", result)
@@ -808,16 +804,16 @@ def member_rotate_token(ctx: click.Context, member_id: str) -> None:
     try:
         result, token = _run(_run_rotate())
     except PermissionDeniedError:
-        # #1843 sub-PR 1: PERMISSION_DENIED code 명시 + CLI surface override.
+        # PERMISSION_DENIED code 명시 + CLI surface override (한국어 친화 문구).
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
         raise SystemExit(1) from None
     except MemberNotFoundError:
-        # #1805: missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface
-        # 한다 (CLI/IPC 일관성: ``member info`` line 231 형제 패턴 미러).
+        # missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface 한다
+        # (CLI/IPC 일관성: ``member info`` 형제 패턴 미러).
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}", code="MEMBER_NOT_FOUND")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     if fmt.is_json:
@@ -878,13 +874,13 @@ def member_reset_password(
     try:
         _run(_run_reset())
     except MemberInvalidRecoveryCredentialError as e:
-        # #1806 (Group R sweep): invalid recovery key 는 안정 코드
+        # invalid recovery credential 은 안정 코드
         # ``MEMBER_INVALID_RECOVERY_CREDENTIAL`` 로 surface. ValueError
         # 다중상속이라 generic 분기보다 먼저 둬야 typed 우선 매칭.
         fmt.error(str(e), code=MemberInvalidRecoveryCredentialError.code)
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     fmt.success("패스워드가 변경되었습니다.")
@@ -938,13 +934,13 @@ def member_regenerate_recovery_key(
     try:
         new_key = _run(_run_regen())
     except MemberInvalidRecoveryCredentialError as e:
-        # #1806 (Group R sweep): invalid 현재 패스워드는 안정 코드
+        # invalid 현재 패스워드는 안정 코드
         # ``MEMBER_INVALID_RECOVERY_CREDENTIAL`` 로 surface. ValueError
         # 다중상속이라 generic 분기보다 먼저 둬야 typed 우선 매칭.
         fmt.error(str(e), code=MemberInvalidRecoveryCredentialError.code)
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
-        # #1843 sub-PR 1: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         emit_cli_error(fmt, e)
 
     if fmt.is_json:

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -18,8 +18,8 @@ from ante.report.models import ReportStatus
 from ante.report.validation import ReportSubmitRequest
 
 # `ReportStatus` enum이 `--status` 필터의 SSOT다. `report list`는 DB 진입 전
-# preflight에서 invalid 값을 차단해야 하며 (#1462), 이를 위해 함수 내부 import
-# 대신 모듈 상단 import을 사용한다. `ante.report.models`는 dataclass + StrEnum
+# preflight에서 invalid 값을 차단해야 하며, 이를 위해 함수 내부 import 대신
+# 모듈 상단 import을 사용한다. `ante.report.models`는 dataclass + StrEnum
 # + math 만 노출하는 light 모듈이라 `tests/unit/test_cli_dependency_isolation.py`
 # 가 회귀를 차단한다.
 
@@ -72,7 +72,7 @@ def submit(
             fmt.error(f"Invalid JSON: {exc}", code="REPORT_VALIDATION_ERROR")
             raise SystemExit(1) from exc
 
-    # ── #1415 codex r1 P3: non-object JSON 거부 ─────────────────────────
+    # ── non-object JSON 거부 ────────────────────────────────────────────
     # 파일이 JSON object가 아닌 array/string/number/bool/null이면 아래
     # ``report_data.pop(...)``/``report_data.get(...)`` 호출이 ``TypeError``/
     # ``AttributeError``로 raise되어 의도한 ``REPORT_VALIDATION_ERROR`` 구조화
@@ -90,7 +90,7 @@ def submit(
     if run_id:
         report_data["backtest_run_id"] = run_id
 
-    # ── #1415: ReportSubmitRequest 검증 ────────────────────────────────
+    # ── ReportSubmitRequest 검증 ───────────────────────────────────────
     # SSOT: ``src/ante/report/validation.py::ReportSubmitRequest``.
     #
     # CLI 입력은 제출 스키마 invariant를 통과해야 한다:
@@ -110,11 +110,11 @@ def submit(
     try:
         validated = ReportSubmitRequest.model_validate(report_data)
     except ValidationError as exc:
-        # 거부된 입력 값/ctx 반사 금지 (보안 invariant #1629 L1 패턴 1:1 미러;
-        # reports.py:194 web sweep 와 동일 sanitizer). 2b 가 sections 미지원
-        # 필드를 ValidationError(extra_forbidden) 경로로 보내므로 ``str(exc)``
-        # 의 ``input_value={...}`` (제출한 sections rationale/evidence) 가
-        # 터미널/CI 로그에 반사되지 않도록 loc/type/msg 만 출력한다 (#1632).
+        # 거부된 입력 값/ctx 반사 금지 (보안 invariant — reports.py web sweep
+        # 와 동일 sanitizer). sections 미지원 필드는 ValidationError
+        # (extra_forbidden) 경로로 들어오므로 ``str(exc)`` 의
+        # ``input_value={...}`` (제출한 sections rationale/evidence) 가
+        # 터미널/CI 로그에 반사되지 않도록 loc/type/msg 만 출력한다.
         fmt.error(
             str(exc.errors(include_context=False, include_input=False)),
             code="REPORT_VALIDATION_ERROR",
@@ -204,8 +204,8 @@ def report_list(ctx: click.Context, status: str | None, db_path: str | None) -> 
     resolved_db_path = db_path or get_db_path(ctx)
 
     # Preflight: invalid `--status`는 `Database` 생성 전에 차단한다.
-    # `ReportStatus` enum이 SSOT이며 (#1462) inline 비교한다.
-    # strategy.py:204-210 패턴과 동형이다.
+    # `ReportStatus` enum이 SSOT이며 inline 비교한다.
+    # strategy.py 패턴과 동형이다.
     if status is not None and status not in {s.value for s in ReportStatus}:
         fmt.error(
             f"잘못된 status 값: {status!r}. "
@@ -221,8 +221,8 @@ def report_list(ctx: click.Context, status: str | None, db_path: str | None) -> 
         # ``list_reports`` 호출 포함)을 ``except BaseException`` 블록으로 감싸
         # 실패 시 ``db.close()``를 보장한다. ``initialize``/``list_reports`` 가
         # raise되면 aiosqlite 연결이 leak되어 asyncio 종료 시 worker thread가
-        # 정리되며 stderr에 traceback이 노출되는 회귀를 차단한다 (#1755;
-        # ``_create_account_service`` (#1722) cleanup 패턴 1:1 미러).
+        # 정리되며 stderr에 traceback이 노출되는 회귀를 차단한다
+        # (``_create_account_service`` cleanup 패턴 1:1 미러).
         db = Database(resolved_db_path)
         try:
             await db.connect()
@@ -317,14 +317,13 @@ def report_performance(
         )
         raise SystemExit(1)
 
-    # monthly --year 비양수 거부 (#1599 oracle A7): #1593 period-exclusive
-    # 블록 직후, _run_performance/asyncio.run 이전에 차단한다. 캘린더 연도는
-    # 양수(>0)만 유효하므로 0/음수는 거부한다. daily+year는 위 #1593
+    # monthly --year 비양수 거부: period-exclusive 블록 직후,
+    # _run_performance/asyncio.run 이전에 차단한다. 캘린더 연도는 양수(>0)만
+    # 유효하므로 0/음수는 거부한다. daily+year는 위 period-exclusive
     # CLI_OPTION_CONFLICT가 먼저 잡으므로(이 블록은 그 after 배치) 여기 도달
     # 하는 year는 monthly 경로뿐이며 daily+year<=0도 CLI_OPTION_CONFLICT다.
     # 에러코드는 report 도메인의 기존 REPORT_VALIDATION_ERROR를 재사용한다
-    # (report submit 검증 report.py:66/77/107과 동일 코드). 상한/미래연도
-    # 검증은 범위 밖(>0만 검증).
+    # (report submit 검증과 동일 코드). 상한/미래연도 검증은 범위 밖(>0만 검증).
     if period == "monthly" and year is not None and year <= 0:
         fmt.error(
             "monthly --year는 양수 calendar year여야 합니다. (0 이하 거부)",
@@ -332,11 +331,11 @@ def report_performance(
         )
         raise SystemExit(1)
 
-    # inverted date range(시작일 > 종료일) 거부: #1593 period-exclusive 블록
-    # 직후, _run_performance/asyncio.run 이전에 차단한다 (backtest.py:72-77
-    # 동형, INVALID_DATE_RANGE + exit 1). #1593이 monthly+start/end는 이미
-    # CLI_OPTION_CONFLICT로 거부했으므로 여기 도달하는 start/end 조합은
-    # daily 경로뿐이다. #1593 순서/코드는 보존(이 블록은 after 배치).
+    # inverted date range(시작일 > 종료일) 거부: period-exclusive 블록 직후,
+    # _run_performance/asyncio.run 이전에 차단한다 (backtest.py 동형,
+    # INVALID_DATE_RANGE + exit 1). period-exclusive 게이트가 monthly+start/end
+    # 는 이미 CLI_OPTION_CONFLICT로 거부했으므로 여기 도달하는 start/end 조합은
+    # daily 경로뿐이다. 순서/코드는 보존(이 블록은 after 배치).
     reject_inverted_date_range(
         start,
         end,
@@ -346,7 +345,8 @@ def report_performance(
     )
 
     async def _run_performance() -> list[dict]:
-        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799 cleanup invariant).
+        # ``open_cli_db`` 헬퍼 lifecycle (cleanup invariant — 예외/cancellation
+        # 시에도 ``Database.close()`` 1회 보장).
         from ante.trade.performance import PerformanceTracker
 
         async with open_cli_db(ctx) as db:

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -39,31 +39,29 @@ def _run(coro):  # noqa: ANN001, ANN202
 async def _create_rule_engine(
     account_id: str, *, ctx: click.Context | None = None
 ) -> AsyncIterator[tuple[RuleEngine, Database]]:
-    """CLI용 RuleEngine async context manager (#1857).
+    """CLI용 RuleEngine async context manager.
 
-    이전 시그니처(``async def`` → ``tuple[RuleEngine, Database]``)에서
-    ``open_cli_db`` 기반 async context manager 로 전환했다 (#1855 factory
-    composition, #1856 account.py 패턴 1:1 미러). 호출 패턴:
+    ``open_cli_db`` 기반 lifecycle (factory composition, account.py 패턴
+    1:1 미러). 호출 패턴:
 
         async with _create_rule_engine(account_id, ctx=ctx) as (engine, db):
             ...
 
     호출자가 ``--account`` 옵션으로 검증된 ``account_id`` 를 반드시 전달
-    해야 한다. fallback 정책상 첫 번째 계좌를 임의로 선택해선 안 된다
-    (#1217). ``RuleEngine`` 생성자가 내부에서 ``require_account_id`` 로
-    재검증한다.
+    해야 한다. fallback 정책상 첫 번째 계좌를 임의로 선택해선 안 된다.
+    ``RuleEngine`` 생성자가 내부에서 ``require_account_id`` 로 재검증한다.
 
     invalid ``account_id`` 검증은 ``open_cli_db`` (==``db.connect()``)
-    **이전**에 수행한다(#1635 Split B Layer 2 — ``treasury.py:37``
-    ``_create_treasury`` 패턴 1:1 미러). resource acquisition 이전에
-    검증·raise 하면 획득 자원이 0이라 정리 대상도 0 — 누수 구조 자체를
-    제거한다 (#1623 lifecycle invariant). ``RuleEngine.__init__`` 내부
-    ``require_account_id`` 는 defense-in-depth 그대로 유지.
+    **이전**에 수행한다 (``treasury.py`` ``_create_treasury`` 패턴 1:1
+    미러). resource acquisition 이전에 검증·raise 하면 획득 자원이 0이라
+    정리 대상도 0 — 누수 구조 자체를 제거한다 (lifecycle invariant).
+    ``RuleEngine.__init__`` 내부 ``require_account_id`` 는 defense-in-depth
+    그대로 유지.
 
     valid-format 이지만 DB에 없는 ``account_id`` (예: ``acc-9999``)는
     ``RuleEngine`` 생성 **이전**에 lightweight ``SELECT 1`` 로 존재를
-    검증해 ``AccountNotFoundError`` 로 분기한다(#1726). ``open_cli_db`` 가
-    ``BaseException`` 까지 catch 하므로 cleanup 보장된다 (#1722 동형).
+    검증해 ``AccountNotFoundError`` 로 분기한다. ``open_cli_db`` 가
+    ``BaseException`` 까지 catch 하므로 cleanup 보장된다.
     """
     from ante.account.scoping import require_account_id
     from ante.eventbus.bus import EventBus
@@ -80,7 +78,7 @@ async def _create_rule_engine(
 
     async with open_cli_db(resolved_ctx) as db:
         # account existence pre-check. ``rule_list`` 의 기존 inline 블록을
-        # 그대로 옮긴 형태이며, ``_create_treasury`` 동형 (#1725).
+        # 그대로 옮긴 형태이며, ``_create_treasury`` 동형.
         #
         # ``AccountService.initialize()`` 는 모든 non-deleted account row를
         # materialize하며 credentials를 복호화하므로, 조회 대상과 무관한
@@ -96,11 +94,11 @@ async def _create_rule_engine(
         # 핸들만 쓰고 ``AccountService`` 를 초기화하지 않으므로, 부분
         # 초기화/legacy DB(예: ``ante init`` 직후)에서는 테이블 자체가 없어
         # ``sqlite3.OperationalError: no such table: accounts`` 가
-        # 호출자까지 전파되어 ACCOUNT_NOT_FOUND 계약을 우회할 수 있다
-        # (#1559). 정의상 accounts 테이블 부재는 해당 account 미존재와
-        # 동치이므로 동일한 ``AccountNotFoundError`` 로 정규화한다. 단,
-        # malformed db 같은 다른 ``OperationalError`` 까지 삼키지 않도록
-        # "no such table" 메시지일 때로만 좁힌다 (#1558 검증 패턴).
+        # 호출자까지 전파되어 ACCOUNT_NOT_FOUND 계약을 우회할 수 있다.
+        # 정의상 accounts 테이블 부재는 해당 account 미존재와 동치이므로
+        # 동일한 ``AccountNotFoundError`` 로 정규화한다. 단, malformed db
+        # 같은 다른 ``OperationalError`` 까지 삼키지 않도록 "no such table"
+        # 메시지일 때로만 좁힌다.
         try:
             account_row = await db.fetch_one(
                 "SELECT 1 FROM accounts WHERE account_id = ?",
@@ -183,20 +181,18 @@ def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> 
     fmt = get_formatter(ctx)
 
     # invalid account_id(`default`/패턴 위반/`""`)를 resource acquisition
-    # 이전에 거부한다(#1635 Split B Layer 1). invalid-format은 여기서
-    # `VALIDATION_ERROR`(#1633 SSOT) + exit 1로 종료된다. valid-but-absent
-    # account_id는 `require_account_id`가 거부하지 않으므로 기존 경로로
-    # 흘러 아래 `_run_list`의 account 존재 SELECT → `AccountNotFoundError`
-    # → `ACCOUNT_NOT_FOUND` 분기를 보존한다(invalid-format ↔ valid-absent
-    # 분리 불변, VALIDATION_ERROR 오분류 금지).
+    # 이전에 거부한다. invalid-format은 여기서 `VALIDATION_ERROR` + exit 1로
+    # 종료된다. valid-but-absent account_id는 `require_account_id`가 거부하지
+    # 않으므로 기존 경로로 흘러 아래 `_run_list`의 account 존재 SELECT →
+    # `AccountNotFoundError` → `ACCOUNT_NOT_FOUND` 분기를 보존한다
+    # (invalid-format ↔ valid-absent 분리 불변, VALIDATION_ERROR 오분류 금지).
     reject_invalid_account_id(account_id, fmt, context="cli.rule")
 
     async def _run_list() -> list[dict]:
         # account existence는 ``_create_rule_engine`` 이 ``SELECT 1`` 로 선
-        # 검증한다(#1726 SSOT consolidation — 기존 여기 inline 블록을 helper
-        # 로 이동). 미존재 account는 ``AccountNotFoundError`` 로 raise되며
-        # 아래 호출 표면의 ``except AccountNotFoundError`` 분기가 받는다.
-        # #1857: ``_create_rule_engine`` async context manager 전환.
+        # 검증한다 (SSOT consolidation — helper 로 이동). 미존재 account는
+        # ``AccountNotFoundError`` 로 raise되며 아래 호출 표면의
+        # ``except AccountNotFoundError`` 분기가 받는다.
         async with _create_rule_engine(account_id, ctx=ctx) as (engine, _):
             try:
                 _load_rules_from_config(engine)
@@ -223,7 +219,7 @@ def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> 
 
     if not result:
         # 실재 account의 0 rules는 정상 계약: exit 0 + 빈 목록 응답을
-        # 그대로 유지한다. 미존재 account만 위에서 exit 1로 분기된다(#1559).
+        # 그대로 유지한다. 미존재 account만 위에서 exit 1로 분기된다.
         fmt.output({"message": "등록된 룰이 없습니다.", "rules": []})
         return
 
@@ -244,17 +240,15 @@ def rule_info(ctx: click.Context, rule_id: str, account_id: str) -> None:
     fmt = get_formatter(ctx)
 
     # invalid account_id(`default`/패턴 위반/`""`)를 resource acquisition
-    # 이전에 거부한다(#1635 Split B Layer 1). invalid-format은 여기서
-    # `VALIDATION_ERROR`(#1633 SSOT) + exit 1로 종료한다. valid-but-absent
-    # account_id(예: ``acc-9999``)는 ``_create_rule_engine`` 이 ``SELECT 1``
-    # 로 검증해 ``AccountNotFoundError`` 를 raise하며, 아래 호출 표면의
+    # 이전에 거부한다. invalid-format은 여기서 `VALIDATION_ERROR` + exit 1로
+    # 종료한다. valid-but-absent account_id(예: ``acc-9999``)는
+    # ``_create_rule_engine`` 이 ``SELECT 1`` 로 검증해
+    # ``AccountNotFoundError`` 를 raise하며, 아래 호출 표면의
     # ``except AccountNotFoundError`` 분기가 ``ACCOUNT_NOT_FOUND`` 로
-    # 매핑한다(#1726 — prior #1635 명시 punt "ACCOUNT_NOT_FOUND 강제
-    # 금지"의 후속, ``rule_list`` line 196-198 패턴 1:1 동형).
+    # 매핑한다 (``rule_list`` 패턴 1:1 동형).
     reject_invalid_account_id(account_id, fmt, context="cli.rule")
 
     async def _run_info() -> dict | None:
-        # #1857: ``_create_rule_engine`` async context manager 전환.
         async with _create_rule_engine(account_id, ctx=ctx) as (engine, _):
             try:
                 _load_rules_from_config(engine)
@@ -365,9 +359,9 @@ def rule_update(
                 actor=actor,
             )
 
-        # #1857: cold-path ``rule update`` lifecycle 을 ``open_cli_db`` 로
-        # 전환했다. ``AccountService``/``DynamicConfigService``/``AuditLogger``
-        # ``initialize()`` 호출은 그대로 유지된다 — #1854 §4.2 명시 예외는
+        # cold-path ``rule update`` lifecycle 은 ``open_cli_db`` 기반.
+        # ``AccountService``/``DynamicConfigService``/``AuditLogger``
+        # ``initialize()`` 호출은 그대로 유지된다 — read-only 명시 예외는
         # AuditLogger/DynamicConfigService만이고, 본 callsite 는 audit 기록을
         # 동반하는 cold-path mutation 이라 안전성을 위해 모두 보존한다.
         from ante.account.service import AccountService

--- a/src/ante/cli/commands/signal.py
+++ b/src/ante/cli/commands/signal.py
@@ -31,8 +31,8 @@ def signal_connect(ctx: click.Context, key: str) -> None:
 async def _run_connect(ctx: click.Context, key: str) -> None:
     """시그널 채널 연결 및 실행.
 
-    #1857: 본 명령은 ``SignalChannel`` 을 통해 외부 시그널 소스 (HTTP/WS 등)
-    와 long-lived loop 를 형성한다. ``Database`` lifecycle 이 external process
+    본 명령은 ``SignalChannel`` 을 통해 외부 시그널 소스 (HTTP/WS 등) 와
+    long-lived loop 를 형성한다. ``Database`` lifecycle 이 external process
     runtime 과 엮여 있어 단순 ``open_cli_db`` async-context wrap 으로 동치
     변환이 불가능하다 — 별도 spec 정렬 PR (#1818 follow-up) 에서 다룬다.
     """

--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -25,9 +25,9 @@ if TYPE_CHECKING:
     from ante.core.database import Database
     from ante.strategy.registry import StrategyRegistry
 
-# `StrategyStatus` enum이 단일 SSOT이며 (#1463에서 임시 frozenset 복사본 제거),
-# `ante.strategy.__init__`의 lazy ``__getattr__`` 정리로 본 import가 heavy
-# 분석 의존성을 끌지 않는다. CLI dispatch path가 light한지는
+# `StrategyStatus` enum이 단일 SSOT다. `ante.strategy.__init__`의 lazy
+# ``__getattr__`` 정리로 본 import가 heavy 분석 의존성을 끌지 않는다.
+# CLI dispatch path가 light한지는
 # ``tests/unit/test_cli_dependency_isolation.py``가 fresh subprocess로 차단한다.
 
 
@@ -44,20 +44,19 @@ def _run(coro):  # noqa: ANN001, ANN202
 async def _create_registry(
     ctx: click.Context | None = None,
 ) -> AsyncIterator[tuple[StrategyRegistry, Database]]:
-    """CLI 에서 ``StrategyRegistry`` async context manager (#1857).
+    """CLI 에서 ``StrategyRegistry`` async context manager.
 
-    이전 시그니처(``async def`` → ``tuple[StrategyRegistry, Database]``)에서
-    ``open_cli_db`` 기반 async context manager 로 전환했다 (#1855 factory
-    composition, #1856 account.py 패턴 1:1 미러). 호출 패턴:
+    ``open_cli_db`` 기반 lifecycle (factory composition, account.py 패턴
+    1:1 미러). 호출 패턴:
 
         async with _create_registry(ctx=ctx) as (registry, db):
             ...
 
-    fresh DB에서도 strategies 테이블이 존재하도록 helper 차원에서
-    보장한다. ``register/get_by_name/list_strategies`` 등 모든 caller 에
-    자동 적용되며, idempotent하므로 기존 명시 ``await registry.initialize()``
-    호출은 회귀 안전을 위해 보존한다 (#1753 — #1854 §4.2 도 read-only 명시
-    예외 대상이지만 본 helper 는 안전성을 위해 호출을 그대로 보존한다).
+    fresh DB에서도 strategies 테이블이 존재하도록 helper 차원에서 보장한다.
+    ``register/get_by_name/list_strategies`` 등 모든 caller 에 자동 적용되며,
+    idempotent하므로 기존 명시 ``await registry.initialize()`` 호출은 회귀
+    안전을 위해 보존한다 (read-only 명시 예외 대상이지만 본 helper 는
+    안전성을 위해 호출을 그대로 보존한다).
     """
     from ante.strategy.registry import StrategyRegistry
 
@@ -160,8 +159,8 @@ def submit(ctx: click.Context, path: str) -> None:
 
     if not validation.valid:
         if fmt.is_json:
-            # #1789: 기존 ad-hoc envelope (``submitted``/``stage``/``errors``)
-            # 은 자동화 의존성 보호를 위해 유지하되, 안정 ``code`` 필드를
+            # 기존 ad-hoc envelope (``submitted``/``stage``/``errors``) 은
+            # 자동화 의존성 보호를 위해 유지하되, 안정 ``code`` 필드를
             # 추가해 표준 JSON 에러 envelope 의 분류 의미를 보존한다 (현존
             # ``meta_validation`` 분기와 동형).
             fmt.output(
@@ -173,8 +172,8 @@ def submit(ctx: click.Context, path: str) -> None:
                 }
             )
         else:
-            # #1843 sub-PR 6: text-mode 도 STRATEGY_VALIDATION_ERROR 안정
-            # 코드를 명시 부여한다 (JSON 분기의 ``code`` 필드와 동일 SSOT).
+            # text-mode 도 STRATEGY_VALIDATION_ERROR 안정 코드를 명시
+            # 부여한다 (JSON 분기의 ``code`` 필드와 동일 SSOT).
             # ``OutputFormatter.error`` 가 text 모드에서 code 를 stdout 에
             # 출력하지 않지만 (포맷 책임 분리), drift guard ``fmt.error``
             # callsite invariant 를 충족하기 위한 명시 부여.
@@ -192,7 +191,7 @@ def submit(ctx: click.Context, path: str) -> None:
         strategy_cls = StrategyLoader.load(filepath)
     except StrategyLoadError as e:
         if fmt.is_json:
-            # #1789: load 실패에도 안정 ``code`` 를 envelope 에 포함한다.
+            # load 실패에도 안정 ``code`` 를 envelope 에 포함한다.
             fmt.output(
                 {
                     "submitted": False,
@@ -202,10 +201,9 @@ def submit(ctx: click.Context, path: str) -> None:
                 }
             )
         else:
-            # #1843 sub-PR 6: helper 가 ``StrategyLoadError`` →
-            # ``STRATEGY_LOAD_ERROR`` 안정 코드를 surface 한다 (JSON 분기의
-            # ``code`` 필드와 동일 SSOT). 도메인 문구 "Load test failed:" 는
-            # ``fallback_message`` 로 보존.
+            # helper 가 ``StrategyLoadError`` → ``STRATEGY_LOAD_ERROR`` 안정
+            # 코드를 surface 한다 (JSON 분기의 ``code`` 필드와 동일 SSOT).
+            # 도메인 문구 "Load test failed:" 는 ``fallback_message`` 로 보존.
             emit_cli_error(fmt, e, fallback_message=f"Load test failed: {e}")
         raise SystemExit(1)
 
@@ -215,7 +213,7 @@ def submit(ctx: click.Context, path: str) -> None:
     # validation error 처리 (dict 등 invalid shape의 AttributeError 누출 차단).
     # registry.register(meta.name, meta.version, ...) 호출 전에 ingress에서
     # 차단해야 StrategyMeta가 아닌 객체가 attribute access 단계에서
-    # AttributeError traceback으로 stderr에 새는 #1756 회귀를 막는다.
+    # AttributeError traceback으로 stderr에 새는 회귀를 막는다.
     if not isinstance(meta, StrategyMeta):
         error_message = (
             f"meta는 StrategyMeta 인스턴스여야 합니다 "
@@ -249,7 +247,7 @@ def submit(ctx: click.Context, path: str) -> None:
 
     # 4. Registry 등록
     async def _register() -> dict:
-        # #1857: ``_create_registry`` async context manager 전환.
+        # ``_create_registry`` async context manager lifecycle.
         async with _create_registry(ctx=ctx) as (registry, _):
             await registry.initialize()
             record = await registry.register(
@@ -276,10 +274,10 @@ def submit(ctx: click.Context, path: str) -> None:
         result = _run(_register())
     except StrategyError as e:
         if fmt.is_json:
-            # #1789: register 실패 (duplicate id 등) envelope 에 typed
-            # ``code`` 를 포함한다. 예외 인스턴스가 class-level ``code`` 를
-            # 가지면 우선 사용하고, 없으면 generic ``STRATEGY_ERROR``
-            # fallback 으로 envelope 일관성을 유지한다.
+            # register 실패 (duplicate id 등) envelope 에 typed ``code`` 를
+            # 포함한다. 예외 인스턴스가 class-level ``code`` 를 가지면 우선
+            # 사용하고, 없으면 generic ``STRATEGY_ERROR`` fallback 으로
+            # envelope 일관성을 유지한다.
             fmt.output(
                 {
                     "submitted": False,
@@ -289,8 +287,8 @@ def submit(ctx: click.Context, path: str) -> None:
                 }
             )
         else:
-            # #1843 sub-PR 6: helper 가 ``StrategyError`` MRO lookup 으로
-            # subclass 별 typed 코드 (예: ``IncompatibleExchangeError`` →
+            # helper 가 ``StrategyError`` MRO lookup 으로 subclass 별 typed
+            # 코드 (예: ``IncompatibleExchangeError`` →
             # ``STRATEGY_INCOMPATIBLE_EXCHANGE``) 를 surface 한다. registry
             # miss + ``.code`` 미부여 시 ``EXECUTION_ERROR`` fallback (구
             # ``str(e)`` no-code 회귀 차단).
@@ -317,9 +315,9 @@ def strategy_list(ctx: click.Context, status: str | None) -> None:
     fmt = get_formatter(ctx)
 
     # Preflight: invalid --status는 registry/DB 진입 전에 차단한다.
-    # `StrategyStatus` enum이 SSOT이며 직접 비교한다 (#1463 임시 frozenset 제거).
-    # 이로써 일반적인 입력 오타가 `StrategyStatus(status)` ValueError →
-    # Python traceback으로 새지 않고 flat JSON error로 종료된다.
+    # `StrategyStatus` enum이 SSOT이며 직접 비교한다. 이로써 일반적인 입력
+    # 오타가 `StrategyStatus(status)` ValueError → Python traceback으로
+    # 새지 않고 flat JSON error로 종료된다.
     valid_statuses = {s.value for s in StrategyStatus}
     if status is not None and status not in valid_statuses:
         fmt.error(
@@ -329,7 +327,7 @@ def strategy_list(ctx: click.Context, status: str | None) -> None:
         raise SystemExit(1)
 
     async def _list() -> list[dict]:
-        # #1857: ``_create_registry`` async context manager 전환.
+        # ``_create_registry`` async context manager lifecycle.
         async with _create_registry(ctx=ctx) as (registry, _):
             filter_status = StrategyStatus(status) if status else None
             records = await registry.list_strategies(status=filter_status)
@@ -355,7 +353,7 @@ def strategy_list(ctx: click.Context, status: str | None) -> None:
     # `sqlite3.OperationalError: no such table: strategies` 는 빈 결과로
     # 정규화한다. `_create_registry()` 가 `await registry.initialize()` 를
     # 보장하므로 정상 경로에서는 발생하지 않지만, race/regress 시에도
-    # 사용자에게 내부 schema 명을 노출하지 않도록 방어한다 (#1753).
+    # 사용자에게 내부 schema 명을 노출하지 않도록 방어한다.
     try:
         rows = _run(_list())
     except click.ClickException:
@@ -412,7 +410,7 @@ def strategy_set_status(ctx: click.Context, strategy_id: str, status: str) -> No
                 actor=actor,
             )
 
-        # #1857: ``_create_registry`` async context manager 전환.
+        # ``_create_registry`` async context manager lifecycle.
         async with _create_registry(ctx=ctx) as (registry, _):
             await registry.initialize()
             await registry.update_status(strategy_id, target_status)
@@ -435,8 +433,8 @@ def strategy_set_status(ctx: click.Context, strategy_id: str, status: str) -> No
         fmt.error(str(e), code="STRATEGY_INVALID_STATUS_TRANSITION")
         raise SystemExit(1) from e
     except Exception as e:
-        # #1796: typed exception 의 class-level ``code`` 속성을 우선 surface
-        # 한다 (예: ``StrategyNotFoundError.code = "STRATEGY_NOT_FOUND"``).
+        # typed exception 의 class-level ``code`` 속성을 우선 surface 한다
+        # (예: ``StrategyNotFoundError.code = "STRATEGY_NOT_FOUND"``).
         # 속성이 없는 일반 ``StrategyError`` 는 기존 ``STRATEGY_ERROR``
         # fallback 으로 유지된다 (회귀 없음).
         fmt.error(str(e), code=getattr(e, "code", "STRATEGY_ERROR"))
@@ -459,7 +457,7 @@ def strategy_info(ctx: click.Context, name: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _info() -> dict | None:
-        # #1857: ``_create_registry`` async context manager 전환.
+        # ``_create_registry`` async context manager lifecycle.
         async with _create_registry(ctx=ctx) as (registry, _):
             records = await registry.get_by_name(name)
             if not records:
@@ -507,8 +505,7 @@ def strategy_info(ctx: click.Context, name: str) -> None:
     # 호출 표면 try/except: fresh DB 또는 race 상황의
     # `sqlite3.OperationalError: no such table: strategies` 는 not-found 로
     # 정규화한다. 다른 OperationalError(예: malformed DB)는 STRATEGY_ERROR 로
-    # 분류하여 내부 traceback 노출을 차단한다 (strategy_summary line 560-564
-    # 동형 SSOT, #1753).
+    # 분류하여 내부 traceback 노출을 차단한다 (strategy_summary 동형 SSOT).
     try:
         result = _run(_info())
     except sqlite3.OperationalError as e:
@@ -522,8 +519,7 @@ def strategy_info(ctx: click.Context, name: str) -> None:
         raise SystemExit(1) from e
 
     if result is None:
-        # `strategy_summary` line 566-568 / spec line 567 STRATEGY_NOT_FOUND
-        # SSOT 재사용 (#1753).
+        # `strategy_summary` / spec STRATEGY_NOT_FOUND SSOT 재사용.
         fmt.error(f"전략을 찾을 수 없습니다: {name}", code="STRATEGY_NOT_FOUND")
         raise SystemExit(1)
 
@@ -635,7 +631,7 @@ def strategy_summary(ctx: click.Context, strategy_id: str, period: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _summary() -> dict | None:
-        # #1857: ``_create_registry`` async context manager 전환.
+        # ``_create_registry`` async context manager lifecycle.
         from ante.trade.performance import PerformanceTracker
 
         async with _create_registry(ctx=ctx) as (registry, db):
@@ -711,7 +707,7 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
     """전략 전체 성과 집계 (모든 봇 합산, Agent 피드백용).
 
     --account-id 옵션은 필수다. 미지정 시 fallback 없이 명시적으로 실패한다
-    (#1218 Edge resolver 정렬, query 정책 일관).
+    (Edge resolver 정렬, query 정책 일관).
     """
     fmt = get_formatter(ctx)
 
@@ -727,15 +723,15 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
     )
 
     async def _perf() -> dict | None:
-        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799 cleanup invariant).
+        # ``open_cli_db`` 헬퍼 lifecycle (cleanup invariant — 예외/cancellation
+        # 시에도 ``Database.close()`` 1회 보장).
         from ante.strategy.registry import StrategyRegistry
         from ante.trade.performance import PerformanceTracker
 
         async with open_cli_db(ctx) as db:
             registry = StrategyRegistry(db)
             # fresh DB에서도 strategies 테이블이 존재하도록 정규화한다
-            # (#1753 Codex Plan v2 must-fix 1: `_create_registry` 경로와
-            # 동형 처리).
+            # (`_create_registry` 경로와 동형 처리).
             await registry.initialize()
             records = await registry.get_by_name(name)
             if not records:
@@ -749,8 +745,8 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
             # 핸들로 lightweight 단건 존재 쿼리만 수행한다. 쿼리 의미는
             # AccountService.get(account_id 단건, status 필터 없음)과
             # 일치하며 미존재 시 동일한 AccountNotFoundError 메시지로
-            # 분기한다 (#1559 일관). db.close()는 아래 finally가 단독
-            # 소유한다(lifecycle 불변).
+            # 분기한다. db.close()는 아래 finally가 단독 소유한다
+            # (lifecycle 불변).
             #
             # ``accounts`` 테이블은 ``AccountService.initialize()`` 에서만
             # 생성된다. 이 경로는 raw ``Database`` 핸들만 쓰고
@@ -761,7 +757,7 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
             # 해당 account 미존재와 동치이므로 동일한
             # AccountNotFoundError 로 정규화한다. 단, malformed db 같은
             # 다른 ``OperationalError`` 까지 삼키지 않도록 "no such table"
-            # 메시지일 때로만 좁힌다 (#1558/#1559 에서 검증된 패턴).
+            # 메시지일 때로만 좁힌다.
             try:
                 account_row = await db.fetch_one(
                     "SELECT 1 FROM accounts WHERE account_id = ?",
@@ -796,8 +792,8 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
         raise SystemExit(1) from e
     except sqlite3.OperationalError as e:
         # fresh DB / race 상황의 `no such table: strategies` 는 not-found 로
-        # 정규화한다 (#1753 Codex Plan v2 must-fix 1, strategy_info 동형
-        # 패턴). 다른 OperationalError 는 STRATEGY_ERROR 로 분류한다.
+        # 정규화한다 (strategy_info 동형 패턴). 다른 OperationalError 는
+        # STRATEGY_ERROR 로 분류한다.
         if "no such table" in str(e).lower():
             result = None
         else:
@@ -808,8 +804,7 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
         raise SystemExit(1) from e
 
     if result is None:
-        # strategy_summary line 567 / strategy_info STRATEGY_NOT_FOUND SSOT
-        # 재사용 (#1753).
+        # strategy_summary / strategy_info STRATEGY_NOT_FOUND SSOT 재사용.
         fmt.error(f"전략을 찾을 수 없습니다: {name}", code="STRATEGY_NOT_FOUND")
         raise SystemExit(1)
 

--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -64,7 +64,7 @@ def start(ctx: click.Context, config_dir: str | None) -> None:
 
     fmt = get_formatter(ctx)
 
-    # Refs #1157: PID 조회는 명시적 ``Config`` 인스턴스로 한다. ``--config-dir``
+    # PID 조회는 명시적 ``Config`` 인스턴스로 한다. ``--config-dir``
     # (서브커맨드 또는 루트 ``ctx.obj["config_dir"]``)이 가리키는 디렉토리의
     # canonical PID 파일만 본다. 0-arg ``read_pid_file()``은 ``ANTE_CONFIG_DIR``
     # env 또는 default 폴백을 보므로, 다른 ``config_dir``로 실행 중인 server를
@@ -103,13 +103,12 @@ def start(ctx: click.Context, config_dir: str | None) -> None:
 
     try:
         if fmt.is_json:
-            # #1757: JSON 모드 — 부모 stdout 에는 ``fmt.success`` 가 출력한
-            # 단일 JSON document 하나만 남아야 한다. 자식 프로세스
+            # JSON 모드 — 부모 stdout 에는 ``fmt.success`` 가 출력한 단일
+            # JSON document 하나만 남아야 한다. 자식 프로세스
             # (``python -m ante.main``) 의 runtime logger 가 inherit 된 stdout
             # 으로 흘러 들면 자동화 호출자(ante-oracle host probe 등)가
-            # ``json.loads`` 로 응답을 파싱하지 못한다 (A7
-            # ``cli_system_start_json_stdout_contract`` probe). 자식 stdout/
-            # stderr 를 부모 stderr 로 redirect 해 stdout 격리를 보존한다.
+            # ``json.loads`` 로 응답을 파싱하지 못한다. 자식 stdout/stderr 를
+            # 부모 stderr 로 redirect 해 stdout 격리를 보존한다.
             proc = subprocess.run(cmd, env=env, stdout=sys.stderr, stderr=sys.stderr)
         else:
             # text 모드: 자식 stdout/stderr inherit (기존 동작 보존).
@@ -130,9 +129,9 @@ def stop(ctx: click.Context) -> None:
 
     fmt = get_formatter(ctx)
 
-    # Refs #1157: PID 경로는 `runtime.pid_path` resolver로 결정한다.
-    # 같은 `config_dir`을 쓰는 server runtime/IPC client/cold-path guard와
-    # 동일한 canonical 위치(`<config_dir>/run/ante.pid`)를 본다.
+    # PID 경로는 `runtime.pid_path` resolver로 결정한다. 같은 `config_dir`을
+    # 쓰는 server runtime/IPC client/cold-path guard와 동일한 canonical
+    # 위치(`<config_dir>/run/ante.pid`)를 본다.
     config_dir = ctx.obj.get("config_dir") if ctx.obj else None
     config = Config.load(config_dir=config_dir)
     pid_path = config.runtime_pid_path()
@@ -147,8 +146,8 @@ def stop(ctx: click.Context) -> None:
 
     if not _is_process_alive(pid):
         # 프로세스가 없으면 canonical + legacy ``db/ante.pid`` 양쪽 stale PID
-        # 정리 (Refs #1157). ``read_pid_file``은 canonical만 보지만, cleanup은
-        # transitional 환경의 legacy 잔여까지 best-effort로 unlink한다.
+        # 정리. ``read_pid_file``은 canonical만 보지만, cleanup은 transitional
+        # 환경의 legacy 잔여까지 best-effort로 unlink한다.
         _remove_pid_file(config)
         fmt.error(
             f"프로세스가 존재하지 않습니다 (pid={pid}). PID 파일을 정리했습니다.",
@@ -164,10 +163,10 @@ def stop(ctx: click.Context) -> None:
 async def _create_services(
     ctx: click.Context | None = None,
 ) -> AsyncIterator[tuple[Database, EventBus]]:
-    """오프라인/bootstrap 커맨드용 DB/EventBus async context manager (#1857).
+    """오프라인/bootstrap 커맨드용 DB/EventBus async context manager.
 
-    ``open_cli_db`` 기반 lifecycle 로 전환했다 (#1855 factory composition,
-    #1856 account.py 패턴 1:1 미러). 호출 패턴:
+    ``open_cli_db`` 기반 lifecycle 로 전환했다 (factory composition,
+    account.py 패턴 1:1 미러). 호출 패턴:
 
         async with _create_services(ctx=ctx) as (db, eventbus):
             ...
@@ -196,7 +195,7 @@ def status(ctx: click.Context) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_status() -> dict:
-        # #1857: ``_create_services`` async context manager 전환.
+        # ``_create_services`` async context manager lifecycle.
         from ante.account.service import AccountService
 
         async with _create_services(ctx=ctx) as (db, eventbus):

--- a/src/ante/cli/commands/trade.py
+++ b/src/ante/cli/commands/trade.py
@@ -35,17 +35,17 @@ def _run(coro):  # noqa: ANN001, ANN202
 async def _create_trade_service(
     ctx: click.Context | None = None,
 ) -> AsyncIterator[tuple[TradeService, Database]]:
-    """CLI 에서 ``TradeService`` async context manager (#1857).
+    """CLI 에서 ``TradeService`` async context manager.
 
-    ``open_cli_db`` 기반 lifecycle 로 전환했다 (#1855 factory composition,
-    #1856 account.py 패턴 1:1 미러). 호출 패턴:
+    ``open_cli_db`` 기반 lifecycle (factory composition, account.py 패턴
+    1:1 미러). 호출 패턴:
 
         async with _create_trade_service(ctx=ctx) as (service, db):
             ...
 
     ``PositionHistory``/``TradeRecorder`` ``initialize()`` 는 표 생성용으로
-    그대로 보존한다 (#1854 §4.2 예외는 AuditLogger/DynamicConfigService 만;
-    본 helper 는 안전성을 위해 호출 유지).
+    그대로 보존한다 (read-only 명시 예외는 AuditLogger/DynamicConfigService
+    만; 본 helper 는 안전성을 위해 호출 유지).
     """
     from ante.trade.performance import PerformanceTracker
     from ante.trade.position import PositionHistory
@@ -114,7 +114,7 @@ def trade_list(
     )
 
     async def _run_list() -> list[dict]:
-        # #1857: ``_create_trade_service`` async context manager 전환.
+        # ``_create_trade_service`` async context manager lifecycle.
         async with _create_trade_service(ctx=ctx) as (service, _):
             fd = datetime.fromisoformat(from_date) if from_date else None
             td = datetime.fromisoformat(to_date) if to_date else None
@@ -175,14 +175,15 @@ def trade_info(ctx: click.Context, trade_id: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_info() -> dict | None:
-        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799 cleanup invariant).
+        # ``open_cli_db`` 헬퍼 lifecycle (cleanup invariant — 예외/cancellation
+        # 시에도 ``Database.close()`` 1회 보장).
         async with open_cli_db(ctx) as db:
             # fresh DB 에서는 `trades` 테이블이 아직 생성되지 않은 상태일 수
             # 있다. (`_create_trade_service` 경로와 달리 `trade info` 는
             # raw db 핸들만 쓰고 `TradeRecorder.initialize` 를 거치지 않는다.)
             # 정의상 테이블 부재는 해당 trade 미존재와 동치이므로 not-found 로
             # 정규화한다. malformed DB 같은 다른 OperationalError 까지
-            # 삼키지 않도록 "no such table" 메시지로만 좁힌다 (#1753).
+            # 삼키지 않도록 "no such table" 메시지로만 좁힌다.
             try:
                 row = await db.fetch_one(
                     "SELECT * FROM trades WHERE trade_id = ?", (trade_id,)
@@ -194,7 +195,7 @@ def trade_info(ctx: click.Context, trade_id: str) -> None:
             return dict(row) if row else None
 
     # 호출 표면 try/except: 위 _run_info 에서 흡수하지 못한 비정상 예외는
-    # TRADE_ERROR 로 분류해 raw traceback 노출을 차단한다 (#1753).
+    # TRADE_ERROR 로 분류해 raw traceback 노출을 차단한다.
     try:
         result = _run(_run_info())
     except Exception as e:

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -50,11 +50,10 @@ async def _create_treasury(
     *,
     ctx: click.Context | None = None,
 ) -> AsyncIterator[tuple[Treasury, Database]]:
-    """CLI 에서 ``Treasury`` async context manager (#1857).
+    """CLI 에서 ``Treasury`` async context manager.
 
-    이전 시그니처(``async def`` → ``tuple[Treasury, Database]``)에서
-    ``open_cli_db`` 기반 async context manager 로 전환했다 (#1855 factory
-    composition, #1856 account.py 패턴 1:1 미러). 호출 패턴:
+    ``open_cli_db`` 기반 lifecycle (factory composition, account.py 패턴
+    1:1 미러). 호출 패턴:
 
         async with _create_treasury(account_id, ctx=ctx) as (t, db):
             ...
@@ -64,8 +63,8 @@ async def _create_treasury(
     initialize`` 라이프사이클 실패 시에도 ``db.close()`` 가 보장된다.
     valid-but-missing account_id(예: ``acc-9999``) 가 들어오면
     ``account_service.get`` 이 :class:`AccountNotFoundError` 를 raise 하는데,
-    이전 inline 패턴(#1725) 에서 aiosqlite 연결이 leak 되어 6초 hang 회귀가
-    있었고 본 helper 가 동일 cleanup 을 보장한다.
+    이전 inline 패턴에서 aiosqlite 연결이 leak 되어 6초 hang 회귀가 있었고
+    본 helper 가 동일 cleanup 을 보장한다.
     """
     from ante.account.scoping import require_account_id
     from ante.account.service import AccountService
@@ -102,7 +101,7 @@ async def _create_treasury(
 async def _create_treasury_manager(
     ctx: click.Context | None = None,
 ) -> AsyncIterator[tuple[TreasuryManager, Database]]:
-    """CLI 에서 ``TreasuryManager`` async context manager (#1857).
+    """CLI 에서 ``TreasuryManager`` async context manager.
 
     ``_create_treasury`` 동형 패턴. ``open_cli_db`` 가 ``initialize_all`` /
     ``account_service.list`` 등 lifecycle 실패 시에도 ``db.close()`` 를
@@ -139,22 +138,21 @@ def status(ctx: click.Context, account_id: str) -> None:
     fmt = get_formatter(ctx)
 
     # invalid account_id(`default`/패턴 위반/`""`)를 resource acquisition
-    # 이전에 거부한다(#1635 Split B Layer 1). `_create_treasury`는 이미
-    # `require_account_id`를 `db.connect()` 이전에 호출하지만(leak-free), CLI
-    # 콜백이 non-Click `InvalidAccountIdError`를 명시적으로 catch하지 않아
-    # traceback으로 새던 contract-drift를 본 ingress 거부가 닫는다. 에러코드는
-    # #1633 SSOT `VALIDATION_ERROR`(helper가 `e.code` 재사용).
+    # 이전에 거부한다. `_create_treasury`는 이미 `require_account_id`를
+    # `db.connect()` 이전에 호출하지만(leak-free), CLI 콜백이 non-Click
+    # `InvalidAccountIdError`를 명시적으로 catch하지 않아 traceback으로 새던
+    # contract-drift를 본 ingress 거부가 닫는다. 에러코드는 SSOT
+    # `VALIDATION_ERROR` (helper가 `e.code` 재사용).
     reject_invalid_account_id(account_id, fmt, context="cli.treasury")
 
     async def _run_status() -> dict:
-        # #1857: ``_create_treasury`` async context manager 전환.
         async with _create_treasury(account_id, ctx=ctx) as (t, _):
             return t.get_summary()
 
     # valid-but-missing account_id(예: `acc-9999`)는 `account_service.get`에서
     # `AccountNotFoundError`로 raise된다. Click 기본 핸들러가 typed exception을
-    # 모르고 traceback/빈 stdout으로 새던 contract-drift를 본 매핑이 닫는다
-    # (#1725). 에러코드는 `ACCOUNT_NOT_FOUND` SSOT.
+    # 모르고 traceback/빈 stdout으로 새던 contract-drift를 본 매핑이 닫는다.
+    # 에러코드는 `ACCOUNT_NOT_FOUND` SSOT.
     try:
         result = _run(_run_status())
     except AccountNotFoundError as e:
@@ -213,7 +211,8 @@ def transactions(
     reject_inverted_date_range(from_date, to_date, fmt)
 
     async def _run_transactions() -> dict:
-        # #1857: ``open_cli_db`` 헬퍼 lifecycle (#1722/#1799 cleanup invariant).
+        # ``open_cli_db`` 헬퍼 lifecycle (cleanup invariant — 예외/cancellation
+        # 시에도 ``Database.close()`` 1회 보장).
         async with open_cli_db(ctx) as db:
             where: list[str] = []
             params: list[str | int] = []
@@ -286,8 +285,8 @@ def budgets(ctx: click.Context, account_id: str | None) -> None:
         )
 
     async def _run_budgets() -> dict:
-        # #1857: ``_create_treasury`` / ``_create_treasury_manager`` async
-        # context manager 전환. 두 분기 모두 ``open_cli_db`` 가 normal/
+        # ``_create_treasury`` / ``_create_treasury_manager`` async context
+        # manager lifecycle. 두 분기 모두 ``open_cli_db`` 가 normal/
         # exception/cancellation 모든 경로에서 ``db.close()`` 를 보장한다.
         async def _collect_items(treasuries: list) -> dict:
             items = []
@@ -308,7 +307,7 @@ def budgets(ctx: click.Context, account_id: str | None) -> None:
     # valid-but-missing account_id(예: `acc-9999`)는 `_create_treasury` 내부의
     # `account_service.get`에서 `AccountNotFoundError`로 raise된다. Click 기본
     # 핸들러가 typed exception을 모르고 traceback/빈 stdout으로 새던
-    # contract-drift를 본 매핑이 닫는다 (#1758, status/snapshot #1725 동형).
+    # contract-drift를 본 매핑이 닫는다 (status/snapshot 동형).
     # 에러코드는 `ACCOUNT_NOT_FOUND` SSOT.
     try:
         result = _run(_run_budgets())
@@ -316,7 +315,7 @@ def budgets(ctx: click.Context, account_id: str | None) -> None:
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         # registry MRO lookup 으로 treasury typed exception 은 안정 코드
         # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
         # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
@@ -357,7 +356,7 @@ def set_balance(ctx: click.Context, amount: float, account_id: str) -> None:
                 {"account_id": account_id, "balance": amount},
                 actor=actor,
             )
-        # #1857: ``_create_treasury`` async context manager 전환.
+        # ``_create_treasury`` async context manager lifecycle.
         async with _create_treasury(account_id, ctx=ctx) as (t, _):
             await t.set_account_balance(amount)
             return {
@@ -366,8 +365,8 @@ def set_balance(ctx: click.Context, amount: float, account_id: str) -> None:
                 "updated_at": datetime.now(UTC).isoformat(),
             }
 
-    # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다
-    # (#1758, #1725). Click/Exception fallback은 기존(#1722 IPC 분기)을 보존한다.
+    # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다.
+    # Click/Exception fallback은 기존(IPC 분기)을 보존한다.
     try:
         result = _run(_run_set_balance())
     except click.ClickException as e:
@@ -379,7 +378,7 @@ def set_balance(ctx: click.Context, amount: float, account_id: str) -> None:
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         # registry MRO lookup 으로 treasury typed exception 은 안정 코드
         # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
         # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
@@ -404,12 +403,12 @@ def allocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) ->
     fmt = get_formatter(ctx)
     actor = _get_member_id(ctx)
 
-    # #1656 E bucket defense-in-depth: invalid account_id(`default`/패턴
-    # 위반/`""`)를 `ipc_send`(→`_handle_treasury_allocate`) 이전에 거부한다.
+    # defense-in-depth: invalid account_id(`default`/패턴 위반/`""`)를
+    # `ipc_send`(→`_handle_treasury_allocate`) 이전에 거부한다.
     # IPC handler가 1차 보증(handler-first require_account_id)하지만, CLI
-    # ingress 거부는 clean early exit(traceback 부재) + #1634/#1635 동형
-    # 방어선이다. `--account` required arg라 전 입력을 검증한다. 에러코드는
-    # #1633 SSOT `VALIDATION_ERROR`(helper가 `e.code` 재사용).
+    # ingress 거부는 clean early exit(traceback 부재) 방어선이다.
+    # `--account` required arg라 전 입력을 검증한다. 에러코드는 SSOT
+    # `VALIDATION_ERROR` (helper가 `e.code` 재사용).
     account_id = reject_invalid_account_id(
         account_id, fmt, context="cli.treasury.allocate"
     )
@@ -423,14 +422,14 @@ def allocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) ->
             actor=actor,
         )
 
-    # #1809 (oracle A7 @ a5d8edf): ``Treasury.allocate`` 가 reject 시 typed
-    # exception 을 raise 하고 IPC server 가 stable ``code``
-    # (``TREASURY_INSUFFICIENT_BALANCE`` / ``TREASURY_INVALID_AMOUNT``) 로
-    # envelope ``error`` 를 만들어 보낸다. ``ipc_send`` 는 그 envelope 을
+    # ``Treasury.allocate`` 가 reject 시 typed exception 을 raise 하고 IPC
+    # server 가 stable ``code`` (``TREASURY_INSUFFICIENT_BALANCE`` /
+    # ``TREASURY_INVALID_AMOUNT``) 로 envelope ``error`` 를 만들어 보낸다.
+    # ``ipc_send`` 는 그 envelope 을
     # ``ClickException.ipc_error_code`` / ``ipc_error_message`` 로 부착하여
     # raise 한다. 이전 ``except ClickException: raise`` 흐름은 middleware
     # fallback 에서 ``IPC_ERROR`` 로 표준화되어 stable code 가 surface 되지
-    # 않았다. ``set_balance``/``snapshot``/``status`` (#1758/#1725) 와 동형
+    # 않았다. ``set_balance``/``snapshot``/``status`` 와 동형
     # ``ipc_error_code`` 직접 매핑 패턴으로 일치시킨다.
     try:
         result = _run(_run_allocate())
@@ -443,14 +442,14 @@ def allocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) ->
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         # registry MRO lookup 으로 treasury typed exception 은 안정 코드
         # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
         # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
         # click.exceptions.Exit(1) 로 동형 보존.
         emit_cli_error(fmt, e)
 
-    # #1809: ``_handle_treasury_allocate`` 가 reject 시 typed exception 으로
+    # ``_handle_treasury_allocate`` 가 reject 시 typed exception 으로
     # raise 하므로 정상 응답은 항상 ``success=True``. 잔존 false 경로는
     # 방어적 invariant 로 유지하되 stable ``code`` 를 부착한다.
     if result.get("success"):
@@ -478,9 +477,9 @@ def deallocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) 
     fmt = get_formatter(ctx)
     actor = _get_member_id(ctx)
 
-    # #1656 E bucket defense-in-depth: `allocate`와 동형 — invalid account_id를
+    # defense-in-depth: `allocate`와 동형 — invalid account_id를
     # `ipc_send`(→`_handle_treasury_deallocate`) 이전에 거부한다(required arg
-    # 전검증, clean early exit). 에러코드는 #1633 SSOT `VALIDATION_ERROR`.
+    # 전검증, clean early exit). 에러코드는 SSOT `VALIDATION_ERROR`.
     account_id = reject_invalid_account_id(
         account_id, fmt, context="cli.treasury.deallocate"
     )
@@ -494,7 +493,7 @@ def deallocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) 
             actor=actor,
         )
 
-    # #1809: allocate 와 동형 — typed exception envelope ``code``
+    # allocate 와 동형 — typed exception envelope ``code``
     # (``TREASURY_INVALID_AMOUNT`` / ``TREASURY_BUDGET_NOT_FOUND`` /
     # ``TREASURY_DEALLOCATE_EXCEEDS_AVAILABLE``) 를 surface 한다.
     try:
@@ -508,7 +507,7 @@ def deallocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) 
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         # registry MRO lookup 으로 treasury typed exception 은 안정 코드
         # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
         # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
@@ -568,9 +567,9 @@ def snapshot(
     fmt = get_formatter(ctx)
 
     # invalid account_id(`default`/패턴 위반/`""`)를 resource acquisition
-    # 이전에 거부한다(#1635 Split B Layer 1). `status`와 동일 `_create_treasury`
+    # 이전에 거부한다. `status`와 동일 `_create_treasury`
     # construction-lifecycle 경계를 공유하므로 동형으로 ingress에서 차단한다.
-    # 에러코드는 #1633 SSOT `VALIDATION_ERROR`(helper가 `e.code` 재사용).
+    # 에러코드는 SSOT `VALIDATION_ERROR` (helper가 `e.code` 재사용).
     reject_invalid_account_id(account_id, fmt, context="cli.treasury")
 
     # 옵션 검증: --date 와 --from/--to 는 동시 사용 불가
@@ -593,7 +592,7 @@ def snapshot(
     )
 
     async def _run_snapshot() -> dict | list[dict] | None:
-        # #1857: ``_create_treasury`` async context manager 전환.
+        # ``_create_treasury`` async context manager lifecycle.
         async with _create_treasury(account_id, ctx=ctx) as (t, _):
             if date_str:
                 return await t.get_daily_snapshot(date_str)
@@ -606,7 +605,7 @@ def snapshot(
             today = datetime.now(UTC).strftime("%Y-%m-%d")
             return await t.get_daily_snapshot(today)
 
-    # valid-but-missing account_id 매핑은 status와 동형이다 (#1725).
+    # valid-but-missing account_id 매핑은 status와 동형이다.
     try:
         result = _run(_run_snapshot())
     except AccountNotFoundError as e:
@@ -675,8 +674,8 @@ def portfolio_value(ctx: click.Context, account_id: str | None) -> None:
         )
 
     async def _run_value() -> dict:
-        # #1857: ``_create_treasury`` / ``_create_treasury_manager`` async
-        # context manager 전환. 분기별로 별도 with 블록을 열어 두 분기 모두
+        # ``_create_treasury`` / ``_create_treasury_manager`` async context
+        # manager lifecycle. 분기별로 별도 with 블록을 열어 두 분기 모두
         # ``open_cli_db`` 가 normal/exception/cancellation 경로에서
         # ``db.close()`` 를 보장한다.
         async def _collect_values(treasuries: list) -> dict:
@@ -726,16 +725,16 @@ def portfolio_value(ctx: click.Context, account_id: str | None) -> None:
         async with _create_treasury_manager(ctx=ctx) as (manager, _):
             return await _collect_values(manager.list_all())
 
-    # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다
-    # (#1758, #1725). outer try는 `_create_treasury`(line ~612)와
-    # `_create_treasury_manager`(line ~615) 두 경로의 raise를 모두 cover한다.
+    # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다.
+    # outer try는 `_create_treasury`와 `_create_treasury_manager` 두 경로의
+    # raise를 모두 cover한다.
     try:
         result = _run(_run_value())
     except AccountNotFoundError as e:
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         # registry MRO lookup 으로 treasury typed exception 은 안정 코드
         # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
         # EXECUTION_ERROR. raise SystemExit 동작은 helper 가
@@ -779,8 +778,8 @@ def portfolio_history(
     )
 
     async def _run_history() -> dict:
-        # #1857: ``_create_treasury`` / ``_create_treasury_manager`` async
-        # context manager 전환. budgets/portfolio.value 와 동형 분기 패턴.
+        # ``_create_treasury`` / ``_create_treasury_manager`` async context
+        # manager lifecycle. budgets/portfolio.value 와 동형 분기 패턴.
         async def _collect_history(treasuries: list) -> dict:
             by_date: dict[str, dict[str, float | str]] = {}
             for treasury_obj in treasuries:
@@ -818,16 +817,16 @@ def portfolio_history(
         async with _create_treasury_manager(ctx=ctx) as (manager, _):
             return await _collect_history(manager.list_all())
 
-    # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다
-    # (#1758, #1725). outer try는 `_create_treasury`(line ~699)와
-    # `_create_treasury_manager`(line ~702) 두 경로의 raise를 모두 cover한다.
+    # valid-but-missing account_id 매핑은 status/snapshot/budgets와 동형이다.
+    # outer try는 `_create_treasury`와 `_create_treasury_manager` 두 경로의
+    # raise를 모두 cover한다.
     try:
         result = _run(_run_history())
     except AccountNotFoundError as e:
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
         raise SystemExit(1) from e
     except Exception as e:
-        # #1843 sub-PR 4: emit_cli_error 정렬 — CLI/IPC 동일 public code surface.
+        # emit_cli_error 로 CLI/IPC 동일 public code surface 정렬.
         # registry MRO lookup 으로 treasury typed exception 은 안정 코드
         # (TREASURY_*) 로 resolve, 나머지는 .code 속성 fallback 또는
         # EXECUTION_ERROR. raise SystemExit 동작은 helper 가

--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -49,8 +49,8 @@ def check_disk_space(db_path: Path) -> tuple[bool, str]:
 def check_server_running() -> bool:
     """서버가 실행 중인지 PID 파일로 확인. stale PID는 무시.
 
-    Refs #1157: ``--config-dir``로 가리킨 디렉토리의 canonical PID 파일만 본다.
-    명시적으로 ``Config.load(config_dir=get_config_dir())``로 인스턴스를 만들어
+    ``--config-dir``로 가리킨 디렉토리의 canonical PID 파일만 본다. 명시적으로
+    ``Config.load(config_dir=get_config_dir())``로 인스턴스를 만들어
     ``read_pid_file(config)``에 전달한다 — 0-arg ``read_pid_file()``은
     ``ANTE_CONFIG_DIR`` env/default 폴백을 보므로, 다른 ``config_dir``로 실행 중인
     server runtime을 누락해 update를 server 실행 중에 진행하는 위험이 있다.
@@ -104,7 +104,7 @@ def update(
     종료한다. `--yes` 게이트는 server 상태 검사와 PyPI 조회 **앞에**
     평가하므로, 서버 실행/네트워크 느림·실패 환경에서도 `--yes` 누락
     호출은 server-running 안내나 PyPI 실패가 아닌 동일한 구조화 에러
-    코드로 거절된다 (#1626 D1, Codex P2 2차).
+    코드로 거절된다.
     """
     from ante.update.checker import (
         get_current_version,
@@ -132,7 +132,7 @@ def update(
             click.echo(f"현재 버전: {current}")
         latest = get_latest_version()
         if latest is None:
-            # #1843 sub-PR 6: PyPI 조회 실패 (네트워크/HTTP 오류) 안정 코드.
+            # PyPI 조회 실패 (네트워크/HTTP 오류) 안정 코드.
             # ``UPDATE_CHECK_FAILED`` 는 ``--check`` dry-run 경로의 외부
             # 의존성 실패 surface (taxonomy ``external`` 카테고리 의미).
             fmt.error("PyPI 버전 확인 실패", code="UPDATE_CHECK_FAILED")
@@ -152,15 +152,15 @@ def update(
             click.echo("이미 최신 버전입니다")
         return
 
-    # 2) 비대화형 입력 계약 (#1170, #1171, #1626 SSOT): `--check`이 아닌 실제
-    #    업데이트 실행 호출에는 `--yes`가 반드시 필요하다. 이 게이트는
-    #    server 상태 검사(`check_server_running()`)와 PyPI 조회
-    #    (`get_latest_version()`) **앞에** 위치해야 한다 — 그래야:
+    # 2) 비대화형 입력 계약: `--check`이 아닌 실제 업데이트 실행 호출에는
+    #    `--yes`가 반드시 필요하다. 이 게이트는 server 상태 검사
+    #    (`check_server_running()`)와 PyPI 조회 (`get_latest_version()`)
+    #    **앞에** 위치해야 한다 — 그래야:
     #    (a) 서버 실행 환경에서도 `--yes` 누락 호출이 server-running 안내가
-    #        아닌 ``CLI_CONFIRMATION_REQUIRED``로 거절된다 (#1626 D1: spec
-    #        precedence — confirmation gate가 server 상태보다 우선).
+    #        아닌 ``CLI_CONFIRMATION_REQUIRED``로 거절된다 (spec precedence:
+    #        confirmation gate가 server 상태보다 우선).
     #    (b) 네트워크 느림/실패 환경에서도 PyPI 실패가 아닌 동일한 구조화
-    #        에러 코드로 거절된다 (Codex P2 finding 2차).
+    #        에러 코드로 거절된다.
     #    자동화는 server/네트워크 상태와 무관하게 동일한 코드를 받는다.
     #    게이트 통과 전이므로 server 상태 검사/PyPI 조회/backup/pip upgrade/
     #    migration 등 부수 효과는 일체 발생하지 않는다.
@@ -174,9 +174,9 @@ def update(
 
     # 3) 서버 실행 중 확인 — `--yes` 게이트 통과 후, 실제 update 부수 효과
     #    이전에 평가한다. `--force` 없이 서버가 실행 중이면
-    #    ``UPDATE_SERVER_RUNNING``(#1626 D2: SSOT 02-design-decisions.md:115,
-    #    03-commands.md)으로 거절한다. `--force` 시 가드를 우회한다(현
-    #    graceful shutdown은 미구현 TODO — 본 이슈 범위 밖, 후속 후보).
+    #    ``UPDATE_SERVER_RUNNING`` (SSOT: docs/specs/cli/02-design-decisions.md,
+    #    03-commands.md) 으로 거절한다. `--force` 시 가드를 우회한다(현
+    #    graceful shutdown은 미구현 TODO).
     if check_server_running():
         if force:
             if not fmt.is_json:
@@ -196,9 +196,9 @@ def update(
     # 업데이트 실행 — `--yes` 게이트 통과 후에만 PyPI를 조회한다.
     latest = target_version or get_latest_version()
     if latest is None:
-        # #1843 sub-PR 6: 실제 업데이트 경로 PyPI 조회 실패 동일 안정 코드.
-        # ``--check`` dry-run 경로 (line 135) 와 동일 ``UPDATE_CHECK_FAILED``
-        # SSOT — 두 경로의 외부 의존성 실패 surface 일치.
+        # 실제 업데이트 경로 PyPI 조회 실패 동일 안정 코드.
+        # ``--check`` dry-run 경로와 동일 ``UPDATE_CHECK_FAILED`` SSOT —
+        # 두 경로의 외부 의존성 실패 surface 일치.
         fmt.error("PyPI 버전 확인 실패", code="UPDATE_CHECK_FAILED")
         raise SystemExit(1)
 
@@ -221,7 +221,7 @@ def update(
     db_path = Path(get_db_path(ctx))
     # 마이그레이션 서브프로세스에 넘길 데이터 루트.
     # 런타임이 `data.path` 로 보는 경로와 동일해야 v002 Parquet 마이그레이션이
-    # 실제 데이터 트리에 적용된다 (Refs #1125 Codex 13차 review Finding 1).
+    # 실제 데이터 트리에 적용된다.
     data_path = get_data_path(ctx)
     ok, msg = check_disk_space(db_path)
     if not ok:
@@ -245,7 +245,7 @@ def update(
 
     # 의존성 스냅샷 저장 — 스냅샷은 DB 디렉터리 옆에 저장해 백업과 위치를
     # 통일한다. `get_db_path(ctx)` 결과의 부모 디렉터리를 그대로 전달해
-    # 과거 `./db` CWD 폴백이 남기던 유령 파일을 없앤다 (Refs #1125).
+    # 과거 `./db` CWD 폴백이 남기던 유령 파일을 없앤다.
     if not fmt.is_json:
         click.echo("의존성 스냅샷 저장 중...")
     snapshot_path = snapshot_dependencies(current, db_dir=db_path.parent)
@@ -259,9 +259,9 @@ def update(
     if not fmt.is_json:
         click.echo(f"업데이트 중: {current} → {latest}...")
     if not pip_upgrade(target_version):
-        # #1843 sub-PR 6: pip install 실패의 안정 코드. ``UPDATE_INSTALL_FAILED``
-        # 는 pip subprocess 비정상 종료 surface (taxonomy ``external``
-        # 카테고리 의미 — pip/PyPI 인프라 의존성 실패).
+        # pip install 실패의 안정 코드. ``UPDATE_INSTALL_FAILED`` 는 pip
+        # subprocess 비정상 종료 surface (taxonomy ``external`` 카테고리 의미
+        # — pip/PyPI 인프라 의존성 실패).
         fmt.error("업데이트 실패", code="UPDATE_INSTALL_FAILED")
         raise SystemExit(1)
 

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -27,34 +27,34 @@
 #       module = dotted module path (예: ante.account.errors).
 #       class_anchor = class 이름.
 
-# bot.py 931/967/1001 (구 882/918/952) 와 config.py 214/217 (구 176/179) 의
-# ``ipc_send`` ClickException text-mode 분기는 ``text = f"{code}: {message}"``
-# prefix 패턴이 의도된 영구 UX 계약이다. 회귀 lock
-# ``test_bot_start_error_text_mode_carries_code_prefix`` 와
+# bot.py 924/960/994 (구 931/967/1001 → 구 882/918/952) 와 config.py 212/215
+# (구 214/217 → 구 176/179) 의 ``ipc_send`` ClickException text-mode 분기는
+# ``text = f"{code}: {message}"`` prefix 패턴이 의도된 영구 UX 계약이다. 회귀
+# lock ``test_bot_start_error_text_mode_carries_code_prefix`` 와
 # ``test_config_set_server_error`` 의 ``"STATIC_CONFIG" in result.output`` 가
 # text 모드에서 ``code: message`` prefix 톤을 명시 요구하므로 단순
 # ``fmt.error(message, code=code)`` 정렬이 UX 회귀가 된다. 따라서
 # ``known_drift`` deferred 가 아닌 ``intended_no_code`` 영구 면제로 분류한다
-# (#1870 옵션 3).
+# (#1870 옵션 3). #1941 commands 주석 정리로 line 번호가 7줄 위로 이동.
 intended_no_code:
   - path: src/ante/cli/commands/bot.py
-    line: 931
+    line: 924
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 967
+    line: 960
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 1001
+    line: 994
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/config.py
-    line: 214
+    line: 212
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/config.py
-    line: 217
+    line: 215
     snippet_sha1: "1b05e8ebf6bd"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
 


### PR DESCRIPTION
Closes #1941

## Summary
`src/ante/cli/commands/` 20 files, 330건 이슈번호/리뷰 히스토리 인용을 runbook §10 정책에 따라 정리.

- 유지: 현재 invariant, 호출 계약, 보안/cleanup/defense-in-depth 이유, SSOT 인용, envelope code
- 축약: 이슈 번호 prefix(`#1843 sub-PR N`, `#1842`, `#1857`, `#1856`, `#1462`, `#1635` 등), Codex review attempt N 인용, line 번호 인용
- 보존: `#1818 follow-up` 3건 (broker.py L28/L346, signal.py L37 — 별도 spec 정렬 PR 추적)

330건 → 3건 보존 reference만 남음.

## #1924 시리즈 구성
- 정책 SSOT: runbook §10 (#1938 merged)
- 1차: middleware.py 21건 (#1939 merged)
- 2차: src/ante/bot/ 71건 (#1940 merged)
- **3차 (본 PR): src/ante/cli/commands/ 330건**

## Test Plan
- `pytest tests/unit/cli/` 306 PASS
- `pytest tests/unit/test_cli_*.py` 1169 PASS
- 추가 도메인 회귀(account_cli, account_cli_ipc_error_equivalence, approval/bot IPC error equivalence, success output drift, bot_info) 141 PASS
- `ruff check` / `mypy src/ante/cli/commands/` clean
- AST parse sanity check OK
- 런타임 동작/public API/contract/identifier 그대로

## Review
- Codex 브랜치 review PASS