### PR TITLE
feat(trade): #1949 체결 이벤트 transactional outbox — durability/at-least-once 무손실 전달

### DIFF
--- a/docs/architecture/generated/db-schema.md
+++ b/docs/architecture/generated/db-schema.md
@@ -6,8 +6,8 @@ Ante 시스템의 전체 데이터베이스 스키마를 정리한 문서입니�
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py --check`
 > 마지막 갱신: 2026-05-29
 
-- 테이블: **22**개
-- 인덱스: **31**개
+- 테이블: **23**개
+- 인덱스: **32**개
 
 ## 목차
 
@@ -56,14 +56,15 @@ erDiagram
 | 12 | [members](#members) | `member` | 멤버 (사용자/에이전트) 등록 정보 | 17 |
 | 13 | [reports](#reports) | `report` | 전략 리포트 | 20 |
 | 14 | [strategies](#strategies) | `strategy` | 전략 등록 정보 | 12 |
-| 15 | [order_tracker](#order_tracker) | `trade` |  | 16 |
-| 16 | [positions](#positions) | `trade` | 현재 포지션 | 7 |
-| 17 | [position_history](#position_history) | `trade` | 포지션 변동 이력 | 12 |
-| 18 | [trades](#trades) | `trade` | 체결 기록 | 17 |
-| 19 | [bot_budgets](#bot_budgets) | `treasury` | 봇별 예산 | 8 |
-| 20 | [treasury_transactions](#treasury_transactions) | `treasury` | 자금 트랜잭션 이력 | 7 |
-| 21 | [treasury_state](#treasury_state) | `treasury` | 계좌별 자산 상태 | 6 |
-| 22 | [treasury_daily_snapshots](#treasury_daily_snapshots) | `treasury` | 일간 자산 스냅샷 | 14 |
+| 15 | [fill_outbox](#fill_outbox) | `trade` | 체결 이벤트 transactional outbox (#1949) | 6 |
+| 16 | [order_tracker](#order_tracker) | `trade` |  | 16 |
+| 17 | [positions](#positions) | `trade` | 현재 포지션 | 7 |
+| 18 | [position_history](#position_history) | `trade` | 포지션 변동 이력 | 12 |
+| 19 | [trades](#trades) | `trade` | 체결 기록 | 17 |
+| 20 | [bot_budgets](#bot_budgets) | `treasury` | 봇별 예산 | 8 |
+| 21 | [treasury_transactions](#treasury_transactions) | `treasury` | 자금 트랜잭션 이력 | 7 |
+| 22 | [treasury_state](#treasury_state) | `treasury` | 계좌별 자산 상태 | 6 |
+| 23 | [treasury_daily_snapshots](#treasury_daily_snapshots) | `treasury` | 일간 자산 스냅샷 | 14 |
 
 ## DDL
 
@@ -386,6 +387,24 @@ CREATE TABLE IF NOT EXISTS strategies (
 );
 ```
 
+### fill_outbox
+
+모듈: `trade.fill_outbox`
+
+```sql
+CREATE TABLE IF NOT EXISTS fill_outbox (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    fill_dedup_key  TEXT NOT NULL UNIQUE,
+    payload         TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    published       INTEGER NOT NULL DEFAULT 0,
+    published_at    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_fill_outbox_unpublished
+    ON fill_outbox(published, id);
+```
+
 ### order_tracker
 
 모듈: `trade.order_tracker`
