### PR TITLE
fix(core): #1974 Database read-only 연결 모드(mode=ro+immutable fallback) — backtest history 실제 read-only mount 지원

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -660,7 +660,8 @@ tests/
 │   ├── test_fill_dedup_guard.py
 │   ├── test_fill_outbox.py
 │   ├── test_kis_error_codes_40240000.py
-│   └── test_treasury_fill_dedup.py
+│   ├── test_treasury_fill_dedup.py
+│   └── test_cli_backtest_history_readonly_fs.py
 └── __init__.py
 ```
 

--- a/docs/specs/contracts/README.md
+++ b/docs/specs/contracts/README.md
@@ -28,7 +28,7 @@ socket)이 사용자/Agent에게 노출하는 **wire-level 계약의 SSOT**를 �
 | Vocabulary code | [src/ante/contracts/vocab.py](../../../src/ante/contracts/vocab.py) | #1822 | `ContractKind`, `EnvelopeForm`, `AuthMode` Literal SSOT |
 | Drift helper skeleton | [tests/unit/contracts/helpers.py](../../../tests/unit/contracts/helpers.py) | #1823 | Click/IPC iterator, `*Error` class / `fmt.error` callsite helper |
 | Error taxonomy | [docs/specs/contracts/error-taxonomy.md](error-taxonomy.md) | #1816 / #1839 | `code` vocabulary + 8 category + auth legacy alias + 대표 fault lock |
-| Offline service factory contract | [docs/specs/contracts/offline-factory.md](offline-factory.md) | #1818 / #1854 | CLI `offline`/`cold-path` factory 책임·비책임 + `read_only` skip 정책 + ctx path resolution + read-only 예외 |
+| Offline service factory contract | [docs/specs/contracts/offline-factory.md](offline-factory.md) | #1818 / #1854 / #1974 | CLI `offline`/`cold-path` factory 책임·비책임 + `read_only` 정책(옵션 B skip + 옵션 A Database read-only 연결 모드) + ctx path resolution + read-only 예외 |
 | Migration domain order | 본 문서 [Migration Domain Order](#migration-domain-order) | #1820 | `account → member → approval → bot → treasury → broker → strategy → 기타` |
 
 ### Envelope shape (#1821)
@@ -132,9 +132,14 @@ error-taxonomy.md 자체를 갱신한다.
 - factory 비책임: IPC 호출, IPC fallback, runtime vs offline 분기, active
   runtime guard 호출, audit logging, auth/scope 검증, envelope 직렬화, error
   code 매핑.
-- `read_only` 정책: 옵션 B (factory-level skip) — `Database` API는 변경하지
-  않고, read-only 명령에서 factory가 `service.initialize()` 호출을 skip해 schema
-  /DDL trigger를 차단한다.
+- `read_only` 정책 (#1974 R2 amend): `read_only=True` ≡ 옵션 B (factory-level
+  `service.initialize()` skip) + 옵션 A (`Database` SQLite read-only 연결 모드).
+  옵션 A는 `Database(db_path, *, read_only=False)` backward-compatible 파라미터로,
+  `read_only=True`이면 `file:...?mode=ro` 단일 reader 연결(WAL 쓰기 PRAGMA skip,
+  실패 시 `immutable=1` fallback)을 열어 실제 read-only 파일시스템에서도 schema
+  /WAL 쓰기 없이 read한다. `read_only=False` 경로는 기존 baseline과 byte-for-byte
+  동일(모든 write 소비자 무영향). 옵션 A의 `read_only=True`는 기존 스키마를
+  부트스트랩 없이 읽는 명령(현재 `backtest history`)에만 적용한다.
 - ctx 정책: 신규 factory 내부에서 `get_db_path(ctx)` 명시 전달이 권장. ctx 없는
   암시 fallback은 deprecated.
 - read-only 예외: `AccountService`/`MemberService`/`ApprovalService`/

--- a/docs/specs/contracts/offline-factory.md
+++ b/docs/specs/contracts/offline-factory.md
@@ -2,8 +2,8 @@
 
 > Parent epic: [#1818 CLI offline service composition factory & runtime guard SSOT](https://github.com/joshua-jingu-lee/ante/issues/1818)
 > Owning issue: [#1854 CLI offline service factory 계약 및 read_only 초기화 정책 정리](https://github.com/joshua-jingu-lee/ante/issues/1854)
-> Status: 1.0 normative — CLI `offline` / `cold-path` execution class가 사용하는 service composition factory의 책임/비책임, read_only 초기화 정책, ctx 기반 path resolution 정책의 단일 SSOT.
-> Scope: 본 문서는 SSOT spec. production factory 구현(`open_cli_db`)은 [#1855](https://github.com/joshua-jingu-lee/ante/issues/1855)에서 도입되어 `src/ante/cli/db_context.py`에 존재한다.
+> Status: 1.1 normative — CLI `offline` / `cold-path` execution class가 사용하는 service composition factory의 책임/비책임, read_only 초기화 정책, ctx 기반 path resolution 정책의 단일 SSOT. 1.1(#1974 R2, 2026-05-31 KST)에서 §2를 amend해 `read_only=True`에 옵션 A(`Database` SQLite read-only 연결 모드)를 옵션 B와 함께 normative로 채택했다.
+> Scope: 본 문서는 SSOT spec. production factory 구현(`open_cli_db`)은 [#1855](https://github.com/joshua-jingu-lee/ante/issues/1855)에서 도입되어 `src/ante/cli/db_context.py`에 존재하며, 옵션 A(`Database` read-only 연결 모드)는 [#1974](https://github.com/joshua-jingu-lee/ante/issues/1974) R2에서 `src/ante/core/database.py`에 도입된다.
 > Migration order: [docs/specs/contracts/README.md#migration-domain-order](README.md#migration-domain-order)와 [#1820](https://github.com/joshua-jingu-lee/ante/issues/1820)에서 SSOT로 결정된 `account → member → approval → bot → treasury → broker → strategy → 기타` 순서를 따른다. 본 문서는 본 순서를 **재선언하지 않는다**.
 
 ## 목적
@@ -95,18 +95,71 @@ command 본체 또는 별도 wrapper)가 가진다.
 
 ### 2.1 결정
 
-**옵션 B (factory-level skip)**를 normative로 채택한다.
+`read_only=True`는 **옵션 B (factory-level `initialize()` skip)**와 **옵션 A
+(`Database` SQLite read-only 연결 모드)**를 **함께** 의미한다(2026-05-31 KST
+#1974 R2 amend). 즉:
 
-- `Database.__init__` signature는 변경하지 않는다. 현재 baseline
-  (`src/ante/core/database.py`의 `Database(db_path: str)`)을 그대로 유지한다.
-  본 SSOT는 `Database` API에 `read_only` kwarg를 추가하지 **않는다**.
-- 대신 factory가 호출 시점에 `read_only: bool` (또는 동등 분류) 값을 받아
-  다음을 결정한다.
+> **`read_only=True` ≡ (a) `service.initialize()` skip(옵션 B) + (b) `Database`
+> 연결을 SQLite read-only(`mode=ro`)로 open(옵션 A).**
+
+본 amend 이전(1.0)에는 옵션 B만 normative였고 §2.3에서 옵션 A를 보류했다. 그러나
+옵션 B만으로는 `service.initialize()`를 skip해도 `Database.connect()`가
+writer+reader 두 연결을 열고 각각 `PRAGMA journal_mode=WAL`(쓰기 필요)을
+실행하므로, **실제 read-only 파일시스템(DB 파일 0444 / 디렉터리 0555)에서는
+여전히 `attempt to write a readonly database`로 실패**한다(#1974 재현). 본
+amend는 §2.3의 보류를 해제하고 옵션 A를 normative로 채택해 이 gap을 닫는다.
+
+#### (a) 옵션 B — factory-level `initialize()` skip
+
+- factory가 호출 시점에 `read_only: bool` (또는 동등 분류) 값을 받아 다음을
+  결정한다.
   - `read_only=True`: `service.initialize()` 호출을 **skip**한다. 해당 service
     가 `_db.execute_script(...)` / `_db.execute(ALTER ...)` 등의 schema/DDL
     trigger를 가지더라도 read-only 명령 경로에서는 그것을 발화하지 않는다.
   - `read_only=False`: `service.initialize()`를 호출한다. schema migration /
     DDL이 발동될 수 있다.
+
+#### (b) 옵션 A — `Database` SQLite read-only 연결 모드
+
+- `Database.__init__`은 backward-compatible keyword-only 파라미터
+  `read_only: bool = False`를 가진다
+  (`Database(db_path: str, *, read_only: bool = False)`).
+  - **`read_only=False` 경로는 기존 baseline과 byte-for-byte 동일**해야 한다
+    — writer + reader 두 연결을 열고 WAL/synchronous 포함 기존 PRAGMA 시퀀스를
+    그대로 적용한다. 22+ callsite·`main.py`·모든 write 경로는 무영향이다(invariant).
+  - `read_only=True`이면:
+    - reader **단일 연결**만 SQLite `file:<escaped-abs-path>?mode=ro` URI로
+      연다(`aiosqlite.connect(uri, uri=True)` — `uri=True` 필수). writer는
+      개방하지 않으며, writer 경로(`execute`/`execute_script`/`execute_fetch_*`/
+      `transaction`) 호출은 read-only 전용 에러(`ReadOnlyDatabaseError`)로 실패한다.
+    - 쓰기 PRAGMA(`journal_mode=WAL`, `synchronous=NORMAL`)는 **skip**한다
+      (read-only fs에서 실패하므로). `foreign_keys=ON`/`busy_timeout`/
+      `temp_store=MEMORY`/`row_factory`만 적용한다.
+    - **immutable fallback**: `mode=ro` 연결 직후 최소 probe read
+      (`PRAGMA schema_version`)를 수행한다. probe가 WAL artifact/권한 계열
+      `sqlite3.OperationalError`(메시지 allowlist: `attempt to write a readonly
+      database`, `unable to open database file`, `disk I/O error`,
+      `-wal`/`-shm` 접근 실패류)로 실패하면 `file:...?mode=ro&immutable=1`로
+      **재연결**한다. `no such table`(테이블 부재 — query 시점 발생, connect
+      probe 단계 아님), `database disk image is malformed`, `file is not a
+      database`는 fallback 대상이 **아니며 재전파**한다(blanket OperationalError
+      fallback 금지 — 메시지 allowlist로만 좁힌다).
+    - `immutable=1`은 **read-only artifact 전용**이다. immutable 모드는 `-wal`/
+      `-shm` sidecar를 무시하고 메인 DB 파일만 읽으므로, live 동시쓰기 DB나
+      checkpoint되지 않은 WAL frame이 메인 DB에 합쳐지지 않은 artifact에는
+      적용하지 않는다(Non-Goals 참조). Ante의 `Database.close()`는 마지막 연결
+      종료 시 WAL을 checkpoint하고 sidecar를 제거하므로, 정상적으로 freeze된
+      backtest artifact는 모든 커밋 데이터가 메인 DB에 있어 immutable fallback이
+      데이터 손실 없이 신뢰 가능하다.
+- factory(`open_cli_db`)는 `read_only=True`일 때만 `Database(db_path,
+  read_only=True)`로 전달한다. `read_only=False`이면 기존 `Database(db_path)`
+  호출을 byte-for-byte 유지한다(kwarg 미전달).
+
+#### 적용 범위
+
+옵션 A의 `read_only=True`는 **기존 스키마를 부트스트랩 없이 읽을 수 있는
+명령(현재 `backtest history`)에만** 적용한다. §4 예외 service는 본 모드의
+대상이 아니다(§4.1 명확화 참조).
 
 ### 2.2 read-only / read-write 분류 결정 기준
 
@@ -121,19 +174,28 @@ command 본체 또는 별도 wrapper)가 가진다.
   **않는다**. enumeration은 [docs/specs/cli/03-commands.md](../cli/03-commands.md)
   + #1815 registry가 SSOT다.
 
-### 2.3 옵션 A를 채택하지 않은 이유
+### 2.3 옵션 A 채택 (#1974 R2, 2026-05-31 KST)
 
-Plan v1 Codex review 권고:
+본 절은 1.0에서 "옵션 A를 채택하지 않은 이유"였다. #1974 R2 amend로 **옵션 A를
+채택**한다. 이력과 채택 근거는 다음과 같다.
 
-- `Database`에 `read_only: bool = False`를 추가하는 옵션 A는 본 spec PR 범위가
-  아닌 `Database` API 변경이다. spec-only PR (#1854)에서 `Database` API
-  contract를 변경하면 docs PR과 code PR이 충돌한다.
-- factory-level skip(옵션 B)은 `Database` API를 그대로 두고도 invariant
-  ("read-only 명령은 schema/DDL trigger하지 않는다")를 만족한다.
-- #1855/#1856/#1857 구현 시 `Database` API에 `read_only` mode 추가가
-  고려되었으나, 본 spec은 옵션 B(factory-level skip)를 normative로 채택한
-  결정만 lock하며 — 향후 `Database` API에 `read_only` mode를 추가하는 결정이
-  내려지더라도 본 spec과 충돌하지 않는다.
+이력(1.0): spec-only PR(#1854)에서 `Database` API를 변경하면 docs PR과 code
+PR이 충돌하므로, 당시에는 factory-level skip(옵션 B)만 normative로 lock하고
+옵션 A를 보류했다. 단, 1.0은 "향후 `Database` API에 `read_only` mode를 추가하는
+결정이 내려지더라도 본 spec과 충돌하지 않는다"고 명시했다 — **본 amend가 바로 그
+결정**이다.
+
+채택 근거(#1974 R2): 옵션 B만으로는 실제 read-only 파일시스템에서 `backtest
+history`가 `attempt to write a readonly database`로 실패한다(§2.1 amend 참조).
+`service.initialize()`를 skip해도 `Database.connect()`의 writer+reader WAL
+PRAGMA가 쓰기를 요구하기 때문이다. 따라서 옵션 A를 normative로 채택해
+`Database`에 backward-compatible `read_only` 연결 모드를 도입한다. 본 amend의
+구체 정책은 §2.1 (b)에 lock한다.
+
+- 옵션 B와 옵션 A는 상호배타가 아니라 **함께** `read_only=True`의 의미를
+  구성한다(§2.1).
+- 옵션 A는 `Database` API에 keyword-only `read_only: bool = False`를 추가하되,
+  `read_only=False` 경로를 byte-for-byte 보존해 기존 소비자에 무영향이다.
 
 ## 3. ctx 기반 path resolution 정책
 
@@ -182,6 +244,17 @@ non-bootstrapped DB에서는 read-only 명령이라도 schema가 한 번은 생�
 service는 read-only 명령에서도 `initialize()`를 호출한다 (즉 옵션 B의 skip
 규칙에서 제외된다).
 
+**§2 옵션 A와의 관계 (중요, #1974 R2 명확화)**: §4 예외 service
+(`AccountService`/`MemberService`/`ApprovalService`/`AuditLogger`/
+`DynamicConfigService`)는 `initialize()`가 schema DDL을 발화해야 read가
+가능하므로 — fresh/non-bootstrapped DB에서 schema를 쓰기로 생성해야 하므로 —
+**schema 분리(§4.3) 전까지 `read_only=True`의 대상이 아니다.** 옵션 A의
+`read_only=True`(Database read-only 연결 모드)는 **기존 스키마를 부트스트랩 없이
+읽을 수 있는 명령(현재 `backtest history`)에만** 적용한다. §4 예외 service를
+read-only 연결 모드로 강제하면 `initialize()`의 schema DDL이 read-only 연결에서
+실패하므로, 이들은 본 amend의 적용 대상에서 명시적으로 제외한다. 이들의 read-only
+지원은 §4.3 schema 분리 결정을 선행 조건으로 하는 별도 follow-up이다.
+
 ### 4.2 예외 목록 (baseline 2026-05-27 KST)
 
 본 표는 `src/ante/{domain}/service.py`의 `initialize()` 본문이 schema /
@@ -199,14 +272,17 @@ service를 변경하면 본 표를 갱신한다.
 ### 4.3 후속 분리 가능성
 
 본 예외는 **service `initialize()` 내부에 read path와 schema 부트스트랩이
-얽혀 있기 때문**에 발생한다. #1855는 factory 책임 경계(spec §2)를 lock하는
-방향으로 진행됐으며, `Database` API에 `read_only` mode를 도입하지 않는
-옵션 B 정책은 본 spec §2 결정에 따라 유지된다. 향후 다음 중 하나를 채택하면
-본 표는 축소될 수 있다 — 본 SSOT는 어느 쪽도 강제하지 않는다.
+얽혀 있기 때문**에 발생한다. #1974 R2 amend로 §2는 옵션 A(`Database` read-only
+연결 모드)를 채택했으나, **이는 기존 스키마를 부트스트랩 없이 읽는 명령에만
+적용**되므로 본 §4 예외 service에는 직접 적용할 수 없다 — 이들은
+`initialize()`의 schema DDL을 쓰기로 생성해야 read가 가능하기 때문이다(§4.1
+명확화). 따라서 본 예외 service의 read-only 지원은 아래 schema 분리를 **선행
+조건**으로 한다. 향후 다음 중 하나를 채택하면 본 표는 축소될 수 있다 — 본 SSOT는
+어느 쪽도 강제하지 않는다.
 
 - service에 `ensure_schema()` / `open_existing()` 등의 분리 entrypoint 도입 →
-  read-only factory는 `ensure_schema()`만 호출, write path는 기존
-  `initialize()` 호출
+  read-only factory는 schema 부트스트랩 없이 기존 스키마를 `read_only=True`로
+  읽고, write path는 기존 `initialize()` 호출
 - factory가 schema 부재를 감지해 `ensure_schema()` 호출 후 read 진행
 
 본 표는 baseline lock일 뿐, 후속 schema separation 결정은 별도 spec change로
@@ -290,13 +366,20 @@ account/member/approval을 같은 1차 PR(#1856)에 함께 다뤘다" — 가
 
 본 SSOT가 다루지 **않는** 항목.
 
-- factory production code 구현 — #1855/#1856/#1857에서 완료.
+- factory production code 구현 — #1855/#1856/#1857에서 완료. 옵션 A
+  (`Database` read-only 연결 모드)의 production 구현은 #1974 R2에서 완료한다.
 - CLI command migration enumeration — 동일.
 - DI framework 도입.
 - IPC routing / IPC fallback 통합.
-- `Database` API 확장 (`read_only` kwarg 등) — 본 SSOT는 옵션 B를 채택해
-  `Database` API 변경 없이 invariant를 만족하도록 lock 한다.
-- runtime `src/ante/main.py` composition root 변경.
+- 옵션 A `read_only=True`를 `backtest history` 외 명령(report/data/§4 예외
+  service 등)으로 확대 — 별도 follow-up. §4 예외 service는 schema 분리(§4.3)를
+  선행 조건으로 한다.
+- live 동시쓰기 DB의 read-only 일관성 — `immutable=1`은 read-only artifact
+  전용이며, checkpoint되지 않은 live WAL frame은 대상이 아니다(§2.1 (b)).
+- WAL→다른 journal 마이그레이션, DB immutable 정책 전면 재설계.
+- runtime `src/ante/main.py` composition root에 `read_only` 적용 — 서버 runtime은
+  write가 필요하다.
 - envelope/error taxonomy 본문 변경.
-- service `initialize()` schema 분리 — 본 spec §2가 factory-level skip(옵션 B)로
-  lock; #1855/#1856/#1857 migration이 그 lock을 따른다.
+- service `initialize()` schema 분리 — 본 spec §2가 옵션 B(factory-level skip) +
+  옵션 A(Database read-only 연결 모드)를 lock하나, §4 예외 service의 read path와
+  schema 부트스트랩 분리는 별도 spec change(§4.3)로 다룬다.

--- a/docs/specs/contracts/offline-factory.md
+++ b/docs/specs/contracts/offline-factory.md
@@ -161,6 +161,29 @@ amend는 §2.3의 보류를 해제하고 옵션 A를 normative로 채택해 이 
 명령(현재 `backtest history`)에만** 적용한다. §4 예외 service는 본 모드의
 대상이 아니다(§4.1 명확화 참조).
 
+**CLI 인증 경로와의 경계 (중요, #1974 R2 [P2] 명확화)**: 옵션 A의
+`read_only=True`(Database read-only 연결 모드)는 **command 본문이 여는
+`--db-path` 아티팩트 read에만** 적용된다. 이는 command 본문 실행 **전에**
+`AuthenticatedGroup`/`require_auth`가 발화하는 **CLI 인증 경로와 독립**이다:
+`authenticate_member()` → `_run_authenticate()`는 `get_db_path(ctx)`
+(= `--config-dir`로 해석되는 `<config_dir>/db/ante.db`, **config-dir 멤버 DB**)
+에 쓰기 `Database()` + `MemberService.initialize()`(schema DDL)를 연다. 이
+멤버 DB 경로는 본문의 `--db-path` 아티팩트와 **다른 트리**이며 read-only 연결
+모드의 대상이 **아니다**.
+
+따라서 운영 시나리오는 두 갈래로 갈린다.
+
+- **read-only 아티팩트 + writable config-dir** (본 결정이 해소): 멤버 DB가
+  쓰기 가능하면 auth는 그 DB로 통과하고, command 본문은 read-only `--db-path`
+  아티팩트를 옵션 A로 읽는다 → exit 0. 운영자 repro
+  (`backtest history`가 auth는 통과하고 본문에서 `BACKTEST_ERROR`로 실패)가
+  정확히 이 갈래이며, 본 amend가 그 본문 실패를 해소한다.
+- **config-dir 멤버 DB까지 read-only인 'full read-only ante home'** (범위 밖):
+  멤버 DB가 read-only면 `MemberService`(§4 예외 service)의 `initialize()`
+  schema DDL이 read-only 연결에서 실패하므로, 본 시나리오는 §4 schema
+  분리(§4.3)를 **선행 조건**으로 한다. 본 결정의 범위 밖이며 follow-up
+  [#1978](https://github.com/joshua-jingu-lee/ante/issues/1978)로 분리한다.
+
 ### 2.2 read-only / read-write 분류 결정 기준
 
 - 1차 SSOT: [docs/specs/cli/03-commands.md](../cli/03-commands.md)의
@@ -286,7 +309,12 @@ service를 변경하면 본 표를 갱신한다.
 - factory가 schema 부재를 감지해 `ensure_schema()` 호출 후 read 진행
 
 본 표는 baseline lock일 뿐, 후속 schema separation 결정은 별도 spec change로
-다룬다.
+다룬다. 특히 CLI 인증 경로(`require_auth` → `MemberService.initialize()`)가
+config-dir 멤버 DB에 schema DDL을 써야 하므로, **config-dir 멤버 DB까지
+read-only인 'full read-only ante home'** 지원은 본 schema 분리를 선행 조건으로
+하는 별도 follow-up
+[#1978](https://github.com/joshua-jingu-lee/ante/issues/1978)에서 다룬다(§2.1
+"CLI 인증 경로와의 경계" 참조).
 
 ### 4.4 예외 외 service
 

--- a/src/ante/cli/db_context.py
+++ b/src/ante/cli/db_context.py
@@ -16,8 +16,15 @@ Codex Plan Review v2 lock:
 2. cleanup은 ``except BaseException``으로 ``asyncio.CancelledError``까지 catch한다.
 3. ``Database.close()``가 실패해도 원래 body 예외를 가린다거나 chain되지 않도록
    inner try/except로 ``close()`` 실패를 무시하고 원래 예외만 surface한다.
-4. ``read_only``는 caller hint metadata일 뿐, ``Database`` 생성자에는 전달하지
-   않는다 (#1854 contract 옵션 B — Database API 변경 금지).
+4. ``read_only=True``일 때만 ``Database(db_path, read_only=True)``로 전달한다
+   (#1974 offline-factory.md §2 옵션 A — Database read-only 연결 모드 채택).
+   ``read_only=False``이면 기존 ``Database(db_path)`` 호출을 byte-for-byte
+   유지한다(kwarg 미전달 — #1856/#1857 patch 호환 및 모든 write 소비자 무영향
+   invariant). read-only 모드는 기존 스키마를 부트스트랩 없이 읽는 offline read
+   명령(현재 ``backtest history``)에만 적용된다 — §4 예외 service
+   (`AccountService`/`MemberService`/`ApprovalService`/`AuditLogger`/
+   `DynamicConfigService`)는 ``initialize()``가 schema DDL을 발화해야 read가
+   가능하므로 schema 분리 전까지 ``read_only=True`` 대상이 아니다.
 """
 
 from __future__ import annotations
@@ -54,10 +61,14 @@ async def open_cli_db(
             를 통해 결정된 DB 경로를 ``get_db_path(ctx)``로 해석한다.
             ``None``을 전달하면 ``ValueError``를 발생시킨다 — legacy 암시
             fallback에 의존하지 않는다.
-        read_only: caller hint. ``Database`` 생성자에는 전달되지 않으며,
-            현재는 메타데이터로만 유지된다 (#1854 contract 옵션 B). 후속
-            이슈에서 read-only enforcement가 필요하면 이 플래그를 통해
-            확장한다.
+        read_only: ``True`` 면 ``Database(db_path, read_only=True)`` 로 전달해
+            SQLite ``mode=ro`` 단일 reader 연결을 열고 schema/WAL 쓰기를 회피한다
+            (#1974 offline-factory.md §2 옵션 A — Database read-only 연결 모드).
+            ``False`` (기본) 이면 기존 ``Database(db_path)`` 호출을
+            byte-for-byte 유지한다 (kwarg 미전달, 모든 write 소비자 무영향).
+            read-only 모드는 기존 스키마를 부트스트랩 없이 읽는 offline read
+            명령(현재 ``backtest history``)에만 사용한다 — §4 예외 service 는
+            schema 분리 전까지 ``read_only=True`` 대상이 아니다.
         db_path_override: optional 명시 DB 경로. ``None`` 이면
             ``get_db_path(ctx)`` 로 해석한다. ``approval list/info/review/
             audit-types`` 등 ``--db-path`` Click option 을 지원하는 명령은
@@ -81,10 +92,6 @@ async def open_cli_db(
         raise ValueError(
             "open_cli_db requires explicit Click context (legacy fallback deprecated)"
         )
-    # ``read_only`` is a caller hint only; it is intentionally not forwarded
-    # to ``Database.__init__`` per #1854 contract option B (no Database API
-    # signature change in this PR scope).
-    _ = read_only
     # #1857: lazy module-attribute access for ``get_db_path`` /
     # ``Database`` to honor test patches of either:
     #   - ``ante.cli.main.get_db_path`` (callsite import binding)
@@ -110,7 +117,13 @@ async def open_cli_db(
         _db_cls = _module_db_cls
     else:
         _db_cls = _ORIGINAL_DATABASE
-    db = _db_cls(db_path)
+    # #1974: ``read_only=True`` 일 때만 ``read_only`` kwarg 를 전달한다. False
+    # 경로는 기존 ``_db_cls(db_path)`` 호출을 byte-for-byte 유지해 모든 write
+    # 소비자·#1856/#1857 patch(mock) 호환을 보존한다 (offline-factory.md §2 옵션 A).
+    if read_only:
+        db = _db_cls(db_path, read_only=True)
+    else:
+        db = _db_cls(db_path)
     await db.connect()
     try:
         yield db

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -185,6 +185,13 @@ mirror, ``BotNotFoundError`` 는 #1840 lock 그대로 보존):
 baseline 으로 그대로 유지된다 (#1842 ``AccountError`` 와 동일 패턴,
 #1843 sub-PR 1/2/3/4/5 Non-Goals 동형).
 
+#1974 R2 가 추가한 core 1 class lock:
+
+- ``ReadOnlyDatabaseError`` → ``EXECUTION_ERROR`` / ``internal`` (read-only
+  ``Database`` 에서 writer 경로 호출 시 발생하는 프로그래밍/사용 오류 guard.
+  정상 경로에서는 발생하지 않으며, 발생 시 호출 코드 버그를 의미하므로
+  taxonomy ``internal`` 로 명시 매핑 — 암묵적 fallback drift 가 아님을 lock).
+
 추가로 ``SERVICE_NOT_CONFIGURED`` 는 #1819 dispatch wrapper 가 도입할 예정인
 ``ServiceNotConfiguredError`` 의 ErrorSpec value 를 module-level constant
 (``_SERVICE_NOT_CONFIGURED_SPEC``) 로 reserved 보존한다. 해당 exception class
@@ -237,6 +244,7 @@ from ante.broker.registry import (
 )
 from ante.config.exceptions import ConfigValidationError
 from ante.contracts.errors import ErrorSpec
+from ante.core.database import ReadOnlyDatabaseError
 from ante.member.errors import (
     MemberAlreadyExistsError,
     MemberInvalidEmojiError,
@@ -704,6 +712,21 @@ _SERVICE_NOT_CONFIGURED_SPEC: Final[ErrorSpec] = ErrorSpec(
 )
 
 
+# ── core 1 class lock (#1974 R2) ─────────────────────────────────────────────
+#
+# ``ReadOnlyDatabaseError`` 는 read-only ``Database`` (``read_only=True``) 에서
+# writer 경로(``execute``/``execute_script``/``transaction`` 등)를 호출했을 때
+# 발생하는 **프로그래밍/사용 오류** guard 다 (offline-factory.md §2 옵션 A). 정상
+# 코드 경로에서는 발생하지 않으며, 발생 시 호출 코드의 버그를 의미한다. 따라서
+# taxonomy SSOT (#1839) 의 ``EXECUTION_ERROR`` / ``internal`` (코드 버그 /
+# unexpected programming error) 로 명시 매핑한다 — 암묵적 fallback drift 가
+# 아니라 의도된 분류임을 registry 로 lock 한다.
+_READ_ONLY_DATABASE_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="EXECUTION_ERROR",
+    category="internal",
+)
+
+
 # ── fallback (registry miss + .code 도 없을 때) ──────────────────────────────
 
 EXECUTION_ERROR_SPEC: Final[ErrorSpec] = ErrorSpec(
@@ -784,6 +807,8 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     ConfigValidationError: _CONFIG_VALIDATION_ERROR_SPEC,
     # ── #1843 sub-PR 6 rule 1 sub-class (실측 .code mirror) ───────────────
     RuleConfigError: _RULE_CONFIG_ERROR_SPEC,
+    # ── #1974 R2 core 1 class (read-only Database write-guard) ────────────
+    ReadOnlyDatabaseError: _READ_ONLY_DATABASE_SPEC,
 }
 """대표 fault lock registry (#1839 normative 4건).
 

--- a/src/ante/core/__init__.py
+++ b/src/ante/core/__init__.py
@@ -1,6 +1,6 @@
 """Core infrastructure — Database wrapper, canonical exchange vocabulary."""
 
-from ante.core.database import Database
+from ante.core.database import Database, ReadOnlyDatabaseError
 from ante.core.exchange import (
     CANONICAL_EXCHANGES,
     STRATEGY_EXCHANGES,
@@ -15,6 +15,7 @@ __all__ = [
     "STRATEGY_EXCHANGES",
     "STRATEGY_WILDCARD",
     "Database",
+    "ReadOnlyDatabaseError",
     "is_canonical",
     "is_strategy_allowed",
     "normalize_exchange",

--- a/src/ante/core/database.py
+++ b/src/ante/core/database.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import logging
+import sqlite3
+import urllib.request
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -9,12 +11,54 @@ import aiosqlite
 
 logger = logging.getLogger(__name__)
 
+# read-only(``mode=ro``) probe(``PRAGMA schema_version``) 가 아래 메시지 계열
+# ``sqlite3.OperationalError`` 로 실패하면 ``immutable=1`` 로 재연결 fallback 한다
+# (offline-factory.md §2 옵션 A). WAL DB 를 실제 read-only 파일시스템에서 ro 로
+# 열면 SQLite 가 ``-wal``/``-shm`` 을 생성/쓰기 시도하다 실패하는데, 그 표면
+# 메시지는 환경(권한·잔여 WAL artifact)에 따라 아래 중 하나로 나타난다.
+#
+# 반대로 ``no such table`` (테이블 부재 — query 시점에 발생, connect probe 단계
+# 아님), ``database disk image is malformed``, ``file is not a database`` 는
+# 데이터 무결성/스키마 문제이지 WAL/권한 문제가 아니므로 fallback 하지 않고
+# 재전파한다(blanket OperationalError fallback 금지 — 메시지 allowlist 로만 좁힘).
+_RO_IMMUTABLE_FALLBACK_SIGNATURES: tuple[str, ...] = (
+    "attempt to write a readonly database",
+    "unable to open database file",
+    "disk i/o error",
+    "-wal",
+    "-shm",
+)
+
+
+def _is_ro_fallback_error(exc: sqlite3.OperationalError) -> bool:
+    """probe 실패가 ``immutable=1`` fallback 대상(WAL/권한 계열)인지 판별한다."""
+    message = str(exc).lower()
+    return any(sig in message for sig in _RO_IMMUTABLE_FALLBACK_SIGNATURES)
+
+
+class ReadOnlyDatabaseError(RuntimeError):
+    """read-only ``Database`` 에서 write 연산을 시도했을 때 발생한다.
+
+    ``read_only=True`` 로 생성된 ``Database`` 는 writer 연결을 열지 않으므로
+    ``execute``/``execute_script``/``execute_fetch_*``/``transaction`` 등 writer
+    경로를 호출하면 "연결되지 않음"이 아니라 본 예외로 명확히 실패한다
+    (offline-factory.md §2 옵션 A).
+    """
+
 
 class Database:
-    """SQLite WAL 모드 비동기 래퍼. 모든 모듈이 공유."""
+    """SQLite WAL 모드 비동기 래퍼. 모든 모듈이 공유.
 
-    def __init__(self, db_path: str) -> None:
+    기본(``read_only=False``)은 writer + reader 두 연결을 열고 WAL 모드를
+    설정한다(기존 baseline). ``read_only=True``는 reader 단일 연결만 SQLite
+    ``file:...?mode=ro`` URI 로 열어 schema/WAL 쓰기 없이 기존 DB 를 읽는다
+    (offline-factory.md §2 옵션 A). read-only 모드는 기존 스키마를 부트스트랩
+    없이 읽는 offline read 명령(현재 ``backtest history``)에만 적용된다.
+    """
+
+    def __init__(self, db_path: str, *, read_only: bool = False) -> None:
         self._db_path = db_path
+        self._read_only = read_only
         self._writer: aiosqlite.Connection | None = None
         self._reader: aiosqlite.Connection | None = None
         self._in_transaction: bool = False
@@ -90,8 +134,96 @@ class Database:
             raise
         return conn
 
+    def _ro_uri(self, *, immutable: bool) -> str:
+        """read-only SQLite URI 를 생성한다.
+
+        절대경로를 ``urllib.request.pathname2url`` 로 escape 해 공백/특수문자/
+        Windows drive 문자를 안전하게 처리한다(f-string 직접 보간 금지). 본
+        URI 는 ``aiosqlite.connect(..., uri=True)`` 로만 열어야 한다 — ``uri``
+        플래그가 없으면 ``mode=ro``/``immutable=1`` 쿼리스트링이 리터럴 파일명의
+        일부로 취급된다.
+
+        ``immutable=1`` 은 read-only artifact 전용이다(live 동시쓰기 DB 비대상).
+        WAL DB 를 실제 read-only 파일시스템에서 ``mode=ro`` 만으로 열면 SQLite 가
+        ``-wal``/``-shm`` 를 생성/쓰기하려다 실패하므로, immutable fallback 으로
+        DB 파일을 변경 불가 스냅샷으로 간주해 sidecar 없이 read 한다.
+        """
+        url = urllib.request.pathname2url(self._db_path)
+        query = "mode=ro&immutable=1" if immutable else "mode=ro"
+        return f"file:{url}?{query}"
+
+    async def _init_ro_conn(self) -> aiosqlite.Connection:
+        """read-only(``mode=ro``) 연결을 초기화한다(쓰기 PRAGMA skip).
+
+        ``mode=ro`` 로 연결한 직후 ``PRAGMA schema_version`` probe read 를
+        수행한다. WAL artifact/권한 계열 ``sqlite3.OperationalError`` 로 probe 가
+        실패하면(:func:`_is_ro_fallback_error`) ``immutable=1`` 로 재연결한다.
+        그 외(예: ``no such table`` — query 시점 발생, ``malformed`` 등)는
+        재전파한다.
+
+        쓰기 PRAGMA(``journal_mode=WAL``/``synchronous=NORMAL``)는 read-only 파일
+        시스템에서 실패하므로 발화하지 않고, ``foreign_keys``/``busy_timeout``/
+        ``temp_store``/``row_factory`` 만 적용한다.
+
+        연결 실패 시 :meth:`_init_conn` 과 동일하게 :meth:`_drain_failed_conn`
+        으로 worker thread 를 결정적으로 정리한다(#1965/#1970).
+        """
+        conn = await self._open_ro_conn(immutable=False)
+        try:
+            await self._probe_ro_conn(conn)
+        except sqlite3.OperationalError as exc:
+            if not _is_ro_fallback_error(exc):
+                # no such table / malformed / not a database 등은 fallback 대상이
+                # 아니다 — 연결을 정리하고 원본 예외를 재전파한다.
+                await self._drain_failed_conn(conn)
+                raise
+            logger.debug(
+                "read-only mode=ro probe 실패 — immutable=1 fallback 재연결: %s",
+                exc,
+            )
+            await self._drain_failed_conn(conn)
+            conn = await self._open_ro_conn(immutable=True)
+            try:
+                await self._probe_ro_conn(conn)
+            except BaseException:
+                await self._drain_failed_conn(conn)
+                raise
+        except BaseException:
+            await self._drain_failed_conn(conn)
+            raise
+        return conn
+
+    async def _open_ro_conn(self, *, immutable: bool) -> aiosqlite.Connection:
+        """``mode=ro``(또는 ``immutable=1``) URI 로 연결하고 read-only PRAGMA 적용."""
+        uri = self._ro_uri(immutable=immutable)
+        conn = aiosqlite.connect(uri, uri=True)
+        try:
+            await conn
+            await conn.execute("PRAGMA temp_store=MEMORY")
+            await conn.execute("PRAGMA foreign_keys=ON")
+            await conn.execute("PRAGMA busy_timeout=5000")
+            conn.row_factory = aiosqlite.Row
+        except BaseException:
+            await self._drain_failed_conn(conn)
+            raise
+        return conn
+
+    @staticmethod
+    async def _probe_ro_conn(conn: aiosqlite.Connection) -> None:
+        """최소 probe read(``PRAGMA schema_version``)로 ro 연결 가독성을 확인."""
+        async with conn.execute("PRAGMA schema_version") as cursor:
+            await cursor.fetchone()
+
     async def connect(self) -> None:
-        """DB 연결 초기화. writer + reader 두 연결 생성.
+        """DB 연결 초기화.
+
+        ``read_only=True`` 면 reader 단일 ``mode=ro`` 연결만 열고 ``_writer`` 는
+        미개방한다(write 경로는 :class:`ReadOnlyDatabaseError`). probe/fallback
+        실패 시에도 :meth:`_init_ro_conn` 이 worker thread 를 drain 하므로 leak
+        없이 정리된다(#1965/#1970).
+
+        ``read_only=False`` 면 기존 baseline 그대로 writer + reader 두 연결을
+        생성한다(아래 docstring 의 partial-failure drain 보존).
 
         어느 한쪽 연결이라도 실패하면 이미 열린 연결(writer)을 worker thread
         join 까지 포함해 **결정적으로 drain** 한 뒤 원본 예외를 재전파한다.
@@ -116,6 +248,11 @@ class Database:
         bounded(5s) + 예외 swallow 이므로 원본 connect 예외를 가리거나 hang
         하지 않는다.
         """
+        if self._read_only:
+            # reader 단일 mode=ro 연결만. probe/fallback 실패 시 _init_ro_conn 이
+            # 이미 worker thread 를 drain 하므로 여기서 추가 정리는 불필요하다.
+            self._reader = await self._init_ro_conn()
+            return
         try:
             self._writer = await self._init_conn()
             self._reader = await self._init_conn()
@@ -134,6 +271,11 @@ class Database:
         self._writer = self._reader = None
 
     def _get_writer(self) -> aiosqlite.Connection:
+        if self._read_only:
+            raise ReadOnlyDatabaseError(
+                "read-only Database: write operation not permitted "
+                "(read_only=True 로 생성된 연결은 writer 가 없습니다)"
+            )
         if not self._writer:
             raise RuntimeError("DB 연결되지 않음. connect()를 먼저 호출하세요.")
         return self._writer

--- a/tests/unit/cli/test_db_context_manager.py
+++ b/tests/unit/cli/test_db_context_manager.py
@@ -1,12 +1,14 @@
 """Tests for :func:`ante.cli.db_context.open_cli_db` lifecycle context manager.
 
-Plan v2 SSOT — 8 시나리오:
+Plan v2 SSOT (+ #1974 R2 옵션 A) — 9 시나리오:
 1. ``open_cli_db``가 connect된 :class:`Database`를 yield 한다.
 2. normal exit에서 ``close()``가 호출된다.
 3. body 예외가 발생해도 ``close()``가 호출된다.
 4. ``asyncio.CancelledError`` cancellation 경로에서도 ``close()``가 호출된다.
 5. ``get_db_path(ctx)``가 ctx로부터 명시적으로 resolve된다 (``--config-dir``).
-6. ``read_only=True``는 ``Database.__init__``에 전달되지 않는다 (#1854 옵션 B).
+6. ``read_only=True``는 ``Database.__init__``에 ``read_only=True`` kwarg로
+   전달되고, ``read_only=False``(기본)는 kwarg 미전달로 byte-for-byte 유지된다
+   (#1974 R2 옵션 A — offline-factory.md §2).
 7. ``ctx=None``은 ``ValueError``로 명시적으로 거부된다 (legacy fallback 의존 안 함).
 8. body 예외와 ``db.close()`` 실패가 함께 발생할 때 body 예외만 surface한다.
 
@@ -125,12 +127,13 @@ async def test_open_cli_db_uses_ctx_db_path(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_open_cli_db_read_only_not_passed_to_database_init(
+async def test_open_cli_db_read_only_true_passed_to_database_init(
     tmp_path: Path,
 ) -> None:
-    """6) ``read_only=True``는 hint일 뿐 ``Database.__init__``에 전달되지 않는다.
+    """6a) ``read_only=True``는 ``Database(db_path, read_only=True)``로 전달된다.
 
-    #1854 contract 옵션 B — Database API 시그니처 변경 금지.
+    #1974 R2 contract 옵션 A — Database read-only 연결 모드. factory 는
+    ``read_only=True`` 일 때만 ``read_only`` kwarg 를 forward 한다.
     """
     cfg_dir = _bootstrap_config_dir(tmp_path)
     ctx = _make_ctx_with_config_dir(cfg_dir)
@@ -141,7 +144,28 @@ async def test_open_cli_db_read_only_not_passed_to_database_init(
         instance.close = AsyncMock()
         async with open_cli_db(ctx, read_only=True):
             pass
-    # 위치 인자 1개(db_path)만 전달, read_only는 kwargs에 없어야 한다.
+    db_cls.assert_called_once_with(expected_db_path, read_only=True)
+
+
+@pytest.mark.asyncio
+async def test_open_cli_db_read_only_false_byte_for_byte_no_kwarg(
+    tmp_path: Path,
+) -> None:
+    """6b) ``read_only=False``(기본)는 기존 ``Database(db_path)`` 호출을 유지한다.
+
+    #1974 R2 invariant — False 경로는 kwarg 미전달로 byte-for-byte 동일해야
+    하며(모든 write 소비자·#1856/#1857 patch 호환), ``read_only`` 가 kwargs 에
+    없어야 한다.
+    """
+    cfg_dir = _bootstrap_config_dir(tmp_path)
+    ctx = _make_ctx_with_config_dir(cfg_dir)
+    expected_db_path = str(cfg_dir / "db" / "ante.db")
+    with patch("ante.cli.db_context.Database") as db_cls:
+        instance = db_cls.return_value
+        instance.connect = AsyncMock()
+        instance.close = AsyncMock()
+        async with open_cli_db(ctx):  # read_only 기본값 False
+            pass
     db_cls.assert_called_once_with(expected_db_path)
     call = db_cls.call_args
     assert "read_only" not in call.kwargs

--- a/tests/unit/test_cli_backtest_history_readonly_fs.py
+++ b/tests/unit/test_cli_backtest_history_readonly_fs.py
@@ -22,6 +22,29 @@ read-only 디렉터리 때문에 실패하지 않도록 한다. root/권한무�
 가 의미 없으므로 skip 한다.
 
 수정 전에는 ``attempt to write a readonly database`` 로 FAIL (BACKTEST_ERROR).
+
+추가 (R2 [P2] 후속, offline-factory.md §2 옵션 A 가정 검증):
+:class:`TestBacktestHistoryRealAuthReadOnlyFilesystem` 는 ``authenticate_member``
+를 **mock 하지 않고** 실제 CLI 인증 경로를 통과시킨다. ``backtest history`` 는
+``@require_auth`` 라 본문 실행 전에 ``authenticate_member()`` 가
+``get_db_path(ctx)`` (= ``--config-dir`` 의 ``<config_dir>/db/ante.db``, **쓰기**
+멤버 DB) 에 ``Database()`` + ``MemberService.initialize()`` (DDL) 를 연다. 이는
+``--db-path`` 아티팩트와 **독립** 경로다. 따라서:
+
+- writable config-dir 에 ``MemberService.bootstrap_master`` 로 실제 master 멤버 +
+  토큰을 생성하고 (``get_db_path`` 가 가리키는 ``<config_dir>/db/ante.db``),
+  토큰을 ``ANTE_MEMBER_TOKEN`` 환경변수로 설정한다. master(HUMAN) 는
+  ``require_scope("backtest:run")`` 를 무제한 통과한다.
+- **별도** read-only 아티팩트 DB(0o444/0o555) 를 ``--db-path`` 로 지정한다.
+- ``ante --format json backtest history momentum --db-path <ro>
+  --config-dir <writable>`` → exit 0 + runs 1 건.
+
+이는 운영자 repro (auth 통과 + 본문 ``BACKTEST_ERROR``) 의 정확한 mock-free
+재현이다: auth 는 writable config DB 로 통과하고, 실패는 read-only ``--db-path``
+본문에서 발생했었다 → R2 의 ``Database`` read-only 연결 모드가 그 본문 실패를
+해소한다. (config-dir 멤버 DB 까지 read-only 인 'full read-only ante home' 은
+``MemberService`` §4 예외 service 의 DDL 때문에 §4 스키마 분리가 선행이며 본
+결정 범위 밖 — follow-up #1978.)
 """
 
 from __future__ import annotations
@@ -37,9 +60,12 @@ import pytest
 from click.testing import CliRunner
 
 from ante.backtest.run_store import BACKTEST_RUNS_SCHEMA
+from ante.cli.commands.init import _DB_FILENAME, SYSTEM_TOML_TEMPLATE
 from ante.cli.main import cli
 from ante.core.database import Database
+from ante.eventbus.bus import EventBus
 from ante.member.models import Member, MemberRole, MemberType
+from ante.member.service import MemberService
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -228,3 +254,137 @@ class TestBacktestHistoryReadOnlyFilesystem:
         assert len(data["runs"]) == 1, data
         assert data["runs"][0]["strategy_name"] == "momentum"
         assert data["runs"][0]["run_id"] == "run-momentum-1"
+
+
+# ── 실 인증(비-mock) end-to-end ────────────────────────────────────────────
+
+
+def _bootstrap_writable_config(config_dir: Path) -> str:
+    """writable config-dir 에 실제 master 멤버 + 토큰을 부트스트랩하고 토큰 반환.
+
+    ``ante init`` 이 만드는 것과 동형으로 ``<config_dir>/system.toml`` (``[db]
+    path = "db/ante.db"``) + ``<config_dir>/db/ante.db`` 에 master 멤버를 만든다.
+    ``get_db_path(ctx)`` 가 ``--config-dir`` 로부터 이 경로를 해석하므로,
+    ``authenticate_member`` 의 실제 auth 경로 (``MemberService.initialize()`` DDL
+    + ``authenticate(token)``) 가 mock 없이 통과한다.
+
+    토큰 발급 패턴은 ``ante init`` 의 ``_bootstrap_master``
+    (``MemberService.bootstrap_master`` → ``(member, token, recovery_key)``) 를
+    미러한다. master(HUMAN) 는 ``require_scope("backtest:run")`` 를 무제한
+    통과하므로 별도 scope 부여가 필요 없다.
+    """
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "system.toml").write_text(
+        SYSTEM_TOML_TEMPLATE.format(db_path=_DB_FILENAME)
+    )
+    member_db = config_dir / _DB_FILENAME
+    member_db.parent.mkdir(parents=True, exist_ok=True)
+
+    async def _create() -> str:
+        db = Database(str(member_db))
+        await db.connect()
+        try:
+            svc = MemberService(db, EventBus())
+            await svc.initialize()
+            _member, token, _recovery = await svc.bootstrap_master(
+                "owner", "pass123", name="Owner"
+            )
+            return token
+        finally:
+            await db.close()
+
+    return asyncio.run(_create())
+
+
+def _run_history_real_auth(
+    artifact_dir: Path,
+    artifact_db: Path,
+    config_dir: Path,
+):
+    """read-only 아티팩트를 ``--db-path`` 로, writable config-dir 를
+    ``--config-dir`` 로 주어 실제 auth 경로를 통과하는 ``backtest history`` 실행.
+
+    아티팩트 디렉터리/파일을 read-only(파일 0o444 / 디렉터리 0o555) 로 만들고
+    ``try/finally`` 로 권한 복구한다. config-dir 은 writable 로 둔다 (auth 가
+    ``MemberService.initialize()`` DDL 을 써야 하므로).
+    """
+    sidecars = [
+        artifact_dir / f"{artifact_db.name}-wal",
+        artifact_dir / f"{artifact_db.name}-shm",
+    ]
+    os.chmod(artifact_db, 0o444)
+    for s in sidecars:
+        if s.exists():
+            os.chmod(s, 0o444)
+    os.chmod(artifact_dir, 0o555)
+    try:
+        return CliRunner().invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "--config-dir",
+                str(config_dir),
+                "backtest",
+                "history",
+                "momentum",
+                "--db-path",
+                str(artifact_db),
+            ],
+        )
+    finally:
+        os.chmod(artifact_dir, 0o755)
+        os.chmod(artifact_db, 0o644)
+        for s in sidecars:
+            if s.exists():
+                os.chmod(s, 0o644)
+
+
+@_requires_unprivileged
+class TestBacktestHistoryRealAuthReadOnlyFilesystem:
+    """``authenticate_member`` 를 mock 하지 않는 실 end-to-end (#1974 R2 [P2]).
+
+    R1 의 프록시(쓰기 가능 temp DB + auth mock) 가 실제 read-only mount 의 본문
+    실패를 가리지 못했던 교훈에 따라, 본 테스트는 실제 CLI 경로를 mock 없이
+    증명한다:
+
+    - auth (``get_db_path(ctx)`` = writable config-dir 멤버 DB) → 실제
+      ``MemberService.initialize()`` DDL + ``authenticate(token)`` 통과.
+    - 본문 (``--db-path`` = 별도 read-only 아티팩트, 0o444/0o555) → ``Database``
+      read-only 연결 모드(mode=ro/immutable) 로 read.
+
+    두 경로가 독립이므로 auth 는 writable config 로 통과하고 본문은 read-only
+    아티팩트를 읽어 exit 0 + runs 1 건이어야 한다. 이는 운영자 repro
+    (auth 통과 + 본문 ``BACKTEST_ERROR``) 의 mock-free 재현이다.
+    """
+
+    def test_real_auth_history_on_readonly_artifact_checkpointed(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # 1) writable config-dir 에 실제 master + 토큰.
+        config_dir = tmp_path / "config"
+        token = _bootstrap_writable_config(config_dir)
+        monkeypatch.setenv("ANTE_MEMBER_TOKEN", token)
+        # 토큰 파일 폴백 경로가 환경에 따라 끼어들지 않도록 차단.
+        monkeypatch.setenv("ANTE_TOKEN_FILE", str(tmp_path / "nonexistent-token"))
+
+        # 2) 별도 read-only 아티팩트 DB (config-dir 와 다른 트리).
+        artifact_dir = tmp_path / "artifact"
+        artifact_dir.mkdir()
+        artifact_db = artifact_dir / "ante.db"
+        _seed_db_with_one_run(str(artifact_db))
+        _checkpoint_truncate(str(artifact_db))
+
+        # 3) 실 auth(writable config) + 본문(read-only --db-path) 동시 통과.
+        result = _run_history_real_auth(artifact_dir, artifact_db, config_dir)
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "runs" in data, data
+        assert len(data["runs"]) == 1, data
+        assert data["runs"][0]["strategy_name"] == "momentum"
+        assert data["runs"][0]["run_id"] == "run-momentum-1"
+        # config-dir 멤버 DB 는 writable 이어야 한다 (auth DDL). 회귀 방지로
+        # auth 경로가 read-only 아티팩트를 건드리지 않았음을 확인한다.
+        member_db = config_dir / _DB_FILENAME
+        assert member_db.exists(), "auth 는 config-dir 멤버 DB 로 통과해야 한다"

--- a/tests/unit/test_cli_backtest_history_readonly_fs.py
+++ b/tests/unit/test_cli_backtest_history_readonly_fs.py
@@ -1,0 +1,230 @@
+"""``ante backtest history`` 실제 read-only 파일시스템 회귀 테스트 (#1974 R2).
+
+#1976 은 ``backtest history`` 에서 ``BacktestRunStore.initialize()`` (schema DDL)
+만 제거했고, 검증은 쓰기 가능 temp DB 의 "테이블 미생성" 프록시였다. 그러나
+**실제 read-only 파일시스템 (DB 파일 0444 / 디렉터리 0555)** 에서는 여전히
+``Database.connect()`` 가 writer+reader 두 연결을 열고 각각
+``PRAGMA journal_mode=WAL`` (쓰기 필요) 을 실행해
+``attempt to write a readonly database`` 로 실패한다.
+
+본 테스트는 그 실제 권한 조건을 재현한다 (offline-factory.md §2 옵션 A):
+
+- 임시 DB 에 ``backtest_runs`` 스키마 + ``momentum`` 이력 1 건을 미리 생성 후 close.
+- WAL 잔여 처리 두 케이스:
+  - (case A) ``PRAGMA wal_checkpoint(TRUNCATE)`` 로 ``-wal``/``-shm`` 을 비운 artifact.
+  - (case B) ``-wal``/``-shm`` 이 존재하는 상태.
+- ``os.chmod(db, 0o444)`` + ``os.chmod(dir, 0o555)`` 후
+  ``ante --format json backtest history momentum --db-path <ro>/ante.db`` 실행 →
+  exit 0 + ``runs`` 1 건.
+
+권한 복구는 ``try/finally`` 로 보장 (dir 0o755, file 0o644) — tmp cleanup 이
+read-only 디렉터리 때문에 실패하지 않도록 한다. root/권한무시 환경에서는 chmod
+가 의미 없으므로 skip 한다.
+
+수정 전에는 ``attempt to write a readonly database`` 로 FAIL (BACKTEST_ERROR).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.backtest.run_store import BACKTEST_RUNS_SCHEMA
+from ante.cli.main import cli
+from ante.core.database import Database
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+# root (또는 권한무시 환경) 에서는 0o444/0o555 chmod 가 효력이 없어
+# read-only fs 시나리오를 재현할 수 없으므로 skip 한다.
+_requires_unprivileged = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only fs 시나리오는 root/권한무시 환경에서 재현되지 않음",
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _seed_db_with_one_run(path: str) -> None:
+    """``backtest_runs`` 스키마 + ``momentum`` 이력 1 건을 가진 DB 를 생성한다.
+
+    실제 ``Database`` write 경로 (WAL) 로 생성하므로, close 시점에 ``-wal``/
+    ``-shm`` artifact 가 남을 수 있다 (case B). case A 는 호출자가 이후
+    ``PRAGMA wal_checkpoint(TRUNCATE)`` 로 비운다.
+    """
+
+    async def _create() -> None:
+        db = Database(path)
+        await db.connect()
+        try:
+            await db.execute_script(BACKTEST_RUNS_SCHEMA)
+            await db.execute(
+                """INSERT INTO backtest_runs
+                   (run_id, strategy_name, strategy_version, params_json,
+                    total_return_pct, sharpe_ratio, max_drawdown_pct,
+                    total_trades, win_rate, result_path, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    "run-momentum-1",
+                    "momentum",
+                    "1.0.0",
+                    "{}",
+                    12.34,
+                    1.5,
+                    -3.2,
+                    7,
+                    0.57,
+                    "",
+                    "2026-05-31T00:00:00+00:00",
+                ),
+            )
+        finally:
+            await db.close()
+
+    asyncio.run(_create())
+
+
+def _checkpoint_truncate(path: str) -> None:
+    """``PRAGMA wal_checkpoint(TRUNCATE)`` 로 ``-wal``/``-shm`` 을 비운다 (case A)."""
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _run_history_under_readonly(runner, db_dir: Path, db_file: Path):
+    """디렉터리/파일을 read-only 로 만든 뒤 ``backtest history`` 를 실행한다.
+
+    권한 복구는 ``try/finally`` 로 보장한다.
+    """
+    sidecars = [
+        db_dir / f"{db_file.name}-wal",
+        db_dir / f"{db_file.name}-shm",
+    ]
+    # 파일 → 디렉터리 순으로 read-only. 디렉터리가 0o555 이면 그 안의 파일
+    # 권한 변경이 불가하므로 파일을 먼저 chmod 한다.
+    os.chmod(db_file, 0o444)
+    for s in sidecars:
+        if s.exists():
+            os.chmod(s, 0o444)
+    os.chmod(db_dir, 0o555)
+    try:
+        return runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "backtest",
+                "history",
+                "momentum",
+                "--db-path",
+                str(db_file),
+            ],
+        )
+    finally:
+        os.chmod(db_dir, 0o755)
+        os.chmod(db_file, 0o644)
+        for s in sidecars:
+            if s.exists():
+                os.chmod(s, 0o644)
+
+
+@_requires_unprivileged
+class TestBacktestHistoryReadOnlyFilesystem:
+    def test_history_on_readonly_fs_checkpointed_wal(self, runner, tmp_path) -> None:
+        """case A: ``-wal``/``-shm`` 을 truncate 한 read-only artifact 조회.
+
+        실제 권한 (파일 0o444 / 디렉터리 0o555) 에서 exit 0 + runs 1 건.
+        수정 전: ``attempt to write a readonly database`` 로 FAIL.
+        """
+        db_dir = tmp_path / "ro_checkpointed"
+        db_dir.mkdir()
+        db_file = db_dir / "ante.db"
+        _seed_db_with_one_run(str(db_file))
+        _checkpoint_truncate(str(db_file))
+
+        result = _run_history_under_readonly(runner, db_dir, db_file)
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "runs" in data, data
+        assert len(data["runs"]) == 1, data
+        assert data["runs"][0]["strategy_name"] == "momentum"
+        assert data["runs"][0]["run_id"] == "run-momentum-1"
+
+    def test_history_on_readonly_fs_with_wal_sidecars(self, runner, tmp_path) -> None:
+        """case B: ``-wal`` 잔여 + ``-shm`` 부재 → immutable fallback 경로.
+
+        ``backtest_runs`` 데이터를 메인 DB 로 checkpoint(TRUNCATE) 한 뒤, crash
+        잔여를 모사한 ``-wal`` 헤더 파일을 만들고 ``-shm`` 은 두지 않는다. 실제
+        read-only fs(파일 0o444 / 디렉터리 0o555) 에서:
+          - ``mode=ro`` 는 ``-shm`` 을 생성할 수 없어 ``unable to open database
+            file`` 로 실패한다.
+          - ``immutable=1`` fallback 이 메인 DB(모든 커밋 데이터 보유) 를 일관
+            read 한다.
+        → exit 0 + runs 1 건. 수정 전: ``attempt to write a readonly database``
+        로 FAIL.
+
+        주의: Ante 의 ``Database.close()`` 는 마지막 연결 종료 시 WAL 을
+        checkpoint 하고 sidecar 를 제거하므로, 정상적으로 freeze 된 backtest
+        artifact 는 모든 커밋 데이터가 메인 DB 에 있다. 따라서 immutable fallback
+        은 데이터 손실 없이 신뢰 가능하다(non-checkpointed live WAL 은 artifact
+        대상이 아님 — offline-factory.md §2 옵션 A Non-Goals).
+        """
+        db_dir = tmp_path / "ro_with_wal"
+        db_dir.mkdir()
+        db_file = db_dir / "ante.db"
+        _seed_db_with_one_run(str(db_file))
+        # 데이터를 메인 DB 로 합치고 -wal/-shm 을 비운다.
+        _checkpoint_truncate(str(db_file))
+        # crash 잔여를 모사: -shm 없이 -wal 헤더만 존재 → mode=ro 가 실패하고
+        # immutable fallback 이 트리거된다.
+        wal = db_dir / "ante.db-wal"
+        shm = db_dir / "ante.db-shm"
+        if shm.exists():
+            shm.unlink()
+        wal.write_bytes(b"\x37\x7f\x06\x82" + b"\x00" * 28)
+
+        result = _run_history_under_readonly(runner, db_dir, db_file)
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "runs" in data, data
+        assert len(data["runs"]) == 1, data
+        assert data["runs"][0]["strategy_name"] == "momentum"
+        assert data["runs"][0]["run_id"] == "run-momentum-1"

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,8 +1,10 @@
 """Database 래퍼 단위 테스트."""
 
 import asyncio
+import sqlite3
 from unittest.mock import patch
 
+import aiosqlite
 import pytest
 
 from ante.core import Database
@@ -294,3 +296,255 @@ async def test_transaction_rollback_failure_preserves_original_exception(db):
 
     # _in_transaction 플래그도 finally에서 해제되어야 한다.
     assert db._in_transaction is False
+
+
+# --- read-only 연결 모드 (#1974 offline-factory.md §2 옵션 A) ---
+
+
+async def _seed_rw_db(path: str) -> None:
+    """write 가능한 ``Database`` 로 테이블 1개 + 행 1건을 생성 후 close 한다."""
+    writer = Database(path)
+    await writer.connect()
+    try:
+        await writer.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);")
+        await writer.execute("INSERT INTO t (id, v) VALUES (1, 'alpha')")
+    finally:
+        await writer.close()
+
+
+async def test_read_only_reads_existing_db(tmp_path):
+    """``read_only=True`` 로 기존 DB 를 schema/WAL 쓰기 없이 read 한다."""
+    db_path = str(tmp_path / "ro.db")
+    await _seed_rw_db(db_path)
+
+    ro = Database(db_path, read_only=True)
+    await ro.connect()
+    try:
+        rows = await ro.fetch_all("SELECT id, v FROM t ORDER BY id")
+        assert rows == [{"id": 1, "v": "alpha"}]
+        one = await ro.fetch_one("SELECT v FROM t WHERE id = 1")
+        assert one == {"v": "alpha"}
+    finally:
+        await ro.close()
+
+
+async def test_read_only_opens_reader_only_no_writer(tmp_path):
+    """``read_only=True`` 는 reader 단일 연결만 열고 writer 는 미개방."""
+    db_path = str(tmp_path / "ro.db")
+    await _seed_rw_db(db_path)
+
+    ro = Database(db_path, read_only=True)
+    await ro.connect()
+    try:
+        assert ro._reader is not None
+        assert ro._writer is None
+    finally:
+        await ro.close()
+
+
+async def test_read_only_write_methods_raise_read_only_error(tmp_path):
+    """ro 모드에서 write 경로 호출 시 ReadOnlyDatabaseError 로 명확히 실패한다.
+
+    "DB 연결되지 않음" 이 아니라 read-only 전용 에러여야 한다(_writer 미개방).
+    """
+    from ante.core.database import ReadOnlyDatabaseError
+
+    db_path = str(tmp_path / "ro.db")
+    await _seed_rw_db(db_path)
+
+    ro = Database(db_path, read_only=True)
+    await ro.connect()
+    try:
+        with pytest.raises(ReadOnlyDatabaseError, match="read-only Database"):
+            await ro.execute("INSERT INTO t (id, v) VALUES (2, 'beta')")
+        with pytest.raises(ReadOnlyDatabaseError, match="read-only Database"):
+            await ro.execute_script("CREATE TABLE t2 (id INTEGER)")
+        with pytest.raises(ReadOnlyDatabaseError, match="read-only Database"):
+            await ro.execute_fetch_one("UPDATE t SET v = 'x' RETURNING id")
+        with pytest.raises(ReadOnlyDatabaseError, match="read-only Database"):
+            await ro.execute_fetch_all("UPDATE t SET v = 'x' RETURNING id")
+        with pytest.raises(ReadOnlyDatabaseError, match="read-only Database"):
+            async with ro.transaction():
+                pass  # pragma: no cover
+    finally:
+        await ro.close()
+
+
+async def test_read_only_skips_write_pragmas(tmp_path):
+    """ro 연결은 쓰기 PRAGMA(journal_mode=WAL/synchronous)를 발화하지 않는다.
+
+    ``mode=ro`` 연결의 ``PRAGMA journal_mode`` 는 메인 DB 가 WAL 모드여도 ro
+    연결에서 변경되지 않으며, ``synchronous`` 도 설정하지 않는다. 본 테스트는
+    ``_open_ro_conn`` 이 실행하는 PRAGMA 시퀀스를 가로채 WAL/synchronous 쓰기
+    PRAGMA 가 발화되지 않음을 단언한다.
+    """
+    db_path = str(tmp_path / "ro.db")
+    await _seed_rw_db(db_path)
+
+    executed: list[str] = []
+    real_execute = aiosqlite.Connection.execute
+
+    def _spy_execute(self, sql, *a, **kw):  # noqa: ANN001, ANN002, ANN003, ANN202
+        executed.append(sql)
+        return real_execute(self, sql, *a, **kw)
+
+    ro = Database(db_path, read_only=True)
+    with patch.object(aiosqlite.Connection, "execute", _spy_execute):
+        await ro.connect()
+    try:
+        normalized = [s.strip().lower() for s in executed]
+        assert not any("journal_mode" in s for s in normalized), (
+            f"ro 연결이 journal_mode PRAGMA 를 발화함: {executed}"
+        )
+        assert not any("synchronous" in s for s in normalized), (
+            f"ro 연결이 synchronous PRAGMA 를 발화함: {executed}"
+        )
+        # read-only PRAGMA 는 적용되어야 한다.
+        assert any("foreign_keys" in s for s in normalized)
+        assert any("busy_timeout" in s for s in normalized)
+        assert any("temp_store" in s for s in normalized)
+    finally:
+        await ro.close()
+
+
+async def test_read_only_uri_uses_mode_ro_and_uri_flag(tmp_path):
+    """ro 연결은 ``file:...?mode=ro`` URI 를 ``uri=True`` 로 연다."""
+    db_path = str(tmp_path / "ro.db")
+    await _seed_rw_db(db_path)
+
+    captured: dict = {}
+    real_connect = aiosqlite.connect
+
+    def _spy_connect(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        if not captured:
+            captured["args"] = args
+            captured["kwargs"] = dict(kwargs)
+        return real_connect(*args, **kwargs)
+
+    ro = Database(db_path, read_only=True)
+    with patch("ante.core.database.aiosqlite.connect", side_effect=_spy_connect):
+        await ro.connect()
+    try:
+        uri = captured["args"][0]
+        assert uri.startswith("file:"), uri
+        assert "mode=ro" in uri, uri
+        assert "immutable" not in uri, uri  # 정상 DB → fallback 미발생
+        assert captured["kwargs"].get("uri") is True, captured["kwargs"]
+    finally:
+        await ro.close()
+
+
+async def test_read_only_immutable_fallback_on_wal_artifact(tmp_path):
+    """mode=ro probe 가 WAL/권한 OperationalError 로 실패하면 immutable 재연결.
+
+    첫 ``_open_ro_conn`` (mode=ro) 의 probe 가 ``unable to open database file`` 로
+    실패하도록 강제하면, ``_init_ro_conn`` 이 ``immutable=1`` URI 로 재연결해
+    read 에 성공해야 한다.
+    """
+    db_path = str(tmp_path / "ro.db")
+    await _seed_rw_db(db_path)
+
+    real_probe = Database._probe_ro_conn
+    calls = {"n": 0}
+
+    async def _probe_first_fails(conn):  # noqa: ANN001, ANN202
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise sqlite3.OperationalError("unable to open database file")
+        return await real_probe(conn)
+
+    uris: list[str] = []
+    real_connect = aiosqlite.connect
+
+    def _spy_connect(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        uris.append(args[0])
+        return real_connect(*args, **kwargs)
+
+    ro = Database(db_path, read_only=True)
+    with (
+        patch.object(Database, "_probe_ro_conn", staticmethod(_probe_first_fails)),
+        patch("ante.core.database.aiosqlite.connect", side_effect=_spy_connect),
+    ):
+        await ro.connect()
+    try:
+        # 첫 연결은 mode=ro, 재연결은 immutable=1.
+        assert any("immutable=1" in u for u in uris), uris
+        rows = await ro.fetch_all("SELECT id, v FROM t ORDER BY id")
+        assert rows == [{"id": 1, "v": "alpha"}]
+    finally:
+        await ro.close()
+
+
+async def test_read_only_no_such_table_not_fallback(tmp_path):
+    """probe 가 ``no such table`` 로 실패하면 immutable fallback 하지 않고 재전파.
+
+    ``no such table``/``malformed``/``not a database`` 는 WAL/권한 계열이 아니므로
+    fallback 대상이 아니다. probe 단계에서 이런 메시지가 나오면 재연결 없이
+    원본 예외를 재전파해야 한다(연결 leak 없이 정리).
+    """
+    db_path = str(tmp_path / "ro.db")
+    await _seed_rw_db(db_path)
+
+    before = set(_live_worker_threads())
+    connect_count = {"n": 0}
+    real_connect = aiosqlite.connect
+
+    def _count_connect(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        connect_count["n"] += 1
+        return real_connect(*args, **kwargs)
+
+    async def _probe_no_such_table(conn):  # noqa: ANN001, ANN202
+        raise sqlite3.OperationalError("no such table: backtest_runs")
+
+    ro = Database(db_path, read_only=True)
+    with (
+        patch.object(Database, "_probe_ro_conn", staticmethod(_probe_no_such_table)),
+        patch("ante.core.database.aiosqlite.connect", side_effect=_count_connect),
+    ):
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            await ro.connect()
+
+    # fallback 재연결이 일어나지 않았어야 한다(연결 1회만).
+    assert connect_count["n"] == 1, connect_count
+    # 실패한 연결의 worker thread 가 leak 되지 않아야 한다(#1965 보존).
+    leaked = set(_live_worker_threads()) - before
+    assert not leaked, f"no-such-table 재전파 후 worker thread 누수: {leaked}"
+
+
+async def test_read_only_malformed_not_fallback(tmp_path):
+    """probe 가 ``database disk image is malformed`` 면 fallback 하지 않고 재전파."""
+    db_path = str(tmp_path / "ro.db")
+    await _seed_rw_db(db_path)
+
+    connect_count = {"n": 0}
+    real_connect = aiosqlite.connect
+
+    def _count_connect(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        connect_count["n"] += 1
+        return real_connect(*args, **kwargs)
+
+    async def _probe_malformed(conn):  # noqa: ANN001, ANN202
+        raise sqlite3.OperationalError("database disk image is malformed")
+
+    ro = Database(db_path, read_only=True)
+    with (
+        patch.object(Database, "_probe_ro_conn", staticmethod(_probe_malformed)),
+        patch("ante.core.database.aiosqlite.connect", side_effect=_count_connect),
+    ):
+        with pytest.raises(sqlite3.OperationalError, match="malformed"):
+            await ro.connect()
+
+    assert connect_count["n"] == 1, connect_count
+
+
+async def test_read_only_connect_failure_drains_worker_thread(tmp_path):
+    """ro 연결 자체가 실패해도 aiosqlite worker thread 가 누수되지 않는다(#1965)."""
+    bad_path = str(tmp_path / "no-such-dir" / "ro.db")
+    ro = Database(bad_path, read_only=True)
+
+    before = set(_live_worker_threads())
+    with pytest.raises(Exception, match="unable to open database file"):
+        await ro.connect()
+
+    leaked = set(_live_worker_threads()) - before
+    assert not leaked, f"ro connect 실패 후 worker thread 누수: {leaked} (#1965)"


### PR DESCRIPTION
Closes #1974

## Summary
`ante backtest history`(offline read 명령)가 **실제 read-only 파일시스템(DB 0444 / 디렉터리 0555)**에서 `attempt to write a readonly database`로 실패하던 문제(재오픈)를 해소한다.

선행 PR #1976은 `BacktestRunStore.initialize()` schema DDL만 제거했으나, `Database.connect()`가 writer+reader 연결을 열고 `PRAGMA journal_mode=WAL`(쓰기 필요)을 실행해 read-only mount에서 여전히 실패했다. `open_cli_db(read_only=True)`의 `read_only`는 connection에 미전달(hint)이었다.

**대표 결정 = Option A**: `docs/specs/contracts/offline-factory.md` §2를 amend해 **Database read-only 연결 모드**를 normative로 채택(§2.3가 예고한 옵션 A).

## Changes
- **`docs/specs/contracts/offline-factory.md`**: §2 amend(옵션 A 채택 — `read_only=True` = `initialize()` skip + DB read-only 연결), §2.1에 CLI 인증 경로 경계, §4 명확화(§4 예외 service는 schema 분리 전까지 `read_only=True` 비대상), `README.md` 옵션 B 요약 갱신.
- **`src/ante/core/database.py`**: `Database(db_path, *, read_only=False)` backward-compatible 추가. read_only=True 시 `urllib.request.pathname2url` escaping → `file:{url}?mode=ro`를 `aiosqlite.connect(uri, uri=True)`로 단일 reader 연결. `PRAGMA schema_version` probe 후 **WAL/권한 계열 `OperationalError`만** `immutable=1` fallback(`no such table`/malformed/not-a-db는 재전파). 쓰기 PRAGMA(`journal_mode=WAL`/`synchronous`) skip. `ReadOnlyDatabaseError`(writer 호출 시). #1965/#1970 worker-thread leak drain 보존. **read_only=False 경로는 byte-for-byte 불변**.
- **`src/ante/cli/db_context.py`**: `open_cli_db`가 `read_only=True`일 때만 `Database(db_path, read_only=True)` 전달(False는 기존 호출 유지).
- **`src/ante/contracts/error_registry.py`** + **`core/__init__.py`**: `ReadOnlyDatabaseError → EXECUTION_ERROR/internal` 매핑 + re-export(taxonomy drift 방지).
- **`tests/unit/test_database.py`**: Database read-only 모드 단위 테스트(ro read / writer 에러 / WAL PRAGMA 미실행 / immutable fallback / no-such-table·malformed 재전파 / leak 없음).
- **`tests/unit/test_cli_backtest_history_readonly_fs.py`**(신규): (1) mock-auth 실권한 fs 테스트 case A(checkpointed)/B(-wal 잔여→immutable fallback), (2) **비-mock 실 e2e** — writable config-dir + 실 토큰(`MemberService.bootstrap_master`) + read-only `--db-path` 아티팩트로 `ante backtest history` exit 0 + runs 1건(잘못된 토큰 시 auth_failed로 auth 실제 실행 증명).

## Scope / Follow-up
- 본 PR은 운영자 시나리오(writable config-dir + **read-only `--db-path` 아티팩트**)를 해결한다. auth는 `get_db_path(ctx)`(config-dir DB)를 쓰며 `--db-path`와 독립(운영자 repro의 `BACKTEST_ERROR` 코드가 auth 통과를 입증).
- **"full read-only ante home"**(config-dir 멤버 DB까지 read-only → auth 단계 write 실패)는 `MemberService`(§4 예외) DDL 때문에 §4 schema 분리가 필요 → **follow-up #1978**로 분리(offline-factory §4.3가 예고).

## Test Plan
- `pytest tests/unit/test_database.py tests/unit/test_cli_backtest_history_readonly_fs.py tests/unit/test_cli_backtest_history_readonly.py tests/unit/cli/test_factory_drift_check.py -q` — PASS
- `pytest tests/unit/ -q` — **5852 passed, 2 skipped, 0 failed**
- `mypy src/` — no issues (230 files); ruff clean
- `python scripts/generate_project_structure.py --check` — up to date

## Review
- Codex Plan Review: approve-implement (3 rounds: revise-plan x2 → approve)
- Codex 브랜치 리뷰 (`/codex:review --base main`): attempt1 FAIL([P2] auth 경로) → 실 e2e 테스트 강화 + §4 경계 문서화 + #1978 분리 → attempt2 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
