### PR TITLE
fix(bot): #2137 bot status/positions 조회를 봇 계좌로 스코핑

### DIFF
--- a/src/ante/bot/info.py
+++ b/src/ante/bot/info.py
@@ -25,6 +25,7 @@ async def enrich_bot_info(
     strategy_registry: Any | None = None,
     treasury: Any | None = None,
     trade_service: Any | None = None,
+    account_id: str | None = None,
 ) -> dict[str, Any]:
     """``bot.get_info()`` 결과에 strategy/budget/positions 정보를 보강한다.
 
@@ -45,6 +46,12 @@ async def enrich_bot_info(
             include_closed=...)`` await coroutine 을 노출하는 stub). None
             이면 ``positions`` 키가 추가되지 않는다 (회귀 lock — cold-path
             / legacy 환경 호환).
+        account_id: 봇 소속 계좌(``bot.config.account_id``). ``None`` 이 아니면
+            (#2137) ``trade_service.get_positions(...)`` 호출에 ``account_id=``
+            kwarg 를 추가해 포지션 조회를 봇 계좌로 스코핑한다(타 계좌 stale
+            /legacy 포지션 누출 차단). ``None`` 이면 기존 ``get_positions(bot_id=
+            ..., include_closed=True)`` call shape 를 그대로 보존한다(legacy
+            stub / 미전달 호출처 회귀 lock). 응답 shape 에는 영향을 주지 않는다.
 
     Returns:
         ``bot.get_info()`` base dict + 보강 키 dict.
@@ -78,10 +85,18 @@ async def enrich_bot_info(
             }
 
     # 포지션 정보 추가 — include_closed=True 보존.
+    # account_id 가 주어지면(#2137) 봇 계좌로 스코핑해 타 계좌 stale/legacy
+    # 포지션 누출을 차단한다. None 이면 기존 call shape 를 그대로 유지한다
+    # (legacy stub / 미전달 호출처 회귀 lock).
     if trade_service is not None:
-        positions = await trade_service.get_positions(
-            bot_id=bot.bot_id, include_closed=True
-        )
+        if account_id is not None:
+            positions = await trade_service.get_positions(
+                bot_id=bot.bot_id, include_closed=True, account_id=account_id
+            )
+        else:
+            positions = await trade_service.get_positions(
+                bot_id=bot.bot_id, include_closed=True
+            )
         info["positions"] = [
             {
                 "symbol": p.symbol,

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import click
 
+from ante.account.scoping import is_invalid_account_id
 from ante.cli._validators import (
     reject_invalid_account_id,
     validate_positive_finite_amount,
@@ -629,7 +630,7 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
             # 일 때로만 좁힌다.
             try:
                 bot_row = await db.fetch_one(
-                    "SELECT 1 FROM bots WHERE bot_id = ?", (bot_id,)
+                    "SELECT account_id FROM bots WHERE bot_id = ?", (bot_id,)
                 )
             except sqlite3.OperationalError as e:
                 if "no such table" in str(e).lower():
@@ -638,6 +639,21 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
             if bot_row is None:
                 return None
 
+            # #2137: 봇 row 의 account_id 로 포지션 조회를 스코핑한다.
+            # ``TradeService.get_positions(bot_id)`` 는 account_id 생략 시
+            # all-account 조회로 동작해 같은 bot_id 의 타 계좌 stale/legacy
+            # 포지션이 섞일 수 있다. invalid (None/""/"default"/형식 위반) 면
+            # fail-closed 로 ``VALIDATION_ERROR`` (``raise SystemExit(1)``) 해
+            # 빈 성공 응답(0 포지션과 구분 불가) 을 차단한다.
+            account_id = bot_row["account_id"]
+            if is_invalid_account_id(account_id):
+                fmt.error(
+                    f"봇의 account_id 가 유효하지 않아 포지션을 조회할 수 없습니다:"
+                    f" {bot_id} (account_id={account_id!r})",
+                    code="VALIDATION_ERROR",
+                )
+                raise SystemExit(1)
+
             position_history = PositionHistory(db)
             await position_history.initialize()
             recorder = TradeRecorder(db, position_history)
@@ -645,7 +661,7 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
             performance = PerformanceTracker(db)
 
             service = TradeService(recorder, position_history, performance)
-            positions = await service.get_positions(bot_id)
+            positions = await service.get_positions(bot_id, account_id=account_id)
             return [
                 {
                     "symbol": p.symbol,

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -426,11 +426,15 @@ async def _handle_bot_status(
         except KeyError:
             treasury_for_bot = None
 
+    # #2137: 포지션 보강을 봇 계좌로 스코핑한다. account_id 가 전달되면
+    # ``enrich_bot_info`` 가 ``get_positions(..., account_id=...)`` 로 조회해
+    # 타 계좌 stale/legacy 포지션 누출을 차단한다.
     info = await enrich_bot_info(
         bot,
         strategy_registry=getattr(svc, "strategy_registry", None),
         treasury=treasury_for_bot,
         trade_service=getattr(svc, "trade_service", None),
+        account_id=bot.config.account_id,
     )
     return {"bot": info}
 

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -27,7 +27,7 @@
 #       module = dotted module path (예: ante.account.errors).
 #       class_anchor = class 이름.
 
-# bot.py 924/960/994 (구 931/967/1001 → 구 882/918/952) 와 config.py 212/215
+# bot.py 940/976/1010 (구 924/960/994 → 구 931/967/1001 → 구 882/918/952) 와 config.py 212/215
 # (구 214/217 → 구 176/179) 의 ``ipc_send`` ClickException text-mode 분기는
 # ``text = f"{code}: {message}"`` prefix 패턴이 의도된 영구 UX 계약이다. 회귀
 # lock ``test_bot_start_error_text_mode_carries_code_prefix`` 와
@@ -36,17 +36,18 @@
 # ``fmt.error(message, code=code)`` 정렬이 UX 회귀가 된다. 따라서
 # ``known_drift`` deferred 가 아닌 ``intended_no_code`` 영구 면제로 분류한다
 # (#1870 옵션 3). #1941 commands 주석 정리로 line 번호가 7줄 위로 이동.
+# #2137 bot status positions scope 변경으로 +16줄 이동 (924/960/994 → 940/976/1010).
 intended_no_code:
   - path: src/ante/cli/commands/bot.py
-    line: 924
+    line: 940
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 960
+    line: 976
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 994
+    line: 1010
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/config.py

--- a/tests/unit/test_bot_info.py
+++ b/tests/unit/test_bot_info.py
@@ -140,6 +140,73 @@ class TestEnrichBotInfo:
             bot_id="bot-1", include_closed=True
         )
 
+    async def test_account_id_propagated_to_get_positions(self) -> None:
+        """#2137: ``account_id`` 전달 시 ``get_positions`` 에 kwarg 로 전파.
+
+        포지션 조회가 봇 계좌로 스코핑되어 타 계좌 stale/legacy 포지션 누출을
+        차단한다. 응답 shape 은 불변이다.
+        """
+        bot = _make_bot()
+        position = SimpleNamespace(
+            symbol="005930",
+            quantity=10,
+            avg_entry_price=70000.0,
+            realized_pnl=1500.0,
+        )
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[position])
+
+        info = await enrich_bot_info(
+            bot, trade_service=trade_service, account_id="acc-a"
+        )
+
+        trade_service.get_positions.assert_awaited_once_with(
+            bot_id="bot-1", include_closed=True, account_id="acc-a"
+        )
+        # 응답 shape 불변 — account_id 는 호출 인자에만 영향, dict 에는 미반영.
+        assert info["positions"] == [
+            {
+                "symbol": "005930",
+                "quantity": 10,
+                "avg_entry_price": 70000.0,
+                "realized_pnl": 1500.0,
+            }
+        ]
+
+    async def test_account_id_omitted_preserves_call_shape_and_response(
+        self,
+    ) -> None:
+        """#2137 회귀 lock: ``account_id`` 미전달 시 기존 call shape 보존.
+
+        legacy stub / 미전달 호출처가 ``account_id`` kwarg 없이 호출되던 동작을
+        그대로 유지한다 (account_id kwarg 가 추가되지 않아야 함). 응답 dict 도
+        기존과 동일하다.
+        """
+        bot = _make_bot()
+        position = SimpleNamespace(
+            symbol="005930",
+            quantity=10,
+            avg_entry_price=70000.0,
+            realized_pnl=1500.0,
+        )
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[position])
+
+        info = await enrich_bot_info(bot, trade_service=trade_service)
+
+        # account_id kwarg 가 추가되지 않은 기존 call shape — 회귀 lock.
+        trade_service.get_positions.assert_awaited_once_with(
+            bot_id="bot-1", include_closed=True
+        )
+        assert info["positions"] == [
+            {
+                "symbol": "005930",
+                "quantity": 10,
+                "avg_entry_price": 70000.0,
+                "realized_pnl": 1500.0,
+            }
+        ]
+
     async def test_trade_service_none_omits_positions(self) -> None:
         """#1712 회귀 lock: ``trade_service=None`` 시 positions 키 부재.
 

