### PR TITLE
fix(feed): #1964 fundamental 다중소스 merge 데이터손실 방지 + report.warnings + DART checkpoint clamp

### DIFF
--- a/docs/specs/data-feed/02-design-decisions.md
+++ b/docs/specs/data-feed/02-design-decisions.md
@@ -10,9 +10,25 @@ DataFeed는 `ante.data.store.ParquetStore.write()`를 호출하여 저장한다.
 자체 Parquet 읽기/쓰기 구현(`store/parquet.py`)을 두지 않는다.
 
 **쓰기 모드는 merge/dedup**이다. `write()`는 기존 월별 파티션과 새 데이터를 병합한 뒤
-natural key(`timestamp` 또는 `date`) 기준으로 중복을 제거하고 정렬한다.
+natural key 기준으로 중복을 제거하고 정렬한다.
 이로써 **멱등성이 보장**되므로 장애 후 같은 범위를 다시 수집해도 중복 행이 누적되지 않는다.
 값 정정이나 전체 재생성을 위한 true partition replace는 1.0 계약에 포함하지 않는다.
+
+natural key는 data_type별로 결정된다:
+
+| data_type | natural key | 근거 |
+|-----------|-------------|------|
+| `ohlcv` / `tick` | `timestamp` | 시점당 한 행 |
+| `fundamental` | `(date, source)` | 다중 소스 공존 (아래 참조) |
+
+`fundamental`은 **다중 소스가 같은 월 파티션을 공유**한다 — data.go.kr의 일별
+`market_cap`/`shares_listed`와 DART의 분기 재무제표가 모두
+`{data.path}/fundamental/{exchange}/{symbol}/{YYYY-MM}.parquet`에 기록된다.
+DART date는 분기말일(3/31·6/30·9/30·12/31)이라 data.go.kr의 같은 거래일 일별 행과
+date가 충돌할 수 있다. 따라서 natural key를 `date` 단독이 아닌 `(date, source)`로 두어
+두 소스의 서로 다른(null-complementary) 행을 **모두 보존**한다. 병합은 컬럼 합집합 +
+null-fill(schema-union) 방식이며, merge가 (방어적으로) 실패해도 기존 파티션을
+덮어쓰지 않고 데이터 품질 경고(report `warnings`)로 표면화한다(데이터 무손실 우선).
 
 ### 쓰기 소유권
 

--- a/docs/specs/data-feed/04-schema.md
+++ b/docs/specs/data-feed/04-schema.md
@@ -40,6 +40,15 @@ DataFeed는 `ante.data.schemas`를 직접 import하여 사용한다. 스키마�
 | 디렉토리 | OHLCV: `{data.path}/ohlcv/{timeframe}/{exchange}/{symbol}/{YYYY-MM}.parquet`; 기타: `{data.path}/{data_type}/{exchange}/{symbol}/{YYYY-MM}.parquet` |
 | 파티셔닝 | 1m 이상: 월별, 10s/30s: 일별 (YYYY-MM-DD) |
 | 쓰기 방식 | `ParquetStore.write()` 호출 (natural-key merge/dedup — 멱등성 보장) |
+| natural key | OHLCV/tick: `timestamp`; fundamental: `(date, source)` |
 | 정렬 | timestamp/date 오름차순 |
-| 중복 | 동일 timestamp 행 없을 것 |
+| 중복 | natural key 동일 행 없을 것 (OHLCV/tick: 동일 `timestamp`; fundamental: 동일 `(date, source)`) |
 | 타임존 | UTC |
