### PR TITLE
fix(feed): #1943 feed run daily --date를 명시 파라미터로 전달

### DIFF
--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -348,32 +348,18 @@ def run_daily(
 
     orchestrator = _build_orchestrator(cfg)
 
-    # --date 옵션이 있으면 generate_daily_date를 패치
-    if target_date is not None:
-        import ante.feed.pipeline.scheduler as _sched
-
-        _original_generate = _sched.generate_daily_date
-
-        def _override(reference: object = None) -> str:
-            return target_date  # type: ignore[return-value]
-
-        _sched.generate_daily_date = _override  # type: ignore[assignment]
-        try:
-            result = asyncio.run(
-                orchestrator.run_daily(
-                    data_path=Path(data_path),
-                    config=config,
-                )
-            )
-        finally:
-            _sched.generate_daily_date = _original_generate
-    else:
-        result = asyncio.run(
-            orchestrator.run_daily(
-                data_path=Path(data_path),
-                config=config,
-            )
+    # #1943: --date 값을 명시 파라미터로 chain 한다. 이전에는
+    # `scheduler.generate_daily_date` 모듈 속성을 monkey-patch 했으나
+    # daily_runner.py 가 import 시점에 함수 객체를 local 로 바인딩하므로
+    # 그 패치는 실제 호출 경로에 닿지 않아 --date 가 무시되었다.
+    # ``target_date=None`` 이면 DailyRunner 내부에서 기본 fallback(어제).
+    result = asyncio.run(
+        orchestrator.run_daily(
+            data_path=Path(data_path),
+            config=config,
+            target_date=target_date,
         )
+    )
 
     format_daily_result(result, fmt)
 

--- a/src/ante/feed/cli_scheduler.py
+++ b/src/ante/feed/cli_scheduler.py
@@ -91,9 +91,13 @@ async def _run_daily_job(
     """Daily 수집 작업을 1회 실행한다."""
     logger.info("Daily 수집 시작 (%s)", current_date)
     try:
+        # #1943: 스케줄러 호출은 generate_daily_date() (어제) fallback 유지.
+        # ``target_date=None`` 을 명시해 의도를 문서화하고, 추후 시그니처
+        # 변경이 있어도 keyword 의미를 명확히 보존한다.
         result = await orchestrator.run_daily(
             data_path=Path(data_path),
             config=config,
+            target_date=None,
         )
         click.echo(
             f"[{current_date}] Daily 완료: "

--- a/src/ante/feed/pipeline/daily_runner.py
+++ b/src/ante/feed/pipeline/daily_runner.py
@@ -56,9 +56,21 @@ class DailyRunner:
         feed_dir: Path,
         started_at: datetime,
         is_blocked: Any,
+        target_date: str | None = None,
     ) -> CollectionResult:
-        """Daily 내부 구현."""
-        target_date = generate_daily_date()
+        """Daily 내부 구현.
+
+        ``target_date`` 가 ``None`` 이면 ``generate_daily_date()`` (어제)로
+        fallback 한다. 명시 값(예: CLI ``--date`` 또는 스케줄러가 직접
+        지정한 날짜)을 받으면 그 값을 그대로 수집 대상일로 사용한다.
+        #1943: 기존에는 cli 에서 ``scheduler.generate_daily_date`` 모듈
+        속성을 monkey-patch 했으나, 이 모듈이 import 시점에
+        ``from ... import generate_daily_date`` 로 함수 객체를 local
+        namespace 에 바인딩하기 때문에 패치가 무효였다. 명시 파라미터
+        chain 으로 대체한다.
+        """
+        if target_date is None:
+            target_date = generate_daily_date()
 
         if is_blocked(config, target_date):
             logger.info("Daily: 방어 가드에 의해 스킵 (date=%s)", target_date)

--- a/src/ante/feed/pipeline/orchestrator.py
+++ b/src/ante/feed/pipeline/orchestrator.py
@@ -123,8 +123,14 @@ class FeedOrchestrator:
         self,
         data_path: Path,
         config: dict[str, Any],
+        target_date: str | None = None,
     ) -> CollectionResult:
-        """일별 증분 수집 (daily 모드)."""
+        """일별 증분 수집 (daily 모드).
+
+        ``target_date`` 가 ``None`` 이면 ``DailyRunner.run`` 내부에서
+        ``generate_daily_date()`` (어제)로 fallback 한다. CLI ``--date``
+        같이 명시 지정된 값은 그대로 forward 된다. #1943.
+        """
         feed_dir = data_path / ".feed"
         started_at = datetime.now(tz=UTC)
 
@@ -142,6 +148,7 @@ class FeedOrchestrator:
                 feed_dir,
                 started_at,
                 self._is_blocked,
+                target_date=target_date,
             )
             self._save_report(data_path, feed_dir, result, "daily")
             return result

--- a/tests/unit/feed/test_cli_daily_date_forward.py
+++ b/tests/unit/feed/test_cli_daily_date_forward.py
@@ -1,0 +1,138 @@
+"""`ante feed run daily --date` CLI 회귀 테스트.
+
+#1943: monkey-patch 무효로 ``--date`` 가 무시되던 버그를 명시 파라미터
+chain으로 고친 변경의 end-to-end 회귀 잠금. orchestrator를 mock 으로 두고
+CLI 가 ``target_date`` 를 keyword 인자로 전달하는지만 검증한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.feed.models.result import CollectionResult
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(_ctx: object) -> None:
+                import click
+
+                cur = click.get_current_context()
+                cur.obj = cur.obj or {}
+                cur.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+@pytest.fixture
+def initialized_data_path(tmp_path: Path) -> str:
+    data_dir = tmp_path / "data"
+    feed_dir = data_dir / ".feed"
+    feed_dir.mkdir(parents=True)
+    (feed_dir / "config.toml").write_text(
+        "[schedule]\n"
+        'daily_at = "16:00"\n'
+        'backfill_at = "01:00"\n'
+        'backfill_since = "2024-01-01"\n'
+        "\n"
+        "[guard]\n"
+        "blocked_days = []\n"
+        'blocked_hours = ["09:00-15:30"]\n'
+        "pause_during_trading = true\n"
+    )
+    (feed_dir / "checkpoints").mkdir()
+    (feed_dir / "reports").mkdir()
+    return str(data_dir)
+
+
+def _result_for(target_date: str | None) -> CollectionResult:
+    return CollectionResult(
+        mode="daily",
+        started_at="2026-05-28T00:00:00Z",
+        finished_at="2026-05-28T00:00:01Z",
+        duration_seconds=1.0,
+        target_date=target_date,
+    )
+
+
+def test_cli_forwards_explicit_date_to_orchestrator(
+    runner: CliRunner, initialized_data_path: str
+) -> None:
+    """``--date 2024-12-30`` 가 ``run_daily(target_date=...)`` 로 전달된다."""
+    with patch("ante.feed.cli._build_orchestrator") as mock_build:
+        mock_orch = AsyncMock()
+        mock_orch.run_daily = AsyncMock(return_value=_result_for("2024-12-30"))
+        mock_build.return_value = mock_orch
+
+        result = runner.invoke(
+            cli,
+            [
+                "feed",
+                "run",
+                "daily",
+                "--data-path",
+                initialized_data_path,
+                "--date",
+                "2024-12-30",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    mock_orch.run_daily.assert_awaited_once()
+    kwargs = mock_orch.run_daily.await_args.kwargs
+    assert kwargs.get("target_date") == "2024-12-30"
+
+
+def test_cli_without_date_forwards_none(
+    runner: CliRunner, initialized_data_path: str
+) -> None:
+    """``--date`` 미지정 시 ``target_date=None`` 으로 전달된다."""
+    with patch("ante.feed.cli._build_orchestrator") as mock_build:
+        mock_orch = AsyncMock()
+        mock_orch.run_daily = AsyncMock(return_value=_result_for("2026-05-27"))
+        mock_build.return_value = mock_orch
+
+        result = runner.invoke(
+            cli,
+            [
+                "feed",
+                "run",
+                "daily",
+                "--data-path",
+                initialized_data_path,
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    mock_orch.run_daily.assert_awaited_once()
+    kwargs = mock_orch.run_daily.await_args.kwargs
+    assert kwargs.get("target_date") is None

--- a/tests/unit/feed/test_daily_runner_target_date.py
+++ b/tests/unit/feed/test_daily_runner_target_date.py
@@ -1,0 +1,177 @@
+"""DailyRunner.run의 target_date 파라미터 회귀 테스트.
+
+#1943: `feed run daily --date` 가 monkey-patch 무효로 무시되던 버그를
+명시 파라미터 chain으로 고친 변경의 회귀 잠금.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ante.feed.pipeline.daily_runner import DailyRunner
+
+
+@pytest.fixture
+def runner_with_mock_collectors() -> tuple[DailyRunner, AsyncMock, AsyncMock]:
+    """DataGoKr / DART collector를 mock으로 채운 DailyRunner."""
+    data_go_kr = AsyncMock()
+    data_go_kr.collect = AsyncMock(return_value=(0, set(), []))
+
+    dart = AsyncMock()
+    dart.collect = AsyncMock(return_value=(0, set(), []))
+
+    indicator = MagicMock()
+    indicator.compute = MagicMock(return_value=0)
+
+    store = MagicMock()
+
+    runner = DailyRunner(
+        data_go_kr_collector=data_go_kr,
+        dart_collector=dart,
+        indicator_calculator=indicator,
+        store=store,
+    )
+    return runner, data_go_kr, dart
+
+
+@pytest.mark.asyncio
+async def test_run_uses_explicit_target_date(
+    runner_with_mock_collectors: tuple[DailyRunner, AsyncMock, AsyncMock],
+    tmp_path: Path,
+) -> None:
+    """``target_date`` 명시 시 그 값이 collector에 전달된다."""
+    runner, data_go_kr, _dart = runner_with_mock_collectors
+
+    explicit_date = "2024-12-30"
+    started_at = datetime(2026, 5, 28, tzinfo=UTC)
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    def _never_blocked(_config: dict, _target_date: str) -> bool:
+        return False
+
+    # generate_daily_date가 호출되지 않아야 함 — 명시 값이 우선.
+    with patch("ante.feed.pipeline.daily_runner.generate_daily_date") as mock_fallback:
+        result = await runner.run(
+            data_path=tmp_path,
+            config={},
+            feed_dir=feed_dir,
+            started_at=started_at,
+            is_blocked=_never_blocked,
+            target_date=explicit_date,
+        )
+
+    assert mock_fallback.call_count == 0
+    # data.go.kr collector가 명시 날짜로 호출됨
+    data_go_kr.collect.assert_awaited_once()
+    call_args = data_go_kr.collect.await_args
+    assert call_args.args[0] == explicit_date
+    # 결과 target_date도 명시 값
+    assert result.target_date == explicit_date
+
+
+@pytest.mark.asyncio
+async def test_run_falls_back_when_target_date_none(
+    runner_with_mock_collectors: tuple[DailyRunner, AsyncMock, AsyncMock],
+    tmp_path: Path,
+) -> None:
+    """``target_date=None`` 시 ``generate_daily_date()`` fallback."""
+    runner, data_go_kr, _dart = runner_with_mock_collectors
+
+    fallback_date = "2026-05-27"  # 어제 가정
+    started_at = datetime(2026, 5, 28, tzinfo=UTC)
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    def _never_blocked(_config: dict, _target_date: str) -> bool:
+        return False
+
+    with patch(
+        "ante.feed.pipeline.daily_runner.generate_daily_date",
+        return_value=fallback_date,
+    ) as mock_fallback:
+        result = await runner.run(
+            data_path=tmp_path,
+            config={},
+            feed_dir=feed_dir,
+            started_at=started_at,
+            is_blocked=_never_blocked,
+            target_date=None,
+        )
+
+    mock_fallback.assert_called_once()
+    data_go_kr.collect.assert_awaited_once()
+    assert data_go_kr.collect.await_args.args[0] == fallback_date
+    assert result.target_date == fallback_date
+
+
+@pytest.mark.asyncio
+async def test_run_default_target_date_is_none(
+    runner_with_mock_collectors: tuple[DailyRunner, AsyncMock, AsyncMock],
+    tmp_path: Path,
+) -> None:
+    """``target_date`` 인자 미제공(기본값) 시에도 fallback 경로."""
+    runner, data_go_kr, _dart = runner_with_mock_collectors
+
+    fallback_date = "2026-05-27"
+    started_at = datetime(2026, 5, 28, tzinfo=UTC)
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    def _never_blocked(_config: dict, _target_date: str) -> bool:
+        return False
+
+    with patch(
+        "ante.feed.pipeline.daily_runner.generate_daily_date",
+        return_value=fallback_date,
+    ) as mock_fallback:
+        # target_date 인자 자체를 생략 — 기존 호출자(테스트/내부) 보호.
+        result = await runner.run(
+            data_path=tmp_path,
+            config={},
+            feed_dir=feed_dir,
+            started_at=started_at,
+            is_blocked=_never_blocked,
+        )
+
+    mock_fallback.assert_called_once()
+    assert data_go_kr.collect.await_args.args[0] == fallback_date
+    assert result.target_date == fallback_date
+
+
+@pytest.mark.asyncio
+async def test_run_explicit_target_date_propagates_to_blocked_check(
+    runner_with_mock_collectors: tuple[DailyRunner, AsyncMock, AsyncMock],
+    tmp_path: Path,
+) -> None:
+    """방어 가드(is_blocked)에 명시 날짜가 전달된다."""
+    runner, data_go_kr, _dart = runner_with_mock_collectors
+
+    explicit_date = "2024-12-30"
+    started_at = datetime(2026, 5, 28, tzinfo=UTC)
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    seen: list[str] = []
+
+    def _capturing_blocked(_config: dict, target_date: str) -> bool:
+        seen.append(target_date)
+        return True  # 가드로 차단 → 빠른 종료
+
+    result = await runner.run(
+        data_path=tmp_path,
+        config={},
+        feed_dir=feed_dir,
+        started_at=started_at,
+        is_blocked=_capturing_blocked,
+        target_date=explicit_date,
+    )
+
+    assert seen == [explicit_date]
+    # 차단됐으므로 collector 호출 없음
+    data_go_kr.collect.assert_not_awaited()
+    assert result.target_date == explicit_date

--- a/tests/unit/feed/test_orchestrator_run_daily_target_date.py
+++ b/tests/unit/feed/test_orchestrator_run_daily_target_date.py
@@ -1,0 +1,96 @@
+"""FeedOrchestrator.run_daily의 target_date forward 회귀 테스트.
+
+#1943: CLI ``--date`` → orchestrator → DailyRunner 의 명시 파라미터
+chain 회귀 잠금. ``_daily_runner`` 를 mock으로 교체해 호출 인자만 검증.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.feed.models.result import CollectionResult
+from ante.feed.pipeline.orchestrator import FeedOrchestrator
+
+
+def _make_runner_result(target_date: str | None) -> CollectionResult:
+    return CollectionResult(
+        mode="daily",
+        started_at="2026-05-28T00:00:00Z",
+        finished_at="2026-05-28T00:00:01Z",
+        duration_seconds=1.0,
+        target_date=target_date,
+    )
+
+
+def _make_orchestrator_with_mock_runner(
+    expected_result: CollectionResult,
+) -> tuple[FeedOrchestrator, AsyncMock]:
+    """`_daily_runner.run` 만 mock 으로 바꾼 orchestrator."""
+    orch = FeedOrchestrator()
+    mock_run = AsyncMock(return_value=expected_result)
+    orch._daily_runner = MagicMock()  # type: ignore[assignment]
+    orch._daily_runner.run = mock_run  # type: ignore[assignment]
+    # 리포트 생성 부수효과 차단
+    orch._save_report = MagicMock()  # type: ignore[assignment]
+    return orch, mock_run
+
+
+@pytest.mark.asyncio
+async def test_run_daily_forwards_explicit_target_date(
+    tmp_path: Path,
+) -> None:
+    """명시 ``target_date`` 가 DailyRunner.run 에 keyword 로 전달된다."""
+    explicit = "2024-12-30"
+    orch, mock_run = _make_orchestrator_with_mock_runner(_make_runner_result(explicit))
+
+    result = await orch.run_daily(
+        data_path=tmp_path,
+        config={},
+        target_date=explicit,
+    )
+
+    mock_run.assert_awaited_once()
+    kwargs = mock_run.await_args.kwargs
+    assert kwargs.get("target_date") == explicit
+    assert result.target_date == explicit
+
+
+@pytest.mark.asyncio
+async def test_run_daily_forwards_none_target_date_default(
+    tmp_path: Path,
+) -> None:
+    """``target_date`` 미제공 시 None 이 forward 된다 (fallback은 DailyRunner 책임)."""
+    orch, mock_run = _make_orchestrator_with_mock_runner(
+        _make_runner_result("2026-05-27")
+    )
+
+    await orch.run_daily(
+        data_path=tmp_path,
+        config={},
+    )
+
+    mock_run.assert_awaited_once()
+    kwargs = mock_run.await_args.kwargs
+    assert kwargs.get("target_date") is None
+
+
+@pytest.mark.asyncio
+async def test_run_daily_forwards_explicit_none(
+    tmp_path: Path,
+) -> None:
+    """스케줄러처럼 ``target_date=None`` 명시 전달 케이스."""
+    orch, mock_run = _make_orchestrator_with_mock_runner(
+        _make_runner_result("2026-05-27")
+    )
+
+    await orch.run_daily(
+        data_path=tmp_path,
+        config={},
+        target_date=None,
+    )
+
+    kwargs = mock_run.await_args.kwargs
+    assert kwargs.get("target_date") is None


### PR DESCRIPTION
Closes #1943

## Summary
`ante feed run daily --date <YYYY-MM-DD>`가 지정 날짜를 무시하고 기본(어제)을 사용하던 버그 fix.

## Root cause
`src/ante/feed/cli.py`의 monkey-patch (`_sched.generate_daily_date = _override`)가 `src/ante/feed/pipeline/daily_runner.py:17`의 `from ante.feed.pipeline.scheduler import generate_daily_date` 바인딩에 영향을 주지 못함. `from ... import` 시점에 함수 객체가 daily_runner 모듈의 local namespace로 복사되어 이후 scheduler 모듈 속성 교체가 무효.

## Fix
monkey-patch 제거, `target_date: str | None = None` 명시 파라미터 chain:
- `daily_runner.run(..., target_date=None)`: None이면 `generate_daily_date()` fallback
- `orchestrator.run_daily(..., target_date=None)`: daily_runner.run에 forward
- `cli.py:run_daily()`: monkey-patch 블록 제거, `target_date=target_date` 명시 전달
- `cli_scheduler.py:94`: `target_date=None` 명시 (기본 동작 보존, 의도 문서화)

## Test Plan
신규 9 케이스:
- `tests/unit/feed/test_daily_runner_target_date.py` 4건 (explicit/fallback/default/blocked)
- `tests/unit/feed/test_orchestrator_run_daily_target_date.py` 3건 (forward)
- `tests/unit/feed/test_cli_daily_date_forward.py` 2건 (CLI keyword 검증)

회귀: `tests/unit/feed/` 355 PASS (신규 9 + 기존 346)
ruff/mypy clean

## Review
- Plan Preflight v1 Codex approve-implement (cli_scheduler.py:94 명시 권장 반영)
- Codex 브랜치 review PASS (8 invariants 확인)