### PR TITLE
fix(feed): #1972 backfill 가드 분리 — blocked_days skip / blocked_hours 대기(+취소·관측성)

### DIFF
--- a/docs/specs/data-feed/07-execution-modes.md
+++ b/docs/specs/data-feed/07-execution-modes.md
@@ -38,7 +38,10 @@ ante feed run backfill
   ├─ 날짜 범위 결정 (체크포인트 이후 ~ 오늘)
   │
   ├─ [날짜별 루프]
-  │   ├─ 방어 가드 (blocked_days/blocked_hours) → 해당 시 대기
+  │   ├─ 방어 가드
+  │   │   ├─ blocked_days(해당 날짜 요일) → 해당 날짜 skip (비거래일, 데이터 없음)
+  │   │   └─ blocked_hours(pause_during_trading, 현재 시각) → 해당 시 대기 후 resume
+  │   │       (대기 상한 초과 또는 SIGTERM 중단 시 체크포인트 저장 + config_error로 종료)
   │   ├─ 일일 한도 확인 → 도달 시 체크포인트 저장 후 종료
   │   │
   │   ├─ Extract: API 호출 (전종목 조회, 페이지네이션)

--- a/src/ante/feed/cli_scheduler.py
+++ b/src/ante/feed/cli_scheduler.py
@@ -58,7 +58,9 @@ async def run_scheduler_loop(
             daily_ran_today = True
 
         if not backfill_ran_today and current_time >= str(backfill_at):
-            await _run_backfill_job(orchestrator, data_path, config, current_date)
+            await _run_backfill_job(
+                orchestrator, data_path, config, current_date, stop_event
+            )
             backfill_ran_today = True
 
         await _wait_or_stop(stop_event, timeout=60.0)
@@ -113,21 +115,33 @@ async def _run_backfill_job(
     data_path: str,
     config: dict[str, Any],
     current_date: str,
+    stop_event: asyncio.Event | None = None,
 ) -> None:
     """Backfill 수집 작업을 1회 실행한다.
 
     `result.config_errors`에 coded date error(CLI_INVALID_DATE /
-    INVALID_DATE_RANGE)가 포함된 경우 "Backfill 완료" 메시지를 출력하지
-    않고 명시 오류를 echo/log한다. 기존 비날짜 config_errors(소스 누락·
-    lock 경합·rate-limit 등)는 현행 완료 메시지 흐름을 유지한다.
+    INVALID_DATE_RANGE / GUARD_PERMANENTLY_BLOCKED /
+    BACKFILL_STOP_REQUESTED)가 포함된 경우 "Backfill 완료" 메시지를
+    출력하지 않고 명시 오류/중단을 echo/log한다. 기존 비날짜
+    config_errors(소스 누락·lock 경합·rate-limit 등)는 현행 완료 메시지
+    흐름을 유지한다.
+
+    ``stop_event`` 는 상주 스케줄러 루프가 보유한 종료 이벤트로, 거래시간
+    가드 대기 중 SIGTERM/SIGINT 수신 시 backfill 루프를 깨워 안전 종료
+    시키기 위해 ``orchestrator.run_backfill`` 로 전파한다(#1972). 직접
+    호출(테스트 등)에서는 ``None`` 이며 one-shot 의미로 동작한다.
     """
-    from ante.feed.pipeline.backfill_runner import BACKFILL_DATE_ERROR_CODES
+    from ante.feed.pipeline.backfill_runner import (
+        BACKFILL_DATE_ERROR_CODES,
+        CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED,
+    )
 
     logger.info("Backfill 수집 시작 (%s)", current_date)
     try:
         result = await orchestrator.run_backfill(
             data_path=Path(data_path),
             config=config,
+            stop_event=stop_event,
         )
         coded_date_errors = [
             entry
@@ -139,13 +153,21 @@ async def _run_backfill_job(
             for entry in coded_date_errors:
                 code = entry.get("code")
                 message = entry.get("error", "")
+                # stop_event 중단은 "중단", 그 외 coded error(미래/형식 오류·
+                # 가드 영구차단)는 "차단"으로 구분해 echo/log한다.
+                label = (
+                    "중단"
+                    if code == CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED
+                    else "차단"
+                )
                 logger.error(
-                    "Backfill 차단 (%s): code=%s, error=%s",
+                    "Backfill %s (%s): code=%s, error=%s",
+                    label,
                     current_date,
                     code,
                     message,
                 )
-                click.echo(f"[{current_date}] Backfill 차단: {code} — {message}")
+                click.echo(f"[{current_date}] Backfill {label}: {code} — {message}")
             return
         click.echo(
             f"[{current_date}] Backfill 완료: "

--- a/src/ante/feed/pipeline/backfill_runner.py
+++ b/src/ante/feed/pipeline/backfill_runner.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
+from collections.abc import Callable
 from datetime import UTC, date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -44,14 +46,36 @@ _BACKFILL_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 CONFIG_ERROR_CODE_INVALID_DATE = "CLI_INVALID_DATE"
 CONFIG_ERROR_CODE_INVALID_DATE_RANGE = "INVALID_DATE_RANGE"
 
+# 거래시간 가드(`blocked_hours`+`pause_during_trading`) 대기 관련 coded
+# config_error 코드 (#1972). backfill 날짜별 루프가 거래시간 window 안에서
+# 대기하다가, 누적 대기가 상한(MAX_GUARD_WAIT_SECONDS)을 넘으면
+# ``GUARD_PERMANENTLY_BLOCKED`` 를, 상주 스케줄러 stop_event로 대기가
+# 중단되면 ``BACKFILL_STOP_REQUESTED`` 를 result.config_errors에 적재한다.
+# 둘 다 mid-range partial 종료를 관측 가능하게 만드는 마커이며
+# (clean-success 차단), BACKFILL_DATE_ERROR_CODES에 포함되어 CLI exit-1 /
+# daemon 차단 echo 경로를 그대로 탄다.
+CONFIG_ERROR_CODE_GUARD_PERMANENTLY_BLOCKED = "GUARD_PERMANENTLY_BLOCKED"
+CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED = "BACKFILL_STOP_REQUESTED"
+
 # 신설 coded config_errors의 코드 집합. CLI/scheduler에서 이 집합으로만
 # 새 envelope/차단 분기를 trigger한다 (기존 비날짜 entries 보존).
 BACKFILL_DATE_ERROR_CODES = frozenset(
     {
         CONFIG_ERROR_CODE_INVALID_DATE,
         CONFIG_ERROR_CODE_INVALID_DATE_RANGE,
+        CONFIG_ERROR_CODE_GUARD_PERMANENTLY_BLOCKED,
+        CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED,
     }
 )
+
+# 거래시간 가드 대기 폴링 주기/상한 (초). 모듈 상수 — `[guard]` 스키마
+# 확장 없이 고정값으로 둔다(#1972 Non-Goal). 테스트는 이 상수들을
+# patch/주입해 시간 비의존(결정적)으로 검증한다.
+GUARD_WAIT_POLL_SECONDS = 60.0
+# 상한은 하루를 충분히 넘긴다(거래시간 window가 자정 안에 끝나면 그날
+# 안에 반드시 해제되므로, 정상 운영에서는 도달하지 않는다). 도달은
+# 설정 오류(예: 24시간 전체 차단)를 의미한다.
+MAX_GUARD_WAIT_SECONDS = 26 * 60 * 60.0
 
 # `today`는 KST 캘린더 기준으로 산출한다. backfill_since는 거래일 단위
 # 날짜이며 cli_scheduler도 KST(UTC+9)로 동작한다(see cli_scheduler.KST).
@@ -141,13 +165,26 @@ class BackfillRunner:
         config: dict[str, Any],
         feed_dir: Path,
         started_at: datetime,
-        is_blocked: Any,
+        is_blocked_day: Callable[[dict[str, Any], str], bool],
+        is_trading_paused: Callable[[dict[str, Any]], bool],
+        stop_event: asyncio.Event | None = None,
     ) -> CollectionResult:
         """Backfill 내부 구현. data.go.kr + DART 수집 후 지표 계산.
 
         backfill_since strict 검증은 수렴점이므로 수집 메서드 진입 전
         가장 먼저 수행한다. malformed/future일 때는 체크포인트·소스
         접근 없이 coded config_error만 담은 result를 즉시 반환한다.
+
+        가드는 두 술어로 분리되어 주입된다 (#1972):
+            ``is_blocked_day(config, target_date)`` — ``blocked_days``
+            (target_date 요일). 해당 날짜는 데이터가 없어 **skip**.
+            ``is_trading_paused(config)`` — ``blocked_hours`` +
+            ``pause_during_trading`` (현재 시각). 해당 시 window가 풀릴
+            때까지 **대기 후** 그 날짜를 수집한다.
+
+        ``stop_event`` 가 주어지면(상주 스케줄러) 거래시간 대기 중
+        SIGTERM/SIGINT로 깨어나 체크포인트를 저장한 partial을 반환하며
+        ``BACKFILL_STOP_REQUESTED`` 마커를 적재한다.
         """
         # strict 날짜 검증을 가장 먼저 수행해 malformed/future config가
         # checkpoint/소스/지표 어디에도 도달하지 않도록 한다.
@@ -183,7 +220,9 @@ class BackfillRunner:
             store,
             ohlcv_checkpoint,
             ctx,
-            is_blocked,
+            is_blocked_day,
+            is_trading_paused,
+            stop_event,
         )
         ctx.warnings.extend(store.drain_warnings())
         await self._collect_dart(
@@ -273,16 +312,37 @@ class BackfillRunner:
         store: ParquetStore,
         checkpoint: Checkpoint,
         ctx: _RunContext,
-        is_blocked: Any,
+        is_blocked_day: Callable[[dict[str, Any], str], bool],
+        is_trading_paused: Callable[[dict[str, Any]], bool],
+        stop_event: asyncio.Event | None,
     ) -> None:
-        """data.go.kr 날짜별 수집을 실행한다."""
+        """data.go.kr 날짜별 수집을 실행한다.
+
+        가드 분리 (#1972):
+            - ``is_blocked_day`` 가 True인 비거래 요일은 **skip**한다
+              (그 과거 날짜는 데이터가 없어 대기해도 영원히 안 채워짐).
+            - 그 외 날짜는 ``is_trading_paused`` 가 풀릴 때까지 **대기한 뒤**
+              수집한다(window가 지나면 데이터는 존재).
+        """
         if self._data_go_kr is None:
             return
 
         for target_date in dates:
-            if is_blocked(config, target_date):
-                logger.debug("방어 가드: %s 스킵", target_date)
+            if is_blocked_day(config, target_date):
+                logger.debug("방어 가드(blocked_days): %s 스킵", target_date)
                 continue
+
+            # 거래시간 가드가 활성이면 풀릴 때까지 대기한다. 대기가 stop_event
+            # 또는 max-wait 상한으로 중단되면 체크포인트만 저장된 partial로
+            # 루프를 빠져나간다(관측 가능한 coded marker 적재).
+            should_stop = await self._wait_out_trading_pause(
+                config,
+                is_trading_paused,
+                stop_event,
+                ctx,
+            )
+            if should_stop:
+                break
 
             try:
                 written, syms, warns = await self._data_go_kr.collect(
@@ -316,6 +376,85 @@ class BackfillRunner:
                         "reason": str(exc),
                     }
                 )
+
+    async def _wait_out_trading_pause(
+        self,
+        config: dict[str, Any],
+        is_trading_paused: Callable[[dict[str, Any]], bool],
+        stop_event: asyncio.Event | None,
+        ctx: _RunContext,
+    ) -> bool:
+        """거래시간 가드(``blocked_hours``)가 풀릴 때까지 대기한다.
+
+        ``is_trading_paused(config)`` 가 True인 동안 ``GUARD_WAIT_POLL_SECONDS``
+        주기로 폴링한다.
+
+        - 상주 스케줄러(``stop_event`` 주어짐): ``asyncio.wait_for`` 로 poll
+          만큼 대기하되 stop_event가 set되면 즉시 깨어난다(SIGTERM 안전종료).
+        - one-shot(``stop_event=None``): ``asyncio.sleep`` 로 대기하며,
+          ``asyncio.run`` 의 SIGINT가 task를 취소해 중단할 수 있다.
+
+        Returns:
+            ``True``  — stop_event 또는 max-wait 상한으로 대기가 중단됨.
+                루프는 즉시 break하고 체크포인트만 저장된 partial을 반환한다.
+                (각각 ``BACKFILL_STOP_REQUESTED`` /
+                ``GUARD_PERMANENTLY_BLOCKED`` coded marker가 적재됨.)
+            ``False`` — 가드가 풀려 정상적으로 해당 날짜를 수집할 수 있음.
+        """
+        waited = 0.0
+        first_log = True
+
+        while is_trading_paused(config):
+            # 대기 진입 직전에 stop이 이미 요청되었으면 즉시 중단한다.
+            if stop_event is not None and stop_event.is_set():
+                logger.info("Backfill 중단 요청 수신, 거래시간 대기 종료")
+                ctx.config_errors.append(
+                    {
+                        "code": CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED,
+                        "error": "중단 요청으로 backfill 거래시간 대기를 종료했습니다",
+                        "source": "data_go_kr",
+                    }
+                )
+                return True
+
+            if waited >= MAX_GUARD_WAIT_SECONDS:
+                logger.error(
+                    "거래시간 가드 대기 상한(%.0fs) 초과 — backfill 중단",
+                    MAX_GUARD_WAIT_SECONDS,
+                )
+                ctx.config_errors.append(
+                    {
+                        "code": CONFIG_ERROR_CODE_GUARD_PERMANENTLY_BLOCKED,
+                        "error": (
+                            "거래시간 가드(blocked_hours)가 대기 상한"
+                            f"({MAX_GUARD_WAIT_SECONDS:.0f}s)을 초과해 해제되지 "
+                            "않았습니다. blocked_hours 설정을 확인하세요"
+                        ),
+                        "source": "data_go_kr",
+                    }
+                )
+                return True
+
+            if first_log:
+                logger.info("방어 가드(blocked_hours): 거래시간 종료까지 대기")
+                first_log = False
+
+            if stop_event is not None:
+                # stop set 시 즉시 깨어난다. 그 외에는 poll만큼 대기 후 재확인.
+                try:
+                    await asyncio.wait_for(
+                        stop_event.wait(),
+                        timeout=GUARD_WAIT_POLL_SECONDS,
+                    )
+                except TimeoutError:
+                    pass
+            else:
+                # one-shot: asyncio.run SIGINT가 이 sleep을 취소해 중단 가능.
+                await asyncio.sleep(GUARD_WAIT_POLL_SECONDS)
+
+            waited += GUARD_WAIT_POLL_SECONDS
+
+        return False
 
     async def _collect_dart(
         self,

--- a/src/ante/feed/pipeline/backfill_runner.py
+++ b/src/ante/feed/pipeline/backfill_runner.py
@@ -447,11 +447,24 @@ class BackfillRunner:
                         timeout=GUARD_WAIT_POLL_SECONDS,
                     )
                 except TimeoutError:
-                    pass
-            else:
-                # one-shot: asyncio.run SIGINT가 이 sleep을 취소해 중단 가능.
-                await asyncio.sleep(GUARD_WAIT_POLL_SECONDS)
+                    # poll 경과(stop 미수신) — window/상한을 루프 top에서 재확인.
+                    waited += GUARD_WAIT_POLL_SECONDS
+                    continue
+                # TimeoutError 아님 ⇒ wait 도중 stop_event가 set됨 ⇒ 즉시 중단.
+                # 같은 사이클에 거래시간 window가 동시에 풀려 while 재평가가
+                # False가 되더라도 그 race를 통과시키지 않고 stop을 우선한다.
+                logger.info("Backfill 중단 요청 수신, 거래시간 대기 종료")
+                ctx.config_errors.append(
+                    {
+                        "code": CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED,
+                        "error": "중단 요청으로 backfill 거래시간 대기를 종료했습니다",
+                        "source": "data_go_kr",
+                    }
+                )
+                return True
 
+            # one-shot: asyncio.run SIGINT가 이 sleep을 취소해 중단 가능.
+            await asyncio.sleep(GUARD_WAIT_POLL_SECONDS)
             waited += GUARD_WAIT_POLL_SECONDS
 
         return False

--- a/src/ante/feed/pipeline/orchestrator.py
+++ b/src/ante/feed/pipeline/orchestrator.py
@@ -6,6 +6,7 @@ lock 관리, 방어 가드, 리포트 생성만 담당한다.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from datetime import UTC, date, datetime, timedelta, timezone
@@ -75,6 +76,7 @@ class FeedOrchestrator:
         self,
         data_path: Path,
         config: dict[str, Any],
+        stop_event: asyncio.Event | None = None,
     ) -> CollectionResult:
         """과거 데이터 대량 수집 (backfill 모드).
 
@@ -82,6 +84,12 @@ class FeedOrchestrator:
         수행한다. malformed/future일 때는 lock 파일을 만들지 않고
         coded config_error만 담은 결과를 즉시 반환한다(체크포인트·소스
         진입 차단).
+
+        ``stop_event`` 는 상주 스케줄러(``feed start``)가 SIGTERM/SIGINT
+        수신 시 거래시간 대기 중인 backfill 루프를 깨워 안전 종료시키기
+        위해 전달한다. one-shot(``feed run backfill``)은 ``None`` 이며,
+        이 경우 대기는 ``asyncio.sleep`` 로 동작해 ``asyncio.run`` 의
+        SIGINT 취소로 중단된다.
         """
         feed_dir = data_path / ".feed"
         started_at = datetime.now(tz=UTC)
