### PR TITLE
feat(trade): #1948 전략 get_open_orders(live) OrderTracker sync 백엔드

### DIFF
--- a/docs/specs/strategy/03-04-provider-and-views.md
+++ b/docs/specs/strategy/03-04-provider-and-views.md
@@ -33,7 +33,28 @@ StrategyContext에 주입되는 인터페이스. 라이브/백테스트/모의�
 
 | 메서드 | 파라미터 | 반환값 | 설명 |
 |--------|---------|--------|------|
-| `get_open_orders` | `bot_id: str` | `list[dict[str, Any]]` | 미체결 주문 목록 조회 |
+| `get_open_orders` | `bot_id: str` | `list[dict[str, Any]]` | 미체결 주문 목록 조회. dict 필드는 아래 **OpenOrder dict 스키마** 참조 |
+
+##### OpenOrder dict 스키마 (SSOT)
+
+`get_open_orders`가 반환하는 dict의 필드 스키마. 세 구현체(live/virtual/backtest)가 동일 스키마를 따른다. IPC `signal_channel`의 `open_orders` query도 이 dict를 `data`로 그대로 pass-through하므로(envelope 일관성), 전략·telegram·IPC 세 소비자가 공통으로 의존한다.
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `order_id` | `str` | ante 내부 주문 ID (전역 유일) |
+| `symbol` | `str` | 종목 코드 |
+| `side` | `str` | `buy` / `sell` |
+| `ordered_qty` | `float` | 주문 수량 |
+| `recorded_filled_qty` | `float` | 기록된 누적 체결 수량 |
+| `remaining_qty` | `float` | 미체결 잔량 (`ordered_qty - recorded_filled_qty`, 음수면 0) |
+| `status` | `str` | `open` / `partially_filled` (terminal은 목록에서 제외됨) |
+| `submitted_at` | `str \| None` | 주문 제출 시각 (ISO8601, nullable) |
+
+- **`amount`(예약 금액) 제외**: 예약 금액은 Treasury 도메인(`treasury` reserved)이지 주문 가시성(OrderView)이 아니다. OpenOrder 스키마는 **수량 기반**이다.
+- **scope = ante 제출 한정**: LIVE는 OrderTracker(ante 제출 미체결/체결 SSOT)를 경유하므로, 수동/외부 주문은 반영되지 않는다. 전략의 "미체결" 정의 = ante가 제출한 주문 한정.
+- **가시성 한계 (known-limitation)**:
+  - **cross-step만 보장**: 이전 step에서 제출돼 `OrderSubmittedEvent`로 OrderTracker에 seed된 주문만 가시. 같은 step 안에서 이벤트 발행 전 연속 제출하는 intra-step 중복은 미가시(전략 책임, submit-side pending guard는 별도 후속 범위).
+  - **cold-cache best-effort**: LIVE는 OrderTracker의 sync 인메모리 캐시(commit된 DB 미러)에서 조회한다. startup warm 완료 전에는 빈 결과가 가능하다. DB가 진리원이며 잔여 안전망은 reconciler.
 
 **구현체 매핑**:
 
@@ -41,4 +62,17 @@ StrategyContext에 주입되는 인터페이스. 라이브/백테스트/모의�
 |-----|---------|---------|---------|
 | DataProvider | LiveDataProvider (API Gateway 경유) | LiveDataProvider (동일) | BacktestDataProvider (Parquet) |
 | PortfolioView | LivePortfolioView (Treasury + Trade) | VirtualPortfolioView (인메모리) | BacktestPortfolioView |
-| OrderView | LiveOrderView (BrokerAdapter 경유) | VirtualOrderView (인메모리) | BacktestOrderView |
+| OrderView | LiveOrderView (**OrderTracker SSOT 경유** — sync open 캐시, account scope) | VirtualOrderView (인메모리, OrderTracker 미사용 — 즉시 체결로 open window 없음) | BacktestOrderView (`[]`, 미체결 미지원) |
+
+**OrderView 미체결 가시성 데이터 흐름** (LIVE):
+
+```
+OrderSubmittedEvent → OrderTracker.open() (DB INSERT + open 캐시 upsert)
+체결 관측(스트림/폴) → FillApplier 트랜잭션 (record_fill CAS)
+                    → commit 직후 OrderTracker.mirror_fill_to_cache() (확정값 미러, filled면 evict)
+terminal(취소/거부/실패) → OrderTracker.mark_terminal() (DB UPDATE + 캐시 evict)
+EOD 만료 → OrderTracker.expire_stale() (DB UPDATE + 캐시 evict)
+전략/telegram/IPC → ctx.get_open_orders() → LiveOrderView → OrderTracker sync 캐시 (account scope, OPEN_STATUSES만)
+```
+
+캐시는 **commit된 DB 상태의 미러**일 뿐 진리원이 아니다. 체결 미러는 FillApplier 트랜잭션이 정상 COMMIT된 직후에만 일어나므로, rollback 시 캐시는 DB와 일관되게 불변이다.

--- a/docs/specs/strategy/03-design-decisions.md
+++ b/docs/specs/strategy/03-design-decisions.md
@@ -68,7 +68,7 @@
 
 #### OrderView 메서드 시그니처
 
-상세 내용: [03-04-provider-and-views.md](03-04-provider-and-views.md)
+`get_open_orders`는 통일 **OpenOrder dict 스키마**(`order_id`, `symbol`, `side`, `ordered_qty`, `recorded_filled_qty`, `remaining_qty`, `status`, `submitted_at` — `amount` 제외)를 반환한다. LIVE는 **OrderTracker SSOT 경유**(ante 제출 미체결 한정, cross-step 가시성). 상세 스키마·매핑·known-limitation: [03-04-provider-and-views.md](03-04-provider-and-views.md)
 
 ### StrategyContext — 전략에 노출되는 제한된 API
 

--- a/docs/specs/strategy/strategy.md
+++ b/docs/specs/strategy/strategy.md
@@ -73,7 +73,7 @@
 
 #### OrderView 메서드 시그니처
 
-상세 내용: [03-design-decisions.md](03-design-decisions.md)
+`get_open_orders`는 통일 **OpenOrder dict 스키마**(`order_id`, `symbol`, `side`, `ordered_qty`, `recorded_filled_qty`, `remaining_qty`, `status`, `submitted_at` — `amount` 제외)를 반환한다. LIVE는 **OrderTracker SSOT 경유**(ante 제출 미체결 한정, cross-step 가시성). 상세 스키마·매핑·known-limitation: [03-design-decisions.md](03-design-decisions.md)
 
 ### StrategyContext — 전략에 노출되는 제한된 API
 

--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ante.account.models import TradingMode
 from ante.bot.config import BotConfig
@@ -13,6 +13,7 @@ from ante.bot.providers.virtual import (
     VirtualOrderView,
     VirtualPortfolioView,
 )
+from ante.strategy.base import OrderView
 from ante.strategy.context import StrategyContext
 
 if TYPE_CHECKING:
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
     from ante.data.store import ParquetStore
     from ante.gateway.gateway import APIGateway
     from ante.strategy.base import DataProvider
+    from ante.trade.order_tracker import OrderTracker
     from ante.trade.position import PositionHistory
     from ante.treasury.manager import TreasuryManager
 
@@ -55,6 +57,7 @@ class StrategyContextFactory:
         position_history: PositionHistory | None = None,
         api_gateway: APIGateway | None = None,
         parquet_store: ParquetStore | None = None,
+        order_tracker: OrderTracker | None = None,
     ) -> None:
         self._data_provider = data_provider
         self._account_service = account_service
@@ -66,6 +69,10 @@ class StrategyContextFactory:
         self._position_history = position_history
         self._api_gateway = api_gateway
         self._parquet_store = parquet_store