+
+> **fundamental 다중 소스 공존**: `fundamental` 파티션에는 data.go.kr의 일별
+> `market_cap`/`shares_listed`와 DART의 분기 재무제표가 같은 `{YYYY-MM}.parquet`에
+> 함께 기록된다. DART date는 분기말일(3/31·6/30·9/30·12/31)이라 data.go.kr 일별 행과
+> date가 충돌할 수 있으므로, natural key를 `date` 단독이 아닌 `(date, source)`로 두어
+> 두 소스의 행을 모두 보존한다. 병합은 컬럼 합집합 + null-fill(schema-union)이며,
+> 한 소스에만 있는 컬럼은 다른 소스 행에서 null로 채워진다. 자세한 근거는
+> [02-design-decisions.md](02-design-decisions.md) `운영 모델 — DataStore 경유 저장` 절 참조.

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -59,6 +59,40 @@ _TIME_COLUMN: dict[str, str] = {
     "tick": "timestamp",
 }
 
+
+def _natural_key(data_type: str, columns: list[str]) -> list[str]:
+    """data_type별 merge/dedup용 natural key 컬럼 목록을 결정한다.
+
+    natural key는 같은 월 파티션 내에서 "같은 논리 행"을 식별하는 기준이며,
+    merge 시 `unique(subset=key, keep="last")`로 멱등성을 보장한다.
+
+    - fundamental: `["date", "source"]`(둘 다 존재 시) 또는 `["date"]`.
+      DART 재무제표 date는 분기말일(3/31·6/30·9/30·12/31)이라
+      data.go.kr의 같은 거래일 일별 fundamental과 같은 월 파티션에서
+      date가 충돌할 수 있다. `source`까지 키에 포함하면 두 소스의
+      서로 다른(null-complementary) 행을 **모두 보존**한다(#1964).
+    - ohlcv/tick(및 기타 default): `["timestamp"]`(존재 시) 또는 `[]`.
+
+    Args:
+        data_type: 데이터 타입 (ohlcv/fundamental/tick/...).
+        columns: 대상 DataFrame의 컬럼 목록.
+
+    Returns:
+        natural key 컬럼 목록. 키 컬럼이 데이터에 없으면 빈 목록.
+    """
+    cols = set(columns)
+    if data_type == "fundamental":
+        if "date" in cols and "source" in cols:
+            return ["date", "source"]
+        if "date" in cols:
+            return ["date"]
+        return []
+    # ohlcv/tick 및 default: 단일 timestamp 키
+    if "timestamp" in cols:
+        return ["timestamp"]
+    return []
+
+
 # 알려진 거래소 이름 — 마이그레이션 시 이미 exchange 디렉토리인지 판별용.
 # 코드 레벨 SSOT(`ante.core.exchange.CANONICAL_EXCHANGES`)에 위임한다.
 # 값(canonical 5종 frozenset)·`migrate_parquet_paths()` 동작은 위임
@@ -171,10 +205,29 @@ class ParquetStore:
     ) -> None:
         self._base = Path(base_path)
         self._compression = compression
+        # merge 이상(데이터 손실 가능성이 있던 케이스)을 구조화 경고로 버퍼링.
+        # backfill_runner가 collector/indicator 호출 직후 drain하여
+        # CollectionResult.warnings(→ report `warnings`)로 전파한다(#1964).
+        self._pending_warnings: list[dict] = []
 
     @property
     def base_path(self) -> Path:
         return self._base