--- a/tests/unit/test_bot_success_output_drift.py
+++ b/tests/unit/test_bot_success_output_drift.py
@@ -467,8 +467,9 @@ def test_bot_positions_empty_envelope_matches_raw_legacy(
     책임 밖이다.
     """
     db, _ = mock_database_direct
-    # bot 존재 확인 → 실재 (SELECT 1 FROM bots WHERE bot_id = ?)
-    db.fetch_one.return_value = {"1": 1}
+    # bot 존재 확인 → 실재 (SELECT account_id FROM bots WHERE bot_id = ?).
+    # #2137: account_id 스코핑 — valid account_id row 를 반환한다.
+    db.fetch_one.return_value = {"account_id": "acc-1"}
 
     # TradeService.get_positions 가 빈 list 반환하도록 mock.
     trade_service = AsyncMock()
@@ -502,7 +503,8 @@ def test_bot_positions_non_empty_envelope_matches_raw_legacy(
 ) -> None:
     """``bot positions`` non-empty: ``{positions: [...]}`` 평면 dict."""
     db, _ = mock_database_direct
-    db.fetch_one.return_value = {"1": 1}
+    # #2137: account_id 스코핑 — valid account_id row 를 반환한다.
+    db.fetch_one.return_value = {"account_id": "acc-1"}
 
     # Position dataclass 같은 객체 mock.
     pos = MagicMock()

--- a/tests/unit/test_cli_bot_positions_account_scope.py
+++ b/tests/unit/test_cli_bot_positions_account_scope.py
@@ -1,0 +1,204 @@
+"""#2137: ``ante bot positions <bot_id>`` 의 account_id 스코핑 / fail-closed 테스트.
+
+``bot positions`` 는 ``bots`` 테이블의 ``account_id`` 를 읽어
+``TradeService.get_positions(bot_id, account_id=...)`` 로 포지션 조회를 봇 계좌로
+스코핑한다. account_id 가 생략되면 ``TradeService`` 가 all-account 조회로 동작해
+같은 ``bot_id`` 의 타 계좌 stale/legacy 포지션이 섞일 수 있으므로:
+
+- valid account_id 면 ``get_positions(bot_id, account_id=<acct>)`` 로 스코핑.
+- invalid (None/""/"default"/형식 위반) 면 ``get_positions`` 를 호출하지 않고
+  ``VALIDATION_ERROR`` 구조화 에러 + nonzero exit 으로 fail-closed 한다. 빈 성공
+  응답(0 포지션과 구분 불가) 을 차단하기 위함이다.
+
+harness 는 in-process ``CliRunner(mix_stderr=False)`` 로, ``open_cli_db`` 가 lazy
+import 하는 ``ante.cli.db_context.Database`` 와 함수 내부 lazy import 되는
+``ante.trade.service.TradeService`` / ``PositionHistory`` / ``TradeRecorder`` /
+``PerformanceTracker`` 를 patch 한다.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MASTER = Member(
+    member_id="pos-scope-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Positions Scope Master",
+    status="active",
+    scopes=[],
+)
+
+
+def _parse_json(stdout: str) -> dict:
+    """CLI stdout 에서 JSON envelope 을 파싱한다.
+
+    성공 envelope 은 ``json.dumps(indent=2)`` 로 multi-line 이고, error envelope
+    (``fmt.error``) 은 single-line 이다. 전체 stdout 파싱을 우선 시도하고,
+    실패하면 마지막 비어있지 않은 줄을 파싱한다.
+    """
+    text = stdout.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return json.loads(text.splitlines()[-1])
+
+
+def _make_db(account_id_row: dict | None) -> MagicMock:
+    """``open_cli_db`` 가 yield 하는 ``Database`` 대역.
+
+    ``fetch_one("SELECT account_id FROM bots ...")`` 가 주어진 row 를 반환한다.
+    """
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    db.fetch_one = AsyncMock(return_value=account_id_row)
+    return db
+
+
+def _invoke(args: list[str], *, db: MagicMock, trade_service: MagicMock):
+    """auth 우회 + DB/TradeService patch 하에 CLI 를 호출한다."""
+    runner = CliRunner(mix_stderr=False)
+
+    def _auth_set(ctx):  # noqa: ANN001, ANN202
+        ctx.obj = ctx.obj or {}
+        ctx.obj["member"] = _MASTER
+
+    # PositionHistory / TradeRecorder / PerformanceTracker 는 lifecycle 만
+    # 충족하면 되므로 가벼운 mock 으로 대체한다 (실제 SQL 미수행).
+    pos_history = MagicMock()
+    pos_history.initialize = AsyncMock()
+    recorder = MagicMock()
+    recorder.initialize = AsyncMock()
+
+    with (
+        patch("ante.cli.main.authenticate_member", side_effect=_auth_set),
+        patch("ante.cli.main.get_db_path", return_value="/tmp/unused-pos-scope.db"),
+        patch("ante.cli.db_context.Database", MagicMock(return_value=db)),
+        patch("ante.trade.position.PositionHistory", return_value=pos_history),
+        patch("ante.trade.recorder.TradeRecorder", return_value=recorder),
+        patch("ante.trade.performance.PerformanceTracker", return_value=MagicMock()),
+        patch("ante.trade.service.TradeService", return_value=trade_service),
+    ):
+        return runner.invoke(cli, args)
+
+
+class TestBotPositionsValidAccountScope:
+    """valid account_id → ``get_positions(bot_id, account_id=...)`` 스코핑."""
+
+    def test_positions_scoped_to_bot_account(self) -> None:
+        db = _make_db({"account_id": "acc-a"})
+
+        position = SimpleNamespace(
+            symbol="AAA",
+            quantity=1.0,
+            avg_entry_price=100.0,
+            realized_pnl=10.0,
+        )
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[position])
+
+        result = _invoke(
+            ["--format", "json", "bot", "positions", "bot-shared"],
+            db=db,
+            trade_service=trade_service,
+        )
+
+        assert result.exit_code == 0, (
+            f"exit={result.exit_code}\nstdout={result.stdout!r}\n"
+            f"stderr={result.stderr!r}"
+        )
+        # 봇 계좌(acc-a) 로 스코핑된 호출 — account_id 전파 lock.
+        trade_service.get_positions.assert_awaited_once_with(
+            "bot-shared", account_id="acc-a"
+        )
+        payload = _parse_json(result.stdout)
+        symbols = [p["symbol"] for p in payload["positions"]]
+        assert symbols == ["AAA"], payload
+
+
+class TestBotPositionsInvalidAccountFailClosed:
+    """invalid account_id → ``get_positions`` 미호출 + ``VALIDATION_ERROR`` + exit 1."""
+
+    def test_default_account_id_fails_closed(self) -> None:
+        """bots row 의 account_id 가 fallback 예약어 ``"default"`` 면 거부."""
+        db = _make_db({"account_id": "default"})
+
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[])
+
+        result = _invoke(
+            ["--format", "json", "bot", "positions", "bot-shared"],
+            db=db,
+            trade_service=trade_service,
+        )
+
+        # get_positions 가 호출되지 않아야 한다 (빈 성공 응답 차단).
+        trade_service.get_positions.assert_not_called()
+
+        assert result.exit_code == 1, (
+            f"exit={result.exit_code}\nstdout={result.stdout!r}\n"
+            f"stderr={result.stderr!r}"
+        )
+        assert "Traceback" not in result.stderr, result.stderr
+        payload = _parse_json(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "VALIDATION_ERROR", payload
+        # 빈 성공 응답이 새지 않아야 한다 (0 포지션과 구분 불가).
+        assert "보유 포지션 없음" not in result.stdout, result.stdout
+
+    def test_empty_account_id_fails_closed(self) -> None:
+        """bots row 의 account_id 가 빈 문자열이어도 동일하게 거부."""
+        db = _make_db({"account_id": ""})
+
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[])
+
+        result = _invoke(
+            ["--format", "json", "bot", "positions", "bot-shared"],
+            db=db,
+            trade_service=trade_service,
+        )
+
+        trade_service.get_positions.assert_not_called()
+        assert result.exit_code == 1, (
+            f"exit={result.exit_code}\nstdout={result.stdout!r}\n"
+            f"stderr={result.stderr!r}"
+        )
+        payload = _parse_json(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "VALIDATION_ERROR", payload
+
+
+class TestBotPositionsMissingBotPreserved:
+    """미존재 bot 정규화 회귀 lock (#1810 형제 계약 유지)."""
+
+    def test_missing_bot_returns_not_found(self) -> None:
+        """bots row 부재 → ``BOT_NOT_FOUND`` + exit 1 (account 검증 이전)."""
+        db = _make_db(None)
+
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[])
+
+        result = _invoke(
+            ["--format", "json", "bot", "positions", "bot-missing"],
+            db=db,
+            trade_service=trade_service,
+        )
+
+        trade_service.get_positions.assert_not_called()
+        assert result.exit_code == 1, (
+            f"exit={result.exit_code}\nstdout={result.stdout!r}\n"
+            f"stderr={result.stderr!r}"
+        )
+        payload = _parse_json(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "BOT_NOT_FOUND", payload

--- a/tests/unit/test_ipc_bot_lifecycle.py
+++ b/tests/unit/test_ipc_bot_lifecycle.py
@@ -321,12 +321,60 @@ class TestHandleBotStatus:
                 "realized_pnl": 1500.0,
             }
         ]
