### PR TITLE
fix(eventbus): #2145 BotStopEvent에 account_id 필드+marker 추가 및 RuleEngine 전파

### DIFF
--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -57,8 +57,11 @@ override하면, `Event.__post_init__` 이 다음을 수행한다:
   `OrderCancelledEvent`, `OrderFailedEvent`
 - Stop order / 취소 실패: `OrderCancelFailedEvent`, `StopOrderRegisteredEvent`,
   `StopOrderTriggeredEvent`, `StopOrderExpiredEvent`
-- 봇 lifecycle: `BotStartedEvent`, `BotStoppedEvent`, `BotErrorEvent`,
-  `BotStepCompletedEvent`, `BotRestartExhaustedEvent`
+- 봇 lifecycle: `BotStartedEvent`, `BotStopEvent`, `BotStoppedEvent`,
+  `BotErrorEvent`, `BotStepCompletedEvent`, `BotRestartExhaustedEvent` —
+  `BotStopEvent` (#2145) 는 봇 중지 요청으로, 발행자(`RuleEngine`)가
+  봇 계좌(`RuleEngine._account_id`)를 명시 전달하며 `_requires_account_id`
+  로 invalid fallback 을 차단한다.
 - 계좌/잔고/리포트: `AccountSuspendedEvent`, `AccountActivatedEvent`,
   `BalanceSyncedEvent`, `DailyReportEvent`
 - 실시간 스트림 (#1242 SPLIT-3): `StreamConnectedEvent`,
@@ -77,7 +80,6 @@ override하면, `Event.__post_init__` 이 다음을 수행한다:
   `ApprovalResolvedEvent`, `MemberRegisteredEvent`, `MemberSuspendedEvent`,
   `MemberReactivatedEvent`, `MemberRevokedEvent`, `MemberAuthFailedEvent`,
   `CircuitBreakerEvent`,
-  `BotStopEvent`,
   `PositionMismatchEvent`, `ReconcileEvent` (현재 ext spec 단계에서 marker 미적용)
 
 **구현 노트**:

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -301,8 +301,20 @@ class BotStartedEvent(Event):
 
 @dataclass(frozen=True)
 class BotStopEvent(Event):
-    """RuleEngine/사용자 → EventBus: 봇 중지 요청."""
+    """RuleEngine/사용자 → EventBus: 봇 중지 요청.
 
+    Refs #2145: ``BotStopEvent`` 는 봇 계좌(``RuleEngine._account_id``)에
+    귀속되는 account-scoped 이벤트다. 다른 봇 lifecycle 이벤트
+    (``BotStartedEvent``/``BotStoppedEvent``/``BotErrorEvent``) 와 동일한
+    컨벤션으로 ``account_id`` 를 첫 데이터 필드로 배치하고,
+    ``_requires_account_id`` 마커로 invalid fallback (``""``, ``None``,
+    ``"default"``, 형식 위반) 을 ``Event.__post_init__`` 에서 차단한다.
+    발행자(``RuleEngine._execute_actions``)는 봇 계좌를 명시 전달한다.
+    """
+
+    _requires_account_id: ClassVar[bool] = True
+
+    account_id: str = ""
     bot_id: str = ""
     reason: str = ""
 

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -1097,6 +1097,7 @@ class RuleEngine:
             elif action == RuleAction.STOP_BOT:
                 await self._eventbus.publish(
                     BotStopEvent(
+                        account_id=self._account_id,
                         bot_id=event.bot_id,
                         reason="Rule violation",
                     )

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -933,7 +933,9 @@ class TestBotManager:
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.start_bot("bot1")
 
-        await eventbus.publish(BotStopEvent(bot_id="bot1", reason="rule violation"))
+        await eventbus.publish(
+            BotStopEvent(account_id="acc-test", bot_id="bot1", reason="rule violation")
+        )
 
         assert manager.get_bot("bot1").status == BotStatus.STOPPED
 

--- a/tests/unit/test_bot_lifecycle_state_conflict.py
+++ b/tests/unit/test_bot_lifecycle_state_conflict.py
@@ -218,7 +218,9 @@ async def test_on_bot_stop_request_silent_ignores_state_conflict(
     # 핸들러가 BotStateConflict 를 흡수하는지 직접 호출로 검증한다
     # (eventbus.publish 는 핸들러 예외를 로깅만 하고 삼킬 수 있어 회귀
     # 보장이 약하다 — 핸들러 함수를 직접 await 한다).
-    event = BotStopEvent(bot_id=bot.bot_id, reason="test-1759-cold-path")
+    event = BotStopEvent(
+        account_id="acc-test", bot_id=bot.bot_id, reason="test-1759-cold-path"
+    )
     # raise 가 전파되지 않으면 통과. 어떤 예외든 잡히면 회귀.
     await manager._on_bot_stop_request(event)
     # 상태는 CREATED 그대로 (silent ignore).

--- a/tests/unit/test_eventbus_account_events.py
+++ b/tests/unit/test_eventbus_account_events.py
@@ -7,6 +7,7 @@
 
 import pytest
 
+from ante.account.errors import InvalidAccountIdError
 from ante.eventbus import EventBus
 from ante.eventbus.events import (
     AccountActivatedEvent,
@@ -14,6 +15,7 @@ from ante.eventbus.events import (
     BalanceSyncedEvent,
     BotErrorEvent,
     BotStartedEvent,
+    BotStopEvent,
     BotStoppedEvent,
     OrderApprovedEvent,
     OrderCancelEvent,
@@ -199,3 +201,40 @@ class TestAccountIdBackwardCompat:
 
         assert len(received) == 1
         assert received[0].account_id == "acc-001"
+
+
+# ── #2145: BotStopEvent account-scoped marker ────────
+
+
+class TestBotStopEventAccountScoped:
+    """#2145: BotStopEvent 가 account-scoped marker 를 갖는지 검증.
+
+    #2146 ExternalSignalEvent 패턴 미러: 봇 중지 요청은 봇 계좌에 귀속되며
+    invalid fallback (None/""/"default") 을 ``Event.__post_init__`` 에서 차단한다.
+    """
+
+    def test_requires_account_id_marker(self) -> None:
+        """_requires_account_id marker 가 True 이고 account_id 필드가 존재한다."""
+        assert BotStopEvent._requires_account_id is True
+        assert "account_id" in BotStopEvent.__dataclass_fields__
+
+    def test_valid_account_id_constructs(self) -> None:
+        """valid account_id 면 정상 생성되고 필드가 보존된다."""
+        event = BotStopEvent(
+            account_id="acc-test",
+            bot_id="bot-001",
+            reason="Rule violation",
+        )
+        assert event.account_id == "acc-test"
+        assert event.bot_id == "bot-001"
+        assert event.reason == "Rule violation"
+
+    @pytest.mark.parametrize("invalid", [None, "", "default"])
+    def test_invalid_account_id_raises(self, invalid: str | None) -> None:
+        """invalid account_id(None/""/"default") 면 InvalidAccountIdError raise."""
+        with pytest.raises(InvalidAccountIdError):
+            BotStopEvent(
+                account_id=invalid,  # type: ignore[arg-type]
+                bot_id="bot-001",
+                reason="Rule violation",
+            )

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -893,6 +893,36 @@ class TestRuleEngineEventBus:
             suspended_by="rule_engine",
         )
 
+    async def test_stop_bot_action_carries_account_id(self, engine, eventbus):
+        """STOP_BOT 발동 시 봇 계좌(account_id)를 실은 BotStopEvent 발행 (#2145).
+
+        engine fixture 는 account_id="domestic" 이므로, 발행된 BotStopEvent 의
+        account_id 가 봇 계좌로 전파되어 multi-account 환경에서 감사/필터링이
+        가능해야 한다. account_id 가 없으면 InvalidAccountIdError 로 발행
+        자체가 차단된다.
+        """
+        from ante.eventbus.events import BotStopEvent, OrderRequestEvent
+
+        received: list[BotStopEvent] = []
+        eventbus.subscribe(BotStopEvent, lambda e: received.append(e))
+
+        event = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            price=50000.0,
+        )
+        await engine._execute_actions([RuleAction.STOP_BOT], event)
+
+        assert len(received) == 1
+        assert received[0].account_id == "domestic"
+        assert received[0].bot_id == "bot1"
+        assert received[0].reason == "Rule violation"
+
     async def test_rule_engine_rejects_invalid_signal_side(
         self, engine, eventbus, monkeypatch
     ):


### PR DESCRIPTION
Closes #2145

## Summary
- BotStopEvent에 `account_id` 필드 + `_requires_account_id=True` 마커 추가(spec 핵심 필드, #2146 ExternalSignalEvent 패턴 미러)
- RuleEngine STOP_BOT 경로가 `account_id=self._account_id` 전파, 생성처 2개 테스트 valid account_id, eventbus.md 비대상→대상 이동(BotStopEvent — #2146이 남긴 이동 완료)

## Test Plan
- 신규: marker/invalid account_id raise + RuleEngine STOP_BOT account 전파. -k(bot_stop/lifecycle/rule/eventbus/stop) 646 passed, contracts 145; ruff/mypy 통과; Codex 브랜치 리뷰 PASS

## Non-Goals
- 다른 누락 이벤트(#2147/2150/2155/2058), eventbus.md 다른 marker 항목(#2146 완료), BotStoppedEvent