### PR TITLE
fix(feed): #2087 validate_schema가 모든 레코드의 필수 필드/타입 검사

### DIFF
--- a/src/ante/feed/transform/validate.py
+++ b/src/ante/feed/transform/validate.py
@@ -116,18 +116,19 @@ def validate_schema(
         warnings.append("레코드가 비어있음")
         return ValidationResult(passed=True, warnings=warnings, errors=errors)
 
-    # 첫 레코드 기준으로 필수 필드 존재 여부 확인
-    first_record_keys = set(records[0].keys())
-    missing_fields = set(required_fields) - first_record_keys
-    if missing_fields:
-        errors.append(f"필수 필드 누락: {sorted(missing_fields)}")
-
-    # 숫자 필드 타입 변환 가능 여부 확인
+    required_set = set(required_fields)
     numeric_fields = {"open", "high", "low", "close", "volume", "amount"}
-    check_fields = numeric_fields & first_record_keys
 
     for i, record in enumerate(records):
-        for field_name in check_fields:
+        record_keys = set(record.keys())
+
+        # 레코드별 필수 필드 존재 여부 확인
+        missing = required_set - record_keys
+        if missing:
+            errors.append(f"레코드 {i}: 필수 필드 누락: {sorted(missing)}")
+
+        # 레코드별 숫자 필드 타입 변환 가능 여부 확인
+        for field_name in numeric_fields & record_keys:
             value = record.get(field_name)
             if value is None:
                 continue

--- a/tests/unit/feed/test_validate.py
+++ b/tests/unit/feed/test_validate.py
@@ -200,6 +200,69 @@ class TestValidateSchema:
         result = validate_schema([record], OHLCV_REQUIRED_FIELDS)
         assert result.passed is True
 
+    def test_later_record_missing_field_detected(self) -> None:
+        """첫 레코드 정상 + 이후 레코드 필수 필드 누락 → passed=False (#2087)."""
+        first = _make_ohlcv_record(symbol="005930")
+        second = _make_ohlcv_record(symbol="000660")
+        del second["close"]
+        result = validate_schema([first, second], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is False
+        assert any("레코드 1" in e and "close" in e for e in result.errors)
+        # 첫 레코드는 정상이므로 "레코드 0" 누락 에러는 없어야 함
+        assert not any("레코드 0: 필수 필드 누락" in e for e in result.errors)
+
+    def test_all_records_valid_multi(self) -> None:
+        """모든 레코드가 정상이면 passed=True (회귀)."""
+        records = [
+            _make_ohlcv_record(symbol="005930", timestamp="2024-01-02"),
+            _make_ohlcv_record(symbol="000660", timestamp="2024-01-03"),
+            _make_ohlcv_record(symbol="035720", timestamp="2024-01-04"),
+        ]
+        result = validate_schema(records, OHLCV_REQUIRED_FIELDS)
+        assert result.passed is True
+        assert result.errors == []
+
+    def test_later_record_only_numeric_field_checked(self) -> None:
+        """첫 레코드에 없고 이후 레코드에만 있는 숫자 필드의 비숫자 값도 검출."""
+        first = {
+            "timestamp": "2024-01-02",
+            "symbol": "005930",
+            "open": "100.0",
+            "high": "110.0",
+            "low": "90.0",
+            "close": "105.0",
+            "volume": "1000",
+            "source": "data_go_kr",
+            # amount 없음
+        }
+        second = {
+            "timestamp": "2024-01-03",
+            "symbol": "000660",
+            "open": "100.0",
+            "high": "110.0",
+            "low": "90.0",
+            "close": "105.0",
+            "volume": "1000",
+            "source": "data_go_kr",
+            "amount": "not_a_number",  # 첫 레코드엔 없는 숫자 필드
+        }
+        required = [
+            "timestamp",
+            "symbol",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "source",
+        ]
+        result = validate_schema([first, second], required)
+        assert result.passed is False
+        assert any(
+            "레코드 1" in e and "amount" in e and "변환 불가" in e
+            for e in result.errors
+        )
+
 
 # ===========================================================================
 # 4. 비즈니스 계층 (validate_business)


### PR DESCRIPTION
Closes #2087

## Summary
- `validate_schema`가 `records[0]`만이 아닌 **모든 레코드**의 필수 필드 존재/숫자 타입 변환을 검사 → 후속 레코드 결측이 passed=False로 차단(레코드 index+누락 필드 errors)
- 빈 records 조기 반환(passed=True+warning), ValidationResult shape 불변

## Test Plan
- pytest test_validate.py(48) + -k validate/feed/injector(614) + contracts(145) — passed
- 재현(레코드 1 close 누락→fail) / 다중 정상 / 빈 records / 후속-only 숫자 필드 검출 / 단일-레코드 회귀
- ruff/mypy OK
- 비목표: NaN/inf(#2089 별건), validate_business 미변경