### PR TITLE
fix(eventbus): #2146 ExternalSignalEvent account_id 필드+marker 추가 및 SignalChannel 전파

### DIFF
--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -55,6 +55,8 @@ override하면, `Event.__post_init__` 이 다음을 수행한다:
   `OrderModifyRejectedEvent`, `OrderValidatedEvent`, `OrderRejectedEvent`,
   `OrderApprovedEvent`, `OrderSubmittedEvent`, `OrderFilledEvent`,
   `OrderCancelledEvent`, `OrderFailedEvent`
+- Stop order / 취소 실패: `OrderCancelFailedEvent`, `StopOrderRegisteredEvent`,
+  `StopOrderTriggeredEvent`, `StopOrderExpiredEvent`
 - 봇 lifecycle: `BotStartedEvent`, `BotStoppedEvent`, `BotErrorEvent`,
   `BotStepCompletedEvent`, `BotRestartExhaustedEvent`
 - 계좌/잔고/리포트: `AccountSuspendedEvent`, `AccountActivatedEvent`,
@@ -74,8 +76,7 @@ override하면, `Event.__post_init__` 이 다음을 수행한다:
   `BacktestCompleteEvent`, `ConfigChangedEvent`, `ApprovalCreatedEvent`,
   `ApprovalResolvedEvent`, `MemberRegisteredEvent`, `MemberSuspendedEvent`,
   `MemberReactivatedEvent`, `MemberRevokedEvent`, `MemberAuthFailedEvent`,
-  `CircuitBreakerEvent`, `OrderCancelFailedEvent`, `StopOrderRegisteredEvent`,
-  `StopOrderTriggeredEvent`, `StopOrderExpiredEvent`,
+  `CircuitBreakerEvent`,
   `BotStopEvent`,
   `PositionMismatchEvent`, `ReconcileEvent` (현재 ext spec 단계에서 marker 미적용)
 

--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -63,6 +63,11 @@ override하면, `Event.__post_init__` 이 다음을 수행한다:
   `StreamDisconnectedEvent` — KIS multi-account 환경에서 각 계좌마다 별도의
   ``KISStreamClient`` 인스턴스가 발행하므로 `account_id` 가 명시 전달되어야
   한다 (한 계좌 disconnect 가 다른 계좌의 fallback 을 켜지 않도록 격리).
