### PR TITLE
fix(cli): #1965 init 상대 db.path(relocatable) + auth connect 실패 aiosqlite 정리

### DIFF
--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -583,10 +583,19 @@ def init(
 
     # 1. 디렉토리 생성 및 누락 파일 보충 (state 2/3/4/5 공통)
     config_path.mkdir(parents=True, exist_ok=True)
-    # db.path는 절대 경로로 기록한다. 서버(`ante system start`)와 IPC가
-    # cwd와 무관하게 동일한 DB 파일을 보도록 보장하기 위함이다.
-    db_absolute = (config_path / _DB_FILENAME).resolve()
-    system_toml_content = SYSTEM_TOML_TEMPLATE.format(db_path=str(db_absolute))
+    # db.path는 스펙(`docs/specs/config/03-design-decisions.md:203`)에 따라
+    # **상대 경로 기본값**(`db/ante.db`)으로 기록한다 — "ante init은 상대 경로
+    # 기본값을 기록하고, resolver가 절대 경로로 정규화한다". 절대 경로를
+    # baking하면 config 디렉토리를 다른 위치로 복사·마운트(`--config-dir`/
+    # `ANTE_CONFIG_DIR`)했을 때 baked된 원본 절대 경로를 계속 가리켜
+    # relocatable하지 않다 (#1965).
+    #
+    # cwd 독립성은 상대 경로로도 유지된다: `Config.load`는 항상 config_dir를
+    # arg/env/`~/.config/ante`/`./config`에서 확정해 기억하고(`config.py`
+    # `resolve_config_dir`), `resolve_path`가 상대 경로를 그 config_dir 기준으로
+    # 결합하기 때문이다(cwd 무관). 서버(`main.py`)·CLI(`get_db_path`)·IPC·
+    # cold-path 모두 동일한 config_dir resolution을 공유한다.
+    system_toml_content = SYSTEM_TOML_TEMPLATE.format(db_path=_DB_FILENAME)
     _ensure_file(artifacts["system.toml"], system_toml_content)
     # secrets.env는 ANTE_DB_ENCRYPTION_KEY를 보장하기 위해 별도 helper로 처리한다.
     # 이미 존재하는 파일은 내용을 보존하면서 키 라인만 갱신/추가하며, 신규

--- a/src/ante/cli/middleware.py
+++ b/src/ante/cli/middleware.py
@@ -135,6 +135,24 @@ def _run_authenticate(token: str, db_path: str) -> Member:
         try:
             await db.connect()
         except Exception as e:  # noqa: BLE001 — sqlite/OS 오류 통일 처리
+            # connect 실패 경로에서도 ``db.close()`` 를 보장한다. ``connect()`` 가
+            # 부분적으로 성공(writer만 열림)한 뒤 raise되면 aiosqlite worker
+            # thread가 leak되어, JSON envelope 출력 **이후** ``asyncio.run`` 종료
+            # 시 닫힌 이벤트 루프를 건드려 stderr에 ``RuntimeError: Event loop
+            # is closed`` traceback을 남긴다(#1965). 이는 ``--format json`` 의
+            # stderr 청결 계약을 위반한다. ``report.py`` / ``db_context.py`` 의
+            # ``except BaseException`` cleanup 패턴을 미러한다.
+            #
+            # NOTE: ``Database.connect()`` 자체도 부분 연결을 정리하므로
+            # (``core/database.py``) 통상 ``db.close()`` 는 no-op이지만, auth
+            # 표면에서도 동일 invariant를 이중 방어로 보장한다. ``close()`` 실패는
+            # 원본 ``PermissionError`` 를 가리지 않도록 swallow한다.
+            try:
+                await db.close()
+            except Exception:
+                logger.debug(
+                    "db.close() after failed connect raised — ignored", exc_info=True
+                )
             msg = (
                 f"DB 접근 불가 ({db_path}): {e}. "
                 "`ante init --dir <config_dir>` 이후 동일 `--config-dir`로 실행하세요."

--- a/src/ante/core/database.py
+++ b/src/ante/core/database.py
@@ -1,9 +1,13 @@
 """SQLite WAL 모드 비동기 래퍼."""
 
+import asyncio
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import aiosqlite
+
+logger = logging.getLogger(__name__)
 
 
 class Database:
@@ -15,21 +19,97 @@ class Database:
         self._reader: aiosqlite.Connection | None = None
         self._in_transaction: bool = False
 
+    @staticmethod
+    async def _drain_failed_conn(conn: aiosqlite.Connection) -> None:
+        """실패한 aiosqlite 연결의 background worker thread를 결정적으로 정리한다.
+
+        근본 배경(#1965): ``await aiosqlite.connect(...)`` 의 ``__await__`` 는
+        먼저 worker thread를 ``start()`` 한 뒤 실제 ``sqlite3.connect`` 를 큐에
+        넣는다. 파일을 열 수 없으면(예: ``unable to open database file``)
+        aiosqlite 의 ``_connect`` 가 내부적으로 ``stop()`` 을 호출해 종료
+        sentinel을 큐에 넣지만, 그 **future를 폐기**하고 예외를 재전파한다.
+        따라서 worker thread는 (스스로 곧 종료하긴 하나) 호출자 쪽에서 종료를
+        **동기화할 수단이 없다**. 이 상태로 ``asyncio.run`` 이 이벤트 루프를
+        먼저 닫으면, worker thread가 닫힌 루프에 ``call_soon_threadsafe`` 를
+        시도해 stderr에 ``RuntimeError: Event loop is closed`` traceback이
+        남는다(``--format json`` stderr 청결 계약 위반).
+
+        정리 전략:
+
+        1. ``conn.close()`` — 연결이 실제로 열렸던 경우(PRAGMA 단계 실패 등)
+           내부 종료 future를 await 해 worker를 비운다. 연결이 안 열렸으면
+           (``_connection is None``) no-op으로 빠르게 반환한다.
+        2. 그래도 thread가 살아 있으면(=connect 자체 실패로 future가 폐기된
+           경우), 그 thread를 이벤트 루프 밖(executor)에서 ``join`` 해 루프
+           teardown **이전**에 worker가 확실히 종료하도록 동기화한다.
+
+        ``_thread`` 접근은 aiosqlite 내부 구현에 의존하지만, 모두 ``getattr``
+        방어로 감싸 향후 구현이 바뀌어도 graceful degrade(예외 없이 best-effort)
+        하도록 한다. 어떤 단계의 예외든 swallow하여 호출자에게는 원본 connect
+        예외만 surface한다.
+        """
+        try:
+            await conn.close()
+        except Exception:
+            logger.debug("aiosqlite close() on failed connect raised", exc_info=True)
+
+        thread = getattr(conn, "_thread", None)
+        if thread is None:
+            return
+        try:
+            if thread.is_alive():
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(None, thread.join, 5.0)
+        except Exception:
+            logger.debug("joining aiosqlite worker thread raised", exc_info=True)
+
     async def _init_conn(self) -> aiosqlite.Connection:
-        """공통 PRAGMA 설정으로 연결 초기화."""
-        conn = await aiosqlite.connect(self._db_path)
-        await conn.execute("PRAGMA journal_mode=WAL")
-        await conn.execute("PRAGMA synchronous=NORMAL")
-        await conn.execute("PRAGMA temp_store=MEMORY")
-        await conn.execute("PRAGMA foreign_keys=ON")
-        await conn.execute("PRAGMA busy_timeout=5000")
-        conn.row_factory = aiosqlite.Row
+        """공통 PRAGMA 설정으로 연결 초기화.
+
+        ``aiosqlite.connect`` 의 ``await`` 또는 이후 PRAGMA 단계가 실패하면,
+        이미 ``start()`` 된 worker thread가 leak된다(``connect()`` 가
+        ``self._writer``/``self._reader`` 에 할당하기 **전**에 raise되므로
+        ``Database.close()`` 로도 회수할 수 없다). 이 경우 :meth:`_drain_failed_conn`
+        으로 worker thread를 결정적으로 정리한 뒤 원본 예외를 재전파한다(#1965).
+
+        ``aiosqlite.connect(...)`` 는 ``await`` 전에 ``Connection`` 객체를
+        반환하므로, ``await`` 자체가 실패하더라도 그 객체 핸들을 잡아 thread를
+        정리할 수 있도록 ``await`` 를 객체 생성과 분리한다.
+        """
+        conn = aiosqlite.connect(self._db_path)
+        try:
+            await conn
+            await conn.execute("PRAGMA journal_mode=WAL")
+            await conn.execute("PRAGMA synchronous=NORMAL")
+            await conn.execute("PRAGMA temp_store=MEMORY")
+            await conn.execute("PRAGMA foreign_keys=ON")
+            await conn.execute("PRAGMA busy_timeout=5000")
+            conn.row_factory = aiosqlite.Row
+        except BaseException:
+            await self._drain_failed_conn(conn)
+            raise
         return conn
 
     async def connect(self) -> None:
-        """DB 연결 초기화. writer + reader 두 연결 생성."""
-        self._writer = await self._init_conn()
-        self._reader = await self._init_conn()
+        """DB 연결 초기화. writer + reader 두 연결 생성.
+
+        어느 한쪽 연결이라도 실패하면 이미 열린 연결(writer)을 ``close()`` 로
+        정리한 뒤 원본 예외를 재전파한다. ``connect()`` 가 부분적으로 성공한
+        상태(예: writer만 열림)에서 raise되면 호출자가 받은 ``Database`` 핸들에
+        leak된 aiosqlite worker thread가 남아, ``asyncio.run`` 종료 시 닫힌
+        이벤트 루프를 건드려 stderr noise를 유발하기 때문이다(#1965). ``close()``
+        는 ``None`` 연결을 건너뛰므로 부분 성공/완전 실패 모두에서 안전하다.
+
+        ``_init_conn`` 이 raise하는 경우(예: 첫 writer 연결 실패) 해당 연결의
+        worker thread는 ``_init_conn`` 내부에서 이미 drain되며, 여기서는 이미
+        할당된 ``self._writer`` 만 ``close()`` 한다.
+        """
+        try:
+            self._writer = await self._init_conn()
+            self._reader = await self._init_conn()
+        except BaseException:
+            await self.close()
+            raise
 
     async def close(self) -> None:
         """연결 종료."""

--- a/tests/unit/cli/test_auth_format_json.py
+++ b/tests/unit/cli/test_auth_format_json.py
@@ -206,6 +206,112 @@ class TestInvalidTokenJsonFormat:
         assert "인증 실패" in result.stderr, result.stderr
 
 
+# ── auth DB connect 실패 시 aiosqlite traceback noise 부재 (#1965) ──────────
+
+
+class TestAuthDbFailureNoAiosqliteTraceback:
+    """auth 가 DB connect 실패로 ``auth_failed`` 를 낼 때 aiosqlite worker thread
+    traceback 이 stderr 에 새지 않아야 한다 (#1965).
+
+    근본 원인: ``_run_authenticate`` 의 ``await db.connect()`` 가
+    'unable to open database file' 로 실패하면, ``asyncio.run`` 종료 시 정리되지
+    않은 aiosqlite worker thread 가 닫힌 이벤트 루프를 건드려
+    ``Exception in thread Thread-N (_connection_worker_thread): ...
+    RuntimeError: Event loop is closed`` 가 JSON envelope **이후** stderr 로
+    출력됐다. 이는 ``--format json`` stderr 청결 계약(스펙
+    ``docs/specs/cli/02-design-decisions.md``)을 위반한다.
+
+    수정: ``Database.connect()`` 가 실패 연결의 worker thread 를 결정적으로
+    drain(``_drain_failed_conn``)하고, ``_run_authenticate`` 가 connect 실패
+    경로에서도 ``db.close()`` 를 보장한다.
+
+    플랫폼 주의: ``RuntimeError: Event loop is closed`` traceback 의 발생 자체는
+    OS/런타임 thread teardown 타이밍에 의존(Linux/Docker 에서 재현, macOS 에서는
+    드묾). 따라서 본 테스트는 (a) 깨끗한 ``auth_failed`` JSON envelope 와
+    (b) stderr 에 aiosqlite traceback marker 부재를 확인하는 contract 회귀로
+    구성한다. 결정적 worker-thread drain 자체는
+    ``tests/unit/test_database.py`` 의 connect-failure drain 테스트가 보장한다.
+    """
+
+    _AIOSQLITE_NOISE_MARKERS = (
+        "Event loop is closed",
+        "_connection_worker_thread",
+        "Exception in thread",
+        "Traceback (most recent call last)",
+    )
+
+    def test_auth_db_failure_emits_clean_json_without_traceback(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """접근 불가 DB → ``auth_failed`` JSON(stdout) + stderr 청결."""
+        monkeypatch.setenv("ANTE_MEMBER_TOKEN", "sk_stale_invalid")
+        monkeypatch.setenv("ANTE_TOKEN_FILE", str(tmp_path / "no-such-token"))
+        # 존재하지 않는 config_dir → system.toml 없음 → db.path 기본
+        # ``<config_dir>/db/ante.db`` 의 부모 디렉토리가 없어 connect 가
+        # 'unable to open database file' 로 실패한다.
+        missing_dir = tmp_path / "no-such-config-dir"  # mkdir 하지 않음
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "--config-dir",
+                str(missing_dir),
+                "bot",
+                "list",
+            ],
+        )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        # (a) stdout 은 깨끗한 단일 JSON auth_failed envelope.
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "auth_failed", payload
+        assert "인증 실패" in str(payload["message"]), payload
+
+        # (b) stderr 에 aiosqlite traceback noise 가 없어야 한다.
+        for marker in self._AIOSQLITE_NOISE_MARKERS:
+            assert marker not in result.stderr, (
+                f"stderr 에 aiosqlite traceback noise({marker!r}) 가 새어 나옴:\n"
+                f"{result.stderr!r}"
+            )
+
+    def test_auth_db_failure_run_authenticate_drains_failed_connection(
+        self, tmp_path: Path
+    ) -> None:
+        """``_run_authenticate`` 의 connect 실패 경로가 실패 연결을 결정적으로
+        정리한다 (#1965).
+
+        ``_run_authenticate`` 는 자체 ``asyncio.run`` 을 돌리고, connect 실패 시
+        그 안에서 ``Database.connect()`` 가 ``_drain_failed_conn`` 으로 실패 연결의
+        worker thread 를 join 한다. 본 테스트는 그 drain 이 실제로 호출되는지를
+        spy 로 검증한다 — 루프 teardown 타이밍에 의존하지 않는 결정적 회귀.
+
+        수정 전: ``Database`` 에 ``_drain_failed_conn`` 자체가 없고 connect 실패
+        연결을 정리하지 않으므로(worker thread 누수), 이 검증은 성립하지 않는다.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from ante.cli.middleware import _run_authenticate
+        from ante.core.database import Database
+
+        bad_path = str(tmp_path / "no-such-dir" / "ante.db")
+
+        real_drain = Database._drain_failed_conn
+        drain_spy = AsyncMock(side_effect=real_drain)
+        with patch.object(Database, "_drain_failed_conn", drain_spy):
+            with pytest.raises(PermissionError, match="DB 접근 불가"):
+                _run_authenticate("sk_stale_invalid", bad_path)
+
+        assert drain_spy.await_count >= 1, (
+            "connect 실패 연결의 worker thread 가 drain 되지 않음 (#1965)"
+        )
+
+
 # ── scope 부족 분기 (agent + --format json) ─────────────────────────────────
 
 

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -1229,17 +1229,28 @@ class TestInitConfigDirContract:
         assert (target / "secrets.env").exists()
 
 
-class TestInitSystemTomlAbsoluteDbPath:
-    """init이 생성하는 system.toml의 db.path가 절대 경로여야 한다.
+class TestInitSystemTomlRelocatableDbPath:
+    """init이 생성하는 system.toml의 db.path가 **상대 경로**여야 한다 (#1965).
 
-    Codex 12차 리뷰 Finding 2 회귀 — 상대 경로 `db/ante.db`를 그대로 쓰면
-    서버(`ante system start`)와 IPC가 cwd 기준 `./db/ante.db`를 보고,
-    CLI는 `<config_dir>/db/ante.db`를 보아 두 DB가 어긋난다.
+    스펙 SSOT: ``docs/specs/config/03-design-decisions.md:203`` — "ante init은
+    상대 경로 기본값을 기록하고, resolver가 절대 경로로 정규화한다." 같은 문서
+    :213 표는 ``db.path`` 기본값을 ``db/ante.db`` → ``<config_dir>/db/ante.db``로
+    규정한다.
+
+    절대 경로를 baking하면 config 디렉토리를 다른 위치로 복사·마운트
+    (``--config-dir``/``ANTE_CONFIG_DIR``)했을 때 baked된 원본 절대 경로를
+    계속 가리켜 relocatable하지 않다 — 이것이 #1965의 근본 원인이었다
+    (auth가 baked된 ``/opt/ante-config/db/ante.db``를 봄). cwd 독립성은
+    ``Config.load``가 항상 config_dir를 확정·보존하므로 상대 경로로도 유지된다.
+
+    (과거 회귀 노트: Codex 12차 리뷰 Finding 2는 cwd 독립성을 위해 절대 경로를
+    요구했으나, 그 fix는 relocatability를 깨뜨렸다. 올바른 invariant는
+    "상대 db.path + config_dir-anchored resolution"이다 — 스펙 :201-203.)
     """
 
-    def test_system_toml_db_path_is_absolute(self, runner, tmp_path):
-        """fresh init 후 system.toml의 db.path가 `<config>/db/ante.db` 절대 경로."""
-        target = tmp_path / "abs-cfg"
+    def test_system_toml_db_path_is_relative(self, runner, tmp_path):
+        """fresh init 후 system.toml의 db.path가 상대 경로 ``db/ante.db``."""
+        target = tmp_path / "rel-cfg"
 
         patches = _patch_init()
         for p in patches:
@@ -1253,16 +1264,21 @@ class TestInitSystemTomlAbsoluteDbPath:
         assert result.exit_code == 0, result.output
 
         toml_text = (target / "system.toml").read_text()
-        expected = (target / "db" / "ante.db").resolve()
-        assert f'path = "{expected}"' in toml_text, (
-            f"db.path 절대 경로가 system.toml에 없음:\n{toml_text}"
+        # 스펙 :213 기본값 — 상대 경로가 그대로 기록되어야 한다.
+        assert 'path = "db/ante.db"' in toml_text, (
+            f"db.path 상대 경로가 system.toml에 없음:\n{toml_text}"
         )
-        # 더 이상 상대 경로 'db/ante.db' (큰따옴표 포함)가 system.toml에 없어야
-        assert 'path = "db/ante.db"' not in toml_text
+        # baked된 절대 경로는 더 이상 기록되지 않아야 한다 (relocatability).
+        absolute = (target / "db" / "ante.db").resolve()
+        assert f'path = "{absolute}"' not in toml_text, (
+            f"db.path가 여전히 절대 경로로 baked됨:\n{toml_text}"
+        )
 
-    def test_system_toml_db_path_with_root_config_dir(self, runner, tmp_path):
-        """`--config-dir <path> init` 경로에서도 db.path가 절대 경로."""
-        target = tmp_path / "abs-root"
+    def test_system_toml_db_path_with_root_config_dir_is_relative(
+        self, runner, tmp_path
+    ):
+        """``--config-dir <path> init`` 경로에서도 db.path가 상대 경로."""
+        target = tmp_path / "rel-root"
 
         patches = _patch_init()
         for p in patches:
@@ -1275,8 +1291,68 @@ class TestInitSystemTomlAbsoluteDbPath:
 
         assert result.exit_code == 0, result.output
         toml_text = (target / "system.toml").read_text()
-        expected = (target / "db" / "ante.db").resolve()
-        assert f'path = "{expected}"' in toml_text
+        assert 'path = "db/ante.db"' in toml_text, toml_text
+
+    def test_db_dir_still_created(self, runner, tmp_path):
+        """상대 경로 기록과 무관하게 ``<config_dir>/db/`` 디렉토리는 생성된다."""
+        target = tmp_path / "rel-dbdir"
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        assert (target / "db").is_dir(), (
+            "init이 <config_dir>/db/ 디렉토리를 생성해야 함"
+        )
+
+    def test_relative_db_path_relocatable_to_new_config_dir(self, runner, tmp_path):
+        """init한 config를 새 위치로 복사하고 ``--config-dir B``로 가리키면
+        db.path가 ``B/db/ante.db``로 해석된다 (relocatable).
+
+        이것이 #1965의 핵심 회귀 게이트다: 수정 전에는 system.toml에 baked된
+        절대 ``A/db/ante.db``를 계속 봐서 새 위치 B로 옮겨도 A를 가리켰다.
+        """
+        import shutil
+
+        from ante.cli.main import get_db_path
+
+        dir_a = tmp_path / "config-a"
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(dir_a)])
+        finally:
+            for p in patches:
+                p.stop()
+        assert result.exit_code == 0, result.output
+
+        # A를 다른 경로 B로 통째로 복사 (Docker mount/relocate 시나리오 모사).
+        dir_b = tmp_path / "config-b"
+        shutil.copytree(dir_a, dir_b)
+
+        # ctx.obj["config_dir"] = B 인 Click 컨텍스트로 get_db_path 호출.
+        ctx = click.Context(cli)
+        ctx.obj = {"config_dir": dir_b}
+        with ctx:
+            resolved = Path(get_db_path(ctx))
+
+        expected = (dir_b / "db" / "ante.db").resolve()
+        assert resolved.resolve() == expected, (
+            f"relocated config의 db.path가 B로 해석되지 않음:\n"
+            f"  resolved={resolved}\n  expected={expected}\n"
+            f"  (baked 절대 경로 A를 계속 가리키면 #1965 회귀)"
+        )
+        # 옛 위치 A를 가리키지 않아야 한다.
+        assert (dir_a / "db" / "ante.db").resolve() != resolved.resolve(), (
+            "relocated config가 여전히 원본 A 경로를 가리킴 (#1965 회귀)"
+        )
 
 
 class TestInitSystemTomlRuntimeSection:

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -90,6 +90,97 @@ async def test_not_connected_raises():
         await db.execute("SELECT 1")
 
 