+        # #1948: 주입되면 봇별 LiveOrderView 를 account_id closure 로 생성해
+        # OrderTracker sync 캐시에서 미체결을 조회한다. 미주입(virtual-only/legacy)
+        # 이면 공유 fallback ``live_order_view`` (없으면 빈 결과 stub)를 쓴다.
+        self._order_tracker = order_tracker
 
     def create(self, config: BotConfig) -> StrategyContext:
         """BotConfig 기반으로 적절한 StrategyContext 생성.
@@ -113,18 +120,38 @@ class StrategyContextFactory:
         msg = "Live 봇 생성에 필요한 Portfolio Provider가 설정되지 않았습니다"
         raise ValueError(msg)
 
+    def _resolve_live_order_view(self, config: BotConfig) -> OrderView:
+        """봇별 LiveOrderView 를 결정 (#1948).
+
+        ``order_tracker`` 가 주입돼 있으면 ``config.account_id`` 를 closure 로
+        binding 한 **봇별** ``LiveOrderView`` 를 생성한다(``LiveDataProvider`` 패턴
+        미러). 단일계좌 다중봇에서 봇별 account scope 격리를 보장한다. 미주입이면
+        공유 fallback ``live_order_view`` 를, 그것도 없으면 빈 결과 stub 을 쓴다
+        (virtual-only/legacy 환경 호환 — 회귀 방지).
+        """
+        if self._order_tracker is not None:
+            from ante.bot.providers.live import LiveOrderView
+
+            return LiveOrderView(
+                order_tracker=self._order_tracker,
+                account_id=config.account_id,
+            )
+        if self._live_order_view is not None:
+            return self._live_order_view
+        return _EmptyOrderView()
+
     def _create_live_context(self, config: BotConfig) -> StrategyContext:
         """Live 봇용 StrategyContext 생성.
 
         ``APIGateway`` 가 주입돼 있으면 봇별로 새 ``LiveDataProvider``
         인스턴스를 만들어 ``config.account_id`` 를 closure 로 binding 한다.
         그 외 환경에서는 공유 ``self._data_provider`` 를 그대로 사용한다.
+
+        OrderView 도 동일하게 ``order_tracker`` 주입 시 봇별 ``LiveOrderView`` 를
+        생성해 ``account_id`` 를 closure 로 격리한다(#1948).
         """
         portfolio = self._get_live_portfolio(config)
-
-        if self._live_order_view is None:
-            msg = "Live 봇 생성에 필요한 Provider가 설정되지 않았습니다"
-            raise ValueError(msg)
+        order_view = self._resolve_live_order_view(config)
 
         data_provider = self._data_provider
         if self._api_gateway is not None:
@@ -140,7 +167,7 @@ class StrategyContextFactory:
             bot_id=config.bot_id,
             data_provider=data_provider,
             portfolio=portfolio,
-            order_view=self._live_order_view,
+            order_view=order_view,
             trade_history=self._live_trade_history,
         )
         logger.info("Live StrategyContext 생성: %s", config.bot_id)
@@ -206,3 +233,14 @@ class StrategyContextFactory:
                     config.account_id,
                 )
         return 0.0
+
+
+class _EmptyOrderView(OrderView):
+    """order_tracker 와 공유 live_order_view 가 모두 미주입일 때의 fallback.
+
+    virtual-only/legacy 환경에서 LIVE 컨텍스트 생성이 ValueError 로 깨지지 않도록
+    빈 미체결 목록을 반환한다(#1948 회귀 방지).
+    """
+
+    def get_open_orders(self, bot_id: str) -> list[dict[str, Any]]:
+        return []

--- a/src/ante/bot/providers/live.py
+++ b/src/ante/bot/providers/live.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from ante.strategy.base import OrderView, PortfolioView, TradeHistoryView
 
 if TYPE_CHECKING:
-    from ante.broker.order_registry import OrderRegistry
+    from ante.trade.order_tracker import OrderTracker
     from ante.trade.position import PositionHistory
     from ante.trade.recorder import TradeRecorder
     from ante.treasury.treasury import Treasury
@@ -57,18 +57,29 @@ class LivePortfolioView(PortfolioView):
 
 
 class LiveOrderView(OrderView):
-    """Live 봇용 OrderView. Broker OrderRegistry에서 미체결 주문 조회."""
+    """Live 봇용 OrderView. OrderTracker(ante 제출 미체결 SSOT) 경유 (#1948).
 
-    def __init__(self, order_registry: OrderRegistry) -> None:
-        self._registry = order_registry
+    ``account_id`` 는 봇별 컨텍스트 생성 시 ``StrategyContextFactory`` 가 closure
+    로 binding 한다(``LiveDataProvider`` 패턴 미러). ``get_open_orders`` 는
+    OrderTracker 의 sync 인메모리 open 캐시(commit 된 DB 미러)를
+    ``(account_id, bot_id)`` 스코프로 조회한다 — DB I/O 없이 이벤트 루프 위
+    await 된 코루틴 내부에서 안전하게 sync 호출된다.
+
+    **scope 경계**: OrderTracker 는 ante 가 제출한 주문만 추적한다. 수동/외부
+    주문은 반영되지 않는다(전략 "미체결" 정의 = ante 제출 한정). cold-cache(warm
+    완료 전) 시 빈 결과가 가능하다(best-effort, reconciler net) — known-limitation.
+    """
+
+    def __init__(self, order_tracker: OrderTracker, account_id: str) -> None:
+        self._order_tracker = order_tracker
+        self._account_id = account_id
 
     def get_open_orders(self, bot_id: str) -> list[dict[str, Any]]:
-        """미체결 주문 목록 조회.
-
-        OrderRegistry는 DB 기반이므로 동기 조회가 제한적이다.
-        현재는 빈 목록을 반환하며, 실시간 주문 추적은 Phase 2에서 구현.
-        """
-        return []
+        """ante 제출 미체결 주문 목록 조회 (통일 OpenOrder dict 스키마)."""
+        records = self._order_tracker.get_open_orders_for_bot_sync(
+            self._account_id, bot_id
+        )
+        return [r.to_open_order_dict() for r in records]
 
 
 class LiveTradeHistoryView(TradeHistoryView):

--- a/src/ante/bot/providers/virtual.py
+++ b/src/ante/bot/providers/virtual.py
@@ -104,17 +104,39 @@ class VirtualPortfolioView(PortfolioView):
 
 
 class VirtualOrderView(OrderView):
-    """Virtual 계좌 봇용 OrderView. VirtualPortfolioView의 미체결 주문 추적."""
+    """Virtual 계좌 봇용 OrderView. VirtualPortfolioView의 미체결 주문 추적.
+
+    #1948: VirtualExecutor 는 ``OrderApprovedEvent`` 를 즉시 가상 체결하고
+    ``OrderSubmittedEvent`` 를 발행하지 않으므로(발행처는 live gateway 단독),
+    virtual 주문은 OrderTracker 에 들어가지 않는다 → OrderTracker 백엔드 미사용.
+    virtual 은 즉시 체결로 open window 가 사실상 없어
+    ``_pending_orders`` (프로덕션 대개 빈)를 **통일 OpenOrder dict 스키마**로
+    best-effort 매핑한다. amount(예약 금액)는 OrderView 스키마에서 제외한다.
+    """
 
     def __init__(self, portfolio: VirtualPortfolioView) -> None:
         self._portfolio = portfolio
 
     def get_open_orders(self, bot_id: str) -> list[dict[str, Any]]:
-        """미체결 주문 목록 조회."""
-        return [
-            {"order_id": oid, **info}
-            for oid, info in self._portfolio._pending_orders.items()
-        ]
+        """미체결 주문 목록 조회 (통일 OpenOrder dict 스키마)."""
+        result: list[dict[str, Any]] = []
+        for oid, info in self._portfolio._pending_orders.items():
+            ordered_qty = float(info.get("ordered_qty", 0.0))
+            recorded = float(info.get("recorded_filled_qty", 0.0))
+            remaining = ordered_qty - recorded
+            result.append(
+                {
+                    "order_id": oid,
+                    "symbol": info.get("symbol", ""),
+                    "side": info.get("side", ""),
+                    "ordered_qty": ordered_qty,
+                    "recorded_filled_qty": recorded,
+                    "remaining_qty": remaining if remaining > 0 else 0.0,
+                    "status": info.get("status", "open"),
+                    "submitted_at": info.get("submitted_at"),
+                }
+            )
+        return result
 
 
 class VirtualExecutor:

--- a/src/ante/core/database.py
+++ b/src/ante/core/database.py
@@ -80,6 +80,24 @@ class Database:
             await conn.commit()
         return result
 
+    async def execute_fetch_all(self, sql: str, params: tuple = ()) -> list[dict]:
+        """writer 연결에서 실행 후 다중 행을 반환 (다건 RETURNING 등 atomic 패턴용).
+
+        ``execute_fetch_one`` 의 다건 버전. ``execute`` 와 동일하게 **writer
+        연결**에서 단일 호출로 실행하므로, 한 번의 UPDATE/DELETE ... RETURNING 으로
+        실제 영향받은 행들을 원자적으로 받는다(읽기↔쓰기 분리 race 없음). reader
+        연결을 쓰는 ``fetch_all`` 은 진행 중인 writer 트랜잭션의 uncommitted row 를
+        보지 못하므로, 영향 행 집합을 RETURNING 으로 받아야 하는 경로는 이 메서드를
+        쓴다. ``_in_transaction`` 이 아니면 ``execute`` 와 동일하게 commit한다.
+        """
+        conn = self._get_writer()
+        async with conn.execute(sql, params) as cursor:
+            rows = await cursor.fetchall()
+            result = [dict(row) for row in rows]
+        if not self._in_transaction:
+            await conn.commit()
+        return result
+
     async def fetch_all(self, sql: str, params: tuple = ()) -> list[dict]:
         """다중 행 조회."""
         conn = self._get_reader()

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -162,7 +162,6 @@ class Services:
     bot_manager: Any = None
     virtual_executor: Any = None
     live_portfolio: Any = None
-    live_order_view: Any = None
     strategy_snapshot: Any = None
     api_gateway: Any = None
     # SPLIT-3 (#1242): multi-account StreamIntegration pool. KIS 활성 계좌마다
@@ -533,9 +532,9 @@ async def _init_trading(s: Services) -> None:
     )
     s.virtual_executor.subscribe()
 
-    from ante.bot.providers.live import LiveOrderView
-
-    s.live_order_view = LiveOrderView(order_registry=None)  # type: ignore[arg-type]  # Broker 연결 후 설정
+    # #1948: 봇별 LiveOrderView 는 StrategyContextFactory 가 order_tracker +
+    # config.account_id 로 생성한다(account scope closure binding). 과거의 단일
+    # 공유 LiveOrderView(order_registry=None — 항상 빈 결과)는 제거됐다.
 
     strategies_dir = Path(s.config.get("strategy.dir", "strategies"))
     s.strategy_snapshot = StrategySnapshot(strategies_dir)
@@ -1056,13 +1055,15 @@ def _init_context_factory(s: Services) -> None:
         data_provider=s.data_provider,
         account_service=s.account_service,
         live_portfolio=s.live_portfolio,
-        live_order_view=s.live_order_view,
         virtual_executor=s.virtual_executor,
         live_trade_history=live_trade_history,
         treasury_manager=s.treasury_manager,
         position_history=s.position_history,
         api_gateway=s.api_gateway,
         parquet_store=s.parquet_store,
+        # #1948: LIVE get_open_orders 백엔드 — 봇별 LiveOrderView 가 이 tracker 의
+        # sync open 캐시를 account scope 로 조회한다.
+        order_tracker=s.order_tracker,
     )
     s.bot_manager._context_factory = context_factory
     logger.info("StrategyContextFactory 설정 완료")

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -623,7 +623,10 @@ class TelegramCommandReceiver:
 
         # 보유 종목 있음 — 메시지 B
         symbols = sorted(positions.keys())
-        pending_amount = sum(order.get("amount", 0) for order in open_orders)
+        # #1948: 통일 OpenOrder dict 스키마는 amount(예약 금액)를 담지 않는다
+        # (Treasury 도메인). 미체결 가시성은 주문 건수로 표시한다. live 봇은 과거
+        # amount 부재로 0원 오표시였으므로, 건수 표시가 의미상 정확한 정정이다.
+        pending_count = len(open_orders)
 
         lines = [
             header,
@@ -632,7 +635,7 @@ class TelegramCommandReceiver:
             "중지 후 포지션을 직접 관리해야 합니다.",
             "",
             f"보유: {', '.join(symbols)}",
-            f"체결대기: {pending_amount:,.0f}원",
+            f"체결대기 주문: {pending_count}건",
         ]
         return "\n".join(lines)
 

--- a/src/ante/trade/fill_applier.py
+++ b/src/ante/trade/fill_applier.py
@@ -183,6 +183,13 @@ class FillApplier:
         outbox 에 INSERT 한다(원자 커밋). commit 성공 = 이벤트 영속 보장이므로
         commit↔publish 사이 crash window 가 닫힌다. 발행은 트랜잭션 밖에서
         publisher 워커(at-least-once)에 위임한다.
+
+        #1948 open 캐시 미러: ``record_fill`` 은 트랜잭션 내부 호출이라 캐시를
+        건드리지 않는다(rollback 시 stale 방지). LIVE ``get_open_orders`` 의 sync
+        캐시는 트랜잭션 블록이 **정상 COMMIT 된 직후** ``mirror_fill_to_cache`` 로만
+        갱신한다. rollback(``_save_trade``/position/outbox 실패) 시 commit 이후
+        지점에 도달하지 못해 캐시는 불변 — DB(원복)와 일관된다. 스트림/폴 양
+        경로의 공통 코어라 미러 호출은 이 한 지점뿐이다.
         """
         from ante.trade.fill_outbox import make_fill_dedup_key
         from ante.trade.order_tracker import OrderTrackerRecord
@@ -225,7 +232,14 @@ class FillApplier:
                     fill_dedup_key=fill_dedup_key, payload=payload
                 )
 
-        # commit 성공. outbox 경유면 워커가 발행(crash window 닫힘), 미주입이면
+        # commit 성공 (rollback 시 이 지점 미도달). #1948: LIVE get_open_orders 의
+        # sync open 캐시를 CAS 확정값(confirmed_cumulative)/확정 status 로 미러링.
+        # delta>0 경로만 도달하므로 항상 유효한 advance 다.
+        self._tracker.mirror_fill_to_cache(
+            order_id, result.confirmed_cumulative, result.new_status
+        )
+
+        # outbox 경유면 워커가 발행(crash window 닫힘), 미주입이면
         # 기존처럼 commit 직후 직접 발행한다.
         if self._outbox is not None:
             if self._publisher is not None:

--- a/src/ante/trade/order_tracker.py
+++ b/src/ante/trade/order_tracker.py
@@ -161,8 +161,9 @@ class OrderTracker:
        캐시를 바꾸면 rollback 시 stale. 체결 미러는 commit 직후 FillApplier 가
        ``mirror_fill_to_cache`` 로 한다(post-commit 전용).
     3. ``mark_terminal`` — DB write 후 ``_evict_open_cache``.
-    4. ``expire_stale``  — batch UPDATE 영향 order_id 를 ``RETURNING`` 으로 받아
-       일괄 ``_evict_open_cache``.
+    4. ``expire_stale``  — 단일 ``UPDATE … RETURNING`` 으로 **실제 expired 된**
+       order_id 만 받아 그 ID 만 ``_evict_open_cache``. 사전 SELECT 가 없어
+       SELECT↔UPDATE 사이 fill commit(open→partial/filled) TOCTOU 가 없다.
 
     **invariant**: ``open``/``mark_terminal``/``expire_stale`` 는 자체 commit 을
     소유한다 — 외부 ``Database.transaction()`` 내부에서 호출하지 않는다. Database 는
@@ -568,26 +569,25 @@ class OrderTracker:
         체결분을 영구 만료/오분류하지 않는다(I7). 만료 건수를 반환한다.
         """
         validated = require_account_id(account_id, context="order_tracker.expire_stale")
-        # #1948: 사전 SELECT 로 만료 대상 order_id 를 받아, DB UPDATE 성공 후
-        # 일괄 ``_evict_open_cache`` 한다(batch terminal 전이 캐시 정합).
-        # 사전 SELECT 와 후속 UPDATE 의 WHERE 절은 동일 조건(account/date/status='open')
-        # 이므로 standalone 단일 writer 경로에서 집합이 일치한다.
-        targets = await self._db.fetch_all(
-            """SELECT order_id FROM order_tracker
+        # #1948: 단일 원자 UPDATE ... RETURNING. 사전 SELECT 를 두면 SELECT↔UPDATE
+        # 사이에 다른 코루틴(FillApplier)이 fill 을 commit 해 open→partially_filled/
+        # filled 로 전이시킬 때, UPDATE(WHERE status='open')는 그 주문을 건드리지
+        # 않는데도 pre-SELECT 결과로 evict 해 여전히 open(또는 partial)인 주문이
+        # 캐시에서 사라진다(캐시=commit 된 DB open 미러 invariant 위반). UPDATE 가
+        # 실제로 expired 한 order_id 만 RETURNING 으로 받아 그 ID 들만 evict 하면
+        # TOCTOU race 자체가 구조적으로 사라진다. writer 연결 단일 호출이라
+        # 읽기↔쓰기 분리도 없다.
+        expired = await self._db.execute_fetch_all(
+            """UPDATE order_tracker
+                   SET status = 'expired', terminal_at = datetime('now')
                  WHERE account_id = ? AND submitted_date < ?
-                   AND status = 'open'""",
+                   AND status = 'open'
+            RETURNING order_id""",
             (validated, before_date),
         )
-        count = len(targets)
+        count = len(expired)
         if count:
-            await self._db.execute(
-                """UPDATE order_tracker
-                       SET status = 'expired', terminal_at = datetime('now')
-                     WHERE account_id = ? AND submitted_date < ?
-                       AND status = 'open'""",
-                (validated, before_date),
-            )
-            for row in targets:
+            for row in expired:
                 self._evict_open_cache(row["order_id"])
             logger.info(
                 "OrderTracker EOD 만료: account=%s, %d건 (before=%s)",

--- a/src/ante/trade/order_tracker.py
+++ b/src/ante/trade/order_tracker.py
@@ -72,10 +72,15 @@ class RecordFillResult:
             outbox/이벤트의 결정적 ``fill_dedup_key`` 는 **이 확정값**으로 생성해야
             한다(입력 ``observed_cumulative`` 가 아니다). 동일 advance 경계는 항상
             같은 확정값을 내므로, 재전달 시 키가 결정적이다.
+        new_status: advance 후 확정된 주문 상태(``filled`` 또는
+            ``partially_filled``). no-op(``delta<=0``)이면 직전 status 를 반영한다.
+            #1948 의 ``FillApplier`` post-commit ``mirror_fill_to_cache`` 에서
+            캐시 상태/evict 판단에 쓴다.
     """
 
     delta: float
     confirmed_cumulative: float
+    new_status: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,21 +121,99 @@ class OrderTrackerRecord:
             submitted_date=row["submitted_date"],
         )
 
+    def to_open_order_dict(self) -> dict[str, object]:
+        """통일 OpenOrder dict 스키마로 매핑 (#1948).
+
+        OrderView ``get_open_orders`` 의 SSOT 스키마. 전략/telegram/IPC 소비자가
+        공통으로 의존한다. ``remaining_qty = ordered_qty - recorded_filled_qty``
+        (중복방어 판단용). ``amount`` (예약 금액)는 Treasury 도메인이지
+        OrderView 가시성이 아니므로 **제외**한다.
+
+        스키마 SSOT: ``docs/specs/strategy/03-04-provider-and-views.md``.
+        """
+        remaining = self.ordered_qty - self.recorded_filled_qty
+        return {
+            "order_id": self.order_id,
+            "symbol": self.symbol,
+            "side": self.side,
+            "ordered_qty": self.ordered_qty,
+            "recorded_filled_qty": self.recorded_filled_qty,
+            "remaining_qty": remaining if remaining > 0 else 0.0,
+            "status": self.status,
+            "submitted_at": self.submitted_at,
+        }
+
 
 class OrderTracker:
     """추적 주문 영속 저장소 + 누적 체결 단조 advance.
 
     ``record_fill`` 은 ``FillApplier`` 의 단일 트랜잭션 + ``asyncio.Lock`` 안에서만
     호출되어야 한다 (멱등·crash 원자성은 FillApplier 가 보장).
+
+    인메모리 open 캐시 (#1948): LIVE ``ctx.get_open_orders()`` 의 sync 백엔드.
+    캐시는 **commit 된 DB 상태의 미러**일 뿐 진리원이 아니다(DB 가 SSOT).
+    캐시 키 = ``(account_id, bot_id, order_id)`` — 단일계좌 다중봇에서 타-봇 누출
+    방지. 캐시 진입 경로는 4개뿐이며 모두 **DB commit 확정 이후** 반영한다:
+
+    1. ``open``      — ``INSERT … RETURNING`` 으로 write 성공 확인 후 upsert
+                       (중복 OrderSubmittedEvent 의 blind 덮어쓰기 방지).
+    2. ``record_fill`` → **캐시 미접근**. FillApplier 트랜잭션 내부 호출이라 여기서
+       캐시를 바꾸면 rollback 시 stale. 체결 미러는 commit 직후 FillApplier 가
+       ``mirror_fill_to_cache`` 로 한다(post-commit 전용).
+    3. ``mark_terminal`` — DB write 후 ``_evict_open_cache``.
+    4. ``expire_stale``  — batch UPDATE 영향 order_id 를 ``RETURNING`` 으로 받아
+       일괄 ``_evict_open_cache``.
+
+    **invariant**: ``open``/``mark_terminal``/``expire_stale`` 는 자체 commit 을
+    소유한다 — 외부 ``Database.transaction()`` 내부에서 호출하지 않는다. Database 는
+    중첩 트랜잭션을 ``RuntimeError`` 로 거부하므로(``core/database.py``) 위반 시
+    silent stale 이 아니라 loud 실패로 드러난다.
     """
 
     def __init__(self, db: Database) -> None:
         self._db = db
+        # 인메모리 open 캐시. key=(account_id, bot_id, order_id) → 레코드.
+        # commit 된 open/partially_filled 만 보관(terminal 은 evict).
+        self._open_cache: dict[tuple[str, str, str], OrderTrackerRecord] = {}
 
     async def initialize(self) -> None:
-        """스키마 생성."""
+        """스키마 생성 + open 캐시 warm.
+
+        DB 의 open/partially_filled row 로 캐시를 적재한다. warm 완료 전 sync
+        조회는 빈 결과(cold)일 수 있으며, 이는 best-effort 한계다(DB 가 진리원,
+        잔여 안전망은 reconciler). #1948 known-limitation.
+        """
         await self._db.execute_script(ORDER_TRACKER_SCHEMA)
-        logger.info("OrderTracker 초기화 완료")
+        await self._warm_open_cache()
+        logger.info("OrderTracker 초기화 완료 (open 캐시 %d건)", len(self._open_cache))
+
+    async def _warm_open_cache(self) -> None:
+        """DB 의 non-terminal 주문을 인메모리 open 캐시에 적재."""
+        placeholders = ", ".join("?" for _ in OPEN_STATUSES)
+        rows = await self._db.fetch_all(
+            f"""SELECT * FROM order_tracker
+                 WHERE status IN ({placeholders})""",
+            tuple(sorted(OPEN_STATUSES)),
+        )
+        self._open_cache.clear()
+        for row in rows:
+            record = OrderTrackerRecord.from_row(row)
+            self._open_cache[self._cache_key(record)] = record
+
+    @staticmethod
+    def _cache_key(record: OrderTrackerRecord) -> tuple[str, str, str]:
+        """캐시 키 = (account_id, bot_id, order_id)."""
+        return (record.account_id, record.bot_id, record.order_id)
+
+    def _evict_open_cache(self, order_id: str) -> None:
+        """terminal 전이 공통 헬퍼 — order_id 의 캐시 엔트리를 제거.
+
+        ``mark_terminal``/``expire_stale`` 가 DB write 성공 직후 호출한다. 캐시
+        키는 (account_id, bot_id, order_id) 라 order_id 단독으로는 직접 찾을 수
+        없으므로 order_id 일치 엔트리를 모두 제거한다(order_id 는 PK 라 유일).
+        """
+        for key in [k for k in self._open_cache if k[2] == order_id]:
+            del self._open_cache[key]
 
     async def open(
         self,
@@ -152,15 +235,22 @@ class OrderTracker:
         order_id PK 재제출(중복 이벤트)은 무시한다 (``ON CONFLICT DO NOTHING``).
         같은 ``(account_id, broker_order_id, submitted_date)`` UNIQUE 충돌도
         동일하게 무시되어 seed 멱등성을 보장한다.
+
+        #1948: ``RETURNING`` 으로 **실제 INSERT 가 일어났을 때에만** open 캐시에
+        upsert 한다. 중복 OrderSubmittedEvent(ON CONFLICT DO NOTHING — row 미반환)
+        는 캐시를 건드리지 않아, 이후 advance 된 캐시 상태를 blind 하게 덮어쓰지
+        않는다. **외부 ``Database.transaction()`` 안에서 호출 금지(자체 commit
+        소유)** — 위반 시 nested-txn RuntimeError 로 loud 실패.
         """
         validated = require_account_id(account_id, context="order_tracker.open")
-        await self._db.execute(
+        inserted = await self._db.execute_fetch_one(
             """INSERT INTO order_tracker
                    (order_id, account_id, bot_id, strategy_id, broker_order_id,
                     symbol, side, order_type, ordered_qty, recorded_filled_qty,
                     avg_fill_price, status, submitted_at, submitted_date)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0.0, 0.0, 'open', ?, ?)
-               ON CONFLICT DO NOTHING""",
+               ON CONFLICT DO NOTHING
+               RETURNING order_id""",
             (
                 order_id,
                 validated,
@@ -175,14 +265,34 @@ class OrderTracker:
                 submitted_date,
             ),
         )
+        if inserted is not None:
+            # DB write 확정 — 캐시 upsert (open, recorded=0).
+            record = OrderTrackerRecord(
+                order_id=order_id,
+                account_id=validated,
+                bot_id=bot_id,
+                strategy_id=strategy_id,
+                broker_order_id=broker_order_id,
+                symbol=symbol,
+                side=side,
+                order_type=order_type,
+                ordered_qty=ordered_qty,
+                recorded_filled_qty=0.0,
+                avg_fill_price=0.0,
+                status="open",
+                submitted_at=submitted_at,
+                submitted_date=submitted_date,
+            )
+            self._open_cache[self._cache_key(record)] = record
         logger.debug(
-            "주문 추적 seed: %s / odno=%s %s %s qty=%s (account=%s)",
+            "주문 추적 seed: %s / odno=%s %s %s qty=%s (account=%s, inserted=%s)",
             order_id,
             broker_order_id,
             side,
             symbol,
             ordered_qty,
             validated,
+            inserted is not None,
         )
 
     async def record_fill(
@@ -207,6 +317,13 @@ class OrderTracker:
         writer 연결에서 현재값을 읽고(``execute_fetch_one``) 진행 중인 트랜잭션의
         일관된 상태를 본 뒤 CAS UPDATE 하므로, 단일 writer + Lock 으로 read↔update
         사이 race 가 없다.
+
+        #1948 invariant: 이 메서드는 **인메모리 open 캐시를 절대 건드리지 않는다.**
+        FillApplier 트랜잭션 내부 호출이라, 여기서 캐시를 advance/evict 하면 이후
+        ``_save_trade``/position/outbox 실패로 트랜잭션이 rollback 될 때 DB 는
+        원복돼도 캐시는 stale advance 로 남아 sync 조회가 잘못된 값을 본다. 체결
+        캐시 미러는 **commit 성공 직후** FillApplier 가 ``mirror_fill_to_cache`` 로
+        한다.
         """
         row = await self._db.execute_fetch_one(
             """SELECT recorded_filled_qty, ordered_qty, status
@@ -214,14 +331,18 @@ class OrderTracker:
             (order_id,),
         )
         if row is None:
-            return RecordFillResult(delta=0.0, confirmed_cumulative=0.0)
+            return RecordFillResult(delta=0.0, confirmed_cumulative=0.0, new_status="")
 
         prev = float(row["recorded_filled_qty"] or 0.0)
         ordered = float(row["ordered_qty"] or 0.0)
         delta = new_cumulative - prev
         if delta <= 0:
             # 관측 역전 또는 이미 반영됨 — 단조성 유지, no-op. 확정값은 직전 recorded.
-            return RecordFillResult(delta=0.0, confirmed_cumulative=prev)
+            return RecordFillResult(
+                delta=0.0,
+                confirmed_cumulative=prev,
+                new_status=str(row["status"]),
+            )
 
         # terminal(취소/거부/실패/만료) 이후에도 잔여 체결이 관측되면 부분/완료로
         # 되돌린다. CAS WHERE 절은 단조성(recorded < :c)만 강제한다.
@@ -252,15 +373,66 @@ class OrderTracker:
         if updated is None:
             # 동시 advance 로 다른 호출이 먼저 recorded 를 올림 — 단조성 보존, no-op.
             # (단일 Lock 경로에선 발생하지 않으나 방어적으로 처리.)
-            return RecordFillResult(delta=0.0, confirmed_cumulative=prev)
+            return RecordFillResult(
+                delta=0.0, confirmed_cumulative=prev, new_status=str(row["status"])
+            )
         # CAS RETURNING 으로 확정된 누적값. fill_dedup_key 의 결정적 기준.
         confirmed = float(updated["recorded_filled_qty"] or 0.0)
-        return RecordFillResult(delta=delta, confirmed_cumulative=confirmed)
+        return RecordFillResult(
+            delta=delta, confirmed_cumulative=confirmed, new_status=new_status
+        )
+
+    def mirror_fill_to_cache(
+        self,
+        order_id: str,
+        confirmed_cumulative: float,
+        new_status: str,
+    ) -> None:
+        """**post-commit 전용** 체결 캐시 미러 (#1948, sync).
+
+        FillApplier 가 ``Database.transaction()`` 블록이 **정상 COMMIT 된 직후**에만
+        호출한다(rollback 경로에서는 호출되지 않는다). 캐시의
+        ``recorded_filled_qty``/``status`` 를 **CAS 확정값**(``confirmed_cumulative``)
+        으로 미러링하고, terminal(``filled``)이면 evict 한다. 입력 observed 값이
+        아니라 DB 가 RETURNING 으로 확정한 값만 반영해 단조성을 보존한다.
+
+        캐시 miss(cold-cache 등 캐시에 해당 order 가 없는 경우)는 보수적으로
+        무시한다 — DB 가 진리원이며, 다음 warm/조회는 DB 기준이다(best-effort).
+        """
+        for key, record in list(self._open_cache.items()):
+            if key[2] != order_id:
+                continue
+            if new_status == "filled" or new_status in TERMINAL_STATUSES:
+                # 완료/종료 — open window 종료, evict.
+                del self._open_cache[key]
+                return
+            self._open_cache[key] = OrderTrackerRecord(
+                order_id=record.order_id,
+                account_id=record.account_id,
+                bot_id=record.bot_id,
+                strategy_id=record.strategy_id,
+                broker_order_id=record.broker_order_id,
+                symbol=record.symbol,
+                side=record.side,
+                order_type=record.order_type,
+                ordered_qty=record.ordered_qty,
+                recorded_filled_qty=confirmed_cumulative,
+                avg_fill_price=record.avg_fill_price,
+                status=new_status or record.status,
+                submitted_at=record.submitted_at,
+                submitted_date=record.submitted_date,
+            )
+            return
 
     async def mark_terminal(self, order_id: str, status: str) -> None:
         """주문을 종료 상태로 표기 (취소/거부/실패/만료).
 
         이미 ``filled`` 인 주문은 덮어쓰지 않는다 (체결 완료가 우선).
+
+        #1948: DB write 후 ``_evict_open_cache`` 로 캐시에서 제거(terminal 은 open
+        이 아니므로). **외부 ``Database.transaction()`` 안에서 호출 금지(자체 commit
+        소유)**. 이미 ``filled`` 였던 주문은 캐시에 없으므로 evict 가 no-op 이고,
+        non-terminal 이었던 주문만 제거된다.
         """
         if status not in TERMINAL_STATUSES:
             raise ValueError(f"비-terminal status: {status!r}")
@@ -270,6 +442,29 @@ class OrderTracker:
                 WHERE order_id = ? AND status != 'filled'""",
             (status, order_id),
         )
+        self._evict_open_cache(order_id)
+
+    def get_open_orders_for_bot_sync(
+        self, account_id: str, bot_id: str
+    ) -> list[OrderTrackerRecord]:
+        """``(account_id, bot_id)`` 의 non-terminal 주문 sync 조회 (#1948).
+
+        LIVE ``ctx.get_open_orders()`` 의 백엔드. 이벤트 루프 스레드 위 await 된
+        코루틴 내부에서 전략이 sync 호출하므로 **DB I/O 없이 인메모리 캐시만** 읽는다.
+        캐시는 OPEN_STATUSES(open/partially_filled) 만 보관하므로 terminal 은
+        자연히 제외된다. ``(account_id, bot_id)`` 스코프로 필터해 단일계좌 다중봇에서
+        타-봇 주문 누출을 막는다. cold-cache 시 빈 결과(best-effort) — known-limitation.
+        """
+        validated = require_account_id(
+            account_id, context="order_tracker.get_open_orders_for_bot_sync"
+        )
+        records = [
+            record
+            for (acct, bid, _oid), record in self._open_cache.items()
+            if acct == validated and bid == bot_id
+        ]
+        records.sort(key=lambda r: (r.submitted_at or "", r.order_id))
+        return records
 
     async def get_open_orders(self, account_id: str) -> list[OrderTrackerRecord]:
         """계좌의 non-terminal(open/partially_filled) 주문."""
@@ -373,13 +568,17 @@ class OrderTracker:
         체결분을 영구 만료/오분류하지 않는다(I7). 만료 건수를 반환한다.
         """
         validated = require_account_id(account_id, context="order_tracker.expire_stale")
-        before = await self._db.fetch_one(
-            """SELECT COUNT(*) AS c FROM order_tracker
+        # #1948: 사전 SELECT 로 만료 대상 order_id 를 받아, DB UPDATE 성공 후
+        # 일괄 ``_evict_open_cache`` 한다(batch terminal 전이 캐시 정합).
+        # 사전 SELECT 와 후속 UPDATE 의 WHERE 절은 동일 조건(account/date/status='open')
+        # 이므로 standalone 단일 writer 경로에서 집합이 일치한다.
+        targets = await self._db.fetch_all(
+            """SELECT order_id FROM order_tracker
                  WHERE account_id = ? AND submitted_date < ?
                    AND status = 'open'""",
             (validated, before_date),
         )
-        count = int(before["c"]) if before else 0
+        count = len(targets)
         if count:
             await self._db.execute(
                 """UPDATE order_tracker
@@ -388,6 +587,8 @@ class OrderTracker:
                        AND status = 'open'""",
                 (validated, before_date),
             )
+            for row in targets:
+                self._evict_open_cache(row["order_id"])
             logger.info(
                 "OrderTracker EOD 만료: account=%s, %d건 (before=%s)",
                 validated,

--- a/tests/unit/test_bot_providers.py
+++ b/tests/unit/test_bot_providers.py
@@ -127,10 +127,74 @@ class TestLivePortfolioView:
         assert balance["available"] == 1_000_000.0
 
 
+class _StubTracker:
+    """OrderTracker sync 접근자만 모사하는 stub (#1948)."""
+
+    def __init__(self, records=None):
+        self._records = records or []
+
+    def get_open_orders_for_bot_sync(self, account_id, bot_id):
+        return [
+            r
+            for r in self._records
+            if r.account_id == account_id and r.bot_id == bot_id
+        ]
+
+
+def _make_record(**kw):
+    from ante.trade.order_tracker import OrderTrackerRecord
+
+    defaults = dict(
+        order_id="ord-1",
+        account_id="acct-A",
+        bot_id="bot1",
+        strategy_id="s1",
+        broker_order_id="0001",
+        symbol="005930",
+        side="buy",
+        order_type="market",
+        ordered_qty=100.0,
+        recorded_filled_qty=0.0,
+        avg_fill_price=0.0,
+        status="open",
+        submitted_at="2026-05-29T00:00:00+00:00",
+        submitted_date="20260529",
+    )
+    defaults.update(kw)
+    return OrderTrackerRecord(**defaults)
+
+
 class TestLiveOrderView:
     def test_get_open_orders_empty(self):
-        """미체결 주문 없으면 빈 목록."""
-        view = LiveOrderView(order_registry=None)
+        """미체결 주문 없으면 빈 목록 (OrderTracker 캐시 비어있음)."""
+        view = LiveOrderView(order_tracker=_StubTracker(), account_id="acct-A")
+        assert view.get_open_orders("bot1") == []
+
+    def test_get_open_orders_maps_unified_schema(self):
+        """OrderTracker 레코드를 통일 OpenOrder dict 스키마로 매핑."""
+        rec = _make_record(ordered_qty=100.0, recorded_filled_qty=40.0)
+        view = LiveOrderView(order_tracker=_StubTracker([rec]), account_id="acct-A")
+        orders = view.get_open_orders("bot1")
+        assert len(orders) == 1
+        o = orders[0]
+        assert set(o.keys()) == {
+            "order_id",
+            "symbol",
+            "side",
+            "ordered_qty",
+            "recorded_filled_qty",
+            "remaining_qty",
+            "status",
+            "submitted_at",
+        }
+        assert "amount" not in o
+        assert o["order_id"] == "ord-1"
+        assert o["remaining_qty"] == 60.0
+
+    def test_get_open_orders_account_scope(self):
+        """다른 account 의 봇 주문은 누출되지 않음."""
+        rec = _make_record(account_id="acct-B", bot_id="bot1")
+        view = LiveOrderView(order_tracker=_StubTracker([rec]), account_id="acct-A")
         assert view.get_open_orders("bot1") == []
 
 
@@ -205,14 +269,27 @@ class TestVirtualOrderView:
         assert ov.get_open_orders("virtual1") == []
 
     def test_pending_orders_tracked(self):
-        """예약된 주문이 미체결 목록에 나타남."""
+        """예약된 주문이 미체결 목록에 통일 스키마로 나타남."""
         pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
         pv.reserve("ord1", 500_000.0)
 
         ov = VirtualOrderView(portfolio=pv)
         orders = ov.get_open_orders("virtual1")
         assert len(orders) == 1
-        assert orders[0]["order_id"] == "ord1"
+        o = orders[0]
+        assert o["order_id"] == "ord1"
+        # #1948: 통일 OpenOrder dict 스키마 — amount(예약 금액) 제외, 수량 기반.
+        assert set(o.keys()) == {
+            "order_id",
+            "symbol",
+            "side",
+            "ordered_qty",
+            "recorded_filled_qty",
+            "remaining_qty",
+            "status",
+            "submitted_at",
+        }
+        assert "amount" not in o
 
 
 # ── US-3: VirtualExecutor ─────────────────────────
@@ -555,6 +632,90 @@ class TestStrategyContextFactory:
 
         assert isinstance(ctx, StrategyContext)
         assert ctx.bot_id == "live1"
+
+    def test_create_live_context_per_bot_order_view_account_binding(self, eventbus):
+        """order_tracker 주입 시 봇별 LiveOrderView 가 config.account_id 로 binding."""
+        from ante.account.models import Account, TradingMode
+        from ante.bot.providers.live import LivePortfolioView
+
+        class FakeAccountService:
+            def get_sync(self, account_id):
+                return Account(
+                    account_id=account_id,
+                    name="test",
+                    exchange="KRX",
+                    currency="KRW",
+                    trading_mode=TradingMode.LIVE,
+                )
+
+        class FakeLivePortfolio(LivePortfolioView):
+            def __init__(self):
+                pass
+
+            def get_positions(self, bot_id):
+                return {}
+
+            def get_balance(self, bot_id):
+                return {"allocated": 0.0, "available": 0.0, "reserved": 0.0}
+
+        # 두 계좌의 동일 bot_id 주문이 캐시에 공존 — account scope 격리 검증.
+        rec_a = _make_record(order_id="ord-a", account_id="acct-A", bot_id="bot-x")
+        rec_b = _make_record(order_id="ord-b", account_id="acct-B", bot_id="bot-x")
+        tracker = _StubTracker([rec_a, rec_b])
+
+        factory = StrategyContextFactory(
+            data_provider=FakeDataProvider(),
+            account_service=FakeAccountService(),
+            live_portfolio=FakeLivePortfolio(),
+            order_tracker=tracker,
+        )
+
+        ctx_a = factory.create(
+            BotConfig(bot_id="bot-x", strategy_id="s1", account_id="acct-A")
+        )
+        orders_a = ctx_a.get_open_orders()
+        assert [o["order_id"] for o in orders_a] == ["ord-a"]
+
+        ctx_b = factory.create(
+            BotConfig(bot_id="bot-x", strategy_id="s1", account_id="acct-B")
+        )
+        orders_b = ctx_b.get_open_orders()
+        assert [o["order_id"] for o in orders_b] == ["ord-b"]
+
+    def test_create_live_context_empty_order_view_fallback(self, eventbus):
+        """order_tracker·live_order_view 모두 미주입이면 빈 결과 stub (회귀 방지)."""
+        from ante.account.models import Account, TradingMode
+        from ante.bot.providers.live import LivePortfolioView
+
+        class FakeAccountService:
+            def get_sync(self, account_id):
+                return Account(
+                    account_id=account_id,
+                    name="test",
+                    exchange="KRX",
+                    currency="KRW",
+                    trading_mode=TradingMode.LIVE,
+                )
+
+        class FakeLivePortfolio(LivePortfolioView):
+            def __init__(self):
+                pass
+
+            def get_positions(self, bot_id):
+                return {}
+
+            def get_balance(self, bot_id):
+                return {"allocated": 0.0, "available": 0.0, "reserved": 0.0}
+
+        factory = StrategyContextFactory(
+            data_provider=FakeDataProvider(),
+            account_service=FakeAccountService(),
+            live_portfolio=FakeLivePortfolio(),
+        )
+        ctx = factory.create(
+            BotConfig(bot_id="live1", strategy_id="s1", account_id="live-acct")
+        )
+        assert ctx.get_open_orders() == []
 
     def test_resolve_virtual_balance_with_budget(self, eventbus):
         """TreasuryManager 존재 + BotBudget 배정 시 allocated 값 반환."""

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -45,6 +45,35 @@ async def test_fetch_one_returns_none(db):
     assert await db.fetch_one("SELECT * FROM t WHERE id = 999") is None
 
 
+async def test_execute_fetch_all_returns_affected_rows(db):
+    """UPDATE … RETURNING 으로 실제 영향받은 다건을 writer 단일 호출로 반환."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, status TEXT);")
+    await db.execute("INSERT INTO t (id, status) VALUES (1, 'open')")
+    await db.execute("INSERT INTO t (id, status) VALUES (2, 'open')")
+    await db.execute("INSERT INTO t (id, status) VALUES (3, 'filled')")
+
+    rows = await db.execute_fetch_all(
+        "UPDATE t SET status = 'expired' WHERE status = 'open' RETURNING id",
+        (),
+    )
+    # status='open' 2건만 RETURNING — 'filled' 는 영향 없음.
+    assert sorted(r["id"] for r in rows) == [1, 2]
+    # 실제 DB 도 갱신됨(reader 에서도 commit 관측).
+    after = await db.fetch_all("SELECT id, status FROM t ORDER BY id")
+    assert [r["status"] for r in after] == ["expired", "expired", "filled"]
+
+
+async def test_execute_fetch_all_empty_when_no_match(db):
+    """매칭 행이 없으면 빈 리스트 반환."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, status TEXT);")
+    await db.execute("INSERT INTO t (id, status) VALUES (1, 'filled')")
+    rows = await db.execute_fetch_all(
+        "UPDATE t SET status = 'expired' WHERE status = 'open' RETURNING id",
+        (),
+    )
+    assert rows == []
+
+
 async def test_wal_mode(db):
     """WAL 모드가 활성화되어 있다."""
     row = await db.fetch_one("PRAGMA journal_mode")

--- a/tests/unit/test_fill_applier.py
+++ b/tests/unit/test_fill_applier.py
@@ -334,3 +334,85 @@ async def test_crash_during_apply_rolls_back(
     assert delta == 40.0
     pos = await position_history.get_current("bot-1", "005930", account_id=ACCT)
     assert pos["quantity"] == 40.0
+
+
+# ── #1948 R2: txn rollback ↔ sync open 캐시 정합 (NEW blocking 회귀) ──
+
+
+async def test_rollback_does_not_advance_sync_open_cache(
+    db, tracker, position_history, eventbus, monkeypatch
+):
+    """record_fill 성공 후 _save_trade/position 실패 → rollback → sync
+    get_open_orders 가 **stale advance 를 미반환** (R2 핵심 회귀 락).
+
+    캐시는 record_fill 에서 건드리지 않고 commit 직후 mirror_fill_to_cache 로만
+    갱신되므로, rollback 시 캐시는 DB(원복)와 일관되게 불변이어야 한다.
+    """
+    rec = TradeRecorder(db, position_history)
+    await rec.initialize()
+    applier = FillApplier(
+        db=db,
+        order_tracker=tracker,
+        position_history=position_history,
+        eventbus=eventbus,
+    )
+    await _seed(tracker)
+    # warm 직후 캐시는 open, recorded=0.
+    before = tracker.get_open_orders_for_bot_sync(ACCT, "bot-1")
+    assert len(before) == 1
+    assert before[0].recorded_filled_qty == 0.0
+
+    orig_on_trade = position_history.on_trade
+
+    async def _boom(record):
+        raise RuntimeError("simulated crash mid-transaction")
+
+    monkeypatch.setattr(position_history, "on_trade", _boom)
+    with pytest.raises(RuntimeError):
+        await applier.apply_cumulative(
+            account_id=ACCT,
+            broker_order_id="0001",
+            observed_cumulative=40.0,
+            avg_price=1000.0,
+            submitted_date=DATE,
+        )
+
+    # rollback — DB 미advance + 캐시도 stale advance 없음 (여전히 recorded=0, open).
+    rec_row = await tracker.get("ord-1")
+    assert rec_row.recorded_filled_qty == 0.0
+    cached = tracker.get_open_orders_for_bot_sync(ACCT, "bot-1")
+    assert len(cached) == 1
+    assert cached[0].recorded_filled_qty == 0.0
+    assert cached[0].status == "open"
+
+    # 복구 후 정상 적용 → commit 직후 mirror 로 캐시가 advance 된다.
+    monkeypatch.setattr(position_history, "on_trade", orig_on_trade)
+    delta = await applier.apply_cumulative(
+        account_id=ACCT,
+        broker_order_id="0001",
+        observed_cumulative=40.0,
+        avg_price=1000.0,
+        submitted_date=DATE,
+    )
+    assert delta == 40.0
+    advanced = tracker.get_open_orders_for_bot_sync(ACCT, "bot-1")
+    assert len(advanced) == 1
+    assert advanced[0].recorded_filled_qty == 40.0
+    assert advanced[0].status == "partially_filled"
+
+
+async def test_full_fill_evicts_sync_open_cache_post_commit(
+    applier, tracker, position_history
+):
+    """완전 체결 commit 후 mirror 가 캐시에서 evict → sync 미노출."""
+    await _seed(tracker)
+    assert len(tracker.get_open_orders_for_bot_sync(ACCT, "bot-1")) == 1
+    delta = await applier.apply_cumulative(
+        account_id=ACCT,
+        broker_order_id="0001",
+        observed_cumulative=100.0,  # ordered_qty 도달 → filled
+        avg_price=1000.0,
+        submitted_date=DATE,
+    )
+    assert delta == 100.0
+    assert tracker.get_open_orders_for_bot_sync(ACCT, "bot-1") == []

--- a/tests/unit/test_order_tracker.py
+++ b/tests/unit/test_order_tracker.py
@@ -384,6 +384,58 @@ async def test_expire_stale_evicts_cache(tracker):
     assert _open_ids(tracker) == ["ord-new"]
 
 
+async def test_expire_stale_returning_does_not_evict_non_open(tracker):
+    """#1948 회귀: expire_stale 은 실제 open→expired 된 주문만 evict 한다.
+
+    pre-SELECT→별도 UPDATE 구조였을 때는 SELECT↔UPDATE 사이에 fill 이 commit 돼
+    open→partially_filled 로 전이되면, ``UPDATE … WHERE status='open'`` 은 그
+    주문을 건드리지 않는데도 pre-SELECT 결과로 캐시에서 evict 되어 여전히 open(
+    partial)인 주문이 sync 캐시에서 사라지는 TOCTOU race 가 있었다(캐시=commit 된
+    DB open 미러 invariant 위반). UPDATE … RETURNING 단일 원자 연산으로 바꿔
+    실제 expired 된 order_id 만 evict 하므로, 비-open 주문은 evict 후보에 구조적으로
+    들어갈 수 없다.
+
+    검증: 전일 ``open`` 1건 + 전일 ``partially_filled`` 1건(캐시에 미러)을 두고
+    expire_stale 호출 시 — (a) count 는 open→expired 된 건수만, (b) partially_filled
+    는 evict 되지 않고 sync 에 계속 노출(partially_filled ∈ OPEN_STATUSES), (c)
+    expired 된 open 만 sync 에서 사라진다.
+    """
+    # 전일 open (genuinely-dead — 체결 없음).
+    await _seed(
+        tracker, order_id="ord-open", broker_order_id="0101", submitted_date="20260528"
+    )
+    # 전일 partially_filled — fill 이 관측·commit 되어 비-open 으로 전이된 주문.
+    # record_fill(DB advance) 후 mirror_fill_to_cache(commit 직후 캐시 미러).
+    await _seed(
+        tracker,
+        order_id="ord-partial",
+        broker_order_id="0102",
+        submitted_date="20260528",
+        ordered_qty=100.0,
+    )
+    result = await tracker.record_fill("ord-partial", 40.0, 1000.0)
+    assert result.new_status == "partially_filled"
+    tracker.mirror_fill_to_cache("ord-partial", 40.0, "partially_filled")
+
+    # 사전: 두 주문 모두 sync 캐시에 노출(open + partially_filled).
+    assert sorted(_open_ids(tracker)) == ["ord-open", "ord-partial"]
+
+    count = await tracker.expire_stale("acct-A", before_date="20260529")
+
+    # (a) open → expired 된 1건만 count.
+    assert count == 1
+    # DB 상태: open 만 expired, partially_filled 는 보존.
+    assert (await tracker.get("ord-open")).status == "expired"
+    assert (await tracker.get("ord-partial")).status == "partially_filled"
+    # (b)+(c) partially_filled 는 캐시 잔존(sync 노출), expired open 만 사라짐.
+    assert _open_ids(tracker) == ["ord-partial"]
+    # partially_filled 미러값(recorded=40)도 보존 — blind evict 흔적 없음.
+    recs = tracker.get_open_orders_for_bot_sync("acct-A", "bot-1")
+    assert len(recs) == 1
+    assert recs[0].order_id == "ord-partial"
+    assert recs[0].recorded_filled_qty == 40.0
+
+
 async def test_sync_cache_account_bot_scope(tracker):
     """(account_id, bot_id) 스코프 — 타 account/bot 누출 없음."""
     await _seed(tracker, order_id="a1", account_id="acct-A", broker_order_id="0001")

--- a/tests/unit/test_order_tracker.py
+++ b/tests/unit/test_order_tracker.py
@@ -301,3 +301,149 @@ async def test_expire_stale_excludes_partially_filled(tracker):
     assert count == 1
     assert (await tracker.get("ord-partial")).status == "partially_filled"
     assert (await tracker.get("ord-dead")).status == "expired"
+
+
+# ── #1948: sync open 캐시 + LIVE get_open_orders 백엔드 ──────
+
+
+def _open_ids(tracker, account_id="acct-A", bot_id="bot-1"):
+    return [
+        r.order_id for r in tracker.get_open_orders_for_bot_sync(account_id, bot_id)
+    ]
+
+
+async def test_open_seeds_sync_cache(tracker):
+    """open() 후 sync 캐시에 즉시 노출."""
+    await _seed(tracker)
+    assert _open_ids(tracker) == ["ord-1"]
+
+
+async def test_duplicate_open_event_single_cache_entry(tracker):
+    """중복 OrderSubmittedEvent(open) 2회 → 캐시 단일 entry (blind insert 회귀 락)."""
+    await _seed(tracker)
+    # 첫 체결로 캐시를 advance.
+    await tracker.record_fill("ord-1", 40.0, 1000.0)
+    tracker.mirror_fill_to_cache("ord-1", 40.0, "partially_filled")
+    # 중복 open 이벤트(ON CONFLICT DO NOTHING — DB 미변경) 재수신.
+    await _seed(tracker)
+    records = tracker.get_open_orders_for_bot_sync("acct-A", "bot-1")
+    assert len(records) == 1
+    # 중복 open 이 advance 된 캐시(40)를 blind 하게 0 으로 덮어쓰지 않음.
+    assert records[0].recorded_filled_qty == 40.0
+
+
+async def test_record_fill_alone_does_not_touch_cache(tracker):
+    """record_fill 단독 호출은 캐시 미변경 (캐시는 mirror_fill_to_cache 로만)."""
+    await _seed(tracker)
+    result = await tracker.record_fill("ord-1", 100.0, 1000.0)  # filled
+    assert result.delta == 100.0
+    assert result.new_status == "filled"
+    # record_fill 만으로는 캐시가 그대로 — 여전히 open, recorded=0.
+    records = tracker.get_open_orders_for_bot_sync("acct-A", "bot-1")
+    assert len(records) == 1
+    assert records[0].recorded_filled_qty == 0.0
+    assert records[0].status == "open"
+
+
+async def test_mirror_fill_partial_then_filled_evicts(tracker):
+    """mirror_fill_to_cache: partial 은 미러, filled 는 evict."""
+    await _seed(tracker)
+    # partial 미러.
+    await tracker.record_fill("ord-1", 40.0, 1000.0)
+    tracker.mirror_fill_to_cache("ord-1", 40.0, "partially_filled")
+    recs = tracker.get_open_orders_for_bot_sync("acct-A", "bot-1")
+    assert len(recs) == 1
+    assert recs[0].recorded_filled_qty == 40.0
+    assert recs[0].status == "partially_filled"
+    # filled 미러 → evict.
+    await tracker.record_fill("ord-1", 100.0, 1010.0)
+    tracker.mirror_fill_to_cache("ord-1", 100.0, "filled")
+    assert _open_ids(tracker) == []
+
+
+async def test_mark_terminal_evicts_cache(tracker):
+    """mark_terminal 후 sync 조회에서 제외."""
+    await _seed(tracker)
+    assert _open_ids(tracker) == ["ord-1"]
+    await tracker.mark_terminal("ord-1", "cancelled")
+    assert _open_ids(tracker) == []
+
+
+async def test_expire_stale_evicts_cache(tracker):
+    """expire_stale 후 만료 주문 sync 미노출 (batch evict)."""
+    await _seed(
+        tracker, order_id="ord-old", broker_order_id="0009", submitted_date="20260528"
+    )
+    await _seed(
+        tracker, order_id="ord-new", broker_order_id="0010", submitted_date="20260529"
+    )
+    assert sorted(_open_ids(tracker)) == ["ord-new", "ord-old"]
+    count = await tracker.expire_stale("acct-A", before_date="20260529")
+    assert count == 1
+    # 만료된 ord-old 는 캐시에서 제거, ord-new 는 유지.
+    assert _open_ids(tracker) == ["ord-new"]
+
+
+async def test_sync_cache_account_bot_scope(tracker):
+    """(account_id, bot_id) 스코프 — 타 account/bot 누출 없음."""
+    await _seed(tracker, order_id="a1", account_id="acct-A", broker_order_id="0001")
+    await _seed(tracker, order_id="b1", account_id="acct-B", broker_order_id="0002")
+    # 타-봇 주문(다른 bot_id) 직접 open.
+    await tracker.open(
+        order_id="other-bot",
+        account_id="acct-A",
+        bot_id="bot-2",
+        strategy_id="s",
+        broker_order_id="0003",
+        symbol="005930",
+        side="buy",
+        order_type="market",
+        ordered_qty=10.0,
+        submitted_date="20260529",
+    )
+    assert _open_ids(tracker, "acct-A", "bot-1") == ["a1"]
+    assert _open_ids(tracker, "acct-B", "bot-1") == ["b1"]
+    assert _open_ids(tracker, "acct-A", "bot-2") == ["other-bot"]
+
+
+async def test_to_open_order_dict_schema(tracker):
+    """통일 OpenOrder dict 스키마 + remaining_qty."""
+    await _seed(tracker, ordered_qty=100.0)
+    await tracker.record_fill("ord-1", 30.0, 1000.0)
+    tracker.mirror_fill_to_cache("ord-1", 30.0, "partially_filled")
+    recs = tracker.get_open_orders_for_bot_sync("acct-A", "bot-1")
+    d = recs[0].to_open_order_dict()
+    assert set(d.keys()) == {
+        "order_id",
+        "symbol",
+        "side",
+        "ordered_qty",
+        "recorded_filled_qty",
+        "remaining_qty",
+        "status",
+        "submitted_at",
+    }
+    assert "amount" not in d
+    assert d["ordered_qty"] == 100.0
+    assert d["recorded_filled_qty"] == 30.0
+    assert d["remaining_qty"] == 70.0
+
+
+async def test_warm_open_cache_from_db(db):
+    """initialize() 가 DB 의 open/partially_filled 를 캐시에 warm."""
+    # 1st tracker 로 DB 에 주문 seed + 부분 체결.
+    t1 = OrderTracker(db)
+    await t1.initialize()
+    await _seed(t1, order_id="ord-open", broker_order_id="0001")
+    await _seed(t1, order_id="ord-part", broker_order_id="0002")
+    await t1.record_fill("ord-part", 40.0, 1000.0)
+    t1.mirror_fill_to_cache("ord-part", 40.0, "partially_filled")
+    await _seed(t1, order_id="ord-done", broker_order_id="0003")
+    await t1.record_fill("ord-done", 100.0, 1000.0)  # filled (DB)
+    t1.mirror_fill_to_cache("ord-done", 100.0, "filled")
+
+    # 새 tracker 가 동일 DB 로 warm — terminal(filled) 제외, open/partial 만.
+    t2 = OrderTracker(db)
+    await t2.initialize()
+    ids = sorted(_open_ids(t2))
+    assert ids == ["ord-open", "ord-part"]

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -297,7 +297,12 @@ class TestCommands:
         )
 
     async def test_stop_bot_with_positions(self, receiver, bot_manager):
-        """보유 종목 있으면 메시지 B — 종목명 및 체결대기 금액 표시."""
+        """보유 종목 있으면 메시지 B — 종목명 및 미체결 주문 건수 표시.
+
+        #1948: 통일 OpenOrder dict 스키마에 amount(예약 금액)가 없으므로
+        체결대기는 금액 합이 아닌 **주문 건수**로 표시한다(live amount 부재
+        0원 오표시 버그 정정).
+        """
         bot = _make_running_bot(
             positions={
                 "005930": {
@@ -307,7 +312,28 @@ class TestCommands:
                 },
                 "035720": {"symbol": "035720", "quantity": 5, "avg_entry_price": 50000},
             },
-            open_orders=[{"amount": 500_000}, {"amount": 300_000}],
+            open_orders=[
+                {
+                    "order_id": "o1",
+                    "symbol": "005930",
+                    "side": "buy",
+                    "ordered_qty": 10.0,
+                    "recorded_filled_qty": 0.0,
+                    "remaining_qty": 10.0,
+                    "status": "open",
+                    "submitted_at": None,
+                },
+                {
+                    "order_id": "o2",
+                    "symbol": "035720",
+                    "side": "buy",
+                    "ordered_qty": 5.0,
+                    "recorded_filled_qty": 0.0,
+                    "remaining_qty": 5.0,
+                    "status": "open",
+                    "submitted_at": None,
+                },
+            ],
         )
         bot_manager.get_bot.return_value = bot
         result = await receiver._cmd_stop(["bot-1"])
@@ -316,7 +342,7 @@ class TestCommands:
         assert "포지션을 직접 관리" in result
         assert "005930" in result
         assert "035720" in result
-        assert "800,000원" in result
+        assert "체결대기 주문: 2건" in result
 
     async def test_stop_bot_already_stopped(self, receiver, bot_manager):
         """이미 중지된 봇은 안내 메시지 반환."""


### PR DESCRIPTION
Closes #1948

## Summary
- 전략 `ctx.get_open_orders()` **LIVE 백엔드를 OrderTracker(ante 제출 미체결 SSOT, #1946)에 실연결** — 체결 확정 전 미체결 주문 가시성 제공(#1945 반복 buy 증상 완화). 기존 LiveOrderView는 항상 `[]`, VirtualPortfolio.reserve는 프로덕션 미호출이라 양쪽 다 사실상 비기능이었음.
- **sync 인메모리 open 캐시**(키 (account_id,bot_id,order_id))가 **commit된 DB 상태만 미러** — sync OrderView 제약(이벤트루프 코루틴 내부)을 LivePortfolioView.get_positions_sync 패턴으로 해소. record_fill은 캐시 미접근, FillApplier가 **txn commit 직후** `mirror_fill_to_cache(confirmed_cumulative)` 호출(rollback-stale 차단). open=`INSERT…RETURNING` 확정 후 upsert, mark_terminal/expire_stale=`_evict_open_cache`. expire_stale은 `UPDATE…RETURNING order_id` 원자 연산으로 TOCTOU evict race 제거.
- **통일 OpenOrder 스키마**(수량 기반: order_id/symbol/side/ordered_qty/recorded_filled_qty/remaining_qty/status/submitted_at; 예약금 amount 제외). LiveOrderView=OrderTracker 경유, VirtualOrderView=통일 스키마 best-effort(OrderTracker 미경유), backtest=`[]`. telegram 미체결 표시를 예약금 합→건수로 정정.
- StrategyContextFactory에 order_tracker 주입 + 봇별 LiveOrderView(account_id closure). 스펙 3축(03-04/03-design-decisions/strategy.md) 동기화.
- known-limitation: cold-cache best-effort(reconciler net), same-step intra-step 중복(cross-step 가시성만; submit-side guard 후속 후보), ante 제출 주문 한정.

## Plan/Review
- Plan Preflight: Codex approve-implement (R0 revise→R1 revise→R2 approve, round 3)
- Codex 브랜치 리뷰: attempt1 FAIL(expire_stale race)→fix→attempt2 PASS

## Test Plan
- ruff / ruff format --check: PASS
- mypy src/ (229 files): Success
- generate_db_schema.py --check: up to date
- pytest tests/unit: 5780 passed, 2 skipped (필수 신규: txn rollback 후 stale 미반환, record_fill 캐시 미변경, expire_stale RETURNING 비-open 미evict, 중복 open 단일 entry, account/bot 스코프, 통일 스키마, telegram 건수, virtual 동형)

🤖 Generated with [Claude Code](https://claude.com/claude-code)