+- 외부 시그널 (#2146): `ExternalSignalEvent` — 외부 AI Agent 시그널은
+  대상 봇 계좌(`bot.config.account_id`)에 귀속된다. `SignalChannel` 이 봇
+  계좌를 명시 전달하며, multi-account 환경에서 시그널을 account 기준으로
+  감사/필터링/추적할 수 있도록 `_requires_account_id` 로 invalid fallback 을
+  차단한다.
 
 **비대상 (system-wide event)**:
 - `SystemStartedEvent`, `SystemShutdownEvent`, `NotificationEvent`,
@@ -71,7 +76,7 @@ override하면, `Event.__post_init__` 이 다음을 수행한다:
   `MemberReactivatedEvent`, `MemberRevokedEvent`, `MemberAuthFailedEvent`,
   `CircuitBreakerEvent`, `OrderCancelFailedEvent`, `StopOrderRegisteredEvent`,
   `StopOrderTriggeredEvent`, `StopOrderExpiredEvent`,
-  `BotStopEvent`, `ExternalSignalEvent`,
+  `BotStopEvent`,
   `PositionMismatchEvent`, `ReconcileEvent` (현재 ext spec 단계에서 marker 미적용)
 
 **구현 노트**:

--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -111,6 +111,7 @@ class SignalChannel:
         signal_id = f"sig-{uuid4().hex[:12]}"
 
         event = ExternalSignalEvent(
+            account_id=self._bot.config.account_id,
             bot_id=self._bot.bot_id,
             signal_id=signal_id,
             symbol=msg.get("symbol", ""),

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -426,8 +426,19 @@ class ReconcileEvent(Event):
 
 @dataclass(frozen=True)
 class ExternalSignalEvent(Event):
-    """REST API → EventBus: 외부 AI Agent 시그널."""
+    """REST API → EventBus: 외부 AI Agent 시그널.
 
+    Refs #2146: ``ExternalSignalEvent`` 는 봇 계좌(``bot.config.account_id``)에
+    귀속되는 account-scoped 이벤트다. 다른 account-scoped 이벤트와 동일한
+    컨벤션으로 ``account_id`` 를 첫 데이터 필드로 배치하고,
+    ``_requires_account_id`` 마커로 invalid fallback (``""``, ``None``,
+    ``"default"``, 형식 위반) 을 ``Event.__post_init__`` 에서 차단한다.
+    발행자(``SignalChannel._handle_signal``)는 봇 계좌를 명시 전달한다.
+    """
+
+    _requires_account_id: ClassVar[bool] = True
+
+    account_id: str = ""
     bot_id: str = ""
     signal_id: str = ""
     symbol: str = ""

--- a/tests/unit/test_external_signal_subscription.py
+++ b/tests/unit/test_external_signal_subscription.py
@@ -156,6 +156,7 @@ class TestBotManagerSignalSubscription:
         bot.strategy = _AcceptingStrategy(ctx=ctx)
 
         event = ExternalSignalEvent(
+            account_id="acc-test",
             bot_id="bot-001",
             signal_id="sig-001",
             symbol="005930",
@@ -192,6 +193,7 @@ class TestBotManagerSignalSubscription:
         await manager.remove_bot("bot-001")
 
         event = ExternalSignalEvent(
+            account_id="acc-test",
             bot_id="bot-001",
             signal_id="sig-002",
             symbol="005930",

--- a/tests/unit/test_external_signals.py
+++ b/tests/unit/test_external_signals.py
@@ -6,6 +6,9 @@ import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from ante.account.errors import InvalidAccountIdError
 from ante.eventbus.events import ExternalSignalEvent
 from ante.strategy.base import Signal, Strategy, StrategyMeta
 from ante.strategy.validator import StrategyValidator
@@ -181,6 +184,7 @@ class TestBotExternalSignal:
         bot = _make_bot(_InhouseStrategy)
 
         event = ExternalSignalEvent(
+            account_id="test",
             bot_id="bot-001",
             signal_id="sig-001",
             symbol="005930",
@@ -199,6 +203,7 @@ class TestBotExternalSignal:
         bot = _make_bot(_OutsourcedStrategy)
 
         event = ExternalSignalEvent(
+            account_id="test",
             bot_id="bot-001",
             signal_id="sig-001",
             symbol="005930",
@@ -220,6 +225,7 @@ class TestBotExternalSignal:
         bot = _make_bot(_OutsourcedStrategy)
 
         event = ExternalSignalEvent(
+            account_id="test",
             bot_id="bot-999",  # 다른 봇
             signal_id="sig-001",
             symbol="005930",
@@ -241,6 +247,7 @@ class TestBotExternalSignal:
         bot.strategy = None
 
         event = ExternalSignalEvent(
+            account_id="test",
             bot_id="bot-001",
             signal_id="sig-001",
             symbol="005930",
@@ -249,3 +256,38 @@ class TestBotExternalSignal:
 
         await bot.on_external_signal(event)
         bot._eventbus.publish.assert_not_called()
+
+
+# ── #2146: ExternalSignalEvent account-scoped marker ────────
+
+
+class TestExternalSignalAccountScoped:
+    """#2146: ExternalSignalEvent 가 account-scoped marker 를 갖는지 검증."""
+
+    def test_requires_account_id_marker(self) -> None:
+        """_requires_account_id marker 가 True 다."""
+        assert ExternalSignalEvent._requires_account_id is True
+        assert "account_id" in ExternalSignalEvent.__dataclass_fields__
+
+    def test_valid_account_id_constructs(self) -> None:
+        """valid account_id 면 정상 생성된다."""
+        event = ExternalSignalEvent(
+            account_id="acc-test",
+            bot_id="bot-001",
+            signal_id="sig-001",
+            symbol="005930",
+            action="buy",
+        )
+        assert event.account_id == "acc-test"
+
+    @pytest.mark.parametrize("invalid", [None, "", "default"])
+    def test_invalid_account_id_raises(self, invalid: str | None) -> None:
+        """invalid account_id(None/""/"default") 면 InvalidAccountIdError raise."""
+        with pytest.raises(InvalidAccountIdError):
+            ExternalSignalEvent(
+                account_id=invalid,  # type: ignore[arg-type]
+                bot_id="bot-001",
+                signal_id="sig-001",
+                symbol="005930",
+                action="buy",
+            )

--- a/tests/unit/test_signal_channel.py
+++ b/tests/unit/test_signal_channel.py
@@ -22,6 +22,10 @@ def bot() -> MagicMock:
     """Bot mock."""
     b = MagicMock()
     b.bot_id = "bot-001"
+    # #2146: _handle_signal 이 bot.config.account_id 를 ExternalSignalEvent 에
+    # 싣는다. MagicMock default account_id 는 invalid 라 검증기에서 거부되므로
+    # valid 값을 명시 설정한다.
+    b.config.account_id = "acc-test"
     return b
 
 
@@ -90,6 +94,8 @@ class TestHandleSignal:
         assert event.symbol == "005930"
         assert event.action == "buy"
         assert event.bot_id == "bot-001"
+        # #2146: 봇 계좌(bot.config.account_id)가 이벤트에 실려야 한다.
+        assert event.account_id == "acc-test"
 
         # ack 응답
         resp = json.loads(output.getvalue().strip())
@@ -114,6 +120,18 @@ class TestHandleSignal:
         event = eventbus.publish.call_args[0][0]
         assert event.confidence == 0.95
         assert event.action == "sell"
+
+    async def test_signal_carries_bot_account_id(
+        self, channel: SignalChannel, eventbus: MagicMock
+    ) -> None:
+        """#2146: _handle_signal 이 봇 계좌(account_id)를 실은 이벤트를 발행한다."""
+        msg = json.dumps({"type": "signal", "symbol": "005930", "side": "buy"})
+        await channel._handle_line(msg)
+
+        event = eventbus.publish.call_args[0][0]
+        assert isinstance(event, ExternalSignalEvent)
+        # bot fixture 의 config.account_id 가 그대로 이벤트에 전파되어야 한다.
+        assert event.account_id == "acc-test"
 
 
 class TestHandleQuery:


### PR DESCRIPTION
Closes #2146

## Summary
- `ExternalSignalEvent`에 `account_id` 필드 + `_requires_account_id=True` 마커 추가 (OrderRequestEvent 패턴 미러)
- `SignalChannel._handle_signal`이 봇 계좌(`bot.config.account_id`)를 이벤트에 전파
- 직접 생성처 6곳 + test_signal_channel bot fixture에 valid account_id 반영
- `docs/specs/eventbus/eventbus.md` marker 분류 목록을 코드 `_requires_account_id`와 정합화: ExternalSignalEvent를 대상으로 이동, 추가로 코드상 marker=True인데 비대상에 오분류돼 있던 OrderCancelFailedEvent/StopOrder* 4건도 대상으로 이동 (대상 27건 = 코드 marker 27건 일치)

## Test Plan
- `pytest tests/unit/test_external_signals.py test_external_signal_subscription.py test_signal_channel.py -q` → 44 passed (신규: marker/invalid raise, _handle_signal account 전파)
- 회귀 `-k 'event or signal'`: 458 passed
- ruff/mypy 통과, Codex 브랜치 리뷰 PASS

## Non-Goals
- BotStopEvent 필드표↔코드 account_id 불일치는 #2145 소관(코드 변경 필요)
- 그 외 EventBus 필드표 보강은 #2153/#2158