### PR TITLE
fix(bot): #2138 _liquidate_positions를 봇 계좌로 스코핑 + fail-closed 방어

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -884,8 +884,32 @@ class BotManager:
 
         from ante.eventbus.events import OrderRequestEvent
 
-        positions = await self._trade_service.get_positions(bot_id=bot.bot_id)
-        open_positions = [p for p in positions if p.quantity > 0]
+        account_id = bot.config.account_id
+        # 1차 방어: 봇 계좌로 조회 범위를 한정한다 (account_id=None이면 타 계좌
+        # 포지션까지 섞여 반환되므로 반드시 봇 계좌를 지정).
+        positions = await self._trade_service.get_positions(
+            bot_id=bot.bot_id, account_id=account_id
+        )
+
+        # 2차 방어 (fail-closed): 조회 결과가 비정상적으로 혼입되더라도, 봇 계좌와
+        # 엄격히 일치하는 포지션만 청산한다. 불일치/None/""/누락(falsy/missing)은
+        # 모두 제외하고 경고 로그를 남긴다 (truthy 비교가 아니라 엄격 동등 비교).
+        open_positions: list[Any] = []
+        for p in positions:
+            if p.quantity <= 0:
+                continue
+            pos_account_id = getattr(p, "account_id", None)
+            if pos_account_id != account_id:
+                logger.warning(
+                    "청산 대상 제외 (계좌 불일치): bot=%s symbol=%s "
+                    "pos_account_id=%r bot_account_id=%r",
+                    bot.bot_id,
+                    getattr(p, "symbol", None),
+                    pos_account_id,
+                    account_id,
+                )
+                continue
+            open_positions.append(p)
 
         if not open_positions:
             logger.info("청산 대상 포지션 없음: bot=%s", bot.bot_id)
@@ -893,7 +917,7 @@ class BotManager:
 
         for pos in open_positions:
             event = OrderRequestEvent(
-                account_id=bot.config.account_id,
+                account_id=account_id,
                 bot_id=bot.bot_id,
                 strategy_id=bot.config.strategy_id,
                 symbol=pos.symbol,

--- a/tests/unit/test_bot_delete_positions.py
+++ b/tests/unit/test_bot_delete_positions.py
@@ -66,12 +66,14 @@ class FakePositionSnapshot:
         quantity: float,
         avg_entry_price: float = 0.0,
         exchange: str = "KRX",
+        account_id: str = "test",
     ) -> None:
         self.bot_id = bot_id
         self.symbol = symbol
         self.quantity = quantity
         self.avg_entry_price = avg_entry_price
         self.exchange = exchange
+        self.account_id = account_id
 
 
 class FakeTradeService:
@@ -79,10 +81,23 @@ class FakeTradeService:
 
     def __init__(self) -> None:
         self._positions: dict[str, list[FakePositionSnapshot]] = {}
+        # get_positions 호출 시 전달된 account_id 인자 캡처 (검증용).
+        self.get_positions_calls: list[dict[str, object]] = []
 
     async def get_positions(
-        self, bot_id: str, include_closed: bool = False
+        self,
+        bot_id: str,
+        include_closed: bool = False,
+        *,
+        account_id: str | None = None,
     ) -> list[FakePositionSnapshot]:
+        self.get_positions_calls.append(
+            {
+                "bot_id": bot_id,
+                "include_closed": include_closed,
+                "account_id": account_id,
+            }
+        )
         return self._positions.get(bot_id, [])
 
 
@@ -304,3 +319,78 @@ class TestDeleteBotHandlePositions:
         await manager.delete_bot("bot1", handle_positions="liquidate")
 
         assert "bot1" in published[0].reason
+
+
+class TestLiquidateAccountScope:
+    """#2138: 청산 조회/발행이 봇 계좌로만 스코핑되는지 검증."""
+
+    async def test_get_positions_called_with_bot_account_id(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """get_positions가 봇 계좌(account_id)로 호출된다 (1차 방어)."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-a")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "AAA", 50, account_id="acc-a"),
+        ]
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        # get_positions가 봇 계좌(acc-a)로 호출되었는지 인자 캡처로 검증.
+        assert trade_service.get_positions_calls
+        last_call = trade_service.get_positions_calls[-1]
+        assert last_call["bot_id"] == "bot1"
+        assert last_call["account_id"] == "acc-a"
+
+    async def test_liquidate_excludes_other_account_positions(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """타 계좌(acc-b) 포지션이 혼입돼도 청산 주문이 발행되지 않는다 (2차 방어).
+
+        invariant: 발행된 모든 OrderRequestEvent의 (account_id, symbol)이
+        봇 계좌(acc-a) 포지션에서만 유래한다.
+        """
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-a")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        # get_positions가 비정상적으로 타 계좌(acc-b) 포지션까지 반환하는 상황.
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "AAA", 50, account_id="acc-a"),
+            FakePositionSnapshot("bot1", "BBB", 30, account_id="acc-b"),
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        # acc-a의 AAA만 발행되고 acc-b의 BBB는 절대 발행되지 않는다.
+        assert len(published) == 1
+        allowed = {("acc-a", "AAA")}
+        for event in published:
+            assert (event.account_id, event.symbol) in allowed
+        symbols = {e.symbol for e in published}
+        assert "BBB" not in symbols
+
+    async def test_liquidate_excludes_falsy_or_missing_account_id(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """account_id가 None/""/봇계좌 불일치인 포지션은 모두 제외된다 (fail-closed)."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-a")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        valid = FakePositionSnapshot("bot1", "AAA", 50, account_id="acc-a")
+        none_acc = FakePositionSnapshot("bot1", "NNN", 10, account_id="acc-a")
+        none_acc.account_id = None  # type: ignore[assignment]
+        empty_acc = FakePositionSnapshot("bot1", "EEE", 10, account_id="")
+        trade_service._positions["bot1"] = [valid, none_acc, empty_acc]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert len(published) == 1
+        assert published[0].symbol == "AAA"
+        assert published[0].account_id == "acc-a"


### PR DESCRIPTION
Closes #2138

## Summary
- `BotManager._liquidate_positions()`가 `get_positions(bot_id=...)`를 account_id 없이 호출해 타 계좌 포지션까지 봇 계좌 시장가 매도로 청산하던 P0 버그 수정
- 1차 방어: `get_positions(bot_id=..., account_id=bot.config.account_id)`로 조회 범위를 봇 계좌로 한정
- 2차 방어(fail-closed, 엄격 일치): `pos.account_id == bot.config.account_id`인 포지션만 청산. 불일치·None·""·누락은 모두 제외 + WARNING 로그

## Test Plan
- `PYTHONPATH=src python -m pytest tests/unit/test_bot_delete_positions.py -q` → 11 passed (기존 8 + 신규 3: 봇계좌 스코프 호출 / 타계좌 혼입 invariant / falsy·None 제외)
- `ruff check`, `ruff format --check`, `mypy src/ante/bot/manager.py` 통과
- Codex 브랜치 리뷰 PASS (blocking 없음)

## Non-Goals
- 다른 account_id 스코핑 누락 경로(#2136/2137/2139/2140/2141)는 별도 sibling 이슈에서 처리
- get_positions/OrderRequestEvent 시그니처 변경 없음