### PR TITLE
fix(cli): #1974 backtest history offline read-only — initialize() 제거 + no such table 정규화

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-05-29 (KST)
+> 마지막 생성 시점: 2026-05-31 (KST)
 
 ## 최상위 구조
 
@@ -61,7 +61,8 @@ src/ante/
 │   ├── bus.py                        # EventBus — asyncio.Queue 기반 발행/구독
 │   ├── events.py                     # 전체 이벤트 dataclass 정의
 │   ├── history.py                    # EventHistory — 이벤트 이력 추적
-│   └── __init__.py
+│   ├── __init__.py
+│   └── fill_dedup_guard.py
 ├── audit/
 │   ├── logger.py                     # AuditLogger — 감사 로그 기록 (SQLite)
 │   └── __init__.py
@@ -136,7 +137,8 @@ src/ante/
 │   ├── __init__.py
 │   ├── daily_report.py
 │   ├── fill_applier.py
-│   └── order_tracker.py
+│   ├── order_tracker.py
+│   └── fill_outbox.py
 ├── broker/
 │   ├── base.py                       # BrokerAdapter ABC
 │   ├── models.py                     # CommissionInfo dataclass
@@ -393,7 +395,9 @@ tests/
 │   │   ├── test_cli_backfill_until_removed.py
 │   │   ├── test_cli_daily_date_forward.py
 │   │   ├── test_daily_runner_target_date.py
-│   │   └── test_orchestrator_run_daily_target_date.py
+│   │   ├── test_orchestrator_run_daily_target_date.py
+│   │   ├── test_backfill_guard_wait.py
+│   │   └── test_indicator_calculator.py
 │   ├── cli/
 │   │   ├── __init__.py
 │   │   ├── test_version.py
@@ -651,7 +655,12 @@ tests/
 │   ├── test_fill_recovery_integration.py
 │   ├── test_fill_scheduler.py
 │   ├── test_kis_order_history_fold.py
