### PR TITLE
fix(feed): #2089 validate_business가 NaN/inf 값을 warning으로 관측

### DIFF
--- a/src/ante/feed/transform/validate.py
+++ b/src/ante/feed/transform/validate.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from datetime import datetime
 from typing import Any
 
@@ -174,6 +175,7 @@ def validate_business(records: list[dict[str, Any]]) -> ValidationResult:
 
     for i, record in enumerate(records):
         symbol = record.get("symbol", f"record_{i}")
+        _check_finite_values(record, symbol, warnings)
         _check_positive_prices(record, symbol, warnings)
         _check_volume_non_negative(record, symbol, warnings)
         _check_ohlc_relationship(record, symbol, warnings)
@@ -189,6 +191,36 @@ def validate_business(records: list[dict[str, Any]]) -> ValidationResult:
         warnings=warnings,
         errors=[],
     )
+
+
+def _check_finite_values(
+    record: dict[str, Any],
+    symbol: str,
+    warnings: list[str],
+) -> None:
+    """OHLCV 숫자 필드가 유한(finite)한지 검증한다.
+
+    NaN/inf 값은 schema 계층(float 변환 가능)을 통과하지만 데이터 품질
+    문제이므로 business 계층 경고로 관측한다. 숫자 변환 실패는 schema 계층
+    소관이므로 건너뛴다.
+
+    Args:
+        record: 검증할 레코드.
+        symbol: 심볼 식별자 (경고 메시지용).
+        warnings: 경고를 추가할 목록.
+    """
+    for field_name in ("open", "high", "low", "close", "volume", "amount"):
+        value = record.get(field_name)
+        if value is None:
+            continue
+        try:
+            num = float(str(value))
+        except (ValueError, TypeError):
+            continue  # 숫자 변환 실패는 스키마 계층 소관
+        if not math.isfinite(num):
+            warnings.append(
+                f"{symbol}: {field_name} 비정상 값(NaN/inf) ({field_name}={value})"
+            )
 
 
 def _check_positive_prices(
@@ -209,8 +241,10 @@ def _check_positive_prices(
             continue
         try:
             price = float(value)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
             continue  # 스키마 검증에서 이미 잡힘
+        if not math.isfinite(price):
+            continue  # NaN/inf는 _check_finite_values가 단독 관측
         if price <= 0:
             warnings.append(f"{symbol}: {price_field} <= 0 ({price_field}={price})")
 
@@ -232,8 +266,8 @@ def _check_volume_non_negative(
         return
     try:
         vol = int(float(str(volume_val)))
-    except (ValueError, TypeError):
-        return
+    except (ValueError, TypeError, OverflowError):
+        return  # NaN/inf(int 변환 OverflowError 포함)는 _check_finite_values가 관측
     if vol < 0:
         warnings.append(f"{symbol}: volume < 0 (volume={vol})")
 
@@ -255,11 +289,14 @@ def _check_ohlc_relationship(
         h = float(record["high"]) if "high" in record else None
         low_val = float(record["low"]) if "low" in record else None
         c = float(record["close"]) if "close" in record else None
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, OverflowError):
         return  # 숫자 변환 실패는 스키마 계층에서 처리
 
     if o is None or h is None or low_val is None or c is None:
         return
+
+    if not all(math.isfinite(v) for v in (o, h, low_val, c)):
+        return  # NaN/inf는 _check_finite_values가 단독 관측 (관계 오탐 차단)
 
     if low_val > c:
         warnings.append(f"{symbol}: low > close (low={low_val}, close={c})")

--- a/tests/unit/feed/test_validate.py
+++ b/tests/unit/feed/test_validate.py
@@ -358,6 +358,80 @@ class TestValidateBusiness:
         assert len(result.warnings) > 0
         assert result.errors == []
 
+    # --- NaN/inf finite 검증 (#2089) ---------------------------------------
+
+    def test_nan_inf_observed_as_warning(self) -> None:
+        """이슈 재현: NaN/inf 값은 business 경고로 관측되며 passed=True (#2089)."""
+        record = _make_ohlcv_record()
+        record["open"] = "NaN"
+        record["high"] = "inf"
+        record["low"] = float("nan")
+        result = validate_business([record])
+        assert result.passed is True
+        assert result.errors == []
+        finite_warnings = [w for w in result.warnings if "비정상 값(NaN/inf)" in w]
+        # open/high/low 세 필드 모두 finite 경고가 남아야 함
+        assert any("open" in w for w in finite_warnings)
+        assert any("high" in w for w in finite_warnings)
+        assert any("low" in w for w in finite_warnings)
+
+    def test_finite_warnings_propagate_via_validate_all(self) -> None:
+        """schema 통과(필수 필드 충족) 시 business finite 경고가 전파된다 (#2089)."""
+        record = _make_ohlcv_record()
+        record["open"] = "NaN"
+        record["high"] = "inf"
+        result = validate_all([record], OHLCV_REQUIRED_FIELDS, status_code=200)
+        assert result.passed is True
+        assert any("비정상 값(NaN/inf)" in w for w in result.warnings)
+
+    def test_valid_finite_data_no_finite_warning(self) -> None:
+        """회귀: 정상 finite 데이터에는 finite 경고가 없다 (#2089)."""
+        record = _make_ohlcv_record()
+        result = validate_business([record])
+        assert result.passed is True
+        assert not any("비정상 값(NaN/inf)" in w for w in result.warnings)
+
+    def test_volume_inf_no_crash(self) -> None:
+        """volume=inf는 int() OverflowError 없이 finite 경고만 남긴다 (#2089)."""
+        record = _make_ohlcv_record()
+        record["volume"] = "inf"
+        result = validate_business([record])
+        assert result.passed is True
+        assert any("비정상 값(NaN/inf)" in w and "volume" in w for w in result.warnings)
+        # volume<0 오탐 경고는 없어야 함
+        assert not any("volume < 0" in w for w in result.warnings)
+
+    def test_none_fields_skipped_by_finite_check(self) -> None:
+        """None 필드는 finite 검사에서 건너뛴다 (경고 없음) (#2089)."""
+        record = _make_ohlcv_record()
+        record["amount"] = None
+        result = validate_business([record])
+        assert result.passed is True
+        assert not any("비정상 값(NaN/inf)" in w for w in result.warnings)
+
+    def test_nonfinite_does_not_trigger_downstream_false_positive(self) -> None:
+        """중복/오탐 차단 lock: -inf/inf는 finite 경고만, downstream 오탐 없음 (#2089).
+
+        open=-inf는 _check_positive_prices의 price<=0 오탐 위치,
+        low=inf는 _check_ohlc_relationship의 low>close 오탐 위치를 유발한다.
+        finite 가드로 이들 downstream 경고가 발생하지 않아야 한다.
+        """
+        record = _make_ohlcv_record()
+        record["open"] = float("-inf")
+        record["low"] = float("inf")
+        result = validate_business([record])
+        assert result.passed is True
+        assert result.errors == []
+
+        finite_warnings = [w for w in result.warnings if "비정상 값(NaN/inf)" in w]
+        # finite 경고는 open/low 두 필드에 대해 존재
+        assert any("open" in w for w in finite_warnings)
+        assert any("low" in w for w in finite_warnings)
+        # finite 경고 외 downstream 오탐 경고는 전무해야 함
+        assert len(result.warnings) == len(finite_warnings)
+        for substring in ("<= 0", "low > close", "open > high", "low > open"):
+            assert not any(substring in w for w in result.warnings)
+
 
 # ===========================================================================
 # 5. 통합 검증 (validate_all)


### PR DESCRIPTION
Closes #2089

## Summary
- `validate_business`에 `_check_finite_values` 헬퍼 추가 — OHLCV 6개 숫자 필드(open/high/low/close/volume/amount)의 NaN/inf를 business 계층 **warning**으로 관측(passed=True 유지, 저장 허용). NaN/inf 경고의 유일한 소스.
- 기존 3개 헬퍼(_check_positive_prices/_check_ohlc_relationship/_check_volume_non_negative)는 non-finite를 graceful skip — ±inf 비교 오탐(`-inf<=0`, `inf>high`) 및 중복 경고 차단.
- `int(float("inf"))` OverflowError 크래시 가드(volume inf) — except에 OverflowError 추가.
- passed 정책 불변, validate_schema/validate_all 흐름 미변경(#2087 영역 비침범).

## Test Plan
- `PYTHONPATH=src pytest tests/unit/feed/test_validate.py -q` → 54 passed
- `PYTHONPATH=src pytest tests/unit/ -q -k "validate or feed"` → 620 passed
- `PYTHONPATH=src pytest tests/unit/contracts/ -q` → 145 passed
- `mypy src/ante/feed/transform/validate.py` → clean
- ruff check/format → clean
- test (f): open=-inf + low=inf → finite 경고만, downstream 오탐 없음 lock