+
+    def drain_warnings(self) -> list[dict]:
+        """누적된 store 이상 경고를 반환하고 버퍼를 비운다.
+
+        호출자(backfill_runner)가 한 단계(collector/indicator) 종료 직후
+        drain하여 run context의 warnings로 옮긴다. 반환 후 내부 버퍼는
+        비워지므로 같은 경고가 중복 전파되지 않는다.
+
+        Returns:
+            누적 경고 목록의 복사본. 각 항목은
+            `{"type": "store_merge", "path": str, "message": str}` 형태.
+        """
+        drained = list(self._pending_warnings)
+        self._pending_warnings.clear()
+        return drained
 
     def _resolve_path(
         self,
@@ -295,7 +348,10 @@ class ParquetStore:
         if not dfs:
             return pl.DataFrame()
 
-        df = pl.concat(dfs)
+        # 월별 파티션은 소스/시기에 따라 이종 스키마일 수 있다
+        # (data.go.kr-only, DART-only, 지표 보강 후 등). diagonal_relaxed로
+        # 컬럼 합집합 + null-fill + supertype 강제 결합하여 raise 없이 읽는다.
+        df = pl.concat(dfs, how="diagonal_relaxed")
         time_col = _TIME_COLUMN.get(data_type, "timestamp")
 
         if start and time_col in df.columns:
@@ -346,12 +402,12 @@ class ParquetStore:
         path.mkdir(parents=True, exist_ok=True)
 
         time_col = _TIME_COLUMN.get(data_type, "timestamp")
+        key = _natural_key(data_type, data.columns)
         partitioned = self._partition_by_month(data, time_col)
 
         for month_val, group in partitioned:
             filepath = path / f"{month_val}.parquet"
-            unique_col = time_col if time_col in group.columns else None
-            self._persist_partition(filepath, group, unique_col)
+            self._persist_partition(filepath, group, key)
 
         logger.debug("Wrote %d rows for %s/%s", len(data), symbol, timeframe)
 
@@ -377,24 +433,60 @@ class ParquetStore:
         ]
 
     def _persist_partition(
-        self, filepath: Path, group: pl.DataFrame, unique_col: str | None
+        self, filepath: Path, group: pl.DataFrame, key: list[str]
     ) -> None:
-        """단일 파티션을 Parquet 파일에 기록. 기존 파일이 있으면 merge."""
+        """단일 파티션을 Parquet 파일에 기록. 기존 파일이 있으면 merge.
+
+        merge 전략(#1964):
+        - 기존 파일이 있으면 `pl.concat(how="diagonal_relaxed")`로
+          컬럼 합집합 + null-fill + supertype 강제 결합한다(이종 스키마 무손실).
+        - natural key가 있으면 `unique(subset=key, keep="last")`로 신규 write
+          우선 dedup 후 key로 정렬한다(멱등성).
+        - **silent overwrite 금지**: concat이 (방어적으로) 여전히 raise하면
+          기존 파일을 덮어쓰지 않고 store 이상 경고만 기록한 뒤 반환한다.
+          기존 데이터 보존을 데이터 신규 반영보다 우선한다.
+
+        Args:
+            filepath: 대상 파티션 파일 경로.
+            group: 이번 write로 들어온 (단일 월) DataFrame.
+            key: natural key 컬럼 목록. 비어 있으면 dedup/sort 생략.
+        """
         if filepath.exists():
             try:
                 existing = pl.read_parquet(filepath)
-                merged = pl.concat([existing, group])
-                if unique_col:
-                    merged = merged.unique(subset=[unique_col]).sort(unique_col)
+                merged = pl.concat([existing, group], how="diagonal_relaxed")
+                if key:
+                    present = [c for c in key if c in merged.columns]
+                    if present:
+                        merged = merged.unique(subset=present, keep="last").sort(
+                            present
+                        )
                 merged.write_parquet(str(filepath), compression=self._compression)
                 return
-            except Exception:
+            except Exception as exc:
+                # 방어: diagonal_relaxed로도 결합 불가한 케이스. 기존 파일을
+                # 절대 덮어쓰지 않고(데이터 손실 방지) 이상만 기록한다.
                 logger.warning(
-                    "Failed to merge with existing file: %s, overwriting", filepath
+                    "Parquet 파티션 merge 실패: %s — 기존 파일 보존, write 건너뜀 (%s)",
+                    filepath,
+                    exc,
                 )
+                self._pending_warnings.append(
+                    {
+                        "type": "store_merge",
+                        "path": str(filepath),
+                        "message": (
+                            f"파티션 merge 실패로 이번 write를 건너뛰어 기존 데이터를 "
+                            f"보존했습니다: {exc}"
+                        ),
+                    }
+                )
+                return
 
