### PR TITLE
fix(feed): #1968 파생지표 cadence-aware as-of join (다중소스 fundamental null 해소)

### DIFF
--- a/src/ante/feed/pipeline/indicator_calculator.py
+++ b/src/ante/feed/pipeline/indicator_calculator.py
@@ -1,4 +1,25 @@
-"""IndicatorCalculator — PER/PBR/EPS/BPS/ROE/부채비율 파생 지표 계산."""
+"""IndicatorCalculator — PER/PBR/EPS/BPS/ROE/부채비율 파생 지표 계산.
+
+fundamental 데이터는 cadence가 다른 두 소스로 구성된다(#1964):
+
+- data.go.kr(``source == "data_go_kr"``): **일별** ``market_cap`` / ``shares_listed``
+  (DART 재무 컬럼은 null).
+- DART(``source == "dart"``): **분기별** ``net_income`` / ``total_equity`` /
+  ``total_debt`` 등 재무 항목(가격/주식수 컬럼은 null).
+
+`(date, source)` natural key로 두 소스가 **별도 행**으로 보존되므로, 단일 행
+row-wise 계산(예: ``per = market_cap / net_income``)은 한 행에 cross-source
+피연산자가 동시에 존재하지 않아 **모든 지표가 null**이 된다. 이를 해소하기
+위해 source별로 분리한 뒤 **as-of join**으로 결합한다.
+
+semantic(#1968, PR 명문화):
+    net_income / total_equity / total_debt 는 "일별 date 기준 **가장 최근에
+    보고된 분기 재무 값**"(``join_asof(strategy="backward")``)을 사용한다.
+    TTM(trailing-twelve-months) 합산이나 연간환산은 **하지 않는다**(Non-Goal,
+    후속 정제 이슈). 분모가 0/null이면 해당 지표는 null이다
+    (``_ratio_expr`` 가드 유지). 지표는 가격 기반 지표의 자연 단위인 **일별
+    행**(data.go.kr 행)에 부여하여 write-back한다.
+"""
 
 from __future__ import annotations
 
@@ -6,9 +27,41 @@ import logging
 
 import polars as pl
 
+from ante.data.schemas import FUNDAMENTAL_COLUMNS
 from ante.data.store import ParquetStore
 
 logger = logging.getLogger(__name__)
+
+# source별 행 분리 기준 (normalizer가 부여하는 source 문자열 SSOT).
+_DAILY_SOURCE = "data_go_kr"
+_QUARTERLY_SOURCE = "dart"
+
+# as-of join 키.
+_JOIN_KEY = "date"
+
+# DART 분기 행이 기여하는 재무 컬럼 — 6종 비율의 분자/분모 피연산자다
+# (net_income/total_equity/total_debt). as-of join 시 이 컬럼들만 분기
+# 프레임에서 일별 프레임으로 가져온다.
+#
+# 주의(#1968 핵심): `store.read`는 월별 이종 파티션을 `diagonal_relaxed`로
+# union하므로, source로 행을 분리해도 daily/quarterly **양쪽 sub-frame이
+# 동일한 컬럼 union**을 보유한다(상대 소스 컬럼은 null-fill). 따라서 "일별에
+# 없는 컬럼" 같은 동적 판별은 쓸 수 없다(모든 컬럼이 양쪽에 존재). 대신
+# 컬럼의 **provenance(소스 귀속)** 를 명시 상수로 고정해, 일별 프레임에서는
+# 이 재무 컬럼(일별 행에서는 null)을 **버리고**, 분기 프레임에서는 이
+# 컬럼만 join 키와 함께 **가져온다**. 이로써 (1) source/symbol 충돌(_right
+# 중복 누출) 차단, (2) 일별 행의 null 재무가 실제 분기 값을 덮어쓰는 사고
+# 방지.
+_QUARTERLY_FINANCIAL_COLUMNS: tuple[str, ...] = (
+    "net_income",
+    "total_equity",
+    "total_debt",
+)
+
+# write-back 프레임은 FUNDAMENTAL 스키마 부분집합으로 유지한다. DART
+# normalizer가 내보내는 total_assets 등 스키마 밖 컬럼이 read union으로
+# 섞여 들어와도 write 전에 제거한다(스키마 일탈 방지).
+_FUNDAMENTAL_COLUMN_SET = frozenset(FUNDAMENTAL_COLUMNS)
 
 
 class IndicatorCalculator:
