### PR TITLE
fix(treasury): #1947 매수 부분체결 비례 정산

### DIFF
--- a/docs/specs/treasury/03-treasury-model.md
+++ b/docs/specs/treasury/03-treasury-model.md
@@ -33,6 +33,47 @@
 - `reserve_for_order()`: 주문 제출 시 available → reserved 이동
 - `on_buy_filled()`: reserved → spent 이동 (실제 체결 금액 기준)
 - `on_sell_filled()`: returned 증가, available 증가
-- `release_reservation()`: 주문 취소/실패 시 reserved → available 복원
+- `release_reservation()`: 주문 취소/실패 시 **잔여 예약**을 reserved → available 복원
 
 소스: `src/ante/treasury/models.py`
+
+### 매수 부분체결 비례 정산 (#1947)
+
+스트림/폴 fill-recovery 경로(`FillApplier`)는 **체결 delta마다** `OrderFilledEvent`를
+발행한다. 따라서 한 주문이 여러 번에 나눠 체결되면 Treasury는 fill마다 그 delta의
+실비용만큼만 예약을 차감하고, **주문이 terminal(전량 체결/취소/실패/봇중지)에 도달한
+경우에만** 잔여 예약을 회수한다. 첫 partial 체결이 전체 예약을 통째로 해제하지 않는다.
+
+주문별로 **잔여 예약**(`remaining_reserved`)을 추적한다. `reserve_for_order()`가 예약
+총액 `R`로 초기화하고, 매수 fill마다 아래와 같이 정산한다.
+
+- `actual_cost = quantity * price + commission`
+- `covered = min(remaining_reserved, actual_cost)`
+- `reserved -= covered` ; `remaining_reserved -= covered` ; `spent += actual_cost`
+- `shortfall = actual_cost - covered`; `shortfall > 0`이면 `available -= shortfall`
+  (체결가가 잔여 예약분을 초과 — 시장가 가격 변동 등. 기존 시장가 reserve shortfall
+  동작 보존, audit warning 유지)
+
+**terminal 판정**은 `OrderTracker`(`recorded_filled_qty >= ordered_qty`)로 한다.
+`FillApplier`가 `record_fill()` 커밋 후 `OrderFilledEvent`를 발행하므로 Treasury가
+보는 tracker 상태는 이번 fill을 이미 포함한다. terminal이면 잔여 예약(`remaining_
+reserved`, under-fill surplus)을 `reserved → available`로 회수하고 추적 entry를
+제거한다. 중간 partial이면 entry를 유지해 다음 fill 정산에 이월한다.
+
+**OrderTracker 부재 fallback**: `OrderTracker.get(order_id)`가 `None`인 주문(예:
+`VirtualProvider`가 OrderTracker에 seed 없이 직접 발행하는 단일 full-fill 이벤트)은
+기존 full-fill pop-once semantics(전액 예약 차감 + surplus/shortfall 1회 정산)로
+fallback한다. 단일 full-fill엔 pop-once가 정확하다.
+
+**취소/실패/봇중지**: 부분체결 후 취소/실패/봇중지 시 이미 체결된 분은 위 per-fill
+정산으로 `spent`에 반영되어 `reserved`에서 빠진 상태이므로, **잔여 예약만** 회수해
+기체결분을 보존한다.
+
+이 전 구간에서 불변식 `available = allocated - reserved - spent + returned`가 유지된다.
+
+**범위**: buy 한정. 매도는 예약을 하지 않고 fill마다 `actual_proceeds = quantity*price
+- commission`을 `returned`/`available`에 독립 누적 가산하므로 부분 매도가 이미 정확하다
+(`on_sell_filled()`). 따라서 sell-side는 변경 대상이 아니다.
+
+소스: `src/ante/treasury/treasury.py` (`_on_order_filled` buy 분기 · `_settle_buy_fill`),
+`src/ante/trade/order_tracker.py`