@@ -112,7 +120,9 @@ class FeedOrchestrator:
                 config,
                 feed_dir,
                 started_at,
-                self._is_blocked,
+                self._is_blocked_day,
+                self._is_trading_paused,
+                stop_event=stop_event,
             )
             self._save_report(data_path, feed_dir, result, "backfill")
             return result
@@ -156,35 +166,72 @@ class FeedOrchestrator:
             self._release_lock(feed_dir)
 
     # ── 방어 가드 ─────────────────────────────────────────
+    #
+    # 가드는 의미가 다른 두 축으로 분리한다 (#1972):
+    #   - ``_is_blocked_day``  : ``blocked_days``. **target_date 기반**.
+    #     과거 특정 요일(예: 주말)은 데이터가 없어 영원히 채워지지 않으므로
+    #     backfill 루프는 해당 날짜를 **skip** 해야 한다(대기하면 그 날짜의
+    #     요일은 절대 안 바뀌어 무한 hang).
+    #   - ``_is_trading_paused`` : ``pause_during_trading`` + ``blocked_hours``.
+    #     **현재 시각(KST) 기반**. 거래시간 동안 API 부하를 피하려는 의도이며
+    #     window가 지나면 데이터는 존재하므로 backfill 루프는 **대기 후
+    #     resume** 해야 한다.
+    # ``_is_blocked`` 는 두 축의 OR 합성으로 동작을 보존한다 — daily_runner는
+    # 이 결합 술어를 그대로 사용한다(무변경).
 
     @staticmethod