@@ -21,6 +74,9 @@ class IndicatorCalculator:
     - BPS = 자본총계 / 상장주식수
     - ROE = 당기순이익 / 자본총계
     - 부채비율 = 부채총계 / 자본총계
+
+    cadence가 다른 두 소스(data.go.kr 일별 / DART 분기)를 as-of join으로
+    결합하여 일별 행에 지표를 부여한다(자세한 semantic은 모듈 docstring).
     """
 
     def compute(
@@ -51,7 +107,13 @@ class IndicatorCalculator:
         store: ParquetStore,
         sym: str,
     ) -> int:
-        """단일 심볼의 파생 지표를 계산한다."""
+        """단일 심볼의 파생 지표를 as-of join으로 계산한다.
+
+        data.go.kr 일별 행에 그 날짜 이전 가장 최근 DART 분기 재무를
+        ``join_asof(strategy="backward")``로 결합한 뒤 비율을 계산하여
+        일별 행을 write-back한다. 두 소스 중 하나라도 비어 있거나
+        source/date 컬럼이 없으면 0을 반환한다(graceful).
+        """
         try:
             fundamental = store.read(sym, "krx", data_type="fundamental")
         except Exception:
@@ -60,13 +122,65 @@ class IndicatorCalculator:
         if fundamental.is_empty():
             return 0
 
-        exprs = self._build_expressions(set(fundamental.columns))
+        cols = set(fundamental.columns)
+        if "source" not in cols or _JOIN_KEY not in cols:
+            return 0
+
+        daily = fundamental.filter(pl.col("source") == _DAILY_SOURCE)
+        quarterly = fundamental.filter(pl.col("source") == _QUARTERLY_SOURCE)
+        if daily.is_empty() or quarterly.is_empty():
+            return 0
+
+        joined = self._join_asof(daily, quarterly)
+        if joined is None:
+            return 0
+
+        exprs = self._build_expressions(set(joined.columns))
         if not exprs:
             return 0
 
-        updated = fundamental.with_columns(exprs)
+        updated = joined.with_columns(exprs)
+        # write-back 전 FUNDAMENTAL 스키마 밖 컬럼(total_assets 등) 제거.
+        keep = [c for c in updated.columns if c in _FUNDAMENTAL_COLUMN_SET]
+        updated = updated.select(keep)
         store.write(sym, "krx", updated, data_type="fundamental")
         return len(updated)
+
+    @staticmethod
+    def _join_asof(
+        daily: pl.DataFrame,
+        quarterly: pl.DataFrame,
+    ) -> pl.DataFrame | None:
+        """일별 프레임에 그 날짜 기준 가장 최근 분기 재무를 as-of 결합한다.
+
+        ``store.read``의 ``diagonal_relaxed`` union 때문에 daily/quarterly
+        sub-frame은 동일한 컬럼 union을 보유한다(상대 소스 컬럼은 null-fill).
+        따라서 컬럼 provenance를 명시 상수로 고정해 결합한다:
+
+        - 일별 프레임에서 ``_QUARTERLY_FINANCIAL_COLUMNS``(일별 행에선 null)를
+          **버려** join 후 분기 값이 null로 덮이지 않게 한다.
+        - 분기 프레임에서는 그 재무 컬럼만 join 키(date)와 함께 **가져온다**.
+
+        결합 결과는 일별 identity(date, symbol, source=data_go_kr,
+        market_cap, shares_listed 등)를 유지하면서 그 날짜 이전 가장 최근
+        분기 재무를 부여받는다. 가져올 분기 재무 컬럼이 하나도 없으면
+        ``None``을 반환한다.
+        """
+        financial_cols = [
+            col for col in _QUARTERLY_FINANCIAL_COLUMNS if col in quarterly.columns
+        ]
+        if not financial_cols:
+            return None
+
+        # 일별 프레임에서 분기 재무 컬럼(null-fill된 잔재)을 제거해 충돌 차단.
+        daily_identity = daily.drop([c for c in financial_cols if c in daily.columns])
+        quarterly_fin = quarterly.select([_JOIN_KEY, *financial_cols])
+
+        return daily_identity.sort(_JOIN_KEY).join_asof(
+            quarterly_fin.sort(_JOIN_KEY),
+            on=_JOIN_KEY,
+            strategy="backward",
+        )
 
     @staticmethod
     def _build_expressions(cols: set[str]) -> list[pl.Expr]:
@@ -107,7 +221,11 @@ def _ratio_expr(
     denominator: str,
     alias: str,
 ) -> pl.Expr:
-    """분모가 0이면 None을 반환하는 나눗셈 표현식."""
+    """분모가 0이면 None을 반환하는 나눗셈 표현식.
+
+    분모가 null(as-of 결합 이전 날짜 등)이면 비교/나눗셈이 null로 전파되어
+    결과도 null이 된다.
+    """
     return (
         pl.when(pl.col(denominator) != 0)
         .then(pl.col(numerator).cast(pl.Float64) / pl.col(denominator).cast(pl.Float64))

--- a/tests/unit/feed/test_indicator_calculator.py
+++ b/tests/unit/feed/test_indicator_calculator.py
@@ -1,0 +1,393 @@
+"""IndicatorCalculator (feed pipeline) — cadence-aware as-of join 단위 테스트.
+
+#1968: data.go.kr 일별(market_cap/shares_listed) + DART 분기(net_income/
+total_equity/total_debt)가 `(date, source)` natural key로 별도 행으로 보존된다
+(#1964). 파생지표는 일별 행에 그 날짜 기준 **가장 최근 보고된 분기 재무**를
+`join_asof(strategy="backward")`로 결합하여 계산한다.
+
+이 모듈은 `ante.feed.pipeline.indicator_calculator.IndicatorCalculator`
+(fundamental 비율 계산기)를 검증한다 — `ante.strategy.indicators`의
+pandas-ta 기술지표 계산기와는 별개다.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from ante.data.schemas import FUNDAMENTAL_COLUMNS
+from ante.data.store import ParquetStore
+from ante.feed.pipeline.indicator_calculator import IndicatorCalculator
+
+SYMBOL = "005930"
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> ParquetStore:
+    """임시 디렉토리 기반 ParquetStore."""
+    return ParquetStore(base_path=tmp_path / "data")
+
+
+def _write_daily(store: ParquetStore, rows: list[dict]) -> None:
+    """data.go.kr 일별 fundamental 행을 기록한다 (재무 컬럼 없음)."""
+    store.write(SYMBOL, "krx", pl.DataFrame(rows), data_type="fundamental")
+
+
+def _write_quarterly(store: ParquetStore, rows: list[dict]) -> None:
+    """DART 분기 fundamental 행을 기록한다 (가격/주식수 컬럼 없음)."""
+    store.write(SYMBOL, "krx", pl.DataFrame(rows), data_type="fundamental")
+
+
+def _daily_rows(store: ParquetStore) -> pl.DataFrame:
+    """저장된 data.go.kr 일별 행을 date순으로 반환한다."""
+    result = store.read(SYMBOL, "krx", data_type="fundamental")
+    return result.filter(pl.col("source") == "data_go_kr").sort("date")
+
+
+def test_indicator_asof_join_non_null(store: ParquetStore) -> None:
+    """일별+분기 혼합 fixture에서 as-of 결합 후 6종 지표가 non-null & 정확하다.
+
+    수정 전(row-wise): 일별 행에 net_income 등이 null이라 모든 지표 null → FAIL.
+    """
+    # data.go.kr 일별 행: Q1 보고(3/31) 이후 두 날짜 (4월/7월).
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 4, 15),
+                "symbol": SYMBOL,
+                "market_cap": 420_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+            {
+                "date": date(2024, 7, 15),
+                "symbol": SYMBOL,
+                "market_cap": 440_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    # DART 분기 행: Q1(3/31), Q2(6/30).
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+            {
+                "date": date(2024, 6, 30),
+                "symbol": SYMBOL,
+                "net_income": 55_000_000_000_000,
+                "total_equity": 310_000_000_000_000,
+                "total_debt": 105_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    rows = IndicatorCalculator().compute(store, [SYMBOL])
+    assert rows == 2
+
+    daily = _daily_rows(store)
+    assert len(daily) == 2
+
+    # 4/15 → as-of Q1(3/31) 재무.
+    apr = daily.filter(pl.col("date") == date(2024, 4, 15)).row(0, named=True)
+    assert apr["per"] is not None
+    assert abs(apr["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
+    assert abs(apr["pbr"] - 420_000_000_000_000 / 300_000_000_000_000) < 1e-9
+    assert abs(apr["eps"] - 50_000_000_000_000 / 5_969_782_550) < 1e-3
+    assert abs(apr["bps"] - 300_000_000_000_000 / 5_969_782_550) < 1e-3
+    assert abs(apr["roe"] - 50_000_000_000_000 / 300_000_000_000_000) < 1e-12
+    assert (
+        abs(apr["debt_to_equity"] - 100_000_000_000_000 / 300_000_000_000_000) < 1e-12
+    )
+
+    # 7/15 → as-of Q2(6/30) 재무 (가장 최근 보고서).
+    jul = daily.filter(pl.col("date") == date(2024, 7, 15)).row(0, named=True)
+    assert abs(jul["per"] - 440_000_000_000_000 / 55_000_000_000_000) < 1e-6
+    assert abs(jul["pbr"] - 440_000_000_000_000 / 310_000_000_000_000) < 1e-9
+    assert abs(jul["roe"] - 55_000_000_000_000 / 310_000_000_000_000) < 1e-12
+    assert (
+        abs(jul["debt_to_equity"] - 105_000_000_000_000 / 310_000_000_000_000) < 1e-12
+    )
+
+
+def test_indicator_asof_boundary_before_first_report_null(store: ParquetStore) -> None:
+    """첫 분기 보고 이전 일별 날짜는 결합할 재무가 없어 지표가 null이다."""
+    # 일별 행: 1/15(Q1 3/31 이전), 4/15(Q1 이후).
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 1, 15),
+                "symbol": SYMBOL,
+                "market_cap": 400_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+            {
+                "date": date(2024, 4, 15),
+                "symbol": SYMBOL,
+                "market_cap": 420_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    IndicatorCalculator().compute(store, [SYMBOL])
+
+    daily = _daily_rows(store)
+
+    # 1/15: 첫 분기 보고(3/31) 이전 → null.
+    jan = daily.filter(pl.col("date") == date(2024, 1, 15)).row(0, named=True)
+    assert jan["per"] is None
+    assert jan["pbr"] is None
+    assert jan["eps"] is None
+    assert jan["bps"] is None
+    assert jan["roe"] is None
+    assert jan["debt_to_equity"] is None
+
+    # 4/15: 분기 보고 이후 → non-null.
+    apr = daily.filter(pl.col("date") == date(2024, 4, 15)).row(0, named=True)
+    assert apr["per"] is not None
+    assert abs(apr["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
+
+
+def test_indicator_zero_denominator_null(store: ParquetStore) -> None:
+    """분모가 0이면 해당 지표가 null이다 (as-of 결합 경로)."""
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 4, 15),
+                "symbol": SYMBOL,
+                "market_cap": 400_000_000_000_000,
+                "shares_listed": 0,  # EPS/BPS 분모 0
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                "symbol": SYMBOL,
+                "net_income": 0,  # PER 분모 0
+                "total_equity": 0,  # PBR/ROE/부채비율 분모 0
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    IndicatorCalculator().compute(store, [SYMBOL])
+
+    row = _daily_rows(store).row(0, named=True)
+    assert row["per"] is None
+    assert row["pbr"] is None
+    assert row["eps"] is None
+    assert row["bps"] is None
+    assert row["roe"] is None
+    assert row["debt_to_equity"] is None
+
+
+def test_indicator_null_denominator_null(store: ParquetStore) -> None:
+    """분기 재무 일부가 null이면 그 분모를 쓰는 지표만 null이 된다."""
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 4, 15),
+                "symbol": SYMBOL,
+                "market_cap": 400_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    # net_income은 보고됐으나 total_equity는 null인 분기.
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": None,  # PBR/ROE/부채비율 분모 null
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    IndicatorCalculator().compute(store, [SYMBOL])
+
+    row = _daily_rows(store).row(0, named=True)
+    # net_income 기반: PER/EPS 산출.
+    assert abs(row["per"] - 400_000_000_000_000 / 50_000_000_000_000) < 1e-6
+    assert abs(row["eps"] - 50_000_000_000_000 / 5_969_782_550) < 1e-3
+    # total_equity null → PBR/ROE/BPS/부채비율 null.
+    assert row["pbr"] is None
+    assert row["roe"] is None
+    assert row["bps"] is None
+    assert row["debt_to_equity"] is None
+
+
+def test_indicator_only_daily_source_returns_zero(store: ParquetStore) -> None:
+    """DART 분기 소스가 없으면 graceful하게 0 반환 (지표 미부여)."""
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 4, 15),
+                "symbol": SYMBOL,
+                "market_cap": 400_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+
+    rows = IndicatorCalculator().compute(store, [SYMBOL])
+    assert rows == 0
+
+
+def test_indicator_only_quarterly_source_returns_zero(store: ParquetStore) -> None:
+    """data.go.kr 일별 소스가 없으면 graceful하게 0 반환."""
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    rows = IndicatorCalculator().compute(store, [SYMBOL])
+    assert rows == 0
+
+
+def test_indicator_no_data_returns_zero(store: ParquetStore) -> None:
+    """fundamental 데이터가 전혀 없으면 0을 반환한다."""
+    rows = IndicatorCalculator().compute(store, ["999999"])
+    assert rows == 0
+
+
+def test_indicator_writeback_within_fundamental_schema(store: ParquetStore) -> None:
+    """write-back된 일별 행은 FUNDAMENTAL 스키마 부분집합이다.
+
+    DART normalizer가 내보내는 스키마 밖 컬럼(total_assets 등)이 read union으로
+    섞여도, 일별 write-back 프레임에는 누출되지 않아야 한다.
+    """
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 4, 15),
+                "symbol": SYMBOL,
+                "market_cap": 420_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    # 분기 행에 스키마 밖 컬럼(total_assets) 포함.
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "total_assets": 400_000_000_000_000,  # 스키마 밖
+                "source": "dart",
+            },
+        ],
+    )
+
+    IndicatorCalculator().compute(store, [SYMBOL])
+
+    # 일별 행이 들어간 파티션 파일을 직접 검사 → 스키마 밖 컬럼 없어야 함.
+    daily_path = store.resolve_path(SYMBOL, "krx", data_type="fundamental")
+    schema_set = set(FUNDAMENTAL_COLUMNS)
+    daily_partition = daily_path / "2024-04.parquet"
+    assert daily_partition.exists()
+    written = pl.read_parquet(daily_partition)
+    assert set(written.columns).issubset(schema_set), (
+        f"일별 write-back에 스키마 밖 컬럼 누출: {set(written.columns) - schema_set}"
+    )
+    assert written["source"].to_list() == ["data_go_kr"]
+
+
+def test_indicator_idempotent_recompute(store: ParquetStore) -> None:
+    """반복 compute해도 행 수가 폭증하지 않는다 ((date,source) keep=last 멱등)."""
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 4, 15),
+                "symbol": SYMBOL,
+                "market_cap": 420_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    calc = IndicatorCalculator()
+    calc.compute(store, [SYMBOL])
+    first = store.read(SYMBOL, "krx", data_type="fundamental")
+    calc.compute(store, [SYMBOL])
+    second = store.read(SYMBOL, "krx", data_type="fundamental")
+
+    assert len(second) == len(first)
+    # 지표 값도 안정적.
+    apr_first = first.filter(pl.col("source") == "data_go_kr").row(0, named=True)
+    apr_second = second.filter(pl.col("source") == "data_go_kr").row(0, named=True)
+    assert apr_first["per"] == apr_second["per"]