+        # #2137: bot.status handler 가 봇 계좌(``acc-1``) 로 포지션 조회를
+        # 스코핑한다 — ``account_id`` kwarg 전파를 lock 한다.
         trade_service.get_positions.assert_awaited_once_with(
-            bot_id="bot-1", include_closed=True
+            bot_id="bot-1", include_closed=True, account_id="acc-1"
         )
         # read-only — audit 호출 없음
         assert audit_log is not None
         audit_log.assert_not_awaited()
+
+    async def test_positions_scoped_to_bot_account_blocks_other_account(
+        self,
+    ) -> None:
+        """#2137: bot.status 는 봇 계좌(``acc-a``) 로만 포지션을 조회한다.
+
+        ``get_positions`` stub 이 ``account_id`` kwarg 에 따라 계좌별 포지션을
+        반환하도록 모사한다. 봇 계좌가 ``acc-a`` 이므로 ``acc-b`` 포지션
+        (``BBB``) 은 status 결과에 누출되지 않아야 한다 (이슈 재현 시나리오).
+        """
+        bot = _make_bot(
+            bot_id="bot-shared",
+            account_id="acc-a",
+            info={"bot_id": "bot-shared", "status": "running", "strategy_id": ""},
+        )
+
+        pos_a = SimpleNamespace(
+            symbol="AAA", quantity=1.0, avg_entry_price=100.0, realized_pnl=10.0
+        )
+        pos_b = SimpleNamespace(
+            symbol="BBB", quantity=2.0, avg_entry_price=200.0, realized_pnl=20.0
+        )
+
+        async def _scoped_get_positions(
+            *, bot_id: str, include_closed: bool, account_id: str | None = None
+        ) -> list[SimpleNamespace]:
+            # account_id 미전달(=all-account) 이면 두 계좌 포지션이 모두 섞인다.
+            if account_id is None:
+                return [pos_a, pos_b]
+            if account_id == "acc-a":
+                return [pos_a]
+            return [pos_b]
+
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(side_effect=_scoped_get_positions)
+
+        svc, _ = _make_svc(bot=bot, trade_service=trade_service)
+
+        result = await _handle_bot_status(svc, {"bot_id": "bot-shared"}, "admin-master")
+
+        symbols = [p["symbol"] for p in result["bot"]["positions"]]
+        assert symbols == ["AAA"], symbols
+        assert "BBB" not in symbols
+        trade_service.get_positions.assert_awaited_once_with(
+            bot_id="bot-shared", include_closed=True, account_id="acc-a"
+        )
 
     async def test_success_without_trade_service_omits_positions(self) -> None:
         """``trade_service=None`` 시 positions 키 부재 (회귀 lock)."""


### PR DESCRIPTION
Closes #2137

## Summary
- bot status(enrich_bot_info)/positions가 account_id 없이 `get_positions` 호출해 타 계좌 포지션을 노출하던 P2 버그 수정
- enrich_bot_info에 account_id keyword 추가(account_id is not None일 때만 전달 → 기존 call/response shape 보존), registry bot.status가 봇 계좌 전달
- cli bot positions가 bots.account_id를 읽어 `is_invalid_account_id` 검증: invalid면 get_positions 없이 VALIDATION_ERROR+exit 1 (fail-closed), valid면 스코핑

## Test Plan
- 신규 test_cli_bot_positions_account_scope.py + test_bot_info/test_ipc_bot_lifecycle 보강 → 타깃 242 passed + 회귀 83 passed
- ruff/mypy 통과, Codex 브랜치 리뷰 PASS

## Non-Goals
- #2112(IPC vs local-DB 정책), enrich 응답 shape 변경, #2141 경로 미변경