-    def _is_blocked(config: dict[str, Any], target_date: str) -> bool:
-        """방어 가드 조건을 확인한다."""
+    def _is_blocked_day(config: dict[str, Any], target_date: str) -> bool:
+        """``blocked_days`` 가드 — target_date의 요일 기반.
+
+        해당 요일이면 ``True`` (그 과거 날짜는 데이터가 없어 skip 대상).
+        """
         guard = config.get("guard", {})
-
         blocked_days = guard.get("blocked_days", [])
-        if blocked_days:
-            d = date.fromisoformat(target_date)
-            day_names = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
-            current_day = day_names[d.weekday()]
-            if current_day in [bd.lower() for bd in blocked_days]:
-                return True
+        if not blocked_days:
+            return False
 
+        d = date.fromisoformat(target_date)
+        day_names = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+        current_day = day_names[d.weekday()]
+        return current_day in [bd.lower() for bd in blocked_days]
+
+    @staticmethod
+    def _is_trading_paused(config: dict[str, Any]) -> bool:
+        """``pause_during_trading`` + ``blocked_hours`` 가드 — 현재 시각 기반.
+
+        현재 KST 시각이 거래시간 window 안에 있으면 ``True`` (대기 대상).
+        midnight-spanning window(예: "23:00-02:00")는 현 문자열 비교가
+        다루지 못한다(pre-existing known-limitation, 본 이슈 범위 밖).
+        """
+        guard = config.get("guard", {})
         pause_during_trading = guard.get("pause_during_trading", False)
         blocked_hours = guard.get("blocked_hours", [])
 
