### PR TITLE
fix(feed): #2054 DART 분기 실패 시 checkpoint 미전진 (monotonic-safe 재시도)

### DIFF
--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -162,6 +162,16 @@ class DARTCollector:
         # 이로써 checkpoint가 미래 분기로 전진하지 않는다(#1964).
         today = _today_kst()
 
+        # 첫 실패(ok=False) 이후에는 이 run에서 checkpoint를 더 전진시키지
+        # 않는다(#2054). checkpoint는 quarter_key 오름차순 last-write-wins로
+        # monotonic 전진하므로, 실패 분기 이후의 성공 분기를 save하면 checkpoint가
+        # 실패 분기를 넘어 전진해 다음 run에서 재시도되지 않는다. halt 플래그로
+        # 실패 분기 직전에 checkpoint를 고정해 다음 run이 실패 분기부터 재개한다.
+        # 실패 이후 분기 fetch는 best-effort로 계속하며(데이터는 best-effort
+        # 저장), 재-fetch는 ParquetStore의 natural-key dedup(keep="last")로
+        # overwrite 멱등이라 중복 누적이 발생하지 않는다.
+        halt = False
+
         for year in range(start_year, end_year + 1):
             for reprt_code in REPRT_CODES:
                 quarter_key = f"{year}-{REPRT_TO_QUARTER[reprt_code]}"
@@ -173,7 +183,7 @@ class DARTCollector:
                     # 미래 분기: fetch/save 모두 건너뛴다.
                     continue
 
-                written, syms = await self._fetch_quarter(
+                written, syms, ok = await self._fetch_quarter(
                     corp_codes_list,
                     corp_code_map,
                     store,
@@ -183,7 +193,10 @@ class DARTCollector:
                 )
                 rows_written += written
                 symbols.update(syms)
-                checkpoint.save(quarter_key)
+                if not ok:
+                    halt = True
+                if ok and not halt:
+                    checkpoint.save(quarter_key)
 
         logger.info(
             "DART 수집 완료: symbols=%d rows=%d",
@@ -200,8 +213,22 @@ class DARTCollector:
         year: int,
         reprt_code: str,
         warns: list[dict],
-    ) -> tuple[int, set[str]]:
-        """단일 분기 재무제표를 수집/정규화/저장한다."""
+    ) -> tuple[int, set[str], bool]:
+        """단일 분기 재무제표를 수집/정규화/저장한다.
+
+        Returns:
+            (기록 행 수, 수집된 심볼 집합, ok). ``ok``는 이 분기가 checkpoint
+            전진 자격을 갖는지를 나타낸다(#2054):
+
+            - transient 예외(warn 추가) → ``ok=False``(미전진, 다음 run 재시도)
+            - ``not raw_items``(upstream terminal no-data) → ``ok=True``
+              (정당한 빈-성공; checkpoint 전진하여 무한 재시도 방지)
+            - ``raw_items``는 있는데 정규화/저장 결과 0 rows(no-storable) →
+              warn 추가 + ``ok=False``(데이터 손실 surface, 미전진)
+            - 정상 저장(written>0) → ``ok=True``
+
+            ``DARTDailyLimitError``/``DARTCriticalError``는 기존대로 re-raise.
+        """
         try:
             raw_items = await self._source.fetch_financial(
                 corp_codes_list,
@@ -225,16 +252,42 @@ class DARTCollector:
                     "message": str(exc),
                 }
             )
-            return 0, set()
+            return 0, set(), False
 
         if not raw_items:
-            return 0, set()
+            # upstream terminal no-data: 정당한 빈-성공. checkpoint를 전진시켜
+            # 데이터 없는 분기를 무한 재시도하지 않는다.
+            return 0, set(), True
 
