### PR TITLE
fix(data): #2100 RetentionPolicy가 실제 월말 기준으로 age 계산

### DIFF
--- a/src/ante/data/retention.py
+++ b/src/ante/data/retention.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import calendar
 import logging
 from datetime import UTC, datetime
 
@@ -158,7 +159,9 @@ class RetentionPolicy:
         """
         try:
             year, month = month_str.split("-")
-            file_month_end = datetime(int(year), int(month), 28, tzinfo=UTC)
+            y, m = int(year), int(month)
+            last_day = calendar.monthrange(y, m)[1]
+            file_month_end = datetime(y, m, last_day, tzinfo=UTC)
             age_days = (now - file_month_end).days
             return age_days > max_days
         except (ValueError, IndexError):

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -926,6 +926,59 @@ class TestRetentionPolicy:
         result = store.read("005930", "", data_type="fundamental")
         assert result.is_empty()
 
+    def test_is_expired_month_end_31day_regression(self):
+        """#2100: 31일 월은 실제 월말(05-31) 기준 age를 계산해 보존.
+
+        수정 전엔 월말을 28로 하드코딩해 05-31 데이터를 3일 일찍
+        만료 처리(True)했다. 05-31 기준 30일 경과는 보존 기간(31일)
+        이내이므로 보존(False)이어야 한다.
+        """
+        assert (
+            RetentionPolicy._is_expired(
+                "2026-05", 31, datetime(2026, 6, 30, tzinfo=UTC)
+            )
+            is False
+        )
+
+    def test_is_expired_leap_february_boundary(self):
+        """#2100: 윤년 2월은 실제 월말(02-29) 기준으로 age 계산."""
+        assert (
+            RetentionPolicy._is_expired("2024-02", 1, datetime(2024, 3, 1, tzinfo=UTC))
+            is False
+        )
+
+    def test_is_expired_common_february_boundary(self):
+        """#2100: 평년 2월은 실제 월말(02-28) 기준으로 age 계산."""
+        assert (
+            RetentionPolicy._is_expired("2026-02", 1, datetime(2026, 3, 1, tzinfo=UTC))
+            is False
+        )
+
+    def test_is_expired_31day_month_expires(self):
+        """#2100: 보존 기간을 실제로 넘긴 31일 월은 정상 만료."""
+        assert (
+            RetentionPolicy._is_expired(
+                "2026-05", 29, datetime(2026, 6, 30, tzinfo=UTC)
+            )
+            is True
+        )
+
+    def test_is_expired_invalid_filename(self):
+        """#2100: 잘못된 파일명은 except 경로로 보존(False) 유지."""
+        assert (
+            RetentionPolicy._is_expired(
+                "invalid", 30, datetime(2026, 6, 30, tzinfo=UTC)
+            )
+            is False
+        )
+
+    def test_is_expired_invalid_month(self):
+        """#2100: 잘못된 월은 IllegalMonthError(⊂ ValueError)로 보존(False)."""
+        assert (
+            RetentionPolicy._is_expired("2024-13", 30, datetime(2026, 1, 1, tzinfo=UTC))
+            is False
+        )
+
 
 # ── DARTNormalizer 테스트 ─────────────────────────────
 


### PR DESCRIPTION
Closes #2100

## Summary
- `RetentionPolicy._is_expired()`가 월별 parquet 파티션 종료일을 하드코딩 28 대신 `calendar.monthrange(year, month)[1]` 실제 월말로 계산. 29/30/31일 월 데이터의 최대 3일 조기 삭제와 윤년 2월 off-by-one 해소.
- `except (ValueError, IndexError)` 불변 — `calendar.IllegalMonthError`(⊂ ValueError)로 잘못된 월/파일명은 기존처럼 catch.

## Test Plan
- `pytest tests/unit/test_data_pipeline.py -q -k Retention` → 13 passed (신규 6: 이슈 a~f)
- `pytest tests/unit/ -q -k "retention or data_pipeline"` → 90 passed
- `pytest tests/unit/contracts/ -q` → 145 passed
- mypy / ruff clean