### PR TITLE
fix(backtest): #2083 strategy file-access 공용 helper 추출 + BacktestStrategyContext.load_file/load_text

### DIFF
--- a/docs/specs/backtest/02-design-decisions.md
+++ b/docs/specs/backtest/02-design-decisions.md
@@ -278,6 +278,8 @@ def _validate_config(self, config: dict[str, Any]) -> BacktestConfig:
 | `get_open_orders() → list[dict]` | 미체결 주문 (백테스트에서는 항상 빈 리스트) |
 | `cancel_order(order_id, reason) → None` | 주문 취소 (백테스트에서는 무시) |
 | `modify_order(order_id, quantity, price, reason) → None` | 주문 정정 (백테스트에서는 무시) |
+| `load_file(path) → bytes` | 전략 전용 파일 읽기 (바이너리). 라이브와 동일하게 `strategies/` 하위만 허용하고 절대경로/탈출/symlink escape는 `StrategyFileAccessError`로 거부 (#2083) |
+| `load_text(path, encoding="utf-8") → str` | 전략 전용 파일 읽기 (텍스트). `load_file` 위임 후 디코딩 (#2083) |
 | `log(message, level) → None` | 전략 로그 출력 |
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조

--- a/src/ante/backtest/context.py
+++ b/src/ante/backtest/context.py
@@ -6,8 +6,15 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ante.strategy.base import OrderAction
+from ante.strategy.file_access import (
+    STRATEGIES_ROOT,
+    load_strategy_file,
+    load_strategy_text,
+)
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import polars as pl
 
     from ante.backtest.data_provider import BacktestDataProvider
@@ -28,12 +35,19 @@ class BacktestStrategyContext:
         bot_id: str,
         data_provider: BacktestDataProvider,
         portfolio: BacktestExecutor,
+        strategies_dir: Path | None = None,
     ) -> None:
         self._bot_id = bot_id
         self._data = data_provider
         self._portfolio = portfolio
         self._actions: list[OrderAction] = []
         self.logger = logging.getLogger(f"backtest.strategy.{bot_id}")
+        # 라이브 StrategyContext 와 동일한 strategies/ 샌드박스 기본값을 쓴다.
+        # 보안 경계 SSOT 는 ante.strategy.file_access 가 단일 소유한다(#2083).
+        # ante.strategy.context._STRATEGIES_ROOT 를 직접 import 하지 않는다.
+        self._strategies_dir = (
+            strategies_dir.resolve() if strategies_dir else STRATEGIES_ROOT.resolve()
+        )
 
     async def get_ohlcv(
         self,
@@ -96,6 +110,23 @@ class BacktestStrategyContext:
         reason: str = "",
     ) -> None:
         """주문 정정 (백테스트에서는 무시)."""
+
+    def load_file(self, path: str) -> bytes:
+        """전략 전용 파일 읽기 (바이너리).
+
+        라이브 ``StrategyContext.load_file`` 과 동일한 보안 경계(strategies/
+        하위만 허용, 절대경로/탈출/symlink escape 차단, 미존재 거부)를 공용
+        helper 위임으로 제공한다(#2083).
+        """
+        return load_strategy_file(self._strategies_dir, path)
+
+    def load_text(self, path: str, encoding: str = "utf-8") -> str:
+        """전략 전용 파일 읽기 (텍스트).
+
+        라이브 ``StrategyContext.load_text`` 과 동일한 보안 경계를 공용 helper
+        위임으로 제공한다(#2083).
+        """
+        return load_strategy_text(self._strategies_dir, path, encoding)
 
     def log(self, message: str, level: str = "info") -> None:
         """전략 로그 출력."""

--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -10,6 +10,8 @@ from ante.backtest.context import BacktestStrategyContext
 from ante.backtest.result import BacktestResult, BacktestTrade
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ante.backtest.data_provider import BacktestDataProvider
     from ante.strategy.base import Signal, Strategy
 
@@ -59,6 +61,7 @@ class BacktestExecutor:
         sell_commission_rate: float = 0.00195,
         slippage_rate: float = 0.001,
         exchange: str = "KRX",
+        strategies_dir: Path | None = None,
     ) -> None:
         self._strategy_cls = strategy_cls
         self._data = data_provider
