### PR TITLE
fix(bot): #2143 BOT_SCHEMA account_id DEFAULT 'test' 제거(스펙 정렬)

### DIFF
--- a/docs/architecture/generated/db-schema.md
+++ b/docs/architecture/generated/db-schema.md
@@ -4,7 +4,7 @@ Ante 시스템의 전체 데이터베이스 스키마를 정리한 문서입니�
 
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py --check`
-> 마지막 갱신: 2026-05-29
+> 마지막 갱신: 2026-06-02
 
 - 테이블: **24**개
 - 인덱스: **32**개
@@ -181,7 +181,7 @@ CREATE TABLE IF NOT EXISTS bots (
     bot_id       TEXT PRIMARY KEY,
     name         TEXT NOT NULL DEFAULT '',
     strategy_id  TEXT NOT NULL,
-    account_id   TEXT NOT NULL DEFAULT 'test',
+    account_id   TEXT NOT NULL,
     config_json  TEXT NOT NULL,
     auto_start   BOOLEAN DEFAULT 0,
     status       TEXT DEFAULT 'created',

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-05-31 (KST)
+> 마지막 생성 시점: 2026-06-02 (KST)
 
 ## 최상위 구조
 
@@ -110,7 +110,8 @@ src/ante/
 │   ├── loader.py                     # StrategyLoader — 전략 파일 동적 로드
 │   ├── registry.py                   # StrategyRegistry — 전략 등록/관리
 │   ├── validator.py                  # StrategyValidator — AST 기반 정적 검증
-│   └── __init__.py
+│   ├── __init__.py
+│   └── file_access.py
 ├── rule/
 │   ├── base.py                       # Rule ABC, RuleContext, RuleEvaluation, EvaluationResult
 │   ├── engine.py                     # RuleEngine — 전역/전략별 룰 평가
@@ -397,7 +398,8 @@ tests/
 │   │   ├── test_daily_runner_target_date.py
 │   │   ├── test_orchestrator_run_daily_target_date.py
 │   │   ├── test_backfill_guard_wait.py
-│   │   └── test_indicator_calculator.py
+│   │   ├── test_indicator_calculator.py
+│   │   └── test_backfill_data_go_kr_checkpoint.py
 │   ├── cli/
 │   │   ├── __init__.py
 │   │   ├── test_version.py
@@ -661,7 +663,16 @@ tests/
 │   ├── test_fill_outbox.py
 │   ├── test_kis_error_codes_40240000.py
 │   ├── test_treasury_fill_dedup.py
-│   └── test_cli_backtest_history_readonly_fs.py
+│   ├── test_cli_backtest_history_readonly_fs.py
+│   ├── test_approval_bot_delete_account_scope.py
+│   ├── test_bot_live_account_scope.py
+│   ├── test_bot_schema.py
+│   ├── test_bot_step_completed_fields.py
+│   ├── test_cli_bot_positions_account_scope.py
+│   ├── test_feedback_account_scope.py
+│   ├── test_member_security_events.py
+│   ├── test_rule_engine_unrealized_account_scope.py
+│   └── test_strategy_file_access.py
 └── __init__.py
 ```
 

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS bots (
     bot_id       TEXT PRIMARY KEY,
     name         TEXT NOT NULL DEFAULT '',
     strategy_id  TEXT NOT NULL,
-    account_id   TEXT NOT NULL DEFAULT 'test',
+    account_id   TEXT NOT NULL,
     config_json  TEXT NOT NULL,
     auto_start   BOOLEAN DEFAULT 0,
     status       TEXT DEFAULT 'created',

--- a/tests/unit/test_bot_schema.py
+++ b/tests/unit/test_bot_schema.py
@@ -1,0 +1,69 @@
+"""Refs #2143 — BOT_SCHEMA ``account_id`` NOT NULL (no DEFAULT) 검증.
+
+스펙(bot/03-design-decisions + account/14-account-id-contract)은
+``account_id TEXT NOT NULL`` (DEFAULT 없음). 이전 ``DEFAULT 'test'`` 는
+계좌 누락 row 를 실패시키지 않고 'test' 로 귀속시키는 버그였다.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from ante.bot.manager import BOT_SCHEMA
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    """BOT_SCHEMA 로 생성한 fresh in-memory DB."""
+    connection = sqlite3.connect(":memory:")
+    connection.executescript(BOT_SCHEMA)
+    yield connection
+    connection.close()
+
+
+def test_insert_without_account_id_raises_integrity_error(
+    conn: sqlite3.Connection,
+) -> None:
+    """account_id 없이 insert 하면 NOT NULL(no default) 위반으로 실패한다.
+
+    이전 ``DEFAULT 'test'`` 라면 'test' 로 silent 귀속됐을 row 가
+    이제 결정적으로 거부된다.
+    """
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """INSERT INTO bots (bot_id, strategy_id, config_json)
+               VALUES (?, ?, ?)""",
+            ("bot-1", "strat", "{}"),
+        )
+
+
+def test_insert_with_account_id_succeeds(conn: sqlite3.Connection) -> None:
+    """account_id 를 명시한 insert 는 정상 성공한다(회귀 방지)."""
+    conn.execute(
+        """INSERT INTO bots (bot_id, strategy_id, account_id, config_json)
+           VALUES (?, ?, ?, ?)""",
+        ("bot-1", "strat", "acct-1", "{}"),
+    )
+    row = conn.execute(
+        "SELECT account_id FROM bots WHERE bot_id = ?",
+        ("bot-1",),
+    ).fetchone()
+    assert row == ("acct-1",)
+
+
+def test_account_id_has_no_column_default(conn: sqlite3.Connection) -> None:
+    """``PRAGMA table_info`` 에서 account_id 의 dflt_value 는 None 이다.
+
+    이전 ``DEFAULT 'test'`` 가 사라졌음을 컬럼 메타데이터로 확인한다.
+    """
+    columns = {
+        row[1]: row for row in conn.execute("PRAGMA table_info(bots)").fetchall()
+    }
+    account_id_col = columns["account_id"]
+    # PRAGMA table_info: (cid, name, type, notnull, dflt_value, pk)
+    notnull = account_id_col[3]
+    dflt_value = account_id_col[4]
+    assert notnull == 1
+    assert dflt_value is None


### PR DESCRIPTION
Closes #2143

## Summary
- `BOT_SCHEMA` account_id `DEFAULT 'test'` 제거 → 계좌 누락 row가 fresh schema에서 NOT NULL로 즉시 거부(스펙 bot/03 + account/14 정렬)
- 생성 산출물 재생성: `db-schema.md`(account_id DEFAULT 제거) + `project-structure.md`(신규 test 파일 반영). 둘 다 스크립트 출력(--check PASS)
- 모든 INSERT INTO bots는 이미 account_id 명시 → 회귀 없음. 기존 DB 마이그레이션은 비목표(fresh schema 정렬)

## Test Plan
- pytest bot schema/manager/cold_path(148) + test_generate_db_schema(2) + contracts(145) — passed
- generate_db_schema --check / generate_project_structure --check — PASS
- account_id-less insert→IntegrityError, PRAGMA dflt_value None