### PR TITLE
fix(backtest): #1991 invalid Signal(side/quantity) 검증 추가 (#2066 포함)

### DIFF
--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import TYPE_CHECKING, Any
 
 from ante.backtest.context import BacktestStrategyContext
@@ -13,6 +14,33 @@ if TYPE_CHECKING:
     from ante.strategy.base import Signal, Strategy
 
 logger = logging.getLogger(__name__)
+
+# 라이브 preflight가 허용하는 side vocabulary. RuleEngine이 OrderRequestEvent를
+# 검증할 때와 동일하게 case-sensitive로 buy/sell만 허용한다(#1991).
+_ALLOWED_SIDES = ("buy", "sell")
+
+
+def _is_valid_quantity(value: object) -> bool:
+    """``value``가 finite한 ``int``/``float`` quantity인지 판정.
+
+    RuleEngine ``_is_finite_quantity``와 동일 정책 (cross-module import 회피):
+    private helper를 import하면 backtest가 rule 모듈 내부 구현에 결합되므로,
+    같은 정책을 backtest 안에 작은 local mirror로 둔다(#1991, codex 지시).
+
+    - ``bool``은 제외한다(``True``/``False``를 수량으로 보지 않음).
+      ``isinstance(True, int) == True`` 이므로 명시적으로 잠근다.
+    - ``int``/``float``만 허용하고, ``math.isfinite``로 ``NaN``/``inf``를 차단한다.
+    - Python ``int``는 임의 정밀도라 ``10**10000`` 같은 거대 정수는 ``float``
+      변환 시 ``OverflowError`` (또는 ``ValueError``/``TypeError``)를 던진다.
+      이때도 finite-호환이 아니므로 ``False``로 떨어뜨린다(overflow guard).
+    - 본 helper는 절대 raise하지 않는 invariant를 유지한다.
+    """
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(value)
+    except (OverflowError, ValueError, TypeError):
+        return False
 
 
 class BacktestExecutor:
@@ -128,7 +156,50 @@ class BacktestExecutor:
         거래 기록을 모두 체결 수량 기준으로 계산한다. 보유 수량을 초과하는 매도는
         보유분만 체결되므로, 초과 요청 수량이 수수료·슬리피지·거래 수량에
         반영되지 않는다(#1989).
+
+        가격 조회/분기 이전에 Signal을 검증한다(#1991, #2066 포괄). 라이브
+        ``RuleEngine`` preflight와 동일하게 ``side ∈ {"buy","sell"}`` 와 finite
+        양수 ``quantity`` 만 허용한다. 무효 Signal은 거래를 발행하지 않고 진단
+        로그만 남긴 뒤 skip한다(라이브 OrderRejectedEvent와 달리 backtest는
+        이벤트 없음). 특히 ``hold`` 등 buy/sell 이외 side는 **절대 sell 분기로
+        라우팅하지 않는다**(unknown side가 매도로 처리되던 회귀 차단).
         """
+        # ── Signal 검증 (가격 조회/분기 이전) ──────────────────────────
+        # side 검증: case-sensitive로 buy/sell만 허용. hold/unknown은 skip하여
+        # sell 분기 라우팅을 차단한다. 진단 로그는 hold(전략 작성 가이드)와
+        # unknown side(잘못된 값 경고)를 문구로 구분한다.
+        if signal.side not in _ALLOWED_SIDES:
+            if signal.side == "hold":
+                logger.warning(
+                    "Signal skip(hold): symbol=%s side=%r quantity=%r — "
+                    "hold는 no-op이므로 Signal을 발행하지 말 것(거래 미발행)",
+                    signal.symbol,
+                    signal.side,
+                    signal.quantity,
+                )
+            else:
+                logger.warning(
+                    "Signal skip(unknown side): symbol=%s side=%r quantity=%r — "
+                    'side는 {"buy","sell"}만 허용(거래 미발행)',
+                    signal.symbol,
+                    signal.side,
+                    signal.quantity,
+                )
+            return
+
+        # quantity 검증: finite numeric이 아니거나(NaN/inf/non-number/bool/거대
+        # 정수) <= 0(음수/0)이면 skip. 음수 buy는 cost가 음수가 되어 잔고
+        # 검사를 통과하므로 여기서 fail-closed로 막는다.
+        if not _is_valid_quantity(signal.quantity) or signal.quantity <= 0:
+            logger.warning(
+                "Signal skip(invalid quantity): symbol=%s side=%r quantity=%r — "
+                "quantity는 finite한 양수여야 함(거래 미발행)",
+                signal.symbol,
+                signal.side,
+                signal.quantity,
+            )
+            return
+
         price = await self._data.get_current_price(signal.symbol)
 
         if signal.side == "buy":

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -775,6 +775,231 @@ class TestBacktestExecutor:
         assert buy_trade.commission != sell_trade.commission
 
 
+# ── Signal 검증 테스트 (#1991, #2066 포괄) ─────────
+
+
+class _OneSignalStrategy(Strategy):
+    """첫 스텝에 주어진 Signal 하나만 발행하는 전략."""
+
+    meta = StrategyMeta(name="one_signal", version="1.0", description="t")
+
+    #: 클래스 변수로 발행할 Signal을 주입한다.
+    signal: Signal
+
+    def __init__(self, ctx: Any) -> None:
+        super().__init__(ctx)
+        self._emitted = False
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        if not self._emitted:
+            self._emitted = True
+            return [self.signal]
+        return []
+
+
+def _make_one_signal_strategy(signal: Signal) -> type[Strategy]:
+    """첫 스텝에 ``signal`` 하나만 발행하는 전략 클래스를 만든다."""
+    return type(
+        "InjectedOneSignalStrategy",
+        (_OneSignalStrategy,),
+        {"signal": signal},
+    )
+
+
+class TestBacktestSignalValidation:
+    """무효 Signal(side/quantity)을 거래 발행 없이 skip하는지 검증.
+
+    라이브 RuleEngine preflight와 동일 vocabulary: side ∈ {"buy","sell"},
+    quantity finite & > 0. #2066(음수/0/NaN quantity)을 포괄한다.
+    """
+
+    async def _run_single_signal(self, store, signal: Signal):
+        """평탄 가격(close=100) fixture에서 단일 Signal 백테스트 실행."""
+        df = _make_ohlcv_df_with_closes([100.0, 100.0, 100.0, 100.0])
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        executor = BacktestExecutor(
+            strategy_cls=_make_one_signal_strategy(signal),
+            data_provider=provider,
+            initial_balance=10_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        result = await executor.run()
+        return executor, result
+
+    async def test_negative_buy_quantity_skipped(self, store):
+        """Signal(side="buy", quantity=-1) → 거래 미발행 + 현금/포지션 불변."""
+        executor, result = await self._run_single_signal(
+            store, Signal(symbol="005930", side="buy", quantity=-1)
+        )
+        assert len(result.trades) == 0
+        # 음수 buy가 cost를 음수로 만들어 현금을 늘리던 회귀를 차단(현금 불변).
+        assert result.equity_curve[-1]["balance"] == pytest.approx(10_000)
+        assert executor._positions == {}
+
+    async def test_nan_buy_quantity_skipped(self, store):
+        """#2066: Signal(side="buy", quantity=NaN) → skip."""
+        executor, result = await self._run_single_signal(
+            store, Signal(symbol="005930", side="buy", quantity=float("nan"))
+        )
+        assert len(result.trades) == 0
+        assert result.equity_curve[-1]["balance"] == pytest.approx(10_000)
+        assert executor._positions == {}
+
+    async def test_inf_buy_quantity_skipped(self, store):
+        """#2066: Signal(side="buy", quantity=inf) → skip."""
+        executor, result = await self._run_single_signal(
+            store, Signal(symbol="005930", side="buy", quantity=float("inf"))
+        )
+        assert len(result.trades) == 0
+        assert result.equity_curve[-1]["balance"] == pytest.approx(10_000)
+        assert executor._positions == {}
+
+    async def test_zero_buy_quantity_skipped(self, store):
+        """#2066: Signal(side="buy", quantity=0) → skip."""
+        executor, result = await self._run_single_signal(
+            store, Signal(symbol="005930", side="buy", quantity=0)
+        )
+        assert len(result.trades) == 0
+        assert result.equity_curve[-1]["balance"] == pytest.approx(10_000)
+        assert executor._positions == {}
+
+    async def test_bool_buy_quantity_skipped(self, store):
+        """정책 일치: bool quantity(True)는 수량으로 보지 않고 skip."""
+        executor, result = await self._run_single_signal(
+            store, Signal(symbol="005930", side="buy", quantity=True)
+        )
+        assert len(result.trades) == 0
+        assert result.equity_curve[-1]["balance"] == pytest.approx(10_000)
+        assert executor._positions == {}
+
+    async def test_unknown_side_skipped(self, store):
+        """unknown side("foo") → skip(거래 미발행)."""
+        executor, result = await self._run_single_signal(
+            store, Signal(symbol="005930", side="foo", quantity=1)
+        )
+        assert len(result.trades) == 0
+        assert result.equity_curve[-1]["balance"] == pytest.approx(10_000)
+        assert executor._positions == {}
+
+    async def test_hold_side_not_routed_to_sell(self, store):
+        """포지션 보유 중 Signal(side="hold", quantity=1) → 매도되지 않음.
+
+        Repro 2 회귀(#1991): buy/sell 이외 side가 sell 분기로 라우팅되어
+        포지션이 청산되고 ledger side가 hold로 기록되던 버그를 차단한다.
+        hold Signal은 거래를 발행하지 않고 포지션을 그대로 유지해야 한다.
+        """
+        df = _make_ohlcv_df_with_closes([100.0, 100.0, 100.0, 100.0])
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        class BuyThenHold(Strategy):
+            meta = StrategyMeta(name="buy_then_hold", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 1:
+                    return [Signal(symbol="005930", side="buy", quantity=1)]
+                if self._step == 2:
+                    return [Signal(symbol="005930", side="hold", quantity=1)]
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyThenHold,
+            data_provider=provider,
+            initial_balance=10_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        result = await executor.run()
+
+        # 매수 거래 1건만 기록되고, hold는 거래를 발행하지 않는다.
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+        assert all(t.side != "hold" for t in result.trades)
+        # 포지션이 hold로 청산되지 않고 유지된다(1주 보유).
+        assert executor._positions["005930"]["quantity"] == 1
+
+    async def test_valid_buy_processed(self, store):
+        """회귀: 유효 Signal(side="buy", quantity=5)는 정상 처리."""
+        executor, result = await self._run_single_signal(
+            store, Signal(symbol="005930", side="buy", quantity=5)
+        )
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+        assert result.trades[0].quantity == 5
+        assert executor._positions["005930"]["quantity"] == 5
+
+    async def test_valid_sell_processed(self, store):
+        """회귀: 유효 Signal(side="sell", quantity=3)은 정상 처리."""
+        df = _make_ohlcv_df_with_closes([100.0, 100.0, 100.0, 100.0])
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        class BuyThenSell(Strategy):
+            meta = StrategyMeta(name="buy_then_sell", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 1:
+                    return [Signal(symbol="005930", side="buy", quantity=5)]
+                if self._step == 2:
+                    return [Signal(symbol="005930", side="sell", quantity=3)]
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyThenSell,
+            data_provider=provider,
+            initial_balance=10_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        result = await executor.run()
+
+        assert len(result.trades) == 2
+        assert result.trades[0].side == "buy"
+        assert result.trades[1].side == "sell"
+        assert result.trades[1].quantity == 3
+        # buy 5 - sell 3 = 2주 잔여
+        assert executor._positions["005930"]["quantity"] == 2
+
+    async def test_skip_emits_warning_with_diagnostics(self, store, caplog):
+        """skip 시 logger.warning에 symbol/side/quantity가 포함된다."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="ante.backtest.executor"):
+            await self._run_single_signal(
+                store, Signal(symbol="005930", side="buy", quantity=-1)
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "무효 Signal skip 시 경고 로그가 있어야 함"
+        msg = warnings[0].getMessage()
+        assert "005930" in msg
+        assert "buy" in msg
+        assert "-1" in msg
+
+
 # ── Mark-to-Market 평가 테스트 (#1987) ─────────────
 
 


### PR DESCRIPTION
Closes #1991
Closes #2066

## Summary
- 백테스트 `_execute_signal`이 Signal을 검증 없이 적용해 음수 매수로 현금 증가, unknown/hold side가 매도 처리, NaN/0 수량이 결과를 오염시키던 P1 버그 수정
- 메서드 시작(가격 조회 전)에 검증 추가: side ∈ {buy,sell}(case-sensitive) 아니면 skip(hold vs unknown 진단 구분, sell 분기 미라우팅), quantity는 local `_is_valid_quantity`(bool 제외/int·float/math.isfinite/overflow guard, RuleEngine 정책 미러)로 finite&>0 아니면 skip
- **#2066(invalid Signal.quantity 음수/0/NaN) 포괄** — 동일 검증으로 해소

## Test Plan
- `pytest tests/unit/test_backtest.py -q` 69 passed (음수/NaN/inf/0/bool/unknown-side/hold-with-position skip + 유효 buy/sell 회귀 + 진단 로그)
- backtest 회귀 231 passed, contracts 145 passed; ruff/mypy 통과; Codex 브랜치 리뷰 PASS

## Non-Goals
- on_fill(#2073), partial fill, shape 변경, 라이브 RuleEngine 수정 없음 (private _is_finite_quantity import 회피, local mirror)