@@ -67,6 +70,9 @@ class BacktestExecutor:
         self._sell_commission_rate = sell_commission_rate
         self._slippage_rate = slippage_rate
         self._exchange = exchange
+        # 전략 파일 접근 샌드박스 루트. None 이면 BacktestStrategyContext 가
+        # 라이브와 동일한 기본 strategies/ 루트를 쓴다(#2083).
+        self._strategies_dir = strategies_dir
 
         self._balance = initial_balance
         self._positions: dict[str, dict[str, float]] = {}
@@ -88,6 +94,7 @@ class BacktestExecutor:
             bot_id="backtest",
             data_provider=self._data,
             portfolio=self,
+            strategies_dir=self._strategies_dir,
         )
         strategy = self._strategy_cls(ctx)
         strategy.on_start()

--- a/src/ante/strategy/context.py
+++ b/src/ante/strategy/context.py
@@ -14,14 +14,17 @@ from ante.strategy.base import (
     TradeHistoryView,
 )
 from ante.strategy.exceptions import StrategyFileAccessError
+from ante.strategy.file_access import STRATEGIES_ROOT, resolve_strategy_path
 
 if TYPE_CHECKING:
     import polars as pl
 
 logger = logging.getLogger(__name__)
 
-# strategies/ 디렉토리 기준 경로 (프로젝트 루트 기준)
-_STRATEGIES_ROOT = Path("strategies")
+# strategies/ 디렉토리 기준 경로 (프로젝트 루트 기준).
+# 보안 경계 SSOT 는 ``ante.strategy.file_access.STRATEGIES_ROOT`` 로 이동했다.
+# 기존 ``_STRATEGIES_ROOT`` 이름을 참조하던 코드 호환을 위해 alias 로 재노출한다.
+_STRATEGIES_ROOT = STRATEGIES_ROOT
 
 
 class StrategyContext:
@@ -155,22 +158,20 @@ class StrategyContext:
     # ── 파일 접근 ──
 
     def _resolve_strategy_path(self, path: str) -> Path:
-        """전략 파일 경로를 검증하고 절대 경로로 변환."""
-        # 절대 경로 차단
-        if Path(path).is_absolute():
-            raise StrategyFileAccessError(f"Absolute paths are not allowed: {path}")
+        """전략 파일 경로를 검증하고 절대 경로로 변환.
 
-        # 경로 탈출 시도 차단
-        resolved = (self._strategies_dir / path).resolve()
-        if not resolved.is_relative_to(self._strategies_dir):
-            raise StrategyFileAccessError(f"Path escapes strategies directory: {path}")
-
-        return resolved
+        보안 경계는 공용 helper ``resolve_strategy_path`` 가 단일 소유한다
+        (절대경로 거부/탈출 차단/symlink escape 차단, #2083).
+        """
+        return resolve_strategy_path(self._strategies_dir, path)
 
     def load_file(self, path: str) -> bytes:
         """전략 전용 파일 읽기 (바이너리).
 
         strategies/ 하위 경로만 허용. 경로 탈출 시도 차단.
+
+        경로 검증(절대경로/탈출 차단)을 통과한 뒤에만 로그를 남긴다(기존 동작
+        보존). 미존재 파일은 helper 가 ``StrategyFileAccessError`` 로 거부한다.
         """
         resolved = self._resolve_strategy_path(path)
 
@@ -183,7 +184,8 @@ class StrategyContext:
     def load_text(self, path: str, encoding: str = "utf-8") -> str:
         """전략 전용 파일 읽기 (텍스트).
 
-        strategies/ 하위 경로만 허용. 경로 탈출 시도 차단.
+        strategies/ 하위 경로만 허용. 경로 탈출 시도 차단. ``load_file`` 을
+        경유해 로그/보안 동작을 그대로 공유한다(기존 동작 보존).
         """
         data = self.load_file(path)
         return data.decode(encoding)