-        if unique_col and unique_col in group.columns:
-            group = group.sort(unique_col)
+        if key:
+            present = [c for c in key if c in group.columns]
+            if present:
+                group = group.unique(subset=present, keep="last").sort(present)
         group.write_parquet(str(filepath), compression=self._compression)
 
     def append(

--- a/src/ante/feed/pipeline/backfill_runner.py
+++ b/src/ante/feed/pipeline/backfill_runner.py
@@ -185,6 +185,7 @@ class BackfillRunner:
             ctx,
             is_blocked,
         )
+        ctx.warnings.extend(store.drain_warnings())
         await self._collect_dart(
             data_path,
             feed_dir,
@@ -193,7 +194,9 @@ class BackfillRunner:
             store,
             ctx,
         )
+        ctx.warnings.extend(store.drain_warnings())
         self._compute_indicators(store, ctx)
+        ctx.warnings.extend(store.drain_warnings())
 
         return ctx.to_result("backfill", started_at)
 

--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
+from calendar import monthrange
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 import polars as pl
 
-from ante.data.normalizer import DARTNormalizer
+from ante.data.normalizer import _REPRT_CODE_MAP, DARTNormalizer
 from ante.data.store import ParquetStore
 from ante.feed.pipeline.checkpoint import Checkpoint
 from ante.feed.sources.dart import (
@@ -33,6 +35,33 @@ REPRT_TO_QUARTER: dict[str, str] = {
 
 # 기본 설정 상수
 DEFAULT_BACKFILL_SINCE = "2015-01-01"
+
+# `today`는 KST(UTC+9) 캘린더 기준으로 산출한다. 분기 period-end 비교는
+# backfill_runner._today_kst()와 동일 기준이어야 한다(repo 전반 KST 정합).
+_KST = timezone(timedelta(hours=9))
+
+
+def _today_kst() -> date:
+    """오늘 날짜(KST 캘린더)를 반환한다."""
+    return datetime.now(tz=_KST).date()
+
+
+def _quarter_period_end(year: int, reprt_code: str) -> date | None:
+    """(year, reprt_code)가 가리키는 분기의 period-END 날짜를 반환한다.
+
+    reprt_code → 종료월(3/6/9/12) 매핑은 normalizer `_REPRT_CODE_MAP`를
+    SSOT로 재사용하며, 그 월의 말일을 period-end로 본다(DART normalizer의
+    `_convert_report_date`와 동일 규칙).
+
+    Returns:
+        period-end 날짜. reprt_code가 매핑에 없으면 None.
+    """
+    mapping = _REPRT_CODE_MAP.get(reprt_code)
+    if mapping is None:
+        return None
+    _, month = mapping
+    day = monthrange(year, month)[1]
+    return date(year, month, day)
 
 
 class DARTCollector:
@@ -92,13 +121,15 @@ class DARTCollector:
     def _resolve_year_range(
         config: dict[str, Any],
     ) -> tuple[int, int]:
-        """설정에서 수집 연도 범위를 결정한다."""
-        from datetime import date
+        """설정에서 수집 연도 범위를 결정한다.
 
+        end_year는 KST 기준 현재 연도이며, 분기 단위 미래 컷오프는
+        `_collect_quarters`의 period-end(KST) 비교가 담당한다(#1964).
+        """
         schedule = config.get("schedule", {})
         backfill_since = schedule.get("backfill_since", DEFAULT_BACKFILL_SINCE)
         start_year = int(backfill_since[:4])
-        end_year = date.today().year
+        end_year = _today_kst().year
         return start_year, end_year
 
     @staticmethod
@@ -125,10 +156,21 @@ class DARTCollector:
         symbols: set[str] = set()
         warns: list[dict] = []
 
+        # collectable 상한: period-end가 today(KST)를 지난 분기만 fetch/save.
+        # 미래 분기(예: 실행일 2026-05-29 기준 2026-Q2/Q3/Q4)는 데이터가
+        # 존재할 수 없으므로 fetch도 checkpoint.save도 수행하지 않는다.
+        # 이로써 checkpoint가 미래 분기로 전진하지 않는다(#1964).
+        today = _today_kst()
+
         for year in range(start_year, end_year + 1):
             for reprt_code in REPRT_CODES:
                 quarter_key = f"{year}-{REPRT_TO_QUARTER[reprt_code]}"
                 if last_checkpoint and quarter_key <= last_checkpoint:
+                    continue
+
+                period_end = _quarter_period_end(year, reprt_code)
+                if period_end is not None and period_end > today:
+                    # 미래 분기: fetch/save 모두 건너뛴다.
                     continue
 
                 written, syms = await self._fetch_quarter(

--- a/tests/unit/feed/test_dart_collector.py
+++ b/tests/unit/feed/test_dart_collector.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from ante.data.store import ParquetStore
+from ante.feed.pipeline.checkpoint import Checkpoint
 from ante.feed.pipeline.dart_collector import REPRT_TO_QUARTER, DARTCollector
 
 
@@ -78,3 +85,76 @@ class TestCheckpointMigration:
         """빈 문자열은 그대로 반환한다."""
         result = DARTCollector._migrate_checkpoint_key("")
         assert result == ""
+
+
+class _StubDARTSource:
+    """fetch_corp_codes/fetch_financial을 흉내내는 최소 DART 소스 스텁.
+
+    호출된 (year, reprt_code) 조합을 기록하여 미래 분기 fetch 여부를 검증한다.
+    """
+
+    def __init__(self, corp_code_map: dict[str, str]) -> None:
+        self._corp_code_map = corp_code_map
+        self.fetched: list[tuple[str, str]] = []
+
+    async def fetch_corp_codes(self, save_path: Path) -> dict[str, str]:
+        return self._corp_code_map
+
+    async def fetch_financial(
+        self,
+        corp_codes: list[str],
+        year: str,
+        reprt_code: str,
+    ) -> list[dict]:
+        # fetch된 분기를 기록. 데이터는 없는 것으로 처리(과거 분기여도 빈 응답).
+        self.fetched.append((year, reprt_code))
+        return []
+
+
+class TestCheckpointFutureQuarterClamp:
+    """checkpoint가 today(KST) 기준 미래 분기로 전진하지 않는지 검증한다(#1964)."""
+
+    async def test_dart_checkpoint_not_future_quarter(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """today=2026-05-29 mock 시 period-end > today 분기는 fetch/save 모두 skip.
+
+        2026-05-29 기준:
+          - 2026-Q1 (period-end 3/31) = collectable
+          - 2026-Q2 (6/30) / Q3 (9/30) / Q4 (12/31) = 미래 → skip
+        수정 전에는 _collect_quarters가 모든 분기를 무조건 save하여
+        checkpoint가 2026-Q4까지 전진했다.
+        """
+        import ante.feed.pipeline.dart_collector as dc
+
+        monkeypatch.setattr(dc, "_today_kst", lambda: date(2026, 5, 29))
+
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        store = ParquetStore(base_path=tmp_path / "data")
+        checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+
+        source = _StubDARTSource({"00126380": "005930"})
+        collector = DARTCollector(source=source)
+
+        config = {"schedule": {"backfill_since": "2026-01-01"}}
+        await collector.collect(
+            data_path=tmp_path / "data",
+            feed_dir=feed_dir,
+            checkpoint=checkpoint,
+            config=config,
+            store=store,
+        )
+
+        last = checkpoint.get_last_date()
+        # 미래 분기(Q2/Q3/Q4)로 전진하지 않음. Q1만 collectable.
+        assert last not in {"2026-Q2", "2026-Q3", "2026-Q4"}
+        assert last == "2026-Q1"
+
+        # 미래 분기는 fetch조차 하지 않는다 (period-end > today).
+        future_codes = {"11012", "11014", "11011"}  # Q2/Q3/Q4 reprt_code
+        fetched_2026 = {rc for (yr, rc) in source.fetched if yr == "2026"}
+        assert fetched_2026 & future_codes == set()
+        assert ("2026", "11013") in source.fetched  # Q1은 fetch됨

--- a/tests/unit/feed/test_report.py
+++ b/tests/unit/feed/test_report.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, date, datetime
 from pathlib import Path
 
+import polars as pl
 import pytest
 
+from ante.data.store import ParquetStore
 from ante.feed.models.result import CollectionResult
+from ante.feed.pipeline.backfill_runner import BackfillRunner
 from ante.feed.report.generator import REPORTS_DIR, ReportGenerator
 
 
@@ -338,3 +342,75 @@ class TestReportListReports:
         reports = gen.list_reports()
         assert reports[0].name == "2026-03-15-daily.json"
         assert reports[1].name == "2026-03-10-daily.json"
+
+
+class _AnomalyDataGoKrCollector:
+    """store merge 이상을 발생시키는 stub data.go.kr collector.
+
+    `.collect()`가 호출되면, 사전에 손상시켜 둔(읽기 불가) 파티션 위로
+    fundamental write를 시도한다. ParquetStore는 기존 파일을 덮어쓰지 않고
+    `store_merge` 이상 경고만 버퍼에 적재한다(#1964 silent-overwrite 제거).
+    """
+
+    async def collect(
+        self,
+        target_date: str,
+        store: ParquetStore,
+    ) -> tuple[int, set[str], list[dict]]:
+        df = pl.DataFrame(
+            {
+                "date": [date(2025, 9, 30)],
+                "symbol": ["005930"],
+                "market_cap": [510000000000],
+                "source": ["data_go_kr"],
+            }
+        )
+        store.write("005930", "krx", df, data_type="fundamental")
+        return 1, {"005930"}, []
+
+
+class TestBackfillReportSurfacesStoreMergeWarning:
+    """store merge 이상이 CollectionResult.warnings로 전파되는지 검증한다(#1964)."""
+
+    async def test_backfill_report_surfaces_store_merge_warning(
+        self, tmp_path: Path
+    ) -> None:
+        """store merge anomaly가 backfill 결과의 warnings에 등장한다.
+
+        수정 전에는 store 덮어쓰기가 stderr 로그로만 남고
+        CollectionResult.warnings는 비어 있었다.
+        """
+        data_path = tmp_path / "data"
+        feed_dir = data_path / ".feed"
+        (feed_dir / "checkpoints").mkdir(parents=True)
+
+        # 손상된(읽기 불가) 파티션을 사전 배치 → 다음 write에서 merge 실패 유발.
+        part_dir = data_path / "fundamental" / "KRX" / "005930"
+        part_dir.mkdir(parents=True)
+        (part_dir / "2025-09.parquet").write_bytes(b"corrupt-not-parquet")
+
+        store = ParquetStore(base_path=data_path)
+        runner = BackfillRunner(
+            data_go_kr_collector=_AnomalyDataGoKrCollector(),
+            dart_collector=None,
+            store=store,
+        )
+
+        result = await runner.run(
+            data_path=data_path,
+            config={"schedule": {"backfill_since": "2025-09-29"}},
+            feed_dir=feed_dir,
+            started_at=datetime.now(tz=UTC),
+            is_blocked=lambda config, target_date: False,
+        )
+
+        store_merge_warnings = [
+            w for w in result.warnings if w.get("type") == "store_merge"
+        ]
+        assert store_merge_warnings, (
+            f"store_merge 경고가 result.warnings에 없음: {result.warnings}"
+        )
+        assert "2025-09.parquet" in store_merge_warnings[0]["path"]
+
+        # 손상 파일은 보존됨(데이터 손실 방지).
+        assert (part_dir / "2025-09.parquet").read_bytes() == b"corrupt-not-parquet"

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -344,6 +344,102 @@ class TestParquetStore:
         result = store.read("005930", "1m")
         assert len(result) == 5
 
+    async def test_store_fundamental_multisource_no_data_loss(self, store):
+        """다중 소스 fundamental이 같은 월 파티션에서 서로 덮어쓰지 않는다(#1964).
+
+        data.go.kr(market_cap/shares_listed)를 먼저 쓰고, 같은 symbol/월에
+        DART(재무제표)를 quarter-end date로 쓴 뒤 read하면 양쪽 소스의 행과
+        컬럼이 **모두** 보존되어야 한다. 수정 전에는 schema mismatch로
+        DART write가 기존 파일을 덮어써 data.go.kr 행이 소실됐다.
+        """
+        from datetime import date
+
+        # data.go.kr: 9월 일별 fundamental (quarter-end 9/30 포함)
+        dg = pl.DataFrame(
+            {
+                "date": [date(2025, 9, 29), date(2025, 9, 30)],
+                "symbol": ["005930", "005930"],
+                "market_cap": [500000000000, 510000000000],
+                "shares_listed": [5970000000, 5970000000],
+                "source": ["data_go_kr", "data_go_kr"],
+            }
+        )
+        # DART: 3Q 재무제표 (date = quarter-end 9/30) — 다른 스키마
+        dart = pl.DataFrame(
+            {
+                "date": [date(2025, 9, 30)],
+                "symbol": ["005930"],
+                "total_assets": [9000000000000.0],
+                "total_debt": [3000000000000.0],
+                "total_equity": [6000000000000.0],
+                "revenue": [2000000000000.0],
+                "net_income": [300000000000.0],
+                "source": ["dart"],
+            }
+        )
+        store.write("005930", "krx", dg, data_type="fundamental")
+        store.write("005930", "krx", dart, data_type="fundamental")
+
+        result = store.read("005930", "krx", data_type="fundamental")
+
+        # 양쪽 소스 행이 모두 보존: data.go.kr 2행 + DART 1행 = 3행
+        assert len(result) == 3
+        assert sorted(result["source"].unique().to_list()) == ["dart", "data_go_kr"]
+
+        # 양쪽 컬럼 집합이 모두 보존(합집합 스키마)
+        cols = set(result.columns)
+        assert {"market_cap", "shares_listed"} <= cols  # data.go.kr
+        assert {"total_assets", "total_equity", "net_income"} <= cols  # DART
+
+        # quarter-end(9/30)에서 data.go.kr 행과 DART 행이 공존
+        q_end = result.filter(pl.col("date") == date(2025, 9, 30))
+        assert len(q_end) == 2
+        dg_row = q_end.filter(pl.col("source") == "data_go_kr")
+        dart_row = q_end.filter(pl.col("source") == "dart")
+        assert dg_row["market_cap"][0] == 510000000000
+        assert dart_row["total_assets"][0] == 9000000000000.0
+
+        # merge 이상이 없었음(silent overwrite 경로 제거 확인)
+        assert store.drain_warnings() == []
+
+    async def test_store_read_heterogeneous_monthly_schemas(self, store):
+        """월마다 스키마가 다른 파티션을 raise 없이 합집합으로 읽는다(#1964).
+
+        data.go.kr-only 월과 DART-only 월이 섞여 있어도 read가 예외 없이
+        컬럼 합집합 DataFrame을 반환해야 한다. 수정 전에는 vertical concat이
+        스키마 불일치로 raise했다.
+        """
+        from datetime import date
+
+        # 8월: data.go.kr-only 스키마
+        aug = pl.DataFrame(
+            {
+                "date": [date(2025, 8, 14)],
+                "symbol": ["005930"],
+                "market_cap": [480000000000],
+                "shares_listed": [5970000000],
+                "source": ["data_go_kr"],
+            }
+        )
+        # 9월: DART-only 스키마 (완전히 다른 컬럼 집합)
+        sep = pl.DataFrame(
+            {
+                "date": [date(2025, 9, 30)],
+                "symbol": ["005930"],
+                "total_assets": [9000000000000.0],
+                "net_income": [300000000000.0],
+                "source": ["dart"],
+            }
+        )
+        store.write("005930", "krx", aug, data_type="fundamental")
+        store.write("005930", "krx", sep, data_type="fundamental")
+
+        # raise 없이 합집합 반환
+        result = store.read("005930", "krx", data_type="fundamental")
+        assert len(result) == 2
+        cols = set(result.columns)
+        assert {"market_cap", "shares_listed", "total_assets", "net_income"} <= cols
+
 
 # ── normalizer.py 테스트 ─────────────────────────────
 


### PR DESCRIPTION
Closes #1964

## Summary
fundamental backfill의 다중소스(data.go.kr + DART) 저장 데이터손실을 막고, merge 이상을 리포트에 노출하며, DART checkpoint의 미래 분기 전진을 차단한다.

- **Axis 1 — 데이터손실 방지** (`src/ante/data/store.py`): `_persist_partition`이 schema mismatch 시 기존 파티션을 덮어쓰던 silent-overwrite를 제거. `pl.concat(how="diagonal_relaxed")` + natural key `(date, source)` dedup(`keep="last"`)으로 두 소스 행을 **모두 보존**. `read`도 `diagonal_relaxed`로 이종 월별 스키마를 무손실 결합. (DART date=분기말일이 data.go.kr 일별 date와 같은 월 파티션에서 충돌하던 손실 제거.)
- **Axis 2 — report.warnings** (`store.py` + `feed/pipeline/backfill_runner.py`): `ParquetStore._pending_warnings` + `drain_warnings()`; `backfill_runner`가 collector/indicator 직후 drain하여 `CollectionResult.warnings`(→ report `warnings`)로 전파(기존엔 stderr `logger.warning`만).
- **Axis 3 — checkpoint clamp** (`feed/pipeline/dart_collector.py`): `period-end > today(KST)`인 분기는 fetch/save를 모두 건너뛰어 미래 분기(예: 실행일 2026-05-29의 `2026-Q4`) checkpoint 전진을 차단.
- **스펙**: `docs/specs/data-feed/02-design-decisions.md`·`04-schema.md`에 fundamental natural key `(date, source)` + multi-source schema-union 공존 규칙 명문화.

## Non-Goals (별도 follow-up)
- 파생지표 **정확도**(daily market_cap × quarterly financials as-of join) — 본 PR은 무손실·무크래시만 보장(cross-source 값 부재 시 지표 null 허용).
- 소스별 분리 저장 레이아웃(option A) / 기존 파티션 마이그레이션.

## Test Plan
- **failing-first 4테스트**(축별 회귀 락): 수정 전 4 failed → 수정 후 4 passed.
  - `test_store_fundamental_multisource_no_data_loss`, `test_store_read_heterogeneous_monthly_schemas` (`tests/unit/test_data_pipeline.py`)
  - `test_dart_checkpoint_not_future_quarter` (`tests/unit/feed/test_dart_collector.py`)
  - `test_backfill_report_surfaces_store_merge_warning` (`tests/unit/feed/test_report.py`)
- 전체 `python -m pytest -q`: **5805 passed, 2 skipped**.
- `python -m mypy src/`: **Success (230 files, 0 issues)**. `ruff check`/`format --check`: clean.

## Review note
Codex 플랜·브랜치 리뷰가 이 환경에서 verifying 단계 stall(각 ~9–12분 로그 무진행)로 완료되지 못해, 오케스트레이터 full-diff self-review(`store.py`/`dart_collector.py`/`backfill_runner.py` 정확성 직접 확인)로 대체했다. CI required gate가 독립 검증한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