--- a/docs/specs/treasury/05-treasury-manager.md
+++ b/docs/specs/treasury/05-treasury-manager.md
@@ -52,7 +52,9 @@ Treasury는 아래 이벤트를 구독하여 자금 정산을 수행한다 (prio
 | 구독 이벤트 | priority | 처리 내용 |
 |------------|----------|----------|
 | OrderValidatedEvent | 80 | 룰 검증 통과 후 자금 예약. 예산 부족 시 OrderRejectedEvent 발행, 성공 시 OrderApprovedEvent 발행 |
-| OrderFilledEvent | 80 | 매수: 예약 → 투입 정산 (차액 복원). 매도: 회수 금액을 가용 예산에 복원. 거래 이력 기록 |
-| OrderCancelledEvent | 80 | 예약 자금 해제 (원래 예약 금액 정확히 복원) |
-| OrderFailedEvent | 80 | 예약 자금 해제 (원래 예약 금액 정확히 복원) |
-| BotStoppedEvent | 80 | 봇 중지 시 해당 봇의 모든 미체결 예약 자금 일괄 해제 |
+| OrderFilledEvent | 80 | 매수: fill(delta)마다 실비용만큼 예약 차감(비례 정산), terminal에서만 잔여 예약 회수. 매도: 회수 금액을 가용 예산에 복원. 거래 이력 기록 (부분체결 비례 정산 #1947 — [03-treasury-model.md](03-treasury-model.md) 참조) |
+| OrderCancelledEvent | 80 | **잔여 예약**만 해제 (부분체결 후 취소 시 기체결분 보존) |
+| OrderFailedEvent | 80 | **잔여 예약**만 해제 (부분체결 후 실패 시 기체결분 보존) |
+| BotStoppedEvent | 80 | 봇 중지 시 해당 봇의 각 주문 **잔여 예약** 일괄 회수 (기체결분 보존) |
+
+> 매수 부분체결 비례 정산(per-fill 차감 · terminal 잔여 회수 · `OrderTracker` terminal 판정 · tracker 부재 시 full-fill fallback)의 상세 의미는 [03-treasury-model.md](03-treasury-model.md) "매수 부분체결 비례 정산"을 따른다. buy 한정 — 매도는 예약 부재로 per-fill 누적 가산이 이미 정확하다(#1947, D5).

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -474,7 +474,12 @@ async def _init_trading(s: Services) -> None:
     # TreasuryManager — 계좌별 Treasury 인스턴스 관리
     from ante.treasury import TreasuryManager
 
-    s.treasury_manager = TreasuryManager(db=s.db, eventbus=s.eventbus)
+    # #1947: 부분체결 비례 정산을 위해 OrderTracker(상단에서 생성)를 주입한다.
+    # Treasury 가 buy fill 에서 order_id 로 ordered_qty/recorded_filled_qty 를
+    # 조회해 terminal(전량 체결) 판정 후에만 잔여 예약을 회수한다.
+    s.treasury_manager = TreasuryManager(
+        db=s.db, eventbus=s.eventbus, order_tracker=s.order_tracker
+    )
     accounts = await s.account_service.list()
     await s.treasury_manager.initialize_all(accounts)
     logger.info("TreasuryManager 초기화 완료: %d개 계좌", len(accounts))

--- a/src/ante/treasury/manager.py
+++ b/src/ante/treasury/manager.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from ante.account.models import Account
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
+    from ante.trade.order_tracker import OrderTracker
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +20,18 @@ logger = logging.getLogger(__name__)
 class TreasuryManager:
     """계좌별 Treasury 인스턴스를 생성하고 관리하는 상위 계층."""
 
-    def __init__(self, db: Database, eventbus: EventBus) -> None:
+    def __init__(
+        self,
+        db: Database,
+        eventbus: EventBus,
+        *,
+        order_tracker: OrderTracker | None = None,
+    ) -> None:
         self._db = db
         self._eventbus = eventbus
+        # #1947: 부분체결 비례 정산용 OrderTracker 를 각 Treasury 에 주입한다.
+        # 단일 인스턴스(account-agnostic — PK 가 전역 유일 order_id)를 공유한다.
+        self._order_tracker = order_tracker
         self._treasuries: dict[str, Treasury] = {}
 
     async def create_treasury(self, account: Account) -> Treasury:
@@ -42,6 +52,7 @@ class TreasuryManager:
             buy_commission_rate=float(account.buy_commission_rate),
             sell_commission_rate=float(account.sell_commission_rate),
             market_order_reserve_buffer_rate=account.market_order_reserve_buffer_rate,
+            order_tracker=self._order_tracker,
         )
         await treasury.initialize()
         self._treasuries[account.account_id] = treasury

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from ante.broker.base import BrokerAdapter
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
+    from ante.trade.order_tracker import OrderTracker
     from ante.trade.position import PositionHistory
 
 logger = logging.getLogger(__name__)
@@ -155,6 +156,7 @@ class Treasury:
         market_order_reserve_buffer_rate: Decimal = Decimal("0"),
         order_reserve_price_resolver: Callable[[str], Awaitable[float]] | None = None,
         bot_status_checker: Callable[[str], str] | None = None,
+        order_tracker: OrderTracker | None = None,
     ) -> None:
         self._db = db
         self._eventbus = eventbus
@@ -173,6 +175,12 @@ class Treasury:
         # ``set_order_reserve_price_resolver``로 후속 주입된다.
         self._order_reserve_price_resolver = order_reserve_price_resolver
         self._bot_status_checker = bot_status_checker
+        # #1947: 부분체결 비례 정산을 위한 OrderTracker 참조 (read-only 조회).
+        # ``_on_order_filled`` buy 분기에서 order_id 로 ordered_qty /
+        # recorded_filled_qty 를 조회해 terminal(전량 체결) 판정을 한다.
+        # None 이면(미주입 또는 VirtualProvider 직접 full-fill 등 tracker 부재
+        # 주문) buy 정산은 기존 full-fill pop-once semantics 로 fallback 한다.
+        self._order_tracker = order_tracker
 
         self._account_balance: float = 0.0
         self._purchasable_amount: float = 0.0
@@ -184,9 +192,12 @@ class Treasury:
         self._external_eval_amount: float = 0.0
         self._budgets: dict[str, BotBudget] = {}
         self._unallocated: float = 0.0
-        self._reservations: dict[
-            str, tuple[str, float]
-        ] = {}  # order_id -> (bot_id, amount)
+        # order_id -> (bot_id, remaining_reserved).
+        # #1947: 두번째 항은 주문의 **잔여 예약**(아직 정산되지 않은 예약 자금)이다.
+        # ``reserve_for_order`` 에서 예약 총액 R 로 초기화되고, 매수 부분체결마다
+        # 그 fill 이 커버한 만큼 감소한다. 주문이 terminal(전량 체결/취소/실패/봇중지)
+        # 에 도달하면 잔여 예약을 budget 으로 회수하고 entry 를 제거한다.
+        self._reservations: dict[str, tuple[str, float]] = {}
         self._sync_task: asyncio.Task[None] | None = None
 
         # KIS 계좌 메타 정보 (broker 연결 후 set_account_info로 설정)
@@ -335,6 +346,16 @@ class Treasury:
     def set_bot_status_checker(self, checker: Callable[[str], str]) -> None:
         """봇 상태 확인 콜백 설정 (초기화 후 BotManager 연결 시 호출)."""
         self._bot_status_checker = checker
+
+    def set_order_tracker(self, order_tracker: OrderTracker) -> None:
+        """부분체결 비례 정산용 OrderTracker 참조 주입 (#1947).
+
+        생성자 주입 대신 부팅 순서상 OrderTracker 가 Treasury 보다 먼저
+        준비될 수 없는 partial wiring 경로(테스트 등)를 위한 후속 주입 경로다.
+        미주입(``None``) 시 buy 정산은 full-fill pop-once semantics 로 fallback
+        한다 (R1-2 — VirtualProvider 직접 full-fill 보존).
+        """
+        self._order_tracker = order_tracker
 
     def set_order_reserve_price_resolver(
         self, resolver: Callable[[str], Awaitable[float]]
@@ -641,21 +662,29 @@ class Treasury:
         budget.available -= amount
         budget.reserved += amount
         budget.last_updated = datetime.now(UTC)
+        # #1947: 잔여 예약(remaining_reserved)을 예약 총액 R(=amount)로 초기화한다.
+        # 이후 매수 부분체결마다 그 fill 의 covered 만큼 감소한다.
         self._reservations[order_id] = (bot_id, amount)
 
         await self._save_budget(budget)
         return True
 
     async def release_reservation(self, bot_id: str, order_id: str) -> None:
-        """주문 취소/실패 시 예약 해제."""
+        """주문 취소/실패 시 **잔여 예약**만 해제 (#1947).
+
+        ``self._reservations[order_id][1]`` 은 잔여 예약(``remaining_reserved``)
+        이다. 부분체결 후 취소/실패라면 이미 체결된 분은 ``_on_order_filled`` 에서
+        ``spent`` 로 정산되며 ``reserved`` 에서 차감되었으므로, 여기서는 아직
+        정산되지 않은 잔여 예약만 회수해 기체결분을 보존한다.
+        """
         budget = self._budgets.get(bot_id)
         entry = self._reservations.pop(order_id, None)
-        amount = entry[1] if entry else 0.0
-        if not budget or amount <= 0:
+        remaining = entry[1] if entry else 0.0
+        if not budget or remaining <= 0:
             return
 
-        budget.reserved = max(0.0, budget.reserved - amount)
-        budget.available += amount
+        budget.reserved = max(0.0, budget.reserved - remaining)
+        budget.available += remaining
         budget.last_updated = datetime.now(UTC)
 
         await self._save_budget(budget)
@@ -664,7 +693,9 @@ class Treasury:
         """특정 봇의 미체결 예약 내역 조회.
 
         Returns:
-            {order_id: amount, ...}
+            ``{order_id: remaining_reserved, ...}`` — 두번째 항은 #1947 이후
+            주문의 **잔여 예약**(아직 정산되지 않은 예약 자금)이다. 부분체결된
+            주문이면 이미 체결된 분을 제외한 잔여만 반영한다.
         """
         return {
             oid: amt for oid, (bid, amt) in self._reservations.items() if bid == bot_id
@@ -1053,34 +1084,7 @@ class Treasury:
         commission = event.commission
 
         if event.side == "buy":
-            entry = self._reservations.pop(event.order_id, None)
-            reserved_amount = entry[1] if entry else 0.0
-            actual_cost = fill_value + commission
-            budget.reserved = max(0.0, budget.reserved - reserved_amount)
-            budget.spent += actual_cost
-            surplus = reserved_amount - actual_cost
-            if surplus > 0:
-                # 체결가가 reserve 보다 낮음 — 잔여 reserve 를 available 로 환수.
-                budget.available += surplus
-            elif surplus < 0:
-                # 체결가가 reserve 보다 높음 (시장가 매수의 가격 변동 등).
-                # 초과분을 available 에서 추가 차감한다 — invariant: 결과적으로
-                # available 이 음수가 될 수 있으나 이는 정상 운영 상태가 아니며
-                # 후속 매수 reserve 가 거부되는 것은 자연스러운 결과다 (#1333).
-                # 별도 EventBus 이벤트는 신설하지 않으며 audit 용 warning 만
-                # 남긴다.
-                extra_cost = -surplus
-                budget.available -= extra_cost
-                logger.warning(
-                    "market_order_reserve_shortfall: bot=%s order=%s "
-                    "extra_cost=%s reserved=%s actual=%s "
-                    "(available may be negative)",
-                    event.bot_id,
-                    event.order_id,
-                    f"{extra_cost:,.2f}",
-                    f"{reserved_amount:,.2f}",
-                    f"{actual_cost:,.2f}",
-                )
+            await self._settle_buy_fill(event, budget, fill_value, commission)
         else:
             actual_proceeds = fill_value - commission
             budget.returned += actual_proceeds
@@ -1096,6 +1100,116 @@ class Treasury:
                 f"{event.side} {event.symbol} {event.quantity} @ {event.price:,.0f}"
             ),
         )
+
+    async def _settle_buy_fill(
+        self, event: Any, budget: BotBudget, fill_value: float, commission: float
+    ) -> None:
+        """매수 체결 정산 — 부분체결 비례 정산 + terminal 잔여 회수 (#1947).
+
+        per-fill 회계(R1-1):
+          - ``actual_cost = quantity*price + commission``
+          - ``covered = min(remaining_reserved, actual_cost)``
+          - ``reserved -= covered`` ; ``remaining_reserved -= covered`` ;
+            ``spent += actual_cost``
+          - ``shortfall = actual_cost - covered``; ``shortfall>0`` 이면
+            ``available -= shortfall`` (체결가>예약분 = 기존 #1333 shortfall
+            동작 보존, audit warning 유지)
+
+        terminal 판정은 OrderTracker(``recorded_filled_qty >= ordered_qty``)로
+        한다 — FillApplier 가 ``record_fill()`` 커밋 후 ``OrderFilledEvent`` 를
+        발행하므로 Treasury 가 보는 tracker 상태는 이번 fill 을 이미 포함한다
+        (R1-3). terminal 이면 잔여 예약(under-fill surplus)을 회수하고 entry 를
+        제거한다; 중간 partial 이면 entry 를 유지한다.
+
+        OrderTracker 미주입 또는 ``get(order_id)`` 가 None 이면(예:
+        VirtualProvider 직접 full-fill — tracker 에 seed 안 됨) 기존 full-fill
+        pop-once semantics 로 fallback 한다 (R1-2).
+
+        불변식 ``available = allocated - reserved - spent + returned`` 가 부분체결
+        전 구간에서 유지된다.
+        """
+        order_id = event.order_id
+        actual_cost = fill_value + commission
+
+        record = None
+        if self._order_tracker is not None:
+            record = await self._order_tracker.get(order_id)
+
+        if record is None:
+            # Fallback (R1-2): tracker 부재 주문 — 단일 full-fill 가정 pop-once.
+            self._settle_buy_full_fill(event, budget, actual_cost)
+            return
+
+        # Per-fill 비례 정산 (R1-1).
+        entry = self._reservations.get(order_id)
+        remaining = entry[1] if entry else 0.0
+
+        covered = min(remaining, actual_cost)
+        budget.reserved = max(0.0, budget.reserved - covered)
+        budget.spent += actual_cost
+        remaining -= covered
+
+        shortfall = actual_cost - covered
+        if shortfall > 0:
+            # 체결가가 잔여 예약분을 초과 (시장가 가격 변동 등). 초과분을
+            # available 에서 추가 차감한다 (#1333 동작 보존). available 이 음수가
+            # 될 수 있으나 정상 상태가 아니며 후속 reserve 거부로 자연 수렴한다.
+            budget.available -= shortfall
+            logger.warning(
+                "market_order_reserve_shortfall: bot=%s order=%s "
+                "shortfall=%s actual=%s (available may be negative)",
+                event.bot_id,
+                order_id,
+                f"{shortfall:,.2f}",
+                f"{actual_cost:,.2f}",
+            )
+
+        terminal = record.ordered_qty > 0 and (
+            record.recorded_filled_qty >= record.ordered_qty
+        )
+        if terminal:
+            # 전량 체결 — 잔여 예약(미체결분 버퍼)을 available 로 회수.
+            if remaining > 0:
+                budget.reserved = max(0.0, budget.reserved - remaining)
+                budget.available += remaining
+            self._reservations.pop(order_id, None)
+        elif entry is not None:
+            # 중간 partial — 잔여 예약을 갱신해 다음 fill 정산에 이월.
+            self._reservations[order_id] = (entry[0], remaining)
+
+    def _settle_buy_full_fill(
+        self, event: Any, budget: BotBudget, actual_cost: float
+    ) -> None:
+        """tracker 부재 매수 full-fill pop-once 정산 (#1947 R1-2 fallback).
+
+        VirtualProvider 처럼 단일 full-fill 이벤트만 발행하고 OrderTracker 에
+        seed 되지 않는 주문은 #1947 이전과 동일한 전액 pop + surplus/shortfall
+        1회 정산이 정확하다.
+        """
+        entry = self._reservations.pop(event.order_id, None)
+        reserved_amount = entry[1] if entry else 0.0
+        budget.reserved = max(0.0, budget.reserved - reserved_amount)
+        budget.spent += actual_cost
+        surplus = reserved_amount - actual_cost
+        if surplus > 0:
+            # 체결가가 reserve 보다 낮음 — 잔여 reserve 를 available 로 환수.
+            budget.available += surplus
+        elif surplus < 0:
+            # 체결가가 reserve 보다 높음 (시장가 매수의 가격 변동 등).
+            # 초과분을 available 에서 추가 차감한다 (#1333). available 이 음수가
+            # 될 수 있으나 정상 상태가 아니며 후속 reserve 거부로 자연 수렴한다.
+            extra_cost = -surplus
+            budget.available -= extra_cost
+            logger.warning(
+                "market_order_reserve_shortfall: bot=%s order=%s "
+                "extra_cost=%s reserved=%s actual=%s "
+                "(available may be negative)",
+                event.bot_id,
+                event.order_id,
+                f"{extra_cost:,.2f}",
+                f"{reserved_amount:,.2f}",
+                f"{actual_cost:,.2f}",
+            )
 
     async def _on_order_cancelled(self, event: object) -> None:
         """주문 취소 시 예약 해제."""
@@ -1122,7 +1236,13 @@ class Treasury:
         await self.release_reservation(event.bot_id, event.order_id)
 
     async def _on_bot_stopped(self, event: object) -> None:
-        """봇 중지 시 해당 봇의 모든 예약 자금 일괄 해제."""
+        """봇 중지 시 해당 봇의 모든 주문 **잔여 예약**을 일괄 회수 (#1947).
+
+        ``get_reservations`` 가 주문별 잔여 예약(``remaining_reserved``)을
+        반환하므로, 부분체결된 주문이라도 이미 체결된 분은 ``_on_order_filled``
+        에서 ``spent`` 로 정산되어 ``reserved`` 에서 빠진 상태이고 여기서는 잔여만
+        회수한다. 기체결분 정산은 보존된다.
+        """
         from ante.eventbus.events import BotStoppedEvent
 
         if not isinstance(event, BotStoppedEvent):

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -1724,3 +1724,449 @@ class TestUpdateBudget:
         assert budget.allocated == 0.0
         assert budget.available == 0.0
         assert treasury.unallocated == 10_000_000.0
+
+
+# -- 부분체결 비례 정산 (#1947) -------------------------------
+
+
+def _assert_treasury_invariant(treasury, bot_id):
+    """불변식 available = allocated - reserved - spent + returned 검증."""
+    budget = treasury.get_budget(bot_id)
+    assert budget is not None
+    expected_available = (
+        budget.allocated - budget.reserved - budget.spent + budget.returned
+    )
+    assert budget.available == pytest.approx(expected_available), (
+        f"불변식 위반: available={budget.available} != "
+        f"allocated({budget.allocated}) - reserved({budget.reserved}) - "
+        f"spent({budget.spent}) + returned({budget.returned}) = {expected_available}"
+    )
+
+
+async def _seed_tracker(order_tracker, *, order_id, bot_id, ordered_qty, side="buy"):
+    """OrderTracker 에 추적 주문을 seed (open seed)."""
+    await order_tracker.open(
+        order_id=order_id,
+        account_id=ACCOUNT_ID,
+        bot_id=bot_id,
+        strategy_id="s1",
+        broker_order_id=f"bk-{order_id}",
+        symbol="005930",
+        side=side,
+        order_type="limit",
+        ordered_qty=ordered_qty,
+        submitted_date="2026-05-29",
+    )
+
+
+def _buy_fill_event(*, order_id, bot_id, quantity, price, commission):
+    return OrderFilledEvent(
+        order_id=order_id,
+        broker_order_id=f"bk-{order_id}",
+        bot_id=bot_id,
+        strategy_id="s1",
+        symbol="005930",
+        side="buy",
+        quantity=quantity,
+        price=price,
+        commission=commission,
+        order_type="limit",
+        account_id=ACCOUNT_ID,
+    )
+
+
+@pytest.fixture
+async def order_tracker(db):
+    from ante.trade.order_tracker import OrderTracker
+
+    tracker = OrderTracker(db=db)
+    await tracker.initialize()
+    return tracker
+
+
+@pytest.fixture
+async def tracked_treasury(db, eventbus, order_tracker):
+    """OrderTracker 가 주입된 Treasury — 부분체결 비례 정산 경로."""
+    t = Treasury(
+        db=db,
+        eventbus=eventbus,
+        account_id=ACCOUNT_ID,
+        currency=CURRENCY,
+        buy_commission_rate=0.00015,
+        sell_commission_rate=0.00195,
+        order_tracker=order_tracker,
+    )
+    await t.initialize()
+    await t.set_account_balance(10_000_000.0)
+    return t
+
+
+class TestPartialFillSettlement:
+    """부분체결 비례 정산: per-fill 차감 + terminal 잔여 회수 (#1947)."""
+
+    async def test_partial_fill_two_steps_settles_proportionally(
+        self, tracked_treasury, order_tracker, eventbus
+    ):
+        """10주 매수, 4주+6주 부분체결 → 단계별 reserved/spent/available 정확.
+
+        첫 4주 fill 이 전체 예약을 해제하지 않고(과거 결함), 둘째 6주 fill 에서만
+        terminal 에 도달해 잔여 예약을 회수해야 한다.
+        """
+        treasury = tracked_treasury
+        await treasury.allocate("bot1", 1_000_000.0)
+        # 10주 * 50,000 = 500,000 + buffer 100 → 예약 500,100
+        await treasury.reserve_for_order("bot1", "ord1", 500_100.0)
+        await _seed_tracker(
+            order_tracker, order_id="ord1", bot_id="bot1", ordered_qty=10.0
+        )
+
+        # 1차 체결: 4주 @ 50,000, commission 30 → actual_cost 200,030
+        await order_tracker.record_fill("ord1", 4.0, 50_000.0)
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=4.0,
+                price=50_000.0,
+                commission=30.0,
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        # covered = min(500_100, 200_030) = 200_030
+        assert budget.spent == pytest.approx(200_030.0)
+        assert budget.reserved == pytest.approx(500_100.0 - 200_030.0)  # 300,070
+        # 첫 fill 에서 예약이 전액 해제되지 않음 — entry 유지
+        assert "ord1" in treasury.get_reservations("bot1")
+        assert treasury.get_reservations("bot1")["ord1"] == pytest.approx(300_070.0)
+        _assert_treasury_invariant(treasury, "bot1")
+
+        # 2차 체결: 6주 @ 50,000, commission 45 → actual_cost 300,045 → terminal
+        await order_tracker.record_fill("ord1", 10.0, 50_000.0)
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=6.0,
+                price=50_000.0,
+                commission=45.0,
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        # spent = 200,030 + 300,045 = 500,075
+        assert budget.spent == pytest.approx(500_075.0)
+        # terminal: 잔여 예약(300,070 - 300,045 = 25) 회수 → reserved 0
+        assert budget.reserved == pytest.approx(0.0)
+        # available: 1M - 500,100 + 25(잔여 회수) = 499,925
+        assert budget.available == pytest.approx(499_925.0)
+        # terminal 도달 → entry 제거
+        assert "ord1" not in treasury.get_reservations("bot1")
+        _assert_treasury_invariant(treasury, "bot1")
+
+    async def test_terminal_only_releases_remaining(
+        self, tracked_treasury, order_tracker, eventbus
+    ):
+        """중간 partial 에서는 잔여를 회수하지 않고 terminal 에서만 회수한다."""
+        treasury = tracked_treasury
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+        await _seed_tracker(
+            order_tracker, order_id="ord1", bot_id="bot1", ordered_qty=10.0
+        )
+
+        # 3주 체결 (non-terminal)
+        await order_tracker.record_fill("ord1", 3.0, 50_000.0)
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=3.0,
+                price=50_000.0,
+                commission=0.0,
+            )
+        )
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        # non-terminal: 잔여 예약 유지 (회수 없음)
+        assert budget.reserved == pytest.approx(500_000.0 - 150_000.0)  # 350,000
+        assert "ord1" in treasury.get_reservations("bot1")
+        _assert_treasury_invariant(treasury, "bot1")
+
+    async def test_partial_then_cancel_releases_only_remaining(
+        self, tracked_treasury, order_tracker, eventbus
+    ):
+        """부분체결 후 취소 시 잔여 예약만 회수, 기체결분은 spent 로 보존."""
+        treasury = tracked_treasury
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+        await _seed_tracker(
+            order_tracker, order_id="ord1", bot_id="bot1", ordered_qty=10.0
+        )
+
+        # 4주 체결 (non-terminal)
+        await order_tracker.record_fill("ord1", 4.0, 50_000.0)
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=4.0,
+                price=50_000.0,
+                commission=0.0,
+            )
+        )
+        # 잔여 6주분 취소
+        await eventbus.publish(
+            OrderCancelledEvent(
+                order_id="ord1",
+                broker_order_id="bk-ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=6.0,
+                price=50_000.0,
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        # 기체결 4주분 spent = 200,000 보존
+        assert budget.spent == pytest.approx(200_000.0)
+        # 잔여 예약(500,000 - 200,000 = 300,000) 회수 → reserved 0
+        assert budget.reserved == pytest.approx(0.0)
+        # available: 1M - 200,000(spent) = 800,000
+        assert budget.available == pytest.approx(800_000.0)
+        assert "ord1" not in treasury.get_reservations("bot1")
+        _assert_treasury_invariant(treasury, "bot1")
+
+    async def test_partial_then_failed_releases_only_remaining(
+        self, tracked_treasury, order_tracker, eventbus
+    ):
+        """부분체결 후 실패 시 잔여 예약만 회수."""
+        treasury = tracked_treasury
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+        await _seed_tracker(
+            order_tracker, order_id="ord1", bot_id="bot1", ordered_qty=10.0
+        )
+
+        await order_tracker.record_fill("ord1", 5.0, 50_000.0)
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=5.0,
+                price=50_000.0,
+                commission=0.0,
+            )
+        )
+        await eventbus.publish(
+            OrderFailedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=5.0,
+                price=50_000.0,
+                order_type="limit",
+                error_message="broker error",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.spent == pytest.approx(250_000.0)
+        assert budget.reserved == pytest.approx(0.0)
+        assert budget.available == pytest.approx(750_000.0)
+        _assert_treasury_invariant(treasury, "bot1")
+
+    async def test_partial_then_bot_stopped_releases_only_remaining(
+        self, tracked_treasury, order_tracker, eventbus
+    ):
+        """부분체결 후 봇 중지 시 각 주문의 잔여 예약만 회수."""
+        treasury = tracked_treasury
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 300_000.0)
+        await treasury.reserve_for_order("bot1", "ord2", 200_000.0)
+        await _seed_tracker(
+            order_tracker, order_id="ord1", bot_id="bot1", ordered_qty=6.0
+        )
+        await _seed_tracker(
+            order_tracker, order_id="ord2", bot_id="bot1", ordered_qty=4.0
+        )
+
+        # ord1 부분체결 2주 (non-terminal)
+        await order_tracker.record_fill("ord1", 2.0, 50_000.0)
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=2.0,
+                price=50_000.0,
+                commission=0.0,
+            )
+        )
+
+        # 봇 중지 → ord1 잔여(300,000-100,000=200,000) + ord2 전액(200,000) 회수
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1", account_id=ACCOUNT_ID))
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.spent == pytest.approx(100_000.0)
+        assert budget.reserved == pytest.approx(0.0)
+        # available: 1M - 100,000(spent) = 900,000
+        assert budget.available == pytest.approx(900_000.0)
+        assert treasury.get_reservations("bot1") == {}
+        _assert_treasury_invariant(treasury, "bot1")
+
+    async def test_partial_shortfall_deducts_available(
+        self, tracked_treasury, order_tracker, eventbus
+    ):
+        """체결가 > 잔여 예약분이면 초과분을 available 에서 차감 (불변식 유지).
+
+        시장가 매수의 가격 변동 등으로 fill 실비용이 남은 예약을 초과하는
+        경우 (#1333 shortfall 동작 보존).
+        """
+        treasury = tracked_treasury
+        await treasury.allocate("bot1", 1_000_000.0)
+        # 10주 예약 500,000 (50,000/주 가정)
+        await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+        await _seed_tracker(
+            order_tracker, order_id="ord1", bot_id="bot1", ordered_qty=10.0
+        )
+
+        # 1차: 9주 @ 55,000 = 495,000 → covered 495,000, 잔여 5,000
+        await order_tracker.record_fill("ord1", 9.0, 55_000.0)
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=9.0,
+                price=55_000.0,
+                commission=0.0,
+            )
+        )
+        _assert_treasury_invariant(treasury, "bot1")
+
+        # 2차(terminal): 1주 @ 55,000 = 55,000, 잔여 예약 5,000 → shortfall 50,000
+        await order_tracker.record_fill("ord1", 10.0, 55_000.0)
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=1.0,
+                price=55_000.0,
+                commission=0.0,
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        # spent = 495,000 + 55,000 = 550,000
+        assert budget.spent == pytest.approx(550_000.0)
+        assert budget.reserved == pytest.approx(0.0)
+        # available: 1M - 550,000 = 450,000 (shortfall 50,000 차감 반영)
+        assert budget.available == pytest.approx(450_000.0)
+        _assert_treasury_invariant(treasury, "bot1")
+
+    async def test_tracker_missing_falls_back_to_full_fill(
+        self, tracked_treasury, eventbus
+    ):
+        """OrderTracker.get=None (tracker 미seed) → full-fill pop-once fallback.
+
+        VirtualProvider 가 OrderTracker 에 seed 하지 않고 직접 단일 full-fill
+        이벤트를 발행하는 경로 (R1-2). tracked_treasury 는 tracker 가 주입돼
+        있으나 해당 order_id 를 seed 하지 않아 get=None 이 된다.
+        """
+        treasury = tracked_treasury
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_100.0)
+        # 의도적으로 order_tracker 에 seed 하지 않음 → get(ord1)=None
+
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=10.0,
+                price=50_000.0,
+                commission=75.0,
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        # full-fill pop-once: spent 500,075, surplus 25 환수
+        assert budget.reserved == pytest.approx(0.0)
+        assert budget.spent == pytest.approx(500_075.0)
+        assert budget.available == pytest.approx(499_925.0)
+        assert "ord1" not in treasury.get_reservations("bot1")
+        _assert_treasury_invariant(treasury, "bot1")
+
+    async def test_no_order_tracker_injected_uses_full_fill(self, treasury, eventbus):
+        """OrderTracker 미주입 Treasury 도 full-fill fallback 으로 정산 (회귀)."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_100.0)
+
+        await eventbus.publish(
+            _buy_fill_event(
+                order_id="ord1",
+                bot_id="bot1",
+                quantity=10.0,
+                price=50_000.0,
+                commission=75.0,
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.reserved == pytest.approx(0.0)
+        assert budget.spent == pytest.approx(500_075.0)
+        assert budget.available == pytest.approx(499_925.0)
+        _assert_treasury_invariant(treasury, "bot1")
+
+    async def test_sell_side_unchanged_with_tracker(
+        self, tracked_treasury, order_tracker, eventbus
+    ):
+        """매도 부분체결은 예약 부재로 per-fill 누적 가산이 그대로 정확 (회귀)."""
+        treasury = tracked_treasury
+        await treasury.allocate("bot1", 1_000_000.0)
+        await _seed_tracker(
+            order_tracker,
+            order_id="sell1",
+            bot_id="bot1",
+            ordered_qty=10.0,
+            side="sell",
+        )
+
+        # 매도 4주 + 6주 부분체결
+        for qty in (4.0, 6.0):
+            await eventbus.publish(
+                OrderFilledEvent(
+                    order_id="sell1",
+                    broker_order_id="bk-sell1",
+                    bot_id="bot1",
+                    strategy_id="s1",
+                    symbol="005930",
+                    side="sell",
+                    quantity=qty,
+                    price=55_000.0,
+                    commission=qty * 55_000.0 * 0.00195,
+                    order_type="limit",
+                    account_id=ACCOUNT_ID,
+                )
+            )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        total_proceeds = sum(
+            qty * 55_000.0 - qty * 55_000.0 * 0.00195 for qty in (4.0, 6.0)
+        )
+        assert budget.returned == pytest.approx(total_proceeds)
+        assert budget.available == pytest.approx(1_000_000.0 + total_proceeds)
+        _assert_treasury_invariant(treasury, "bot1")


### PR DESCRIPTION
Closes #1947

## Summary
KIS 매수 **부분체결** 시 Treasury 예약 정산을 비례 정산으로 교정 (#1945 인시던트 epic, #1946 fill-recovery 후속).

기존 `_on_order_filled`(buy)는 첫 fill에서 예약을 **전액 pop**해, 부분체결에서 미체결분 예약을 과다 환수하고 둘째 fill부터 이중 차감했다(스트림 경로에도 존재한 pre-existing 결함, #1946으로 fill 활성화되며 노출).

- `_reservations[order_id]` → `(bot_id, remaining_reserved)`로 확장, 주문별 잔여 예약 추적.
- **per-fill 비례 정산** (`_settle_buy_fill`): `covered = min(remaining, actual_cost)` → `reserved -= covered`, `remaining -= covered`, `spent += actual_cost`, `shortfall → available -= shortfall`(#1333 보존). **terminal**(OrderTracker `recorded_filled ≥ ordered`)에서만 잔여 surplus 회수 → 불변식 `available = allocated - reserved - spent + returned` 전 구간 유지.
- **OrderTracker 부재**(VirtualProvider 직접 full-fill 등) → 기존 **full-fill pop-once fallback**(`_settle_buy_full_fill`).
- 취소/실패/봇중지: `remaining`만 회수(부분체결 기체결분 보존).
- `set_order_tracker` 주입 배선(manager.py/main.py). **sell-side·OrderFilledEvent 계약 무변경**.
- 스펙: `treasury/03-treasury-model.md`·`05-treasury-manager.md`에 부분체결 비례 정산 의미 명시.

## Test Plan
- `ruff check`/`format` ✅ · `mypy src`: no issues (228) ✅
- `pytest tests/unit/test_treasury.py`: **98 passed** (89 회귀 + **9 신규** `TestPartialFillSettlement` — 각 단계 `_assert_treasury_invariant`로 불변식 직접 검증: multi-partial, terminal release, partial-cancel/fail/bot-stopped, **partial-shortfall**, **tracker-missing/virtual fallback**, sell-side 회귀)
- treasury/order_tracker/fill 도메인 549 passed · `generate_db_schema`/`project_structure --check` up to date · main HEAD 불변

## Plan Preflight & Review
- 방안 분석: ultracode 워크플로 + Codex 적대검증으로 코드근거 의사결정(방안 1·D1~D5) 도출 후 본문 기록.
- Plan Preflight: Codex Plan Review **R1→R2 approve-implement** (F1 shortfall 회계·F3 virtual fallback 반영).
- Codex 브랜치 리뷰: **attempt 1 PASS** (불변식·double-count·fallback·remaining 회수 확인).

## Non-goals (epic #1945 후속)
- get_open_orders(live) #1948 · 체결 outbox #1949 · reconciler self-fill #1950 · 40240000 CB #1951 · sell-side 변경 · orphan/재기동 복구(pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