--- a/src/ante/strategy/file_access.py
+++ b/src/ante/strategy/file_access.py
@@ -1,0 +1,83 @@
+"""전략 파일 접근 보안 경계 공용 helper (#2083).
+
+라이브 ``StrategyContext`` 와 ``BacktestStrategyContext`` 가 동일한 전략 파일
+접근 시맨틱(strategies/ 디렉터리 샌드박스)을 공유하도록, 보안 경계 로직을 이
+모듈에 **단일 소유**시킨다.
+
+보안 시맨틱(SSOT):
+
+- 절대 경로는 거부한다 (``StrategyFileAccessError``, ``"Absolute paths"``).
+- ``strategies_dir`` 하위로 resolve 되지 않는 경로(``../`` 탈출, symlink 탈출
+  포함)는 거부한다 (``StrategyFileAccessError``, ``"escapes"``). base/candidate
+  를 **모두 ``resolve()`` 후** 비교해 symlink escape 도 차단한다.
+- 미존재 파일은 거부한다 (``StrategyFileAccessError``, ``"File not found"``).
+
+에러 메시지는 라이브 ``StrategyContext`` 의 기존 동작과 1:1 동일하게 보존한다
+(기존 strategy context 테스트가 메시지를 lock 한다).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ante.strategy.exceptions import StrategyFileAccessError
+
+# strategies/ 디렉토리 기준 경로 (프로젝트 루트 기준).
+# 기존 ``ante.strategy.context._STRATEGIES_ROOT`` 와 동일 값/계산을 이리로 이동.
+STRATEGIES_ROOT = Path("strategies")
+
+
+def resolve_strategy_path(strategies_dir: Path, path: str) -> Path:
+    """전략 파일 경로를 검증하고 절대 경로로 변환.
+
+    Args:
+        strategies_dir: 허용된 샌드박스 루트. resolve 된 절대 경로를 권장한다.
+        path: 전략이 요청한 상대 경로.
+
+    Returns:
+        ``strategies_dir`` 하위로 resolve 된 절대 경로.
+
+    Raises:
+        StrategyFileAccessError: 절대 경로이거나, resolve 결과가
+            ``strategies_dir`` 하위가 아닌 경우(symlink 탈출 포함).
+    """
+    # 절대 경로 차단
+    if Path(path).is_absolute():
+        raise StrategyFileAccessError(f"Absolute paths are not allowed: {path}")
+
+    # 경로 탈출 시도 차단. base/candidate 모두 resolve() 후 비교하여
+    # symlink escape 도 차단한다.
+    base = strategies_dir.resolve()
+    resolved = (base / path).resolve()
+    if not resolved.is_relative_to(base):
+        raise StrategyFileAccessError(f"Path escapes strategies directory: {path}")
+
+    return resolved
+
+
+def load_strategy_file(strategies_dir: Path, path: str) -> bytes:
+    """전략 전용 파일 읽기 (바이너리).
+
+    ``strategies_dir`` 하위 경로만 허용하며, 경로 탈출 시도를 차단한다.
+
+    Raises:
+        StrategyFileAccessError: 경로 검증 실패 또는 파일 미존재.
+    """
+    resolved = resolve_strategy_path(strategies_dir, path)
+
+    if not resolved.exists():
+        raise StrategyFileAccessError(f"File not found: {path}")
+
+    return resolved.read_bytes()
+
+
+def load_strategy_text(strategies_dir: Path, path: str, encoding: str = "utf-8") -> str:
+    """전략 전용 파일 읽기 (텍스트).
+
+    ``strategies_dir`` 하위 경로만 허용하며, 경로 탈출 시도를 차단한다.
+
+    Raises:
+        StrategyFileAccessError: 경로 검증 실패 또는 파일 미존재.
+    """
+    data = load_strategy_file(strategies_dir, path)
+    return data.decode(encoding)

--- a/tests/unit/test_strategy_file_access.py
+++ b/tests/unit/test_strategy_file_access.py
@@ -1,0 +1,274 @@
+"""전략 파일 접근 공용 helper + BacktestStrategyContext parity 테스트 (#2083).
+
+라이브 ``StrategyContext`` 와 ``BacktestStrategyContext`` 가 동일한 보안 경계
+(strategies/ 샌드박스, 절대경로/탈출/symlink escape 차단, 미존재 거부)를
+공유하는지 검증한다. 보안 경계 SSOT 는 ``ante.strategy.file_access`` 다.
+
+라이브 ``StrategyContext.load_file/load_text`` 의 동작 회귀는
+``tests/unit/test_strategy.py::TestStrategyContextFileAccess`` 가 lock 한다
+(helper 추출 이후에도 동작 불변).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import polars as pl
+import pytest
+
+from ante.backtest.context import BacktestStrategyContext
+from ante.backtest.data_provider import BacktestDataProvider
+from ante.backtest.executor import BacktestExecutor
+from ante.data.store import ParquetStore
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+from ante.strategy.exceptions import StrategyFileAccessError
+from ante.strategy.file_access import (
+    STRATEGIES_ROOT,
+    load_strategy_file,
+    load_strategy_text,
+    resolve_strategy_path,
+)
+
+# ── 공용 helper 직접 테스트 ────────────────────────
+
+
+class TestStrategyFileAccessHelper:
+    @pytest.fixture
+    def strategies_dir(self, tmp_path):
+        d = tmp_path / "strategies"
+        d.mkdir()
+        return d
+
+    def test_default_root_constant(self):
+        """STRATEGIES_ROOT 기본 상수가 strategies/ 로 정렬돼 있다."""
+        assert str(STRATEGIES_ROOT) == "strategies"
+
+    def test_load_file_success(self, strategies_dir):
+        """strategies_dir 하위 바이너리 파일을 읽는다."""
+        (strategies_dir / "data.bin").write_bytes(b"\x00\x01\x02")
+        assert load_strategy_file(strategies_dir, "data.bin") == b"\x00\x01\x02"
+
+    def test_load_text_success(self, strategies_dir):
+        """strategies_dir 하위 텍스트 파일을 읽는다."""
+        (strategies_dir / "config.txt").write_text("hello", encoding="utf-8")
+        assert load_strategy_text(strategies_dir, "config.txt") == "hello"
+
+    def test_load_text_subdirectory(self, strategies_dir):
+        """하위 디렉토리 파일도 읽는다."""
+        sub = strategies_dir / "sub"
+        sub.mkdir()
+        (sub / "data.csv").write_text("a,b,c", encoding="utf-8")
+        assert load_strategy_text(strategies_dir, "sub/data.csv") == "a,b,c"
+
+    @pytest.mark.parametrize("encoding", ["cp949", "euc-kr", "utf-8"])
+    def test_load_text_encoding(self, strategies_dir, encoding):
+        """다양한 인코딩으로 디코딩한다."""
+        (strategies_dir / "kr.txt").write_text("한글", encoding=encoding)
+        assert load_strategy_text(strategies_dir, "kr.txt", encoding=encoding) == "한글"
+
+    def test_absolute_path_rejected(self, strategies_dir):
+        """절대 경로는 StrategyFileAccessError 로 거부한다."""
+        with pytest.raises(StrategyFileAccessError, match="Absolute paths"):
+            load_strategy_file(strategies_dir, "/etc/passwd")
+
+    def test_path_escape_rejected(self, strategies_dir):
+        """`../` 탈출은 StrategyFileAccessError 로 거부한다."""
+        with pytest.raises(StrategyFileAccessError, match="escapes"):
+            load_strategy_file(strategies_dir, "../../etc/passwd")
+
+    def test_symlink_escape_rejected(self, strategies_dir, tmp_path):
+        """symlink 를 통한 탈출도 StrategyFileAccessError 로 거부한다.
+
+        strategies_dir 안에 strategies_dir 밖(tmp_path/secret) 을 가리키는
+        symlink 를 두고, 그 링크 너머의 파일을 읽으려 하면 base/candidate 를
+        모두 resolve() 후 비교하므로 escape 로 차단된다.
+        """
+        outside = tmp_path / "secret"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("top-secret", encoding="utf-8")
+        link = strategies_dir / "link"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink 미지원 플랫폼")
+        with pytest.raises(StrategyFileAccessError, match="escapes"):
+            load_strategy_file(strategies_dir, "link/secret.txt")
+
+    def test_not_found_rejected(self, strategies_dir):
+        """미존재 파일은 StrategyFileAccessError 로 거부한다."""
+        with pytest.raises(StrategyFileAccessError, match="File not found"):
+            load_strategy_file(strategies_dir, "nonexistent.txt")
+
+    def test_resolve_returns_under_base(self, strategies_dir):
+        """resolve 결과는 strategies_dir(resolve) 하위 절대 경로다."""
+        resolved = resolve_strategy_path(strategies_dir, "sub/data.csv")
+        assert resolved.is_relative_to(strategies_dir.resolve())
+
+
+# ── BacktestStrategyContext.load_file / load_text ──
+
+
+class TestBacktestStrategyContextFileAccess:
+    @pytest.fixture
+    def strategies_dir(self, tmp_path):
+        d = tmp_path / "strategies"
+        d.mkdir()
+        return d
+
+    @pytest.fixture
+    def ctx(self, strategies_dir):
+        # data_provider / portfolio 는 파일 접근 테스트에서 호출하지 않으므로
+        # None placeholder 로 충분하다(타입 무관 단위 테스트).
+        return BacktestStrategyContext(
+            bot_id="bt",
+            data_provider=None,  # type: ignore[arg-type]
+            portfolio=None,  # type: ignore[arg-type]
+            strategies_dir=strategies_dir,
+        )
+
+    def test_load_file_success(self, ctx, strategies_dir):
+        (strategies_dir / "data.bin").write_bytes(b"\x00\x01\x02")
+        assert ctx.load_file("data.bin") == b"\x00\x01\x02"
+
+    def test_load_text_success(self, ctx, strategies_dir):
+        (strategies_dir / "config.txt").write_text("hello", encoding="utf-8")
+        assert ctx.load_text("config.txt") == "hello"
+
+    def test_load_text_subdirectory(self, ctx, strategies_dir):
+        sub = strategies_dir / "sub"
+        sub.mkdir()
+        (sub / "data.csv").write_text("a,b,c", encoding="utf-8")
+        assert ctx.load_text("sub/data.csv") == "a,b,c"
+
+    def test_load_text_encoding(self, ctx, strategies_dir):
+        (strategies_dir / "kr.txt").write_text("한글", encoding="cp949")
+        assert ctx.load_text("kr.txt", encoding="cp949") == "한글"
+
+    def test_absolute_path_rejected(self, ctx):
+        with pytest.raises(StrategyFileAccessError, match="Absolute paths"):
+            ctx.load_file("/etc/passwd")
+
+    def test_path_escape_rejected(self, ctx):
+        with pytest.raises(StrategyFileAccessError, match="escapes"):
+            ctx.load_file("../../etc/passwd")
+
+    def test_symlink_escape_rejected(self, ctx, strategies_dir, tmp_path):
+        outside = tmp_path / "secret"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("top-secret", encoding="utf-8")
+        link = strategies_dir / "link"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink 미지원 플랫폼")
+        with pytest.raises(StrategyFileAccessError, match="escapes"):
+            ctx.load_file("link/secret.txt")
+
+    def test_not_found_rejected(self, ctx):
+        with pytest.raises(StrategyFileAccessError, match="File not found"):
+            ctx.load_file("nonexistent.txt")
+
+    def test_default_strategies_dir(self):
+        """strategies_dir 미지정 시 기본 STRATEGIES_ROOT(resolve)로 정렬된다."""
+        ctx = BacktestStrategyContext(
+            bot_id="bt",
+            data_provider=None,  # type: ignore[arg-type]
+            portfolio=None,  # type: ignore[arg-type]
+        )
+        assert ctx._strategies_dir == STRATEGIES_ROOT.resolve()
+
+
+# ── executor-level 재현(#2083) ─────────────────────
+
+
+def _make_ohlcv_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "timestamp": [
+                datetime(2026, 1, 2, 0, 0, tzinfo=UTC),
+                datetime(2026, 1, 3, 0, 0, tzinfo=UTC),
+            ],
+            "symbol": ["005930", "005930"],
+            "open": [1.0, 2.0],
+            "high": [1.0, 2.0],
+            "low": [1.0, 2.0],
+            "close": [1.0, 2.0],
+            "volume": [10, 20],
+            "source": ["test", "test"],
+        }
+    )
+
+
+class UsesLoadText(Strategy):
+    """ctx.load_text 로 전략 전용 파일을 읽는 재현 전략."""
+
+    meta = StrategyMeta(name="uses_load_text", version="1.0.0", description="repro")
+
+    def __init__(self, ctx: Any) -> None:
+        super().__init__(ctx)
+        self.loaded: str | None = None
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        if self.loaded is None:
+            self.loaded = self.ctx.load_text("config.txt")
+        return []
+
+
+class TestExecutorLoadTextRepro:
+    @pytest.fixture
+    def data_provider(self, tmp_path):
+        store = ParquetStore(base_path=tmp_path / "data")
+        store.write("005930", "1d", _make_ohlcv_df())
+        provider = BacktestDataProvider(
+            store=store,
+            start_date="2026-01-02",
+            end_date="2026-01-03",
+        )
+        provider.load("005930", "1d")
+        return provider
+
+    @pytest.fixture
+    def strategies_dir(self, tmp_path):
+        d = tmp_path / "strategies"
+        d.mkdir()
+        (d / "config.txt").write_text("threshold=42", encoding="utf-8")
+        return d
+
+    async def test_run_with_strategies_dir_no_attribute_error(
+        self, data_provider, strategies_dir
+    ):
+        """strategies_dir 주입 시 ctx.load_text 가 AttributeError 없이 동작한다.
+
+        수정 전에는 BacktestStrategyContext 에 load_text 가 없어
+        ``AttributeError: 'BacktestStrategyContext' object has no attribute
+        'load_text'`` 로 실패했다(#2083 재현).
+        """
+        executor = BacktestExecutor(
+            strategy_cls=UsesLoadText,
+            data_provider=data_provider,
+            strategies_dir=strategies_dir,
+        )
+        result = await executor.run()
+        assert result.strategy_name == "uses_load_text"
+
+    async def test_run_load_text_escape_rejected(self, data_provider, strategies_dir):
+        """주입된 strategies_dir 밖을 읽으려는 전략은 StrategyFileAccessError.
+
+        executor.run 경로에서도 보안 경계가 라이브와 동일하게 적용된다.
+        """
+
+        class UsesEscapingLoadText(Strategy):
+            meta = StrategyMeta(name="escaping", version="1.0.0", description="escape")
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self.ctx.load_text("../../etc/passwd")
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=UsesEscapingLoadText,
+            data_provider=data_provider,
+            strategies_dir=strategies_dir,
+        )
+        with pytest.raises(StrategyFileAccessError, match="escapes"):
+            await executor.run()


### PR DESCRIPTION
Closes #2083

## Summary
- BacktestStrategyContext에 `load_file`/`load_text`가 없어 파일 의존 라이브 전략이 백테스트에서 AttributeError로 실패하던 P2 버그 수정
- 보안 경계(strategies/ 샌드박스: 절대경로 거부, ../·symlink 탈출 차단, StrategyFileAccessError)를 공용 helper `strategy/file_access.py`로 추출(복제 대신 단일 소유), live StrategyContext는 위임으로 리팩터(동작 불변)
- BacktestStrategyContext에 strategies_dir 주입 + load_file/load_text, BacktestExecutor pass-through, backtest 스펙 메서드 표 정렬

## Test Plan
- 신규 test_strategy_file_access.py 23 passed (symlink/encoding/subdir/executor-level repro), targeted 311 passed, **live 회귀 84 passed(동작 불변)**, backtest 78, contracts 145; ruff/mypy 통과; Codex 브랜치 리뷰 PASS

## Non-Goals
- #2074(get_positions schema), #2076(get_ohlcv), live 동작/보안 시맨틱 변경 없음(리팩터는 동작 보존)