-        if pause_during_trading and blocked_hours:
-            kst = timezone(timedelta(hours=9))
-            now_kst = datetime.now(tz=kst)
-            current_hour_min = now_kst.strftime("%H:%M")
+        if not (pause_during_trading and blocked_hours):
+            return False
 
-            for window in blocked_hours:
-                if "-" in window:
-                    start_time, end_time = window.split("-")
-                    if start_time.strip() <= current_hour_min <= end_time.strip():
-                        return True
+        kst = timezone(timedelta(hours=9))
+        now_kst = datetime.now(tz=kst)
+        current_hour_min = now_kst.strftime("%H:%M")
+
+        for window in blocked_hours:
+            if "-" in window:
+                start_time, end_time = window.split("-")
+                if start_time.strip() <= current_hour_min <= end_time.strip():
+                    return True
 
         return False
+
+    @classmethod
+    def _is_blocked(cls, config: dict[str, Any], target_date: str) -> bool:
+        """방어 가드 조건을 확인한다(두 축의 합성).
+
+        daily 모드 등 "차단 시 skip(다음 run 재시도)" 의미가 필요한 호출자가
+        사용한다. 동작은 분리 이전과 동일하다(behavior-preserving).
+        """
+        return cls._is_blocked_day(config, target_date) or cls._is_trading_paused(
+            config
+        )
 
     # ── Lock 파일 관리 ────────────────────────────────────
 