+# --- connect 실패 시 aiosqlite worker thread 정리 (#1965) ---
+
+
+def _live_worker_threads() -> list[str]:
+    """살아 있는 aiosqlite worker thread 이름 목록."""
+    import threading
+
+    return [
+        t.name for t in threading.enumerate() if "_connection_worker_thread" in t.name
+    ]
+
+
+async def test_connect_failure_drains_worker_thread_open_error(tmp_path):
+    """``connect()`` 가 'unable to open database file' 로 실패해도 aiosqlite
+    worker thread 가 누수되지 않는다 (#1965).
+
+    근본 원인: ``await aiosqlite.connect`` 는 worker thread 를 먼저 ``start()``
+    한 뒤 ``sqlite3.connect`` 를 큐잉한다. 파일 오픈 실패 시 aiosqlite 가 내부
+    ``stop()`` 의 future 를 폐기하므로, 호출자가 종료를 동기화하지 못한 채
+    ``asyncio.run`` 이 루프를 닫으면 worker 가 닫힌 루프를 건드려 stderr 에
+    ``RuntimeError: Event loop is closed`` traceback 이 남는다. 이는
+    ``--format json`` stderr 청결 계약을 위반한다.
+
+    수정 전: 이 테스트는 connect 실패 직후 worker thread 가 살아 있어 FAIL.
+    """
+    # 존재하지 않는 부모 디렉토리 → 첫(writer) 연결의 sqlite3.connect 가 실패.
+    bad_path = str(tmp_path / "no-such-dir" / "ante.db")
+    db = Database(bad_path)
+
+    before = set(_live_worker_threads())
+    with pytest.raises(Exception, match="unable to open database file"):
+        await db.connect()
+
+    # connect 실패 직후(루프 teardown 이전)에 새 worker thread 가 남아 있으면 안 된다.
+    leaked = set(_live_worker_threads()) - before
+    assert not leaked, (
+        f"connect 실패 후 aiosqlite worker thread 가 누수됨: {leaked} "
+        "(#1965 — _drain_failed_conn 가 join 으로 동기 정리해야 함)"
+    )
+
+
+async def test_connect_failure_drains_worker_thread_pragma_error(tmp_path):
+    """``aiosqlite.connect`` 성공 후 PRAGMA 단계에서 실패해도 worker thread 가
+    누수되지 않는다 (#1965).
+
+    디렉토리를 DB 경로로 주면 ``sqlite3.connect`` 는 lazy 하게 성공하지만 첫
+    PRAGMA 실행에서 'unable to open database file' 이 발생한다. 이 경우
+    연결 객체는 열려 있으므로 ``conn.close()`` 로 worker 가 정리되어야 한다.
+    """
+    db = Database(str(tmp_path))  # tmp_path 는 디렉토리
+
+    before = set(_live_worker_threads())
+    with pytest.raises(Exception, match="unable to open database file"):
+        await db.connect()
+
+    leaked = set(_live_worker_threads()) - before
+    assert not leaked, (
+        f"PRAGMA 실패 후 aiosqlite worker thread 가 누수됨: {leaked} (#1965)"
+    )
+
+
+async def test_connect_partial_failure_closes_writer(tmp_path):
+    """writer 는 열렸으나 reader(2번째 _init_conn) 가 실패하면 이미 열린 writer
+    연결과 그 worker thread 가 ``connect()`` 의 cleanup 으로 정리된다 (#1965)."""
+    db_path = str(tmp_path / "partial.db")
+    db = Database(db_path)
+
+    before = set(_live_worker_threads())
+
+    real_init = Database._init_conn
+    calls = {"n": 0}
+
+    async def init_with_reader_failure(self):  # noqa: ANN001, ANN202
+        calls["n"] += 1
+        if calls["n"] == 2:  # 2번째 호출(reader) 만 실패시킨다.
+            raise RuntimeError("simulated reader init failure")
+        return await real_init(self)
+
+    with patch.object(Database, "_init_conn", init_with_reader_failure):
+        with pytest.raises(RuntimeError, match="simulated reader init failure"):
+            await db.connect()
+
+    # connect 가 부분 성공(writer) 상태를 close 로 정리했어야 한다.
+    assert db._writer is None
+    assert db._reader is None
+    leaked = set(_live_worker_threads()) - before
+    assert not leaked, (
+        f"reader 실패 후 writer worker thread 가 누수됨: {leaked} (#1965)"
+    )
+
+
 # --- 트랜잭션 컨텍스트 매니저 테스트 ---
 
 