@@ -598,17 +617,18 @@ CREATE TABLE IF NOT EXISTS treasury_daily_snapshots (
 | 18 | `idx_members_org` | `members` | `org` |
 | 19 | `idx_reports_strategy` | `reports` | `strategy_name` |
 | 20 | `idx_reports_status` | `reports` | `status` |
-| 21 | `idx_order_tracker_broker` | `order_tracker` | `account_id, broker_order_id, submitted_date` |
-| 22 | `idx_order_tracker_open` | `order_tracker` | `account_id, status` |
-| 23 | `idx_position_history_bot` | `position_history` | `bot_id, timestamp` |
-| 24 | `idx_position_history_account` | `position_history` | `account_id, bot_id, timestamp` |
-| 25 | `idx_trades_account` | `trades` | `account_id, timestamp` |
-| 26 | `idx_trades_bot` | `trades` | `bot_id, timestamp` |
-| 27 | `idx_trades_strategy` | `trades` | `strategy_id, timestamp` |
-| 28 | `idx_trades_symbol` | `trades` | `symbol, timestamp` |
-| 29 | `idx_trades_status` | `trades` | `status` |
-| 30 | `idx_bot_budgets_account` | `bot_budgets` | `account_id` |
-| 31 | `idx_treasury_transactions_account` | `treasury_transactions` | `account_id` |
+| 21 | `idx_fill_outbox_unpublished` | `fill_outbox` | `published, id` |
+| 22 | `idx_order_tracker_broker` | `order_tracker` | `account_id, broker_order_id, submitted_date` |
+| 23 | `idx_order_tracker_open` | `order_tracker` | `account_id, status` |
+| 24 | `idx_position_history_bot` | `position_history` | `bot_id, timestamp` |
+| 25 | `idx_position_history_account` | `position_history` | `account_id, bot_id, timestamp` |
+| 26 | `idx_trades_account` | `trades` | `account_id, timestamp` |
+| 27 | `idx_trades_bot` | `trades` | `bot_id, timestamp` |
+| 28 | `idx_trades_strategy` | `trades` | `strategy_id, timestamp` |
+| 29 | `idx_trades_symbol` | `trades` | `symbol, timestamp` |
+| 30 | `idx_trades_status` | `trades` | `status` |
+| 31 | `idx_bot_budgets_account` | `bot_budgets` | `account_id` |
+| 32 | `idx_treasury_transactions_account` | `treasury_transactions` | `account_id` |
 
 ## 보존 정책
 
@@ -628,6 +648,7 @@ CREATE TABLE IF NOT EXISTS treasury_daily_snapshots (
 | `members` | 영구 보존 |
 | `reports` | 영구 보존 |
 | `strategies` | 영구 보존 |
+| `fill_outbox` | 영구 보존 |
 | `order_tracker` | 영구 보존 |
 | `positions` | 영구 보존 |
 | `position_history` | 영구 보존 |

--- a/docs/specs/broker-adapter/18-fill-recovery.md
+++ b/docs/specs/broker-adapter/18-fill-recovery.md
@@ -103,10 +103,14 @@ paper·live 간 / 영업일 재사용으로 충돌할 수 있다. 따라서:
 
 - `open(order_id, account_id, bot_id, strategy_id, broker_order_id, symbol, side, order_type, ordered_qty, submitted_date)`:
   `OrderSubmittedEvent`로 추적 주문 seed.
-- `record_fill(order_id, new_cumulative, avg_price) → applied_delta`:
-  원자 CAS advance. `delta = new_cumulative - 이전 recorded`. `delta<=0`이면 0
-  반환(no-op), `delta>0`이면 `recorded=new_cumulative`로 갱신 후 delta 반환.
-  status를 부분/완료로 갱신. **FillApplier의 트랜잭션 안에서만 호출**.
+- `record_fill(order_id, new_cumulative, avg_price) → RecordFillResult(delta, confirmed_cumulative)`:
+  원자 CAS advance. `delta = new_cumulative - 이전 recorded`. `delta<=0`이면
+  `delta=0` no-op(`confirmed_cumulative`=직전 recorded), `delta>0`이면
+  `recorded=new_cumulative`로 갱신하고 status를 부분/완료로 전이한 뒤
+  **CAS `RETURNING recorded_filled_qty`로 확정된 누적값**을 `confirmed_cumulative`로
+  반환한다. **FillApplier의 트랜잭션 안에서만 호출**. `confirmed_cumulative`는
+  체결 이벤트 outbox의 결정적 `fill_dedup_key` 산출 기준이다(§10, #1949) —
+  입력 `observed_cumulative`가 아니라 DB가 RETURNING으로 확정한 값을 쓴다.
 - `mark_terminal(order_id, status)`: 취소·거부·실패·만료 종료 표기.
 - `get_open_orders(account_id)`: 계좌의 non-terminal(open/partially_filled) 주문.
 - `lookup_order_id(account_id, broker_order_id, submitted_date) → order_id | None`:
@@ -148,13 +152,25 @@ publish 전체**를 감싼다.
 `asyncio.Lock`은 프로세스 내 동시성만 막는다. crash 원자성은 단일 트랜잭션이
 보장한다.
 
-### 5.2 bounded limitation — 이벤트 전달 (후속)
+### 5.2 이벤트 전달 durability (#1949 — R4 한계 해소)
 
-commit ↔ event-publish 사이 narrow crash window에서 다운스트림 이벤트 전달
-(Treasury 정산·strategy `on_fill` 알림)이 유실될 수 있다. 이는 (i) 재기동
-catch-up + 기존 position/treasury reconcile로 재정합되며, (ii) 완전한
-transactional-outbox 기반 exactly-once **이벤트 전달**은 별도 후속 이슈(#1949)로
-분리한다. **positions durability는 본 스펙에서 종결**한다.
+이전에는 `OrderFilledEvent`가 **commit 이후** 발행되어, commit ↔ event-publish
+사이 narrow crash window에서 다운스트림 이벤트 전달(Treasury 정산·strategy
+`on_fill` 알림)이 유실될 수 있었다(#1946 R4 bounded-limitation).
+
+**#1949 transactional outbox로 이 crash window를 닫는다(이벤트 무손실)**: §3의
+체결 적용 트랜잭션 **안**에서 `OrderFilledEvent` payload를 `fill_outbox`
+테이블에 함께 INSERT한다(recorded advance + trade + position과 동일 원자 커밋).
+commit 성공 = 이벤트 영속 보장이므로, commit-후-crash에서도 재기동 시
+`FillOutboxPublisher`가 미발행 row를 재전달한다(§10). 상세는 §10과
+`docs/specs/eventbus/eventbus.md`(전달 시맨틱).
+
+전달 시맨틱은 **at-least-once(무손실)**다. publish↔mark 사이 micro-window에서
+같은 이벤트가 두 번 발행될 수 있으나, 각 이벤트는 결정적 `fill_dedup_key`를 실어
+보낸다. **at-least-once 재전달 시 비멱등 소비자(Treasury/Bot/SignalChannel)의
+이중처리 가능은 #1949 범위 밖의 알려진 잔여이며, 소비자 멱등화는 별도 이슈
+(#1957)에서 해소**한다. #1949는 outbox 무손실 전달 + 결정적 키 제공까지 책임진다.
+**positions durability는 #1946에서, 이벤트 전달 durability는 #1949에서 종결**한다.
 
 ## 6. FillReconcileScheduler — 백스톱 폴러
 
@@ -237,3 +253,65 @@ hard barrier**다.
 - 전략 `ctx.get_open_orders()`(live) 백엔드 연결은 별도 후속 이슈(유저스토리 #2).
 - 스트림 `H0STCNI0` HTS ID 복원은 선택적 지연 최적화 — 정합성은 REST 백스톱이
   보장한다.
+- **소비자 멱등화**(Treasury txn-dedup·Bot/SignalChannel bounded)는 #1949 범위
+  밖이며 별도 이슈(#1957)에서 해소한다. #1949는 소비자 무변경이다.
+
+## 10. 체결 이벤트 transactional outbox (#1949)
+
+commit↔publish crash window(§5.2)를 닫는 durability/at-least-once 메커니즘.
+구현체: `src/ante/trade/fill_outbox.py`(`FillOutbox`, `FillOutboxPublisher`).
+
+### 10.1 outbox 테이블 (`fill_outbox`)
+
+| 컬럼 | 설명 |
+|------|------|
+| `id` | PK (AUTOINCREMENT, 발행 순서 보존) |
+| `fill_dedup_key` | **UNIQUE**. 결정적 체결 식별자 = `order_id:canonical(confirmed_cumulative)` |
+| `payload` | `OrderFilledEvent` 생성자 인자 JSON (`event_id`/`timestamp` 제외 — 발행 시 생성) |
+| `created_at` | 생성 시각 |
+| `published` | 발행 여부 (0/1) |
+| `published_at` | 발행 시각 |
+
+`UNIQUE(fill_dedup_key)` + `ON CONFLICT DO NOTHING`으로 같은 체결의 중복 outbox
+row 생성을 막는다(같은 fill을 두 번 관측해도 row 1개).
+
+### 10.2 결정적 `fill_dedup_key`
+
+`fill_dedup_key = f"{order_id}:{canonical(confirmed_cumulative)}"`.
+
+- `confirmed_cumulative`는 §4.3 `record_fill`이 CAS `RETURNING
+  recorded_filled_qty`로 **확정**한 누적값이다(입력 `observed_cumulative`가
+  아니다). 같은 advance 경계는 항상 같은 확정값을 내므로 키가 결정적이다.
+- `canonical(value)` = `repr(float(value))`. SQLite REAL·Python `float`은 모두
+  IEEE754 double이며 `repr`은 round-trip을 보장하는 최단 표현이라, 재전달 시
+  키 비결정성이 없다. 고정 소수 포맷(`f"{:.Nf}"`)은 유효 자릿수를 잘라 서로 다른
+  체결량이 같은 키로 충돌할 수 있어 쓰지 않는다.
+
+### 10.3 원자 INSERT (FillApplier)
+
+`FillApplier._apply_locked`의 체결 적용 `Database.transaction()` **안**에서
+recorded advance + `TradeRecord` insert + `PositionHistory.on_trade`와 함께
+outbox row를 INSERT한다. commit 성공 = 이벤트 영속 보장. (outbox 미주입
+fallback 경로는 #1949 이전과 동일하게 commit 직후 직접 1회 발행하며, 이 경로는
+crash window가 잔존하고 빈 `fill_dedup_key`를 쓴다.)
+
+### 10.4 퍼블리셔 워커 (`FillOutboxPublisher`)
+
+- **순서 불변식**: row마다 **publish 성공 → mark_published** 순서를 지킨다
+  (역순 금지). publish가 실패(예외)하면 마킹하지 않아 다음 사이클·기동에 재전달
+  한다(at-least-once).
+- **기동 재전달**: `catch_up_once()`가 미발행 row를 id 오름차순으로 한 번 드레인
+  한다. main 기동에서 소비자 구독·체결 catch-up 이후 await하여, commit-후-crash로
+  미발행된 이벤트를 재전달한다.
+- **드레인 트리거**: `FillApplier`가 enqueue 직후 `notify()`로 워커를 깨운다.
+  주기 루프(`start()`)는 통지 누락에 대한 백스톱이다.
+- **graceful stop**: `stop()`은 루프를 취소한다. 미발행 row는 outbox에 durable
+  하게 남아 다음 기동의 `catch_up_once`가 재전달한다(무손실).
+
+### 10.5 VirtualProvider 빈키 정책
+
+`VirtualExecutor`(`src/ante/bot/providers/virtual.py`)는 가상 체결을 즉시 1회
+직접 발행하며 FillApplier/OrderTracker(CAS)·outbox를 거치지 않는다. 결정적 키의
+산출 기반(CAS 확정 누적값)이 없고 at-least-once 재전달도 없으므로 dedup 비대상
+이다 → `fill_dedup_key`는 **빈키(`""`)**로 발행한다. 소비자(#1957)는 빈키를
+"dedup 비대상"으로 본다.

--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -100,7 +100,7 @@ D-005에서 정의한 EventBus 대상 이벤트. 모든 이벤트는 `Event`를 
 | `OrderRejectedEvent` | RuleEngine / Treasury | Bot, Notification | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `order_type`, `reason`, `exchange` |
 | `OrderApprovedEvent` | Treasury | APIGateway | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `order_type`, `stop_price?`, `reserved_amount`, `exchange` |
 | `OrderSubmittedEvent` | APIGateway | Bot, Trade | `account_id`, `order_id`, `bot_id`, `strategy_id`, `broker_order_id`, `symbol`, `side`, `quantity`, `order_type`, `exchange` |
-| `OrderFilledEvent` | BrokerAdapter | Bot, Treasury, Trade, Notification | `account_id`, `order_id`, `broker_order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price`, `requested_quantity`, `remaining_quantity`, `commission`, `order_type`, `reason`, `exchange` |
+| `OrderFilledEvent` | BrokerAdapter / FillApplier(outbox) | Bot, Treasury, Trade, Notification | `account_id`, `order_id`, `broker_order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price`, `requested_quantity`, `remaining_quantity`, `commission`, `order_type`, `reason`, `exchange`, `fill_dedup_key` |
 | `OrderCancelledEvent` | BrokerAdapter | Bot, Treasury | `account_id`, `order_id`, `broker_order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price`, `reason`, `exchange` |
 | `OrderFailedEvent` | BrokerAdapter | Bot, Treasury | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price`, `order_type`, `error_message`, `exchange` |
 
@@ -231,6 +231,32 @@ canonical DB 상태를 남긴 뒤 서버 재시작 시 반영된다.
 4. **핸들러별 에러 격리 (FreqTrade 패턴)**
    - 한 핸들러의 예외가 다른 핸들러 실행을 막지 않음
    - 예외 발생 시 로깅 후 다음 핸들러 계속 실행
+
+### 체결 이벤트 전달 시맨틱: at-least-once (transactional outbox — #1949)
+
+`EventBus.publish`는 fire-and-forget(인메모리, 핸들러 예외 swallow)이라 발행 직후
+crash하면 이벤트가 유실된다. 체결(`OrderFilledEvent`)은 Treasury 정산·전략
+`on_fill`·notification 등 다운스트림 효과가 있어, FillApplier 경로의 발행을
+**transactional outbox**로 durable하게 만든다(#1949).
+
+- **원자 기록**: `FillApplier`는 체결 적용 `Database.transaction()` 안에서
+  `OrderFilledEvent` payload를 `fill_outbox` 테이블에 함께 커밋한다(recorded
+  advance + trade + position과 동일 원자 경계). commit 성공 = 이벤트 영속 보장
+  → commit↔publish 사이 crash window가 닫힌다(이벤트 무손실).
+- **at-least-once 발행**: `FillOutboxPublisher` 워커가 미발행 row를 읽어
+  **publish 성공 → mark published 순서**(역순 금지)로 발행하고, 기동 시 미발행분을
+  재전달한다. publish↔mark 사이 micro-window에서 같은 이벤트가 **두 번 발행될 수
+  있다**(at-least-once).
+- **결정적 `fill_dedup_key`**: 모든 outbox 발행 이벤트는
+  `fill_dedup_key = order_id:canonical(confirmed_cumulative)`(CAS로 확정된 누적
+  체결량 기준)를 싣는다. 소비자가 at-least-once 재전달을 식별·멱등 처리하는 키다.
+  outbox 미경유 직접 발행 경로(VirtualProvider)는 dedup 비대상이며 빈키(`""`)다.
+- **소비자 멱등화 경계**: at-least-once 재전달 시 비멱등 소비자
+  (Treasury/Bot/SignalChannel)의 이중처리 가능은 #1949 범위 밖의 알려진 잔여이며,
+  소비자 멱등화는 별도 이슈(#1957)에서 `fill_dedup_key`를 소비해 해소한다.
+  #1949는 소비자 무변경(무손실 전달 + 결정적 키 제공까지).
+
+상세: `docs/specs/broker-adapter/18-fill-recovery.md` §10.
 
 ### Transient `_consumed` marker (Gateway-only stop, OrderModifyEvent — #1331)
 

--- a/docs/specs/trade/03-08-fill-recovery.md
+++ b/docs/specs/trade/03-08-fill-recovery.md
@@ -33,7 +33,7 @@ DB 트랜잭션으로 수행한다. 빠른 경로(실시간 체결 통보 스트
 |---|---|---|
 | `initialize` | `None` | 스키마 생성 |
 | `open(order_id, account_id, bot_id, strategy_id, broker_order_id, symbol, side, order_type, ordered_qty, submitted_date)` | `None` | `OrderSubmittedEvent`로 추적 주문 seed |
-| `record_fill(order_id, new_cumulative, avg_price)` | `applied_delta: float` | 원자 CAS advance. `delta = new_cumulative - 이전 recorded`; `<=0`이면 0(no-op), `>0`이면 recorded 갱신 후 delta. **FillApplier 트랜잭션 내에서만 호출** |
+| `record_fill(order_id, new_cumulative, avg_price)` | `RecordFillResult(delta, confirmed_cumulative)` | 원자 CAS advance. `delta = new_cumulative - 이전 recorded`; `<=0`이면 `delta=0`(no-op), `>0`이면 recorded 갱신 후 delta. `confirmed_cumulative` = CAS `RETURNING recorded_filled_qty` 확정값(체결 이벤트 outbox `fill_dedup_key` 산출 기준, #1949). **FillApplier 트랜잭션 내에서만 호출** |
 | `mark_terminal(order_id, status)` | `None` | 취소·거부·실패·만료 종료 표기 |
 | `get_open_orders(account_id)` | `list[OrderTrackerRecord]` | 계좌의 non-terminal 주문 |
 | `lookup_order_id(account_id, broker_order_id, submitted_date)` | `str \| None` | 관측 → 내부 order_id 매핑(non-terminal/same-day) |
@@ -55,9 +55,12 @@ DB 트랜잭션으로 수행한다. 빠른 경로(실시간 체결 통보 스트
    외부 포지션은 reconciler 영역).
 2. `Database.transaction()` 단일 트랜잭션 안에서: CAS advance(delta 산출) →
    `delta<=0`이면 no-op → `delta>0`이면 `TradeRecord` insert +
-   `PositionHistory.on_trade` → commit.
-3. commit 이후 `OrderFilledEvent`(quantity=delta, price=avg_price,
-   order_id/bot_id/strategy_id/account_id는 tracker에서 복원) 1회 발행.
+   `PositionHistory.on_trade` + (#1949) `OrderFilledEvent` payload를
+   `fill_outbox`에 INSERT → commit.
+3. commit 이후 `FillOutboxPublisher` 워커가 outbox 미발행분을 at-least-once 발행
+   한다(이벤트는 quantity=delta, price=avg_price, order_id/bot_id/strategy_id/
+   account_id는 tracker 복원, `fill_dedup_key` 포함). outbox 미주입 fallback
+   경로는 commit 직후 직접 1회 발행한다(crash window 잔존, #1949 이전 동작).
 
 ### crash 원자성
 
@@ -65,10 +68,13 @@ CAS advance와 trade insert·position update가 단일 트랜잭션으로 묶이
 도중 crash하면 rollback되어 recorded가 advance되지 않고 재기동 후 다음 폴이
 동일 delta를 재적용한다. → positions/trades는 **crash-safe exactly-once**.
 
-`OrderFilledEvent`는 **커밋 이후 발행되는 알림**(strategy `on_fill`, Treasury
-정산, notification)이다. commit↔publish 사이 narrow crash window의 이벤트 전달
-유실은 재기동 catch-up + reconcile로 재정합되며, 완전한 exactly-once 이벤트
-전달은 별도 후속(transactional outbox)으로 분리한다.
+`OrderFilledEvent`는 다운스트림 알림(strategy `on_fill`, Treasury 정산,
+notification)이다. **#1949 transactional outbox로 commit↔publish crash window를
+닫는다**: 체결 적용 txn 안에서 이벤트 payload를 `fill_outbox`에 함께 커밋하므로
+(commit 성공 = 이벤트 영속), commit-후-crash에서도 재기동 시 퍼블리셔가 미발행분을
+재전달한다(**at-least-once 무손실**). 전달 시맨틱·결정적 `fill_dedup_key`·소비자
+멱등화 경계(#1957)는 `docs/specs/broker-adapter/18-fill-recovery.md` §10과
+`docs/specs/eventbus/eventbus.md`를 따른다.
 
 ## TradeRecorder와의 관계 (권위 일원화)
 

--- a/scripts/generate_db_schema.py
+++ b/scripts/generate_db_schema.py
@@ -66,6 +66,7 @@ TABLE_DESCRIPTIONS: dict[str, str] = {
     "signal_keys": "봇별 시그널 키",
     "strategies": "전략 등록 정보",
     "trades": "체결 기록",
+    "fill_outbox": "체결 이벤트 transactional outbox (#1949)",
     "positions": "현재 포지션",
     "position_history": "포지션 변동 이력",
     "bot_budgets": "봇별 예산",

--- a/src/ante/bot/providers/virtual.py
+++ b/src/ante/bot/providers/virtual.py
@@ -222,7 +222,15 @@ class VirtualExecutor:
         # 가상 체결: 포지션/잔고 업데이트
         portfolio.apply_fill(symbol, side, quantity, fill_price, commission)
 
-        # OrderFilledEvent 발행
+        # OrderFilledEvent 발행.
+        #
+        # #1949 fill_dedup_key 빈키 정책: VirtualProvider 는 가상 체결을 즉시 1회
+        # 직접 발행하는 경로로, FillApplier/OrderTracker(CAS) 와 outbox 를 거치지
+        # 않는다. 따라서 결정적 fill_dedup_key(= order_id:confirmed_cumulative)의
+        # 산출 기반(CAS 확정 누적값)이 없다. at-least-once 재전달도 없으므로(outbox
+        # 미경유, 단발 in-memory 발행) dedup 대상이 아니다 → fill_dedup_key 는
+        # **빈키("")** 로 둔다. (default 이므로 명시 생략 가능하나, 정책을 코드로
+        # 못박기 위해 명시한다.) 소비자(#1957)는 빈키를 "dedup 비대상" 으로 본다.
         await self._eventbus.publish(
             OrderFilledEvent(
                 order_id=order_id,
@@ -237,6 +245,7 @@ class VirtualExecutor:
                 commission=commission,
                 order_type=order_type,
                 timestamp=datetime.now(UTC),
+                fill_dedup_key="",
             )
         )
         logger.info(

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -197,7 +197,15 @@ class OrderSubmittedEvent(Event):
 
 @dataclass(frozen=True)
 class OrderFilledEvent(Event):
-    """BrokerAdapter → EventBus: 체결 완료."""
+    """BrokerAdapter → EventBus: 체결 완료.
+
+    ``fill_dedup_key`` (#1949): 동일 체결을 결정적으로 식별하는 키.
+    FillApplier 경로는 ``f"{order_id}:{canonical(confirmed_cumulative)}"``
+    (CAS RETURNING 확정 누적값 기준)로 채운다. outbox at-least-once 재전달 시
+    소비자가 이중처리를 식별·억제하는 데 쓰인다(소비는 #1957). default ``""`` 로
+    backward-compat 을 유지하며, VirtualProvider 등 outbox 미경유 직접 발행 경로는
+    빈키(``""``)를 그대로 둔다(dedup 비대상 — eventbus 스펙 참조).
+    """
 
     _requires_account_id: ClassVar[bool] = True
 
@@ -216,6 +224,7 @@ class OrderFilledEvent(Event):
     order_type: str = ""
     reason: str = ""
     exchange: str = "KRX"
+    fill_dedup_key: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -156,6 +156,9 @@ class Services:
     # #1946 fill-recovery: 추적 주문 영속 + 단일 멱등 choke point.
     order_tracker: Any = None
     fill_applier: Any = None
+    # #1949: 체결 이벤트 transactional outbox + 퍼블리셔 워커(durability/at-least-once).
+    fill_outbox: Any = None
+    fill_outbox_publisher: Any = None
     bot_manager: Any = None
     virtual_executor: Any = None
     live_portfolio: Any = None
@@ -449,18 +452,38 @@ async def _init_trading(s: Services) -> None:
     # 단일 트랜잭션으로 수행한다. TradeRecorder 는 fill 경로에서 position 을
     # 다시 갱신하지 않는다(이중 적용 방지). OrderTracker 는 OrderSubmittedEvent
     # 로 open seed, 취소/거부/실패로 terminal 표기한다.
-    from ante.trade import FillApplier, OrderTracker
+    #
+    # #1949 durability: FillOutbox(체결 이벤트 transactional outbox) +
+    # FillOutboxPublisher(미발행 row 발행 워커)를 FillApplier 에 주입한다.
+    # FillApplier 는 체결 적용 txn 안에서 OrderFilledEvent payload 를 outbox 에
+    # 함께 커밋하고(crash window 닫힘), publisher 워커가 commit↔publish 밖에서
+    # at-least-once 로 발행한다. 기동 재전달(catch_up)·graceful stop 은 아래
+    # _init_fill_outbox_publisher / shutdown 에서 처리한다.
+    from ante.trade import (
+        FillApplier,
+        FillOutbox,
+        FillOutboxPublisher,
+        OrderTracker,
+    )
 
     s.order_tracker = OrderTracker(db=s.db)
     await s.order_tracker.initialize()
+    s.fill_outbox = FillOutbox(db=s.db)
+    await s.fill_outbox.initialize()
+    s.fill_outbox_publisher = FillOutboxPublisher(
+        outbox=s.fill_outbox,
+        eventbus=s.eventbus,
+    )
     s.fill_applier = FillApplier(
         db=s.db,
         order_tracker=s.order_tracker,
         position_history=s.position_history,
         eventbus=s.eventbus,
+        outbox=s.fill_outbox,
+        publisher=s.fill_outbox_publisher,
     )
     _subscribe_order_tracker(s.eventbus, s.order_tracker)
-    logger.info("OrderTracker / FillApplier 초기화 완료")
+    logger.info("OrderTracker / FillApplier / FillOutbox 초기화 완료")
 
     s.performance_tracker = PerformanceTracker(db=s.db)
 
@@ -686,6 +709,13 @@ async def _init_gateway(s: Services) -> None:
     if connected_count and s.fill_applier and s.order_tracker:
         await _init_fill_recovery_schedulers(s, accounts)
 
+    # #1949: 체결 catch-up(위)이 만든 outbox row + commit-후-crash 로 미발행된
+    # row 를 publisher 가 기동 재전달한 뒤 주기 드레인 루프를 시작한다. 소비자는
+    # 이 시점에 이미 구독돼 있어 재전달 이벤트를 수신한다. broker 연결 여부와
+    # 무관하게(워커는 enqueue 직후 notify drain 도 담당) 항상 켠다.
+    if s.fill_outbox_publisher:
+        await _init_fill_outbox_publisher(s)
+
     # ReconcileScheduler 초기화 (fill 복구 barrier 이후)
     if connected_count and s.trade_service:
         await _init_reconcile_scheduler(s)
@@ -751,6 +781,26 @@ async def _init_fill_recovery_schedulers(s: Services, accounts: list[Any]) -> No
             len(s.fill_schedulers),
             ", ".join(s.fill_schedulers),
         )
+
+
+async def _init_fill_outbox_publisher(s: Services) -> None:
+    """FillOutboxPublisher 기동 재전달(catch_up) + 주기 드레인 루프 시작 (#1949).
+
+    1. ``catch_up_once()`` 를 **await** 해, 직전 FillReconcileScheduler 카치업이
+       만든 outbox row 와 이전 실행의 commit-후-crash 로 미발행된 row 를 재전달
+       한다(at-least-once 무손실 전달). 소비자는 이 시점에 이미 구독돼 있다.
+    2. 주기 드레인 루프(``start()``)를 시작한다. 워커는 ``FillApplier`` 가 enqueue
+       직후 호출하는 ``notify()`` 로 즉시 드레인되며, 주기 루프는 누락 통지에 대한
+       백스톱이다.
+    """
+    publisher = s.fill_outbox_publisher
+    if publisher is None:
+        return
+    redelivered = await publisher.catch_up_once()
+    if redelivered:
+        logger.info("기동 outbox 재전달: %d건", redelivered)
+    await publisher.start()
+    logger.info("FillOutboxPublisher 시작 완료")
 
 
 async def _init_reconcile_scheduler(s: Services) -> None:
@@ -1911,6 +1961,15 @@ async def _shutdown(s: Services) -> None:
                 exc_info=True,
             )
     s.fill_schedulers.clear()
+
+    # #1949: FillOutboxPublisher graceful stop. 미발행 row 가 남아도 outbox 에
+    # durable 하게 영속돼 있어, 다음 기동의 catch_up_once 가 재전달한다(무손실).
+    if s.fill_outbox_publisher:
+        try:
+            await s.fill_outbox_publisher.stop()
+            logger.info("FillOutboxPublisher 종료")
+        except Exception:
+            logger.warning("FillOutboxPublisher 종료 실패", exc_info=True)
 
     # 각 계좌의 Treasury sync 중지
     if s.treasury_manager:

--- a/src/ante/trade/__init__.py
+++ b/src/ante/trade/__init__.py
@@ -2,6 +2,7 @@
 
 from ante.trade.daily_report import DailyReportScheduler
 from ante.trade.fill_applier import FillApplier
+from ante.trade.fill_outbox import FillOutbox, FillOutboxPublisher
 from ante.trade.models import (
     DailySummary,
     MonthlySummary,
@@ -12,7 +13,11 @@ from ante.trade.models import (
     TradeType,
     WeeklySummary,
 )
-from ante.trade.order_tracker import OrderTracker, OrderTrackerRecord
+from ante.trade.order_tracker import (
+    OrderTracker,
+    OrderTrackerRecord,
+    RecordFillResult,
+)
 from ante.trade.performance import PerformanceTracker
 from ante.trade.position import PositionHistory
 from ante.trade.reconciler import PositionReconciler
@@ -23,6 +28,8 @@ __all__ = [
     "DailyReportScheduler",
     "DailySummary",
     "FillApplier",
+    "FillOutbox",
+    "FillOutboxPublisher",
     "MonthlySummary",
     "WeeklySummary",
     "OrderTracker",
@@ -32,6 +39,7 @@ __all__ = [
     "PositionHistory",
     "PositionReconciler",
     "PositionSnapshot",
+    "RecordFillResult",
     "TradeRecord",
     "TradeRecorder",
     "TradeService",

--- a/src/ante/trade/fill_applier.py
+++ b/src/ante/trade/fill_applier.py
@@ -9,10 +9,18 @@ crash 원자성: ``recorded_filled_qty`` advance(CAS) + ``TradeRecord`` insert +
 적용 도중 crash 하면 rollback 되어 recorded 가 advance 되지 않고, 재기동 후 다음
 폴이 동일 delta 를 재적용한다 → positions/trades crash-safe exactly-once.
 
-``asyncio.Lock`` 은 read → delta → txn → publish 전체를 감싸 프로세스 내 동시
-관측을 직렬화한다.
+이벤트 durability (#1949): outbox 가 주입되면 같은 트랜잭션 안에서
+``OrderFilledEvent`` payload 를 ``fill_outbox`` 에 INSERT 한다. commit 성공 =
+이벤트 영속 보장이므로, commit↔publish 사이 crash window 가 닫힌다(이벤트 무손실).
+실제 발행은 ``FillOutboxPublisher`` 워커가 트랜잭션 밖에서 at-least-once 로 한다.
+(소비자 멱등화는 #1957 범위. #1949 는 무손실 전달 + 결정적 키 제공까지.)
 
-상세 설계: ``docs/specs/trade/03-08-fill-recovery.md``.
+``asyncio.Lock`` 은 read → delta → txn(outbox insert 포함) 전체를 감싸 프로세스
+내 동시 관측을 직렬화한다.
+
+상세 설계: ``docs/specs/trade/03-08-fill-recovery.md``,
+``docs/specs/broker-adapter/18-fill-recovery.md``(§5.2),
+``docs/specs/eventbus/eventbus.md``(전달 시맨틱).
 """
 
 from __future__ import annotations
@@ -29,6 +37,7 @@ from ante.trade.models import TradeRecord, TradeStatus
 if TYPE_CHECKING:
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
+    from ante.trade.fill_outbox import FillOutbox, FillOutboxPublisher
     from ante.trade.order_tracker import OrderTracker
     from ante.trade.position import PositionHistory
 
@@ -45,11 +54,19 @@ class FillApplier:
         order_tracker: OrderTracker,
         position_history: PositionHistory,
         eventbus: EventBus,
+        outbox: FillOutbox | None = None,
+        publisher: FillOutboxPublisher | None = None,
     ) -> None:
         self._db = db
         self._tracker = order_tracker
         self._position_history = position_history
         self._eventbus = eventbus
+        # #1949: outbox 가 주입되면 체결 적용 txn 안에서 이벤트 payload 를 함께
+        # 커밋하고(durability), publisher 워커가 commit↔publish crash window 밖에서
+        # at-least-once 로 발행한다. 미주입(legacy/단위 테스트 partial wiring)이면
+        # 기존처럼 commit 직후 직접 발행(crash window 잔존 — 본 이슈 이전 동작).
+        self._outbox = outbox
+        self._publisher = publisher
         self._lock = asyncio.Lock()
 
     async def apply_cumulative(
@@ -64,8 +81,10 @@ class FillApplier:
         """관측 누적 체결량을 멱등 적용. 적용된 delta 를 반환 (no-op이면 0).
 
         1. ``lookup_order_id`` 로 추적 주문 확인 — 없으면 무시(self/external 경계).
-        2. 단일 트랜잭션: CAS advance → delta>0 이면 TradeRecord + position 적용.
-        3. commit 이후 ``OrderFilledEvent``(delta) 1회 발행.
+        2. 단일 트랜잭션: CAS advance → delta>0 이면 TradeRecord + position 적용 +
+           (#1949) OrderFilledEvent payload 를 outbox 에 INSERT(동일 원자 커밋).
+        3. commit 이후 publisher 워커가 outbox 미발행분을 at-least-once 발행한다
+           (outbox 미주입 fallback 경로는 commit 직후 직접 1회 발행).
         """
         validated = require_account_id(
             account_id, context="fill_applier.apply_cumulative"
@@ -158,14 +177,23 @@ class FillApplier:
 
         ``apply_cumulative`` / ``apply_stream_increment`` 의 공통 코어. 호출자가
         이미 ``self._lock`` 을 보유하고 ``record`` 를 조회한 상태여야 한다.
+
+        #1949 durability: outbox 가 주입되면 recorded advance + trade insert +
+        position update **와 동일 트랜잭션** 안에서 OrderFilledEvent payload 를
+        outbox 에 INSERT 한다(원자 커밋). commit 성공 = 이벤트 영속 보장이므로
+        commit↔publish 사이 crash window 가 닫힌다. 발행은 트랜잭션 밖에서
+        publisher 워커(at-least-once)에 위임한다.
         """
+        from ante.trade.fill_outbox import make_fill_dedup_key
         from ante.trade.order_tracker import OrderTrackerRecord
 
         assert isinstance(record, OrderTrackerRecord)
+        fill_dedup_key = ""
         async with self._db.transaction():
-            delta = await self._tracker.record_fill(
+            result = await self._tracker.record_fill(
                 order_id, observed_cumulative, avg_price
             )
+            delta = result.delta
             if delta <= 0:
                 return 0.0
             trade = TradeRecord(
@@ -185,7 +213,26 @@ class FillApplier:
             await self._save_trade(trade)
             await self._position_history.on_trade(trade)
 
-        await self._publish_filled(record, order_id, delta, avg_price)
+            if self._outbox is not None:
+                # 결정적 키는 CAS RETURNING 확정 누적값으로 산출(입력값 아님).
+                fill_dedup_key = make_fill_dedup_key(
+                    order_id, result.confirmed_cumulative
+                )
+                payload = self._build_payload(
+                    record, order_id, delta, avg_price, fill_dedup_key
+                )
+                await self._outbox.enqueue(
+                    fill_dedup_key=fill_dedup_key, payload=payload
+                )
+
+        # commit 성공. outbox 경유면 워커가 발행(crash window 닫힘), 미주입이면
+        # 기존처럼 commit 직후 직접 발행한다.
+        if self._outbox is not None:
+            if self._publisher is not None:
+                # enqueue 직후 즉시 드레인 트리거. 누락돼도 워커 주기 백스톱.
+                self._publisher.notify()
+        else:
+            await self._publish_filled(record, order_id, delta, avg_price)
         logger.info(
             "체결 반영: order=%s odno=%s %s %s delta=%s @ %s (cumulative=%s)",
             order_id,
@@ -230,6 +277,38 @@ class FillApplier:
             ),
         )
 
+    def _build_payload(
+        self,
+        record: object,
+        order_id: str,
+        delta: float,
+        avg_price: float,
+        fill_dedup_key: str,
+    ) -> dict[str, object]:
+        """outbox 에 저장할 ``OrderFilledEvent`` 생성자 인자 payload (#1949).
+
+        ``event_id``/``timestamp`` 는 발행 시점에 새로 생성되도록 제외한다(재전달
+        시 새 event_id 가 부여돼도 dedup 은 결정적 ``fill_dedup_key`` 로 한다).
+        키 집합은 ``FillOutboxPublisher._publish_row`` 의
+        ``OrderFilledEvent(**payload)`` 와 정확히 호응해야 한다.
+        """
+        from ante.trade.order_tracker import OrderTrackerRecord
+
+        assert isinstance(record, OrderTrackerRecord)
+        return {
+            "account_id": record.account_id,
+            "order_id": order_id,
+            "broker_order_id": record.broker_order_id,
+            "bot_id": record.bot_id,
+            "strategy_id": record.strategy_id,
+            "symbol": record.symbol,
+            "side": record.side,
+            "quantity": delta,
+            "price": avg_price,
+            "order_type": record.order_type,
+            "fill_dedup_key": fill_dedup_key,
+        }
+
     async def _publish_filled(
         self,
         record: object,
@@ -237,7 +316,12 @@ class FillApplier:
         delta: float,
         avg_price: float,
     ) -> None:
-        """``OrderFilledEvent`` 발행 (정체성은 tracker 에서 복원)."""
+        """``OrderFilledEvent`` 직접 발행 (outbox 미주입 legacy fallback).
+
+        outbox 가 주입되지 않은 경로(단위 테스트 partial wiring 등)에서만 쓰인다.
+        이 경로는 commit↔publish crash window 가 잔존하며(#1949 이전 동작),
+        ``fill_dedup_key`` 를 채우지 않는다(빈키).
+        """
         from ante.eventbus.events import OrderFilledEvent
         from ante.trade.order_tracker import OrderTrackerRecord
 

--- a/src/ante/trade/fill_outbox.py
+++ b/src/ante/trade/fill_outbox.py
@@ -1,0 +1,266 @@
+"""FillOutbox — 체결 이벤트 transactional outbox (#1949).
+
+#1946 이후 ``recorded_filled_qty`` advance + ``TradeRecord`` insert +
+``PositionHistory.on_trade`` 는 단일 ``Database.transaction()`` 으로 묶여
+positions/trades crash-safe exactly-once 를 보장한다. 그러나 ``OrderFilledEvent``
+는 **commit 이후** 알림으로 발행되므로, **commit↔publish 사이 narrow crash
+window** 에서는 다운스트림 소비자(Treasury 정산·전략 ``on_fill``·notification)로의
+**이벤트 전달이 유실**될 수 있었다(#1946 R4 bounded-limitation).
+
+FillOutbox 는 그 crash window 를 닫는다:
+
+1. ``FillApplier`` 가 체결 적용 트랜잭션 **안**(recorded advance + trade + position
+   과 동일 원자 커밋)에서 outbox row 를 INSERT 한다. commit 이 성공하면 이벤트
+   payload 도 반드시 영속화돼 있다 → **무손실(durability)**.
+2. ``FillOutboxPublisher`` 워커가 미발행 row 를 읽어 ``OrderFilledEvent`` 를
+   **publish 성공 → mark published 순서**(역순 금지)로 발행한다. 기동 시 미발행분을
+   재전달(at-least-once)하므로 commit-후-crash 에서도 이벤트가 결국 전달된다.
+
+전달 시맨틱은 **at-least-once** 다. publish↔mark 사이 micro-window 에서 같은 row 가
+두 번 발행될 수 있으나, 각 이벤트는 결정적 ``fill_dedup_key``(CAS 로 확정된
+``order_id:confirmed_cumulative``)를 실어 보내므로 소비자가 멱등 처리할 수 있다.
+**소비자 멱등화 자체는 본 이슈(#1949) 범위 밖이며 별도 이슈(#1957)에서 해소**한다.
+#1949 는 outbox 무손실 전달 + 결정적 키 제공까지만 책임진다.
+
+상세 설계: ``docs/specs/eventbus/eventbus.md``(전달 시맨틱),
+``docs/specs/broker-adapter/18-fill-recovery.md``(§5.2 durability 해소).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+# outbox 테이블 DDL (db-schema 생성기가 *_SCHEMA plain-string 상수로 추출하므로
+# f-string 으로 쓰지 않는다). UNIQUE(fill_dedup_key) 가 같은 체결의 중복 outbox
+# row 생성을 막아, 같은 fill 을 두 번 관측해도 row 는 1개만 생긴다.
+FILL_OUTBOX_SCHEMA = """
+CREATE TABLE IF NOT EXISTS fill_outbox (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    fill_dedup_key  TEXT NOT NULL UNIQUE,
+    payload         TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    published       INTEGER NOT NULL DEFAULT 0,
+    published_at    TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_fill_outbox_unpublished
+    ON fill_outbox(published, id);
+"""
+
+
+def canonical_cumulative(value: float) -> str:
+    """누적 체결량을 결정적 문자열로 정규화 (fill_dedup_key 산출용, #1949).
+
+    SQLite REAL 과 Python ``float`` 은 모두 IEEE754 double 이므로,
+    ``record_fill`` 이 CAS ``RETURNING`` 으로 돌려준 확정 누적값을 ``repr`` 로
+    포매팅하면 **round-trip 을 보장하는 최단 표현**이 나온다. 같은 double 값은
+    항상 같은 ``repr`` 을 내므로 재전달 시 키가 결정적이다.
+
+    ``repr(float)`` 을 쓰는 이유: ``str(float)`` 과 동일하게 round-trip-safe 이며,
+    플랫폼·실행 간 동일 double 에 대해 안정적이다. 고정 소수 포맷(``f"{:.Nf}"``)은
+    유효 자릿수를 잘라 서로 다른 체결량이 같은 키로 충돌할 수 있어 쓰지 않는다.
+    """
+    return repr(float(value))
+
+
+def make_fill_dedup_key(order_id: str, confirmed_cumulative: float) -> str:
+    """결정적 ``fill_dedup_key = order_id:canonical(confirmed_cumulative)``.
+
+    ``confirmed_cumulative`` 는 ``record_fill`` CAS ``RETURNING`` 확정값이어야
+    한다(입력 ``observed_cumulative`` 가 아니다). 같은 advance 경계는 항상 같은
+    키를 내므로, outbox 재전달 시 소비자가 중복을 식별할 수 있다.
+    """
+    return f"{order_id}:{canonical_cumulative(confirmed_cumulative)}"
+
+
+class FillOutbox:
+    """체결 이벤트 outbox 저장소 (테이블 관리 + txn 내 insert + 발행 마킹).
+
+    insert 는 ``FillApplier`` 의 체결 적용 ``Database.transaction()`` 안에서
+    호출되어 recorded/trade/position 과 원자 커밋된다. 발행/마킹은
+    ``FillOutboxPublisher`` 워커가 트랜잭션 밖에서 수행한다.
+    """
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def initialize(self) -> None:
+        """스키마 생성."""
+        await self._db.execute_script(FILL_OUTBOX_SCHEMA)
+        logger.info("FillOutbox 초기화 완료")
+
+    async def enqueue(self, *, fill_dedup_key: str, payload: dict[str, Any]) -> None:
+        """체결 이벤트 payload 를 outbox 에 INSERT (**트랜잭션 안에서 호출**).
+
+        반드시 ``FillApplier`` 의 ``async with self._db.transaction():`` 블록
+        안에서 호출해, recorded advance + trade insert + position update 와 같은
+        원자 커밋에 묶여야 한다. 그래야 commit 성공 = 이벤트 영속 보장이 된다.
+
+        ``ON CONFLICT(fill_dedup_key) DO NOTHING`` 으로 같은 체결을 두 번 관측해도
+        outbox row 가 중복 생성되지 않는다(단조 advance 경로에선 같은 키가 두 번
+        커밋되지 않으나, 방어적으로 멱등하게 둔다).
+        """
+        await self._db.execute(
+            """INSERT INTO fill_outbox (fill_dedup_key, payload)
+               VALUES (?, ?)
+               ON CONFLICT(fill_dedup_key) DO NOTHING""",
+            (fill_dedup_key, json.dumps(payload, ensure_ascii=False)),
+        )
+
+    async def fetch_unpublished(self, limit: int = 100) -> list[dict[str, Any]]:
+        """미발행 outbox row 를 id 오름차순으로 조회 (발행 순서 보존)."""
+        rows = await self._db.fetch_all(
+            """SELECT id, fill_dedup_key, payload
+                 FROM fill_outbox
+                WHERE published = 0
+                ORDER BY id
+                LIMIT ?""",
+            (limit,),
+        )
+        return rows
+
+    async def mark_published(self, row_id: int) -> None:
+        """row 를 발행 완료로 마킹.
+
+        **반드시 publish 성공 이후에만 호출**(역순 금지). publish 실패 시 마킹하지
+        않아 다음 사이클·기동 재전달에서 다시 발행된다(at-least-once).
+        """
+        await self._db.execute(
+            """UPDATE fill_outbox
+                  SET published = 1, published_at = datetime('now')
+                WHERE id = ?""",
+            (row_id,),
+        )
+
+
+# 미발행 row 폴 cadence. 워커는 enqueue 직후 ``notify()`` 로 즉시 드레인되며,
+# 이 주기는 누락 통지/기동 잔여분에 대한 백스톱이다.
+DEFAULT_DRAIN_INTERVAL = 1.0
+
+
+class FillOutboxPublisher:
+    """미발행 outbox row 를 ``OrderFilledEvent`` 로 발행하는 워커 (lifecycle).
+
+    - **기동 재전달**: ``catch_up_once`` 가 미발행분을 한 번 드레인한다(commit-후-
+      crash 로 미발행된 이벤트를 재전달). main barrier 에서 await 한다.
+    - **이벤트 드레인**: ``notify()`` 로 enqueue 직후 즉시 드레인하고, ``start()``
+      의 주기 루프가 백스톱으로 미발행분을 처리한다.
+    - **순서 보장**: row 마다 ``publish 성공 → mark_published`` 순서를 지킨다.
+      publish 가 실패(예외)하면 마킹하지 않고 다음 사이클에 재시도한다.
+
+    EventBus 는 fire-and-forget(핸들러 예외 swallow)이므로, publish 자체가 예외를
+    던지지 않는 한 본 워커는 핸들러 실패와 무관하게 mark_published 한다. 즉 전달
+    시맨틱은 at-least-once 이며, 소비자 멱등은 #1957 범위다.
+    """
+
+    def __init__(
+        self,
+        *,
+        outbox: FillOutbox,
+        eventbus: EventBus,
+        drain_interval: float = DEFAULT_DRAIN_INTERVAL,
+    ) -> None:
+        self._outbox = outbox
+        self._eventbus = eventbus
+        self._drain_interval = drain_interval
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+        # enqueue 직후 즉시 드레인을 깨우는 신호. 누락돼도 주기 루프가 백스톱한다.
+        self._wakeup = asyncio.Event()
+        self._drain_lock = asyncio.Lock()
+
+    def notify(self) -> None:
+        """enqueue 직후 호출 — 워커를 깨워 즉시 드레인하게 한다(비동기 트리거)."""
+        self._wakeup.set()
+
+    async def catch_up_once(self) -> int:
+        """미발행 outbox row 를 한 번 드레인. 발행한 건수를 반환 (기동 재전달용).
+
+        main 기동에서 await 하면 commit-후-crash 로 미발행된 체결 이벤트가 소비자
+        구독 이후 재전달된다. 발행 순서는 id 오름차순으로 보존된다.
+        """
+        return await self._drain()
+
+    async def _drain(self) -> int:
+        """미발행 row 를 모두 발행 (publish 성공 → mark 순서). 발행 건수 반환."""
+        published = 0
+        async with self._drain_lock:
+            while True:
+                rows = await self._outbox.fetch_unpublished(limit=100)
+                if not rows:
+                    return published
+                for row in rows:
+                    try:
+                        await self._publish_row(row)
+                    except Exception:
+                        # publish 실패 — mark 하지 않아 다음 사이클/기동에 재전달.
+                        # (역순 금지: mark 가 publish 보다 먼저 일어나지 않는다.)
+                        logger.warning(
+                            "outbox 발행 실패 (id=%s, key=%s) — 재전달 대기",
+                            row.get("id"),
+                            row.get("fill_dedup_key"),
+                            exc_info=True,
+                        )
+                        # 같은 row 에서 무한 루프하지 않도록 이번 드레인은 중단.
+                        return published
+                    await self._outbox.mark_published(int(row["id"]))
+                    published += 1
+
+    async def _publish_row(self, row: dict[str, Any]) -> None:
+        """outbox row payload 를 ``OrderFilledEvent`` 로 복원해 발행."""
+        from ante.eventbus.events import OrderFilledEvent
+
+        payload = json.loads(row["payload"])
+        await self._eventbus.publish(OrderFilledEvent(**payload))
+
+    async def start(self) -> None:
+        """주기 드레인 루프 시작 (catch_up_once 와 별개 background task)."""
+        if self._task and not self._task.done():
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop(), name="fill-outbox-publisher")
+        logger.info(
+            "FillOutboxPublisher 시작 (drain_interval=%.1fs)", self._drain_interval
+        )
+
+    async def stop(self) -> None:
+        """루프 중지 (graceful)."""
+        self._running = False
+        self._wakeup.set()
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _loop(self) -> None:
+        while self._running:
+            try:
+                await asyncio.wait_for(
+                    self._wakeup.wait(), timeout=self._drain_interval
+                )
+            except TimeoutError:
+                # 주기 백스톱 드레인 (notify 누락 대비).
+                pass
+            self._wakeup.clear()
+            if not self._running:
+                return
+            try:
+                await self._drain()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "FillOutboxPublisher 드레인 오류 — 다음 사이클 재시도",
+                    exc_info=True,
+                )

--- a/src/ante/trade/order_tracker.py
+++ b/src/ante/trade/order_tracker.py
@@ -60,6 +60,25 @@ CREATE INDEX IF NOT EXISTS idx_order_tracker_open
 
 
 @dataclass(frozen=True, slots=True)
+class RecordFillResult:
+    """``record_fill`` CAS 결과 (#1949).
+
+    Attributes:
+        delta: 적용된 증분(``new_cumulative - 이전 recorded``). no-op이면 0.
+        confirmed_cumulative: **CAS ``RETURNING recorded_filled_qty`` 로 확정된**
+            누적 체결량. ``delta>0`` 일 때 advance 된 확정값(= new_cumulative)을
+            담고, no-op(``delta<=0``)이면 직전 recorded 값을 그대로 반영한다.
+
+            outbox/이벤트의 결정적 ``fill_dedup_key`` 는 **이 확정값**으로 생성해야
+            한다(입력 ``observed_cumulative`` 가 아니다). 동일 advance 경계는 항상
+            같은 확정값을 내므로, 재전달 시 키가 결정적이다.
+    """
+
+    delta: float
+    confirmed_cumulative: float
+
+
+@dataclass(frozen=True, slots=True)
 class OrderTrackerRecord:
     """추적 주문 스냅샷."""
 
@@ -171,12 +190,18 @@ class OrderTracker:
         order_id: str,
         new_cumulative: float,
         avg_price: float,
-    ) -> float:
-        """원자 CAS advance. 적용된 delta를 반환.
+    ) -> RecordFillResult:
+        """원자 CAS advance. ``RecordFillResult(delta, confirmed_cumulative)`` 반환.
 
         ``delta = new_cumulative - 이전 recorded_filled_qty``.
-        ``delta <= 0`` 이면 0 반환(no-op). ``delta > 0`` 이면 recorded 를
-        new_cumulative 로 갱신하고 status 를 부분/완료로 전이한 뒤 delta 반환.
+        ``delta <= 0`` 이면 ``delta=0`` no-op(직전 recorded 를 confirmed 로 반영).
+        ``delta > 0`` 이면 recorded 를 new_cumulative 로 갱신하고 status 를
+        부분/완료로 전이한 뒤, **CAS ``RETURNING recorded_filled_qty`` 로 확정된
+        누적값**을 ``confirmed_cumulative`` 로 반환한다(#1949).
+
+        ``confirmed_cumulative`` 는 outbox/이벤트의 결정적 ``fill_dedup_key`` 산출
+        기준이다. 입력 ``new_cumulative`` 가 아니라 DB 가 RETURNING 으로 돌려준
+        값을 노출해, 재전달 시 키 비결정성을 없앤다.
 
         **반드시 FillApplier 의 ``Database.transaction()`` + Lock 안에서 호출.**
         writer 연결에서 현재값을 읽고(``execute_fetch_one``) 진행 중인 트랜잭션의
@@ -189,14 +214,14 @@ class OrderTracker:
             (order_id,),
         )
         if row is None:
-            return 0.0
+            return RecordFillResult(delta=0.0, confirmed_cumulative=0.0)
 
         prev = float(row["recorded_filled_qty"] or 0.0)
         ordered = float(row["ordered_qty"] or 0.0)
         delta = new_cumulative - prev
         if delta <= 0:
-            # 관측 역전 또는 이미 반영됨 — 단조성 유지, no-op.
-            return 0.0
+            # 관측 역전 또는 이미 반영됨 — 단조성 유지, no-op. 확정값은 직전 recorded.
+            return RecordFillResult(delta=0.0, confirmed_cumulative=prev)
 
         # terminal(취소/거부/실패/만료) 이후에도 잔여 체결이 관측되면 부분/완료로
         # 되돌린다. CAS WHERE 절은 단조성(recorded < :c)만 강제한다.
@@ -227,8 +252,10 @@ class OrderTracker:
         if updated is None:
             # 동시 advance 로 다른 호출이 먼저 recorded 를 올림 — 단조성 보존, no-op.
             # (단일 Lock 경로에선 발생하지 않으나 방어적으로 처리.)
-            return 0.0
-        return delta
+            return RecordFillResult(delta=0.0, confirmed_cumulative=prev)
+        # CAS RETURNING 으로 확정된 누적값. fill_dedup_key 의 결정적 기준.
+        confirmed = float(updated["recorded_filled_qty"] or 0.0)
+        return RecordFillResult(delta=delta, confirmed_cumulative=confirmed)
 
     async def mark_terminal(self, order_id: str, status: str) -> None:
         """주문을 종료 상태로 표기 (취소/거부/실패/만료).

--- a/tests/unit/test_fill_outbox.py
+++ b/tests/unit/test_fill_outbox.py
@@ -1,0 +1,352 @@
+"""FillOutbox / FillOutboxPublisher 단위·통합 테스트 (#1949).
+
+durability/at-least-once 무손실 전달:
+- (a) commit↔publish 사이 crash 주입 → 재기동 publisher.catch_up_once 가 outbox
+  에서 이벤트 재전달(현 한계 해소).
+- (b) fill_dedup_key 가 CAS 확정 cumulative 기반 canonical·재전달 결정적.
+- (d) 같은 fill 2회 관측 시 outbox UNIQUE(fill_dedup_key) 로 중복 row 미생성.
+- 퍼블리셔 publish 성공 → mark 순서, publish 실패 시 미마킹(재전달 대기).
+
+소비자 멱등화(#1957)는 본 범위 밖이다. 여기서는 outbox 무손실 전달 + 결정적
+키 제공까지만 검증한다.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import OrderFilledEvent
+from ante.trade.fill_applier import FillApplier
+from ante.trade.fill_outbox import (
+    FillOutbox,
+    FillOutboxPublisher,
+    canonical_cumulative,
+    make_fill_dedup_key,
+)
+from ante.trade.order_tracker import OrderTracker
+from ante.trade.position import PositionHistory
+from ante.trade.recorder import TradeRecorder
+
+ACCT = "acct-A"
+DATE = "20260529"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db = Database(str(tmp_path / "outbox.db"))
+    await db.connect()
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+@pytest.fixture
+async def position_history(db):
+    ph = PositionHistory(db)
+    await ph.initialize()
+    return ph
+
+
+@pytest.fixture
+async def tracker(db):
+    t = OrderTracker(db)
+    await t.initialize()
+    return t
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def outbox(db):
+    ob = FillOutbox(db)
+    await ob.initialize()
+    return ob
+
+
+@pytest.fixture
+async def trades_schema(db, position_history):
+    # trades 스키마는 TradeRecorder.initialize 로 생성.
+    rec = TradeRecorder(db, position_history)
+    await rec.initialize()
+    return rec
+
+
+async def _seed(
+    tracker, *, order_id="ord-1", broker_order_id="0001", qty=100.0, side="buy"
+):
+    await tracker.open(
+        order_id=order_id,
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id=broker_order_id,
+        symbol="005930",
+        side=side,
+        order_type="market",
+        ordered_qty=qty,
+        submitted_date=DATE,
+    )
+
+
+def _collect_filled(eventbus):
+    events: list[OrderFilledEvent] = []
+
+    async def _h(event):
+        if isinstance(event, OrderFilledEvent):
+            events.append(event)
+
+    eventbus.subscribe(OrderFilledEvent, _h)
+    return events
+
+
+def _make_applier(db, tracker, position_history, eventbus, outbox, publisher=None):
+    return FillApplier(
+        db=db,
+        order_tracker=tracker,
+        position_history=position_history,
+        eventbus=eventbus,
+        outbox=outbox,
+        publisher=publisher,
+    )
+
+
+# ── fill_dedup_key 결정성 (b) ────────────────────────
+
+
+def test_canonical_cumulative_is_deterministic():
+    """같은 double 값은 항상 같은 canonical 문자열 → 재전달 키 결정적."""
+    assert canonical_cumulative(40.0) == canonical_cumulative(40.0)
+    assert canonical_cumulative(40.0) == "40.0"
+    # int/float 동일 값 정규화.
+    assert canonical_cumulative(40) == canonical_cumulative(40.0)
+    # 서로 다른 값은 서로 다른 키 (충돌 없음).
+    assert canonical_cumulative(40.0) != canonical_cumulative(40.5)
+
+
+def test_make_fill_dedup_key_shape():
+    assert make_fill_dedup_key("ord-1", 40.0) == "ord-1:40.0"
+    assert make_fill_dedup_key("ord-1", 100.0) == "ord-1:100.0"
+
+
+# ── transactional outbox durability (a) ──────────────
+
+
+async def test_outbox_enqueued_in_same_transaction(
+    db, tracker, position_history, eventbus, outbox, trades_schema
+):
+    """체결 적용 시 outbox row 가 trade/position 과 동일 커밋으로 기록된다."""
+    applier = _make_applier(db, tracker, position_history, eventbus, outbox)
+    await _seed(tracker)
+    delta = await applier.apply_cumulative(
+        account_id=ACCT,
+        broker_order_id="0001",
+        observed_cumulative=40.0,
+        avg_price=1000.0,
+        submitted_date=DATE,
+    )
+    assert delta == 40.0
+
+    rows = await outbox.fetch_unpublished()
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["payload"])
+    assert payload["order_id"] == "ord-1"
+    assert payload["quantity"] == 40.0
+    assert payload["account_id"] == ACCT
+    # fill_dedup_key 는 CAS 확정 cumulative(40.0) 기반.
+    assert rows[0]["fill_dedup_key"] == "ord-1:40.0"
+    assert payload["fill_dedup_key"] == "ord-1:40.0"
+
+
+async def test_crash_between_commit_and_publish_redelivers_on_restart(
+    db, tracker, position_history, eventbus, outbox, trades_schema
+):
+    """commit 후 publish 직전 crash 주입 → 재기동 publisher 가 재전달 (현 한계 해소).
+
+    publisher 를 주입하지 않고 apply_cumulative 를 호출하면, outbox 에 row 는
+    커밋되지만 어떤 발행도 일어나지 않는다(= commit↔publish 사이 crash 와 동일한
+    상태: 이벤트 미발행). 이후 새 publisher 가 기동 재전달(catch_up_once)하면
+    소비자가 이벤트를 수신한다.
+    """
+    # crash 모사: publisher 미주입 → enqueue 만 되고 발행 트리거 없음.
+    applier = _make_applier(
+        db, tracker, position_history, eventbus, outbox, publisher=None
+    )
+    await _seed(tracker)
+    await applier.apply_cumulative(
+        account_id=ACCT,
+        broker_order_id="0001",
+        observed_cumulative=40.0,
+        avg_price=1000.0,
+        submitted_date=DATE,
+    )
+
+    # crash 직전: 소비자는 아직 아무 이벤트도 못 받았다.
+    events = _collect_filled(eventbus)
+    assert events == []
+    assert len(await outbox.fetch_unpublished()) == 1
+
+    # 재기동: 소비자 구독 후 publisher 가 미발행분을 재전달.
+    publisher = FillOutboxPublisher(outbox=outbox, eventbus=eventbus)
+    redelivered = await publisher.catch_up_once()
+
+    assert redelivered == 1
+    assert len(events) == 1
+    assert events[0].order_id == "ord-1"
+    assert events[0].quantity == 40.0
+    assert events[0].fill_dedup_key == "ord-1:40.0"
+    # 발행 완료로 마킹 → 더 이상 미발행 row 없음.
+    assert await outbox.fetch_unpublished() == []
+
+
+async def test_publisher_drains_via_notify(
+    db, tracker, position_history, eventbus, outbox, trades_schema
+):
+    """FillApplier 가 publisher.notify() 로 즉시 드레인 트리거 → 정상 발행."""
+    events = _collect_filled(eventbus)
+    publisher = FillOutboxPublisher(outbox=outbox, eventbus=eventbus)
+    applier = _make_applier(
+        db, tracker, position_history, eventbus, outbox, publisher=publisher
+    )
+    await _seed(tracker)
+    await applier.apply_cumulative(
+        account_id=ACCT,
+        broker_order_id="0001",
+        observed_cumulative=40.0,
+        avg_price=1000.0,
+        submitted_date=DATE,
+    )
+    # notify 만으로는 워커 루프가 없으면 드레인되지 않으므로, 명시적 드레인으로
+    # 발행을 확인한다(루프 기동은 lifecycle 테스트가 별도 검증).
+    await publisher.catch_up_once()
+    assert len(events) == 1
+    assert events[0].fill_dedup_key == "ord-1:40.0"
+
+
+# ── 같은 fill 2회 관측 → UNIQUE 로 중복 row 미생성 (d) ─
+
+
+async def test_same_fill_twice_no_duplicate_outbox_row(
+    db, tracker, position_history, eventbus, outbox, trades_schema
+):
+    """같은 누적 2회 관측 → 첫 회만 outbox row, 둘째는 no-op(중복 row 없음).
+
+    둘째 관측은 record_fill delta<=0 으로 enqueue 자체에 도달하지 않지만, 설령
+    동일 키가 다시 enqueue 돼도 UNIQUE(fill_dedup_key) + ON CONFLICT DO NOTHING
+    으로 중복 row 가 생기지 않는다(방어). 두 측면을 모두 확인한다.
+    """
+    applier = _make_applier(db, tracker, position_history, eventbus, outbox)
+    await _seed(tracker)
+    await applier.apply_cumulative(
+        account_id=ACCT,
+        broker_order_id="0001",
+        observed_cumulative=40.0,
+        avg_price=1000.0,
+        submitted_date=DATE,
+    )
+    # 같은 누적 재관측 → record_fill no-op → outbox 미증가.
+    second = await applier.apply_cumulative(
+        account_id=ACCT,
+        broker_order_id="0001",
+        observed_cumulative=40.0,
+        avg_price=1000.0,
+        submitted_date=DATE,
+    )
+    assert second == 0.0
+    rows = await db.fetch_all("SELECT * FROM fill_outbox", ())
+    assert len(rows) == 1
+
+    # UNIQUE 방어: 같은 키를 직접 두 번 enqueue 해도 row 는 1개.
+    await outbox.enqueue(fill_dedup_key="ord-1:40.0", payload={"x": 1})
+    rows = await db.fetch_all("SELECT * FROM fill_outbox", ())
+    assert len(rows) == 1
+
+
+# ── publish 성공 → mark 순서 / 실패 시 미마킹 ─────────
+
+
+async def test_publish_failure_does_not_mark(
+    db, tracker, position_history, eventbus, outbox, trades_schema, monkeypatch
+):
+    """publish 가 예외를 던지면 mark_published 하지 않아 다음 사이클 재전달.
+
+    역순 금지(mark 가 publish 보다 먼저 일어나지 않음)를 락한다.
+    """
+    applier = _make_applier(db, tracker, position_history, eventbus, outbox)
+    await _seed(tracker)
+    await applier.apply_cumulative(
+        account_id=ACCT,
+        broker_order_id="0001",
+        observed_cumulative=40.0,
+        avg_price=1000.0,
+        submitted_date=DATE,
+    )
+
+    publisher = FillOutboxPublisher(outbox=outbox, eventbus=eventbus)
+
+    # publish 자체를 실패시킨다(EventBus 핸들러 예외가 아니라 publish 호출 실패).
+    calls = {"n": 0}
+    orig_publish = eventbus.publish
+
+    async def _boom(event):
+        calls["n"] += 1
+        raise RuntimeError("publish transport failed")
+
+    monkeypatch.setattr(eventbus, "publish", _boom)
+    redelivered = await publisher.catch_up_once()
+    assert redelivered == 0
+    assert calls["n"] == 1
+    # 실패 → 미마킹 → 여전히 미발행 row.
+    assert len(await outbox.fetch_unpublished()) == 1
+
+    # 복구 후 재전달 → 정상 발행 + 마킹.
+    monkeypatch.setattr(eventbus, "publish", orig_publish)
+    events = _collect_filled(eventbus)
+    redelivered = await publisher.catch_up_once()
+    assert redelivered == 1
+    assert len(events) == 1
+    assert await outbox.fetch_unpublished() == []
+
+
+# ── lifecycle (start/stop graceful) ──────────────────
+
+
+async def test_publisher_start_stop_lifecycle(
+    db, tracker, position_history, eventbus, outbox, trades_schema
+):
+    """start → enqueue → notify drain → stop graceful (워커 루프 동작 확인)."""
+    events = _collect_filled(eventbus)
+    publisher = FillOutboxPublisher(outbox=outbox, eventbus=eventbus, drain_interval=10)
+    applier = _make_applier(
+        db, tracker, position_history, eventbus, outbox, publisher=publisher
+    )
+    await publisher.start()
+    try:
+        await _seed(tracker)
+        await applier.apply_cumulative(
+            account_id=ACCT,
+            broker_order_id="0001",
+            observed_cumulative=40.0,
+            avg_price=1000.0,
+            submitted_date=DATE,
+        )
+        # notify 로 워커가 깨어 드레인할 때까지 잠시 양보.
+        import asyncio
+
+        for _ in range(50):
+            if events:
+                break
+            await asyncio.sleep(0.01)
+        assert len(events) == 1
+        assert events[0].fill_dedup_key == "ord-1:40.0"
+    finally:
+        await publisher.stop()
+    # stop 후 task 정리 확인 — 재호출 안전.
+    await publisher.stop()

--- a/tests/unit/test_order_tracker.py
+++ b/tests/unit/test_order_tracker.py
@@ -61,8 +61,11 @@ async def _seed(
 
 async def test_record_fill_first_advance(tracker):
     await _seed(tracker)
-    delta = await tracker.record_fill("ord-1", 40.0, 1000.0)
-    assert delta == 40.0
+    # #1949: record_fill 은 RecordFillResult(delta, confirmed_cumulative) 반환.
+    result = await tracker.record_fill("ord-1", 40.0, 1000.0)
+    assert result.delta == 40.0
+    # confirmed_cumulative 는 CAS RETURNING 확정값(= 입력 누적값과 일치).
+    assert result.confirmed_cumulative == 40.0
     rec = await tracker.get("ord-1")
     assert rec.recorded_filled_qty == 40.0
     assert rec.status == "partially_filled"
@@ -73,8 +76,10 @@ async def test_record_fill_same_cumulative_twice_delta_zero(tracker):
     await _seed(tracker)
     first = await tracker.record_fill("ord-1", 40.0, 1000.0)
     second = await tracker.record_fill("ord-1", 40.0, 1000.0)
-    assert first == 40.0
-    assert second == 0.0
+    assert first.delta == 40.0
+    assert second.delta == 0.0
+    # no-op 의 confirmed_cumulative 는 직전 확정값(40)을 그대로 반영 → 결정적 키.
+    assert second.confirmed_cumulative == 40.0
     rec = await tracker.get("ord-1")
     assert rec.recorded_filled_qty == 40.0
 
@@ -83,8 +88,9 @@ async def test_record_fill_monotonic_increase(tracker):
     """누적 증가 → 정확한 delta (40 → 100: delta 60)."""
     await _seed(tracker)
     await tracker.record_fill("ord-1", 40.0, 1000.0)
-    delta = await tracker.record_fill("ord-1", 100.0, 1010.0)
-    assert delta == 60.0
+    result = await tracker.record_fill("ord-1", 100.0, 1010.0)
+    assert result.delta == 60.0
+    assert result.confirmed_cumulative == 100.0
     rec = await tracker.get("ord-1")
     assert rec.recorded_filled_qty == 100.0
     # ordered_qty(100) 도달 → filled.
@@ -95,15 +101,18 @@ async def test_record_fill_decrease_is_noop(tracker):
     """관측 역전(누적 감소) → 단조성 유지, no-op."""
     await _seed(tracker)
     await tracker.record_fill("ord-1", 100.0, 1000.0)
-    delta = await tracker.record_fill("ord-1", 60.0, 990.0)
-    assert delta == 0.0
+    result = await tracker.record_fill("ord-1", 60.0, 990.0)
+    assert result.delta == 0.0
+    # 역전 no-op 의 확정값은 직전 누적(100) — 재전달 키 결정성 유지.
+    assert result.confirmed_cumulative == 100.0
     rec = await tracker.get("ord-1")
     assert rec.recorded_filled_qty == 100.0
 
 
 async def test_record_fill_unknown_order_returns_zero(tracker):
-    delta = await tracker.record_fill("does-not-exist", 50.0, 1000.0)
-    assert delta == 0.0
+    result = await tracker.record_fill("does-not-exist", 50.0, 1000.0)
+    assert result.delta == 0.0
+    assert result.confirmed_cumulative == 0.0
 
 
 async def test_record_fill_concurrent_no_double(tracker):
@@ -119,7 +128,7 @@ async def test_record_fill_concurrent_no_double(tracker):
         tracker.record_fill("ord-1", 60.0, 1000.0),
     )
     # 정확히 한 호출만 delta>0(=60), 나머지는 0.
-    positive = [r for r in results if r > 0]
+    positive = [r.delta for r in results if r.delta > 0]
     assert positive == [60.0]
     rec = await tracker.get("ord-1")
     assert rec.recorded_filled_qty == 60.0
@@ -278,8 +287,8 @@ async def test_expire_stale_excludes_partially_filled(tracker):
         submitted_date="20260528",
         ordered_qty=100.0,
     )
-    delta = await tracker.record_fill("ord-partial", 40.0, 1000.0)
-    assert delta == 40.0
+    result = await tracker.record_fill("ord-partial", 40.0, 1000.0)
+    assert result.delta == 40.0
     assert (await tracker.get("ord-partial")).status == "partially_filled"
 
     # 전일 genuinely-dead open (체결 없음) 도 함께 둔다.

--- a/tests/unit/test_virtual_provider_stop_guard.py
+++ b/tests/unit/test_virtual_provider_stop_guard.py
@@ -156,3 +156,43 @@ class TestVirtualProviderStopGuard:
         evt = filled[0]
         assert evt.order_type == "limit"
         assert evt.price == 1050.0
+
+
+class TestVirtualProviderFillDedupKeyPolicy:
+    """#1949: VirtualProvider 직접 발행 경로의 fill_dedup_key 빈키 정책.
+
+    VirtualExecutor 는 가상 체결을 즉시 1회 직접 발행하며 FillApplier/OrderTracker
+    (CAS) 와 outbox 를 거치지 않는다. 결정적 키(order_id:confirmed_cumulative)의
+    산출 기반(CAS 확정 누적값)이 없고 at-least-once 재전달도 없으므로, dedup 비대상
+    이며 fill_dedup_key 는 빈키("")로 발행한다.
+    """
+
+    async def test_virtual_fill_has_empty_dedup_key(self, eventbus):
+        executor = VirtualExecutor(eventbus=eventbus, commission_rate=0.00015)
+        portfolio = VirtualPortfolioView(
+            bot_id="virtual1", initial_balance=10_000_000.0
+        )
+        executor.register_bot("virtual1", portfolio)
+        executor.subscribe()
+
+        filled: list[OrderFilledEvent] = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
+
+        await eventbus.publish(
+            OrderApprovedEvent(
+                order_id="ord-virt-1",
+                account_id="acct1",
+                bot_id="virtual1",
+                strategy_id="A7",
+                symbol="069500",
+                side="buy",
+                quantity=1.0,
+                order_type="market",
+                price=1000.0,
+                reserved_amount=1000.0 * 1.00015,
+            )
+        )
+
+        assert len(filled) == 1
+        # 빈키 정책: VirtualProvider 직접 발행은 dedup 비대상.
+        assert filled[0].fill_dedup_key == ""


### PR DESCRIPTION
Closes #1949

## Summary
- FillApplier 체결 적용 트랜잭션과 **동일 원자 경계**에서 OrderFilledEvent를 outbox(`fill_outbox`)에 기록하고, `FillOutboxPublisher` 워커가 미발행 row를 **publish→mark published 순서**로 발행. 기동 시 미발행분 재전달 → **commit↔publish crash window 닫힘(이벤트 무손실, at-least-once)**.
- 결정적 `fill_dedup_key` = `{order_id}:{canonical(CAS 확정 cumulative)}` — `record_fill`이 `RETURNING recorded_filled_qty` 확정값(`RecordFillResult`)을 반환하도록 보강, IEEE754 round-trip canonical 포맷 + outbox `UNIQUE(fill_dedup_key)`로 재관측 중복 row 차단.
- VirtualProvider 직접 발행(outbox 미경유)은 빈키 정책 명시(스펙+테스트).
- **소비자(Treasury/Bot/SignalChannel) 무변경** — at-least-once 재전달 시 소비자 멱등화는 **#1957**(분리 이슈) 범위. 본 PR은 #1946 R4 bounded-limitation(이벤트 유실)을 durability로 해소.
- 스펙: eventbus 전달 시맨틱(at-least-once)·18-fill-recovery R4 해소·trade fill-recovery + db-schema 생성물 재생성.

## Test Plan
- ruff check / ruff format --check: PASS
- mypy src/ (전체 229 files): Success
- python scripts/generate_db_schema.py --check: up to date (23 tables)
- pytest tests/unit (전체): 5762 passed, 2 skipped (신규 test_fill_outbox.py 포함; crash 주입 재전달·키 결정성·VirtualProvider 빈키·UNIQUE 중복차단)
- Codex 브랜치 리뷰: PASS (blocking 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)