### PR TITLE
fix(bot): #2139 Live 전략 컨텍스트 portfolio/trade history를 봇 계좌로 스코핑

### DIFF
--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -24,9 +24,10 @@ if TYPE_CHECKING:
     )
     from ante.data.store import ParquetStore
     from ante.gateway.gateway import APIGateway
-    from ante.strategy.base import DataProvider
+    from ante.strategy.base import DataProvider, TradeHistoryView
     from ante.trade.order_tracker import OrderTracker
     from ante.trade.position import PositionHistory
+    from ante.trade.recorder import TradeRecorder
     from ante.treasury.manager import TreasuryManager
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class StrategyContextFactory:
         api_gateway: APIGateway | None = None,
         parquet_store: ParquetStore | None = None,
         order_tracker: OrderTracker | None = None,
+        trade_recorder: TradeRecorder | None = None,
     ) -> None:
         self._data_provider = data_provider
         self._account_service = account_service
@@ -73,6 +75,11 @@ class StrategyContextFactory:
         # OrderTracker sync 캐시에서 미체결을 조회한다. 미주입(virtual-only/legacy)
         # 이면 공유 fallback ``live_order_view`` (없으면 빈 결과 stub)를 쓴다.
         self._order_tracker = order_tracker
+        # #2139: 주입되면 봇별 LiveTradeHistoryView 를 account_id closure 로 생성해
+        # TradeRecorder 조회를 봇 계좌 스코프로 좁힌다(LiveOrderView 패턴 미러).
+        # 미주입(virtual-only/legacy/test)이면 공유 fallback
+        # ``live_trade_history`` 를 그대로 쓴다.
+        self._trade_recorder = trade_recorder
 
     def create(self, config: BotConfig) -> StrategyContext:
         """BotConfig 기반으로 적절한 StrategyContext 생성.
@@ -107,6 +114,7 @@ class StrategyContextFactory:
                 return LivePortfolioView(
                     treasury=treasury,
                     position_history=self._position_history,
+                    account_id=config.account_id,
                 )
             except KeyError:
                 logger.warning(
@@ -140,6 +148,25 @@ class StrategyContextFactory:
             return self._live_order_view
         return _EmptyOrderView()
 
+    def _resolve_live_trade_history(self, config: BotConfig) -> TradeHistoryView | None:
+        """봇별 LiveTradeHistoryView 를 결정 (#2139).
+
+        ``trade_recorder`` 가 주입돼 있으면 ``config.account_id`` 를 closure 로
+        binding 한 **봇별** ``LiveTradeHistoryView`` 를 생성한다(``LiveOrderView``
+        #1948 패턴 미러). 단일계좌 다중봇에서 봇 계좌 scope 격리를 보장해 타 계좌
+        거래 이력이 전략 컨텍스트에 누출되지 않게 한다. 미주입이면 공유 fallback
+        ``live_trade_history`` 를 그대로 반환한다(virtual-only/legacy/test 환경
+        호환 — 공유 인스턴스의 private 멤버에 접근하지 않는다).
+        """
+        if self._trade_recorder is not None:
+            from ante.bot.providers.live import LiveTradeHistoryView
+
+            return LiveTradeHistoryView(
+                trade_recorder=self._trade_recorder,
+                account_id=config.account_id,
+            )
+        return self._live_trade_history
+
     def _create_live_context(self, config: BotConfig) -> StrategyContext:
         """Live 봇용 StrategyContext 생성.
 
@@ -168,7 +195,7 @@ class StrategyContextFactory:
             data_provider=data_provider,
             portfolio=portfolio,
             order_view=order_view,
-            trade_history=self._live_trade_history,
+            trade_history=self._resolve_live_trade_history(config),
         )
         logger.info("Live StrategyContext 생성: %s", config.bot_id)
         return ctx

--- a/src/ante/bot/providers/live.py
+++ b/src/ante/bot/providers/live.py
@@ -21,19 +21,29 @@ logger = logging.getLogger(__name__)
 
 
 class LivePortfolioView(PortfolioView):
-    """Live 봇용 PortfolioView. Treasury(잔고) + Trade(포지션) 경유."""
+    """Live 봇용 PortfolioView. Treasury(잔고) + Trade(포지션) 경유.
+
+    ``account_id`` 는 봇별 컨텍스트 생성 시 ``StrategyContextFactory`` 가 closure
+    로 binding 한다(``LiveOrderView`` #1948 패턴 미러). ``get_positions`` 는
+    ``PositionHistory`` 인메모리 캐시를 ``(account_id, bot_id)`` 스코프로 조회해
+    타 계좌 포지션이 전략 컨텍스트에 누출되지 않게 한다(#2139).
+    """
 
     def __init__(
         self,
         treasury: Treasury,
         position_history: PositionHistory,
+        account_id: str,
     ) -> None:
         self._treasury = treasury
         self._position_history = position_history
+        self._account_id = account_id
 
     def get_positions(self, bot_id: str) -> dict[str, Any]:
-        """현재 보유 포지션 조회 (인메모리 캐시)."""
-        snapshots = self._position_history.get_positions_sync(bot_id)
+        """현재 보유 포지션 조회 (인메모리 캐시, 봇 계좌 스코프)."""
+        snapshots = self._position_history.get_positions_sync(
+            bot_id, account_id=self._account_id
+        )
         return {
             s.symbol: {
                 "symbol": s.symbol,
@@ -83,10 +93,17 @@ class LiveOrderView(OrderView):
 
 
 class LiveTradeHistoryView(TradeHistoryView):
-    """Live 봇용 TradeHistoryView. TradeRecorder에서 거래 이력 조회."""
+    """Live 봇용 TradeHistoryView. TradeRecorder에서 거래 이력 조회.
 
-    def __init__(self, trade_recorder: TradeRecorder) -> None:
+    ``account_id`` 는 봇별 컨텍스트 생성 시 ``StrategyContextFactory`` 가 closure
+    로 binding 한다(``LiveOrderView`` #1948 패턴 미러). ``get_trade_history`` 는
+    ``get_trades`` 호출을 ``(account_id, bot_id)`` 스코프로 좁혀 타 계좌 거래
+    이력이 전략 컨텍스트에 누출되지 않게 한다(#2139).
+    """
+
+    def __init__(self, trade_recorder: TradeRecorder, account_id: str) -> None:
         self._recorder = trade_recorder
+        self._account_id = account_id
 
     async def get_trade_history(
         self,
@@ -94,9 +111,12 @@ class LiveTradeHistoryView(TradeHistoryView):
         symbol: str | None = None,
         limit: int = 50,
     ) -> list[dict[str, Any]]:
-        """봇의 거래 이력 조회."""
+        """봇의 거래 이력 조회 (봇 계좌 스코프)."""
         records = await self._recorder.get_trades(
-            bot_id=bot_id, symbol=symbol, limit=limit
+            account_id=self._account_id,
+            bot_id=bot_id,
+            symbol=symbol,
+            limit=limit,
         )
         return [
             {

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1041,12 +1041,9 @@ def _init_context_factory(s: Services) -> None:
     설정한다 — 이 경우 strategy 의 OHLCV 호출은 빈 결과를 반환한다.
     """
     from ante.bot import StrategyContextFactory
-    from ante.bot.providers.live import LiveTradeHistoryView
 
     if s.api_gateway:
         s.virtual_executor._gateway = s.api_gateway
-
-    live_trade_history = LiveTradeHistoryView(trade_recorder=s.trade_recorder)
 
     if not s.data_provider:
         s.data_provider = _NullDataProvider()
@@ -1056,7 +1053,6 @@ def _init_context_factory(s: Services) -> None:
         account_service=s.account_service,
         live_portfolio=s.live_portfolio,
         virtual_executor=s.virtual_executor,
-        live_trade_history=live_trade_history,
         treasury_manager=s.treasury_manager,
         position_history=s.position_history,
         api_gateway=s.api_gateway,
@@ -1064,6 +1060,9 @@ def _init_context_factory(s: Services) -> None:
         # #1948: LIVE get_open_orders 백엔드 — 봇별 LiveOrderView 가 이 tracker 의
         # sync open 캐시를 account scope 로 조회한다.
         order_tracker=s.order_tracker,
+        # #2139: LIVE get_trade_history 백엔드 — 봇별 LiveTradeHistoryView 가
+        # 봇 계좌(config.account_id) scope 로 거래 이력을 조회한다.
+        trade_recorder=s.trade_recorder,
     )
     s.bot_manager._context_factory = context_factory
     logger.info("StrategyContextFactory 설정 완료")

--- a/tests/unit/test_bot_live_account_scope.py
+++ b/tests/unit/test_bot_live_account_scope.py
@@ -1,0 +1,329 @@
+"""#2139: Live 전략 컨텍스트의 portfolio/trade history account_id 스코핑 테스트.
+
+``LiveDataProvider`` / ``LiveOrderView`` (#1948) 와 동일하게 live portfolio /
+trade history 도 봇 계좌(``config.account_id``) 를 closure 로 binding 해야 한다.
+이 테스트는 (1) view 직접 호출 격리, (2) factory 경로 격리, (3) symbol/limit
+pass-through 를 검증한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from ante.account.models import Account, TradingMode
+from ante.bot.config import BotConfig
+from ante.bot.context_factory import StrategyContextFactory
+from ante.bot.providers.live import LivePortfolioView, LiveTradeHistoryView
+from ante.strategy.base import DataProvider
+
+# ── Fake/Stub 구현체 ─────────────────────────────
+
+
+class _FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        import polars as pl
+
+        return pl.DataFrame({"close": [50000.0]})
+
+    async def get_current_price(self, symbol):
+        return 50000.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+@dataclass
+class _FakeSnapshot:
+    """PositionHistory.get_positions_sync 가 반환하는 PositionSnapshot 대역."""
+
+    symbol: str
+    quantity: float
+    avg_entry_price: float
+    realized_pnl: float = 0.0
+
+
+@dataclass
+class _FakeTrade:
+    """TradeRecorder.get_trades 가 반환하는 TradeRecord 대역."""
+
+    trade_id: str
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    status: Any
+    order_type: str = "market"
+    reason: str = ""
+    commission: float = 0.0
+    timestamp: Any = None
+
+
+class _FilledStatus:
+    """TradeStatus.FILLED 처럼 ``.value`` 를 갖는 최소 대역."""
+
+    value = "filled"
+
+
+class _FakePositionHistory:
+    """account_id 별 포지션을 분리 저장하고, 조회 시 account_id 를 캡처하는 stub."""
+
+    def __init__(self) -> None:
+        # (account_id, bot_id) -> list[_FakeSnapshot]
+        self._store: dict[tuple[str, str], list[_FakeSnapshot]] = {}
+        self.calls: list[tuple[str, str | None]] = []
+
+    def add(self, account_id: str, bot_id: str, snap: _FakeSnapshot) -> None:
+        self._store.setdefault((account_id, bot_id), []).append(snap)
+
+    def get_positions_sync(
+        self, bot_id: str, *, account_id: str | None = None
+    ) -> list[_FakeSnapshot]:
+        self.calls.append((bot_id, account_id))
+        # account_id 미전달이면 (버그 재현) 모든 계좌의 동일 bot_id 포지션 합침.
+        if account_id is None:
+            merged: list[_FakeSnapshot] = []
+            for (_acc, b_id), snaps in self._store.items():
+                if b_id == bot_id:
+                    merged.extend(snaps)
+            return merged
+        return list(self._store.get((account_id, bot_id), []))
+
+
+class _FakeRecorder:
+    """account_id 별 거래를 분리 저장하고, 조회 시 인자를 캡처하는 stub."""
+
+    def __init__(self) -> None:
+        # (account_id, bot_id) -> list[_FakeTrade]
+        self._store: dict[tuple[str, str], list[_FakeTrade]] = {}
+        self.calls: list[dict[str, Any]] = []
+
+    def add(self, account_id: str, bot_id: str, trade: _FakeTrade) -> None:
+        self._store.setdefault((account_id, bot_id), []).append(trade)
+
+    async def get_trades(
+        self,
+        account_id: str | None = None,
+        bot_id: str | None = None,
+        strategy_id: str | None = None,
+        symbol: str | None = None,
+        status: Any = None,
+        from_date: Any = None,
+        to_date: Any = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[_FakeTrade]:
+        self.calls.append(
+            {
+                "account_id": account_id,
+                "bot_id": bot_id,
+                "symbol": symbol,
+                "limit": limit,
+            }
+        )
+        if account_id is None:
+            merged: list[_FakeTrade] = []
+            for (_acc, b_id), trades in self._store.items():
+                if b_id == bot_id:
+                    merged.extend(trades)
+            results = merged
+        else:
+            results = list(self._store.get((account_id, bot_id), []))
+        if symbol is not None:
+            results = [t for t in results if t.symbol == symbol]
+        return results[:limit]
+
+
+class _FakeTreasury:
+    def get_budget_sync(self, bot_id: str) -> None:
+        return None
+
+
+def _filled(trade_id: str, symbol: str) -> _FakeTrade:
+    return _FakeTrade(
+        trade_id=trade_id,
+        symbol=symbol,
+        side="buy",
+        quantity=1.0,
+        price=100.0,
+        status=_FilledStatus(),
+    )
+
+
+# ── (1) direct view: account_id 격리 + 조회 account_id 캡처 ──
+
+
+class TestLiveViewDirectAccountScope:
+    def test_portfolio_scopes_to_account(self) -> None:
+        """LivePortfolioView(acc-a) 는 acc-a 포지션만 노출하고
+        get_positions_sync 를 account_id=acc-a 로 호출한다."""
+        ph = _FakePositionHistory()
+        ph.add("acc-a", "bot1", _FakeSnapshot("AAA", 1.0, 100.0))
+        ph.add("acc-b", "bot1", _FakeSnapshot("BBB", 2.0, 200.0))
+
+        view = LivePortfolioView(
+            treasury=_FakeTreasury(),
+            position_history=ph,
+            account_id="acc-a",
+        )
+        positions = view.get_positions("bot1")
+
+        assert set(positions.keys()) == {"AAA"}
+        assert "BBB" not in positions
+        # 조회가 account_id=acc-a 로 스코핑됐는지 검증.
+        assert ph.calls == [("bot1", "acc-a")]
+
+    async def test_trade_history_scopes_to_account(self) -> None:
+        """LiveTradeHistoryView(acc-a) 는 acc-a 거래만 노출하고
+        get_trades 를 account_id=acc-a 로 호출한다."""
+        rec = _FakeRecorder()
+        rec.add("acc-a", "bot1", _filled("t-a", "AAA"))
+        rec.add("acc-b", "bot1", _filled("t-b", "BBB"))
+
+        view = LiveTradeHistoryView(trade_recorder=rec, account_id="acc-a")
+        trades = await view.get_trade_history("bot1")
+
+        assert [t["symbol"] for t in trades] == ["AAA"]
+        assert all(t["symbol"] != "BBB" for t in trades)
+        assert len(rec.calls) == 1
+        assert rec.calls[0]["account_id"] == "acc-a"
+        assert rec.calls[0]["bot_id"] == "bot1"
+
+
+# ── (2) factory 경로: 봇 계좌만 노출 ──
+
+
+def _live_account_service() -> Any:
+    class _FakeAccountService:
+        def get_sync(self, account_id: str) -> Account:
+            return Account(
+                account_id=account_id,
+                name="test",
+                exchange="KRX",
+                currency="KRW",
+                trading_mode=TradingMode.LIVE,
+            )
+
+    return _FakeAccountService()
+
+
+class _FakeTreasuryManager:
+    def get(self, account_id: str) -> _FakeTreasury:
+        return _FakeTreasury()
+
+
+class TestFactoryLiveAccountScope:
+    async def test_factory_scopes_portfolio_and_trade_history(self) -> None:
+        """StrategyContextFactory 가 봇 계좌(config.account_id) 로 portfolio /
+        trade_history 를 binding 해 타 계좌 데이터가 노출되지 않는다."""
+        ph = _FakePositionHistory()
+        ph.add("acc-a", "bot1", _FakeSnapshot("AAA", 1.0, 100.0))
+        ph.add("acc-b", "bot1", _FakeSnapshot("BBB", 2.0, 200.0))
+
+        rec = _FakeRecorder()
+        rec.add("acc-a", "bot1", _filled("t-a", "AAA"))
+        rec.add("acc-b", "bot1", _filled("t-b", "BBB"))
+
+        factory = StrategyContextFactory(
+            data_provider=_FakeDataProvider(),
+            account_service=_live_account_service(),
+            treasury_manager=_FakeTreasuryManager(),
+            position_history=ph,
+            trade_recorder=rec,
+        )
+
+        ctx = factory.create(
+            BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-a")
+        )
+
+        positions = ctx.get_positions()
+        assert set(positions.keys()) == {"AAA"}
+
+        trades = await ctx.get_trade_history()
+        assert [t["symbol"] for t in trades] == ["AAA"]
+        # 두 조회 모두 acc-a 로 스코핑됐는지 확인.
+        assert ph.calls[-1] == ("bot1", "acc-a")
+        assert rec.calls[-1]["account_id"] == "acc-a"
+
+    async def test_factory_isolates_per_bot_account(self) -> None:
+        """동일 bot_id 라도 계좌별로 분리된 view 가 생성된다."""
+        ph = _FakePositionHistory()
+        ph.add("acc-a", "bot1", _FakeSnapshot("AAA", 1.0, 100.0))
+        ph.add("acc-b", "bot1", _FakeSnapshot("BBB", 2.0, 200.0))
+
+        rec = _FakeRecorder()
+        rec.add("acc-a", "bot1", _filled("t-a", "AAA"))
+        rec.add("acc-b", "bot1", _filled("t-b", "BBB"))
+
+        factory = StrategyContextFactory(
+            data_provider=_FakeDataProvider(),
+            account_service=_live_account_service(),
+            treasury_manager=_FakeTreasuryManager(),
+            position_history=ph,
+            trade_recorder=rec,
+        )
+
+        ctx_b = factory.create(
+            BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-b")
+        )
+        assert set(ctx_b.get_positions().keys()) == {"BBB"}
+        trades_b = await ctx_b.get_trade_history()
+        assert [t["symbol"] for t in trades_b] == ["BBB"]
+
+    async def test_factory_trade_recorder_absent_uses_shared_fallback(self) -> None:
+        """trade_recorder 미주입이면 공유 live_trade_history fallback 을 쓴다
+        (legacy/test 호환). 공유 인스턴스의 private 멤버에 접근하지 않는다."""
+        shared = LiveTradeHistoryView(
+            trade_recorder=_FakeRecorder(), account_id="shared-acc"
+        )
+
+        factory = StrategyContextFactory(
+            data_provider=_FakeDataProvider(),
+            account_service=_live_account_service(),
+            treasury_manager=_FakeTreasuryManager(),
+            position_history=_FakePositionHistory(),
+            live_trade_history=shared,
+            # trade_recorder 미주입
+        )
+
+        ctx = factory.create(
+            BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-a")
+        )
+        # 공유 인스턴스가 그대로 바인딩됐는지 (fallback) 확인.
+        assert ctx._trade_history is shared
+
+
+# ── (3) symbol / limit pass-through ──
+
+
+class TestTradeHistoryPassThrough:
+    async def test_symbol_and_limit_passed_to_get_trades(self) -> None:
+        """get_trade_history(symbol=..., limit=...) 가 get_trades 에 그대로 전달."""
+        rec = _FakeRecorder()
+        rec.add("acc-a", "bot1", _filled("t-1", "AAA"))
+        rec.add("acc-a", "bot1", _filled("t-2", "BBB"))
+
+        view = LiveTradeHistoryView(trade_recorder=rec, account_id="acc-a")
+        await view.get_trade_history("bot1", symbol="AAA", limit=7)
+
+        assert len(rec.calls) == 1
+        call = rec.calls[0]
+        assert call["account_id"] == "acc-a"
+        assert call["bot_id"] == "bot1"
+        assert call["symbol"] == "AAA"
+        assert call["limit"] == 7
+
+    async def test_default_limit_preserved(self) -> None:
+        """symbol/limit 미지정 시 기본 limit(50) 이 get_trades 로 전달된다."""
+        rec = _FakeRecorder()
+        view = LiveTradeHistoryView(trade_recorder=rec, account_id="acc-a")
+        await view.get_trade_history("bot1")
+
+        assert rec.calls[0]["symbol"] is None
+        assert rec.calls[0]["limit"] == 50
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/unit/test_bot_providers.py
+++ b/tests/unit/test_bot_providers.py
@@ -66,7 +66,11 @@ class TestLivePortfolioView:
         position_history = PositionHistory(db=db)
         await position_history.initialize()
 
-        view = LivePortfolioView(treasury=treasury, position_history=position_history)
+        view = LivePortfolioView(
+            treasury=treasury,
+            position_history=position_history,
+            account_id="acc-test",
+        )
         assert view.get_positions("bot1") == {}
 
     async def test_get_positions_with_data(self, db, eventbus):
@@ -93,7 +97,11 @@ class TestLivePortfolioView:
         )
         await position_history.on_trade(record)
 
-        view = LivePortfolioView(treasury=treasury, position_history=position_history)
+        view = LivePortfolioView(
+            treasury=treasury,
+            position_history=position_history,
+            account_id="acc-test",
+        )
         positions = view.get_positions("bot1")
         assert "005930" in positions
         assert positions["005930"]["quantity"] == 10.0
@@ -106,7 +114,11 @@ class TestLivePortfolioView:
         position_history = PositionHistory(db=db)
         await position_history.initialize()
 
-        view = LivePortfolioView(treasury=treasury, position_history=position_history)
+        view = LivePortfolioView(
+            treasury=treasury,
+            position_history=position_history,
+            account_id="acc-test",
+        )
         balance = view.get_balance("bot1")
         assert balance["allocated"] == 0.0
         assert balance["available"] == 0.0
@@ -121,7 +133,11 @@ class TestLivePortfolioView:
         position_history = PositionHistory(db=db)
         await position_history.initialize()
 
-        view = LivePortfolioView(treasury=treasury, position_history=position_history)
+        view = LivePortfolioView(
+            treasury=treasury,
+            position_history=position_history,
+            account_id="acc-test",
+        )
         balance = view.get_balance("bot1")
         assert balance["allocated"] == 1_000_000.0
         assert balance["available"] == 1_000_000.0


### PR DESCRIPTION
Closes #2139

## Summary
- Live 전략 컨텍스트의 `ctx.get_positions()`/`ctx.get_trade_history()`가 account_id 없이 조회해 타 계좌 포지션/거래를 전략에 노출하던 P1 버그 수정
- `LivePortfolioView`/`LiveTradeHistoryView`에 `account_id` 추가, 조회를 봇 계좌로 스코핑 (get_trade_history는 bot_id/symbol/limit 보존)
- `StrategyContextFactory`에 `trade_recorder` 주입 → `_resolve_live_trade_history`가 봇별 view 생성 (LiveOrderView #1948 패턴), main.py는 공유 인스턴스 생성 제거

## Test Plan
- `pytest tests/unit/test_bot_providers.py test_bot_live_account_scope.py -q` → 46 passed (direct view 격리/account_id 캡처, factory 경로 격리, symbol/limit pass-through, fallback)
- 회귀: -k 'live or context_factory or provider' 146 passed, test_main* 24 passed; ruff/mypy 통과; Codex 브랜치 리뷰 PASS

## Non-Goals
- 다른 account_id 스코핑 경로(#2136/2137/2141), LiveDataProvider/LiveOrderView 변경 없음