### PR DESCRIPTION
Closes #1965

## Summary
`backtest run` 등에서 root `--config-dir`/`ANTE_CONFIG_DIR`로 가리킨 config 디렉토리가 auth DB 경로에 반영되지 않던 문제와, auth 실패 시 stderr로 새던 raw aiosqlite traceback을 수정한다.

- **Axis A — config 디렉토리 relocatable** (`src/ante/cli/commands/init.py`): `ante init`이 system.toml에 **절대** `db.path`를 baking하던 것을 스펙(`docs/specs/config/03-design-decisions.md:203` "ante init은 상대 경로 기본값을 기록")대로 **상대 `db/ante.db`**로 기록한다. `Config.resolve_path`가 이를 `<config_dir>/db/ante.db`로 정규화하므로(cwd 무관), 복사/마운트한 config를 다른 `--config-dir`로 가리켜도 올바른 DB를 본다. 기존 절대-baked config는 무손상(`resolve_path` 절대 passthrough 유지).
- **Axis B — auth aiosqlite leak 차단** (`src/ante/core/database.py`, `src/ante/cli/middleware.py`): `Database.connect()`가 첫 writer 연결 실패(예: `unable to open database file`) 시 aiosqlite worker thread를 leak해, JSON `auth_failed` envelope 출력 **이후** `asyncio.run` 종료 시 `RuntimeError: Event loop is closed` traceback을 stderr에 남기던 것을 차단한다. `_init_conn`/`connect`가 실패 연결의 worker thread를 결정적으로 drain(`_drain_failed_conn`: `close()` + 필요 시 executor에서 `thread.join`). auth 호출부(`_auth`)에 `db.close()` 이중 방어 추가.