-│   └── test_order_tracker.py
+│   ├── test_order_tracker.py
+│   ├── test_cli_backtest_history_readonly.py
+│   ├── test_fill_dedup_guard.py
+│   ├── test_fill_outbox.py
+│   ├── test_kis_error_codes_40240000.py
+│   └── test_treasury_fill_dedup.py
 └── __init__.py
 ```
 

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from typing import TYPE_CHECKING, Any
 
 import click
 
 from ante.cli._data_path import resolve_data_path
 from ante.cli._validators import validate_positive_finite_amount
+from ante.cli.db_context import open_cli_db
 from ante.cli.main import get_formatter
 
 if TYPE_CHECKING:
@@ -243,24 +245,34 @@ def history(
     db_path: str | None,
 ) -> None:
     """전략별 백테스트 실행 이력 조회."""
-    from ante.cli.main import get_db_path
-
     fmt = get_formatter(ctx)
-    resolved_db_path = db_path or get_db_path(ctx)
 
     async def _list() -> list[dict]:
         from ante.backtest.run_store import BacktestRunStore
-        from ante.core.database import Database
 
-        db = Database(resolved_db_path)
-        await db.connect()
-        try:
+        # ``backtest history`` 는 offline read 명령이므로 read-only DB 에서
+        # schema DDL 을 발화하면 안 된다 (offline-factory.md §2 옵션 B —
+        # read-only 명령은 ``service.initialize()`` skip). 따라서
+        # ``BacktestRunStore.initialize()`` (CREATE TABLE backtest_runs) 를
+        # 호출하지 않는다. ``--db-path`` Click option 은 원시 값 (None 가능) 을
+        # 그대로 ``db_path_override`` 로 전달한다 — ``open_cli_db`` 가 None 이면
+        # ``get_db_path(ctx)`` 로 해석하므로 기존 ``--db-path`` 동작과 동치다
+        # (approval.py 패턴; offline-factory.md §1.1).
+        async with open_cli_db(ctx, read_only=True, db_path_override=db_path) as db:
             store = BacktestRunStore(db)
-            await store.initialize()
-            runs = await store.list_by_strategy(strategy_name, limit=limit)
+            # fresh / non-bootstrapped DB 에서는 `backtest_runs` 테이블이 아직
+            # 생성되지 않은 상태일 수 있다 (initialize() 를 거치지 않기 때문).
+            # 정의상 테이블 부재는 해당 전략의 이력 부재와 동치이므로 빈 이력으로
+            # 정규화한다. malformed DB 같은 다른 OperationalError 까지 삼키지
+            # 않도록 "no such table" 메시지로만 좁혀 그 외는 호출 표면의
+            # BACKTEST_ERROR 분류로 재전파한다 (trade.py:trade_info 동형).
+            try:
+                runs = await store.list_by_strategy(strategy_name, limit=limit)
+            except sqlite3.OperationalError as e:
+                if "no such table" in str(e).lower():
+                    return []
+                raise
             return [r.to_dict() for r in runs]
-        finally:
-            await db.close()
 
     try:
         rows = asyncio.run(_list())

--- a/tests/unit/contracts/factory_drift_allowlist.yaml
+++ b/tests/unit/contracts/factory_drift_allowlist.yaml
@@ -51,14 +51,12 @@ direct_database_construction:
     reason: "report performance — offline (deferred migration, post-#1818 follow-up)"
 
   # backtest domain — `backtest run` 은 spec 상 `long_running` 분류 (progress
-  # bar 와 함께 장시간 작업) 이고, `backtest history` 는 `offline` 이지만
-  # #1857 잔여로 본 사이클에서 마이그레이션 보류.
+  # bar 와 함께 장시간 작업) 이라 직접 Database 생성을 유지한다.
+  # `backtest history` 는 `offline` 이며 #1974 에서 `open_cli_db` (read_only)
+  # 로 마이그레이션되어 직접 Database 생성 callsite 가 사라졌다 — 엔트리 제거.
   - path: src/ante/cli/commands/backtest.py
-    line: 212
+    line: 214
     reason: "backtest run — long_running (progress-bar driven, deferred migration)"
-  - path: src/ante/cli/commands/backtest.py
-    line: 255
-    reason: "backtest history — offline (deferred migration, post-#1818 follow-up)"
 
   # data domain — `data list` callsite. #1857 잔여로 본 사이클에서 보류.
   - path: src/ante/cli/commands/data.py

--- a/tests/unit/test_cli_backtest_history_readonly.py
+++ b/tests/unit/test_cli_backtest_history_readonly.py
@@ -1,0 +1,131 @@
+"""``ante backtest history`` offline read-only 회귀 테스트 (#1974).
+
+``backtest history`` 는 offline read 명령이므로 read-only DB 에서 schema DDL
+(``BacktestRunStore.initialize()`` → ``CREATE TABLE backtest_runs``) 을 발화하면
+안 된다 (offline-factory.md §2 옵션 B, §4.4 ``BacktestRunStore`` initialize skip
+가능 후보). 핵심 회귀 락:
+
+1. 기존 (스키마 없는) DB 에서 ``backtest_runs`` 테이블이 없어도 빈 이력으로
+   정규화 (``"no such table"`` → ``[]``), 종료코드 0.
+2. 명령 실행 후에도 ``backtest_runs`` 테이블이 **생성되지 않음** — read-only
+   DDL 부작용 부재 (이게 #1974 의 핵심 수정이다).
+3. JSON envelope shape 가 기존 빈 이력 응답 (``{"message": ..., "runs": []}``)
+   과 동일.
+
+CliRunner / auth 셋업은 ``tests/unit/test_cli_backtest_report.py`` 의
+``require_auth`` 우회 fixture 를 미러한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.core.database import Database
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _make_empty_db(path: str) -> None:
+    """``backtest_runs`` 테이블이 없는 기존 DB 파일을 사전 생성한다.
+
+    파일이 존재하지 않으면 ``open_cli_db`` → ``Database.connect()`` 가 파일을
+    새로 생성해 read-only 시나리오가 깨진다. 따라서 ``Database`` 를
+    connect→close 만 수행해 빈 DB 파일 (스키마 없음) 을 미리 만든다.
+    """
+
+    async def _create() -> None:
+        db = Database(path)
+        await db.connect()
+        await db.close()
+
+    asyncio.run(_create())
+
+
+def _backtest_runs_table_exists(path: str) -> bool:
+    """``backtest_runs`` 테이블의 존재 여부를 sqlite3 로 직접 확인한다."""
+    conn = sqlite3.connect(path)
+    try:
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'backtest_runs'"
+        )
+        return cur.fetchone() is not None
+    finally:
+        conn.close()
+
+
+class TestBacktestHistoryReadOnly:
+    def test_history_empty_does_not_create_backtest_runs_table(
+        self, runner, tmp_path
+    ) -> None:
+        """read-only DB 에서 빈 이력 반환 + ``backtest_runs`` DDL 부작용 부재.
+
+        - 종료코드 0 + 빈 이력 success envelope.
+        - 실행 후 ``backtest_runs`` 테이블이 생성되지 않음 (핵심 회귀 락).
+        - JSON envelope shape 가 기존 빈 이력 응답과 동일.
+        """
+        db_file = tmp_path / "ante.db"
+        _make_empty_db(str(db_file))
+
+        # 사전 조건: 스키마 없는 빈 DB (backtest_runs 테이블 부재).
+        assert not _backtest_runs_table_exists(str(db_file))
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "backtest",
+                "history",
+                "momentum",
+                "--db-path",
+                str(db_file),
+            ],
+        )
+
+        # (a) 종료코드 0 + 빈 이력 success envelope.
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["runs"] == []
+        # (c) JSON envelope shape 가 기존 빈 이력 응답과 동일
+        #     (backtest.py history empty 분기: {"message": ..., "runs": []}).
+        assert "이력이 없습니다" in data["message"]
+
+        # (b) 핵심 회귀 락: 실행 후에도 backtest_runs 테이블이 생성되지 않음
+        #     (read-only DDL 부작용 부재).
+        assert not _backtest_runs_table_exists(str(db_file))


### PR DESCRIPTION
Closes #1974

## Summary
- `ante backtest history`(offline read 명령)가 read-only DB 마운트에서 schema DDL을 발화해 generic `BACKTEST_ERROR`로 실패하던 문제를 해소한다.
- `history` 명령의 read 경로를 `open_cli_db(ctx, read_only=True, db_path_override=db_path)`로 전환하고 **`BacktestRunStore.initialize()` 호출을 제거**한다(offline-factory.md §2 옵션 B — read-only 명령은 `service.initialize()` skip; §4.4가 `BacktestRunStore`를 skip 후보로 명시).
- 테이블 부재(`no such table`)는 해당 전략의 이력 부재와 동치이므로 빈 이력(`[]`)으로 정규화한다. 그 외 `OperationalError`(malformed DB 등)는 기존 `BACKTEST_ERROR` 표면으로 재전파한다(`trade.py:trade_info` 동형).
- `BacktestRunStore`(write 경로 `initialize()`/`save()`)와 `Database` API는 변경하지 않는다 — 정규화를 CLI 명령에 국한해 `report.py`/`main.py`/`backtest run` 영향 0.

## Changes
- `src/ante/cli/commands/backtest.py`: `history._list()` 마이그레이션, `import sqlite3` 추가.
- `tests/unit/contracts/factory_drift_allowlist.yaml`: `backtest history` 엔트리 제거(callsite 소멸), `backtest run` 줄번호 212→214 갱신(양방향 drift 테스트 정합).
- `tests/unit/test_cli_backtest_history_readonly.py`(신규): 스키마 없는 기존 DB에서 (a) 빈 이력 success envelope, (b) 실행 후 `backtest_runs` 테이블 미생성(read-only DDL 부작용 부재 회귀 락), (c) JSON envelope shape 동일.
- `docs/architecture/generated/project-structure.md`: 재생성. 신규 테스트 파일 외에 **main의 pre-existing drift**(`eventbus/fill_dedup_guard.py`, `bot/fill_outbox.py`, `test_fill_dedup_guard.py`, `test_fill_outbox.py`, `test_kis_error_codes_40240000.py`, `test_treasury_fill_dedup.py`, `test_backfill_guard_wait.py`, `test_indicator_calculator.py`)도 correct-by-generation으로 함께 반영됨(생성 기준이 전체 추적 파일 트리).

## Test Plan
- `PYTHONPATH=$PWD/src pytest tests/unit/test_cli_backtest_history_readonly.py tests/unit/cli/test_factory_drift_check.py -q` — 신규 + 드리프트(Family A 양방향/Family C) PASS
- `PYTHONPATH=$PWD/src pytest tests/unit/test_cli_backtest_symbol_timeframe_validation.py tests/unit/test_backtest_success_output_drift.py tests/unit/test_cli_pagination_validation.py tests/unit/test_cli_backtest_report.py -q` — 인접 회귀 43 passed
- `PYTHONPATH=$PWD/src python scripts/generate_project_structure.py --check` — 동기화 PASS
- `mypy src/` — no issues (230 files)
- `pytest tests/unit/ -q` — **5838 passed, 2 skipped, 0 failed**

## Review
- Codex Plan Review: `approve-implement`
- Codex 브랜치 리뷰 (`/codex:review --base main`): PASS (blocking findings 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