-        return self._normalize_and_store(
+        written, syms = self._normalize_and_store(
             raw_items,
             corp_code_map,
             store,
         )
+        if written == 0:
+            # raw_items는 있으나 정규화/저장에서 0 rows(normalized empty,
+            # symbol 컬럼 부재 등 no-storable). 데이터 손실을 surface하고
+            # checkpoint를 전진시키지 않아 다음 run에서 재시도되게 한다.
+            logger.warning(
+                "DART 정규화/저장 결과 0건: year=%s reprt=%s raw=%d",
+                year,
+                reprt_code,
+                len(raw_items),
+            )
+            warns.append(
+                {
+                    "source": "dart",
+                    "year": str(year),
+                    "reprt_code": reprt_code,
+                    "message": (
+                        f"raw {len(raw_items)}건이 정규화/저장에서 0건으로 "
+                        "처리됨(no-storable)"
+                    ),
+                }
+            )
+            return 0, syms, False
+
+        return written, syms, True
 
     def _normalize_and_store(
         self,

--- a/tests/unit/feed/test_dart_collector.py
+++ b/tests/unit/feed/test_dart_collector.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date
 from pathlib import Path
 
+import polars as pl
 import pytest
 
 from ante.data.store import ParquetStore
@@ -158,3 +159,280 @@ class TestCheckpointFutureQuarterClamp:
         fetched_2026 = {rc for (yr, rc) in source.fetched if yr == "2026"}
         assert fetched_2026 & future_codes == set()
         assert ("2026", "11013") in source.fetched  # Q1은 fetch됨
+
+
+class _ScriptedDARTSource:
+    """(year, reprt_code)별로 raise/raw_items 응답을 스크립트로 지정하는 스텁.
+
+    behaviors[(year, reprt_code)] 값:
+      - Exception 인스턴스 → 해당 분기 fetch_financial에서 raise
+      - list[dict]          → 해당 분기 raw_items로 반환
+      - 미지정              → 빈 리스트([]) 반환(terminal no-data)
+    """
+
+    def __init__(
+        self,
+        corp_code_map: dict[str, str],
+        behaviors: dict[tuple[str, str], object] | None = None,
+    ) -> None:
+        self._corp_code_map = corp_code_map
+        self._behaviors = behaviors or {}
+        self.fetched: list[tuple[str, str]] = []
+
+    async def fetch_corp_codes(self, save_path: Path) -> dict[str, str]:
+        return self._corp_code_map
+
+    async def fetch_financial(
+        self,
+        corp_codes: list[str],
+        year: str,
+        reprt_code: str,
+    ) -> list[dict]:
+        self.fetched.append((year, reprt_code))
+        behavior = self._behaviors.get((year, reprt_code), [])
+        if isinstance(behavior, Exception):
+            raise behavior
+        assert isinstance(behavior, list)
+        return behavior
+
+
+class _ScriptedNormalizer:
+    """raw_items 길이/내용과 무관하게 미리 정한 DataFrame을 반환하는 스텁.
+
+    _normalize_and_store가 `normalize(df, corp_code_map)`를 호출하므로
+    동일 시그니처를 제공한다. 반환 DataFrame의 row 수가 written을 결정한다.
+    """
+
+    def __init__(self, result_for: dict[tuple[str, str], pl.DataFrame]) -> None:
+        # raw_items 첫 항목의 (bsns_year, reprt_code)로 결과를 선택한다.
+        self._result_for = result_for
+
+    def normalize(
+        self,
+        df: pl.DataFrame,
+        corp_code_map: dict[str, str],
+    ) -> pl.DataFrame:
+        first = df.row(0, named=True)
+        key = (str(first["bsns_year"]), str(first["reprt_code"]))
+        result = self._result_for.get(key)
+        if result is not None:
+            return result
+        # 기본: symbol 1개, 1행을 가진 정상 정규화 결과
+        return pl.DataFrame(
+            {
+                "date": [date(int(key[0]), 12, 31)],
+                "symbol": ["005930"],
+                "revenue": [100],
+                "source": ["dart"],
+            }
+        )
+
+
+def _raw_item(year: str, reprt_code: str) -> dict:
+    """ScriptedNormalizer가 (year, reprt_code)를 식별할 수 있는 최소 raw row."""
+    return {
+        "corp_code": "00126380",
+        "bsns_year": year,
+        "reprt_code": reprt_code,
+        "account_nm": "매출액",
+        "thstrm_amount": "100",
+        "fs_div": "OFS",
+    }
+
+
+def _stored_df(year: str) -> pl.DataFrame:
+    """정상 저장(written>0)을 유발하는 정규화 결과 DataFrame."""
+    return pl.DataFrame(
+        {
+            "date": [date(int(year), 12, 31)],
+            "symbol": ["005930"],
+            "revenue": [100],
+            "source": ["dart"],
+        }
+    )
+
+
+def _make_collector_env(
+    tmp_path: Path,
+    behaviors: dict[tuple[str, str], object],
+    norm_results: dict[tuple[str, str], pl.DataFrame] | None = None,
+) -> tuple[DARTCollector, Checkpoint, ParquetStore, _ScriptedDARTSource, dict]:
+    """공통 collect 환경(과거 연도 single-year)을 구성한다.
+
+    backfill_since를 과거(2015)로 두고 today를 KST 현재로 두면 모든 분기가
+    collectable하므로 본 테스트들은 단일 연도(2015) 4분기를 순회한다.
+    """
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+    store = ParquetStore(base_path=tmp_path / "data")
+    checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+    source = _ScriptedDARTSource({"00126380": "005930"}, behaviors)
+    normalizer = _ScriptedNormalizer(norm_results or {})
+    collector = DARTCollector(source=source, normalizer=normalizer)
+    config = {"schedule": {"backfill_since": "2015-01-01"}}
+    return collector, checkpoint, store, source, config
+
+
+async def _run_collect(
+    tmp_path: Path,
+    collector: DARTCollector,
+    checkpoint: Checkpoint,
+    store: ParquetStore,
+    config: dict,
+    end_year: int = 2015,
+) -> tuple[int, set[str], list[dict]]:
+    """단일 연도만 순회하도록 _resolve_year_range를 고정해 collect 실행."""
+    # end_year를 고정(_today_kst 기반 현재 연도 대신)하여 단일 연도만 순회.
+    return await collector._collect_quarters(  # type: ignore[attr-defined]
+        {"00126380": "005930"},
+        store,
+        checkpoint,
+        2015,
+        end_year,
+        None,
+    )
+
+
+# 2015-Q1 period-end(3/31)는 today(2026+)보다 과거이므로 모든 분기 collectable.
+# REPRT_CODES 시간순: 11013(Q1) 11012(Q2) 11014(Q3) 11011(Q4).
+
+
+class TestCheckpointHaltOnFailure:
+    """#2054: 분기 수집 실패 시 checkpoint가 전진하지 않는지 검증한다."""
+
+    async def test_single_transient_failure_no_checkpoint(self, tmp_path: Path) -> None:
+        """(a) 단일 분기 transient 실패 → 해당 분기 checkpoint 미저장.
+
+        Q1(11013)에서 RuntimeError raise. 이후 Q2/Q3/Q4는 정상 성공해도
+        halt 이후라 checkpoint는 전진하지 않는다(None).
+        """
+        behaviors: dict[tuple[str, str], object] = {
+            ("2015", "11013"): RuntimeError("temporary upstream error"),
+            ("2015", "11012"): [_raw_item("2015", "11012")],
+            ("2015", "11014"): [_raw_item("2015", "11014")],
+            ("2015", "11011"): [_raw_item("2015", "11011")],
+        }
+        collector, checkpoint, store, _source, config = _make_collector_env(
+            tmp_path, behaviors
+        )
+        rows, syms, warns = await _run_collect(
+            tmp_path, collector, checkpoint, store, config
+        )
+
+        assert checkpoint.get_last_date() is None
+        assert len(warns) == 1
+        assert warns[0]["reprt_code"] == "11013"
+
+    async def test_q2_failure_does_not_advance_past_q1(self, tmp_path: Path) -> None:
+        """(b) Q2 실패 후 Q3 성공이어도 checkpoint가 Q1에 머무름(monotonic 회귀).
+
+        Q1 성공 → checkpoint=2015-Q1. Q2 실패 → halt. Q3 성공해도 save 안 함.
+        checkpoint가 Q3로 전진하면 다음 run에서 Q2가 skip되어 영구 누락된다.
+        """
+        behaviors: dict[tuple[str, str], object] = {
+            ("2015", "11013"): [_raw_item("2015", "11013")],  # Q1 성공
+            ("2015", "11012"): RuntimeError("Q2 transient"),  # Q2 실패
+            ("2015", "11014"): [_raw_item("2015", "11014")],  # Q3 성공
+            ("2015", "11011"): [_raw_item("2015", "11011")],  # Q4 성공
+        }
+        collector, checkpoint, store, _source, config = _make_collector_env(
+            tmp_path, behaviors
+        )
+        await _run_collect(tmp_path, collector, checkpoint, store, config)
+
+        # 실패 분기(Q2)를 넘어 전진하지 않는다. Q1에 고정.
+        assert checkpoint.get_last_date() == "2015-Q1"
+
+    async def test_terminal_no_data_advances_checkpoint(self, tmp_path: Path) -> None:
+        """(c) not raw_items(terminal no-data) → checkpoint 정상 전진(빈-성공).
+
+        모든 분기가 빈 응답([]). 정당한 빈-성공이므로 checkpoint는 마지막
+        분기(Q4)까지 전진하여 무한 재시도를 방지한다.
+        """
+        behaviors: dict[tuple[str, str], object] = {}  # 전부 [] 반환
+        collector, checkpoint, store, _source, config = _make_collector_env(
+            tmp_path, behaviors
+        )
+        _rows, _syms, warns = await _run_collect(
+            tmp_path, collector, checkpoint, store, config
+        )
+
+        assert checkpoint.get_last_date() == "2015-Q4"
+        assert warns == []
+
+    async def test_raw_present_but_stored_zero_halts(self, tmp_path: Path) -> None:
+        """(d) raw_items>0인데 정규화/저장 0건 → warns 추가 + checkpoint 미전진.
+
+        Q1은 raw_items가 있으나 normalize가 빈 DataFrame을 반환(no-storable).
+        데이터 손실을 surface(warns)하고 checkpoint는 전진하지 않는다.
+        """
+        empty_norm = pl.DataFrame(
+            {"date": [], "symbol": [], "revenue": [], "source": []},
+            schema={
+                "date": pl.Date,
+                "symbol": pl.Utf8,
+                "revenue": pl.Int64,
+                "source": pl.Utf8,
+            },
+        )
+        behaviors: dict[tuple[str, str], object] = {
+            ("2015", "11013"): [_raw_item("2015", "11013")],  # raw 있음
+        }
+        norm_results = {("2015", "11013"): empty_norm}  # 정규화 결과 0건
+        collector, checkpoint, store, _source, config = _make_collector_env(
+            tmp_path, behaviors, norm_results
+        )
+        _rows, _syms, warns = await _run_collect(
+            tmp_path, collector, checkpoint, store, config
+        )
+
+        assert checkpoint.get_last_date() is None
+        assert len(warns) == 1
+        assert warns[0]["reprt_code"] == "11013"
+        assert "no-storable" in warns[0]["message"]
+
+    async def test_all_success_advances_checkpoint(self, tmp_path: Path) -> None:
+        """(e) 전 분기 정상 저장 → checkpoint가 마지막 분기까지 정상 전진."""
+        behaviors: dict[tuple[str, str], object] = {
+            ("2015", "11013"): [_raw_item("2015", "11013")],
+            ("2015", "11012"): [_raw_item("2015", "11012")],
+            ("2015", "11014"): [_raw_item("2015", "11014")],
+            ("2015", "11011"): [_raw_item("2015", "11011")],
+        }
+        norm_results = {
+            ("2015", "11013"): _stored_df("2015"),
+            ("2015", "11012"): _stored_df("2015"),
+            ("2015", "11014"): _stored_df("2015"),
+            ("2015", "11011"): _stored_df("2015"),
+        }
+        collector, checkpoint, store, _source, config = _make_collector_env(
+            tmp_path, behaviors, norm_results
+        )
+        rows, syms, warns = await _run_collect(
+            tmp_path, collector, checkpoint, store, config
+        )
+
+        assert checkpoint.get_last_date() == "2015-Q4"
+        assert warns == []
+        assert rows > 0
+        assert syms == {"005930"}
+
+    async def test_issue_repro_all_fail_no_checkpoint(self, tmp_path: Path) -> None:
+        """(f) 이슈 재현: 전 분기 transient 실패 → checkpoint 미전진(None)."""
+        err = RuntimeError("temporary upstream error")
+        behaviors: dict[tuple[str, str], object] = {
+            ("2015", "11013"): err,
+            ("2015", "11012"): err,
+            ("2015", "11014"): err,
+            ("2015", "11011"): err,
+        }
+        collector, checkpoint, store, _source, config = _make_collector_env(
+            tmp_path, behaviors
+        )
+        rows, _syms, warns = await _run_collect(
+            tmp_path, collector, checkpoint, store, config
+        )
+
+        assert checkpoint.get_last_date() is None
+        assert rows == 0
+        assert len(warns) == 4


### PR DESCRIPTION
Closes #2054

## Summary
- DART backfill에서 분기 fetch 실패(transient)에도 checkpoint가 전진해 실패 분기를 영구 skip하던 P1 버그 수정
- `_fetch_quarter` 반환에 `ok` 신호 추가: transient 예외/raw>0-stored-0(데이터손실 warn)→ok=False, empty raw(terminal no-data)/stored>0→ok=True, DARTDailyLimit/Critical re-raise
- `_collect_quarters`: 첫 ok=False 이후 halt → checkpoint.save 중단(monotonic last-write-wins 특성상 이후 성공 분기가 실패 분기를 넘어 전진하는 것 차단)

## Test Plan
- 신규 6 테스트: transient 실패 미전진 / **Q2실패→Q3성공도 checkpoint Q1 고정** / terminal no-data 전진 / raw>0-stored-0 warn+미전진 / 전부성공 전진 / 전분기실패 None. -k(dart/collector/checkpoint/feed) 467 passed, contracts 145; ruff/mypy 통과; Codex 브랜치 리뷰 PASS
- REPRT_CODES Q1→Q4 오름차순 + ParquetStore overwrite 멱등 확인

## Non-Goals
- data.go.kr backfill(#2078), corpcode 캐시(#2116), 정규화 근본수정(#2055)