## Risk note
`Database.connect()`는 공유 lifecycle(14+ consumer)이나, 변경은 **실패 경로 additive cleanup**이며 성공 경로(writer+reader 생성, close drain)는 불변이다. full `pytest -q` 5812 passed로 전 consumer 회귀 없음을 확인했다.

## Test Plan
- **failing-first**: `tests/unit/test_database.py`(connect-failure worker-thread drain 3종: writer-fail / PRAGMA-fail / reader-fail partial — pre-fix `Thread-1`/`Thread-2` leak 실증), `tests/unit/cli/test_auth_format_json.py`(`auth_failed` JSON envelope + stderr aiosqlite traceback 부재 + `_drain_failed_conn` spy).
- 기존 `tests/unit/test_cli_init.py` `TestInitSystemTomlAbsoluteDbPath`(절대 db.path 단언) → **`TestInitSystemTomlRelocatableDbPath`**(상대 + B로 복사 후 `--config-dir B` → `B/db/ante.db` relocatability 회귀 게이트)로 교체.
- full `python -m pytest -q`: **5812 passed, 2 skipped**. `python -m mypy src/`: **Success (230 files)**. `ruff check`/`format`: clean.
- `Event loop is closed` traceback은 플랫폼 thread-teardown 타이밍 의존(Linux/Docker 재현, macOS 미재현)이라, 결정적 회귀 lock은 worker-thread drain 테스트로 확보.

## Non-Goals (별도)
- 기존 절대-baked config 자동 마이그레이션(신규 init만 상대·relocatable).
- `--config-dir`/`ANTE_CONFIG_DIR` precedence 재설계(`_mirror_root_globals_to_obj`로 이미 정상).

## Review note
Codex 플랜·브랜치 리뷰가 이 환경에서 verifying 단계 stall(2/2)로 완료되지 못해, 오케스트레이터 full-diff self-review(init.py/middleware.py/database.py 직접 검증)로 대체했다. CI required gate가 독립 검증한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
