### PR TITLE
fix(backtest): #2074 get_positions에 current_price/unrealized_pnl 추가 (PortfolioView 스키마 parity)

### DIFF
--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -78,6 +78,12 @@ class BacktestExecutor:
         self._positions: dict[str, dict[str, float]] = {}
         self._trades: list[BacktestTrade] = []
         self._equity_curve: list[dict] = []
+        # 현재 step 시점의 보유 심볼별 현재가 스냅샷. run 루프가 매 step
+        # 보유 심볼 기준으로 새로 구성하고, get_positions()는 provider를
+        # 재호출하지 않고 이 캐시만 읽어 PortfolioView 스키마의 current_price/
+        # unrealized_pnl을 합성한다(#2074). step 사이에 stale/lookahead 가격이
+        # 남지 않도록 매 step 새로 채운다.
+        self._current_prices: dict[str, float] = {}
 
     async def run(
         self,
@@ -104,6 +110,12 @@ class BacktestExecutor:
             timestamp = self._data.get_current_timestamp()
             if timestamp is None:
                 break
+
+            # 현재 봉 시점의 현재가 스냅샷을 보유 심볼 기준으로 새로 구성한다.
+            # get_positions()가 이 캐시만 읽으므로, context(portfolio) 생성 이전에
+            # 갱신해야 PortfolioView의 current_price/unrealized_pnl이 현재 봉을
+            # 반영한다(#2074). 매 step 새로 채워 stale/lookahead를 막는다.
+            await self._refresh_current_prices()
 
             context = {
                 "timestamp": timestamp,
@@ -259,6 +271,48 @@ class BacktestExecutor:
             if pos["quantity"] <= 0:
                 del self._positions[symbol]
 
+    async def _refresh_current_prices(self) -> None:
+        """현재 봉 시점의 보유 심볼별 현재가 스냅샷을 새로 구성한다(#2074).
+
+        ``get_positions()`` 가 PortfolioView 스키마(current_price/unrealized_pnl)를
+        제공할 때 읽는 캐시다. provider를 재호출하지 않는 sync get_positions를
+        유지하기 위해, run 루프가 현재 봉 가격을 미리 여기에 채운다.
+
+        - **매 step 새로 구성**한다(dict를 새로 만들어 교체). 이전 봉 가격이
+          남으면 stale/lookahead가 되므로, 직전 step에 보유했다가 청산된 심볼은
+          캐시에서 자연히 사라진다.
+        - 보유 심볼(``self._positions`` 키)에 대해서만 ``get_current_price`` 를
+          조회한다. 조회 실패(예외)/``None``/``<= 0`` 이면 해당 심볼은 그 포지션의
+          ``avg_price`` 로 fallback 확정한다(``_calculate_equity`` 와 동일 정책).
+
+        Note: 현재 봉 가격이 SSOT이므로 반드시 run 루프 안(advance 직후, 다음
+        advance 이전)에서만 호출한다. 루프 종료 후 호출하면 미래 봉을 보는
+        lookahead가 된다.
+        """
+        prices: dict[str, float] = {}
+        for symbol, pos in self._positions.items():
+            avg_price = pos["avg_price"]
+            mark_price = avg_price
+            try:
+                current_price = await self._data.get_current_price(symbol)
+                if current_price is not None and current_price > 0:
+                    mark_price = current_price
+                else:
+                    logger.warning(
+                        "현재가 조회 불가(symbol=%s, price=%r) — avg_price로 fallback",
+                        symbol,
+                        current_price,
+                    )
+            except Exception:
+                logger.warning(
+                    "현재가 조회 실패(symbol=%s) — avg_price로 fallback",
+                    symbol,
+                    exc_info=True,
+                )
+            prices[symbol] = mark_price
+        # 매 step 통째로 교체해 이전 봉/청산 심볼 가격이 남지 않게 한다.
+        self._current_prices = prices
+
     async def _calculate_equity(self) -> float:
         """현재 bar 시점의 자산 가치 (mark-to-market).
 
@@ -318,11 +372,28 @@ class BacktestExecutor:
         return metrics
 
     def get_positions(self, bot_id: str) -> dict[str, Any]:
-        """PortfolioView 인터페이스."""
-        return {
-            s: {"quantity": p["quantity"], "avg_price": p["avg_price"]}
-            for s, p in self._positions.items()
-        }
+        """PortfolioView 인터페이스.
+
+        spec ``03-04-provider-and-views.md`` L29 PortfolioView 스키마대로
+        ``{symbol: {"quantity","avg_price","current_price","unrealized_pnl"}}`` 를
+        반환해 라이브와 parity를 맞춘다(#2074).
+
+        provider를 재호출하지 않고 run 루프가 매 step 미리 채운
+        ``self._current_prices`` 캐시만 읽는다(sync 유지). 캐시에 심볼이 없으면
+        (예: run 루프 밖에서 호출되거나 가격 미조회) ``avg_price`` 로 fallback해
+        ``unrealized_pnl == 0`` 이 된다.
+        """
+        result: dict[str, Any] = {}
+        for symbol, p in self._positions.items():
+            avg_price = p["avg_price"]
+            current_price = self._current_prices.get(symbol, avg_price)
+            result[symbol] = {
+                "quantity": p["quantity"],
+                "avg_price": avg_price,
+                "current_price": current_price,
+                "unrealized_pnl": (current_price - avg_price) * p["quantity"],
+            }
+        return result
 
     def get_balance(self, bot_id: str) -> dict[str, float]:
         """PortfolioView 인터페이스."""

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -1693,3 +1693,233 @@ class TestGetTradeHistory:
         )
         history = executor.get_trade_history()
         assert history[0]["timestamp"] is None
+
+
+# ── get_positions PortfolioView 스키마 테스트 (#2074) ─
+
+
+class TestGetPositionsSchema:
+    """BacktestExecutor.get_positions가 PortfolioView 스키마(current_price/
+    unrealized_pnl)를 라이브와 parity로 제공하는지 검증(#2074).
+
+    spec docs/specs/strategy/03-04-provider-and-views.md L29:
+      get_positions → {symbol: {quantity, avg_price, current_price, unrealized_pnl}}
+    """
+
+    async def test_repro_current_price_and_unrealized_pnl(self, store):
+        """이슈 재현: step1 buy 1주 @100, step2 price 120.
+
+        step2에서 context["portfolio"](run 루프가 만든 dict)와
+        ctx.get_positions()(전략이 호출) 두 경로 모두 005930이
+        {quantity:1, avg_price:100.0, current_price:120.0, unrealized_pnl:20.0}.
+        """
+        # run 루프 첫 on_step은 current_idx=1에서 일어난다.
+        #   step1(on_step #1) -> idx1 close=100 (매수가 100)
+        #   step2(on_step #2) -> idx2 close=120 (현재가 120)
+        # idx0은 매수/현재가에 쓰이지 않으므로 임의값.
+        closes = [50.0, 100.0, 120.0, 120.0]
+        df = _make_ohlcv_df_with_closes(closes)
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        captured: dict[str, Any] = {}
+
+        class BuyStep1CaptureStep2(Strategy):
+            meta = StrategyMeta(name="buy_capture", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 1:
+                    return [Signal(symbol="005930", side="buy", quantity=1)]
+                if self._step == 2:
+                    # run 루프가 만든 context["portfolio"]와 ctx.get_positions()
+                    # 두 경로를 step2에서 캡처한다.
+                    captured["context_portfolio"] = context["portfolio"]
+                    captured["ctx_positions"] = self.ctx.get_positions()
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyStep1CaptureStep2,
+            data_provider=provider,
+            initial_balance=10_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        await executor.run()
+
+        expected = {
+            "quantity": 1,
+            "avg_price": 100.0,
+            "current_price": 120.0,
+            "unrealized_pnl": 20.0,
+        }
+        # 두 경로(run 루프 dict / 전략 호출) 모두 동일 스키마/값.
+        for path in ("context_portfolio", "ctx_positions"):
+            positions = captured[path]
+            assert "005930" in positions, path
+            pos = positions["005930"]
+            assert pos["quantity"] == pytest.approx(expected["quantity"]), path
+            assert pos["avg_price"] == pytest.approx(expected["avg_price"]), path
+            assert pos["current_price"] == pytest.approx(expected["current_price"]), (
+                path
+            )
+            assert pos["unrealized_pnl"] == pytest.approx(expected["unrealized_pnl"]), (
+                path
+            )
+            # 스키마 키 정확성(라이브 PortfolioView parity)
+            assert set(pos.keys()) == {
+                "quantity",
+                "avg_price",
+                "current_price",
+                "unrealized_pnl",
+            }, path
+
+    async def test_price_lookup_failure_falls_back_to_avg_price(self, store):
+        """가격 조회 실패/없음 → current_price=avg_price, unrealized_pnl=0.
+
+        보유 후 get_current_price가 항상 실패(예외)하면, get_positions의
+        current_price는 avg_price(매수가)로 fallback하고 unrealized_pnl=0.
+        """
+        closes = [50.0, 100.0, 120.0, 120.0]
+        df = _make_ohlcv_df_with_closes(closes)
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        captured: dict[str, Any] = {}
+
+        class BuyStep1CaptureStep2(Strategy):
+            meta = StrategyMeta(name="buy_capture_fb", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 1:
+                    return [Signal(symbol="005930", side="buy", quantity=1)]
+                if self._step == 2:
+                    captured["context_portfolio"] = context["portfolio"]
+                    captured["ctx_positions"] = self.ctx.get_positions()
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyStep1CaptureStep2,
+            data_provider=provider,
+            initial_balance=10_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+
+        real_get_price = provider.get_current_price
+
+        async def flaky_get_price(symbol: str) -> float:
+            # 매수 체결에는 정상가가 필요하므로 보유 후(_refresh_current_prices /
+            # _calculate_equity 경로)에만 실패시킨다.
+            if executor._positions:
+                raise BacktestDataError("simulated lookup failure")
+            return await real_get_price(symbol)
+
+        with patch.object(provider, "get_current_price", side_effect=flaky_get_price):
+            await executor.run()
+
+        for path in ("context_portfolio", "ctx_positions"):
+            pos = captured[path]["005930"]
+            # 현재가 조회 실패 → avg_price(매수가 100) fallback, pnl=0
+            assert pos["avg_price"] == pytest.approx(100.0), path
+            assert pos["current_price"] == pytest.approx(100.0), path
+            assert pos["unrealized_pnl"] == pytest.approx(0.0), path
+
+    async def test_get_positions_no_cache_falls_back_to_avg_price(self, data_provider):
+        """run 루프 밖(캐시 미구성)에서 보유 포지션이 있으면 avg_price fallback.
+
+        _current_prices가 비어 있으면 current_price=avg_price, unrealized_pnl=0
+        (lookahead/provider 재호출 없이 안전한 기본값).
+        """
+        executor = BacktestExecutor(
+            strategy_cls=EmptyStrategy,
+            data_provider=data_provider,
+        )
+        # run 없이 포지션만 주입(캐시는 비어 있음).
+        executor._positions["005930"] = {"quantity": 3, "avg_price": 100.0}
+        positions = executor.get_positions("backtest")
+        pos = positions["005930"]
+        assert pos["quantity"] == 3
+        assert pos["avg_price"] == pytest.approx(100.0)
+        assert pos["current_price"] == pytest.approx(100.0)
+        assert pos["unrealized_pnl"] == pytest.approx(0.0)
+
+    async def test_empty_positions_returns_empty(self, data_provider):
+        """보유 포지션이 없으면 빈 dict."""
+        executor = BacktestExecutor(
+            strategy_cls=EmptyStrategy,
+            data_provider=data_provider,
+        )
+        assert executor.get_positions("backtest") == {}
+
+    async def test_no_lookahead_uses_current_bar_price(self, store):
+        """lookahead 방지: 매 step current_price가 그 step 현재가 기준.
+
+        step1에서 매수(idx1 close=100)한 직후 step1의 current_price는 아직
+        step1 봉 가격(100)이어야 하고, 다음 봉(idx2 close=120)을 미리 보지
+        않는다. 또 이전 봉 가격이 다음 step에 stale로 남지 않는다.
+        """
+        closes = [50.0, 100.0, 120.0, 130.0]
+        df = _make_ohlcv_df_with_closes(closes)
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        # step별로 ctx.get_positions()의 current_price를 기록한다.
+        seen: list[float | None] = []
+
+        class BuyThenObserve(Strategy):
+            meta = StrategyMeta(name="buy_observe", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 1:
+                    # step1: on_step 시점엔 미보유 → 매수 신호. 매수 후 같은
+                    # step에서 캐시는 이 step 진입 시점(미보유) 기준이라 비어 있다.
+                    signals = [Signal(symbol="005930", side="buy", quantity=1)]
+                    positions = self.ctx.get_positions()
+                    seen.append(positions.get("005930", {}).get("current_price"))
+                    return signals
+                pos = self.ctx.get_positions().get("005930")
+                seen.append(pos["current_price"] if pos else None)
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyThenObserve,
+            data_provider=provider,
+            initial_balance=10_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        await executor.run()
+
+        # step1: 매수 직전 미보유라 캐시 없음 → current_price None.
+        assert seen[0] is None
+        # step2: idx2 close=120 (이전 봉 100이 stale로 남지 않음).
+        assert seen[1] == pytest.approx(120.0)
+        # step3: idx3 close=130 (lookahead/stale 없음, 매 step 새 가격).
+        assert seen[2] == pytest.approx(130.0)


### PR DESCRIPTION
Closes #2074

## Summary
- BacktestExecutor.get_positions가 spec(03-04) PortfolioView 스키마(current_price/unrealized_pnl)를 누락하던 P2 버그 수정
- run 루프가 매 step advance() 직후·context 빌드 전에 보유 심볼 현재가를 self._current_prices에 새로 캐시(실패/None/<=0→avg_price fallback, stale/lookahead 방지). get_positions는 sync 유지, 캐시만 읽어 {quantity, avg_price, current_price, unrealized_pnl} 반환

## Test Plan
- pytest test_backtest.py 83 passed (context['portfolio']·ctx.get_positions 양 경로 step2 current=120/PnL=20, fallback, lookahead 방지), backtest 회귀 254, contracts 145; ruff/mypy 통과; Codex 브랜치 리뷰 PASS

## Non-Goals
- #2127(live/virtual schema), #2076(get_ohlcv), get_balance 키, provider sync API, 라이브 변경 없음