### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,3082 @@
 
 <!-- version list -->
 
+## v0.10.0 (2026-05-29)
+
+### Bug Fixes
+
+- #1673 config set invalid log_level을 CONFIG_VALIDATION_ERROR JSON envelope로 정리
+  ([#1683](https://github.com/joshua-jingu-lee/ante/pull/1683),
+  [`7d14ac5`](https://github.com/joshua-jingu-lee/ante/commit/7d14ac518922c4e956c629b2d176e82f2d6c65f3))
+
+- #1674 feed backfill_since 4-surface clean-reject coded {CLI_INVALID_DATE, INVALID_DATE_RANGE}
+  ([#1692](https://github.com/joshua-jingu-lee/ante/pull/1692),
+  [`45075c5`](https://github.com/joshua-jingu-lee/ante/commit/45075c54dbd8c6d3b53b7a40555fb74c8085dd5b))
+
+- #1675 StrategyValidator source-read + AST-parse 단계 4클래스 content-free 정규화 (bounded B)
+  ([#1693](https://github.com/joshua-jingu-lee/ante/pull/1693),
+  [`ff1be4c`](https://github.com/joshua-jingu-lee/ante/commit/ff1be4c5de79d4ac20496daca5b6694e0b945777))
+
+- #1676 cursor decode invalid 입력을 안정 'invalid cursor' 400으로 정규화 (strict+canonical, no-reflection)
+  ([#1684](https://github.com/joshua-jingu-lee/ante/pull/1684),
+  [`f99598b`](https://github.com/joshua-jingu-lee/ante/commit/f99598bb58162c7cbad5659c48c1952ccb0977fe))
+
+- #1681 OpenAPI auto-422를 runtime problem+json+ErrorResponse로 정렬 (normalizer 수렴점 + 07-error-format
+  invariant + frontend 동기) ([#1688](https://github.com/joshua-jingu-lee/ante/pull/1688),
+  [`1f3c78b`](https://github.com/joshua-jingu-lee/ante/commit/1f3c78b00474e678afd93ffd4217d6451b0bbf92))
+
+- #1682 빈 notification 그룹을 root help·guide/cli.md 양 표면에서 숨김 (hidden=True + _collect_commands
+  hidden-skip + 재생성) ([#1689](https://github.com/joshua-jingu-lee/ante/pull/1689),
+  [`efa57fb`](https://github.com/joshua-jingu-lee/ante/commit/efa57fb6b68e19ad4c6b447506daef9d81310401))
+
+- #1690 feed backfill --until ghost option 제거 + guide/cli.md 재생성
+  ([#1694](https://github.com/joshua-jingu-lee/ante/pull/1694),
+  [`f9c88f3`](https://github.com/joshua-jingu-lee/ante/commit/f9c88f3b21f1722a64a81930055a33d1c23ccdb6))
+
+- #1696 CLI reference usage line에 required option 인라인 표시 (generator dual-fix)
+  ([#1706](https://github.com/joshua-jingu-lee/ante/pull/1706),
+  [`4b82bc3`](https://github.com/joshua-jingu-lee/ante/commit/4b82bc3097c577da206d9fbd33d2c949788ce812))
+
+- #1701 report schema/data list/bot list/member info에 @format_option decorator 추가
+  ([#1709](https://github.com/joshua-jingu-lee/ante/pull/1709),
+  [`601c4f3`](https://github.com/joshua-jingu-lee/ante/commit/601c4f3293488dfece10a66af14172bffea4ed4a))
+
+- #1705 signal connect 4 validation 오류를 JSON envelope으로 normalize (_fail helper + @format_option)
+  ([#1710](https://github.com/joshua-jingu-lee/ante/pull/1710),
+  [`945971c`](https://github.com/joshua-jingu-lee/ante/commit/945971c90ad7af5f11277cbd707a8cff0b3ac699))
+
+- #1719 remove dashboard/Web API surface from Dockerfile and verify-install
+  ([#1720](https://github.com/joshua-jingu-lee/ante/pull/1720),
+  [`b1f1e7a`](https://github.com/joshua-jingu-lee/ante/commit/b1f1e7a4402708433f6d428093c8541c3d99f6e8))
+
+- #1721 ante init이 ANTE_DB_ENCRYPTION_KEY를 생성·persist + Config.load env export
+  ([#1731](https://github.com/joshua-jingu-lee/ante/pull/1731),
+  [`2d1bc2b`](https://github.com/joshua-jingu-lee/ante/commit/2d1bc2b5f37420610fc7d2af6dc9486c66048164))
+
+- #1722 account CLI crypto error → exit 1 + stable code, no aiosqlite hang
+  ([#1732](https://github.com/joshua-jingu-lee/ante/pull/1732),
+  [`c56a7db`](https://github.com/joshua-jingu-lee/ante/commit/c56a7db3bc6929aa70ec65ea60bdb5842dc883d4))
+
+- #1723 account create reserve buffer가 inf/nan/negative을 거부하도록 SSOT validator 적용
+  ([#1733](https://github.com/joshua-jingu-lee/ante/pull/1733),
+  [`8c2ec9b`](https://github.com/joshua-jingu-lee/ante/commit/8c2ec9b71efe123c7cc9cd5dbb0eb9c50ded6d7a))
+
+- #1724 cold-path account 4 명령에 invalid account_id ingress validation
+  ([#1734](https://github.com/joshua-jingu-lee/ante/pull/1734),
+  [`320bc2a`](https://github.com/joshua-jingu-lee/ante/commit/320bc2a92110e0528dd3850d4830efa6b4416ab1))
+
+- #1724 cold-path account 4 명령에 invalid account_id ingress validation 추가
+  ([#1734](https://github.com/joshua-jingu-lee/ante/pull/1734),
+  [`320bc2a`](https://github.com/joshua-jingu-lee/ante/commit/320bc2a92110e0528dd3850d4830efa6b4416ab1))
+
+- #1725 treasury status/snapshot이 valid-but-missing account_id에 ACCOUNT_NOT_FOUND 반환 + hang 차단
+  ([#1735](https://github.com/joshua-jingu-lee/ante/pull/1735),
+  [`1111e20`](https://github.com/joshua-jingu-lee/ante/commit/1111e2070cd2a75618c5b447232b6dccdc5279b6))
+
+- #1726 _create_rule_engine cleanup이 db.connect() 자체를 감싸도록 정렬
+  ([#1736](https://github.com/joshua-jingu-lee/ante/pull/1736),
+  [`2ad7433`](https://github.com/joshua-jingu-lee/ante/commit/2ad743328658e21b5e81b9fdad1b3bc9ffc3e804))
+
+- #1726 rule info가 valid-but-missing account_id에 ACCOUNT_NOT_FOUND 우선 반환
+  ([#1736](https://github.com/joshua-jingu-lee/ante/pull/1736),
+  [`2ad7433`](https://github.com/joshua-jingu-lee/ante/commit/2ad743328658e21b5e81b9fdad1b3bc9ffc3e804))
+
+- #1726 rule info가 valid-but-missing account_id에 ACCOUNT_NOT_FOUND 우선 반환 + SSOT consolidation
+  ([#1736](https://github.com/joshua-jingu-lee/ante/pull/1736),
+  [`2ad7433`](https://github.com/joshua-jingu-lee/ante/commit/2ad743328658e21b5e81b9fdad1b3bc9ffc3e804))
+
+- #1727 broker balance/positions가 valid-but-missing account_id에 ACCOUNT_NOT_FOUND 반환
+  ([#1737](https://github.com/joshua-jingu-lee/ante/pull/1737),
+  [`db43c04`](https://github.com/joshua-jingu-lee/ante/commit/db43c04403030d4afb841eb0e591be3d69b5ef84))
+
+- #1730 D-018 후 init/config의 [web] 섹션 제거 (web surface stale config sweep)
+  ([#1740](https://github.com/joshua-jingu-lee/ante/pull/1740),
+  [`6ffb6a8`](https://github.com/joshua-jingu-lee/ante/commit/6ffb6a8c9fc59956647bd53ddbf1a2f671721d62))
+
+- #1752 backtest run --format json이 단일 JSON document만 출력하도록 분기
+  ([#1762](https://github.com/joshua-jingu-lee/ante/pull/1762),
+  [`eed2a14`](https://github.com/joshua-jingu-lee/ante/commit/eed2a14a8b1cc135d4a2a1ae27d4c6f6f098e88a))
+
+- #1753 fresh init 후 strategy/trade 조회 CLI public read contract 정합
+  ([#1763](https://github.com/joshua-jingu-lee/ante/pull/1763),
+  [`e0389a9`](https://github.com/joshua-jingu-lee/ante/commit/e0389a9d82a71be348244ebc115a0e08704f28ae))
+
+- #1754 IPC ClickException 경로를 --format json envelope으로 변환
+  ([#1764](https://github.com/joshua-jingu-lee/ante/pull/1764),
+  [`1196f0a`](https://github.com/joshua-jingu-lee/ante/commit/1196f0a35536345f074fd20372b33b85813db0d3))
+
+- #1755 report/approval CLI db cleanup으로 stderr traceback과 hang 차단
+  ([#1765](https://github.com/joshua-jingu-lee/ante/pull/1765),
+  [`dab8580`](https://github.com/joshua-jingu-lee/ante/commit/dab85802715dcb21c2ca7a5960547b641b776421))
+
+- #1756 strategy submit meta shape ingress validation
+  ([#1766](https://github.com/joshua-jingu-lee/ante/pull/1766),
+  [`d18cb9a`](https://github.com/joshua-jingu-lee/ante/commit/d18cb9a7144a3d4e00faea8144578da7b4442278))
+
+- #1757 system start --format json 자식 stdout 격리
+  ([#1767](https://github.com/joshua-jingu-lee/ante/pull/1767),
+  [`2591083`](https://github.com/joshua-jingu-lee/ante/commit/25910838a8f43557e9bcc6d9f01a0c6ab0f199e1))
+
+- #1758 treasury read 계열 valid-but-missing account_id ACCOUNT_NOT_FOUND 매핑
+  ([#1768](https://github.com/joshua-jingu-lee/ante/pull/1768),
+  [`b9da81f`](https://github.com/joshua-jingu-lee/ante/commit/b9da81fda82b025bc554aa3cac86eeb038253d55))
+
+- #1759 BotManager start_bot/stop_bot strict state machine + BOT_STATE_CONFLICT
+  ([#1769](https://github.com/joshua-jingu-lee/ante/pull/1769),
+  [`69b5973`](https://github.com/joshua-jingu-lee/ante/commit/69b5973a186c9a0a0d8d0de59f26920653c7ff22))
+
+- #1760 server-side BotManager에 SignalKeyManager 주입
+  ([#1771](https://github.com/joshua-jingu-lee/ante/pull/1771),
+  [`42f451e`](https://github.com/joshua-jingu-lee/ante/commit/42f451ef0e1e419c4373a291cf90fa770846b7da))
+
+- #1761 bot signal-key --rotate에 accepts_external_signals 게이트
+  ([#1772](https://github.com/joshua-jingu-lee/ante/pull/1772),
+  [`4fc278a`](https://github.com/joshua-jingu-lee/ante/commit/4fc278a3bb9848739f7516c73d0f0de8f01c4785))
+
+- #1773-#1782 CLI 에러코드 명명 규칙 sweep (10 commands)
+  ([#1783](https://github.com/joshua-jingu-lee/ante/pull/1783),
+  [`58bc07a`](https://github.com/joshua-jingu-lee/ante/commit/58bc07a08d2de9a42060c927c71082699189bc88))
+
+- #1784,#1789,#1795-#1798,#1800 Group A typed code + envelope sweep (7 issues)
+  ([#1801](https://github.com/joshua-jingu-lee/ante/pull/1801),
+  [`dca3d8d`](https://github.com/joshua-jingu-lee/ante/commit/dca3d8de7e3964e806e0eee7908742ee81f10fd7))
+
+- #1792 treasury allocate/deallocate에 bot 존재 검증 추가
+  ([#1803](https://github.com/joshua-jingu-lee/ante/pull/1803),
+  [`74cb69b`](https://github.com/joshua-jingu-lee/ante/commit/74cb69b02101a4eae8cad43a275e2f6a2171a4a0))
+
+- #1794 approval CLI args key mismatch (approval_id → id)
+  ([#1802](https://github.com/joshua-jingu-lee/ante/pull/1802),
+  [`254bfc5`](https://github.com/joshua-jingu-lee/ante/commit/254bfc554146c408c9c8f44eb39e70c697675384))
+
+- #1799 bot create cleanup leaked aiosqlite (active account 0/2+ hang)
+  ([#1804](https://github.com/joshua-jingu-lee/ante/pull/1804),
+  [`a5d8edf`](https://github.com/joshua-jingu-lee/ante/commit/a5d8edf77cdbd1235089fa4de6acede7f831e9da))
+
+- #1805/#1808/#1810/#1811 Group P missing-resource typed code sweep (4 issues)
+  ([#1817](https://github.com/joshua-jingu-lee/ante/pull/1817),
+  [`cb48603`](https://github.com/joshua-jingu-lee/ante/commit/cb48603c7604763a22f747f415f12b494db57e68))
+
+- #1806/#1807 Group R member duplicate+validation typed code sweep (2 issues)
+  ([#1826](https://github.com/joshua-jingu-lee/ante/pull/1826),
+  [`bb9e594`](https://github.com/joshua-jingu-lee/ante/commit/bb9e5947e900bcbc6521751815b483b7262f4670))
+
+- #1809 Group S treasury allocate/deallocate typed reject exception (contract change)
+  ([#1828](https://github.com/joshua-jingu-lee/ante/pull/1828),
+  [`eb15e6a`](https://github.com/joshua-jingu-lee/ante/commit/eb15e6a29b2fce62de6b0a35e78e6f328dc7b484))
+
+- #1812/#1813/#1814 Group Q state-conflict typed code sweep (3 issues)
+  ([#1825](https://github.com/joshua-jingu-lee/ante/pull/1825),
+  [`adf8319`](https://github.com/joshua-jingu-lee/ante/commit/adf83197ed209663de7e9e768801af349b111854))
+
+- - src/ante/report/models.py: __post_init__ 제거,
+  ([#1445](https://github.com/joshua-jingu-lee/ante/pull/1445),
+  [`64ab2e7`](https://github.com/joshua-jingu-lee/ante/commit/64ab2e730e2160fb033152b0ec34c76036109dcc))
+
+- Add pyyaml to dev dependencies (CI test fix for #1841 drift allowlist loader)
+  ([#1864](https://github.com/joshua-jingu-lee/ante/pull/1864),
+  [`95cc2e0`](https://github.com/joshua-jingu-lee/ante/commit/95cc2e0454fd79a3f34764a81d1acbc75204eb86))
+
+- Load import guard by path in pytest ([#1290](https://github.com/joshua-jingu-lee/ante/pull/1290),
+  [`01eeb7d`](https://github.com/joshua-jingu-lee/ante/commit/01eeb7d4d33cd0cf28f0ad03cedb40f2d3b0eb09))
+
+- **account**: Allow empty default in POST trading_hours pattern
+  ([#1344](https://github.com/joshua-jingu-lee/ante/pull/1344),
+  [`1dd1cda`](https://github.com/joshua-jingu-lee/ante/commit/1dd1cdacf78e408fff06431a6418e157db1a9064))
+
+- **account**: Allow market_order_reserve_buffer_rate in cold-path update (#1333 P2)
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **account**: Expose InvalidAccountIdError as VALIDATION_ERROR through IPC dispatch
+  ([#1246](https://github.com/joshua-jingu-lee/ante/pull/1246),
+  [`45ae880`](https://github.com/joshua-jingu-lee/ante/commit/45ae880d92861fcc85c2801be4dcdec2387a7fa5))
+
+- **account**: Include multi-step deletion procedure in AccountHasActiveBotsError message
+  ([#1162](https://github.com/joshua-jingu-lee/ante/pull/1162),
+  [`77beea8`](https://github.com/joshua-jingu-lee/ante/commit/77beea89d52837f64cd6a25e1aaaa3e12b4d3db1))
+
+- **account**: Resolve mypy shadow on AccountService.list return types
+  ([#1248](https://github.com/joshua-jingu-lee/ante/pull/1248),
+  [`9623aad`](https://github.com/joshua-jingu-lee/ante/commit/9623aad4b8f43bcfbc9365d199a1d6bedf099324))
+
+- **account**: Validate canonical exchange in service + align OpenAPI enum (#1583)
+  ([#1586](https://github.com/joshua-jingu-lee/ante/pull/1586),
+  [`6e286b4`](https://github.com/joshua-jingu-lee/ante/commit/6e286b4918d74ebe0b12c967e5cf375f2f6b9846))
+
+- **account**: Validate trading_hours_start/end as strict HH:MM
+  ([#1344](https://github.com/joshua-jingu-lee/ante/pull/1344),
+  [`1dd1cda`](https://github.com/joshua-jingu-lee/ante/commit/1dd1cdacf78e408fff06431a6418e157db1a9064))
+
+- **account**: Validate trading_hours_start/end as strict HH:MM (#1334)
+  ([#1344](https://github.com/joshua-jingu-lee/ante/pull/1344),
+  [`1dd1cda`](https://github.com/joshua-jingu-lee/ante/commit/1dd1cdacf78e408fff06431a6418e157db1a9064))
+
+- **account,cli,ipc**: Align account cold-path with 1.0 single-active-runtime policy
+  ([#1162](https://github.com/joshua-jingu-lee/ante/pull/1162),
+  [`77beea8`](https://github.com/joshua-jingu-lee/ante/commit/77beea89d52837f64cd6a25e1aaaa3e12b4d3db1))
+
+- **account,cli,ipc**: Align account cold-path with 1.0 single-active-runtime policy (#1139)
+  ([#1162](https://github.com/joshua-jingu-lee/ante/pull/1162),
+  [`77beea8`](https://github.com/joshua-jingu-lee/ante/commit/77beea89d52837f64cd6a25e1aaaa3e12b4d3db1))
+
+- **account,web**: Align PUT /api/accounts request body schema and add Content-Type 415 gate (#1153)
+  ([#1166](https://github.com/joshua-jingu-lee/ante/pull/1166),
+  [`e901d97`](https://github.com/joshua-jingu-lee/ante/commit/e901d97842cd9de0cca63e194c90dd8153aeab3f))
+
+- **account,web**: Block runtime structural mutations with cold-path 409
+  ([#1146](https://github.com/joshua-jingu-lee/ante/pull/1146),
+  [`57780c2`](https://github.com/joshua-jingu-lee/ante/commit/57780c2882e197e8ce139140bb355b8a0049bc3f))
+
+- **account,web**: Expose POST /api/accounts request body OpenAPI schema (#1143)
+  ([#1155](https://github.com/joshua-jingu-lee/ante/pull/1155),
+  [`91de6fa`](https://github.com/joshua-jingu-lee/ante/commit/91de6fa9c502fd1288863a2f397a7191a30a0bba))
+
+- **account,web-api**: Enforce IANA timezone on PUT ingress + service boundary (#1473)
+  ([#1483](https://github.com/joshua-jingu-lee/ante/pull/1483),
+  [`4cb273c`](https://github.com/joshua-jingu-lee/ante/commit/4cb273cd5d64d4c1234ebcff72d8c0070ebfe9f0))
+
+- **api,cli**: Enforce schema-required fields at report submit boundary (#1625)
+  ([#1638](https://github.com/joshua-jingu-lee/ante/pull/1638),
+  [`25b3ead`](https://github.com/joshua-jingu-lee/ante/commit/25b3ead30d0eee6e7da18aecbc5bb50fed42ed30))
+
+- **api,cli**: Exit/404 on strategy performance for missing account
+  ([#1572](https://github.com/joshua-jingu-lee/ante/pull/1572),
+  [`c690fde`](https://github.com/joshua-jingu-lee/ante/commit/c690fdee46d767e1ffba68c272f29d58970741e8))
+
+- **api,cli**: Exit/404 on strategy performance for missing account (#1563)
+  ([#1572](https://github.com/joshua-jingu-lee/ante/pull/1572),
+  [`c690fde`](https://github.com/joshua-jingu-lee/ante/commit/c690fdee46d767e1ffba68c272f29d58970741e8))
+
+- **approval**: Block legacy invalid approval type approve + executor missing as EXECUTION_FAILED
+  (#1470) ([#1486](https://github.com/joshua-jingu-lee/ante/pull/1486),
+  [`199b9bc`](https://github.com/joshua-jingu-lee/ante/commit/199b9bcf19955ffb8e37891bef9d6afbca9353d5))
+
+- **audit**: Allow human members to read audit logs without scope
+  ([#1369](https://github.com/joshua-jingu-lee/ante/pull/1369),
+  [`b81a785`](https://github.com/joshua-jingu-lee/ante/commit/b81a7859d9fff59e7fa970c76dcdecead0f41872))
+
+- **audit**: Allow members with audit:read scope to read audit logs
+  ([#1369](https://github.com/joshua-jingu-lee/ante/pull/1369),
+  [`b81a785`](https://github.com/joshua-jingu-lee/ante/commit/b81a7859d9fff59e7fa970c76dcdecead0f41872))
+
+- **audit**: Normalize compact/week ISO date to YYYY-MM-DD (codex FAIL r3)
+  ([#1444](https://github.com/joshua-jingu-lee/ante/pull/1444),
+  [`f2dae4f`](https://github.com/joshua-jingu-lee/ante/commit/f2dae4f4b5b8d5d2742c988185db17f557340976))
+
+- **audit**: Normalize Z/offset datetime to storage format (codex FAIL r2)
+  ([#1444](https://github.com/joshua-jingu-lee/ante/pull/1444),
+  [`f2dae4f`](https://github.com/joshua-jingu-lee/ante/commit/f2dae4f4b5b8d5d2742c988185db17f557340976))
+
+- **audit**: Order auth dependency before audit_logger to enforce 401 over 503
+  ([#1369](https://github.com/joshua-jingu-lee/ante/pull/1369),
+  [`b81a785`](https://github.com/joshua-jingu-lee/ante/commit/b81a7859d9fff59e7fa970c76dcdecead0f41872))
+
+- **audit**: Preserve date-only semantic in audit query (codex FAIL r1)
+  ([#1444](https://github.com/joshua-jingu-lee/ante/pull/1444),
+  [`f2dae4f`](https://github.com/joshua-jingu-lee/ante/commit/f2dae4f4b5b8d5d2742c988185db17f557340976))
+
+- **audit**: Reject suspended/revoked members from audit read
+  ([#1369](https://github.com/joshua-jingu-lee/ante/pull/1369),
+  [`b81a785`](https://github.com/joshua-jingu-lee/ante/commit/b81a7859d9fff59e7fa970c76dcdecead0f41872))
+
+- **audit**: Require authenticated audit:read for /api/audit (#1359)
+  ([#1369](https://github.com/joshua-jingu-lee/ante/pull/1369),
+  [`b81a785`](https://github.com/joshua-jingu-lee/ante/commit/b81a7859d9fff59e7fa970c76dcdecead0f41872))
+
+- **backtest**: Programmatic config symbol/timeframe vocabulary 검증 (#1604)
+  ([#1618](https://github.com/joshua-jingu-lee/ante/pull/1618),
+  [`063fe54`](https://github.com/joshua-jingu-lee/ante/commit/063fe54b7dd7f75a81afc4a6127a8c88dcff5c88))
+
+- **bot**: #1901 SignalKeyManager.rotate partial-failure rollback 가드 (defense-in-depth)
+  ([#1907](https://github.com/joshua-jingu-lee/ante/pull/1907),
+  [`e4a099d`](https://github.com/joshua-jingu-lee/ante/commit/e4a099d97347ea79935c6fc7c18ee81d8bb22799))
+
+- **bot**: Atomic rollback for BotConfig on budget failure in update_bot
+  ([#1506](https://github.com/joshua-jingu-lee/ante/pull/1506),
+  [`c1a5d71`](https://github.com/joshua-jingu-lee/ante/commit/c1a5d7177dbe56a34122b96832962c3ab2bdb8f0))
+
+- **bot**: Conditional rollback to avoid concurrent update_bot race
+  ([#1506](https://github.com/joshua-jingu-lee/ante/pull/1506),
+  [`c1a5d71`](https://github.com/joshua-jingu-lee/ante/commit/c1a5d7177dbe56a34122b96832962c3ab2bdb8f0))
+
+- **bot**: Hard-delete bot row on create rollback
+  ([#1345](https://github.com/joshua-jingu-lee/ante/pull/1345),
+  [`016a328`](https://github.com/joshua-jingu-lee/ante/commit/016a3285cb2900a83636eaf6397040b841f4bf6a))
+
+- **bot**: Make update_bot budget failure atomic — rollback runtime control changes
+  ([#1506](https://github.com/joshua-jingu-lee/ante/pull/1506),
+  [`c1a5d71`](https://github.com/joshua-jingu-lee/ante/commit/c1a5d7177dbe56a34122b96832962c3ab2bdb8f0))
+
+- **bot**: Map create budget failure to 422 with hard rollback (#1335)
+  ([#1345](https://github.com/joshua-jingu-lee/ante/pull/1345),
+  [`016a328`](https://github.com/joshua-jingu-lee/ante/commit/016a3285cb2900a83636eaf6397040b841f4bf6a))
+
+- **bot**: Mirror BotConfig invariants at create_bot service boundary
+  ([#1508](https://github.com/joshua-jingu-lee/ante/pull/1508),
+  [`c2b89c4`](https://github.com/joshua-jingu-lee/ante/commit/c2b89c4741812c32df7d1dde230e888890ffde85))
+
+- **bot**: Persist runtime controls + auto_restart across BotConfig DB roundtrip
+  ([#1500](https://github.com/joshua-jingu-lee/ante/pull/1500),
+  [`026a8c4`](https://github.com/joshua-jingu-lee/ante/commit/026a8c4a4087da84b0ed245e8f15fbe7258aaff3))
+
+- **bot**: Serialize update_bot per-bot to prevent concurrent atomicity race
+  ([#1506](https://github.com/joshua-jingu-lee/ante/pull/1506),
+  [`c1a5d71`](https://github.com/joshua-jingu-lee/ante/commit/c1a5d7177dbe56a34122b96832962c3ab2bdb8f0))
+
+- **bot**: Skip update_bot rollback DB save on delete/recreate race
+  ([#1506](https://github.com/joshua-jingu-lee/ante/pull/1506),
+  [`c1a5d71`](https://github.com/joshua-jingu-lee/ante/commit/c1a5d7177dbe56a34122b96832962c3ab2bdb8f0))
+
+- **bot**: Skip update_bot rollback on in-place BotConfig mutation
+  ([#1506](https://github.com/joshua-jingu-lee/ante/pull/1506),
+  [`c1a5d71`](https://github.com/joshua-jingu-lee/ante/commit/c1a5d7177dbe56a34122b96832962c3ab2bdb8f0))
+
+- **bot**: Skip virtual fill for stop/stop_limit OrderApprovedEvent
+  ([#1348](https://github.com/joshua-jingu-lee/ante/pull/1348),
+  [`ce0efab`](https://github.com/joshua-jingu-lee/ante/commit/ce0efab8cc58277b3323d1560ba8f8ef87ccd8ed))
+
+- **bot**: Support cold-path remove ([#1196](https://github.com/joshua-jingu-lee/ante/pull/1196),
+  [`d563f0a`](https://github.com/joshua-jingu-lee/ante/commit/d563f0a00ed9615131c356e9e3b7ab55fa6032ea))
+
+- **broker**: #1951 KIS 40240000 매도가능잔고 없음 PERMANENT 분류
+  ([#1955](https://github.com/joshua-jingu-lee/ante/pull/1955),
+  [`4c4059c`](https://github.com/joshua-jingu-lee/ante/commit/4c4059cb2879477227f71bbf77fe1b56d970012a))
+
+- **broker**: Classify KIS 40570000 (장시작전) as permanent (#1317)
+  ([#1327](https://github.com/joshua-jingu-lee/ante/pull/1327),
+  [`a86fa12`](https://github.com/joshua-jingu-lee/ante/commit/a86fa1277180a99e8843d9d2b63f1612baf3be57))
+
+- **broker**: Preserve KIS msg_cd on HTTP 5xx wrapped business errors (#1338)
+  ([#1347](https://github.com/joshua-jingu-lee/ante/pull/1347),
+  [`9035986`](https://github.com/joshua-jingu-lee/ante/commit/9035986d3554e4c150e6134ac3a1e88ad7b6f076))
+
+- **broker**: Scope reconcile scheduler to its broker account (#1240 review)
+  ([#1243](https://github.com/joshua-jingu-lee/ante/pull/1243),
+  [`83dcd3b`](https://github.com/joshua-jingu-lee/ante/commit/83dcd3b206acade00a7abfd8eb285f0036def1af))
+
+- **broker,ipc,trade**: Account-scope reconcile and skip-aware pagination (#1240 review)
+  ([#1243](https://github.com/joshua-jingu-lee/ante/pull/1243),
+  [`83dcd3b`](https://github.com/joshua-jingu-lee/ante/commit/83dcd3b206acade00a7abfd8eb285f0036def1af))
+
+- **ci**: Restore ruff import order ([#1150](https://github.com/joshua-jingu-lee/ante/pull/1150),
+  [`2e2dd3f`](https://github.com/joshua-jingu-lee/ante/commit/2e2dd3fcca018370d8ea5434f5804efac4454978))
+
+- **ci**: Restore ruff lint pass ([#1150](https://github.com/joshua-jingu-lee/ante/pull/1150),
+  [`2e2dd3f`](https://github.com/joshua-jingu-lee/ante/commit/2e2dd3fcca018370d8ea5434f5804efac4454978))
+
+- **ci**: Satisfy ruff format check ([#1150](https://github.com/joshua-jingu-lee/ante/pull/1150),
+  [`2e2dd3f`](https://github.com/joshua-jingu-lee/ante/commit/2e2dd3fcca018370d8ea5434f5804efac4454978))
+
+- **ci**: Support latest click typing ([#1150](https://github.com/joshua-jingu-lee/ante/pull/1150),
+  [`2e2dd3f`](https://github.com/joshua-jingu-lee/ante/commit/2e2dd3fcca018370d8ea5434f5804efac4454978))
+
+- **ci**: Wrap notification warning log
+  ([#1150](https://github.com/joshua-jingu-lee/ante/pull/1150),
+  [`2e2dd3f`](https://github.com/joshua-jingu-lee/ante/commit/2e2dd3fcca018370d8ea5434f5804efac4454978))
+
+- **cli**: #1657 strategy performance invalid account_id를 VALIDATION_ERROR로 거부 (read-family
+  follow-up) ([#1667](https://github.com/joshua-jingu-lee/ante/pull/1667),
+  [`942cbc0`](https://github.com/joshua-jingu-lee/ante/commit/942cbc052a92ddbf02216e9e58c482e174feb576))
+
+- **cli**: #1900 _create_services mock anti-pattern 일괄 정리 (10 factory + helper + advisory scanner)
+  ([#1903](https://github.com/joshua-jingu-lee/ante/pull/1903),
+  [`c43fccf`](https://github.com/joshua-jingu-lee/ante/commit/c43fccfbb8b405cffdd5313429ad182a4abf7ded))
+
+- **cli**: #1900 _create_services mock anti-pattern 일괄 정리 (10 factory + helper + AST scanner)
+  ([#1903](https://github.com/joshua-jingu-lee/ante/pull/1903),
+  [`c43fccf`](https://github.com/joshua-jingu-lee/ante/commit/c43fccfbb8b405cffdd5313429ad182a4abf7ded))
+
+- **cli**: #1900 helper ctx 시그니처 production 정합 + scanner decorator 형태 검사 (codex review attempt 2
+  finding 2건) ([#1903](https://github.com/joshua-jingu-lee/ante/pull/1903),
+  [`c43fccf`](https://github.com/joshua-jingu-lee/ante/commit/c43fccfbb8b405cffdd5313429ad182a4abf7ded))
+
+- **cli**: #1900 scanner advisory mode 격하 + false positive 2건 fix (codex review attempt 6 finding,
+  final) ([#1903](https://github.com/joshua-jingu-lee/ante/pull/1903),
+  [`c43fccf`](https://github.com/joshua-jingu-lee/ante/commit/c43fccfbb8b405cffdd5313429ad182a4abf7ded))
+
+- **cli**: #1900 scanner decorator-injected mock body assignment + KNOWN-LIMITATION 섹션 (codex review
+  attempt 3 finding 1건, bounded-scope) ([#1903](https://github.com/joshua-jingu-lee/ante/pull/1903),
+  [`c43fccf`](https://github.com/joshua-jingu-lee/ante/commit/c43fccfbb8b405cffdd5313429ad182a4abf7ded))
+
+- **cli**: #1900 scanner new_callable variants + decorator slot mapping + 2-pass stub collection
+  (codex review attempt 4 finding 3건, last fix)
+  ([#1903](https://github.com/joshua-jingu-lee/ante/pull/1903),
+  [`c43fccf`](https://github.com/joshua-jingu-lee/ante/commit/c43fccfbb8b405cffdd5313429ad182a4abf7ded))
+
+- **cli**: #1900 scanner target-specific stub signature + class decorator method body (codex review
+  attempt 5 finding 2건, final) ([#1903](https://github.com/joshua-jingu-lee/ante/pull/1903),
+  [`c43fccf`](https://github.com/joshua-jingu-lee/ante/commit/c43fccfbb8b405cffdd5313429ad182a4abf7ded))
+
+- **cli**: #1900 scanner 완전성 보강 (default patch tuple return + positional new) + pip_freeze 되돌리기
+  (codex review attempt 1 finding 3건) ([#1903](https://github.com/joshua-jingu-lee/ante/pull/1903),
+  [`c43fccf`](https://github.com/joshua-jingu-lee/ante/commit/c43fccfbb8b405cffdd5313429ad182a4abf7ded))
+
+- **cli**: #1911 init lowercase envelope code 일제 SCREAMING_SNAKE 정렬
+  ([#1922](https://github.com/joshua-jingu-lee/ante/pull/1922),
+  [`952b614`](https://github.com/joshua-jingu-lee/ante/commit/952b614448c72c0b8ee01595c16d657e0268ad01))
+
+- **cli**: #1911 non-auth JSON envelope code SCREAMING_SNAKE 정합
+  ([#1922](https://github.com/joshua-jingu-lee/ante/pull/1922),
+  [`952b614`](https://github.com/joshua-jingu-lee/ante/commit/952b614448c72c0b8ee01595c16d657e0268ad01))
+
+- **cli**: #1911 non-auth JSON envelope code를 SCREAMING_SNAKE로 정합
+  ([#1922](https://github.com/joshua-jingu-lee/ante/pull/1922),
+  [`952b614`](https://github.com/joshua-jingu-lee/ante/commit/952b614448c72c0b8ee01595c16d657e0268ad01))
+
+- **cli**: #1913 ANTE_DB_ENCRYPTION_KEY 누락 시 envelope error로 정합
+  ([#1932](https://github.com/joshua-jingu-lee/ante/pull/1932),
+  [`f76d56d`](https://github.com/joshua-jingu-lee/ante/commit/f76d56d51fb14f80067c148c9182348a133e2b50))
+
+- **cli**: #1913 r1 후속 — chokepoint Config.load 실패 시 env-only fallback
+  ([#1932](https://github.com/joshua-jingu-lee/ante/pull/1932),
+  [`f76d56d`](https://github.com/joshua-jingu-lee/ante/commit/f76d56d51fb14f80067c148c9182348a133e2b50))
+
+- **cli**: #1914 --data-path default을 config-resolved data root로 정합
+  ([#1933](https://github.com/joshua-jingu-lee/ante/pull/1933),
+  [`3e526c2`](https://github.com/joshua-jingu-lee/ante/commit/3e526c29f6ea1afd125034bebc79e9c4ff6dfd57))
+
+- **cli**: #1921 update lowercase envelope code를 SCREAMING_SNAKE로 정합
+  ([#1935](https://github.com/joshua-jingu-lee/ante/pull/1935),
+  [`5d1e6eb`](https://github.com/joshua-jingu-lee/ante/commit/5d1e6eb2a91340e6f9b499ded05e25f7f90c1c31))
+
+- **cli**: Account suspend/activate invalid account_id ingress 거부 (#1655) (#1623 D follow-up)
+  ([#1665](https://github.com/joshua-jingu-lee/ante/pull/1665),
+  [`5735a08`](https://github.com/joshua-jingu-lee/ante/commit/5735a08459f5a515da575c11a20beef3a4f7829c))
+
+- **cli**: Ante update confirmation gate precedence over server-running + UPDATE_SERVER_RUNNING code
+  (#1626) ([#1639](https://github.com/joshua-jingu-lee/ante/pull/1639),
+  [`d2ff62a`](https://github.com/joshua-jingu-lee/ante/commit/d2ff62a371e5f7380e5977f26033b79f5e69cb41))
+
+- **cli**: Backtest run symbol/timeframe ingress 검증 (#1603)
+  ([#1617](https://github.com/joshua-jingu-lee/ante/pull/1617),
+  [`1011a59`](https://github.com/joshua-jingu-lee/ante/commit/1011a591df31572791583256d166978c1467acd8))
+
+- **cli**: Bot create local validation must exit 1 in JSON mode (#1534)
+  ([#1546](https://github.com/joshua-jingu-lee/ante/pull/1546),
+  [`d328d5d`](https://github.com/joshua-jingu-lee/ante/commit/d328d5d8b2187b240a9a06cb7dc1ffcf96d59705))
+
+- **cli**: Broker IPC invalid account_id envelope 정렬 (#1636) (#1623 Split C)
+  ([#1649](https://github.com/joshua-jingu-lee/ante/pull/1649),
+  [`690222b`](https://github.com/joshua-jingu-lee/ante/commit/690222b03c388cc909c1f49e4b1d86a92fcf3e6d))
+
+- **cli**: Close db on broker missing-account error to prevent hang (#1535)
+  ([#1547](https://github.com/joshua-jingu-lee/ante/pull/1547),
+  [`6191164`](https://github.com/joshua-jingu-lee/ante/commit/6191164d1ab307175a90f21e0bd7385d336b4839))
+
+- **cli**: Correct mypy type:ignore code for click.group overload
+  ([#1424](https://github.com/joshua-jingu-lee/ante/pull/1424),
+  [`f816780`](https://github.com/joshua-jingu-lee/ante/commit/f816780b25511314e6255bd638f805af0007d14b))
+
+- **cli**: Data validate symbol/timeframe ingress 검증 (#1605)
+  ([#1619](https://github.com/joshua-jingu-lee/ante/pull/1619),
+  [`2472f78`](https://github.com/joshua-jingu-lee/ante/commit/2472f7889a3702182d8539c74096b3aff0449185))
+
+- **cli**: Emit JSON envelope for feed config set unsupported key (#1537)
+  ([#1549](https://github.com/joshua-jingu-lee/ante/pull/1549),
+  [`66d5cfc`](https://github.com/joshua-jingu-lee/ante/commit/66d5cfcf82dbd70e27ca6a251c850f3ae1811834))
+
+- **cli**: Emit JSON envelope on UsageError when --format json
+  ([#1551](https://github.com/joshua-jingu-lee/ante/pull/1551),
+  [`1543db9`](https://github.com/joshua-jingu-lee/ante/commit/1543db952c43d9526e59bf068213a98e06e9bfc2))
+
+- **cli**: Emit structured JSON error for auth failures in --format json
+  ([#1545](https://github.com/joshua-jingu-lee/ante/pull/1545),
+  [`2e2874f`](https://github.com/joshua-jingu-lee/ante/commit/2e2874ffca855c940d5e1c4063608ef705e352eb))
+
+- **cli**: Enforce IntRange min guard on pagination options
+  ([#1522](https://github.com/joshua-jingu-lee/ante/pull/1522),
+  [`a02d0ba`](https://github.com/joshua-jingu-lee/ante/commit/a02d0ba37f480367959598662dcfa4676286e96b))
+
+- **cli**: Enforce ReportSubmitRequest invariant on CLI submit + StrategyReport guard
+  ([#1445](https://github.com/joshua-jingu-lee/ante/pull/1445),
+  [`64ab2e7`](https://github.com/joshua-jingu-lee/ante/commit/64ab2e730e2160fb033152b0ec34c76036109dcc))
+
+- **cli**: Enforce ReportSubmitRequest invariant on CLI submit + StrategyReport store guard (#1415)
+  ([#1445](https://github.com/joshua-jingu-lee/ante/pull/1445),
+  [`64ab2e7`](https://github.com/joshua-jingu-lee/ante/commit/64ab2e730e2160fb033152b0ec34c76036109dcc))
+
+- **cli**: Enforce strict YYYY-MM-DD on audit/treasury date filters
+  ([#1523](https://github.com/joshua-jingu-lee/ante/pull/1523),
+  [`53249e8`](https://github.com/joshua-jingu-lee/ante/commit/53249e8f3bd67c9ebc2ce660672743dda2c04863))
+
+- **cli**: Exit 1 on bot positions for missing bot
+  ([#1568](https://github.com/joshua-jingu-lee/ante/pull/1568),
+  [`f3efcbc`](https://github.com/joshua-jingu-lee/ante/commit/f3efcbcd12f6524b7dbe7e5abbc0a153e3b85049))
+
+- **cli**: Exit 1 on bot positions for missing bot (#1558)
+  ([#1568](https://github.com/joshua-jingu-lee/ante/pull/1568),
+  [`f3efcbc`](https://github.com/joshua-jingu-lee/ante/commit/f3efcbcd12f6524b7dbe7e5abbc0a153e3b85049))
+
+- **cli**: Exit 1 on broker status/reconcile missing-account
+  ([#1566](https://github.com/joshua-jingu-lee/ante/pull/1566),
+  [`3761a3f`](https://github.com/joshua-jingu-lee/ante/commit/3761a3fb39f86f1dbdca6ac176643b0a2a0f2082))
+
+- **cli**: Exit 1 on broker status/reconcile missing-account (#1556)
+  ([#1566](https://github.com/joshua-jingu-lee/ante/pull/1566),
+  [`3761a3f`](https://github.com/joshua-jingu-lee/ante/commit/3761a3fb39f86f1dbdca6ac176643b0a2a0f2082))
+
+- **cli**: Exit 1 on instrument import validation errors
+  ([#1528](https://github.com/joshua-jingu-lee/ante/pull/1528),
+  [`ee3465d`](https://github.com/joshua-jingu-lee/ante/commit/ee3465d3eb760841241ab923a583d4602b893c83))
+
+- **cli**: Exit 1 on member admin command errors (#1557)
+  ([#1567](https://github.com/joshua-jingu-lee/ante/pull/1567),
+  [`fb783f0`](https://github.com/joshua-jingu-lee/ante/commit/fb783f0c0171be7e897391d9ecf9b07e9cb96456))
+
+- **cli**: Exit 1 on missing-resource error in 5 CLI commands
+  ([#1525](https://github.com/joshua-jingu-lee/ante/pull/1525),
+  [`c87a5b0`](https://github.com/joshua-jingu-lee/ante/commit/c87a5b0c276ae679e6f7826c420eaa126344ed57))
+
+- **cli**: Exit 1 on report view and treasury snapshot missing-resource (#1538)
+  ([#1550](https://github.com/joshua-jingu-lee/ante/pull/1550),
+  [`18664ed`](https://github.com/joshua-jingu-lee/ante/commit/18664ed2e1ac4ef244d3523e39c15fddb3729d2a))
+
+- **cli**: Exit 1 on rule list for missing account
+  ([#1569](https://github.com/joshua-jingu-lee/ante/pull/1569),
+  [`c43f8c6`](https://github.com/joshua-jingu-lee/ante/commit/c43f8c61fec5f729a5708d5c5079725827ec9868))
+
+- **cli**: Exit 1 on rule list for missing account (#1559)
+  ([#1569](https://github.com/joshua-jingu-lee/ante/pull/1569),
+  [`c43f8c6`](https://github.com/joshua-jingu-lee/ante/commit/c43f8c61fec5f729a5708d5c5079725827ec9868))
+
+- **cli**: Exit 1 on signal connect failures (#1560)
+  ([#1570](https://github.com/joshua-jingu-lee/ante/pull/1570),
+  [`c193890`](https://github.com/joshua-jingu-lee/ante/commit/c19389000c3fa180d4c66facaca187b216422ed4))
+
+- **cli**: Exit 1 on treasury snapshot option conflict (#1540)
+  ([#1552](https://github.com/joshua-jingu-lee/ante/pull/1552),
+  [`7a9496b`](https://github.com/joshua-jingu-lee/ante/commit/7a9496b5fc94901bff88a352e9b35638d84fa1ef))
+
+- **cli**: Exit non-zero on signal-key DB error
+  ([#1608](https://github.com/joshua-jingu-lee/ante/pull/1608),
+  [`2d92db2`](https://github.com/joshua-jingu-lee/ante/commit/2d92db25b1434083ccbba82d4d5ae4261f46f6b0))
+
+- **cli**: Feed inject symbol/timeframe 저장 전 검증 (#1606)
+  ([#1620](https://github.com/joshua-jingu-lee/ante/pull/1620),
+  [`c5b148c`](https://github.com/joshua-jingu-lee/ante/commit/c5b148c347c46e1ab6203735aa330816fc47d7e3))
+
+- **cli**: Guard non-string import exchange before canonical check
+  ([#1582](https://github.com/joshua-jingu-lee/ante/pull/1582),
+  [`bae5ae0`](https://github.com/joshua-jingu-lee/ante/commit/bae5ae031b42a7d2c04208ca5ae21ee3aa5603f7))
+
+- **cli**: Instrument import KRX symbol ingress 검증 (#1611)
+  ([#1621](https://github.com/joshua-jingu-lee/ante/pull/1621),
+  [`b86b529`](https://github.com/joshua-jingu-lee/ante/commit/b86b5294f91895f86caf580f54b6083e3e68dc0c))
+
+- **cli**: Make broker --account required (#1240 review)
+  ([#1243](https://github.com/joshua-jingu-lee/ante/pull/1243),
+  [`83dcd3b`](https://github.com/joshua-jingu-lee/ante/commit/83dcd3b206acade00a7abfd8eb285f0036def1af))
+
+- **cli**: Normalize missing accounts table as account-not-found in rule list
+  ([#1569](https://github.com/joshua-jingu-lee/ante/pull/1569),
+  [`c43f8c6`](https://github.com/joshua-jingu-lee/ante/commit/c43f8c61fec5f729a5708d5c5079725827ec9868))
+
+- **cli**: Normalize missing bots table as missing bot in bot positions
+  ([#1568](https://github.com/joshua-jingu-lee/ante/pull/1568),
+  [`f3efcbc`](https://github.com/joshua-jingu-lee/ante/commit/f3efcbcd12f6524b7dbe7e5abbc0a153e3b85049))
+
+- **cli**: Preflight strategy list --status with structured validation error (#1461)
+  ([#1480](https://github.com/joshua-jingu-lee/ante/pull/1480),
+  [`a062f74`](https://github.com/joshua-jingu-lee/ante/commit/a062f74af57ade7bd01975f0f38be960abda73ec))
+
+- **cli**: Reject invalid account_id in 3 read-only surfaces before lookup/filter (#1634)
+  ([#1647](https://github.com/joshua-jingu-lee/ante/pull/1647),
+  [`a68cc28`](https://github.com/joshua-jingu-lee/ante/commit/a68cc28375ec04a6eb08f9b0a0466ddda26c5616))
+
+- **cli**: Reject invalid/source-unsupported exchange in instrument list/sync/import (#1577)
+  ([#1582](https://github.com/joshua-jingu-lee/ante/pull/1582),
+  [`bae5ae0`](https://github.com/joshua-jingu-lee/ante/commit/bae5ae031b42a7d2c04208ca5ae21ee3aa5603f7))
+
+- **cli**: Reject inverted date range across 4 read/report commands + spec/error-code SSOT (#1597)
+  ([#1609](https://github.com/joshua-jingu-lee/ante/pull/1609),
+  [`a30935a`](https://github.com/joshua-jingu-lee/ante/commit/a30935a251de1b0beb487a15ade2c2da918b0a00))
+
+- **cli**: Reject NaN/inf/non-positive amounts on treasury allocate/deallocate
+  ([#1529](https://github.com/joshua-jingu-lee/ante/pull/1529),
+  [`84364b2`](https://github.com/joshua-jingu-lee/ante/commit/84364b299f16fc4de9aadd6697c42854e0ea73d9))
+
+- **cli**: Reject non-canonical/source-unsupported exchange in instrument list/sync/import
+  ([#1582](https://github.com/joshua-jingu-lee/ante/pull/1582),
+  [`bae5ae0`](https://github.com/joshua-jingu-lee/ante/commit/bae5ae031b42a7d2c04208ca5ae21ee3aa5603f7))
+
+- **cli**: Reject non-finite/non-positive backtest --balance (#1565)
+  ([#1574](https://github.com/joshua-jingu-lee/ante/pull/1574),
+  [`3528280`](https://github.com/joshua-jingu-lee/ante/commit/352828030b86123047f56b8758911a7921fb1188))
+
+- **cli**: Reject non-positive year in monthly report performance + error-code SSOT (#1599)
+  ([#1610](https://github.com/joshua-jingu-lee/ante/pull/1610),
+  [`8237fb5`](https://github.com/joshua-jingu-lee/ante/commit/8237fb56d51b0bbbc386014886ff44560010797e))
+
+- **cli**: Reject period-exclusive option conflicts in report performance + spec/error-code SSOT
+  (#1593) ([#1600](https://github.com/joshua-jingu-lee/ante/pull/1600),
+  [`854f606`](https://github.com/joshua-jingu-lee/ante/commit/854f606b58bb514312a00f457bc89c93c62d22e5))
+
+- **cli**: Reject signal-key for missing bot
+  ([#1608](https://github.com/joshua-jingu-lee/ante/pull/1608),
+  [`2d92db2`](https://github.com/joshua-jingu-lee/ante/commit/2d92db25b1434083ccbba82d4d5ae4261f46f6b0))
+
+- **cli**: Reject signal-key for missing/deleted bot (#1596)
+  ([#1608](https://github.com/joshua-jingu-lee/ante/pull/1608),
+  [`2d92db2`](https://github.com/joshua-jingu-lee/ante/commit/2d92db25b1434083ccbba82d4d5ae4261f46f6b0))
+
+- **cli**: Require JSON object for approval --params (#1519)
+  ([#1532](https://github.com/joshua-jingu-lee/ante/pull/1532),
+  [`5c17ff1`](https://github.com/joshua-jingu-lee/ante/commit/5c17ff198c54aa83caaa0951eebf1f6401361a89))
+
+- **cli**: Resolve get_db_path through Config.resolve_path
+  ([#1181](https://github.com/joshua-jingu-lee/ante/pull/1181),
+  [`b5e60d7`](https://github.com/joshua-jingu-lee/ante/commit/b5e60d71e2ae2ffb893d657d759d1af9d0fee536))
+
+- **cli**: Reuse validate_iso_date on trade list --from/--to
+  ([#1524](https://github.com/joshua-jingu-lee/ante/pull/1524),
+  [`d013a71`](https://github.com/joshua-jingu-lee/ante/commit/d013a711ea5d36c1407ed536ea05455f363fbc3b))
+
+- **cli**: Show market_order_reserve_buffer_rate in account info text output (#1333 P3)
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **cli**: Strategy validate failure emits single JSON envelope and exit 1 (#1541)
+  ([#1553](https://github.com/joshua-jingu-lee/ante/pull/1553),
+  [`517b34d`](https://github.com/joshua-jingu-lee/ante/commit/517b34d5e4297c48a25e4c5161b238df3ce8a51f))
+
+- **cli**: Strict YYYY-MM-DD validation for feed date options
+  ([#1571](https://github.com/joshua-jingu-lee/ante/pull/1571),
+  [`c2e8549`](https://github.com/joshua-jingu-lee/ante/commit/c2e85490951fa0c43c852b80191e3dca5ce8f045))
+
+- **cli**: Strict YYYY-MM-DD validation for feed date options (#1562)
+  ([#1571](https://github.com/joshua-jingu-lee/ante/pull/1571),
+  [`c2e8549`](https://github.com/joshua-jingu-lee/ante/commit/c2e85490951fa0c43c852b80191e3dca5ce8f045))
+
+- **cli**: Treasury/rule construction lifecycle invalid account_id 경계 (#1635)
+  ([#1648](https://github.com/joshua-jingu-lee/ante/pull/1648),
+  [`1623291`](https://github.com/joshua-jingu-lee/ante/commit/1623291446db187d10dec66fa2f952435feed0a8))
+
+- **cli**: Treat soft-deleted bot as missing in signal-key
+  ([#1608](https://github.com/joshua-jingu-lee/ante/pull/1608),
+  [`2d92db2`](https://github.com/joshua-jingu-lee/ante/commit/2d92db25b1434083ccbba82d4d5ae4261f46f6b0))
+
+- **cli**: Use ACCOUNT_NOT_FOUND error code for broker missing-account
+  ([#1566](https://github.com/joshua-jingu-lee/ante/pull/1566),
+  [`3761a3f`](https://github.com/joshua-jingu-lee/ante/commit/3761a3fb39f86f1dbdca6ac176643b0a2a0f2082))
+
+- **cli**: Use lightweight account existence check in rule list
+  ([#1569](https://github.com/joshua-jingu-lee/ante/pull/1569),
+  [`c43f8c6`](https://github.com/joshua-jingu-lee/ante/commit/c43f8c61fec5f729a5708d5c5079725827ec9868))
+
+- **cli**: Validate feed --until/--date and unify CLI_INVALID_DATE
+  ([#1571](https://github.com/joshua-jingu-lee/ante/pull/1571),
+  [`c2e8549`](https://github.com/joshua-jingu-lee/ante/commit/c2e85490951fa0c43c852b80191e3dca5ce8f045))
+
+- **cli**: Validate feed backfill --since at CLI boundary (#1536)
+  ([#1548](https://github.com/joshua-jingu-lee/ante/pull/1548),
+  [`3eddd58`](https://github.com/joshua-jingu-lee/ante/commit/3eddd5825ecc8610c74ac8856da9a799f3205316))
+
+- **cli**: Validate report performance --start/--end at CLI boundary (#1564)
+  ([#1573](https://github.com/joshua-jingu-lee/ante/pull/1573),
+  [`20794aa`](https://github.com/joshua-jingu-lee/ante/commit/20794aaf2d4b890a658f5c3ab50f466e5114c319))
+
+- **cli**: Wrap _parse_expires_in to suppress traceback on invalid duration
+  ([#1531](https://github.com/joshua-jingu-lee/ante/pull/1531),
+  [`3c80211`](https://github.com/joshua-jingu-lee/ante/commit/3c80211a80a1fc23b9c317021ba10930193d08e3))
+
+- **cli,approval**: Enforce ApprovalType enum on CLI request + service create (#1469)
+  ([#1481](https://github.com/joshua-jingu-lee/ante/pull/1481),
+  [`20918ae`](https://github.com/joshua-jingu-lee/ante/commit/20918aeca0309d17067f193f6128b7f00bfe3947))
+
+- **cli/account**: Pass explicit Config to cold-path guard read_pid_file
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **cli/system**: Pass explicit Config to start's read_pid_file
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **cli/update**: Pass explicit Config to check_server_running
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **config**: Cover register_default and tuple values in finite invariant
+  ([#1433](https://github.com/joshua-jingu-lee/ante/pull/1433),
+  [`6eab379`](https://github.com/joshua-jingu-lee/ante/commit/6eab379ab7a2e5a7c2a253a203e42c2a157b3bbf))
+
+- **config**: Enforce finite numeric invariant at write and read boundaries
+  ([#1433](https://github.com/joshua-jingu-lee/ante/pull/1433),
+  [`6eab379`](https://github.com/joshua-jingu-lee/ante/commit/6eab379ab7a2e5a7c2a253a203e42c2a157b3bbf))
+
+- **config**: Enforce finite numeric invariant for dynamic config (write + read defense)
+  ([#1433](https://github.com/joshua-jingu-lee/ante/pull/1433),
+  [`6eab379`](https://github.com/joshua-jingu-lee/ante/commit/6eab379ab7a2e5a7c2a253a203e42c2a157b3bbf))
+
+- **config**: Recurse finite check into nested dict/list, skip int from isfinite
+  ([#1433](https://github.com/joshua-jingu-lee/ante/pull/1433),
+  [`6eab379`](https://github.com/joshua-jingu-lee/ante/commit/6eab379ab7a2e5a7c2a253a203e42c2a157b3bbf))
+
+- **config**: Reject invalid system.log_level value at service boundary (#1379)
+  ([#1389](https://github.com/joshua-jingu-lee/ante/pull/1389),
+  [`8f26812`](https://github.com/joshua-jingu-lee/ante/commit/8f2681247d913b9b89197bc8bfd05e54bf0e796e))
+
+- **config,cli,main**: Resolve db.path through Config.resolve_path to close cold-path split-brain
+  (#1158) ([#1181](https://github.com/joshua-jingu-lee/ante/pull/1181),
+  [`b5e60d7`](https://github.com/joshua-jingu-lee/ante/commit/b5e60d71e2ae2ffb893d657d759d1af9d0fee536))
+
+- **core**: #1923 Database.transaction이 BaseException 경로에서도 ROLLBACK
+  ([#1937](https://github.com/joshua-jingu-lee/ante/pull/1937),
+  [`c177b28`](https://github.com/joshua-jingu-lee/ante/commit/c177b28429ec4e818140ff7f2fc7b84ca05da4dc))
+
+- **dashboard**: Align notification settings keys with 1.0 contract
+  ([#1163](https://github.com/joshua-jingu-lee/ante/pull/1163),
+  [`d5ec35e`](https://github.com/joshua-jingu-lee/ante/commit/d5ec35e5f153f2c3006c6b2a09b17fbd28e842f9))
+
+- **dashboard**: Align notification settings keys with 1.0 contract (#1141)
+  ([#1163](https://github.com/joshua-jingu-lee/ante/pull/1163),
+  [`d5ec35e`](https://github.com/joshua-jingu-lee/ante/commit/d5ec35e5f153f2c3006c6b2a09b17fbd28e842f9))
+
+- **dashboard**: Preserve INFO fallback and unblock min_level when telegram off
+  ([#1163](https://github.com/joshua-jingu-lee/ante/pull/1163),
+  [`d5ec35e`](https://github.com/joshua-jingu-lee/ante/commit/d5ec35e5f153f2c3006c6b2a09b17fbd28e842f9))
+
+- **data**: DataCollector symbol/timeframe ingress 검증 (#1614)
+  ([#1622](https://github.com/joshua-jingu-lee/ante/pull/1622),
+  [`7ced866`](https://github.com/joshua-jingu-lee/ante/commit/7ced8669da695be8679d8f1e99ecfbde34babc96))
+
+- **data**: Enforce canonical exchange on ParquetStore write/append (#1584)
+  ([#1587](https://github.com/joshua-jingu-lee/ante/pull/1587),
+  [`b037250`](https://github.com/joshua-jingu-lee/ante/commit/b037250d12063ce81cfcc60288cb38ee4b2ccc65))
+
+- **data**: Raise list_datasets limit ceiling to 10000 to preserve dashboard caller
+  ([#1366](https://github.com/joshua-jingu-lee/ante/pull/1366),
+  [`9b12c08`](https://github.com/joshua-jingu-lee/ante/commit/9b12c087492aab7001ca46ea65f8c2b4f664f6f6))
+
+- **deps**: Cap cryptography <47 to avoid arm64 wheel SIGILL
+  ([#1295](https://github.com/joshua-jingu-lee/ante/pull/1295),
+  [`93f6823`](https://github.com/joshua-jingu-lee/ante/commit/93f682395deeb8657e0182c0010d64193943e83e))
+
+- **docs**: #1659 broker health/price docs drift 정합 (docs-only sweep)
+  ([#1668](https://github.com/joshua-jingu-lee/ante/pull/1668),
+  [`14245cf`](https://github.com/joshua-jingu-lee/ante/commit/14245cf05fffdf9e5454d8d33d7fad7d2664f229))
+
+- **docs**: #1660 bot start/stop/status를 미구현(follow-up)으로 명시 (docs + 생성기 annotation)
+  ([#1669](https://github.com/joshua-jingu-lee/ante/pull/1669),
+  [`0c62d69`](https://github.com/joshua-jingu-lee/ante/commit/0c62d691a69799a3e6f1e9a2271886cefbf4be41))
+
+- **docs**: #1660 ipc.md bot.query 모순 정정 — 실재 4명령 live-query 보존·bot status만 미구현 분리
+  ([#1669](https://github.com/joshua-jingu-lee/ante/pull/1669),
+  [`0c62d69`](https://github.com/joshua-jingu-lee/ante/commit/0c62d691a69799a3e6f1e9a2271886cefbf4be41))
+
+- **docs**: #1660 scope를 oracle literal surface로 narrowing (Codex attempt 2 P2x2)
+  ([#1669](https://github.com/joshua-jingu-lee/ante/pull/1669),
+  [`0c62d69`](https://github.com/joshua-jingu-lee/ante/commit/0c62d691a69799a3e6f1e9a2271886cefbf4be41))
+
+- **eventbus**: #1957 체결 이벤트 소비자 멱등화 (Treasury exactly-once + Bot/SignalChannel/TradeRecorder
+  bounded) ([#1960](https://github.com/joshua-jingu-lee/ante/pull/1960),
+  [`15638e4`](https://github.com/joshua-jingu-lee/ante/commit/15638e40682e2de659111c4bf31c18983837168d))
+
+- **eventbus**: Preserve account_id on OrderCancelFailedEvent
+  ([#1342](https://github.com/joshua-jingu-lee/ante/pull/1342),
+  [`71c6d93`](https://github.com/joshua-jingu-lee/ante/commit/71c6d9343eaf7ea58bb307d1e8db21ade1e9e13d))
+
+- **eventbus**: Preserve account_id on OrderCancelFailedEvent (#1332)
+  ([#1342](https://github.com/joshua-jingu-lee/ante/pull/1342),
+  [`71c6d93`](https://github.com/joshua-jingu-lee/ante/commit/71c6d9343eaf7ea58bb307d1e8db21ade1e9e13d))
+
+- **feed**: #1943 feed run daily --date를 명시 파라미터로 전달
+  ([#1944](https://github.com/joshua-jingu-lee/ante/pull/1944),
+  [`3c56d49`](https://github.com/joshua-jingu-lee/ante/commit/3c56d49a65ee6cab3c8306df6d2bb46ae22d9d3e))
+
+- **frontend**: Add release to TRANSACTION_TYPE_LABELS/VARIANT (#1476 codex P2)
+  ([#1482](https://github.com/joshua-jingu-lee/ante/pull/1482),
+  [`9c24fe9`](https://github.com/joshua-jingu-lee/ante/commit/9c24fe933726d7837335bba5c11524f200a20084))
+
+- **frontend**: Normalize legacy percent win_rate values for backwards compatibility
+  ([#1363](https://github.com/joshua-jingu-lee/ante/pull/1363),
+  [`0dcb64a`](https://github.com/joshua-jingu-lee/ante/commit/0dcb64a386730d74acc1f34bf346ae7416db3c93))
+
+- **frontend,member**: Separate display HumanRole from API payload role
+  ([#1487](https://github.com/joshua-jingu-lee/ante/pull/1487),
+  [`7796c11`](https://github.com/joshua-jingu-lee/ante/commit/7796c116574b9670ce6097b4e1a14131597ce9cf))
+
+- **gateway**: Split-3 prefix-exact ResponseCache invalidate
+  ([#1247](https://github.com/joshua-jingu-lee/ante/pull/1247),
+  [`91b2afb`](https://github.com/joshua-jingu-lee/ante/commit/91b2afb3bd264ec5ef212bde1df29c0e0205a180))
+
+- **ipc**: Reject dispatch during resource drain
+  ([#1193](https://github.com/joshua-jingu-lee/ante/pull/1193),
+  [`af00382`](https://github.com/joshua-jingu-lee/ante/commit/af003825ed840c43c706440d0720bb469dfe23bd))
+
+- **ipc**: Reject mutating commands during shutdown
+  ([#1193](https://github.com/joshua-jingu-lee/ante/pull/1193),
+  [`af00382`](https://github.com/joshua-jingu-lee/ante/commit/af003825ed840c43c706440d0720bb469dfe23bd))
+
+- **ipc**: Reject shutdown-time mutating dispatch
+  ([#1193](https://github.com/joshua-jingu-lee/ante/pull/1193),
+  [`af00382`](https://github.com/joshua-jingu-lee/ante/commit/af003825ed840c43c706440d0720bb469dfe23bd))
+
+- **ipc**: Satisfy mypy for unix server kwargs
+  ([#1194](https://github.com/joshua-jingu-lee/ante/pull/1194),
+  [`ecaf0e4`](https://github.com/joshua-jingu-lee/ante/commit/ecaf0e41ac90ddfcc12f774a3d1caf0b7681d704))
+
+- **ipc**: Scope cleanup_socket=False to Python 3.13+ for 3.11/3.12 boot compat
+  ([#1183](https://github.com/joshua-jingu-lee/ante/pull/1183),
+  [`7d8d9a5`](https://github.com/joshua-jingu-lee/ante/commit/7d8d9a53494f6fcd82d7baed8a77235f5d472aab))
+
+- **ipc,cli**: #1656 E bucket invalid account_id를 VALIDATION_ERROR로 거부 (#1623 E follow-up)
+  ([#1666](https://github.com/joshua-jingu-lee/ante/pull/1666),
+  [`ae1b885`](https://github.com/joshua-jingu-lee/ante/commit/ae1b88542909c90b7d424ebe4e263d3bb546e2e4))
+
+- **ipc,main**: Close cold-path race window via 3-phase IPC shutdown ordering (#1159)
+  ([#1183](https://github.com/joshua-jingu-lee/ante/pull/1183),
+  [`7d8d9a5`](https://github.com/joshua-jingu-lee/ante/commit/7d8d9a53494f6fcd82d7baed8a77235f5d472aab))
+
+- **main**: Add startup booting marker guard
+  ([#1195](https://github.com/joshua-jingu-lee/ante/pull/1195),
+  [`609f70a`](https://github.com/joshua-jingu-lee/ante/commit/609f70a166ac34cbffca033f196410b1841269ce))
+
+- **main**: Cutover to single-canonical PID resolver (no legacy read-fallback)
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **main**: Defer IPC socket unlink to after DB close to close cold-path race
+  ([#1183](https://github.com/joshua-jingu-lee/ante/pull/1183),
+  [`7d8d9a5`](https://github.com/joshua-jingu-lee/ante/commit/7d8d9a53494f6fcd82d7baed8a77235f5d472aab))
+
+- **main**: Emit legacy PID deprecation warning at most once per process
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **main**: Resolve _init_core db.path through Config.resolve_path
+  ([#1181](https://github.com/joshua-jingu-lee/ante/pull/1181),
+  [`b5e60d7`](https://github.com/joshua-jingu-lee/ante/commit/b5e60d71e2ae2ffb893d657d759d1af9d0fee536))
+
+- **member**: #1915 emoji/master-protect 오류를 typed exception으로 정합
+  ([#1934](https://github.com/joshua-jingu-lee/ante/pull/1934),
+  [`a3b5c75`](https://github.com/joshua-jingu-lee/ante/commit/a3b5c752092af2ed0c70b0719bb6300d72d58351))
+
+- **member**: Align Web API + CLI surface guards to master-only contract
+  ([#1555](https://github.com/joshua-jingu-lee/ante/pull/1555),
+  [`b656348`](https://github.com/joshua-jingu-lee/ante/commit/b65634867953de5ddee39e9eb1c672c12f539fe1))
+
+- **member**: Block legacy invalid-role member/token in auth read-path (#1466)
+  ([#1484](https://github.com/joshua-jingu-lee/ante/pull/1484),
+  [`2707cf7`](https://github.com/joshua-jingu-lee/ante/commit/2707cf79bed06d20e230ca1b37f6f53902d33464))
+
+- **member**: Include --yes in revoke_command and drop unwired --db-path
+  ([#1509](https://github.com/joshua-jingu-lee/ante/pull/1509),
+  [`71ae6cb`](https://github.com/joshua-jingu-lee/ante/commit/71ae6cb1017d46601b304e5efa6019ada4889bc4))
+
+- **member**: Introduce SCOPE_VOCABULARY SSOT + Pydantic/service/CLI validation (#1439)
+  ([#1451](https://github.com/joshua-jingu-lee/ante/pull/1451),
+  [`207bfc6`](https://github.com/joshua-jingu-lee/ante/commit/207bfc6b361213b052708357aa3d762939c47a51))
+
+- **member**: Normalize --config-dir to absolute path in revoke_command payload
+  ([#1509](https://github.com/joshua-jingu-lee/ante/pull/1509),
+  [`71ae6cb`](https://github.com/joshua-jingu-lee/ante/commit/71ae6cb1017d46601b304e5efa6019ada4889bc4))
+
+- **member**: Preserve --config-dir in revoke_command payload
+  ([#1509](https://github.com/joshua-jingu-lee/ante/pull/1509),
+  [`71ae6cb`](https://github.com/joshua-jingu-lee/ante/commit/71ae6cb1017d46601b304e5efa6019ada4889bc4))
+
+- **member**: Require_master self-sentinel + correct test count
+  ([#1555](https://github.com/joshua-jingu-lee/ante/pull/1555),
+  [`b656348`](https://github.com/joshua-jingu-lee/ante/commit/b65634867953de5ddee39e9eb1c672c12f539fe1))
+
+- **member**: Shell-safe revoke_command and omit on legacy_revoked
+  ([#1509](https://github.com/joshua-jingu-lee/ante/pull/1509),
+  [`71ae6cb`](https://github.com/joshua-jingu-lee/ante/commit/71ae6cb1017d46601b304e5efa6019ada4889bc4))
+
+- **members**: Forbid extra keys on ScopesUpdateRequest to match OpenAPI
+  ([#1361](https://github.com/joshua-jingu-lee/ante/pull/1361),
+  [`bc9fd4a`](https://github.com/joshua-jingu-lee/ante/commit/bc9fd4a9998b0e51000281dbd5f9689898610cf0))
+
+- **members**: Require authenticated master for mutation routes
+  ([#1361](https://github.com/joshua-jingu-lee/ante/pull/1361),
+  [`bc9fd4a`](https://github.com/joshua-jingu-lee/ante/commit/bc9fd4a9998b0e51000281dbd5f9689898610cf0))
+
+- **members**: Require authenticated master for mutation routes (#1351)
+  ([#1361](https://github.com/joshua-jingu-lee/ante/pull/1361),
+  [`bc9fd4a`](https://github.com/joshua-jingu-lee/ante/commit/bc9fd4a9998b0e51000281dbd5f9689898610cf0))
+
+- **members**: Restore update_scopes OpenAPI body schema and propagate PermissionDeniedError to CLI
+  ([#1361](https://github.com/joshua-jingu-lee/ante/pull/1361),
+  [`bc9fd4a`](https://github.com/joshua-jingu-lee/ante/commit/bc9fd4a9998b0e51000281dbd5f9689898610cf0))
+
+- **modify**: Emit terminal OrderModifyRejectedEvent for ctx.modify_order (#1331)
+  ([#1341](https://github.com/joshua-jingu-lee/ante/pull/1341),
+  [`fde7c2e`](https://github.com/joshua-jingu-lee/ante/commit/fde7c2ed4b6b8c91495dc6992dc9bdcdc29bf4b2))
+
+- **report**: Align ReportStore.get_schema win_rate example with percent unit
+  ([#1363](https://github.com/joshua-jingu-lee/ante/pull/1363),
+  [`0dcb64a`](https://github.com/joshua-jingu-lee/ante/commit/0dcb64a386730d74acc1f34bf346ae7416db3c93))
+
+- **report**: Enforce metrics invariant at ReportStore save boundary (codex FAIL r3)
+  ([#1445](https://github.com/joshua-jingu-lee/ante/pull/1445),
+  [`64ab2e7`](https://github.com/joshua-jingu-lee/ante/commit/64ab2e730e2160fb033152b0ec34c76036109dcc))
+
+- **report**: Reject invalid submit metrics and unify win_rate to ratio
+  ([#1363](https://github.com/joshua-jingu-lee/ante/pull/1363),
+  [`0dcb64a`](https://github.com/joshua-jingu-lee/ante/commit/0dcb64a386730d74acc1f34bf346ae7416db3c93))
+
+- **report**: Split StrategyReport invariant to opt-in function + validate JSON shape (codex FAIL
+  r1) ([#1445](https://github.com/joshua-jingu-lee/ante/pull/1445),
+  [`64ab2e7`](https://github.com/joshua-jingu-lee/ante/commit/64ab2e730e2160fb033152b0ec34c76036109dcc))
+
+- **reports**: Reject unknown list status with 422 via ReportStatus enum (#1355)
+  ([#1365](https://github.com/joshua-jingu-lee/ante/pull/1365),
+  [`fa1cb96`](https://github.com/joshua-jingu-lee/ante/commit/fa1cb961af73cc643ea2b3242089b359819cd660))
+
+- **reports**: Validate ReportSubmitRequest input ranges and reject NaN/Inf (#1353)
+  ([#1363](https://github.com/joshua-jingu-lee/ante/pull/1363),
+  [`0dcb64a`](https://github.com/joshua-jingu-lee/ante/commit/0dcb64a386730d74acc1f34bf346ae7416db3c93))
+
+- **review**: Address PR approval findings
+  ([#1136](https://github.com/joshua-jingu-lee/ante/pull/1136),
+  [`4792745`](https://github.com/joshua-jingu-lee/ante/commit/4792745743af86d1f682a248314d25e33bbb66b2))
+
+- **rule**: Also normalize price in safe rejected event builder
+  ([#1311](https://github.com/joshua-jingu-lee/ante/pull/1311),
+  [`6a7f6c2`](https://github.com/joshua-jingu-lee/ante/commit/6a7f6c2e0b24bab3c6b9ad4d8da356ef9e552dc3))
+
+- **rule**: Also reject non-string Signal.side in OrderRequestEvent preflight
+  ([#1306](https://github.com/joshua-jingu-lee/ante/pull/1306),
+  [`f7c9f56`](https://github.com/joshua-jingu-lee/ante/commit/f7c9f56416989186d1c10eb349fa0be0f58e5953))
+
+- **rule**: Apply safe_quantity normalization to all preflight reject paths
+  ([#1311](https://github.com/joshua-jingu-lee/ante/pull/1311),
+  [`6a7f6c2`](https://github.com/joshua-jingu-lee/ante/commit/6a7f6c2e0b24bab3c6b9ad4d8da356ef9e552dc3))
+
+- **rule**: Coerce non-string side to repr in OrderRejectedEvent payload
+  ([#1306](https://github.com/joshua-jingu-lee/ante/pull/1306),
+  [`f7c9f56`](https://github.com/joshua-jingu-lee/ante/commit/f7c9f56416989186d1c10eb349fa0be0f58e5953))
+
+- **rule**: Graceful reject for invalid timezone in TradingHoursRule
+  ([#1507](https://github.com/joshua-jingu-lee/ante/pull/1507),
+  [`d73a98b`](https://github.com/joshua-jingu-lee/ante/commit/d73a98b6ba8f27961ba54ea7b81f9fe8270e991c))
+
+- **rule**: Handle OverflowError in finite-quantity check for large int
+  ([#1311](https://github.com/joshua-jingu-lee/ante/pull/1311),
+  [`6a7f6c2`](https://github.com/joshua-jingu-lee/ante/commit/6a7f6c2e0b24bab3c6b9ad4d8da356ef9e552dc3))
+
+- **rule**: Inject default trading_hours for KIS + classify 40580000 (#1296)
+  ([#1315](https://github.com/joshua-jingu-lee/ante/pull/1315),
+  [`747fd37`](https://github.com/joshua-jingu-lee/ante/commit/747fd3765ef05dd1799f1682a02c0ffff41b33dc))
+
+- **rule**: Inject default trading_hours for KIS + classify 40580000 as permanent
+  ([#1315](https://github.com/joshua-jingu-lee/ante/pull/1315),
+  [`747fd37`](https://github.com/joshua-jingu-lee/ante/commit/747fd3765ef05dd1799f1682a02c0ffff41b33dc))
+
+- **rule**: Merge DynamicConfig overrides on RuleEngineManager init
+  ([#1315](https://github.com/joshua-jingu-lee/ante/pull/1315),
+  [`747fd37`](https://github.com/joshua-jingu-lee/ante/commit/747fd3765ef05dd1799f1682a02c0ffff41b33dc))
+
+- **rule**: Reject invalid KRX numeric symbol at OrderRequestEvent preflight (#1299)
+  ([#1308](https://github.com/joshua-jingu-lee/ante/pull/1308),
+  [`894d5db`](https://github.com/joshua-jingu-lee/ante/commit/894d5db2a7605bc17506fb8b3c626c4340fbb2c5))
+
+- **rule**: Reject invalid Signal.order_type at OrderRequestEvent preflight (#1298)
+  ([#1307](https://github.com/joshua-jingu-lee/ante/pull/1307),
+  [`b1538a1`](https://github.com/joshua-jingu-lee/ante/commit/b1538a1bf219645360663e301b97853fee4ce433))
+
+- **rule**: Reject invalid Signal.side at OrderRequestEvent preflight
+  ([#1306](https://github.com/joshua-jingu-lee/ante/pull/1306),
+  [`f7c9f56`](https://github.com/joshua-jingu-lee/ante/commit/f7c9f56416989186d1c10eb349fa0be0f58e5953))
+
+- **rule**: Reject invalid Signal.side at OrderRequestEvent preflight (#1297)
+  ([#1306](https://github.com/joshua-jingu-lee/ante/pull/1306),
+  [`f7c9f56`](https://github.com/joshua-jingu-lee/ante/commit/f7c9f56416989186d1c10eb349fa0be0f58e5953))
+
+- **rule**: Reject NaN/Inf in account rule params at service boundary (#1380)
+  ([#1390](https://github.com/joshua-jingu-lee/ante/pull/1390),
+  [`94181ef`](https://github.com/joshua-jingu-lee/ante/commit/94181efb2c9a7fc6f809fa46de1181e792b64f9e))
+
+- **rule**: Reject NaN/inf/negative stop_price at OrderRequestEvent preflight (#1319)
+  ([#1329](https://github.com/joshua-jingu-lee/ante/pull/1329),
+  [`8d507b4`](https://github.com/joshua-jingu-lee/ante/commit/8d507b4baf3351260d45dbccbaa6e09c31e5f6e8))
+
+- **rule**: Reject NaN/inf/non-number price at OrderRequestEvent preflight (#1303)
+  ([#1312](https://github.com/joshua-jingu-lee/ante/pull/1312),
+  [`b623ddb`](https://github.com/joshua-jingu-lee/ante/commit/b623ddbd945a5b9bdc93b7cbb77d47043ac047ce))
+
+- **rule**: Reject NaN/inf/non-number quantity + safe reject builder (#1302)
+  ([#1311](https://github.com/joshua-jingu-lee/ante/pull/1311),
+  [`6a7f6c2`](https://github.com/joshua-jingu-lee/ante/commit/6a7f6c2e0b24bab3c6b9ad4d8da356ef9e552dc3))
+
+- **rule**: Reject NaN/inf/non-number quantity at OrderRequestEvent preflight
+  ([#1311](https://github.com/joshua-jingu-lee/ante/pull/1311),
+  [`6a7f6c2`](https://github.com/joshua-jingu-lee/ante/commit/6a7f6c2e0b24bab3c6b9ad4d8da356ef9e552dc3))
+
+- **rule**: Reject negative price at OrderRequestEvent preflight (#1316)
+  ([#1326](https://github.com/joshua-jingu-lee/ante/pull/1326),
+  [`ac9af66`](https://github.com/joshua-jingu-lee/ante/commit/ac9af66124169da5f244c72c686be17e8a1f6fe0))
+
+- **rule**: Reject negative quantity at OrderRequestEvent preflight (#1304)
+  ([#1313](https://github.com/joshua-jingu-lee/ante/pull/1313),
+  [`f818216`](https://github.com/joshua-jingu-lee/ante/commit/f818216435de88e20d9e449d07bcc6678d3bceec))
+
+- **rule**: Reject zero price at OrderRequestEvent preflight (#1318)
+  ([#1328](https://github.com/joshua-jingu-lee/ante/pull/1328),
+  [`05cad6e`](https://github.com/joshua-jingu-lee/ante/commit/05cad6efc66dda0bc454405399fda859d9fb74d9))
+
+- **rule**: Reject zero quantity at OrderRequestEvent preflight (#1305)
+  ([#1314](https://github.com/joshua-jingu-lee/ante/pull/1314),
+  [`1948122`](https://github.com/joshua-jingu-lee/ante/commit/1948122fa15cdc9deb92778bb489011de4b463dd))
+
+- **rule**: Reject zero stop_price at OrderRequestEvent preflight (#1320)
+  ([#1330](https://github.com/joshua-jingu-lee/ante/pull/1330),
+  [`f3d2cfb`](https://github.com/joshua-jingu-lee/ante/commit/f3d2cfb09153b0cb9fbe75c374915a09233f66e5))
+
+- **rule**: Require price for limit/stop_limit at OrderRequestEvent preflight (#1300)
+  ([#1309](https://github.com/joshua-jingu-lee/ante/pull/1309),
+  [`8861cdc`](https://github.com/joshua-jingu-lee/ante/commit/8861cdc81b8d2a4b3f9b9510d832c468229de938))
+
+- **rule**: Require stop_price for stop/stop_limit at OrderRequestEvent preflight (#1301)
+  ([#1310](https://github.com/joshua-jingu-lee/ante/pull/1310),
+  [`28a8233`](https://github.com/joshua-jingu-lee/ante/commit/28a8233571278e625567ebe5f3f73f05384daa45))
+
+- **rule**: Scope ConfigChangedEvent reload to own account key
+  ([#1315](https://github.com/joshua-jingu-lee/ante/pull/1315),
+  [`747fd37`](https://github.com/joshua-jingu-lee/ante/commit/747fd3765ef05dd1799f1682a02c0ffff41b33dc))
+
+- **rule**: Use TypeGuard for _is_finite_quantity to satisfy mypy
+  ([#1311](https://github.com/joshua-jingu-lee/ante/pull/1311),
+  [`6a7f6c2`](https://github.com/joshua-jingu-lee/ante/commit/6a7f6c2e0b24bab3c6b9ad4d8da356ef9e552dc3))
+
+- **rule**: Wrap preflight in try + safe reject builder for fail-closed audit
+  ([#1311](https://github.com/joshua-jingu-lee/ante/pull/1311),
+  [`6a7f6c2`](https://github.com/joshua-jingu-lee/ante/commit/6a7f6c2e0b24bab3c6b9ad4d8da356ef9e552dc3))
+
+- **rule,gateway,bot**: Emit terminal OrderModifyRejectedEvent for ctx.modify_order
+  ([#1341](https://github.com/joshua-jingu-lee/ante/pull/1341),
+  [`fde7c2e`](https://github.com/joshua-jingu-lee/ante/commit/fde7c2ed4b6b8c91495dc6992dc9bdcdc29bf4b2))
+
+- **stop-order**: Split-3 require account_id on price tick
+  ([#1247](https://github.com/joshua-jingu-lee/ante/pull/1247),
+  [`91b2afb`](https://github.com/joshua-jingu-lee/ante/commit/91b2afb3bd264ec5ef212bde1df29c0e0205a180))
+
+- **stream,trade**: Propagate account_id to OrderFilledEvent and position_history (#1240 review)
+  ([#1243](https://github.com/joshua-jingu-lee/ante/pull/1243),
+  [`83dcd3b`](https://github.com/joshua-jingu-lee/ante/commit/83dcd3b206acade00a7abfd8eb285f0036def1af))
+
+- **system**: Emit Z suffix for kill-switch changed_at (#1360)
+  ([#1370](https://github.com/joshua-jingu-lee/ante/pull/1370),
+  [`743c5ed`](https://github.com/joshua-jingu-lee/ante/commit/743c5ede357b7b86b852f6d1a1c91cda50172f70))
+
+- **test**: #1897 aiosqlite/sqlite Connection 누수 fixture 정리 (broker test isolation 해결, #1904
+  unblock) ([#1905](https://github.com/joshua-jingu-lee/ante/pull/1905),
+  [`1c51824`](https://github.com/joshua-jingu-lee/ante/commit/1c51824faca78d24b39c76dd4415a8b5dbd909dc))
+
+- **test**: #1897 follow-up — autouse mock.patch.stopall() in cleanup fixture (PR #1904 unblock)
+  ([#1906](https://github.com/joshua-jingu-lee/ante/pull/1906),
+  [`17700cb`](https://github.com/joshua-jingu-lee/ante/commit/17700cbeeb6c3147721708277c63c9144b9095f7))
+
+- **test**: #1909 contracts shell test를 subprocess isolation으로 변환 (sys.modules pollution → CI 결정적
+  fail 해소) ([#1910](https://github.com/joshua-jingu-lee/ante/pull/1910),
+  [`17c800a`](https://github.com/joshua-jingu-lee/ante/commit/17c800a9656d28db16845897242620675ee822e6))
+
+- **test**: #1941 error_drift_allowlist.yaml anchor 갱신
+  ([#1942](https://github.com/joshua-jingu-lee/ante/pull/1942),
+  [`b8cea12`](https://github.com/joshua-jingu-lee/ante/commit/b8cea12b2d6ae9bab607fa6d613b405418547493))
+
+- **test**: Align trade_info_not_found exit code with #1515 invariant
+  ([#1527](https://github.com/joshua-jingu-lee/ante/pull/1527),
+  [`a11ef76`](https://github.com/joshua-jingu-lee/ante/commit/a11ef7698b1d38b3afabeb6b0a50ed3b77b980ef))
+
+- **test**: Align treasury_allocate_fail exit code with #1517 invariant
+  ([#1530](https://github.com/joshua-jingu-lee/ante/pull/1530),
+  [`e9e2107`](https://github.com/joshua-jingu-lee/ante/commit/e9e2107d54787adb5b340031d93aaeeccccde828))
+
+- **test**: Align two stale exit-code assertions with #1515 missing-resource invariant
+  ([#1526](https://github.com/joshua-jingu-lee/ante/pull/1526),
+  [`f425d71`](https://github.com/joshua-jingu-lee/ante/commit/f425d71f8aaaf351709309ab8229c40a8954b616))
+
+- **test**: Scope BotManager cooldown sleep patch to avoid affecting Bot._run_loop (#1456 codex
+  review) ([#1478](https://github.com/joshua-jingu-lee/ante/pull/1478),
+  [`88015b4`](https://github.com/joshua-jingu-lee/ante/commit/88015b45be0deb674a35490c409e5452907097b9))
+
+- **test**: Use stdout for click split assertions
+  ([#1150](https://github.com/joshua-jingu-lee/ante/pull/1150),
+  [`2e2dd3f`](https://github.com/joshua-jingu-lee/ante/commit/2e2dd3fcca018370d8ea5434f5804efac4454978))
+
+- **trade**: #1946 fill catch-up 실패 barrier 우회·EOD 만료 미호출 수정
+  ([#1953](https://github.com/joshua-jingu-lee/ante/pull/1953),
+  [`9f548b4`](https://github.com/joshua-jingu-lee/ante/commit/9f548b463cf4f6794fc788270a58cfa084471eb4))
+
+- **trade**: #1946 fill-recovery poll-first 순서 invariant로 startup 복구완전성/barrier 종합 수정
+  ([#1953](https://github.com/joshua-jingu-lee/ante/pull/1953),
+  [`9f548b4`](https://github.com/joshua-jingu-lee/ante/commit/9f548b463cf4f6794fc788270a58cfa084471eb4))
+
+- **trade**: #1948 expire_stale UPDATE…RETURNING으로 TOCTOU evict race 제거
+  ([#1959](https://github.com/joshua-jingu-lee/ante/pull/1959),
+  [`241e558`](https://github.com/joshua-jingu-lee/ante/commit/241e558b76aead43f103aefca0e2ae7affd25d79))
+
+- **trade**: #1950 reconciler self-submitted fill 구분 (외부 매수 오분류 방지)
+  ([#1956](https://github.com/joshua-jingu-lee/ante/pull/1956),
+  [`8576711`](https://github.com/joshua-jingu-lee/ante/commit/857671147468454bd6f985265de95d3a94b5fbb2))
+
+- **treasury**: #1947 매수 부분체결 비례 정산 ([#1954](https://github.com/joshua-jingu-lee/ante/pull/1954),
+  [`f2d25fb`](https://github.com/joshua-jingu-lee/ante/commit/f2d25fb6a5fa02d66861b9271a408273b5d2c98c))
+
+- **treasury**: Emit terminal reject for market buy without quote (#1292)
+  ([#1294](https://github.com/joshua-jingu-lee/ante/pull/1294),
+  [`5d3de66`](https://github.com/joshua-jingu-lee/ante/commit/5d3de662c8ddbdef583184da6efd961d540fa47e))
+
+- **treasury**: Enforce finite-positive amount at Web API + Treasury service entry
+  ([#1432](https://github.com/joshua-jingu-lee/ante/pull/1432),
+  [`5292d08`](https://github.com/joshua-jingu-lee/ante/commit/5292d08e628a93feff266a67287c7297aae2e7fa))
+
+- **treasury**: Normalize transaction type vocabulary (5-value) (#1476)
+  ([#1482](https://github.com/joshua-jingu-lee/ante/pull/1482),
+  [`9c24fe9`](https://github.com/joshua-jingu-lee/ante/commit/9c24fe933726d7837335bba5c11524f200a20084))
+
+- **treasury**: Normalize transaction type vocabulary (5-value:
+  allocate/deallocate/release/fill/bot_stopped_release)
+  ([#1482](https://github.com/joshua-jingu-lee/ante/pull/1482),
+  [`9c24fe9`](https://github.com/joshua-jingu-lee/ante/commit/9c24fe933726d7837335bba5c11524f200a20084))
+
+- **treasury**: Reject non-finite/negative balance at API and service
+  ([#1343](https://github.com/joshua-jingu-lee/ante/pull/1343),
+  [`db12f00`](https://github.com/joshua-jingu-lee/ante/commit/db12f0099c75df83a2ab53cbe7ebdb689f8137d0))
+
+- **treasury**: Reject non-finite/negative balance at API and service (#1340)
+  ([#1343](https://github.com/joshua-jingu-lee/ante/pull/1343),
+  [`db12f00`](https://github.com/joshua-jingu-lee/ante/commit/db12f0099c75df83a2ab53cbe7ebdb689f8137d0))
+
+- **treasury**: Reject non-finite/non-positive market buy quote (#1333 P2)
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **treasury**: Skip reserve for buy stop/stop_limit at registration
+  ([#1348](https://github.com/joshua-jingu-lee/ante/pull/1348),
+  [`ce0efab`](https://github.com/joshua-jingu-lee/ante/commit/ce0efab8cc58277b3323d1560ba8f8ef87ccd8ed))
+
+- **treasury**: Skip reserve for buy stop/stop_limit at registration (#1337)
+  ([#1348](https://github.com/joshua-jingu-lee/ante/pull/1348),
+  [`ce0efab`](https://github.com/joshua-jingu-lee/ante/commit/ce0efab8cc58277b3323d1560ba8f8ef87ccd8ed))
+
+- **treasury,trade**: Scope sync/daily-report aggregations to single account (#1240 review)
+  ([#1243](https://github.com/joshua-jingu-lee/ante/pull/1243),
+  [`83dcd3b`](https://github.com/joshua-jingu-lee/ante/commit/83dcd3b206acade00a7abfd8eb285f0036def1af))
+
+- **web**: 422 validation 응답의 거부 입력 값 반사 차단 (#1629 L1)
+  ([#1644](https://github.com/joshua-jingu-lee/ante/pull/1644),
+  [`28953f6`](https://github.com/joshua-jingu-lee/ante/commit/28953f6ddf1d9017cd9969d374bbd0b4d41e272b))
+
+- **web**: Accept ante_session cookie auth in POST /api/members
+  ([#1346](https://github.com/joshua-jingu-lee/ante/pull/1346),
+  [`db30498`](https://github.com/joshua-jingu-lee/ante/commit/db30498a8f3cc526fa01dfe69272a5bd2115bb5b))
+
+- **web**: Accept JSON null body on suspend route as default reason
+  ([#1362](https://github.com/joshua-jingu-lee/ante/pull/1362),
+  [`7bbea7a`](https://github.com/joshua-jingu-lee/ante/commit/7bbea7ac240db8e95d9a8ce5f5d338833112301f))
+
+- **web**: Align PUT /api/accounts/{id} no-op responses to 422 (#1152)
+  ([#1168](https://github.com/joshua-jingu-lee/ante/pull/1168),
+  [`6c34618`](https://github.com/joshua-jingu-lee/ante/commit/6c346186251a53293cc77e87a067f3af3b684ebb))
+
+- **web**: Align PUT no-op responses to 422 (breaking change #1152)
+  ([#1168](https://github.com/joshua-jingu-lee/ante/pull/1168),
+  [`6c34618`](https://github.com/joshua-jingu-lee/ante/commit/6c346186251a53293cc77e87a067f3af3b684ebb))
+
+- **web**: Convert mutable validation errors to 422 explicitly (attempt 5)
+  ([#1146](https://github.com/joshua-jingu-lee/ante/pull/1146),
+  [`57780c2`](https://github.com/joshua-jingu-lee/ante/commit/57780c2882e197e8ce139140bb355b8a0049bc3f))
+
+- **web**: Dataset_id path traversal 차단 — 2계층 path-safe 방어 (#1631)
+  ([#1642](https://github.com/joshua-jingu-lee/ante/pull/1642),
+  [`c0aa6ed`](https://github.com/joshua-jingu-lee/ante/commit/c0aa6ed6e5bf74580adb0c73f2ff97cea3b30406))
+
+- **web**: Drop unreachable POST/DELETE success contract on accounts cold-path
+  ([#1146](https://github.com/joshua-jingu-lee/ante/pull/1146),
+  [`57780c2`](https://github.com/joshua-jingu-lee/ante/commit/57780c2882e197e8ce139140bb355b8a0049bc3f))
+
+- **web**: Enforce auth check before body validation in POST /api/members
+  ([#1346](https://github.com/joshua-jingu-lee/ante/pull/1346),
+  [`db30498`](https://github.com/joshua-jingu-lee/ante/commit/db30498a8f3cc526fa01dfe69272a5bd2115bb5b))
+
+- **web**: Enforce cold-path invariants on account routes (attempt 3)
+  ([#1146](https://github.com/joshua-jingu-lee/ante/pull/1146),
+  [`57780c2`](https://github.com/joshua-jingu-lee/ante/commit/57780c2882e197e8ce139140bb355b8a0049bc3f))
+
+- **web**: Expose MemberCreateRequest in OpenAPI components (#1339 P1)
+  ([#1346](https://github.com/joshua-jingu-lee/ante/pull/1346),
+  [`db30498`](https://github.com/joshua-jingu-lee/ante/commit/db30498a8f3cc526fa01dfe69272a5bd2115bb5b))
+
+- **web**: Forbid extra fields in MemberCreateRequest (#1339 P3)
+  ([#1346](https://github.com/joshua-jingu-lee/ante/pull/1346),
+  [`db30498`](https://github.com/joshua-jingu-lee/ante/commit/db30498a8f3cc526fa01dfe69272a5bd2115bb5b))
+
+- **web**: Lazy resolve account_service in PUT to preserve cold-path 409 (attempt 6)
+  ([#1146](https://github.com/joshua-jingu-lee/ante/pull/1146),
+  [`57780c2`](https://github.com/joshua-jingu-lee/ante/commit/57780c2882e197e8ce139140bb355b8a0049bc3f))
+
+- **web**: Member API가 token/password/recovery hash를 응답에 노출 (#1627)
+  ([#1640](https://github.com/joshua-jingu-lee/ante/pull/1640),
+  [`7e079b5`](https://github.com/joshua-jingu-lee/ante/commit/7e079b5fe1c299dd60b2f8ce817d5a09696123d5))
+
+- **web**: Mirror session caller into request.state.member_id (#1339 P2)
+  ([#1346](https://github.com/joshua-jingu-lee/ante/pull/1346),
+  [`db30498`](https://github.com/joshua-jingu-lee/ante/commit/db30498a8f3cc526fa01dfe69272a5bd2115bb5b))
+
+- **web**: Move account_id guard before strategy registry lookup in get_strategy_performance
+  ([#1637](https://github.com/joshua-jingu-lee/ante/pull/1637),
+  [`1dc7f47`](https://github.com/joshua-jingu-lee/ante/commit/1dc7f47493f99a36ed778bfc5dd3a2108f9aa0d1))
+
+- **web**: Normalize extra_forbidden loc trailing segment at runtime (#1650)
+  ([#1652](https://github.com/joshua-jingu-lee/ante/pull/1652),
+  [`d24d115`](https://github.com/joshua-jingu-lee/ante/commit/d24d1157c7decf6cafeff2192316310b071166c0))
+
+- **web**: POST /api/members invalid member_type을 422로 거부 (#1628)
+  ([#1641](https://github.com/joshua-jingu-lee/ante/pull/1641),
+  [`c7d43e1`](https://github.com/joshua-jingu-lee/ante/commit/c7d43e1d0c80c3eacd1f967091e734f25f54bb13))
+
+- **web**: Preserve nullable suspend body contract in OpenAPI schema
+  ([#1362](https://github.com/joshua-jingu-lee/ante/pull/1362),
+  [`7bbea7a`](https://github.com/joshua-jingu-lee/ante/commit/7bbea7ac240db8e95d9a8ce5f5d338833112301f))
+
+- **web**: Register AccountSuspendRequest in OpenAPI components for suspend route
+  ([#1362](https://github.com/joshua-jingu-lee/ante/pull/1362),
+  [`7bbea7a`](https://github.com/joshua-jingu-lee/ante/commit/7bbea7ac240db8e95d9a8ce5f5d338833112301f))
+
+- **web**: Register ErrorResponse model on PUT account error responses (attempt 7)
+  ([#1146](https://github.com/joshua-jingu-lee/ante/pull/1146),
+  [`57780c2`](https://github.com/joshua-jingu-lee/ante/commit/57780c2882e197e8ce139140bb355b8a0049bc3f))
+
+- **web**: Reject extra body on POST /api/accounts/{id}/activate
+  ([#1521](https://github.com/joshua-jingu-lee/ante/pull/1521),
+  [`a614dfc`](https://github.com/joshua-jingu-lee/ante/commit/a614dfc7f9657edbff44276d33e71170a69c5b8e))
+
+- **web**: Reject invalid timeframe filter in datasets API
+  ([#1601](https://github.com/joshua-jingu-lee/ante/pull/1601),
+  [`e5482b8`](https://github.com/joshua-jingu-lee/ante/commit/e5482b8f39a472113f08569ab03e5f573ef0adb6))
+
+- **web**: Reject invalid timeframe filter in datasets API (#1594)
+  ([#1601](https://github.com/joshua-jingu-lee/ante/pull/1601),
+  [`e5482b8`](https://github.com/joshua-jingu-lee/ante/commit/e5482b8f39a472113f08569ab03e5f573ef0adb6))
+
+- **web**: Reject inverted date range across 4 read APIs
+  ([#1607](https://github.com/joshua-jingu-lee/ante/pull/1607),
+  [`e8ca3ba`](https://github.com/joshua-jingu-lee/ante/commit/e8ca3ba8e1c418fcb39d5d905533c985a30eb2dc))
+
+- **web**: Reject inverted date range across 4 read APIs (#1595)
+  ([#1607](https://github.com/joshua-jingu-lee/ante/pull/1607),
+  [`e8ca3ba`](https://github.com/joshua-jingu-lee/ante/commit/e8ca3ba8e1c418fcb39d5d905533c985a30eb2dc))
+
+- **web**: Reject negative pagination limit across list endpoints (#1356)
+  ([#1366](https://github.com/joshua-jingu-lee/ante/pull/1366),
+  [`9b12c08`](https://github.com/joshua-jingu-lee/ante/commit/9b12c087492aab7001ca46ea65f8c2b4f664f6f6))
+
+- **web**: Reject provided runtime-invalid account_id at read-API ingress
+  ([#1637](https://github.com/joshua-jingu-lee/ante/pull/1637),
+  [`1dc7f47`](https://github.com/joshua-jingu-lee/ante/commit/1dc7f47493f99a36ed778bfc5dd3a2108f9aa0d1))
+
+- **web**: Reject provided runtime-invalid account_id at read-API ingress (#1624)
+  ([#1637](https://github.com/joshua-jingu-lee/ante/pull/1637),
+  [`1dc7f47`](https://github.com/joshua-jingu-lee/ante/commit/1dc7f47493f99a36ed778bfc5dd3a2108f9aa0d1))
+
+- **web**: Reject unknown approval list status with 422 via ApprovalStatus enum (#1357)
+  ([#1367](https://github.com/joshua-jingu-lee/ante/pull/1367),
+  [`a260b80`](https://github.com/joshua-jingu-lee/ante/commit/a260b8060d86978654398c41957154bc65777122))
+
+- **web**: Reject unknown data_type with 422 on data endpoints (#1354)
+  ([#1364](https://github.com/joshua-jingu-lee/ante/pull/1364),
+  [`b09a585`](https://github.com/joshua-jingu-lee/ante/commit/b09a58503b5b46cd1615a597d18340513d0c37ab))
+
+- **web**: Reject unknown member list type/status with 422 via enum (#1358)
+  ([#1368](https://github.com/joshua-jingu-lee/ante/pull/1368),
+  [`6276eca`](https://github.com/joshua-jingu-lee/ante/commit/6276ecadcc206c679580a69c6fb90838c0bed81e))
+
+- **web**: Reject unsupported report submit `sections` field (#1632)
+  ([#1645](https://github.com/joshua-jingu-lee/ante/pull/1645),
+  [`e97535d`](https://github.com/joshua-jingu-lee/ante/commit/e97535d7ef4665a255826cb10b10d6958c1a0e8d))
+
+- **web**: Relax orderable typing for mypy src in date_params
+  ([#1607](https://github.com/joshua-jingu-lee/ante/pull/1607),
+  [`e8ca3ba`](https://github.com/joshua-jingu-lee/ante/commit/e8ca3ba8e1c418fcb39d5d905533c985a30eb2dc))
+
+- **web**: Require auth for POST /api/members (#1339)
+  ([#1346](https://github.com/joshua-jingu-lee/ante/pull/1346),
+  [`db30498`](https://github.com/joshua-jingu-lee/ante/commit/db30498a8f3cc526fa01dfe69272a5bd2115bb5b))
+
+- **web**: Require authenticated master for POST /api/members
+  ([#1346](https://github.com/joshua-jingu-lee/ante/pull/1346),
+  [`db30498`](https://github.com/joshua-jingu-lee/ante/commit/db30498a8f3cc526fa01dfe69272a5bd2115bb5b))
+
+- **web**: Require authenticated master for runtime mutation routes
+  ([#1362](https://github.com/joshua-jingu-lee/ante/pull/1362),
+  [`7bbea7a`](https://github.com/joshua-jingu-lee/ante/commit/7bbea7ac240db8e95d9a8ce5f5d338833112301f))
+
+- **web**: Require authenticated master for runtime mutation routes (#1352)
+  ([#1362](https://github.com/joshua-jingu-lee/ante/pull/1362),
+  [`7bbea7a`](https://github.com/joshua-jingu-lee/ante/commit/7bbea7ac240db8e95d9a8ce5f5d338833112301f))
+
+- **web**: Require config:write or master/human auth for PUT /api/config/{key} (#1373)
+  ([#1383](https://github.com/joshua-jingu-lee/ante/pull/1383),
+  [`1525c9c`](https://github.com/joshua-jingu-lee/ante/commit/1525c9c7c5d983a8854e8d9d3068008089d185d0))
+
+- **web**: Require master auth for bot create/delete (#1371)
+  ([#1381](https://github.com/joshua-jingu-lee/ante/pull/1381),
+  [`74b9995`](https://github.com/joshua-jingu-lee/ante/commit/74b99953cdc74850c9db4ac789900497a2b6d62a))
+
+- **web**: Require master auth for GET /api/audit
+  ([#1369](https://github.com/joshua-jingu-lee/ante/pull/1369),
+  [`b81a785`](https://github.com/joshua-jingu-lee/ante/commit/b81a7859d9fff59e7fa970c76dcdecead0f41872))
+
+- **web**: Require master auth for PATCH /api/members/{id}/password (#1377)
+  ([#1387](https://github.com/joshua-jingu-lee/ante/pull/1387),
+  [`13c5e09`](https://github.com/joshua-jingu-lee/ante/commit/13c5e098c3e8da3aa26bb250054ffd9cebaa88bd))
+
+- **web**: Require master auth for PUT /api/accounts/{id}/rules/{type} (#1376)
+  ([#1386](https://github.com/joshua-jingu-lee/ante/pull/1386),
+  [`05235df`](https://github.com/joshua-jingu-lee/ante/commit/05235df0b63f1efd3e68640b7c88266662f1619b))
+
+- **web**: Require master auth for system halt/clear-halt (#1375)
+  ([#1385](https://github.com/joshua-jingu-lee/ante/pull/1385),
+  [`651a4ce`](https://github.com/joshua-jingu-lee/ante/commit/651a4ceb61fcbce27b9b882fce135069f6e10986))
+
+- **web**: Require master auth for treasury budget allocate/deallocate (#1372)
+  ([#1382](https://github.com/joshua-jingu-lee/ante/pull/1382),
+  [`591be51`](https://github.com/joshua-jingu-lee/ante/commit/591be5170269f1a577dfbb9f12867454b159c17a))
+
+- **web**: Require master/human/report:write auth for POST /api/reports (#1374)
+  ([#1384](https://github.com/joshua-jingu-lee/ante/pull/1384),
+  [`3282074`](https://github.com/joshua-jingu-lee/ante/commit/3282074a660b05ebde3b9898aab1a41837174099))
+
+- **web**: Require master/human/strategy:write auth for PATCH /api/strategies/{id}/status (#1378)
+  ([#1388](https://github.com/joshua-jingu-lee/ante/pull/1388),
+  [`72c0489`](https://github.com/joshua-jingu-lee/ante/commit/72c0489c4b2357a55a996f3d49b2e0fd8332e1a9))
+
+- **web**: Restore mutable field type validation on PUT account (attempt 9)
+  ([#1146](https://github.com/joshua-jingu-lee/ante/pull/1146),
+  [`57780c2`](https://github.com/joshua-jingu-lee/ante/commit/57780c2882e197e8ce139140bb355b8a0049bc3f))
+
+- **web**: Split account PUT mutable schema and convert ValidationError to 422 (attempt 4)
+  ([#1146](https://github.com/joshua-jingu-lee/ante/pull/1146),
+  [`57780c2`](https://github.com/joshua-jingu-lee/ante/commit/57780c2882e197e8ce139140bb355b8a0049bc3f))
+
+- **web**: Validate pagination limit/offset on list endpoints
+  ([#1366](https://github.com/joshua-jingu-lee/ante/pull/1366),
+  [`9b12c08`](https://github.com/joshua-jingu-lee/ante/commit/9b12c087492aab7001ca46ea65f8c2b4f664f6f6))
+
+- **web**: Validate timeframe before store-None guard in datasets API
+  ([#1601](https://github.com/joshua-jingu-lee/ante/pull/1601),
+  [`e5482b8`](https://github.com/joshua-jingu-lee/ante/commit/e5482b8f39a472113f08569ab03e5f573ef0adb6))
+
+- **web,build**: Unify suspend raw-body pattern and restore pip_freeze snapshot
+  ([#1362](https://github.com/joshua-jingu-lee/ante/pull/1362),
+  [`7bbea7a`](https://github.com/joshua-jingu-lee/ante/commit/7bbea7ac240db8e95d9a8ce5f5d338833112301f))
+
+- **web-api**: #1654 PUT /api/accounts unknown-key 422 detail caller key 미반사 (F3)
+  ([#1664](https://github.com/joshua-jingu-lee/ante/pull/1664),
+  [`c5e7479`](https://github.com/joshua-jingu-lee/ante/commit/c5e74798707b5d8a8b79a2e12d6b6ff1ad93a6be))
+
+- **web-api**: Add anyOf strategy_id/strategy_name to BOT_CREATE_REQUEST_SCHEMA (codex FAIL r1)
+  ([#1448](https://github.com/joshua-jingu-lee/ante/pull/1448),
+  [`62e403a`](https://github.com/joshua-jingu-lee/ante/commit/62e403ac25369a6a69ecf47f3bea4f3e35dafa8f))
+
+- **web-api**: Correct bot logs pagination + tz-normalize date filters (codex FAIL r1)
+  ([#1449](https://github.com/joshua-jingu-lee/ante/pull/1449),
+  [`8b6b49a`](https://github.com/joshua-jingu-lee/ante/commit/8b6b49a1cfacbcf9a4f5de6cd55ca71137522fa9))
+
+- **web-api**: Enforce BotCreateRequest extra=forbid + strategy required + serialize ValidationError
+  (#1436) ([#1448](https://github.com/joshua-jingu-lee/ante/pull/1448),
+  [`62e403a`](https://github.com/joshua-jingu-lee/ante/commit/62e403ac25369a6a69ecf47f3bea4f3e35dafa8f))
+
+- **web-api**: Enforce BotCreateRequest extra=forbid + strategy required, sync spec
+  ([#1448](https://github.com/joshua-jingu-lee/ante/pull/1448),
+  [`62e403a`](https://github.com/joshua-jingu-lee/ante/commit/62e403ac25369a6a69ecf47f3bea4f3e35dafa8f))
+
+- **web-api**: Enforce finite-positive budget on BotCreateRequest/BotUpdateRequest (#1435)
+  ([#1447](https://github.com/joshua-jingu-lee/ante/pull/1447),
+  [`d077a1f`](https://github.com/joshua-jingu-lee/ante/commit/d077a1feb0ec503e9969cb10793703d55b027424))
+
+- **web-api**: Enforce HaltRequest/ClearHaltRequest extra=forbid (#1442)
+  ([#1455](https://github.com/joshua-jingu-lee/ante/pull/1455),
+  [`452a4f6`](https://github.com/joshua-jingu-lee/ante/commit/452a4f6fadce766c25ea16b4ec375a0c9fceb872))
+
+- **web-api**: Enforce ISO 8601 on audit date filter
+  ([#1444](https://github.com/joshua-jingu-lee/ante/pull/1444),
+  [`f2dae4f`](https://github.com/joshua-jingu-lee/ante/commit/f2dae4f4b5b8d5d2742c988185db17f557340976))
+
+- **web-api**: Enforce ISO 8601 on audit date filter (#1414)
+  ([#1444](https://github.com/joshua-jingu-lee/ante/pull/1444),
+  [`f2dae4f`](https://github.com/joshua-jingu-lee/ante/commit/f2dae4f4b5b8d5d2742c988185db17f557340976))
+
+- **web-api**: Enforce StatusUpdateRequest extra=forbid + Literal transition (#1441)
+  ([#1453](https://github.com/joshua-jingu-lee/ante/pull/1453),
+  [`1f8e410`](https://github.com/joshua-jingu-lee/ante/commit/1f8e410e368c82961f90572be8e1303af5f7d5d3))
+
+- **web-api**: Expose ApprovalStatusUpdate status enum (approved/rejected) (#1434)
+  ([#1446](https://github.com/joshua-jingu-lee/ante/pull/1446),
+  [`cc0f334`](https://github.com/joshua-jingu-lee/ante/commit/cc0f334d324bb1ad322501e623ecc72dc2e7bb46))
+
+- **web-api**: Expose strategies/validate + approvals/status requestBody and validate path type
+  ([#1431](https://github.com/joshua-jingu-lee/ante/pull/1431),
+  [`5a03510`](https://github.com/joshua-jingu-lee/ante/commit/5a03510b88b63c98884731c0cb0bb116f9cb6674))
+
+- **web-api**: Expose total and offset/start_date/end_date for bot logs
+  ([#1449](https://github.com/joshua-jingu-lee/ante/pull/1449),
+  [`8b6b49a`](https://github.com/joshua-jingu-lee/ante/commit/8b6b49a1cfacbcf9a4f5de6cd55ca71137522fa9))
+
+- **web-api**: Expose total/offset/date filters for bot logs API (#1437)
+  ([#1449](https://github.com/joshua-jingu-lee/ante/pull/1449),
+  [`8b6b49a`](https://github.com/joshua-jingu-lee/ante/commit/8b6b49a1cfacbcf9a4f5de6cd55ca71137522fa9))
+
+- **web-api**: Keyword-only until/offset + SQL payload filter for bot logs (codex FAIL r2)
+  ([#1449](https://github.com/joshua-jingu-lee/ante/pull/1449),
+  [`8b6b49a`](https://github.com/joshua-jingu-lee/ante/commit/8b6b49a1cfacbcf9a4f5de6cd55ca71137522fa9))
+
+- **web-api**: Map bot create budget failure to 422 with rollback
+  ([#1345](https://github.com/joshua-jingu-lee/ante/pull/1345),
+  [`016a328`](https://github.com/joshua-jingu-lee/ante/commit/016a3285cb2900a83636eaf6397040b841f4bf6a))
+
+- **web-api**: Narrow anyOf branches with properties for BotCreateRequest (codex FAIL r2)
+  ([#1448](https://github.com/joshua-jingu-lee/ante/pull/1448),
+  [`62e403a`](https://github.com/joshua-jingu-lee/ante/commit/62e403ac25369a6a69ecf47f3bea4f3e35dafa8f))
+
+- **web-api**: Narrow DELETE dataset data_type to Literal['ohlcv','fundamental'] (#1438)
+  ([#1450](https://github.com/joshua-jingu-lee/ante/pull/1450),
+  [`05633f3`](https://github.com/joshua-jingu-lee/ante/commit/05633f35675ad5bceccd79c7225eda4f85f2ddc7))
+
+- **web-api**: Reject non-zero-padded date strings in query date helper (codex FAIL r1)
+  ([#1452](https://github.com/joshua-jingu-lee/ante/pull/1452),
+  [`e258c2a`](https://github.com/joshua-jingu-lee/ante/commit/e258c2aa9ae4386ca45c34ddca4cf1c3630fe40c))
+
+- **web-api**: Remove in-memory cap so ring buffer-bounded logs return all matching events (codex
+  r3) ([#1449](https://github.com/joshua-jingu-lee/ante/pull/1449),
+  [`8b6b49a`](https://github.com/joshua-jingu-lee/ante/commit/8b6b49a1cfacbcf9a4f5de6cd55ca71137522fa9))
+
+- **web-api**: Serialize ValidationError detail for BotCreateRequest model_validator (codex FAIL r3)
+  ([#1448](https://github.com/joshua-jingu-lee/ante/pull/1448),
+  [`62e403a`](https://github.com/joshua-jingu-lee/ante/commit/62e403ac25369a6a69ecf47f3bea4f3e35dafa8f))
+
+- **web-api**: Validate ISO date params for portfolio/treasury endpoints
+  ([#1452](https://github.com/joshua-jingu-lee/ante/pull/1452),
+  [`e258c2a`](https://github.com/joshua-jingu-lee/ante/commit/e258c2aa9ae4386ca45c34ddca4cf1c3630fe40c))
+
+- **web-api**: Validate ISO date params for portfolio/treasury endpoints (#1440)
+  ([#1452](https://github.com/joshua-jingu-lee/ante/pull/1452),
+  [`e258c2a`](https://github.com/joshua-jingu-lee/ante/commit/e258c2aa9ae4386ca45c34ddca4cf1c3630fe40c))
+
+- **web-api,bot**: Enforce runtime control range on BotUpdateRequest/BotConfig
+  ([#1478](https://github.com/joshua-jingu-lee/ante/pull/1478),
+  [`88015b4`](https://github.com/joshua-jingu-lee/ante/commit/88015b45be0deb674a35490c409e5452907097b9))
+
+- **web-api,bot**: Enforce runtime control range on BotUpdateRequest/BotConfig (#1456)
+  ([#1478](https://github.com/joshua-jingu-lee/ante/pull/1478),
+  [`88015b4`](https://github.com/joshua-jingu-lee/ante/commit/88015b45be0deb674a35490c409e5452907097b9))
+
+- **web-api,member**: Enforce MemberRole enum on MemberCreateRequest + service register (#1465)
+  ([#1479](https://github.com/joshua-jingu-lee/ante/pull/1479),
+  [`565df1e`](https://github.com/joshua-jingu-lee/ante/commit/565df1ec2725948dd867304f0c810d602661a4d2))
+
+- **web-api,treasury**: Enforce Literal vocabulary on GET /api/treasury/transactions type filter
+  (#1477) ([#1485](https://github.com/joshua-jingu-lee/ante/pull/1485),
+  [`1f6ea68`](https://github.com/joshua-jingu-lee/ante/commit/1f6ea681a9e00c74821b709b8451b6155e470f72))
+
+### Chores
+
+- #1843-4 regenerate project-structure.md (treasury equivalence test 등록)
+  ([#1868](https://github.com/joshua-jingu-lee/ante/pull/1868),
+  [`4f23925`](https://github.com/joshua-jingu-lee/ante/commit/4f2392529cd8f6380ff6e641c86037e6af4bc46b))
+
+- Re-trigger CI ([#1884](https://github.com/joshua-jingu-lee/ante/pull/1884),
+  [`2928536`](https://github.com/joshua-jingu-lee/ante/commit/292853678b3c1b5be6634e7dcfacd9045a4b473d))
+
+- Re-trigger CI (post-100min wait) ([#1884](https://github.com/joshua-jingu-lee/ante/pull/1884),
+  [`2928536`](https://github.com/joshua-jingu-lee/ante/commit/292853678b3c1b5be6634e7dcfacd9045a4b473d))
+
+- Trigger workflows ([#1136](https://github.com/joshua-jingu-lee/ante/pull/1136),
+  [`4792745`](https://github.com/joshua-jingu-lee/ante/commit/4792745743af86d1f682a248314d25e33bbb66b2))
+
+- Trigger workflows after bot fix ([#1136](https://github.com/joshua-jingu-lee/ante/pull/1136),
+  [`4792745`](https://github.com/joshua-jingu-lee/ante/commit/4792745743af86d1f682a248314d25e33bbb66b2))
+
+- Trigger workflows after bot fix attempt 2
+  ([#1136](https://github.com/joshua-jingu-lee/ante/pull/1136),
+  [`4792745`](https://github.com/joshua-jingu-lee/ante/commit/4792745743af86d1f682a248314d25e33bbb66b2))
+
+- **ci**: Align GitHub Actions Python runtime to 3.13 (#1188)
+  ([#1198](https://github.com/joshua-jingu-lee/ante/pull/1198),
+  [`fbfe942`](https://github.com/joshua-jingu-lee/ante/commit/fbfe942b33ef464e68483f940cf0a5c24b94ee13))
+
+- **ci**: Extend merge-gate ci wait to 90 minutes
+  ([#1154](https://github.com/joshua-jingu-lee/ante/pull/1154),
+  [`c2666c2`](https://github.com/joshua-jingu-lee/ante/commit/c2666c25c87870f08811df2443f2287eca4c03b1))
+
+- **ci**: Guard merge-gate with ci success wait
+  ([#1154](https://github.com/joshua-jingu-lee/ante/pull/1154),
+  [`c2666c2`](https://github.com/joshua-jingu-lee/ante/commit/c2666c25c87870f08811df2443f2287eca4c03b1))
+
+- **ci**: Mark AI review as advisory check
+  ([#1154](https://github.com/joshua-jingu-lee/ante/pull/1154),
+  [`c2666c2`](https://github.com/joshua-jingu-lee/ante/commit/c2666c25c87870f08811df2443f2287eca4c03b1))
+
+- **ci**: Rely on auto-merge required-check wait
+  ([#1154](https://github.com/joshua-jingu-lee/ante/pull/1154),
+  [`c2666c2`](https://github.com/joshua-jingu-lee/ante/commit/c2666c25c87870f08811df2443f2287eca4c03b1))
+
+- **config,main,cli**: Introduce runtime path canonical resolver (single-canonical cutover) (#1157)
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **deploy**: Remove staging compose override
+  ([`1a6e694`](https://github.com/joshua-jingu-lee/ante/commit/1a6e694f22a50cc89ba372d9ee4babf48a551a56))
+
+- **deps**: Align pyproject to Python 3.13 single runtime contract
+  ([#1199](https://github.com/joshua-jingu-lee/ante/pull/1199),
+  [`8fc0685`](https://github.com/joshua-jingu-lee/ante/commit/8fc0685d886f41f72ff51a80d525e3df81579adf))
+
+- **deps,ipc,docker**: Align project to Python 3.13 single runtime
+  ([#1199](https://github.com/joshua-jingu-lee/ante/pull/1199),
+  [`8fc0685`](https://github.com/joshua-jingu-lee/ante/commit/8fc0685d886f41f72ff51a80d525e3df81579adf))
+
+- **dev**: Add local Python 3.13 runtime drift guards (#1190)
+  ([#1200](https://github.com/joshua-jingu-lee/ante/pull/1200),
+  [`797a769`](https://github.com/joshua-jingu-lee/ante/commit/797a7696d85a5346c9934e245cb91fa6b5d4b060))
+
+- **docker**: Bump runtime base image to python:3.13-slim
+  ([#1199](https://github.com/joshua-jingu-lee/ante/pull/1199),
+  [`8fc0685`](https://github.com/joshua-jingu-lee/ante/commit/8fc0685d886f41f72ff51a80d525e3df81579adf))
+
+- **docs**: #1899 attempt 2 — required checks 확장값을 Gate C/git-workflow/release 게이트 문서에 일관 반영 (codex
+  review finding) ([#1908](https://github.com/joshua-jingu-lee/ante/pull/1908),
+  [`dafd2ab`](https://github.com/joshua-jingu-lee/ante/commit/dafd2ab59950d2bb3ddbe07dd97c23f81735f763))
+
+- **docs**: #1899 attempt 3 — Rationale 정정 (GitHub required check 동작에 맞게 방어 근거 명확화)
+  ([#1908](https://github.com/joshua-jingu-lee/ante/pull/1908),
+  [`dafd2ab`](https://github.com/joshua-jingu-lee/ante/commit/dafd2ab59950d2bb3ddbe07dd97c23f81735f763))
+
+- **docs**: #1899 merge-safety required-checks 컨텍스트 확장 권장값 (옵션 B docs only)
+  ([#1908](https://github.com/joshua-jingu-lee/ante/pull/1908),
+  [`dafd2ab`](https://github.com/joshua-jingu-lee/ante/commit/dafd2ab59950d2bb3ddbe07dd97c23f81735f763))
+
+- **frontend**: Regenerate OpenAPI + types for #1335 422/500 description
+  ([#1345](https://github.com/joshua-jingu-lee/ante/pull/1345),
+  [`016a328`](https://github.com/joshua-jingu-lee/ante/commit/016a3285cb2900a83636eaf6397040b841f4bf6a))
+
+- **frontend**: Regenerate OpenAPI artifacts for BotInfo.config
+  ([#1501](https://github.com/joshua-jingu-lee/ante/pull/1501),
+  [`64c7d45`](https://github.com/joshua-jingu-lee/ante/commit/64c7d451fe5bf399f961b739c6f5aff6092dc022))
+
+- **frontend**: Regenerate openapi.json + api.generated.ts for problem+json alignment
+  ([#1180](https://github.com/joshua-jingu-lee/ante/pull/1180),
+  [`19002a9`](https://github.com/joshua-jingu-lee/ante/commit/19002a996b8757b8fdba9e4e1b524e0ff017c982))
+
+- **frontend**: Sync openapi.json and types for HH:MM pattern
+  ([#1344](https://github.com/joshua-jingu-lee/ante/pull/1344),
+  [`1dd1cda`](https://github.com/joshua-jingu-lee/ante/commit/1dd1cdacf78e408fff06431a6418e157db1a9064))
+
+- **ipc**: Drop Python 3.11/3.12 compat branch and align IPC to 3.13 single runtime
+  ([#1199](https://github.com/joshua-jingu-lee/ante/pull/1199),
+  [`8fc0685`](https://github.com/joshua-jingu-lee/ante/commit/8fc0685d886f41f72ff51a80d525e3df81579adf))
+
+- **openapi**: Include session cookie auth in MemberCreateRequest schema description (#1339 P3)
+  ([#1346](https://github.com/joshua-jingu-lee/ante/pull/1346),
+  [`db30498`](https://github.com/joshua-jingu-lee/ante/commit/db30498a8f3cc526fa01dfe69272a5bd2115bb5b))
+
+- **openapi**: Regenerate frontend openapi.json + TS types
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **openapi**: Regenerate openapi.json and types for balance minimum
+  ([#1343](https://github.com/joshua-jingu-lee/ante/pull/1343),
+  [`db12f00`](https://github.com/joshua-jingu-lee/ante/commit/db12f0099c75df83a2ab53cbe7ebdb689f8137d0))
+
+- **release**: Bump version to 0.9.0 ([#1136](https://github.com/joshua-jingu-lee/ante/pull/1136),
+  [`4792745`](https://github.com/joshua-jingu-lee/ante/commit/4792745743af86d1f682a248314d25e33bbb66b2))
+
+- **runbook**: Align implement-issue advisory wording
+  ([#1154](https://github.com/joshua-jingu-lee/ante/pull/1154),
+  [`c2666c2`](https://github.com/joshua-jingu-lee/ante/commit/c2666c25c87870f08811df2443f2287eca4c03b1))
+
+- **runbook**: Align release docs to advisory ai-review
+  ([#1154](https://github.com/joshua-jingu-lee/ante/pull/1154),
+  [`c2666c2`](https://github.com/joshua-jingu-lee/ante/commit/c2666c25c87870f08811df2443f2287eca4c03b1))
+
+- **scripts**: Drop PR-phase-only AI review and fix support
+  ([#1178](https://github.com/joshua-jingu-lee/ante/pull/1178),
+  [`729950e`](https://github.com/joshua-jingu-lee/ante/commit/729950ecdb0fb267e30b44c0fb277b29346606dc))
+
+- **spec,frontend**: Document PUT 422 semantics + regen artifacts
+  ([#1168](https://github.com/joshua-jingu-lee/ante/pull/1168),
+  [`6c34618`](https://github.com/joshua-jingu-lee/ante/commit/6c346186251a53293cc77e87a067f3af3b684ebb))
+
+- **strategy**: Remove qa fixture strategies
+  ([`040c1af`](https://github.com/joshua-jingu-lee/ante/commit/040c1af1bcea05413872a493e2b9a48bc5a38a08))
+
+- **test**: Remove repo-local qa harness
+  ([`c5fcb93`](https://github.com/joshua-jingu-lee/ante/commit/c5fcb93449871b0913f85b31f339fa3956509977))
+
+- **web**: Align explicit 4xx/5xx OpenAPI content-type to application/problem+json (#1164)
+  ([#1180](https://github.com/joshua-jingu-lee/ante/pull/1180),
+  [`19002a9`](https://github.com/joshua-jingu-lee/ante/commit/19002a996b8757b8fdba9e4e1b524e0ff017c982))
+
+- **web**: Apply ErrorResponse model to all explicit 4xx/5xx responses
+  ([#1165](https://github.com/joshua-jingu-lee/ante/pull/1165),
+  [`700a750`](https://github.com/joshua-jingu-lee/ante/commit/700a750c2a7dd0e7eb77038051c55c3f54900aff))
+
+- **web**: Apply ErrorResponse model to all explicit 4xx/5xx responses (#1145)
+  ([#1165](https://github.com/joshua-jingu-lee/ante/pull/1165),
+  [`700a750`](https://github.com/joshua-jingu-lee/ante/commit/700a750c2a7dd0e7eb77038051c55c3f54900aff))
+
+- **web**: Drop ANTE_TEST_MODE gate and legacy test_seed route
+  ([#1165](https://github.com/joshua-jingu-lee/ante/pull/1165),
+  [`700a750`](https://github.com/joshua-jingu-lee/ante/commit/700a750c2a7dd0e7eb77038051c55c3f54900aff))
+
+- **workflows**: Remove claude/codex PR approval and auto-fix jobs
+  ([#1178](https://github.com/joshua-jingu-lee/ante/pull/1178),
+  [`729950e`](https://github.com/joshua-jingu-lee/ante/commit/729950ecdb0fb267e30b44c0fb277b29346606dc))
+
+- **workflows,docs**: Retire PR-stage AI approval/auto-fix workers (#1167)
+  ([#1178](https://github.com/joshua-jingu-lee/ante/pull/1178),
+  [`729950e`](https://github.com/joshua-jingu-lee/ante/commit/729950ecdb0fb267e30b44c0fb277b29346606dc))
+
+### Continuous Integration
+
+- #1896 ci-gate job을 fail-fast로 강제하여 skip 우회 차단
+  ([#1904](https://github.com/joshua-jingu-lee/ante/pull/1904),
+  [`fe005c8`](https://github.com/joshua-jingu-lee/ante/commit/fe005c825d83b2fe2e22592e6bab39871cdb67e8))
+
+- **frontend**: Gate api type boundary checks
+  ([#1278](https://github.com/joshua-jingu-lee/ante/pull/1278),
+  [`3b6b9aa`](https://github.com/joshua-jingu-lee/ante/commit/3b6b9aa0def4924754264abdff58c187e12280af))
+
+- **release**: Align PyPI publish secret name
+  ([#1962](https://github.com/joshua-jingu-lee/ante/pull/1962),
+  [`78422a0`](https://github.com/joshua-jingu-lee/ante/commit/78422a0c0dfb6953f8ef0581631abdaab523211b))
+
+### Documentation
+
+- #1660 bot start/stop/status CLI 미구현(follow-up) 명시 (oracle literal surface)
+  ([#1669](https://github.com/joshua-jingu-lee/ante/pull/1669),
+  [`0c62d69`](https://github.com/joshua-jingu-lee/ante/commit/0c62d691a69799a3e6f1e9a2271886cefbf4be41))
+
+- #1661 ROOT-ONLY 명령 trailing/bracketed --format json 예시를 root form으로 정렬
+  ([#1670](https://github.com/joshua-jingu-lee/ante/pull/1670),
+  [`a030c00`](https://github.com/joshua-jingu-lee/ante/commit/a030c00e535c10395a413dd7265abf5b312568b6))
+
+- #1662 account-scoped CLI 필수 --account를 required 형태로 정렬
+  ([#1671](https://github.com/joshua-jingu-lee/ante/pull/1671),
+  [`3acdee9`](https://github.com/joshua-jingu-lee/ante/commit/3acdee93958c9ec88e3b6e30646c455d74a55e07))
+
+- #1663 approval reopen 옵션 SSOT를 실제 Click(--body/--params)로 정정
+  ([#1672](https://github.com/joshua-jingu-lee/ante/pull/1672),
+  [`9470a9d`](https://github.com/joshua-jingu-lee/ante/commit/9470a9d5301649a40bb5b499577168758c62d58d))
+
+- #1678 #1213 머지 후 stale 구현상태 노트 제거 (web-api/04-system-endpoints + ipc 대칭)
+  ([#1685](https://github.com/joshua-jingu-lee/ante/pull/1685),
+  [`a6be538`](https://github.com/joshua-jingu-lee/ante/commit/a6be5387612fabeda1e645831fbb7a430e31cf29))
+
+- #1679 비활성 /api/notifications를 paginated-route 주장에서 제거 (06-pagination 수기 + project-structure 생성
+  #1660 dual-fix) ([#1686](https://github.com/joshua-jingu-lee/ante/pull/1686),
+  [`1b613a5`](https://github.com/joshua-jingu-lee/ante/commit/1b613a55918e7cb2604eaaae7a813b5a67e34731))
+
+- #1680 generated project-structure CLI inventory stale 정합 (4 CLI 셀 #1660 dual-fix + 전체 재생성)
+  ([#1687](https://github.com/joshua-jingu-lee/ante/pull/1687),
+  [`5c6d6de`](https://github.com/joshua-jingu-lee/ante/commit/5c6d6de7f497c9fbbf4c942decdd8e9d228b96c2))
+
+- #1691 outdated dashboard user-stories 제거 + 코드/문서/생성산출물 dual-fix
+  ([#1695](https://github.com/joshua-jingu-lee/ante/pull/1695),
+  [`b8ada77`](https://github.com/joshua-jingu-lee/ante/commit/b8ada777c76359c9fe98263358c51f4b252aa85c))
+
+- #1699 account-id-contract historical narrative에서 broker health/price `ante` prefix 제거
+  ([#1707](https://github.com/joshua-jingu-lee/ante/pull/1707),
+  [`9a05315`](https://github.com/joshua-jingu-lee/ante/commit/9a05315b5d43f48055b54c5e3dd97d0eaca25e48))
+
+- #1700 dashboard mockup/React/guide의 ante data show/collect fake CLI 정리
+  ([#1708](https://github.com/joshua-jingu-lee/ante/pull/1708),
+  [`70f2fd6`](https://github.com/joshua-jingu-lee/ante/commit/70f2fd62a075fd4a6256a497e2665c8c537f6512))
+
+- #1702 project-structure CLI inventory 8 항목 현행화 (DEFAULT_DESCRIPTIONS + md 재생성)
+  ([#1714](https://github.com/joshua-jingu-lee/ante/pull/1714),
+  [`8479e53`](https://github.com/joshua-jingu-lee/ante/commit/8479e53878b650f097ce2ef0a58b34bfb93abe40))
+
+- #1711 bot start/stop/status CLI·IPC 계약 스펙 확정 (Web API 라우트 정렬)
+  ([#1715](https://github.com/joshua-jingu-lee/ante/pull/1715),
+  [`cf1e32b`](https://github.com/joshua-jingu-lee/ante/commit/cf1e32b69bc1c18d588ddda052bd41ef4a2e45b5))
+
+- #1728 #1698 epic 완료 후 stale 진행 문구 제거 (bot CLI usage + cli commands)
+  ([#1738](https://github.com/joshua-jingu-lee/ante/pull/1738),
+  [`f835f90`](https://github.com/joshua-jingu-lee/ante/commit/f835f9043970e879ab3dde9bc2c390cb6fea4d78))
+
+- #1729 #1404 close 후 CLI 인증 설계 stale 진행 문구 정리
+  ([#1739](https://github.com/joshua-jingu-lee/ante/pull/1739),
+  [`84278a7`](https://github.com/joshua-jingu-lee/ante/commit/84278a7bf3ee4f5d7349119118937d7540b7f1a4))
+
+- #1746 EventBus 스펙 D-018 정합 publisher 정정
+  ([#1749](https://github.com/joshua-jingu-lee/ante/pull/1749),
+  [`49a7bf6`](https://github.com/joshua-jingu-lee/ante/commit/49a7bf666572a682f9b0145ecd733cbcb933c95f))
+
+- #1747 invalid-role runbook의 stale CLI path 정정
+  ([#1750](https://github.com/joshua-jingu-lee/ante/pull/1750),
+  [`371a168`](https://github.com/joshua-jingu-lee/ante/commit/371a168e35fd26b08c9f5631fe11be6fbb55a048))
+
+- #1748 rule-engine 인덱스의 stale 11-rest-api.md 링크 제거
+  ([#1751](https://github.com/joshua-jingu-lee/ante/pull/1751),
+  [`ae19043`](https://github.com/joshua-jingu-lee/ante/commit/ae190439537e5e6bc649329cbfb83c847e1d3440))
+
+- #1821 CLI/IPC envelope shape SSOT (4 normative forms)
+  ([#1838](https://github.com/joshua-jingu-lee/ante/pull/1838),
+  [`c3f08ff`](https://github.com/joshua-jingu-lee/ante/commit/c3f08ff787c98e370d19cc6ff1359120ef866b3e))
+
+- #1824 contract SSOT index + 4-epic cross-check (meta-epic #1820 close)
+  ([#1838](https://github.com/joshua-jingu-lee/ante/pull/1838),
+  [`c3f08ff`](https://github.com/joshua-jingu-lee/ante/commit/c3f08ff787c98e370d19cc6ff1359120ef866b3e))
+
+- #1839 stable error taxonomy spec + auth middleware code policy
+  ([#1860](https://github.com/joshua-jingu-lee/ante/pull/1860),
+  [`34ad127`](https://github.com/joshua-jingu-lee/ante/commit/34ad127b69a75cdfe1019bb15edfaaed9082deb1))
+
+- #1841 regen project-structure.md (+drift allowlist + 2 test files)
+  ([#1862](https://github.com/joshua-jingu-lee/ante/pull/1862),
+  [`862e37c`](https://github.com/joshua-jingu-lee/ante/commit/862e37cf63e62077fb42a8c2e44550eee7ff87a8))
+
+- #1842 regen project-structure (account CLI/IPC equivalence test 반영)
+  ([#1863](https://github.com/joshua-jingu-lee/ante/pull/1863),
+  [`31a1413`](https://github.com/joshua-jingu-lee/ante/commit/31a14137062f8bc578ae21a4c8bd1698bdd36371))
+
+- #1843 sub-PR 1 regen project-structure (member CLI/IPC equivalence test 반영)
+  ([#1865](https://github.com/joshua-jingu-lee/ante/pull/1865),
+  [`419ddf5`](https://github.com/joshua-jingu-lee/ante/commit/419ddf5a922518263287a74cb936eab5705b5f3f))
+
+- #1843-5 project-structure regen for new broker tests
+  ([#1869](https://github.com/joshua-jingu-lee/ante/pull/1869),
+  [`18b1e94`](https://github.com/joshua-jingu-lee/ante/commit/18b1e9430a7c7c4dd8569512caad51e59a0c6ac1))
+
+- #1843-6 project-structure.md regen — 3 equivalence test 추가 반영
+  ([#1871](https://github.com/joshua-jingu-lee/ante/pull/1871),
+  [`4a194a3`](https://github.com/joshua-jingu-lee/ante/commit/4a194a33e9038b106be544fc6d5f47df7ef601ea))
+
+- #1846 regenerate project-structure (account drift test)
+  ([#1874](https://github.com/joshua-jingu-lee/ante/pull/1874),
+  [`e334589`](https://github.com/joshua-jingu-lee/ante/commit/e334589c466126acec77b8180f43e6a03ad12136))
+
+- #1847 sub-PR 4 regenerate project-structure.md
+  ([#1878](https://github.com/joshua-jingu-lee/ante/pull/1878),
+  [`eaa340f`](https://github.com/joshua-jingu-lee/ante/commit/eaa340f3a7f314799efdc119ce7ea19b04285820))
+
+- #1847 sub-PR 5 regenerate project-structure.md (strategy drift test added)
+  ([#1879](https://github.com/joshua-jingu-lee/ante/pull/1879),
+  [`fa9ccbb`](https://github.com/joshua-jingu-lee/ante/commit/fa9ccbb0b718da19984555b102e0362b595de9f3))
+
+- #1847 sub-PR 6 regenerate project-structure after adding data + report drift tests
+  ([#1880](https://github.com/joshua-jingu-lee/ante/pull/1880),
+  [`0172374`](https://github.com/joshua-jingu-lee/ante/commit/017237446ffdb546bba8725481d06f0a5052c244))
+
+- #1847-2 regenerate project structure (bot drift test added)
+  ([#1876](https://github.com/joshua-jingu-lee/ante/pull/1876),
+  [`3debab9`](https://github.com/joshua-jingu-lee/ante/commit/3debab9189278d47f3db86022f94381a5922af0a))
+
+- #1848 regenerate project-structure.md for new contracts test files
+  ([#1894](https://github.com/joshua-jingu-lee/ante/pull/1894),
+  [`a8bb234`](https://github.com/joshua-jingu-lee/ante/commit/a8bb23457663e9a75ded0ffce05baa95c0987689))
+
+- #1854 CLI offline service factory contract + read_only policy + ctx-based path resolution
+  ([#1887](https://github.com/joshua-jingu-lee/ante/pull/1887),
+  [`a54c397`](https://github.com/joshua-jingu-lee/ante/commit/a54c3972a43ce2f48be982fa7ff509abf6549283))
+
+- Align paper terminology cleanup ([#1288](https://github.com/joshua-jingu-lee/ante/pull/1288),
+  [`173aba3`](https://github.com/joshua-jingu-lee/ante/commit/173aba33d55b0038b4c3f5546fb8722a6142277a))
+
+- Raise autopilot issue limit to 25 ([#1859](https://github.com/joshua-jingu-lee/ante/pull/1859),
+  [`9a2d5a9`](https://github.com/joshua-jingu-lee/ante/commit/9a2d5a93e50063bfeb4c4136a15a98ddfac6bb50))
+
+- **#1847-1**: Regen project-structure with member drift test
+  ([#1875](https://github.com/joshua-jingu-lee/ante/pull/1875),
+  [`d728fc1`](https://github.com/joshua-jingu-lee/ante/commit/d728fc1d0f25c55a33f7e92b887433be1940108e))
+
+- **account**: #1218 Edge resolver SPLIT 적용 위치 추가
+  ([#1249](https://github.com/joshua-jingu-lee/ante/pull/1249),
+  [`c7b6719`](https://github.com/joshua-jingu-lee/ante/commit/c7b67190ba0e4b09d8dd2ccc595bb5888e33cdab))
+
+- **account**: Account create→D follow-up 재분류 + current 런타임 상태 단정 전면 제거 (#1633 attempt 3 blocking
+  2건) ([#1646](https://github.com/joshua-jingu-lee/ante/pull/1646),
+  [`d5c6e0d`](https://github.com/joshua-jingu-lee/ante/commit/d5c6e0d521b3be1b3bbadf04779e1e7338b0eab7))
+
+- **account**: Account_id CLI 에러코드 SSOT + inventory 결정표 확정
+  ([#1646](https://github.com/joshua-jingu-lee/ante/pull/1646),
+  [`d5c6e0d`](https://github.com/joshua-jingu-lee/ante/commit/d5c6e0d521b3be1b3bbadf04779e1e7338b0eab7))
+
+- **account**: Account_id CLI 에러코드 SSOT + inventory 결정표 확정 (#1633)
+  ([#1646](https://github.com/joshua-jingu-lee/ante/pull/1646),
+  [`d5c6e0d`](https://github.com/joshua-jingu-lee/ante/commit/d5c6e0d521b3be1b3bbadf04779e1e7338b0eab7))
+
+- **account**: Align KIS credential key examples with BrokerPreset SSOT
+  ([#1203](https://github.com/joshua-jingu-lee/ante/pull/1203),
+  [`72e2620`](https://github.com/joshua-jingu-lee/ante/commit/72e26204d0d61bfcd3992c4e2ddf541957ec8048))
+
+- **account**: Clarify require_account_id error to exclude 'test' from fallback list
+  ([#1239](https://github.com/joshua-jingu-lee/ante/pull/1239),
+  [`270a17a`](https://github.com/joshua-jingu-lee/ante/commit/270a17a192886233658cf2229d136fc4511c642f))
+
+- **account**: Document service-layer runtime guard invariants S1-S5
+  ([#1169](https://github.com/joshua-jingu-lee/ante/pull/1169),
+  [`90dc2b8`](https://github.com/joshua-jingu-lee/ante/commit/90dc2b8fdb4fd5888ee760e0e0bc305ee8e44a4b))
+
+- **account**: Document trading_hours strict HH:MM invariant
+  ([#1344](https://github.com/joshua-jingu-lee/ante/pull/1344),
+  [`1dd1cda`](https://github.com/joshua-jingu-lee/ante/commit/1dd1cdacf78e408fff06431a6418e157db1a9064))
+
+- **account**: Inventory 결정표를 normative target으로 재프레임 — current 런타임 산출 단정 전면 제거 (#1633 attempt 3)
+  ([#1646](https://github.com/joshua-jingu-lee/ante/pull/1646),
+  [`d5c6e0d`](https://github.com/joshua-jingu-lee/ante/commit/d5c6e0d521b3be1b3bbadf04779e1e7338b0eab7))
+
+- **account**: Make AMEX drift explicit in exchange SSOT pointer
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **account**: Rule account_id 표면 정합 + error-code SSOT require_account_id 한정 (#1633 attempt 2)
+  ([#1646](https://github.com/joshua-jingu-lee/ante/pull/1646),
+  [`d5c6e0d`](https://github.com/joshua-jingu-lee/ante/commit/d5c6e0d521b3be1b3bbadf04779e1e7338b0eab7))
+
+- **account**: Split read surfaces from bucket E — snapshot=B(#1635), strategy-perf=read-family
+  follow-up (#1633 attempt5) ([#1646](https://github.com/joshua-jingu-lee/ante/pull/1646),
+  [`d5c6e0d`](https://github.com/joshua-jingu-lee/ante/commit/d5c6e0d521b3be1b3bbadf04779e1e7338b0eab7))
+
+- **agent**: Align generated artifact checklist (#1268)
+  ([#1281](https://github.com/joshua-jingu-lee/ante/pull/1281),
+  [`377ba52`](https://github.com/joshua-jingu-lee/ante/commit/377ba523c8e0a9743f92d9dd217898f512732cd6))
+
+- **agent**: Align implement-issue stage table and exit criteria with new merge-gate policy
+  ([#1178](https://github.com/joshua-jingu-lee/ante/pull/1178),
+  [`729950e`](https://github.com/joshua-jingu-lee/ante/commit/729950ecdb0fb267e30b44c0fb277b29346606dc))
+
+- **agent**: Drop PR approval references from autopilot/implement-issue/release commands
+  ([#1178](https://github.com/joshua-jingu-lee/ante/pull/1178),
+  [`729950e`](https://github.com/joshua-jingu-lee/ante/commit/729950ecdb0fb267e30b44c0fb277b29346606dc))
+
+- **agent**: Rewrite review-pr/receive-review/code-reviewer to focus on Codex + manual paths
+  ([#1178](https://github.com/joshua-jingu-lee/ante/pull/1178),
+  [`729950e`](https://github.com/joshua-jingu-lee/ante/commit/729950ecdb0fb267e30b44c0fb277b29346606dc))
+
+- **architecture**: Add db schema check mode (#1267)
+  ([#1280](https://github.com/joshua-jingu-lee/ante/pull/1280),
+  [`9846dd8`](https://github.com/joshua-jingu-lee/ante/commit/9846dd845e3daea1821bbff1d8f4ed436370eebd))
+
+- **architecture**: Add project structure generator (#1266)
+  ([#1279](https://github.com/joshua-jingu-lee/ante/pull/1279),
+  [`a2325ce`](https://github.com/joshua-jingu-lee/ante/commit/a2325ceb8187edee986714a1fdb460d6db850c98))
+
+- **auth**: Add D-015 default-deny auth gate ADR + Web/CLI spec updates (#1402)
+  ([#1420](https://github.com/joshua-jingu-lee/ante/pull/1420),
+  [`a125c11`](https://github.com/joshua-jingu-lee/ante/commit/a125c11a8c9c5dd70daa825568c4b7a6625c2231))
+
+- **cli**: #1912 03-commands.md detail block에 누락된 leaf command 13건 추가
+  ([#1925](https://github.com/joshua-jingu-lee/ante/pull/1925),
+  [`df81e28`](https://github.com/joshua-jingu-lee/ante/commit/df81e287fdff69135e26d0f8995439dfd25da28c))
+
+- **cli**: #1916 strategy performance --account-id semantic-required 표기 정합
+  ([#1927](https://github.com/joshua-jingu-lee/ante/pull/1927),
+  [`a1fd48c`](https://github.com/joshua-jingu-lee/ante/commit/a1fd48c39bdf3129be12707b6629fddff8224523))
+
+- **cli**: Adopt non-interactive input contract as CLI SSOT
+  ([#1203](https://github.com/joshua-jingu-lee/ante/pull/1203),
+  [`72e2620`](https://github.com/joshua-jingu-lee/ante/commit/72e26204d0d61bfcd3992c4e2ddf541957ec8048))
+
+- **commands**: Add plan preflight command
+  ([`88d96d7`](https://github.com/joshua-jingu-lee/ante/commit/88d96d7aca14e844bf358b0335efc929df0b39ad))
+
+- **commands**: Remove arch review command
+  ([`92d6b79`](https://github.com/joshua-jingu-lee/ante/commit/92d6b7913c83144c945faffcdcd821d80c2bb225))
+
+- **core**: Align Data API symbol owner + close strategy timeframe enum (#1612 review)
+  ([#1615](https://github.com/joshua-jingu-lee/ante/pull/1615),
+  [`0295cdb`](https://github.com/joshua-jingu-lee/ante/commit/0295cdbfe5f3a5695c7a1ec858bf5dcbb192a3fd))
+
+- **core**: Make DataStore read consistent with legacy policy + section-wide consistency pass
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **core**: Scope Account Web 409 to POST + PUT-structural, allow PUT mutable
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **core**: Scope KRX symbol shape to KRX surface + fix #1611 import consumer (#1612 review2)
+  ([#1615](https://github.com/joshua-jingu-lee/ante/pull/1615),
+  [`0295cdb`](https://github.com/joshua-jingu-lee/ante/commit/0295cdbfe5f3a5695c7a1ec858bf5dcbb192a3fd))
+
+- **core**: Scope matrix to vocabulary contract, defer surface specifics to #1577/#1578
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **core**: Separate exchange-validity vs 1.0 preset-availability axes
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **core**: Symbol-axis cross-spec reconciliation — schema/datasets symbol semantics (#1612 review3
+  meta) ([#1615](https://github.com/joshua-jingu-lee/ante/pull/1615),
+  [`0295cdb`](https://github.com/joshua-jingu-lee/ante/commit/0295cdbfe5f3a5695c7a1ec858bf5dcbb192a3fd))
+
+- **core**: Symbol/timeframe canonical vocabulary 계약 SSOT 신설
+  ([#1615](https://github.com/joshua-jingu-lee/ante/pull/1615),
+  [`0295cdb`](https://github.com/joshua-jingu-lee/ante/commit/0295cdbfe5f3a5695c7a1ec858bf5dcbb192a3fd))
+
+- **core**: Symbol/timeframe canonical vocabulary 계약 SSOT 신설 (#1612)
+  ([#1615](https://github.com/joshua-jingu-lee/ante/pull/1615),
+  [`0295cdb`](https://github.com/joshua-jingu-lee/ante/commit/0295cdbfe5f3a5695c7a1ec858bf5dcbb192a3fd))
+
+- **core**: Use real CLI command name account create
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **core,account**: Use exact MUTABLE_FIELDS names trading_hours_start/end
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **core,decisions**: Define canonical exchange vocabulary SSOT
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **core,decisions**: Define canonical exchange vocabulary SSOT (#1575)
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **db**: Align schema constant convention (#1229)
+  ([#1254](https://github.com/joshua-jingu-lee/ante/pull/1254),
+  [`8f04aff`](https://github.com/joshua-jingu-lee/ante/commit/8f04aff250e76e61e77d0ced10366cf15cbf5731))
+
+- **db**: Regenerate account-aware schema reference (#1260)
+  ([#1273](https://github.com/joshua-jingu-lee/ante/pull/1273),
+  [`92dc769`](https://github.com/joshua-jingu-lee/ante/commit/92dc769f53314e76e66684c91e6e07e92f1e7acc))
+
+- **decisions**: Recover D-016 contract paraphrase to core.md SSOT link
+  ([#1580](https://github.com/joshua-jingu-lee/ante/pull/1580),
+  [`2562168`](https://github.com/joshua-jingu-lee/ante/commit/25621685a511a5aa8f843efa7d7b5e922665e324))
+
+- **eventbus**: Document `_consumed` transient marker convention
+  ([#1341](https://github.com/joshua-jingu-lee/ante/pull/1341),
+  [`fde7c2e`](https://github.com/joshua-jingu-lee/ante/commit/fde7c2ed4b6b8c91495dc6992dc9bdcdc29bf4b2))
+
+- **frontend**: Align API type SSOT rules (#1221)
+  ([#1250](https://github.com/joshua-jingu-lee/ante/pull/1250),
+  [`0ef6963`](https://github.com/joshua-jingu-lee/ante/commit/0ef6963f48ad43f78ce9dfc97c678d2de6f8a4b7))
+
+- **guide**: Align guide with non-interactive CLI contract
+  ([#1210](https://github.com/joshua-jingu-lee/ante/pull/1210),
+  [`40dec44`](https://github.com/joshua-jingu-lee/ante/commit/40dec44a75f34f197be3f0135e77307a7d9be1f1))
+
+- **guide**: Fix KIS credential example missing account_no and reset-password positional arg
+  ([#1210](https://github.com/joshua-jingu-lee/ante/pull/1210),
+  [`40dec44`](https://github.com/joshua-jingu-lee/ante/commit/40dec44a75f34f197be3f0135e77307a7d9be1f1))
+
+- **member**: Clarify member admin mutation is master-only (#1542)
+  ([#1554](https://github.com/joshua-jingu-lee/ante/pull/1554),
+  [`93975fe`](https://github.com/joshua-jingu-lee/ante/commit/93975fe2a6e4165697b20268113b0ff3e4c69894))
+
+- **plan**: Note writing plans superpower
+  ([`21cc97e`](https://github.com/joshua-jingu-lee/ante/commit/21cc97e00bd27d08ee80d44720f58bcd658139ff))
+
+- **plan-preflight**: Narrow split handling to planning
+  ([#1245](https://github.com/joshua-jingu-lee/ante/pull/1245),
+  [`c29ce8d`](https://github.com/joshua-jingu-lee/ante/commit/c29ce8d229f040e6c09650607217ca2930a2f23d))
+
+- **release**: Split prepare and publish flow
+  ([`4269ec6`](https://github.com/joshua-jingu-lee/ante/commit/4269ec620428c42e425f3d908048c01ee31f0d02))
+
+- **runbook**: #1924 코드 주석 정합 원칙을 development-process §10에 추가
+  ([#1938](https://github.com/joshua-jingu-lee/ante/pull/1938),
+  [`f6642fc`](https://github.com/joshua-jingu-lee/ante/commit/f6642fc08d76359639c3e8382b526e81e0b504c2))
+
+- **runbook**: Add plan preflight lane
+  ([`2ec1259`](https://github.com/joshua-jingu-lee/ante/commit/2ec12594dd84f48896acb31697306df1bfddd90d))
+
+- **runbook**: Add release command flow
+  ([`3453f8c`](https://github.com/joshua-jingu-lee/ante/commit/3453f8cea65ab37273375615fb96de4f6940934d))
+
+- **runbook**: Align development/git/agent-structure runbooks with new gate model
+  ([#1178](https://github.com/joshua-jingu-lee/ante/pull/1178),
+  [`729950e`](https://github.com/joshua-jingu-lee/ante/commit/729950ecdb0fb267e30b44c0fb277b29346606dc))
+
+- **runbook**: Align interaction flow with preflight
+  ([`ce46bd1`](https://github.com/joshua-jingu-lee/ante/commit/ce46bd161b061c2ef4239d1d397c6001da98212d))
+
+- **runbook**: Align release pr references
+  ([`f2dc7e5`](https://github.com/joshua-jingu-lee/ante/commit/f2dc7e567a6bdfc7279f350e3882ab7d5d78a924))
+
+- **runbook**: Assign start note to dev agent
+  ([`914d350`](https://github.com/joshua-jingu-lee/ante/commit/914d350d8dcb1a5ffd2833174e3509639441faed))
+
+- **runbook**: Clarify implement issue lane
+  ([`696a8a4`](https://github.com/joshua-jingu-lee/ante/commit/696a8a42acba569d846ca7f00c430f645de356c7))
+
+- **runbook**: Clarify recovery ssot
+  ([`b1afb7e`](https://github.com/joshua-jingu-lee/ante/commit/b1afb7ecbe17c759b46b9bb9d020543e272173c5))
+
+- **runbook**: Delegate plan review to codex
+  ([`80d4419`](https://github.com/joshua-jingu-lee/ante/commit/80d44192517215799c1155d4cbe2abfe9b7f1919))
+
+- **runbook**: Detail issue spec paths
+  ([`555a553`](https://github.com/joshua-jingu-lee/ante/commit/555a5531a9e94dc5c35803d740fed3ecfbef4ef9))
+
+- **runbook**: Fold plan finalization into preflight
+  ([`f10e063`](https://github.com/joshua-jingu-lee/ante/commit/f10e0635ddb75cdc3867187b2f747eb713c29b4d))
+
+- **runbook**: Fold review gate into ci cd
+  ([`1a746ef`](https://github.com/joshua-jingu-lee/ante/commit/1a746ef0899e1ed95572aa49a22804ed5f5459a2))
+
+- **runbook**: Make autopilot command ssot
+  ([`f75bce8`](https://github.com/joshua-jingu-lee/ante/commit/f75bce8b2dbe445dbfbf0850a3cee5089f0cb0e2))
+
+- **runbook**: Map issue processing flow
+  ([`98eac18`](https://github.com/joshua-jingu-lee/ante/commit/98eac1871eb57b79491f100f6b49572413e82bbb))
+
+- **runbook**: Merge plan review flow
+  ([`08e5518`](https://github.com/joshua-jingu-lee/ante/commit/08e55185e87e076b98b79302cacb8384b39846ab))
+
+- **runbook**: Move branch review in process
+  ([`c5158ee`](https://github.com/joshua-jingu-lee/ante/commit/c5158eeba00d53b49a07c7c64c02ee3bfb30611b))
+
+- **runbook**: Realign interaction flow tree
+  ([`9db3392`](https://github.com/joshua-jingu-lee/ante/commit/9db3392522859e56660adc5aa4ef66a494319011))
+
+- **runbook**: Require issue comment checkpoints
+  ([`e5d1c4a`](https://github.com/joshua-jingu-lee/ante/commit/e5d1c4a9d9cc0510e0443f3c0093495b937ebd16))
+
+- **runbook**: Retire PR approval/auto-fix gates from CI/CD spec
+  ([#1178](https://github.com/joshua-jingu-lee/ante/pull/1178),
+  [`729950e`](https://github.com/joshua-jingu-lee/ante/commit/729950ecdb0fb267e30b44c0fb277b29346606dc))
+
+- **runbook**: Route preflight through plan review
+  ([`7a228e8`](https://github.com/joshua-jingu-lee/ante/commit/7a228e81cd57eb9b926253824e3a6d0a39ea6094))
+
+- **runbook**: Split plan preflight labels
+  ([`bebad44`](https://github.com/joshua-jingu-lee/ante/commit/bebad4461c99dc23be9bc4b981df4fa5fdc5fe88))
+
+- **runbook**: Tag preflight-ready issues
+  ([`79dc70f`](https://github.com/joshua-jingu-lee/ante/commit/79dc70f0a75a3ced0df4093a54c9136e6dc8967a))
+
+- **runbook**: Trim delegated process details
+  ([`b153b84`](https://github.com/joshua-jingu-lee/ante/commit/b153b84aa87a2a4657f6dba994f1cca1ee44d5fc))
+
+- **runbook**: Trim issue management process details
+  ([`ef6522b`](https://github.com/joshua-jingu-lee/ante/commit/ef6522b897ed9898382a6fb8f0aa4fcce2bd4a44))
+
+- **runtime**: Align user-facing docs to Python 3.13 single runtime contract (#1186)
+  ([#1197](https://github.com/joshua-jingu-lee/ante/pull/1197),
+  [`7e0c8aa`](https://github.com/joshua-jingu-lee/ante/commit/7e0c8aa103fa4ebcb26dff8bfafc8bf3facd4f2f))
+
+- **spec**: #1917 instrument invalid exchange enforcement #1577 완료 시제 정합
+  ([#1928](https://github.com/joshua-jingu-lee/ante/pull/1928),
+  [`f1d20c5`](https://github.com/joshua-jingu-lee/ante/commit/f1d20c5335882c74b9af054b0cd4fb33eea128be))
+
+- **spec**: #1918 master-only CLI guard #1543 완료 시제 정합
+  ([#1929](https://github.com/joshua-jingu-lee/ante/pull/1929),
+  [`d29b0e2`](https://github.com/joshua-jingu-lee/ante/commit/d29b0e29785072c03fe01c79b06e74465e393b63))
+
+- **spec**: #1919 offline-factory contract #1855/#1856/#1857 완료 시제 정합
+  ([#1931](https://github.com/joshua-jingu-lee/ante/pull/1931),
+  [`1c9ebdb`](https://github.com/joshua-jingu-lee/ante/commit/1c9ebdb9058aed1031e8f445f5631505087f6a29))
+
+- **spec**: #1920 DataCollector ingress enforcement #1614 완료 시제 정합
+  ([#1930](https://github.com/joshua-jingu-lee/ante/pull/1930),
+  [`779c4da`](https://github.com/joshua-jingu-lee/ante/commit/779c4da04621ea1167f8ddbe2d7cc46a82b5cbd1))
+
+- **spec**: #1926 core.md #1577 narrative/sub-axis 시제 정합
+  ([#1936](https://github.com/joshua-jingu-lee/ante/pull/1936),
+  [`1208fb2`](https://github.com/joshua-jingu-lee/ante/commit/1208fb2399846207cb12c90a8762641e31143e72))
+
+- **spec**: #1946 fill-recovery 스펙 선반영 (18-fill-recovery + 11/19 정합 + trade)
+  ([#1953](https://github.com/joshua-jingu-lee/ante/pull/1953),
+  [`9f548b4`](https://github.com/joshua-jingu-lee/ante/commit/9f548b463cf4f6794fc788270a58cfa084471eb4))
+
+- **spec**: Add #1213 implementation status banner to halt/clear-halt SSOT
+  ([#1230](https://github.com/joshua-jingu-lee/ante/pull/1230),
+  [`cc20511`](https://github.com/joshua-jingu-lee/ante/commit/cc205112c61b419b6b9b2d9e64099a4c97d3f3a5))
+
+- **spec**: Align account api field names
+  ([`d638f3e`](https://github.com/joshua-jingu-lee/ante/commit/d638f3eb019b1ead783c6e52d5bdb35c5132ebd4))
+
+- **spec**: Align core/core.md telegram contract and clarify DELETED exclusion
+  ([#1230](https://github.com/joshua-jingu-lee/ante/pull/1230),
+  [`cc20511`](https://github.com/joshua-jingu-lee/ante/commit/cc205112c61b419b6b9b2d9e64099a4c97d3f3a5))
+
+- **spec**: Align System Kill Switch contract to halt/clear-halt
+  ([#1230](https://github.com/joshua-jingu-lee/ante/pull/1230),
+  [`cc20511`](https://github.com/joshua-jingu-lee/ante/commit/cc205112c61b419b6b9b2d9e64099a4c97d3f3a5))
+
+- **spec**: Align treasury virtual sync interface
+  ([`8b567c2`](https://github.com/joshua-jingu-lee/ante/commit/8b567c2f3f9d3a8f598d225b5f571b85bba8a138))
+
+- **spec**: Clarify compatibility document role
+  ([`3793123`](https://github.com/joshua-jingu-lee/ante/commit/3793123133163983a2d89c4ad182652d2c9323b6))
+
+- **spec**: Classify runtime command boundaries
+  ([`0b38ae9`](https://github.com/joshua-jingu-lee/ante/commit/0b38ae9278d5331106fa6c24d07fc27c0a9e54c2))
+
+- **spec**: Clean up legacy contract remnants
+  ([`58552e5`](https://github.com/joshua-jingu-lee/ante/commit/58552e57904e7b338e589c1b9a06839defea7ad7))
+
+- **spec**: Define account lifecycle cold path
+  ([`bf448ce`](https://github.com/joshua-jingu-lee/ante/commit/bf448ceb236fee2539d31efbcfea664a737e7d4d))
+
+- **spec**: Define auth scope ssot
+  ([`928efb7`](https://github.com/joshua-jingu-lee/ante/commit/928efb72c3b75b20d22440d4361e126a96a86af2))
+
+- **spec**: Define cli command inventory ssot
+  ([`ff6fb86`](https://github.com/joshua-jingu-lee/ante/commit/ff6fb8600b555d0fe988582fb4afc27cf15665bc))
+
+- **spec**: Define datastore merge writes
+  ([`19cc3fd`](https://github.com/joshua-jingu-lee/ante/commit/19cc3fd0d32a31db4a97d95f3b1ea72074df25f1))
+
+- **spec**: Define instance path contract
+  ([`63bbadb`](https://github.com/joshua-jingu-lee/ante/commit/63bbadb311e2bdfd85f3f286c92165dd122460bd))
+
+- **spec**: Define rule config storage contract
+  ([`72f1224`](https://github.com/joshua-jingu-lee/ante/commit/72f1224a80e4d0f6269f579d2b460571388035cd))
+
+- **spec**: Document application/problem+json content-type alignment for 4xx/5xx
+  ([#1180](https://github.com/joshua-jingu-lee/ante/pull/1180),
+  [`19002a9`](https://github.com/joshua-jingu-lee/ante/commit/19002a996b8757b8fdba9e4e1b524e0ff017c982))
+
+- **spec**: Mark pykrx flow as phase 2
+  ([`bc531f6`](https://github.com/joshua-jingu-lee/ante/commit/bc531f6799b0f79848a1492f68f52159f00765a3))
+
+- **spec**: Reconcile notification quiet hours status
+  ([`e66105b`](https://github.com/joshua-jingu-lee/ante/commit/e66105b967b48adc6827d8a1c20c1c260067ccf4))
+
+- **spec**: Refine #1213 pending banner — only clear-halt is new
+  ([#1230](https://github.com/joshua-jingu-lee/ante/pull/1230),
+  [`cc20511`](https://github.com/joshua-jingu-lee/ante/commit/cc205112c61b419b6b9b2d9e64099a4c97d3f3a5))
+
+- **spec**: Remove stale open issue docs
+  ([`9eface5`](https://github.com/joshua-jingu-lee/ante/commit/9eface5fe6e4f31132d45e0a0be43f1990742851))
+
+- **spec**: Simplify notification settings contract
+  ([`6be165e`](https://github.com/joshua-jingu-lee/ante/commit/6be165efe6c4d8ecb4bdeb210e0fe98ad361977d))
+
+- **spec**: Split-3 close + stream events marker policy
+  ([#1247](https://github.com/joshua-jingu-lee/ante/pull/1247),
+  [`91b2afb`](https://github.com/joshua-jingu-lee/ante/commit/91b2afb3bd264ec5ef212bde1df29c0e0205a180))
+
+- **spec**: Use /clear_halt for telegram slash command (no hyphen allowed)
+  ([#1230](https://github.com/joshua-jingu-lee/ante/pull/1230),
+  [`cc20511`](https://github.com/joshua-jingu-lee/ante/commit/cc205112c61b419b6b9b2d9e64099a4c97d3f3a5))
+
+- **spec**: Use lowercase wire value for kill switch status enum
+  ([#1230](https://github.com/joshua-jingu-lee/ante/pull/1230),
+  [`cc20511`](https://github.com/joshua-jingu-lee/ante/commit/cc205112c61b419b6b9b2d9e64099a4c97d3f3a5))
+
+- **specs**: Document buy stop/stop_limit no-reserve policy
+  ([#1348](https://github.com/joshua-jingu-lee/ante/pull/1348),
+  [`ce0efab`](https://github.com/joshua-jingu-lee/ante/commit/ce0efab8cc58277b3323d1560ba8f8ef87ccd8ed))
+
+- **specs**: Document market_order_reserve_buffer_rate and quote resolver
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **specs**: Document stop order on_order_update routing policy
+  ([#1349](https://github.com/joshua-jingu-lee/ante/pull/1349),
+  [`58af809`](https://github.com/joshua-jingu-lee/ante/commit/58af809433e1586374dabeaec795cefb2813dae6))
+
+- **test**: Clear qa harness leftovers
+  ([`c29bde8`](https://github.com/joshua-jingu-lee/ante/commit/c29bde8002085ebf6be21505036cd2d7dc2f5e24))
+
+- **web**: Document datasets timeframe 400 contract in OpenAPI
+  ([#1601](https://github.com/joshua-jingu-lee/ante/pull/1601),
+  [`e5482b8`](https://github.com/joshua-jingu-lee/ante/commit/e5482b8f39a472113f08569ab03e5f573ef0adb6))
+
+- **web-api**: #1651 discovery lock known-limitation + follow-up rule (user A decision)
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web-api**: Add 70-route scope decision SSOT (#1409)
+  ([#1425](https://github.com/joshua-jingu-lee/ante/pull/1425),
+  [`3bd69e6`](https://github.com/joshua-jingu-lee/ante/commit/3bd69e6369375b132273a59d89cd51f1a6ef30e7))
+
+- **web-api**: Document POST /api/bots budget failure policy
+  ([#1345](https://github.com/joshua-jingu-lee/ante/pull/1345),
+  [`016a328`](https://github.com/joshua-jingu-lee/ante/commit/016a3285cb2900a83636eaf6397040b841f4bf6a))
+
+### Features
+
+- #1712 bot.start/stop/status IPC handler 등록 (Web API 정렬 + behavior-preserving helper)
+  ([#1716](https://github.com/joshua-jingu-lee/ante/pull/1716),
+  [`8605926`](https://github.com/joshua-jingu-lee/ante/commit/86059263c0dea25cfa32530a6529c3ab3bf20486))
+
+- #1713 ante bot start/stop/status CLI leaf command 등록 (#1698 epic 완료)
+  ([#1717](https://github.com/joshua-jingu-lee/ante/pull/1717),
+  [`386462e`](https://github.com/joshua-jingu-lee/ante/commit/386462ed20f2f1e584251b575fbf879b3a045af5))
+
+- #1820 meta-epic contract SSOT 공통 인프라 (closes #1820/#1821/#1822/#1823/#1824)
+  ([#1838](https://github.com/joshua-jingu-lee/ante/pull/1838),
+  [`c3f08ff`](https://github.com/joshua-jingu-lee/ante/commit/c3f08ff787c98e370d19cc6ff1359120ef866b3e))
+
+- #1822 contract vocabulary SSOT module (ContractKind/EnvelopeForm/AuthMode)
+  ([#1838](https://github.com/joshua-jingu-lee/ante/pull/1838),
+  [`c3f08ff`](https://github.com/joshua-jingu-lee/ante/commit/c3f08ff787c98e370d19cc6ff1359120ef866b3e))
+
+- 70개 Web 라우트 scope 결정 일관 부착 (#1407) ([#1428](https://github.com/joshua-jingu-lee/ante/pull/1428),
+  [`c345244`](https://github.com/joshua-jingu-lee/ante/commit/c345244d32190e013f3024a7fc7a0562b6fecc73))
+
+- **account**: Add account_id scoping helper with runtime/creation policy split
+  ([#1239](https://github.com/joshua-jingu-lee/ante/pull/1239),
+  [`270a17a`](https://github.com/joshua-jingu-lee/ante/commit/270a17a192886233658cf2229d136fc4511c642f))
+
+- **account**: Add market_order_reserve_buffer_rate cold-path field
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **account**: Align edge account resolver fallback policy
+  ([#1249](https://github.com/joshua-jingu-lee/ante/pull/1249),
+  [`c7b6719`](https://github.com/joshua-jingu-lee/ante/commit/c7b67190ba0e4b09d8dd2ccc595bb5888e33cdab))
+
+- **account**: Edge resolver align - cli/strategy account-required
+  ([#1249](https://github.com/joshua-jingu-lee/ante/pull/1249),
+  [`c7b6719`](https://github.com/joshua-jingu-lee/ante/commit/c7b67190ba0e4b09d8dd2ccc595bb5888e33cdab))
+
+- **account**: Edge resolver align - report feedback BotNotFoundError
+  ([#1249](https://github.com/joshua-jingu-lee/ante/pull/1249),
+  [`c7b6719`](https://github.com/joshua-jingu-lee/ante/commit/c7b67190ba0e4b09d8dd2ccc595bb5888e33cdab))
+
+- **account**: Edge resolver align - web/bots single-active resolver
+  ([#1249](https://github.com/joshua-jingu-lee/ante/pull/1249),
+  [`c7b6719`](https://github.com/joshua-jingu-lee/ante/commit/c7b67190ba0e4b09d8dd2ccc595bb5888e33cdab))
+
+- **account**: Edge resolver align - web/strategies cumulative + performance
+  ([#1249](https://github.com/joshua-jingu-lee/ante/pull/1249),
+  [`c7b6719`](https://github.com/joshua-jingu-lee/ante/commit/c7b67190ba0e4b09d8dd2ccc595bb5888e33cdab))
+
+- **account**: Restrict _bootstrap=True to BROKER_PRESETS seed accounts only
+  ([#1239](https://github.com/joshua-jingu-lee/ante/pull/1239),
+  [`270a17a`](https://github.com/joshua-jingu-lee/ante/commit/270a17a192886233658cf2229d136fc4511c642f))
+
+- **account**: Split-1 runtime fallback marker for events/treasury/rule/trade/ipc/web
+  ([#1243](https://github.com/joshua-jingu-lee/ante/pull/1243),
+  [`83dcd3b`](https://github.com/joshua-jingu-lee/ante/commit/83dcd3b206acade00a7abfd8eb285f0036def1af))
+
+- **account**: Split-1 runtime fallback marker for events/treasury/rule/trade/ipc/web (#1240)
+  ([#1243](https://github.com/joshua-jingu-lee/ante/pull/1243),
+  [`83dcd3b`](https://github.com/joshua-jingu-lee/ante/commit/83dcd3b206acade00a7abfd8eb285f0036def1af))
+
+- **account**: Split-2 bot/approval account-scoped require_account_id
+  ([#1246](https://github.com/joshua-jingu-lee/ante/pull/1246),
+  [`45ae880`](https://github.com/joshua-jingu-lee/ante/commit/45ae880d92861fcc85c2801be4dcdec2387a7fa5))
+
+- **account**: Split-2 require_account_id for bot/approval/main.py (#1241)
+  ([#1246](https://github.com/joshua-jingu-lee/ante/pull/1246),
+  [`45ae880`](https://github.com/joshua-jingu-lee/ante/commit/45ae880d92861fcc85c2801be4dcdec2387a7fa5))
+
+- **account**: Split-3 APIGateway/Stream + multi-account lifecycle pool (#1242)
+  ([#1247](https://github.com/joshua-jingu-lee/ante/pull/1247),
+  [`91b2afb`](https://github.com/joshua-jingu-lee/ante/commit/91b2afb3bd264ec5ef212bde1df29c0e0205a180))
+
+- **account**: Split-3 multi-account StreamIntegration pool
+  ([#1247](https://github.com/joshua-jingu-lee/ante/pull/1247),
+  [`91b2afb`](https://github.com/joshua-jingu-lee/ante/commit/91b2afb3bd264ec5ef212bde1df29c0e0205a180))
+
+- **account**: Tighten _bootstrap=True to require (broker_type, default_account_id) pair
+  ([#1239](https://github.com/joshua-jingu-lee/ante/pull/1239),
+  [`270a17a`](https://github.com/joshua-jingu-lee/ante/commit/270a17a192886233658cf2229d136fc4511c642f))
+
+- **account**: Tolerant load + repair-timezone for legacy invalid IANA timezone rows
+  ([#1505](https://github.com/joshua-jingu-lee/ante/pull/1505),
+  [`8092b19`](https://github.com/joshua-jingu-lee/ante/commit/8092b19149df01dae64428f22866be728ff3f07d))
+
+- **account-api**: Expose market_order_reserve_buffer_rate via Web/CLI
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **approval,cli,ipc**: Audit-types + cancel-invalid for legacy invalid approval cleanup (#1472)
+  ([#1520](https://github.com/joshua-jingu-lee/ante/pull/1520),
+  [`acea2c2`](https://github.com/joshua-jingu-lee/ante/commit/acea2c2886585cff8acc6118e1cf11de6b45d5c0))
+
+- **backtest**: Add --exchange override with canonical validation + full propagation (#1585)
+  ([#1588](https://github.com/joshua-jingu-lee/ante/pull/1588),
+  [`7dc6e9b`](https://github.com/joshua-jingu-lee/ante/commit/7dc6e9bce0c1a7fc10d580a86117f372b70e1fa4))
+
+- **backtest**: Add --exchange override with canonical validation + plumbing
+  ([#1588](https://github.com/joshua-jingu-lee/ante/pull/1588),
+  [`7dc6e9b`](https://github.com/joshua-jingu-lee/ante/commit/7dc6e9bce0c1a7fc10d580a86117f372b70e1fa4))
+
+- **backtest**: Plumb --exchange through executor to BacktestTrade labels
+  ([#1588](https://github.com/joshua-jingu-lee/ante/pull/1588),
+  [`7dc6e9b`](https://github.com/joshua-jingu-lee/ante/commit/7dc6e9bce0c1a7fc10d580a86117f372b70e1fa4))
+
+- **backtest**: Serialize trade exchange in BacktestResult.to_dict
+  ([#1588](https://github.com/joshua-jingu-lee/ante/pull/1588),
+  [`7dc6e9b`](https://github.com/joshua-jingu-lee/ante/commit/7dc6e9bce0c1a7fc10d580a86117f372b70e1fa4))
+
+- **bot**: Route StopOrder events through on_order_update
+  ([#1349](https://github.com/joshua-jingu-lee/ante/pull/1349),
+  [`58af809`](https://github.com/joshua-jingu-lee/ante/commit/58af809433e1586374dabeaec795cefb2813dae6))
+
+- **bot,web-api**: Expose runtime controls via nested BotInfo.config
+  ([#1501](https://github.com/joshua-jingu-lee/ante/pull/1501),
+  [`64c7d45`](https://github.com/joshua-jingu-lee/ante/commit/64c7d451fe5bf399f961b739c6f5aff6092dc022))
+
+- **broker**: Make order registry account-aware (#1256)
+  ([#1269](https://github.com/joshua-jingu-lee/ante/pull/1269),
+  [`a7a18ae`](https://github.com/joshua-jingu-lee/ante/commit/a7a18aed708d7fc21e76742a98ea5f37cab1459e))
+
+- **broker**: Split-3 multi-broker ReconcileScheduler pool
+  ([#1247](https://github.com/joshua-jingu-lee/ante/pull/1247),
+  [`91b2afb`](https://github.com/joshua-jingu-lee/ante/commit/91b2afb3bd264ec5ef212bde1df29c0e0205a180))
+
+- **cli**: Add enum preflight to account/approval/report list before DB
+  ([#1503](https://github.com/joshua-jingu-lee/ante/pull/1503),
+  [`9e8d68c`](https://github.com/joshua-jingu-lee/ante/commit/9e8d68cf174e52bff2706b9bfef75f784b8cc392))
+
+- **cli**: Authenticated_group factory default-deny gate (#1404)
+  ([#1422](https://github.com/joshua-jingu-lee/ante/pull/1422),
+  [`c8f698b`](https://github.com/joshua-jingu-lee/ante/commit/c8f698b27deb8a2874050f466b951b26e7fba4a0))
+
+- **cli/init**: Emit [runtime] section in system.toml template
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **config**: Add Config.resolve_path for config_dir-relative path normalization
+  ([#1181](https://github.com/joshua-jingu-lee/ante/pull/1181),
+  [`b5e60d7`](https://github.com/joshua-jingu-lee/ante/commit/b5e60d71e2ae2ffb893d657d759d1af9d0fee536))
+
+- **config**: Add runtime path resolver convenience methods
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **dashboard**: Add 30s polling to kill switch status accounts query
+  ([#1238](https://github.com/joshua-jingu-lee/ante/pull/1238),
+  [`95a4928`](https://github.com/joshua-jingu-lee/ante/commit/95a492814aa77c217aa15cb21bdda4f25af58ec2))
+
+- **dashboard**: Align kill switch frontend to halt/clear-halt SSOT
+  ([#1238](https://github.com/joshua-jingu-lee/ante/pull/1238),
+  [`95a4928`](https://github.com/joshua-jingu-lee/ante/commit/95a492814aa77c217aa15cb21bdda4f25af58ec2))
+
+- **dashboard**: Align system kill switch frontend to halt/clear-halt SSOT
+  ([#1238](https://github.com/joshua-jingu-lee/ante/pull/1238),
+  [`95a4928`](https://github.com/joshua-jingu-lee/ante/commit/95a492814aa77c217aa15cb21bdda4f25af58ec2))
+
+- **db**: Migrate legacy percent win_rate values to ratio (v005)
+  ([#1363](https://github.com/joshua-jingu-lee/ante/pull/1363),
+  [`0dcb64a`](https://github.com/joshua-jingu-lee/ante/commit/0dcb64a386730d74acc1f34bf346ae7416db3c93))
+
+- **eventbus**: Add account_id to StopOrder events
+  ([#1349](https://github.com/joshua-jingu-lee/ante/pull/1349),
+  [`58af809`](https://github.com/joshua-jingu-lee/ante/commit/58af809433e1586374dabeaec795cefb2813dae6))
+
+- **eventbus**: Split-3 account_id strict marker on stream events
+  ([#1247](https://github.com/joshua-jingu-lee/ante/pull/1247),
+  [`91b2afb`](https://github.com/joshua-jingu-lee/ante/commit/91b2afb3bd264ec5ef212bde1df29c0e0205a180))
+
+- **frontend**: Adapt approval generated types
+  ([#1276](https://github.com/joshua-jingu-lee/ante/pull/1276),
+  [`ba3e993`](https://github.com/joshua-jingu-lee/ante/commit/ba3e9933965709e3b6a0db94256ee4f9ef9fbda8))
+
+- **frontend**: Adapt auth member generated types
+  ([#1274](https://github.com/joshua-jingu-lee/ante/pull/1274),
+  [`1cd8277`](https://github.com/joshua-jingu-lee/ante/commit/1cd82777977c65d9d6a2996623f5987da1be8d1e))
+
+- **frontend**: Adapt strategy report data generated types
+  ([#1275](https://github.com/joshua-jingu-lee/ante/pull/1275),
+  [`5f4baa6`](https://github.com/joshua-jingu-lee/ante/commit/5f4baa626909d02e5645c008a75a7ec54a4f5e16))
+
+- **frontend**: Align account bot adapter view contracts (#1223)
+  ([#1252](https://github.com/joshua-jingu-lee/ante/pull/1252),
+  [`6685970`](https://github.com/joshua-jingu-lee/ante/commit/6685970710bdb43bd4cc9acbabcf9a2727b7cae0))
+
+- **frontend**: Align system adapter view contract (#1222)
+  ([#1251](https://github.com/joshua-jingu-lee/ante/pull/1251),
+  [`348afe8`](https://github.com/joshua-jingu-lee/ante/commit/348afe8ced21ca6d6fb906ae2dc6c8936f7460c9))
+
+- **frontend**: Align treasury portfolio adapter views (#1224)
+  ([#1253](https://github.com/joshua-jingu-lee/ante/pull/1253),
+  [`80ec9cd`](https://github.com/joshua-jingu-lee/ante/commit/80ec9cd0042819c0524f7ba5a9ab213788443243))
+
+- **frontend**: Prepare api type boundary strict gate
+  ([#1277](https://github.com/joshua-jingu-lee/ante/pull/1277),
+  [`370b7d9`](https://github.com/joshua-jingu-lee/ante/commit/370b7d9840e4e6f11abe70484be2ccfc7b78252f))
+
+- **frontend,approval**: Extend ApprovalType with backend SSOT 5 entries and add unknown fallback
+  ([#1504](https://github.com/joshua-jingu-lee/ante/pull/1504),
+  [`5b16c96`](https://github.com/joshua-jingu-lee/ante/commit/5b16c96d6132f17451161b096e7a5790936dabf1))
+
+- **gateway**: Split-3 per-bot LiveDataProvider with account_id binding
+  ([#1247](https://github.com/joshua-jingu-lee/ante/pull/1247),
+  [`91b2afb`](https://github.com/joshua-jingu-lee/ante/commit/91b2afb3bd264ec5ef212bde1df29c0e0205a180))
+
+- **gateway**: Split-3 require_account_id on APIGateway and StreamIntegration ctor
+  ([#1247](https://github.com/joshua-jingu-lee/ante/pull/1247),
+  [`91b2afb`](https://github.com/joshua-jingu-lee/ante/commit/91b2afb3bd264ec5ef212bde1df29c0e0205a180))
+
+- **main**: Mark account_service runtime started after boot migration
+  ([#1169](https://github.com/joshua-jingu-lee/ante/pull/1169),
+  [`90dc2b8`](https://github.com/joshua-jingu-lee/ante/commit/90dc2b8fdb4fd5888ee760e0e0bc305ee8e44a4b))
+
+- **main**: Wire APIGateway-backed quote resolver into Treasury
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **member**: Add list-invalid-roles CLI and runbook for legacy cleanup
+  ([#1509](https://github.com/joshua-jingu-lee/ante/pull/1509),
+  [`71ae6cb`](https://github.com/joshua-jingu-lee/ante/commit/71ae6cb1017d46601b304e5efa6019ada4889bc4))
+
+- **member,cli**: Operator cleanup tooling for legacy invalid-role rows
+  ([#1509](https://github.com/joshua-jingu-lee/ante/pull/1509),
+  [`71ae6cb`](https://github.com/joshua-jingu-lee/ante/commit/71ae6cb1017d46601b304e5efa6019ada4889bc4))
+
+- **stop**: Route stop registered/triggered/expired through on_order_update (#1336)
+  ([#1349](https://github.com/joshua-jingu-lee/ante/pull/1349),
+  [`58af809`](https://github.com/joshua-jingu-lee/ante/commit/58af809433e1586374dabeaec795cefb2813dae6))
+
+- **system**: Align kill switch backend to halt/clear-halt SSOT
+  ([#1237](https://github.com/joshua-jingu-lee/ante/pull/1237),
+  [`6304774`](https://github.com/joshua-jingu-lee/ante/commit/6304774ba83a4b74417c690089f962bd58d1982e))
+
+- **trade**: #1946 KIS 체결 반영 경로 — OrderTracker + FillApplier + REST 백스톱 폴
+  ([#1953](https://github.com/joshua-jingu-lee/ante/pull/1953),
+  [`9f548b4`](https://github.com/joshua-jingu-lee/ante/commit/9f548b463cf4f6794fc788270a58cfa084471eb4))
+
+- **trade**: #1946 KIS 체결 반영 경로(fill-recovery) — OrderTracker + FillApplier + REST 백스톱
+  ([#1953](https://github.com/joshua-jingu-lee/ante/pull/1953),
+  [`9f548b4`](https://github.com/joshua-jingu-lee/ante/commit/9f548b463cf4f6794fc788270a58cfa084471eb4))
+
+- **trade**: #1948 전략 get_open_orders(live) OrderTracker sync 백엔드
+  ([#1959](https://github.com/joshua-jingu-lee/ante/pull/1959),
+  [`241e558`](https://github.com/joshua-jingu-lee/ante/commit/241e558b76aead43f103aefca0e2ae7affd25d79))
+
+- **trade**: #1949 체결 이벤트 transactional outbox — durability/at-least-once
+  ([#1958](https://github.com/joshua-jingu-lee/ante/pull/1958),
+  [`ee19d56`](https://github.com/joshua-jingu-lee/ante/commit/ee19d56e6468286f6d6435c409420e5cb917240d))
+
+- **trade**: Enforce account-aware trades schema (#1257)
+  ([#1270](https://github.com/joshua-jingu-lee/ante/pull/1270),
+  [`43bde21`](https://github.com/joshua-jingu-lee/ante/commit/43bde21ecf703289fdfae00917d3809ca7233fb8))
+
+- **trade**: Make positions account-aware (#1259)
+  ([#1272](https://github.com/joshua-jingu-lee/ante/pull/1272),
+  [`71cceb8`](https://github.com/joshua-jingu-lee/ante/commit/71cceb8a02720a4e638bcb000ceeab1a58dd585a))
+
+- **treasury**: Account-scoped quote resolver for market buy reserve (#1333)
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **treasury**: Add quote resolver path for market buy reserve
+  ([#1350](https://github.com/joshua-jingu-lee/ante/pull/1350),
+  [`563df47`](https://github.com/joshua-jingu-lee/ante/commit/563df4742324680ade2126daf6aa4c7b5bb466f5))
+
+- **treasury**: Align account-aware DB schema (#1258)
+  ([#1271](https://github.com/joshua-jingu-lee/ante/pull/1271),
+  [`e1c002c`](https://github.com/joshua-jingu-lee/ante/commit/e1c002c3742d8671233681a3c3e9f228a525e7ca))
+
+- **web**: Add minProperties:1 to mutable update request schema
+  ([#1168](https://github.com/joshua-jingu-lee/ante/pull/1168),
+  [`6c34618`](https://github.com/joshua-jingu-lee/ante/commit/6c346186251a53293cc77e87a067f3af3b684ebb))
+
+- **web**: Install openapi customizer to guarantee ErrorResponse in components
+  ([#1180](https://github.com/joshua-jingu-lee/ante/pull/1180),
+  [`19002a9`](https://github.com/joshua-jingu-lee/ante/commit/19002a996b8757b8fdba9e4e1b524e0ff017c982))
+
+- **web**: RequireAuthMiddleware default-deny gate + 197 fixture migration (#1403)
+  ([#1421](https://github.com/joshua-jingu-lee/ante/pull/1421),
+  [`e3c782f`](https://github.com/joshua-jingu-lee/ante/commit/e3c782ff6018044ee8f6d5aa79ea469a5c2a23f6))
+
+- **web-api**: #1651 비-extra_forbidden loc default-deny discovery lock (옵션3 하이브리드, 사용자 A)
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+### Refactoring
+
+- #1724 validate_new_account_id에 context 파라미터 추가 (require_account_id 동형 정렬)
+  ([#1734](https://github.com/joshua-jingu-lee/ante/pull/1734),
+  [`320bc2a`](https://github.com/joshua-jingu-lee/ante/commit/320bc2a92110e0528dd3850d4830efa6b4416ab1))
+
+- #1823 contract drift test helper skeleton (Click leaf / IPC registry / exception / fmt.error
+  iterators) ([#1838](https://github.com/joshua-jingu-lee/ante/pull/1838),
+  [`c3f08ff`](https://github.com/joshua-jingu-lee/ante/commit/c3f08ff787c98e370d19cc6ff1359120ef866b3e))
+
+- #1840 ErrorSpec mapper + CLI/IPC error helper (helper-only, no callsite migration)
+  ([#1861](https://github.com/joshua-jingu-lee/ante/pull/1861),
+  [`a541176`](https://github.com/joshua-jingu-lee/ante/commit/a541176fecf46c5e83c6bad9de6df9d93a17bb5e))
+
+- #1842 account error contract registry mirror + CLI direct ↔ IPC equivalence lock
+  ([#1863](https://github.com/joshua-jingu-lee/ante/pull/1863),
+  [`31a1413`](https://github.com/joshua-jingu-lee/ante/commit/31a14137062f8bc578ae21a4c8bd1698bdd36371))
+
+- #1842 align account CLI 9 callsites via emit_cli_error
+  ([#1863](https://github.com/joshua-jingu-lee/ante/pull/1863),
+  [`31a1413`](https://github.com/joshua-jingu-lee/ante/commit/31a14137062f8bc578ae21a4c8bd1698bdd36371))
+
+- #1842 register account 12 sub-class to ErrorSpec registry (mirror .code)
+  ([#1863](https://github.com/joshua-jingu-lee/ante/pull/1863),
+  [`31a1413`](https://github.com/joshua-jingu-lee/ante/commit/31a14137062f8bc578ae21a4c8bd1698bdd36371))
+
+- #1843 sub-PR 1 register member 5 sub-class + align CLI member callsites
+  ([#1865](https://github.com/joshua-jingu-lee/ante/pull/1865),
+  [`419ddf5`](https://github.com/joshua-jingu-lee/ante/commit/419ddf5a922518263287a74cb936eab5705b5f3f))
+
+- #1843 sub-PR 2 align approval CLI 9 callsites via emit_cli_error
+  ([#1866](https://github.com/joshua-jingu-lee/ante/pull/1866),
+  [`a19d873`](https://github.com/joshua-jingu-lee/ante/commit/a19d873cc9450df9befb0cc914afb76510980c86))
+
+- #1843 sub-PR 2 register approval 2 sub-class to ErrorSpec registry (mirror .code)
+  ([#1866](https://github.com/joshua-jingu-lee/ante/pull/1866),
+  [`a19d873`](https://github.com/joshua-jingu-lee/ante/commit/a19d873cc9450df9befb0cc914afb76510980c86))
+
+- #1843 sub-PR 3 register bot 5 sub-class + align CLI bot callsites
+  ([#1867](https://github.com/joshua-jingu-lee/ante/pull/1867),
+  [`3b5f2b5`](https://github.com/joshua-jingu-lee/ante/commit/3b5f2b5f0cf64a03916a0875bafd971cceb57929))
+
+- #1843-1 member error contract registry mirror + CLI direct ↔ IPC equivalence lock
+  ([#1865](https://github.com/joshua-jingu-lee/ante/pull/1865),
+  [`419ddf5`](https://github.com/joshua-jingu-lee/ante/commit/419ddf5a922518263287a74cb936eab5705b5f3f))
+
+- #1843-2 approval error contract registry mirror + CLI direct ↔ IPC equivalence lock
+  ([#1866](https://github.com/joshua-jingu-lee/ante/pull/1866),
+  [`a19d873`](https://github.com/joshua-jingu-lee/ante/commit/a19d873cc9450df9befb0cc914afb76510980c86))
+
+- #1843-3 bot error contract registry mirror + CLI direct ↔ IPC equivalence lock
+  ([#1867](https://github.com/joshua-jingu-lee/ante/pull/1867),
+  [`3b5f2b5`](https://github.com/joshua-jingu-lee/ante/commit/3b5f2b5f0cf64a03916a0875bafd971cceb57929))
+
+- #1843-4 CLI treasury callsite emit_cli_error 정렬 (Step 2)
+  ([#1868](https://github.com/joshua-jingu-lee/ante/pull/1868),
+  [`4f23925`](https://github.com/joshua-jingu-lee/ante/commit/4f2392529cd8f6380ff6e641c86037e6af4bc46b))
+
+- #1843-4 register treasury 7 sub-class in error registry (Step 1)
+  ([#1868](https://github.com/joshua-jingu-lee/ante/pull/1868),
+  [`4f23925`](https://github.com/joshua-jingu-lee/ante/commit/4f2392529cd8f6380ff6e641c86037e6af4bc46b))
+
+- #1843-4 treasury error contract registry mirror + CLI direct ↔ IPC equivalence lock
+  ([#1868](https://github.com/joshua-jingu-lee/ante/pull/1868),
+  [`4f23925`](https://github.com/joshua-jingu-lee/ante/commit/4f2392529cd8f6380ff6e641c86037e6af4bc46b))
+
+- #1843-5 broker error contract registry + origin msg_cd log-only separation
+  ([#1869](https://github.com/joshua-jingu-lee/ante/pull/1869),
+  [`18b1e94`](https://github.com/joshua-jingu-lee/ante/commit/18b1e9430a7c7c4dd8569512caad51e59a0c6ac1))
+
+- #1843-5 broker exceptions .code + registry mirror + CLI helper alignment
+  ([#1869](https://github.com/joshua-jingu-lee/ante/pull/1869),
+  [`18b1e94`](https://github.com/joshua-jingu-lee/ante/commit/18b1e9430a7c7c4dd8569512caad51e59a0c6ac1))
+
+- #1843-6 drift allowlist Final lock — strategy/update + base-only
+  ([#1871](https://github.com/joshua-jingu-lee/ante/pull/1871),
+  [`4a194a3`](https://github.com/joshua-jingu-lee/ante/commit/4a194a33e9038b106be544fc6d5f47df7ef601ea))
+
+- #1843-6 strategy/config/rule typed code + ErrorSpec registry
+  ([#1871](https://github.com/joshua-jingu-lee/ante/pull/1871),
+  [`4a194a3`](https://github.com/joshua-jingu-lee/ante/commit/4a194a33e9038b106be544fc6d5f47df7ef601ea))
+
+- #1843-6 strategy/config/rule/update sweep + final allowlist clear (closes #1843)
+  ([#1871](https://github.com/joshua-jingu-lee/ante/pull/1871),
+  [`4a194a3`](https://github.com/joshua-jingu-lee/ante/commit/4a194a33e9038b106be544fc6d5f47df7ef601ea))
+
+- #1843-6 strategy/update CLI fmt.error code 정렬
+  ([#1871](https://github.com/joshua-jingu-lee/ante/pull/1871),
+  [`4a194a3`](https://github.com/joshua-jingu-lee/ante/commit/4a194a33e9038b106be544fc6d5f47df7ef601ea))
+
+- #1844 CLI command contract registry shell + leaf coverage skeleton
+  ([#1872](https://github.com/joshua-jingu-lee/ante/pull/1872),
+  [`cebd617`](https://github.com/joshua-jingu-lee/ante/commit/cebd617d8080903db6d91b2ba73e5b93d3caa534))
+
+- #1846 account domain OutputContract migration (9 leaf entries + drift lock + baseline test 종료)
+  ([#1874](https://github.com/joshua-jingu-lee/ante/pull/1874),
+  [`e334589`](https://github.com/joshua-jingu-lee/ante/commit/e334589c466126acec77b8180f43e6a03ad12136))
+
+- #1846 register account 9 OutputContract entries and ease baseline tests
+  ([#1874](https://github.com/joshua-jingu-lee/ante/pull/1874),
+  [`e334589`](https://github.com/joshua-jingu-lee/ante/commit/e334589c466126acec77b8180f43e6a03ad12136))
+
+- #1847 sub-PR 4 treasury OutputContract registry (9 leaf)
+  ([#1878](https://github.com/joshua-jingu-lee/ante/pull/1878),
+  [`eaa340f`](https://github.com/joshua-jingu-lee/ante/commit/eaa340f3a7f314799efdc119ce7ea19b04285820))
+
+- #1847 sub-PR 5 strategy OutputContract registry (7 leaf)
+  ([#1879](https://github.com/joshua-jingu-lee/ante/pull/1879),
+  [`fa9ccbb`](https://github.com/joshua-jingu-lee/ante/commit/fa9ccbb0b718da19984555b102e0362b595de9f3))
+
+- #1847 sub-PR 7 — broker + system OutputContract migration (9 leaf)
+  ([#1881](https://github.com/joshua-jingu-lee/ante/pull/1881),
+  [`45d5163`](https://github.com/joshua-jingu-lee/ante/commit/45d51639612b21e5ba88534ff7f8f779bc7d977c))
+
+- #1847 sub-PR 8 — instrument + config + rule OutputContract migration (10 leaf)
+  ([#1882](https://github.com/joshua-jingu-lee/ante/pull/1882),
+  [`ba222c5`](https://github.com/joshua-jingu-lee/ante/commit/ba222c574dbb3f1d7e8434d08f47d22a0ae29d22))
+
+- #1847 sub-PR 9 (final) — trade+backtest+audit+signal + leaf coverage final lock (6 leaf)
+  ([#1883](https://github.com/joshua-jingu-lee/ante/pull/1883),
+  [`1e8f4e9`](https://github.com/joshua-jingu-lee/ante/commit/1e8f4e9ea44c5543c0f7785f0950f743dfe0d594))
+
+- #1847-1 member domain OutputContract migration (12 leaf entries)
+  ([#1875](https://github.com/joshua-jingu-lee/ante/pull/1875),
+  [`d728fc1`](https://github.com/joshua-jingu-lee/ante/commit/d728fc1d0f25c55a33f7e92b887433be1940108e))
+
+- #1847-2 bot domain OutputContract migration (11 leaf entries)
+  ([#1876](https://github.com/joshua-jingu-lee/ante/pull/1876),
+  [`3debab9`](https://github.com/joshua-jingu-lee/ante/commit/3debab9189278d47f3db86022f94381a5922af0a))
+
+- #1847-2 register bot domain 11 leaf contracts in CLI registry
+  ([#1876](https://github.com/joshua-jingu-lee/ante/pull/1876),
+  [`3debab9`](https://github.com/joshua-jingu-lee/ante/commit/3debab9189278d47f3db86022f94381a5922af0a))
+
+- #1847-3 approval domain OutputContract migration (10 leaf entries)
+  ([#1877](https://github.com/joshua-jingu-lee/ante/pull/1877),
+  [`caeb3fe`](https://github.com/joshua-jingu-lee/ante/commit/caeb3fec741087786bfa0be483f0e72423fe7dc3))
+
+- #1847-4 treasury domain OutputContract migration (9 leaf entries)
+  ([#1878](https://github.com/joshua-jingu-lee/ante/pull/1878),
+  [`eaa340f`](https://github.com/joshua-jingu-lee/ante/commit/eaa340f3a7f314799efdc119ce7ea19b04285820))
+
+- #1847-5 strategy domain OutputContract migration (7 leaf entries)
+  ([#1879](https://github.com/joshua-jingu-lee/ante/pull/1879),
+  [`fa9ccbb`](https://github.com/joshua-jingu-lee/ante/commit/fa9ccbb0b718da19984555b102e0362b595de9f3))
+
+- #1847-6 data + report domain OutputContract migration (11 leaf entries)
+  ([#1880](https://github.com/joshua-jingu-lee/ante/pull/1880),
+  [`0172374`](https://github.com/joshua-jingu-lee/ante/commit/017237446ffdb546bba8725481d06f0a5052c244))
+
+- #1849 CommandSpec metadata 7 필드 확장 + 27 commands 필수값 채우기
+  ([#1884](https://github.com/joshua-jingu-lee/ante/pull/1884),
+  [`2928536`](https://github.com/joshua-jingu-lee/ante/commit/292853678b3c1b5be6634e7dcfacd9045a4b473d))
+
+- #1849 IPC CommandSpec metadata 필드 확장 + 27 commands 필수값 채우기
+  ([#1884](https://github.com/joshua-jingu-lee/ante/pull/1884),
+  [`2928536`](https://github.com/joshua-jingu-lee/ante/commit/292853678b3c1b5be6634e7dcfacd9045a4b473d))
+
+- #1850 IPC dispatch wrapper required_services + account_id_policy preflight
+  ([#1885](https://github.com/joshua-jingu-lee/ante/pull/1885),
+  [`860125d`](https://github.com/joshua-jingu-lee/ante/commit/860125db8232b49ffb959ea1f24fa161bd19f37a))
+
+- #1851 IPC dispatch wrapper audit_action auto-fire + _audit_detail reserved strip
+  ([#1886](https://github.com/joshua-jingu-lee/ante/pull/1886),
+  [`2b6f42c`](https://github.com/joshua-jingu-lee/ante/commit/2b6f42c6e882fa9858b4391a0f97bb96fbc22c0c))
+
+- #1852 account IPC handler wrapper migration
+  ([#1888](https://github.com/joshua-jingu-lee/ante/pull/1888),
+  [`2a638eb`](https://github.com/joshua-jingu-lee/ante/commit/2a638ebbbcce8bff7729f75ea91081f121b5973f))
+
+- #1853 IPC metadata drift + remaining handler migration (closes #1819)
+  ([#1890](https://github.com/joshua-jingu-lee/ante/pull/1890),
+  [`4fc6a0b`](https://github.com/joshua-jingu-lee/ante/commit/4fc6a0b475ea8a3a0a99458005ed165eeb673a45))
+
+- #1853 rule.update audit handler migration to dispatch wrapper
+  ([#1890](https://github.com/joshua-jingu-lee/ante/pull/1890),
+  [`4fc6a0b`](https://github.com/joshua-jingu-lee/ante/commit/4fc6a0b475ea8a3a0a99458005ed165eeb673a45))
+
+- #1855 CLI DB lifecycle async context manager (open_cli_db)
+  ([#1889](https://github.com/joshua-jingu-lee/ante/pull/1889),
+  [`a183051`](https://github.com/joshua-jingu-lee/ante/commit/a18305198468d007827b4b5956462c5a092d15b6))
+
+- #1856 account/member/approval CLI factory migration (open_cli_db 활용)
+  ([#1891](https://github.com/joshua-jingu-lee/ante/pull/1891),
+  [`1894a23`](https://github.com/joshua-jingu-lee/ante/commit/1894a23db65d62cfb05b7f3f7b5ee38334a592b2))
+
+- #1857 remaining offline/cold-path CLI domain factory migration (broker/signal 제외)
+  ([#1892](https://github.com/joshua-jingu-lee/ante/pull/1892),
+  [`7c1337c`](https://github.com/joshua-jingu-lee/ante/commit/7c1337c4bcc9210c4bd0ced590c4ef3d28945948))
+
+- #1870 bot/config text-mode prefix UX — allowlist intended_no_code 영구 이동
+  ([#1895](https://github.com/joshua-jingu-lee/ante/pull/1895),
+  [`3a0ce2c`](https://github.com/joshua-jingu-lee/ante/commit/3a0ce2c188d9b823a274c2c1044e7ee453d18de1))
+
+- Align approval bot create executor contract
+  ([#1285](https://github.com/joshua-jingu-lee/ante/pull/1285),
+  [`f1be173`](https://github.com/joshua-jingu-lee/ante/commit/f1be17337de35dfe4201410c3a8fdf877d94b104))
+
+- Align bot create auto approve with virtual accounts
+  ([#1284](https://github.com/joshua-jingu-lee/ante/pull/1284),
+  [`c98e6c3`](https://github.com/joshua-jingu-lee/ante/commit/c98e6c3f9399dea7d4b3c5873a33fb53c1b01493))
+
+- Align frontend bot trading mode ([#1287](https://github.com/joshua-jingu-lee/ante/pull/1287),
+  [`dcf7ccb`](https://github.com/joshua-jingu-lee/ante/commit/dcf7ccb393bfbf36da603ecc88449c07a788bf70))
+
+- Dependency scope-only 단순화 — middleware 책임 분리 (#1408)
+  ([#1430](https://github.com/joshua-jingu-lee/ante/pull/1430),
+  [`5535d9f`](https://github.com/joshua-jingu-lee/ante/commit/5535d9f2480e2b4a21eb0fbe924e5aac2b1ae758))
+
+- Nest cli success json data ([#1291](https://github.com/joshua-jingu-lee/ante/pull/1291),
+  [`7b259e7`](https://github.com/joshua-jingu-lee/ante/commit/7b259e725b1663bfdd5069b53a7c0a64a8cf2bc4))
+
+- Remove dashboard and web api core surface
+  ([#1718](https://github.com/joshua-jingu-lee/ante/pull/1718),
+  [`267434f`](https://github.com/joshua-jingu-lee/ante/commit/267434fe57b45d2084be1675d17b065ec098e4c6))
+
+- Rename virtual bot provider internals
+  ([#1286](https://github.com/joshua-jingu-lee/ante/pull/1286),
+  [`17d3f20`](https://github.com/joshua-jingu-lee/ante/commit/17d3f20e9faf07e13c1809d30c006f5740d26303))
+
+- Require_scope dependency factory 일반화 (#1406)
+  ([#1427](https://github.com/joshua-jingu-lee/ante/pull/1427),
+  [`c329a4a`](https://github.com/joshua-jingu-lee/ante/commit/c329a4a170b94e29b994900a57c19956d08ad476))
+
+- **#1847-1**: Register member 12 OutputContract entries
+  ([#1875](https://github.com/joshua-jingu-lee/ante/pull/1875),
+  [`d728fc1`](https://github.com/joshua-jingu-lee/ante/commit/d728fc1d0f25c55a33f7e92b887433be1940108e))
+
+- **account**: Add AccountStructuralChangeRequiresStoppedServerError with stable code
+  ([#1169](https://github.com/joshua-jingu-lee/ante/pull/1169),
+  [`90dc2b8`](https://github.com/joshua-jingu-lee/ante/commit/90dc2b8fdb4fd5888ee760e0e0bc305ee8e44a4b))
+
+- **account**: Add runtime guard to AccountService create/update/delete
+  ([#1169](https://github.com/joshua-jingu-lee/ante/pull/1169),
+  [`90dc2b8`](https://github.com/joshua-jingu-lee/ante/commit/90dc2b8fdb4fd5888ee760e0e0bc305ee8e44a4b))
+
+- **account**: Add service-layer runtime guard for structural mutations (#1144)
+  ([#1169](https://github.com/joshua-jingu-lee/ante/pull/1169),
+  [`90dc2b8`](https://github.com/joshua-jingu-lee/ante/commit/90dc2b8fdb4fd5888ee760e0e0bc305ee8e44a4b))
+
+- **account**: Encapsulate bootstrap seed creation as private helper
+  ([#1239](https://github.com/joshua-jingu-lee/ante/pull/1239),
+  [`270a17a`](https://github.com/joshua-jingu-lee/ante/commit/270a17a192886233658cf2229d136fc4511c642f))
+
+- **bot**: #1924 2차 — src/ante/bot/ invariant 중심 주석 정리
+  ([#1940](https://github.com/joshua-jingu-lee/ante/pull/1940),
+  [`1d628ed`](https://github.com/joshua-jingu-lee/ante/commit/1d628edab10bb99070783d1fb8df36b60a47b64a))
+
+- **cli**: #1924 middleware.py invariant 중심 주석 정리
+  ([#1939](https://github.com/joshua-jingu-lee/ante/pull/1939),
+  [`391f552`](https://github.com/joshua-jingu-lee/ante/commit/391f55287deb6fab046e22edaf1f6a1b9c5d7c39))
+
+- **cli**: #1941 commands/ invariant 중심 주석 정리 (#1924 시리즈 3차)
+  ([#1942](https://github.com/joshua-jingu-lee/ante/pull/1942),
+  [`b8cea12`](https://github.com/joshua-jingu-lee/ante/commit/b8cea12b2d6ae9bab607fa6d613b405418547493))
+
+- **cli**: Align JSON error envelope with SSOT (status/code/message)
+  ([#1226](https://github.com/joshua-jingu-lee/ante/pull/1226),
+  [`b73f9dd`](https://github.com/joshua-jingu-lee/ante/commit/b73f9dd501f018ac75ea58f7bac091cba6a0592d))
+
+- **cli**: Enforce --yes gate before no-update early return
+  ([#1207](https://github.com/joshua-jingu-lee/ante/pull/1207),
+  [`c1b0227`](https://github.com/joshua-jingu-lee/ante/commit/c1b0227ab71b67b2dab82c5f88e813a2c8f61004))
+
+- **cli**: Make account create/set-credentials/delete non-interactive
+  ([#1206](https://github.com/joshua-jingu-lee/ante/pull/1206),
+  [`20034a4`](https://github.com/joshua-jingu-lee/ante/commit/20034a4ec77873c0b2d7a4bfd99e4917dc4f562f))
+
+- **cli**: Make bot create/remove non-interactive (#1175)
+  ([#1204](https://github.com/joshua-jingu-lee/ante/pull/1204),
+  [`cc6565c`](https://github.com/joshua-jingu-lee/ante/commit/cc6565cd2efbaf5a86c79fc0f2b0da28f5cc8e08))
+
+- **cli**: Make member revoke/reset-password/regenerate-recovery-key non-interactive
+  ([#1208](https://github.com/joshua-jingu-lee/ante/pull/1208),
+  [`e875a73`](https://github.com/joshua-jingu-lee/ante/commit/e875a73978930e95ac96aaae4bf3479be4a1a580))
+
+- **cli**: Make update non-interactive ([#1207](https://github.com/joshua-jingu-lee/ante/pull/1207),
+  [`c1b0227`](https://github.com/joshua-jingu-lee/ante/commit/c1b0227ab71b67b2dab82c5f88e813a2c8f61004))
+
+- **cli**: Move update --yes gate before PyPI lookup
+  ([#1207](https://github.com/joshua-jingu-lee/ante/pull/1207),
+  [`c1b0227`](https://github.com/joshua-jingu-lee/ante/commit/c1b0227ab71b67b2dab82c5f88e813a2c8f61004))
+
+- **cli**: Reject empty direct credential value and store decimal broker_config as float
+  ([#1206](https://github.com/joshua-jingu-lee/ante/pull/1206),
+  [`20034a4`](https://github.com/joshua-jingu-lee/ante/commit/20034a4ec77873c0b2d7a4bfd99e4917dc4f562f))
+
+- **cli/ipc**: Resolve IPC socket via runtime resolver
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **contracts**: #1847 sub-PR 6 register data + report OutputContract entries
+  ([#1880](https://github.com/joshua-jingu-lee/ante/pull/1880),
+  [`0172374`](https://github.com/joshua-jingu-lee/ante/commit/017237446ffdb546bba8725481d06f0a5052c244))
+
+- **core**: Introduce ante.core.market_data_vocab SSOT + behavior-preserving consumer delegation
+  (#1613) ([#1616](https://github.com/joshua-jingu-lee/ante/pull/1616),
+  [`1e4ada8`](https://github.com/joshua-jingu-lee/ante/commit/1e4ada8b99e32ed7970fcedbc883aa2b99d1ff2f))
+
+- **core**: Introduce exchange vocabulary SSOT, delegate validator/store (#1576)
+  ([#1581](https://github.com/joshua-jingu-lee/ante/pull/1581),
+  [`2b9352d`](https://github.com/joshua-jingu-lee/ante/commit/2b9352d2cdfb8a8b98cc277f2cc3b9b6202dfc23))
+
+- **ipc**: Split IPCServer.stop into stop_accepting + drain_connections + unlink_socket
+  ([#1183](https://github.com/joshua-jingu-lee/ante/pull/1183),
+  [`7d8d9a5`](https://github.com/joshua-jingu-lee/ante/commit/7d8d9a53494f6fcd82d7baed8a77235f5d472aab))
+
+- **ipc**: Use exception.code attribute for stable error codes
+  ([#1169](https://github.com/joshua-jingu-lee/ante/pull/1169),
+  [`90dc2b8`](https://github.com/joshua-jingu-lee/ante/commit/90dc2b8fdb4fd5888ee760e0e0bc305ee8e44a4b))
+
+- **main,cli/system**: Migrate PID file and IPC socket to runtime resolver with legacy read fallback
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **reports**: Scope down to input validation; defer ratio unification to follow-up
+  ([#1363](https://github.com/joshua-jingu-lee/ante/pull/1363),
+  [`0dcb64a`](https://github.com/joshua-jingu-lee/ante/commit/0dcb64a386730d74acc1f34bf346ae7416db3c93))
+
+- **strategy,cli**: Lazy-load IndicatorCalculator via PEP 562 __getattr__
+  ([#1502](https://github.com/joshua-jingu-lee/ante/pull/1502),
+  [`29c241f`](https://github.com/joshua-jingu-lee/ante/commit/29c241f23043f7189ae98d59d6df7ecb349d1483))
+
+- **web**: Align explicit 4xx/5xx responses to application/problem+json
+  ([#1180](https://github.com/joshua-jingu-lee/ante/pull/1180),
+  [`19002a9`](https://github.com/joshua-jingu-lee/ante/commit/19002a996b8757b8fdba9e4e1b524e0ff017c982))
+
+- **web**: Catch AccountStructuralChangeRequiresStoppedServerError as 409
+  ([#1169](https://github.com/joshua-jingu-lee/ante/pull/1169),
+  [`90dc2b8`](https://github.com/joshua-jingu-lee/ante/commit/90dc2b8fdb4fd5888ee760e0e0bc305ee8e44a4b))
+
+### Testing
+
+- #1722 R3 cleanup spy를 AsyncMock + await_count로 교체
+  ([#1732](https://github.com/joshua-jingu-lee/ante/pull/1732),
+  [`c56a7db`](https://github.com/joshua-jingu-lee/ante/commit/c56a7db3bc6929aa70ec65ea60bdb5842dc883d4))
+
+- #1759 R3/R4 subprocess CLI coverage 추가 (Codex blocking)
+  ([#1770](https://github.com/joshua-jingu-lee/ante/pull/1770),
+  [`7aa83b4`](https://github.com/joshua-jingu-lee/ante/commit/7aa83b40fb855e83a022083112cb57b8682574d8))
+
+- #1841 error taxonomy drift guard + fmt.error code missing allowlist (3 families)
+  ([#1862](https://github.com/joshua-jingu-lee/ante/pull/1862),
+  [`862e37c`](https://github.com/joshua-jingu-lee/ante/commit/862e37cf63e62077fb42a8c2e44550eee7ff87a8))
+
+- #1842 account CLI direct ↔ IPC error code equivalence lock (17 tests)
+  ([#1863](https://github.com/joshua-jingu-lee/ante/pull/1863),
+  [`31a1413`](https://github.com/joshua-jingu-lee/ante/commit/31a14137062f8bc578ae21a4c8bd1698bdd36371))
+
+- #1843 sub-PR 1 member CLI direct ↔ IPC error code equivalence lock (14 tests)
+  ([#1865](https://github.com/joshua-jingu-lee/ante/pull/1865),
+  [`419ddf5`](https://github.com/joshua-jingu-lee/ante/commit/419ddf5a922518263287a74cb936eab5705b5f3f))
+
+- #1843 sub-PR 2 approval CLI direct ↔ IPC error code equivalence lock (7 tests)
+  ([#1866](https://github.com/joshua-jingu-lee/ante/pull/1866),
+  [`a19d873`](https://github.com/joshua-jingu-lee/ante/commit/a19d873cc9450df9befb0cc914afb76510980c86))
+
+- #1843 sub-PR 3 bot CLI direct ↔ IPC envelope error code equivalence lock
+  ([#1867](https://github.com/joshua-jingu-lee/ante/pull/1867),
+  [`3b5f2b5`](https://github.com/joshua-jingu-lee/ante/commit/3b5f2b5f0cf64a03916a0875bafd971cceb57929))
+
+- #1843-4 treasury allowlist 정리 + CLI↔IPC equivalence lock (Steps 3-4)
+  ([#1868](https://github.com/joshua-jingu-lee/ante/pull/1868),
+  [`4f23925`](https://github.com/joshua-jingu-lee/ante/commit/4f2392529cd8f6380ff6e641c86037e6af4bc46b))
+
+- #1843-5 broker CLI ↔ IPC error equivalence + origin msg_cd separation
+  ([#1869](https://github.com/joshua-jingu-lee/ante/pull/1869),
+  [`18b1e94`](https://github.com/joshua-jingu-lee/ante/commit/18b1e9430a7c7c4dd8569512caad51e59a0c6ac1))
+
+- #1843-6 strategy/config/rule CLI ↔ IPC error code equivalence lock
+  ([#1871](https://github.com/joshua-jingu-lee/ante/pull/1871),
+  [`4a194a3`](https://github.com/joshua-jingu-lee/ante/commit/4a194a33e9038b106be544fc6d5f47df7ef601ea))
+
+- #1845 CLI registry auth-scope-master drift tests (4 family deferred lock)
+  ([#1873](https://github.com/joshua-jingu-lee/ante/pull/1873),
+  [`f47007b`](https://github.com/joshua-jingu-lee/ante/commit/f47007baca811e39b17303682201f26f3231de39))
+
+- #1846 account success output ↔ registry OutputContract drift lock
+  ([#1874](https://github.com/joshua-jingu-lee/ante/pull/1874),
+  [`e334589`](https://github.com/joshua-jingu-lee/ante/commit/e334589c466126acec77b8180f43e6a03ad12136))
+
+- #1847 sub-PR 4 treasury success output drift lock (12 scenarios)
+  ([#1878](https://github.com/joshua-jingu-lee/ante/pull/1878),
+  [`eaa340f`](https://github.com/joshua-jingu-lee/ante/commit/eaa340f3a7f314799efdc119ce7ea19b04285820))
+
+- #1847 sub-PR 5 strategy success output drift lock (10 scenarios)
+  ([#1879](https://github.com/joshua-jingu-lee/ante/pull/1879),
+  [`fa9ccbb`](https://github.com/joshua-jingu-lee/ante/commit/fa9ccbb0b718da19984555b102e0362b595de9f3))
+
+- #1847-2 bot CLI success output ↔ registry OutputContract drift lock
+  ([#1876](https://github.com/joshua-jingu-lee/ante/pull/1876),
+  [`3debab9`](https://github.com/joshua-jingu-lee/ante/commit/3debab9189278d47f3db86022f94381a5922af0a))
+
+- #1848 CLI registry ↔ docs drift + guide/cli.md regen idempotent (closes #1815)
+  ([#1894](https://github.com/joshua-jingu-lee/ante/pull/1894),
+  [`a8bb234`](https://github.com/joshua-jingu-lee/ante/commit/a8bb23457663e9a75ded0ffce05baa95c0987689))
+
+- #1848 docs/specs/cli/03-commands.md command table parser helper
+  ([#1894](https://github.com/joshua-jingu-lee/ante/pull/1894),
+  [`a8bb234`](https://github.com/joshua-jingu-lee/ante/commit/a8bb23457663e9a75ded0ffce05baa95c0987689))
+
+- #1848 Family A — CLI registry ↔ docs command table drift tests + baseline
+  ([#1894](https://github.com/joshua-jingu-lee/ante/pull/1894),
+  [`a8bb234`](https://github.com/joshua-jingu-lee/ante/commit/a8bb23457663e9a75ded0ffce05baa95c0987689))
+
+- #1848 Family B — guide/cli.md regen idempotent + determinism tests
+  ([#1894](https://github.com/joshua-jingu-lee/ante/pull/1894),
+  [`a8bb234`](https://github.com/joshua-jingu-lee/ante/commit/a8bb23457663e9a75ded0ffce05baa95c0987689))
+
+- #1850 fixture 보강 — required_services preflight 통과를 위한 mock 주입
+  ([#1885](https://github.com/joshua-jingu-lee/ante/pull/1885),
+  [`860125d`](https://github.com/joshua-jingu-lee/ante/commit/860125db8232b49ffb959ea1f24fa161bd19f37a))
+
+- #1853 IPC docs taxonomy + CLI runtime_ipc cross-ref drift guards
+  ([#1890](https://github.com/joshua-jingu-lee/ante/pull/1890),
+  [`4fc6a0b`](https://github.com/joshua-jingu-lee/ante/commit/4fc6a0b475ea8a3a0a99458005ed165eeb673a45))
+
+- #1858 offline factory drift checks + CLI execution class 연동 검증 (closes #1818)
+  ([#1893](https://github.com/joshua-jingu-lee/ante/pull/1893),
+  [`24a24d2`](https://github.com/joshua-jingu-lee/ante/commit/24a24d29c01b3e6623e912973d738c118538b882))
+
+- Cover explicit --config-dir PID resolution across CLI guards
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- Cover runtime resolver cwd-independence across system/IPC/cold-path
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- Guard local import path ([#1289](https://github.com/joshua-jingu-lee/ante/pull/1289),
+  [`0654e38`](https://github.com/joshua-jingu-lee/ante/commit/0654e3851841a0aada3ca5e90c81b653985644ee))
+
+- Lock cross-resolver db.path integration regression for #1158
+  ([#1181](https://github.com/joshua-jingu-lee/ante/pull/1181),
+  [`b5e60d7`](https://github.com/joshua-jingu-lee/ante/commit/b5e60d71e2ae2ffb893d657d759d1af9d0fee536))
+
+- 라우트 인증 정적 검증 + PUBLIC_PATHS 회귀 테스트 (#1405)
+  ([#1426](https://github.com/joshua-jingu-lee/ante/pull/1426),
+  [`a597583`](https://github.com/joshua-jingu-lee/ante/commit/a59758308926ffa27d6f6d918e0e8929f34a938b))
+
+- **#1841**: Add auth middleware code policy regression lock (Family C)
+  ([#1862](https://github.com/joshua-jingu-lee/ante/pull/1862),
+  [`862e37c`](https://github.com/joshua-jingu-lee/ante/commit/862e37cf63e62077fb42a8c2e44550eee7ff87a8))
+
+- **#1841**: Add error taxonomy drift allowlist baseline YAML
+  ([#1862](https://github.com/joshua-jingu-lee/ante/pull/1862),
+  [`862e37c`](https://github.com/joshua-jingu-lee/ante/commit/862e37cf63e62077fb42a8c2e44550eee7ff87a8))
+
+- **#1841**: Add error taxonomy drift guard (Family A + B + staleness)
+  ([#1862](https://github.com/joshua-jingu-lee/ante/pull/1862),
+  [`862e37c`](https://github.com/joshua-jingu-lee/ante/commit/862e37cf63e62077fb42a8c2e44550eee7ff87a8))
+
+- **#1841**: Add load_drift_allowlist() helper + dataclasses
+  ([#1862](https://github.com/joshua-jingu-lee/ante/pull/1862),
+  [`862e37c`](https://github.com/joshua-jingu-lee/ante/commit/862e37cf63e62077fb42a8c2e44550eee7ff87a8))
+
+- **#1847-1**: Member 12-leaf success output drift lock
+  ([#1875](https://github.com/joshua-jingu-lee/ante/pull/1875),
+  [`d728fc1`](https://github.com/joshua-jingu-lee/ante/commit/d728fc1d0f25c55a33f7e92b887433be1940108e))
+
+- **account**: Split-2 bot/approval account-scoped test coverage
+  ([#1246](https://github.com/joshua-jingu-lee/ante/pull/1246),
+  [`45ae880`](https://github.com/joshua-jingu-lee/ante/commit/45ae880d92861fcc85c2801be4dcdec2387a7fa5))
+
+- **account**: Treasury query 정책 회귀 테스트
+  ([#1249](https://github.com/joshua-jingu-lee/ante/pull/1249),
+  [`c7b6719`](https://github.com/joshua-jingu-lee/ante/commit/c7b67190ba0e4b09d8dd2ccc595bb5888e33cdab))
+
+- **account,ipc**: Add runtime guard / init order / ipc code mapping tests
+  ([#1169](https://github.com/joshua-jingu-lee/ante/pull/1169),
+  [`90dc2b8`](https://github.com/joshua-jingu-lee/ante/commit/90dc2b8fdb4fd5888ee760e0e0bc305ee8e44a4b))
+
+- **bot**: Cover nested BotInfo.config runtime controls
+  ([#1501](https://github.com/joshua-jingu-lee/ante/pull/1501),
+  [`64c7d45`](https://github.com/joshua-jingu-lee/ante/commit/64c7d451fe5bf399f961b739c6f5aff6092dc022))
+
+- **cli**: #1913 r1 — success payload leak assertion + broker healthy 필드 보강
+  ([#1932](https://github.com/joshua-jingu-lee/ante/pull/1932),
+  [`f76d56d`](https://github.com/joshua-jingu-lee/ante/commit/f76d56d51fb14f80067c148c9182348a133e2b50))
+
+- **cli**: #1913 r2 — broker status missing-key stdout exchange 부재 assertion 보강
+  ([#1932](https://github.com/joshua-jingu-lee/ante/pull/1932),
+  [`f76d56d`](https://github.com/joshua-jingu-lee/ante/commit/f76d56d51fb14f80067c148c9182348a133e2b50))
+
+- **cli**: Add dependency-isolation smoke test infra (#1464)
+  ([#1490](https://github.com/joshua-jingu-lee/ante/pull/1490),
+  [`52cc460`](https://github.com/joshua-jingu-lee/ante/commit/52cc4601208d47fbab9ae368fbfc67b220e0c29b))
+
+- **cli**: Clean up dead input_text helper params
+  ([#1209](https://github.com/joshua-jingu-lee/ante/pull/1209),
+  [`0849a5c`](https://github.com/joshua-jingu-lee/ante/commit/0849a5c32c1b19dabf374060744b623176dc3da4))
+
+- **cli**: Cover BadArgumentUsage subclass in usage error json tests
+  ([#1551](https://github.com/joshua-jingu-lee/ante/pull/1551),
+  [`1543db9`](https://github.com/joshua-jingu-lee/ante/commit/1543db952c43d9526e59bf068213a98e06e9bfc2))
+
+- **cli**: Cover require_auth and _wrap_callback_with_auth emit paths
+  ([#1545](https://github.com/joshua-jingu-lee/ante/pull/1545),
+  [`2e2874f`](https://github.com/joshua-jingu-lee/ante/commit/2e2874ffca855c940d5e1c4063608ef705e352eb))
+
+- **cli**: Drop unused unpacked locals in strategy performance tests
+  ([#1572](https://github.com/joshua-jingu-lee/ante/pull/1572),
+  [`c690fde`](https://github.com/joshua-jingu-lee/ante/commit/c690fdee46d767e1ffba68c272f29d58970741e8))
+
+- **cli**: Patch ipc_helpers.ipc_send so reconcile missing-account test stays offline
+  ([#1566](https://github.com/joshua-jingu-lee/ante/pull/1566),
+  [`3761a3f`](https://github.com/joshua-jingu-lee/ante/commit/3761a3fb39f86f1dbdca6ac176643b0a2a0f2082))
+
+- **cli/ipc**: Align config-dir propagation expectations with runtime resolver
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **cli/system**: Cover stop resolver path message and legacy stale cleanup
+  ([#1182](https://github.com/joshua-jingu-lee/ante/pull/1182),
+  [`290bcff`](https://github.com/joshua-jingu-lee/ante/commit/290bcff5afbd8688b251a0cc3c1764cb2071fac8))
+
+- **contracts**: #1847 sub-PR 6 drift tests lock data + report JSON envelope shapes
+  ([#1880](https://github.com/joshua-jingu-lee/ante/pull/1880),
+  [`0172374`](https://github.com/joshua-jingu-lee/ante/commit/017237446ffdb546bba8725481d06f0a5052c244))
+
+- **db**: Load schema generator by file path (#1229)
+  ([#1255](https://github.com/joshua-jingu-lee/ante/pull/1255),
+  [`21db431`](https://github.com/joshua-jingu-lee/ante/commit/21db4317bc7df926a719de993f8cfe3807f5010d))
+
+- **eventbus**: Supply account_id when constructing OrderCancelFailedEvent
+  ([#1342](https://github.com/joshua-jingu-lee/ante/pull/1342),
+  [`71c6d93`](https://github.com/joshua-jingu-lee/ante/commit/71c6d9343eaf7ea58bb307d1e8db21ade1e9e13d))
+
+- **exchange**: Cross-module canonical vocabulary contract regression
+  ([#1589](https://github.com/joshua-jingu-lee/ante/pull/1589),
+  [`e7acbc9`](https://github.com/joshua-jingu-lee/ante/commit/e7acbc9f7163d8fd99b3994c450461ce62291e9f))
+
+- **exchange**: Cross-module canonical vocabulary contract regression (#1579)
+  ([#1589](https://github.com/joshua-jingu-lee/ante/pull/1589),
+  [`e7acbc9`](https://github.com/joshua-jingu-lee/ante/commit/e7acbc9f7163d8fd99b3994c450461ce62291e9f))
+
+- **exchange**: Isolate CLI config-dir/db-path in contract regression
+  ([#1589](https://github.com/joshua-jingu-lee/ante/pull/1589),
+  [`e7acbc9`](https://github.com/joshua-jingu-lee/ante/commit/e7acbc9f7163d8fd99b3994c450461ce62291e9f))
+
+- **rule,gateway,bot**: Cover OrderModifyEvent terminal event lifecycle
+  ([#1341](https://github.com/joshua-jingu-lee/ante/pull/1341),
+  [`fde7c2e`](https://github.com/joshua-jingu-lee/ante/commit/fde7c2ed4b6b8c91495dc6992dc9bdcdc29bf4b2))
+
+- **stop**: Cover stop event account_id propagation and on_order_update routing
+  ([#1349](https://github.com/joshua-jingu-lee/ante/pull/1349),
+  [`58af809`](https://github.com/joshua-jingu-lee/ante/commit/58af809433e1586374dabeaec795cefb2813dae6))
+
+- **strategy**: Add pandas-ta Python 3.13 regression gate
+  ([#1201](https://github.com/joshua-jingu-lee/ante/pull/1201),
+  [`5dd9a36`](https://github.com/joshua-jingu-lee/ante/commit/5dd9a36ca7032e9a92c59213d9f07dd624512595))
+
+- **strategy**: Make pandas-ta filterwarnings pandas-version-neutral
+  ([#1201](https://github.com/joshua-jingu-lee/ante/pull/1201),
+  [`5dd9a36`](https://github.com/joshua-jingu-lee/ante/commit/5dd9a36ca7032e9a92c59213d9f07dd624512595))
+
+- **treasury**: Cover balance API and service invariants
+  ([#1343](https://github.com/joshua-jingu-lee/ante/pull/1343),
+  [`db12f00`](https://github.com/joshua-jingu-lee/ante/commit/db12f0099c75df83a2ab53cbe7ebdb689f8137d0))
+
+- **web**: Allow content-map ErrorResponse refs in 4xx/5xx invariant
+  ([#1165](https://github.com/joshua-jingu-lee/ante/pull/1165),
+  [`700a750`](https://github.com/joshua-jingu-lee/ante/commit/700a750c2a7dd0e7eb77038051c55c3f54900aff))
+
+- **web**: Close discovery-lock fail-open gaps (default-deny default, per-(owner,path) dict proof,
+  per-surface-id CV3, RuleUpdate sentinel)
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web**: Conform discovery-lock to refined INV-1/3/4 (per-site dict key, single fail-closed sink,
+  per-path/non-collateral canary) ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web**: Enforce per-handler ValidationError chokepoint (#1651 attempt-7)
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web**: Helper caller-site preservation + AST-semantic ValidationError-handler gate
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web**: Non-extra_forbidden caller-controlled loc 종합 정책 — S1∪S2 default-deny discovery lock
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web**: Preserve enclosing-handler qualname in S1/S2 site-id (no over-merge)
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web**: Redesign discovery-lock PASS-computation to single default-deny form (INV-1..5)
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web**: S1 recursive routes/** discovery + S2 mount known-type fail-closed
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web**: Seal 3 attempt-9 fail-open vectors in non-extra loc discovery lock
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+- **web**: Seal AnnAssign taint + BaseModel ctor-path S1 + real-resolver canary (#1651 attempt-8)
+  ([#1653](https://github.com/joshua-jingu-lee/ante/pull/1653),
+  [`30b43a5`](https://github.com/joshua-jingu-lee/ante/commit/30b43a5cdba6e282e6fda6d839eeb8c1ae144b3a))
+
+
 ## v0.9.0 (2026-04-25)
 
 ### BREAKING CHANGES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ante"
-version = "0.9.0"
+version = "0.10.0"
 description = "AI-Native Trading Engine"
 requires-python = ">=3.13,<3.14"
 dependencies = [


### PR DESCRIPTION
## Release

- Last tag: `v0.9.0`
- Target version: `v0.10.0`
- Base: `main`
- Head: `release/v0.10.0`

## Included Commits

Semantic-release computed `v0.10.0` from commits after `v0.9.0`. Summary by conventional commit class:

- Breaking-marked commits: 5
- `feat`: 33
- `fix`: 206
- Other release-range commits: 165

Recent highlights:

- `ci(release): align PyPI publish secret name (#1962)`
- `fix(eventbus): #1957 체결 이벤트 소비자 멱등화 (#1960)`
- `feat(trade): #1948 전략 get_open_orders(live) OrderTracker sync 백엔드 (#1959)`
- `feat(trade): #1949 체결 이벤트 transactional outbox (#1958)`
- `feat(trade): #1946 KIS 체결 반영 경로(fill-recovery) (#1953)`

Full generated notes are in `CHANGELOG.md`.

## Release Metadata

- `pyproject.toml`: `0.9.0` -> `0.10.0`
- `CHANGELOG.md`: add `v0.10.0 (2026-05-29)`

## Verification

- `git diff --check`
- `PYTHONPATH=$(pwd -P)/src .venv/bin/python scripts/check_import_path.py`
- `PYTHONPATH=$(pwd -P)/src .venv/bin/python -m ruff check src/ tests/`
- `PYTHONPATH=$(pwd -P)/src .venv/bin/python -m ruff format --check src/ tests/`
- `ANTE_DB_ENCRYPTION_KEY=... PYTHONPATH=$(pwd -P)/src .venv/bin/python -m pytest tests/unit/ -x -n auto --tb=short -q` -> `5801 passed, 2 skipped`
- `.venv/bin/python -m build` -> `ante-0.10.0.tar.gz`, `ante-0.10.0-py3-none-any.whl`
- `docker build -t ante:release-v0.10.0 .`

## Publish

Do not publish from this PR. After this release PR is merged and `main` HEAD is the release merge commit, run `/release publish` for GitHub Release, PyPI, and GHCR image publication.
