### PR TITLE
fix(gateway): #2142 취소 broker False 반환 시 OrderCancelFailedEvent 발행

### DIFF
--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -371,7 +371,21 @@ class APIGateway:
             return
 
         try:
-            await self.cancel_order(event.order_id, account_id=event.account_id)
+            ok = await self.cancel_order(event.order_id, account_id=event.account_id)
+            if not ok:
+                # 브로커가 예외 없이 False(취소 실패)를 반환한 경우.
+                # 성공 이벤트를 발행하지 않고 실패 이벤트로 전환한다 (#2142).
+                logger.warning("주문 취소 실패(broker False 반환): %s", event.order_id)
+                await self._eventbus.publish(
+                    OrderCancelFailedEvent(
+                        account_id=event.account_id,
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        error_message="브로커가 취소 실패(False)를 반환함",
+                    )
+                )
+                return
             await self._eventbus.publish(
                 OrderCancelledEvent(
                     account_id=event.account_id,

--- a/tests/unit/test_gateway_cancel_failed.py
+++ b/tests/unit/test_gateway_cancel_failed.py
@@ -17,6 +17,7 @@ from ante.eventbus import EventBus
 from ante.eventbus.events import (
     OrderCancelEvent,
     OrderCancelFailedEvent,
+    OrderCancelledEvent,
 )
 from ante.gateway import APIGateway
 
@@ -83,6 +84,85 @@ async def test_cancel_failed_includes_strategy_id() -> None:
     assert received[0].strategy_id == "strategy-xyz"
     assert received[0].order_id == "ord1"
     assert received[0].bot_id == "bot1"
+
+
+@pytest.mark.asyncio
+async def test_cancel_broker_returns_false_emits_failed_event() -> None:
+    """broker.cancel_order가 False 반환 → 성공 이벤트 미발행, 실패 이벤트 발행.
+
+    #2142: caller가 cancel_order 반환값을 확인하지 않아 broker가 False(취소 실패)를
+    반환해도 OrderCancelledEvent(성공)가 발행되던 회귀를 잠근다.
+    """
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(return_value=False)
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
+    gw.start()
+
+    failed: list[OrderCancelFailedEvent] = []
+    cancelled: list[OrderCancelledEvent] = []
+    eventbus.subscribe(OrderCancelFailedEvent, lambda e: failed.append(e))
+    eventbus.subscribe(OrderCancelledEvent, lambda e: cancelled.append(e))
+
+    await eventbus.publish(
+        OrderCancelEvent(
+            account_id="acc-test",
+            bot_id="bot1",
+            strategy_id="strategy-xyz",
+            order_id="ord1",
+            reason="test cancel",
+        )
+    )
+
+    # 성공 이벤트는 발행되지 않아야 한다.
+    assert cancelled == []
+    # 실패 이벤트가 1건 발행되며 attribution이 보존된다.
+    assert len(failed) == 1
+    assert failed[0].account_id == "acc-test"
+    assert failed[0].order_id == "ord1"
+    assert failed[0].bot_id == "bot1"
+    assert failed[0].strategy_id == "strategy-xyz"
+    assert failed[0].error_message == "브로커가 취소 실패(False)를 반환함"
+
+
+@pytest.mark.asyncio
+async def test_cancel_broker_returns_true_emits_cancelled_event() -> None:
+    """broker.cancel_order가 True를 반환 → OrderCancelledEvent 발행, 실패 이벤트 미발행.
+
+    #2142: 정상 취소 경로 회귀 잠금.
+    """
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(return_value=True)
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
+    gw.start()
+
+    failed: list[OrderCancelFailedEvent] = []
+    cancelled: list[OrderCancelledEvent] = []
+    eventbus.subscribe(OrderCancelFailedEvent, lambda e: failed.append(e))
+    eventbus.subscribe(OrderCancelledEvent, lambda e: cancelled.append(e))
+
+    await eventbus.publish(
+        OrderCancelEvent(
+            account_id="acc-test",
+            bot_id="bot1",
+            strategy_id="strategy-xyz",
+            order_id="ord1",
+            reason="test cancel",
+        )
+    )
+
+    assert failed == []
+    assert len(cancelled) == 1
+    assert cancelled[0].account_id == "acc-test"
+    assert cancelled[0].order_id == "ord1"
+    assert cancelled[0].reason == "test cancel"
 
 
 def test_cancel_failed_account_id_required() -> None:


### PR DESCRIPTION
Closes #2142

## Summary
- `APIGateway._on_order_cancel`이 `cancel_order`의 bool 반환을 무시하고 broker가 `False`(취소 실패)를 반환해도 `OrderCancelledEvent`(성공)를 발행하던 P1 버그 수정
- 반환값을 `ok`로 캡처: truthy면 기존대로 `OrderCancelledEvent`, falsy면 WARNING 로그 후 `OrderCancelFailedEvent` 발행 (기존 예외→OrderCancelFailedEvent 분기 유지)

## Test Plan
- `pytest tests/unit/test_gateway_cancel_failed.py test_gateway.py -q` → 50 passed (신규: False→failed only, True→cancelled only)
- 회귀 -k gateway 63 passed; ruff/mypy 통과; Codex 브랜치 리뷰 PASS

## Non-Goals
- cancel_order/이벤트 시그니처 변경, 다른 gateway 핸들러 수정 없음