### PR TITLE
fix(eventbus): #2058 PositionMismatchEvent/ReconcileEvent account-scoped 승격

### DIFF
--- a/docs/specs/broker-adapter/17-notification-events.md
+++ b/docs/specs/broker-adapter/17-notification-events.md
@@ -11,6 +11,7 @@
 **트리거**: 대사(Reconcile) 수행 중 봇의 내부 포지션과 브로커 실제 포지션의 수량이 불일치할 때
 
 **데이터 수집**:
+- `PositionReconciler.reconcile(account_id=...)` → 대사 대상 계좌 식별자 (#2058)
 - `TradeService.get_positions(bot_id)` → 내부 포지션 수량
 - `BrokerAdapter.get_account_positions()` → 브로커 실제 수량
 
@@ -21,7 +22,7 @@ level: critical
 title: 포지션 불일치
 category: broker
 
-봇: `{bot_id}` · 종목: `{symbol}`
+계좌: `{account_id}` · 봇: `{bot_id}` · 종목: `{symbol}`
 내부: {internal_qty}주 · 브로커: {broker_qty}주
 사유: {reason}
 ```

--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -73,14 +73,20 @@ override하면, `Event.__post_init__` 이 다음을 수행한다:
   계좌를 명시 전달하며, multi-account 환경에서 시그널을 account 기준으로
   감사/필터링/추적할 수 있도록 `_requires_account_id` 로 invalid fallback 을
   차단한다.
+- 대사 (#2058): `PositionMismatchEvent`, `ReconcileEvent` — 포지션 대사
+  결과는 대사 대상 계좌에 귀속된다. 발행자(`PositionReconciler.reconcile`)가
+  reconcile 입력 `account_id` 를 명시 전달하며, multi-account 환경에서 불일치·
+  보정 알림을 account 기준으로 추적할 수 있도록 `_requires_account_id` 로
+  invalid fallback 을 차단한다. `reconcile()` 진입부에서
+  `require_account_id` 로 valid 를 확정하므로 invalid account_id 는 이벤트
+  발행 이전에 차단된다.
 
 **비대상 (system-wide event)**:
 - `SystemStartedEvent`, `SystemShutdownEvent`, `NotificationEvent`,
   `BacktestCompleteEvent`, `ConfigChangedEvent`, `ApprovalCreatedEvent`,
   `ApprovalResolvedEvent`, `MemberRegisteredEvent`, `MemberSuspendedEvent`,
   `MemberReactivatedEvent`, `MemberRevokedEvent`, `MemberAuthFailedEvent`,
-  `CircuitBreakerEvent`,
-  `PositionMismatchEvent`, `ReconcileEvent` (현재 ext spec 단계에서 marker 미적용)
+  `CircuitBreakerEvent`
 
 **구현 노트**:
 - dataclass field ordering 제약 때문에 `account_id` 필드는 default `""` 를
@@ -145,8 +151,8 @@ D-005에서 정의한 EventBus 대상 이벤트. 모든 이벤트는 `Event`를 
 
 | 이벤트 타입 | 발행자 | 구독자 | 핵심 필드 |
 |------------|--------|--------|----------|
-| `PositionMismatchEvent` | PositionReconciler | Notification | `bot_id`, `symbol`, `internal_qty`, `broker_qty`, `reason` |
-| `ReconcileEvent` | PositionReconciler | Notification | `bot_id`, `discrepancy_count`, `corrections` |
+| `PositionMismatchEvent` | PositionReconciler | Notification | `account_id`, `bot_id`, `symbol`, `internal_qty`, `broker_qty`, `reason` |
+| `ReconcileEvent` | PositionReconciler | Notification | `account_id`, `bot_id`, `discrepancy_count`, `corrections` |
 
 #### 외부 시그널 (External Signal)
 

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -417,8 +417,21 @@ class BacktestCompleteEvent(Event):
 
 @dataclass(frozen=True)
 class PositionMismatchEvent(Event):
-    """포지션 불일치 감지."""
+    """포지션 불일치 감지.
 
+    Refs #2058: ``PositionMismatchEvent`` 는 대사(reconcile) 대상 계좌에
+    귀속되는 account-scoped 이벤트다. 다른 account-scoped 이벤트와 동일한
+    컨벤션으로 ``account_id`` 를 첫 데이터 필드로 배치하고,
+    ``_requires_account_id`` 마커로 invalid fallback (``""``, ``None``,
+    ``"default"``, 형식 위반) 을 ``Event.__post_init__`` 에서 차단한다.
+    발행자(``PositionReconciler.reconcile``)는 reconcile 입력
+    ``account_id`` 를 명시 전달하며, multi-account 환경에서 불일치 알림을
+    계좌 기준으로 추적할 수 있게 한다.
+    """
+
+    _requires_account_id: ClassVar[bool] = True
+
+    account_id: str = ""
     bot_id: str = ""
     symbol: str = ""
     internal_qty: float = 0.0
@@ -428,8 +441,21 @@ class PositionMismatchEvent(Event):
 
 @dataclass(frozen=True)
 class ReconcileEvent(Event):
-    """Reconciler → EventBus: 대사 보정 완료."""
+    """Reconciler → EventBus: 대사 보정 완료.
 
+    Refs #2058: ``ReconcileEvent`` 는 대사(reconcile) 대상 계좌에 귀속되는
+    account-scoped 이벤트다. 다른 account-scoped 이벤트와 동일한 컨벤션으로
+    ``account_id`` 를 첫 데이터 필드로 배치하고, ``_requires_account_id``
+    마커로 invalid fallback (``""``, ``None``, ``"default"``, 형식 위반) 을
+    ``Event.__post_init__`` 에서 차단한다. 발행자
+    (``PositionReconciler.reconcile``)는 reconcile 입력 ``account_id`` 를
+    명시 전달하며, multi-account 환경에서 보정 결과를 계좌 기준으로
+    추적할 수 있게 한다.
+    """
+
+    _requires_account_id: ClassVar[bool] = True
+
+    account_id: str = ""
     bot_id: str = ""
     discrepancy_count: int = 0
     corrections: list = field(default_factory=list)  # type: ignore[assignment]

--- a/src/ante/trade/reconciler.py
+++ b/src/ante/trade/reconciler.py
@@ -68,11 +68,20 @@ class PositionReconciler:
         Returns:
             보정 내역 리스트. 불일치가 없으면 빈 리스트.
         """
+        from ante.account.scoping import require_account_id
         from ante.eventbus.events import (
             NotificationEvent,
             PositionMismatchEvent,
             ReconcileEvent,
         )
+
+        # #2058: PositionMismatchEvent/ReconcileEvent 는 account-scoped 이벤트로
+        # 승격되어 valid account_id 를 요구한다. marker(_requires_account_id) 는
+        # "존재"가 아니라 "valid"를 요구하므로, source 인 reconcile() 진입부에서
+        # invalid("" / None / "default" / 형식 위반) 를 fail-fast 로 차단한다.
+        # 여기서 raise되면 이후 모든 emit/notification/correct_position 경로가
+        # 실행되지 않는다.
+        account_id = require_account_id(account_id, context="reconciler.reconcile")
 
         internal = await self._trade_service.get_positions(
             bot_id, account_id=account_id
@@ -139,6 +148,7 @@ class PositionReconciler:
                     )
                     await self._eventbus.publish(
                         PositionMismatchEvent(
+                            account_id=account_id,
                             bot_id=bot_id,
                             symbol=symbol,
                             internal_qty=i_qty,
@@ -151,7 +161,8 @@ class PositionReconciler:
                             level="info",
                             title="포지션 동기화 지연",
                             message=(
-                                f"봇: `{bot_id}` · 종목: `{symbol}`\n"
+                                f"계좌: `{account_id}` · 봇: `{bot_id}` · "
+                                f"종목: `{symbol}`\n"
                                 f"내부: {i_qty:.0f}주 · 브로커: {b_qty:.0f}주\n"
                                 f"사유: {REASON_SELF_SUBMITTED} "
                                 "(체결 반영 대기 — 자동 보정 없음)"
@@ -192,6 +203,7 @@ class PositionReconciler:
 
             await self._eventbus.publish(
                 PositionMismatchEvent(
+                    account_id=account_id,
                     bot_id=bot_id,
                     symbol=symbol,
                     internal_qty=i_qty,
@@ -204,7 +216,8 @@ class PositionReconciler:
                     level="critical",
                     title="포지션 불일치",
                     message=(
-                        f"봇: `{bot_id}` · 종목: `{symbol}`\n"
+                        f"계좌: `{account_id}` · 봇: `{bot_id}` · "
+                        f"종목: `{symbol}`\n"
                         f"내부: {i_qty:.0f}주 · 브로커: {b_qty:.0f}주\n"
                         f"사유: {reason}"
                     ),
@@ -230,6 +243,7 @@ class PositionReconciler:
             )
             await self._eventbus.publish(
                 ReconcileEvent(
+                    account_id=account_id,
                     bot_id=bot_id,
                     discrepancy_count=len(corrections),
                     corrections=corrections,

--- a/tests/unit/test_module_notification_events.py
+++ b/tests/unit/test_module_notification_events.py
@@ -353,6 +353,55 @@ class TestReconcilerNotification:
         assert "포지션 불일치" in notifs[0].title
         assert "005930" in notifs[0].message
         assert "bot-1" in notifs[0].message
+        # #2058: 알림 메시지 첫 줄에 계좌가 표시된다.
+        assert "acc-test" in notifs[0].message
+        assert "계좌: `acc-test`" in notifs[0].message
+
+    async def test_sync_delay_notification_includes_account(self):
+        """#2058: self-submitted(동기화 지연) info 알림 메시지에도 계좌가 포함된다."""
+        eventbus = EventBus()
+        collected = _collect_notifications(eventbus)
+
+        trade_service = AsyncMock()
+        # 내부 포지션: 005930 50주
+        mock_position = MagicMock()
+        mock_position.symbol = "005930"
+        mock_position.quantity = 50.0
+        mock_position.avg_entry_price = 70000.0
+        trade_service.get_positions.return_value = [mock_position]
+
+        # OrderTracker: broker 초과분(30주)을 설명하는 미체결 매수 주문 존재
+        order_tracker = AsyncMock()
+        open_order = MagicMock()
+        open_order.ordered_qty = 30.0
+        open_order.recorded_filled_qty = 0.0
+        order_tracker.get_open_orders_for.return_value = [open_order]
+
+        from ante.trade.reconciler import PositionReconciler
+
+        reconciler = PositionReconciler(
+            trade_service=trade_service,
+            eventbus=eventbus,
+            order_tracker=order_tracker,
+        )
+
+        # 브로커: 005930 80주 (내부 50주보다 30주 초과 → self-submitted)
+        await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 80.0, "avg_price": 70000}
+            ],
+            account_id="acc-test",
+        )
+
+        notifs = [n for n in collected if n.category == "broker"]
+        assert len(notifs) == 1
+        assert notifs[0].level == "info"
+        assert "포지션 동기화 지연" in notifs[0].title
+        # #2058: info 알림 메시지 첫 줄에도 계좌가 표시된다.
+        assert "계좌: `acc-test`" in notifs[0].message
+        assert "bot-1" in notifs[0].message
+        assert "005930" in notifs[0].message
 
 
 # ── approval/service.py (2건) ──────────────────────────

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from ante.account.errors import InvalidAccountIdError
 from ante.core.database import Database
 from ante.eventbus.bus import EventBus
 from ante.eventbus.events import (
@@ -670,3 +671,143 @@ class TestNoOrderTracker:
         )
         assert len(corrections) == 1
         assert corrections[0]["reason"] == REASON_EXTERNAL_BUY
+
+
+# ── #2058: account-scoped 승격 (account_id 전파 + entry validation) ──────
+
+
+class TestReconcileAccountIdPropagation:
+    """#2058: reconcile 이 발행하는 이벤트에 입력 account_id 가 전파되는지 검증."""
+
+    async def test_mismatch_event_carries_input_account_id(
+        self, reconciler, position_history, eventbus
+    ):
+        """(a) 발행된 PositionMismatchEvent.account_id == reconcile 입력 account_id."""
+        await _set_position(
+            position_history, "bot-1", "005930", 50, 50000, account_id="acc-test"
+        )
+
+        mismatch_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+
+        await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],  # 전량 외부 청산
+            account_id="acc-test",
+        )
+
+        assert len(mismatch_events) == 1
+        assert mismatch_events[0].account_id == "acc-test"
+
+    async def test_reconcile_event_carries_input_account_id(
+        self, reconciler, position_history, eventbus
+    ):
+        """(b) 발행된 ReconcileEvent.account_id == reconcile 입력 account_id."""
+        await _set_position(
+            position_history, "bot-1", "005930", 50, 50000, account_id="acc-test"
+        )
+
+        reconcile_events: list = []
+        eventbus.subscribe(ReconcileEvent, lambda e: reconcile_events.append(e))
+
+        await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+        )
+
+        assert len(reconcile_events) == 1
+        assert reconcile_events[0].account_id == "acc-test"
+
+
+class TestReconcileEntryValidation:
+    """#2058: reconcile() 진입부 require_account_id fail-fast 검증.
+
+    marker(_requires_account_id)가 아니라 entry validation 에서 raise되어,
+    invalid account_id 는 어떤 이벤트도 발행되기 전에 차단된다.
+    """
+
+    @pytest.mark.parametrize("invalid", [None, "", "default"])
+    async def test_invalid_account_id_raises_at_entry(
+        self, reconciler, position_history, eventbus, invalid
+    ):
+        """(c) invalid account_id 면 InvalidAccountIdError raise + 이벤트 미발행."""
+        await _set_position(
+            position_history, "bot-1", "005930", 50, 50000, account_id="acc-test"
+        )
+
+        mismatch_events: list = []
+        reconcile_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+        eventbus.subscribe(ReconcileEvent, lambda e: reconcile_events.append(e))
+
+        with pytest.raises(InvalidAccountIdError):
+            await reconciler.reconcile(
+                bot_id="bot-1",
+                broker_positions=[],
+                account_id=invalid,  # type: ignore[arg-type]
+            )
+
+        # entry 에서 차단되어 어떤 이벤트도 발행되지 않는다.
+        assert mismatch_events == []
+        assert reconcile_events == []
+
+
+class TestReconcileEventsAccountScopedMarker:
+    """#2058: 두 이벤트의 account-scoped marker 동작 (test_external_signals 동형)."""
+
+    def test_mismatch_requires_account_id_marker(self) -> None:
+        """_requires_account_id marker 가 True 이고 account_id 필드가 존재한다."""
+        assert PositionMismatchEvent._requires_account_id is True
+        assert "account_id" in PositionMismatchEvent.__dataclass_fields__
+
+    def test_reconcile_requires_account_id_marker(self) -> None:
+        """_requires_account_id marker 가 True 이고 account_id 필드가 존재한다."""
+        assert ReconcileEvent._requires_account_id is True
+        assert "account_id" in ReconcileEvent.__dataclass_fields__
+
+    def test_mismatch_valid_account_id_constructs(self) -> None:
+        """valid account_id 면 정상 생성된다."""
+        event = PositionMismatchEvent(
+            account_id="acc-test",
+            bot_id="bot-1",
+            symbol="005930",
+            internal_qty=50.0,
+            broker_qty=0.0,
+            reason="외부 청산",
+        )
+        assert event.account_id == "acc-test"
+
+    def test_reconcile_valid_account_id_constructs(self) -> None:
+        """valid account_id 면 정상 생성된다."""
+        event = ReconcileEvent(
+            account_id="acc-test",
+            bot_id="bot-1",
+            discrepancy_count=1,
+            corrections=[],
+        )
+        assert event.account_id == "acc-test"
+
+    @pytest.mark.parametrize("invalid", [None, "", "default"])
+    def test_mismatch_invalid_account_id_raises(self, invalid: str | None) -> None:
+        """invalid account_id 면 InvalidAccountIdError raise."""
+        with pytest.raises(InvalidAccountIdError):
+            PositionMismatchEvent(
+                account_id=invalid,  # type: ignore[arg-type]
+                bot_id="bot-1",
+                symbol="005930",
+                internal_qty=50.0,
+                broker_qty=0.0,
+                reason="외부 청산",
+            )
+
+    @pytest.mark.parametrize("invalid", [None, "", "default"])
+    def test_reconcile_invalid_account_id_raises(self, invalid: str | None) -> None:
+        """invalid account_id 면 InvalidAccountIdError raise."""
+        with pytest.raises(InvalidAccountIdError):
+            ReconcileEvent(
+                account_id=invalid,  # type: ignore[arg-type]
+                bot_id="bot-1",
+                discrepancy_count=1,
+                corrections=[],
+            )


### PR DESCRIPTION
Closes #2058

## Summary
- `PositionMismatchEvent`/`ReconcileEvent`를 account-scoped 이벤트로 승격(정책 1안): `account_id` 첫 데이터 필드 + `_requires_account_id=True` marker
- `reconciler.reconcile()` 진입부 `require_account_id(account_id, context=...)`로 valid invariant를 source에서 확정 → 3 emit + 2 notification + correct_position 경로 모두 valid 값 사용
- 포지션 불일치/동기화 지연 알림 메시지 첫 줄에 계좌 표시
- doc-axis sweep: eventbus.md(대상/비대상/필드표) + broker-adapter/17-notification-events.md

## Test Plan
- pytest reconciler/fill_recovery/notification_events (65), -k reconcil/account (152), contracts (145), 회귀 scheduler/ipc (427) — all passed
- ruff/mypy OK