--- a/tests/unit/feed/test_backfill_guard_wait.py
+++ b/tests/unit/feed/test_backfill_guard_wait.py
@@ -1,0 +1,529 @@
+"""Backfill 방어 가드 분리 동작 검증 (#1972).
+
+가드 두 축을 분리한 뒤의 backfill 날짜별 루프 동작을 검증한다:
+
+- ``blocked_days`` (target_date 요일): 해당 날짜는 **skip** (데이터 없음).
+- ``blocked_hours``+``pause_during_trading`` (현재 시각): 해당 시 window가
+  풀릴 때까지 **대기 후** 그 날짜를 수집한다.
+- 거래시간 가드가 영구히 풀리지 않으면(대기 상한 초과) ``GUARD_PERMANENTLY_BLOCKED``
+  config_error로 비-clean 종료.
+- 상주 스케줄러 stop_event로 대기가 중단되면 ``BACKFILL_STOP_REQUESTED``
+  config_error로 partial 종료(daemon은 "중단" echo).
+
+수정 전(스킵 동작)에는:
+- 거래시간 가드 활성 날짜가 누락되고 체크포인트가 정지 → wait/collect 테스트 FAIL.
+- 거래시간 가드가 영구 활성이면 전 날짜 skip + clean success → permanent 테스트 FAIL.
+- stop 마커가 없어 clean success → cancel 테스트 FAIL.
+
+모든 대기는 patch/주입으로 시간 비의존(결정적)이다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import ante.feed.pipeline.backfill_runner as bf_mod
+from ante.data.store import ParquetStore
+from ante.feed.pipeline.backfill_runner import (
+    BACKFILL_DATE_ERROR_CODES,
+    CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED,
+    CONFIG_ERROR_CODE_GUARD_PERMANENTLY_BLOCKED,
+)
+from ante.feed.pipeline.checkpoint import Checkpoint
+from ante.feed.pipeline.orchestrator import FeedOrchestrator
+
+# ── Fixtures ─────────────────────────────────────────────
+
+
+def _ohlcv_records_for(target_date: str, symbol: str = "005930") -> list[dict]:
+    """``target_date`` (YYYY-MM-DD) 의 OHLCV mock 레코드를 생성한다.
+
+    ``basDt`` 를 ``target_date`` 에서 유도해, 저장된 데이터로 어떤 날짜가
+    실제로 수집되었는지 역추적할 수 있게 한다.
+    """
+    bas_dt = target_date.replace("-", "")
+    return [
+        {
+            "basDt": bas_dt,
+            "srtnCd": symbol,
+            "itmsNm": f"종목{symbol}",
+            "mrktCtg": "KOSPI",
+            "mkp": "70000",
+            "hipr": "72000",
+            "lopr": "69000",
+            "clpr": "71000",
+            "trqu": "10000000",
+            "trPrc": "710000000000",
+            "lstgStCnt": "5969782550",
+            "mrktTotAmt": "423814400050000",
+        }
+    ]
+
+
+@pytest.fixture
+def tmp_data_path(tmp_path: Path) -> Path:
+    """테스트용 데이터 디렉토리."""
+    data_path = tmp_path / "data"
+    data_path.mkdir()
+    feed_dir = data_path / ".feed"
+    feed_dir.mkdir()
+    (feed_dir / "checkpoints").mkdir()
+    (feed_dir / "reports").mkdir()
+    return data_path
+
+
+def _date_driven_source() -> AsyncMock:
+    """fetch(target_date) → 그 날짜의 OHLCV 레코드를 반환하는 소스 mock."""
+    source = AsyncMock()
+
+    async def _fetch(target_date: str) -> list[dict]:
+        return _ohlcv_records_for(target_date)
+
+    source.fetch = AsyncMock(side_effect=_fetch)
+    source.rate_limiter = MagicMock()
+    source.rate_limiter.is_daily_limit_reached.return_value = False
+    return source
+
+
+def _config_with_window(
+    start: str,
+    end: str,
+    *,
+    backfill_since: str,
+    blocked_days: list[str] | None = None,
+) -> dict[str, Any]:
+    """거래시간 window + (옵션) blocked_days 설정을 만든다."""
+    return {
+        "schedule": {"backfill_since": backfill_since},
+        "guard": {
+            "blocked_days": blocked_days or [],
+            "blocked_hours": [f"{start}-{end}"],
+            "pause_during_trading": True,
+        },
+    }
+
+
+def _stored_dates(store: ParquetStore, symbol: str = "005930") -> set[str]:
+    """store에 저장된 OHLCV 날짜(YYYY-MM-DD) 집합을 읽어온다."""
+    df = store.read(symbol, "1d", data_type="ohlcv", exchange="KRX")
+    if df.is_empty() or "timestamp" not in df.columns:
+        return set()
+    return {ts.date().isoformat() for ts in df["timestamp"].to_list()}
+
+
+# ── (1) blocked_hours → 대기 후 해당 날짜 수집 ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_blocked_hours_waits_and_collects_guarded_date(
+    tmp_data_path: Path,
+) -> None:
+    """거래시간 가드 활성 → window가 풀릴 때까지 대기 후 **그 날짜 자체**를 수집.
+
+    다중 날짜 범위에서 ``is_trading_paused`` 가 처음 N회 True → 이후 False가
+    되도록 패치한다(asyncio.sleep no-op로 결정적). 가드가 걸렸던 첫 날짜의
+    행이 store에 존재하고, 체크포인트가 범위 끝까지 진행됨을 단언한다.
+
+    수정 전(skip): 가드 활성 날짜가 누락되고 체크포인트가 정지 → FAIL.
+    """
+    # 2024-01-01(월) ~ 2024-01-03(수): 모두 평일(blocked_days 미적용).
+    # 날짜 범위는 _resolve_dates 패치로 고정(기본 end=today 비결정성 제거).
+    config = _config_with_window("09:00", "15:30", backfill_since="2024-01-01")
+    target_dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+    cp = Checkpoint(tmp_data_path / ".feed", "data_go_kr", "ohlcv")
+
+    store = ParquetStore(base_path=tmp_data_path)
+    source = _date_driven_source()
+    orchestrator = FeedOrchestrator(data_go_kr_source=source, store=store)
+
+    # is_trading_paused: 첫 3회 True(첫 날짜 대기), 이후 False(해제).
+    pause_flags = iter([True, True, True])
+
+    def _fake_paused(_config: dict[str, Any]) -> bool:
+        try:
+            return next(pause_flags)
+        except StopIteration:
+            return False
+
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    with (
+        patch.object(
+            FeedOrchestrator, "_is_trading_paused", staticmethod(_fake_paused)
+        ),
+        patch.object(bf_mod.asyncio, "sleep", _fake_sleep),
+        patch.object(
+            bf_mod.BackfillRunner,
+            "_resolve_dates",
+            staticmethod(lambda _config, _feed_dir: list(target_dates)),
+        ),
+    ):
+        result = await orchestrator.run_backfill(tmp_data_path, config)
+
+    # 가드 marker는 없어야 한다(대기 후 정상 수집 → clean).
+    codes = {e.get("code") for e in result.config_errors if isinstance(e, dict)}
+    assert not (codes & BACKFILL_DATE_ERROR_CODES)
+
+    # 대기가 실제로 발생했다(one-shot sleep 경로, 3회 폴링 후 해제).
+    assert len(sleep_calls) == 3, "거래시간 가드 대기(sleep)가 3회 발생해야 한다"
+
+    # 가드가 걸렸던 첫 날짜(2024-01-01)를 포함해 범위 전체가 수집됐다.
+    stored = _stored_dates(store)
+    assert "2024-01-01" in stored, "가드 활성 날짜 자체가 수집되어야 한다"
+    assert {"2024-01-01", "2024-01-02", "2024-01-03"} == stored
+
+    # 체크포인트가 범위 끝까지 진행됐다.
+    assert cp.get_last_date() == "2024-01-03"
+
+
+# ── (2) blocked_days → 주말 skip, 평일 수집, hang 없음 ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_blocked_days_skips_weekday(
+    tmp_data_path: Path,
+) -> None:
+    """blocked_days=[sat,sun] → 주말 날짜는 skip, 평일은 수집. 무한 hang 없음.
+
+    blocked_days는 target_date 요일 기반이므로 대기하지 않고 즉시 skip한다.
+    """
+    # 2024-01-05(금) ~ 2024-01-08(월): 06(토)/07(일)이 주말.
+    config = {
+        "schedule": {"backfill_since": "2024-01-05"},
+        "guard": {
+            "blocked_days": ["sat", "sun"],
+            "blocked_hours": [],
+            "pause_during_trading": False,
+        },
+    }
+    target_dates = ["2024-01-05", "2024-01-06", "2024-01-07", "2024-01-08"]
+    cp = Checkpoint(tmp_data_path / ".feed", "data_go_kr", "ohlcv")
+
+    store = ParquetStore(base_path=tmp_data_path)
+    source = _date_driven_source()
+    orchestrator = FeedOrchestrator(data_go_kr_source=source, store=store)
+
+    # 거래시간 대기가 절대 호출되지 않아야 한다(주말은 skip이지 wait가 아님).
+    async def _must_not_sleep(_delay: float) -> None:
+        raise AssertionError("blocked_days는 skip이어야 하며 대기하면 안 된다")
+
+    with (
+        patch.object(bf_mod.asyncio, "sleep", _must_not_sleep),
+        patch.object(
+            bf_mod.BackfillRunner,
+            "_resolve_dates",
+            staticmethod(lambda _config, _feed_dir: list(target_dates)),
+        ),
+    ):
+        result = await orchestrator.run_backfill(tmp_data_path, config)
+
+    stored = _stored_dates(store)
+    # 주말(토/일)은 수집되지 않는다.
+    assert "2024-01-06" not in stored
+    assert "2024-01-07" not in stored
+    # 평일(금/월)은 수집된다.
+    assert "2024-01-05" in stored
+    assert "2024-01-08" in stored
+
+    # 가드 marker 없음(skip은 정상 동작).
+    codes = {e.get("code") for e in result.config_errors if isinstance(e, dict)}
+    assert not (codes & BACKFILL_DATE_ERROR_CODES)
+
+    # 체크포인트는 마지막으로 수집된 평일(2024-01-08)까지 진행.
+    assert cp.get_last_date() == "2024-01-08"
+
+
+# ── (3) 거래시간 가드 영구 활성 → GUARD_PERMANENTLY_BLOCKED ──────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_trading_pause_permanent_surfaces_config_error(
+    tmp_data_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """거래시간 가드가 항상 활성 + 짧은 max_wait → GUARD_PERMANENTLY_BLOCKED.
+
+    누적 대기가 상한을 넘으면 config_error를 적재하고 종료한다. 이 code는
+    BACKFILL_DATE_ERROR_CODES에 포함되어 비-clean(one-shot exit-1 / daemon
+    차단 echo).
+
+    수정 전(skip): 전 날짜 skip + clean success → FAIL.
+    """
+    config = _config_with_window("00:00", "23:59", backfill_since="2024-01-01")
+    target_dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+    # 체크포인트 미존재(None) → 범위는 _resolve_dates 패치로 고정.
+
+    store = ParquetStore(base_path=tmp_data_path)
+    source = _date_driven_source()
+    orchestrator = FeedOrchestrator(data_go_kr_source=source, store=store)
+
+    # 짧은 max_wait + poll 주입(2회 polling 후 상한 초과).
+    monkeypatch.setattr(bf_mod, "GUARD_WAIT_POLL_SECONDS", 10.0)
+    monkeypatch.setattr(bf_mod, "MAX_GUARD_WAIT_SECONDS", 20.0)
+
+    # 항상 거래시간(True).
+    def _always_paused(_config: dict[str, Any]) -> bool:
+        return True
+
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    with (
+        patch.object(
+            FeedOrchestrator, "_is_trading_paused", staticmethod(_always_paused)
+        ),
+        patch.object(bf_mod.asyncio, "sleep", _fake_sleep),
+        patch.object(
+            bf_mod.BackfillRunner,
+            "_resolve_dates",
+            staticmethod(lambda _config, _feed_dir: list(target_dates)),
+        ),
+    ):
+        result = await orchestrator.run_backfill(tmp_data_path, config)
+
+    codes = {e.get("code") for e in result.config_errors if isinstance(e, dict)}
+    assert CONFIG_ERROR_CODE_GUARD_PERMANENTLY_BLOCKED in codes
+    # 비-clean 매핑 집합에 포함.
+    assert CONFIG_ERROR_CODE_GUARD_PERMANENTLY_BLOCKED in BACKFILL_DATE_ERROR_CODES
+    # 어떤 날짜도 수집되지 않았다(첫 날짜에서 영구 차단).
+    assert _stored_dates(store) == set()
+    # 무한 루프가 아니라 상한에서 종료(폴링 유한 횟수).
+    assert 0 < len(sleep_calls) <= 3
+
+
+# ── (4) stop_event로 대기 중단 → BACKFILL_STOP_REQUESTED ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_wait_cancelled_by_stop_event(
+    tmp_data_path: Path,
+) -> None:
+    """대기 중 stop_event set → 대기 종료, 체크포인트 저장된 partial 반환.
+
+    ``result.config_errors`` 에 ``BACKFILL_STOP_REQUESTED`` 가 적재되어
+    clean-success가 아니다. ``asyncio.wait_for`` (daemon 경로)가 대기 중
+    stop이 도착한 것을 시뮬레이션한다.
+    """
+    config = _config_with_window("00:00", "23:59", backfill_since="2024-01-01")
+    target_dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+    # 체크포인트 미존재(None) → 범위는 _resolve_dates 패치로 고정.
+
+    store = ParquetStore(base_path=tmp_data_path)
+    source = _date_driven_source()
+    orchestrator = FeedOrchestrator(data_go_kr_source=source, store=store)
+
+    stop_event = asyncio.Event()
+
+    # 항상 거래시간(True) → 대기 진입.
+    def _always_paused(_config: dict[str, Any]) -> bool:
+        return True
+
+    # daemon 경로: wait_for(stop_event.wait(), timeout)가 대기하던 중
+    # stop이 도착한 것을 시뮬레이션 — 이벤트를 set하고 정상 반환한다.
+    async def _fake_wait_for(_awaitable: Any, timeout: float) -> None:
+        # 미사용 coroutine 경고 방지를 위해 닫는다.
+        if asyncio.iscoroutine(_awaitable):
+            _awaitable.close()
+        stop_event.set()
+
+    with (
+        patch.object(
+            FeedOrchestrator, "_is_trading_paused", staticmethod(_always_paused)
+        ),
+        patch.object(bf_mod.asyncio, "wait_for", _fake_wait_for),
+        patch.object(
+            bf_mod.BackfillRunner,
+            "_resolve_dates",
+            staticmethod(lambda _config, _feed_dir: list(target_dates)),
+        ),
+    ):
+        result = await orchestrator.run_backfill(
+            tmp_data_path, config, stop_event=stop_event
+        )
+
+    codes = {e.get("code") for e in result.config_errors if isinstance(e, dict)}
+    assert CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED in codes
+    assert CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED in BACKFILL_DATE_ERROR_CODES
+    # 중단 시점까지 어떤 날짜도 수집되지 않았다(첫 날짜 대기 중 중단).
+    assert _stored_dates(store) == set()
+
+
+@pytest.mark.asyncio
+async def test_backfill_stop_requested_before_wait(
+    tmp_data_path: Path,
+) -> None:
+    """대기 진입 직전 stop_event가 이미 set → 즉시 BACKFILL_STOP_REQUESTED.
+
+    wait_for를 거치지 않고 루프 top 체크에서 즉시 중단되는 경로.
+    """
+    config = _config_with_window("00:00", "23:59", backfill_since="2024-01-01")
+    target_dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+    # 체크포인트 미존재(None) → 범위는 _resolve_dates 패치로 고정.
+
+    store = ParquetStore(base_path=tmp_data_path)
+    source = _date_driven_source()
+    orchestrator = FeedOrchestrator(data_go_kr_source=source, store=store)
+
+    stop_event = asyncio.Event()
+    stop_event.set()  # 진입 전부터 set.
+
+    def _always_paused(_config: dict[str, Any]) -> bool:
+        return True
+
+    async def _must_not_wait(_awaitable: Any, timeout: float) -> None:
+        raise AssertionError("이미 stop된 상태에서는 wait_for를 호출하면 안 된다")
+
+    with (
+        patch.object(
+            FeedOrchestrator, "_is_trading_paused", staticmethod(_always_paused)
+        ),
+        patch.object(bf_mod.asyncio, "wait_for", _must_not_wait),
+        patch.object(
+            bf_mod.BackfillRunner,
+            "_resolve_dates",
+            staticmethod(lambda _config, _feed_dir: list(target_dates)),
+        ),
+    ):
+        result = await orchestrator.run_backfill(
+            tmp_data_path, config, stop_event=stop_event
+        )
+
+    codes = {e.get("code") for e in result.config_errors if isinstance(e, dict)}
+    assert CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED in codes
+
+
+# ── (5) daemon _run_backfill_job: stop 중단 시 "중단" echo ────────────────
+
+
+def test_daemon_run_backfill_job_echoes_stop_not_complete() -> None:
+    """stop 중단 partial을 받은 daemon은 "완료" 대신 "중단"을 echo한다."""
+    from ante.feed import cli_scheduler
+    from ante.feed.models.result import CollectionResult
+
+    started = datetime.now(tz=UTC)
+    finished = started + timedelta(seconds=1)
+    stop_result = CollectionResult(
+        mode="backfill",
+        started_at=started.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        finished_at=finished.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        duration_seconds=1.0,
+        config_errors=[
+            {
+                "code": CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED,
+                "error": "중단 요청으로 backfill 거래시간 대기를 종료했습니다",
+                "source": "data_go_kr",
+            }
+        ],
+    )
+
+    mock_orch = MagicMock()
+    mock_orch.run_backfill = AsyncMock(return_value=stop_result)
+
+    echoed: list[str] = []
+    with patch.object(cli_scheduler.click, "echo", side_effect=echoed.append):
+        asyncio.run(
+            cli_scheduler._run_backfill_job(
+                mock_orch, "data/", {}, "2026-05-30", asyncio.Event()
+            )
+        )
+
+    # 완료 메시지 미출력, "중단" 라인 출력.
+    assert not any("Backfill 완료" in line for line in echoed)
+    assert any("Backfill 중단" in line for line in echoed)
+    assert any(CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED in line for line in echoed)
+
+
+def test_daemon_run_backfill_job_echoes_permanent_block() -> None:
+    """GUARD_PERMANENTLY_BLOCKED partial을 받은 daemon은 "차단"을 echo한다."""
+    from ante.feed import cli_scheduler
+    from ante.feed.models.result import CollectionResult
+
+    started = datetime.now(tz=UTC)
+    finished = started + timedelta(seconds=1)
+    blocked_result = CollectionResult(
+        mode="backfill",
+        started_at=started.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        finished_at=finished.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        duration_seconds=1.0,
+        config_errors=[
+            {
+                "code": CONFIG_ERROR_CODE_GUARD_PERMANENTLY_BLOCKED,
+                "error": "거래시간 가드가 대기 상한을 초과했습니다",
+                "source": "data_go_kr",
+            }
+        ],
+    )
+
+    mock_orch = MagicMock()
+    mock_orch.run_backfill = AsyncMock(return_value=blocked_result)
+
+    echoed: list[str] = []
+    with patch.object(cli_scheduler.click, "echo", side_effect=echoed.append):
+        asyncio.run(
+            cli_scheduler._run_backfill_job(
+                mock_orch, "data/", {}, "2026-05-30", asyncio.Event()
+            )
+        )
+
+    assert not any("Backfill 완료" in line for line in echoed)
+    assert any("Backfill 차단" in line for line in echoed)
+    assert any(CONFIG_ERROR_CODE_GUARD_PERMANENTLY_BLOCKED in line for line in echoed)
+
+
+# ── (6) stop_event 전파: run_scheduler_loop → _run_backfill_job ──────────
+
+
+def test_run_scheduler_loop_forwards_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_scheduler_loop가 보유한 stop_event를 _run_backfill_job로 전달한다."""
+    from ante.feed import cli_scheduler
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_backfill_job(
+        orchestrator: Any,
+        data_path: str,
+        config: dict[str, Any],
+        current_date: str,
+        stop_event: asyncio.Event | None = None,
+    ) -> None:
+        captured["stop_event"] = stop_event
+        # 한 번 실행되면 루프를 종료시킨다.
+        if stop_event is not None:
+            stop_event.set()
+
+    async def _noop_daily(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def _instant_wait(stop_event: asyncio.Event, *, timeout: float) -> None:
+        return None
+
+    monkeypatch.setattr(cli_scheduler, "_run_backfill_job", _fake_backfill_job)
+    monkeypatch.setattr(cli_scheduler, "_run_daily_job", _noop_daily)
+    monkeypatch.setattr(cli_scheduler, "_wait_or_stop", _instant_wait)
+
+    # backfill_at을 항상 도달하도록 과거 시각으로, daily는 미래로 둔다.
+    asyncio.run(
+        cli_scheduler.run_scheduler_loop(
+            orchestrator=MagicMock(),
+            data_path="data/",
+            config={},
+            daily_at="23:59",
+            backfill_at="00:00",
+        )
+    )
+
+    assert "stop_event" in captured
+    assert isinstance(captured["stop_event"], asyncio.Event)

--- a/tests/unit/feed/test_backfill_guard_wait.py
+++ b/tests/unit/feed/test_backfill_guard_wait.py
@@ -360,6 +360,82 @@ async def test_backfill_wait_cancelled_by_stop_event(
 
 
 @pytest.mark.asyncio
+async def test_backfill_stop_wins_when_window_clears_simultaneously(
+    tmp_data_path: Path,
+) -> None:
+    """대기 중 stop_event set과 거래시간 window 동시 해제가 겹쳐도 stop 우선.
+
+    race 시나리오: ``is_trading_paused`` 가 1회 True(대기 진입)였다가, 대기
+    도중 stop_event가 set되고 **동시에** window도 풀려 다음 평가가 False가
+    되는 경우. ``asyncio.wait_for`` 가 (TimeoutError 없이) 정상 반환하므로,
+    수정 전 코드는 ``waited += poll`` 후 ``while is_trading_paused`` 재평가가
+    False가 되어 루프를 빠져나가 ``return False``(수집 진행) — stop 요청을
+    무시한다(race FAIL).
+
+    수정 후에는 wait가 TimeoutError 없이 깨어난 시점에서 즉시
+    ``BACKFILL_STOP_REQUESTED`` 를 적재하고 ``True`` 를 반환해야 한다.
+    """
+    config = _config_with_window("00:00", "23:59", backfill_since="2024-01-01")
+    target_dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+
+    store = ParquetStore(base_path=tmp_data_path)
+    source = _date_driven_source()
+    orchestrator = FeedOrchestrator(data_go_kr_source=source, store=store)
+
+    stop_event = asyncio.Event()
+
+    # 첫 평가(대기 진입)는 True, 이후 평가는 False(window가 동시에 풀림).
+    pause_flags = iter([True])
+
+    def _paused_then_clears(_config: dict[str, Any]) -> bool:
+        try:
+            return next(pause_flags)
+        except StopIteration:
+            return False
+
+    # daemon 경로: wait_for가 대기하던 중 stop이 도착(set)한 것을 시뮬레이션.
+    # TimeoutError 없이 정상 반환하므로, 같은 사이클에 window가 풀려도(다음
+    # is_trading_paused=False) stop이 우선되어야 한다.
+    async def _fake_wait_for(_awaitable: Any, timeout: float) -> None:
+        if asyncio.iscoroutine(_awaitable):
+            _awaitable.close()
+        stop_event.set()
+
+    # sleep 경로(stop_event is None)는 이 테스트에서 사용되지 않아야 한다.
+    async def _must_not_sleep(_delay: float) -> None:
+        raise AssertionError("daemon 경로(stop_event)에서는 sleep을 쓰지 않는다")
+
+    with (
+        patch.object(
+            FeedOrchestrator,
+            "_is_trading_paused",
+            staticmethod(_paused_then_clears),
+        ),
+        patch.object(bf_mod.asyncio, "wait_for", _fake_wait_for),
+        patch.object(bf_mod.asyncio, "sleep", _must_not_sleep),
+        patch.object(
+            bf_mod.BackfillRunner,
+            "_resolve_dates",
+            staticmethod(lambda _config, _feed_dir: list(target_dates)),
+        ),
+    ):
+        result = await orchestrator.run_backfill(
+            tmp_data_path, config, stop_event=stop_event
+        )
+
+    # stop 우선: BACKFILL_STOP_REQUESTED가 적재되어 clean-success가 아니다.
+    codes = {e.get("code") for e in result.config_errors if isinstance(e, dict)}
+    assert CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED in codes, (
+        "window 동시 해제 race에서도 stop 요청이 우선되어야 한다"
+    )
+    assert CONFIG_ERROR_CODE_BACKFILL_STOP_REQUESTED in BACKFILL_DATE_ERROR_CODES
+    # stop이 우선되었으므로 첫 날짜를 포함해 어떤 날짜도 수집되지 않았다.
+    assert _stored_dates(store) == set(), (
+        "stop이 무시되고 수집이 진행되면(race) 날짜가 저장된다 — 그러면 안 된다"
+    )
+
+
+@pytest.mark.asyncio
 async def test_backfill_stop_requested_before_wait(
     tmp_data_path: Path,
 ) -> None:

--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -352,6 +352,87 @@ def test_is_blocked_empty_guard() -> None:
     assert FeedOrchestrator._is_blocked(config, "2024-01-01") is False
 
 
+# ── 가드 분리 (#1972): _is_blocked_day / _is_trading_paused ──────────────
+
+
+def test_is_blocked_day_true_for_listed_weekday() -> None:
+    """blocked_days에 해당하는 target_date 요일이면 True (skip 대상)."""
+    # 2024-01-06 = 토요일
+    config = {"guard": {"blocked_days": ["sat", "sun"]}}
+    assert FeedOrchestrator._is_blocked_day(config, "2024-01-06") is True
+
+
+def test_is_blocked_day_false_for_unlisted_weekday() -> None:
+    """blocked_days에 없는 요일이면 False."""
+    # 2024-01-01 = 월요일
+    config = {"guard": {"blocked_days": ["sat", "sun"]}}
+    assert FeedOrchestrator._is_blocked_day(config, "2024-01-01") is False
+
+
+def test_is_blocked_day_ignores_trading_hours(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_is_blocked_day는 현재 시각/거래시간 가드를 보지 않는다 (target_date 전용)."""
+    # blocked_days가 비어 있으면, blocked_hours/pause가 설정돼 있어도 False.
+    config = {
+        "guard": {
+            "blocked_days": [],
+            "blocked_hours": ["00:00-23:59"],
+            "pause_during_trading": True,
+        }
+    }
+    assert FeedOrchestrator._is_blocked_day(config, "2024-01-01") is False
+
+
+def test_is_trading_paused_true_inside_window() -> None:
+    """현재 KST 시각이 거래시간 window 안이면 True (대기 대상)."""
+    import ante.feed.pipeline.orchestrator as orch_mod
+
+    # 현재 시각을 무조건 포함하는 window로 강제.
+    config = {
+        "guard": {
+            "blocked_hours": ["00:00-23:59"],
+            "pause_during_trading": True,
+        }
+    }
+    # 종일 window이므로 실제 현재 KST 시각과 무관하게 True.
+    assert orch_mod.FeedOrchestrator._is_trading_paused(config) is True
+
+
+def test_is_trading_paused_false_when_disabled() -> None:
+    """pause_during_trading=False면 window가 있어도 False."""
+    config = {
+        "guard": {
+            "blocked_hours": ["00:00-23:59"],
+            "pause_during_trading": False,
+        }
+    }
+    assert FeedOrchestrator._is_trading_paused(config) is False
+
+
+def test_is_trading_paused_ignores_target_date() -> None:
+    """_is_trading_paused는 target_date(요일)를 인자로 받지 않는다."""
+    # blocked_days만 있고 blocked_hours가 없으면 거래시간 가드는 False.
+    config = {"guard": {"blocked_days": ["mon"]}}
+    assert FeedOrchestrator._is_trading_paused(config) is False
+
+
+def test_is_blocked_is_or_composition() -> None:
+    """_is_blocked는 _is_blocked_day OR _is_trading_paused 합성(동작 보존)."""
+    # day만 차단: 2024-01-06 토요일.
+    day_only = {"guard": {"blocked_days": ["sat"]}}
+    assert FeedOrchestrator._is_blocked(day_only, "2024-01-06") is True
+    # hour만 차단: 종일 window.
+    hour_only = {
+        "guard": {
+            "blocked_hours": ["00:00-23:59"],
+            "pause_during_trading": True,
+        }
+    }
+    assert FeedOrchestrator._is_blocked(hour_only, "2024-01-01") is True
+    # 둘 다 비활성: False.
+    neither = {"guard": {"blocked_days": ["sat"]}}
+    assert FeedOrchestrator._is_blocked(neither, "2024-01-01") is False
+
+
 # ── Lock 파일 테스트 ─────────────────────────────────────
 
 

--- a/tests/unit/feed/test_report.py
+++ b/tests/unit/feed/test_report.py
@@ -401,7 +401,8 @@ class TestBackfillReportSurfacesStoreMergeWarning:
             config={"schedule": {"backfill_since": "2025-09-29"}},
             feed_dir=feed_dir,
             started_at=datetime.now(tz=UTC),
-            is_blocked=lambda config, target_date: False,
+            is_blocked_day=lambda config, target_date: False,
+            is_trading_paused=lambda config: False,
         )
 
         store_merge_warnings = [


### PR DESCRIPTION
Closes #1972

## Summary
`ante feed run backfill`이 `[guard].pause_during_trading=true` + `blocked_hours` 진입 시 남은 과거 날짜를 **스킵하고 clean-success로 종료**(OHLCV 체크포인트 중간 정지, silent partial)하던 버그를 수정한다. 스펙(`docs/specs/data-feed/07-execution-modes.md:41`)은 backfill 날짜별 루프 가드를 "**해당 시 대기**"로 규정한다.

핵심: 가드는 의미가 다른 두 축이며 코드가 이를 구분하지 않았다.
- **`blocked_days`** (`_is_blocked_day`, **target_date 요일** 기반): 비거래 요일은 데이터가 없어 **skip이 정답**(대기하면 그 과거 날짜의 요일은 안 바뀌어 무한 hang).
- **`blocked_hours` + `pause_during_trading`** (`_is_trading_paused`, **현재 KST 시각** 기반): 거래시간 API 부하 회피 의도 → window가 지나면 데이터 존재 → **대기 후 resume**.

## 변경
- **orchestrator**: `_is_blocked`를 `_is_blocked_day`(target_date) / `_is_trading_paused`(현재시각)로 분리, `_is_blocked`는 둘의 OR 합성으로 동작 보존(`daily_runner` 무변경). `run_backfill(..., stop_event=None)`.
- **backfill_runner**: `_collect_data_go_kr`가 blocked_day는 skip, trading-pause는 `_wait_out_trading_pause`로 **대기 후 수집**. daemon은 `asyncio.wait_for(stop_event.wait(), timeout=poll)`로 SIGTERM 안전종료 보존, one-shot은 `asyncio.sleep`(SIGINT 취소). 관측성: 대기 상한 초과 `GUARD_PERMANENTLY_BLOCKED`, stop 중단 `BACKFILL_STOP_REQUESTED` — 둘 다 `BACKFILL_DATE_ERROR_CODES`(one-shot exit-1 / daemon echo, **clean-success 차단**).
- **cli_scheduler**: `run_scheduler_loop`→`_run_backfill_job(..., stop_event)`→`run_backfill(stop_event=...)` 전파.
- **spec**: backfill 가드 의미 명확화(blocked_days skip / blocked_hours 대기 후 resume).

## Review (Codex)
- **Plan Review**: v1 `revise-plan`(blocked_days target-date hang / 관측성 / cancellation) → v2 `revise-plan`(stop partial 관측성) → v3 **approve-implement**.
- **Branch Review**: round-1 **FAIL** — `_wait_out_trading_pause`에서 stop_event wake-up이 거래시간 window 동시 해제와 race해 stop 무시 가능. → 수정(stop wake 시 window 재평가 전 즉시 `BACKFILL_STOP_REQUESTED`+return) → round-2 **PASS**.

## Test Plan
- failing-first: `test_backfill_guard_wait.py` — blocked_hours wait&collect(guarded date 자체 수집 단언) / blocked_days skip / permanent→config_error / stop-cancel / **stop-vs-window-clear race**(round-1 finding 회귀 락) 등 9 케이스 + `test_orchestrator.py` 분리술어 8건.
- full `pytest -q`: **5837 passed, 2 skipped**. `mypy src/`: Success(230). ruff clean.

## Non-Goals (known-limitations)
- `daily_runner` 가드(스펙상 daily 대기 미명시), DART 가드(날짜 루프 밖), midnight-spanning `blocked_hours`(pre-existing `_is_blocked` 문자열비교 한계 — 코드 주석 명시), `[guard]` 스키마 확장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
