### PR TITLE
fix(backtest): #2125 무거래 백테스트도 계산 가능한 성과지표 반환

### DIFF
--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -351,11 +351,15 @@ class BacktestExecutor:
         Args:
             final_equity: 마지막 시뮬레이션 봉의 mark-to-market equity.
                 run()에서 equity_curve[-1] 기반으로 전달한다(재계산하지 않음).
+
+        Note: 무거래(``self._trades == []``)여도 early-return하지 않고
+        ``calculate_metrics`` 를 호출한다. ``calculate_metrics`` 는 빈 거래/평탄
+        equity_curve에서도 div-by-zero/NaN/inf 없이 core 13지표를 산출하며
+        (거래 기반 지표는 0/None, equity 기반 지표는 equity_curve 기준),
+        compat 필드(buy_trades/sell_trades/total_slippage)는 빈 거래에서 자연히
+        0이 된다. 무거래 result에서도 지표 키가 안정적으로 존재하도록 한다(#2125).
         """
         from ante.backtest.metrics import calculate_metrics
-
-        if not self._trades:
-            return {}
 
         metrics = calculate_metrics(
             trades=self._trades,

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -567,14 +567,51 @@ class TestBacktestExecutor:
         assert "max_drawdown" in result.metrics
         assert "win_rate" in result.metrics
 
-    async def test_metrics_empty_for_no_trades(self, data_provider):
+    async def test_metrics_computed_for_no_trades(self, data_provider):
+        """무거래여도 metrics는 {}가 아니라 계산 가능한 지표를 채운다(#2125).
+
+        ``calculate_metrics`` 는 빈 거래/평탄 equity_curve에서도 core 13지표를
+        산출하므로(거래 기반은 0/None, equity 기반은 equity_curve 기준),
+        무거래 result도 core 13 + compat 3(총 16키)을 안정적으로 노출한다.
+        """
         data_provider.reset()
         executor = BacktestExecutor(
             strategy_cls=EmptyStrategy,
             data_provider=data_provider,
         )
         result = await executor.run()
-        assert result.metrics == {}
+
+        # 무거래여도 metrics가 비어 있지 않다.
+        assert result.metrics != {}
+        assert len(result.trades) == 0
+
+        # core 13지표 키가 모두 존재한다.
+        core_keys = {
+            "total_return",
+            "annual_return",
+            "sharpe_ratio",
+            "max_drawdown",
+            "max_drawdown_duration",
+            "total_trades",
+            "winning_trades",
+            "losing_trades",
+            "win_rate",
+            "profit_factor",
+            "avg_profit",
+            "avg_loss",
+            "total_commission",
+        }
+        assert core_keys <= set(result.metrics)
+
+        # compat 3필드가 빈 거래에서 자연히 0이 된다.
+        assert result.metrics["buy_trades"] == 0
+        assert result.metrics["sell_trades"] == 0
+        assert result.metrics["total_slippage"] == 0
+
+        # 거래 기반 지표는 무거래 시 0/0.0이다.
+        assert result.metrics["total_trades"] == 0
+        assert result.metrics["win_rate"] == 0.0
+        assert result.metrics["total_commission"] == 0.0
 
     async def test_result_to_dict(self, data_provider):
         data_provider.reset()


### PR DESCRIPTION
Closes #2125

## Summary
- 무거래 백테스트가 `metrics={}`로 지표를 누락하던 P2 버그 수정
- `_calculate_metrics`의 `if not self._trades: return {}` early-return 제거 → calculate_metrics가 equity_curve/잔고 기준 core 13지표 산출, compat 3필드(buy_trades/sell_trades/total_slippage=0) 자연 0

## Test Plan
- 기존 `test_metrics_empty_for_no_trades`(metrics=={}) → `test_metrics_computed_for_no_trades`로 교체(core 13 + compat 3 = 16키, total_trades=0/win_rate=0.0/total_commission=0.0)
- pytest test_backtest.py 83 passed, backtest 회귀 254, contracts 145; ruff/mypy 통과; Codex 브랜치 리뷰 PASS

## Non-Goals
- calculate_metrics 로직 변경 없음, 다른 backtest 결함 미수정