--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -404,37 +404,53 @@ async def test_concurrent_run_blocked(
 
 @pytest.mark.asyncio
 async def test_compute_derived_indicators(tmp_data_path: Path) -> None:
-    """PER/PBR/EPS/BPS/ROE/부채비율이 올바르게 계산된다."""
+    """PER/PBR/EPS/BPS/ROE/부채비율이 cadence-aware as-of join으로 계산된다.
+
+    #1968: data.go.kr 일별(market_cap/shares_listed) + DART 분기(net_income/
+    total_equity/total_debt)가 `(date, source)` 키로 별도 행으로 보존되므로,
+    지표는 일별 행에 그 날짜 기준 가장 최근 분기 재무를 as-of 결합해 계산된다.
+    """
     store = ParquetStore(base_path=tmp_data_path)
 
-    # fundamental 데이터 준비
-    fundamental_df = pl.DataFrame(
+    # data.go.kr 일별 행 (분기 보고 이후 날짜) — 재무 컬럼은 null.
+    daily_df = pl.DataFrame(
         {
             "date": [date(2024, 12, 31)],
             "symbol": ["005930"],
             "market_cap": [400_000_000_000_000],
             "shares_listed": [5_969_782_550],
+            "source": ["data_go_kr"],
+        }
+    )
+    # DART 분기 행 (분기말) — 가격/주식수 컬럼은 null.
+    quarterly_df = pl.DataFrame(
+        {
+            "date": [date(2024, 9, 30)],
+            "symbol": ["005930"],
             "net_income": [50_000_000_000_000],
             "total_equity": [300_000_000_000_000],
             "total_debt": [100_000_000_000_000],
-            "source": ["test"],
+            "source": ["dart"],
         }
     )
 
-    store.write("005930", "krx", fundamental_df, data_type="fundamental")
+    store.write("005930", "krx", daily_df, data_type="fundamental")
+    store.write("005930", "krx", quarterly_df, data_type="fundamental")
 
     calculator = IndicatorCalculator()
     rows = calculator.compute(store, ["005930"])
 
     assert rows > 0
 
-    # 결과 읽기
+    # 결과 읽기 — 지표는 일별(data_go_kr) 행에 부여된다.
     result = store.read("005930", "krx", data_type="fundamental")
     assert not result.is_empty()
 
-    row = result.row(0, named=True)
+    daily = result.filter(pl.col("source") == "data_go_kr")
+    assert len(daily) == 1
+    row = daily.row(0, named=True)
 
-    # PER = 시가총액 / 순이익
+    # PER = 시가총액 / 순이익 (as-of 2024-09-30 분기 재무)
     expected_per = 400_000_000_000_000 / 50_000_000_000_000
     assert abs(row["per"] - expected_per) < 0.01
 
@@ -461,29 +477,37 @@ async def test_compute_derived_indicators(tmp_data_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_compute_derived_zero_division(tmp_data_path: Path) -> None:
-    """분모가 0이면 파생 지표가 None이 된다."""
+    """분모가 0이면 파생 지표가 None이 된다 (#1968 as-of join 경로)."""
     store = ParquetStore(base_path=tmp_data_path)
 
-    fundamental_df = pl.DataFrame(
+    daily_df = pl.DataFrame(
         {
             "date": [date(2024, 12, 31)],
             "symbol": ["005930"],
             "market_cap": [400_000_000_000_000],
-            "shares_listed": [0],  # 0으로 나누기
-            "net_income": [0],  # 0으로 나누기
-            "total_equity": [0],  # 0으로 나누기
+            "shares_listed": [0],  # 0으로 나누기 (EPS/BPS 분모)
+            "source": ["data_go_kr"],
+        }
+    )
+    quarterly_df = pl.DataFrame(
+        {
+            "date": [date(2024, 9, 30)],
+            "symbol": ["005930"],
+            "net_income": [0],  # 0으로 나누기 (PER 분모)
+            "total_equity": [0],  # 0으로 나누기 (PBR/ROE/부채비율 분모)
             "total_debt": [100_000_000_000_000],
-            "source": ["test"],
+            "source": ["dart"],
         }
     )
 
-    store.write("005930", "krx", fundamental_df, data_type="fundamental")
+    store.write("005930", "krx", daily_df, data_type="fundamental")
+    store.write("005930", "krx", quarterly_df, data_type="fundamental")
 
     calculator = IndicatorCalculator()
     calculator.compute(store, ["005930"])
 
     result = store.read("005930", "krx", data_type="fundamental")
-    row = result.row(0, named=True)
+    row = result.filter(pl.col("source") == "data_go_kr").row(0, named=True)
 
     # 분모 0이면 None
     assert row["per"] is None
@@ -496,26 +520,30 @@ async def test_compute_derived_zero_division(tmp_data_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_compute_derived_missing_columns(tmp_data_path: Path) -> None:
-    """필수 컬럼이 없으면 해당 지표를 건너뛴다."""
+    """분기(DART) 소스가 없으면 graceful하게 0을 반환한다 (#1968).
+
+    data.go.kr 일별 행만 있고 DART 분기 행이 없으면, as-of 결합 대상이 없으므로
+    지표를 부여하지 않고 0을 반환한다(에러 없이).
+    """
     store = ParquetStore(base_path=tmp_data_path)
 
-    # market_cap만 있고 net_income 등이 없는 경우
-    fundamental_df = pl.DataFrame(
+    # data.go.kr 일별 행만 존재 (DART 분기 행 없음).
+    daily_df = pl.DataFrame(
         {
             "date": [date(2024, 12, 31)],
             "symbol": ["005930"],
             "market_cap": [400_000_000_000_000],
             "shares_listed": [5_969_782_550],
-            "source": ["test"],
+            "source": ["data_go_kr"],
         }
     )
 
-    store.write("005930", "krx", fundamental_df, data_type="fundamental")
+    store.write("005930", "krx", daily_df, data_type="fundamental")
 
     calculator = IndicatorCalculator()
-    # 에러 없이 실행되어야 함
+    # 에러 없이 실행되고, 분기 소스 부재로 0을 반환해야 함.
     rows = calculator.compute(store, ["005930"])
-    assert rows >= 0
+    assert rows == 0
 
 
 # ── DART 수집 테스트 ─────────────────────────────────────


### PR DESCRIPTION
Closes #1968

## Summary
파생지표(PER/PBR/EPS/BPS/ROE/부채비율)가 `#1964` 이후 다중소스 fundamental에서 **모두 null**로 계산되던 문제를 cadence-aware **as-of join**으로 해소한다.

- **원인**: `IndicatorCalculator._compute_symbol`이 row-wise 계산(`per = market_cap / net_income`)인데, `#1964` 이후 data.go.kr 일별 행(`market_cap`/`shares_listed`)과 DART 분기 행(`net_income`/`total_equity`/`total_debt`)이 `(date, source)` natural key로 **별도 행**으로 보존돼 한 행에 cross-source 피연산자가 없어 전부 null.
- **수정** (`src/ante/feed/pipeline/indicator_calculator.py`): `_compute_symbol`을 source 분리 → `daily.join_asof(quarterly, on="date", strategy="backward")`(일별 행에 그 날짜 이전 가장 최근 분기 재무 결합) → 기존 `_build_expressions`/`_ratio_expr` 재사용 → FUNDAMENTAL 스키마 부분집합으로 일별 행 write-back. 지표는 가격 기반 지표의 자연 단위인 **일별 행**에 부여.
- **semantic**(PR 명문화): `net_income`/`total_equity`/`total_debt` = "일별 date 기준 가장 최근 보고된 분기 재무 값"(`strategy="backward"`). TTM/연간환산은 **Non-Goal**(후속). 분모 0/null → null.

## 컬럼 충돌 처리 (구현 핵심)
`ParquetStore.read`가 월별 이종 파티션을 `diagonal_relaxed`로 union하므로, source로 행을 분리해도 daily/quarterly sub-frame이 동일 컬럼 union(상대 소스 컬럼 null-fill)을 보유한다. 따라서 분기 재무 컬럼의 **provenance를 명시 상수**(`_QUARTERLY_FINANCIAL_COLUMNS = (net_income, total_equity, total_debt)`)로 고정 — 일별에선 그 null 컬럼 drop, 분기에선 join 키와 함께만 select — 해 `_right` 충돌과 "일별 null이 분기 값을 덮는" 사고를 차단한다. write-back은 `FUNDAMENTAL_COLUMNS` 부분집합으로 제한(DART 행의 `total_assets` 등은 별도 행이라 무영향).

## Scope / 미소비 현황
- 파생지표 컬럼은 `schemas.py`에 정의·저장되나 **현재 읽는 내부 소비자 없음**(grep 확인) — 회귀가 아닌 정확성 debt 해소. ParquetStore/`(date,source)` 저장 모델·DART 행 스키마는 불변.

## Test Plan
- **failing-first**: `tests/unit/feed/test_indicator_calculator.py`(신규 8케이스: as-of non-null & 정확값 / as-of 경계 null / 0·null 분모 null / 단일소스 graceful 0 / no-data 0 / 스키마 무누출 / 멱등 recompute). 수정 전 핵심 5케이스 FAIL → 후 green.
- `tests/unit/feed/test_orchestrator.py`: 기존 row-wise 가정 3종 갱신.
- full `python -m pytest -q`: **5821 passed, 2 skipped**. `python -m mypy src/`: **Success (230 files)**. `ruff check`/`format`: clean.

## Review note
Codex 플랜·브랜치 리뷰가 동일 세션에서 verifying 단계 stall(2/2)로 완료되지 못해 오케스트레이터 full-diff self-review로 대체. CI required gate가 독립 검증한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
