### PR TITLE
fix(feed): #2080 DataGoKrCollector가 비KRX srtnCd를 drop+warning 처리

### DIFF
--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import polars as pl
 
+from ante.core.market_data_vocab import is_krx_symbol
 from ante.data.normalizer import DataGoKrNormalizer
 from ante.data.store import ParquetStore
 from ante.feed.transform.validate import validate_all
@@ -54,7 +55,14 @@ class DataGoKrCollector:
             logger.debug("data.go.kr: date=%s 데이터 없음", target_date)
             return 0, set(), []
 
-        warns = self._validate(raw_items, target_date)
+        raw_items, symbol_warns = self._filter_invalid_symbols(raw_items, target_date)
+        warns = symbol_warns + self._validate(raw_items, target_date)
+        if not raw_items:
+            logger.warning(
+                "data.go.kr: date=%s 유효 KRX 심볼 없음(전 row drop)", target_date
+            )
+            return 0, set(), warns
+
         df = pl.DataFrame(raw_items)
         df = self._deduplicate(df)
 
@@ -65,6 +73,29 @@ class DataGoKrCollector:
         )
 
         return rows_written, symbols, warns
+
+    @staticmethod
+    def _filter_invalid_symbols(
+        raw_items: list[dict],
+        target_date: str,
+    ) -> tuple[list[dict], list[dict]]:
+        """srtnCd가 KRX 6자리 형식이 아닌 row를 drop하고 구조화 warning을 반환한다."""
+        valid: list[dict] = []
+        warns: list[dict] = []
+        for item in raw_items:
+            srtn: Any = item.get("srtnCd")
+            if is_krx_symbol(srtn):
+                valid.append(item)
+            else:
+                warns.append(
+                    {
+                        "date": target_date,
+                        "source": "data_go_kr",
+                        "type": "invalid_symbol",
+                        "message": f"비KRX 심볼 drop: srtnCd={srtn!r}",
+                    }
+                )
+        return valid, warns
 
     @staticmethod
     def _validate(

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from ante.data.store import ParquetStore
+from ante.feed.pipeline.data_go_kr_collector import DataGoKrCollector
 from ante.feed.sources.base import RateLimiter
 from ante.feed.sources.data_go_kr import (
     CriticalApiError,
@@ -489,3 +491,117 @@ class TestFetchByDate:
             await source.fetch_by_date("2024-03-01")
 
         assert captured_params[0]["basDt"] == "20240301"
+
+
+# ── DataGoKrCollector: srtnCd KRX 검증 (#2080) ────────────────
+
+
+def _raw(srtn: object) -> dict:
+    """data.go.kr raw item(이슈 재현 dict, normalizer 기대 필드 셋)."""
+    return {
+        "basDt": "20260102",
+        "srtnCd": srtn,
+        "mkp": "100",
+        "hipr": "110",
+        "lopr": "90",
+        "clpr": "105",
+        "trqu": "1000",
+        "trPrc": "100000",
+        "mrktTotAmt": "1000000",
+        "lstgStCnt": "10000",
+    }
+
+
+class _FakeSource:
+    """fetch(date)가 미리 지정한 raw item 리스트를 반환하는 가짜 source."""
+
+    def __init__(self, items: list[dict]) -> None:
+        self._items = items
+
+    async def fetch(self, target_date: str) -> list[dict]:
+        return self._items
+
+
+def _invalid_symbol_warns(warns: list[dict]) -> list[dict]:
+    """warns 목록에서 invalid_symbol 타입만 추출한다."""
+    return [w for w in warns if w.get("type") == "invalid_symbol"]
+
+
+class TestCollectorSymbolValidation:
+    """DataGoKrCollector가 비KRX srtnCd를 drop+warning 처리한다 (#2080)."""
+
+    @pytest.mark.asyncio
+    async def test_non_krx_symbol_dropped(self, tmp_path) -> None:
+        """(a) srtnCd='ABCDEF' 단일 → 저장 0, invalid_symbol warning 1건."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(source=_FakeSource([_raw("ABCDEF")]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows == 0
+        assert symbols == set()
+        invalid = _invalid_symbol_warns(warns)
+        assert len(invalid) == 1
+        assert "ABCDEF" in invalid[0]["message"]
+        assert store.list_symbols("1d") == []
+        assert store.list_symbols(data_type="fundamental") == []
+
+    @pytest.mark.asyncio
+    async def test_valid_krx_symbol_stored(self, tmp_path) -> None:
+        """(b) 정상 KRX '005930' → 저장됨, invalid_symbol warning 없음."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows > 0
+        assert symbols == {"005930"}
+        assert _invalid_symbol_warns(warns) == []
+        assert store.list_symbols("1d") == ["005930"]
+        assert store.list_symbols(data_type="fundamental") == ["005930"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_valid_and_invalid(self, tmp_path) -> None:
+        """(c) 혼합('005930'+'ABCDEF') → valid만 저장, invalid drop+warning."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(
+            source=_FakeSource([_raw("005930"), _raw("ABCDEF")])
+        )
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows > 0
+        assert symbols == {"005930"}
+        invalid = _invalid_symbol_warns(warns)
+        assert len(invalid) == 1
+        assert "ABCDEF" in invalid[0]["message"]
+        assert store.list_symbols("1d") == ["005930"]
+        assert store.list_symbols(data_type="fundamental") == ["005930"]
+
+    @pytest.mark.asyncio
+    async def test_non_string_symbols_dropped(self, tmp_path) -> None:
+        """(d) 비문자열/None srtnCd(None, 123456 int) → drop+warning."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(source=_FakeSource([_raw(None), _raw(123456)]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows == 0
+        assert symbols == set()
+        assert len(_invalid_symbol_warns(warns)) == 2
+        assert store.list_symbols("1d") == []
+        assert store.list_symbols(data_type="fundamental") == []
+
+    @pytest.mark.asyncio
+    async def test_unicode_digit_symbol_dropped(self, tmp_path) -> None:
+        """(e) Unicode digit '１２３４５６' → drop(ASCII 아님)."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(source=_FakeSource([_raw("１２３４５６")]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows == 0
+        assert symbols == set()
+        assert len(_invalid_symbol_warns(warns)) == 1
+        assert store.list_symbols("1d") == []
+        assert store.list_symbols(data_type="fundamental") == []


### PR DESCRIPTION
Closes #2080

## Summary
- `DataGoKrCollector.collect()`가 `srtnCd`를 KRX 6자리(`is_krx_symbol` SSOT)로 검증하지 않아 비-KRX 값(ABCDEF 등)이 OHLCV·fundamental에 무경고 저장되던 문제 수정.
- 신규 `_filter_invalid_symbols()`가 fetch 직후·store 이전 단일 chokepoint에서 invalid row를 drop하고 구조화 warning(type=invalid_symbol) 기록. 비문자열/None/Unicode digit은 is_krx_symbol로 안전 처리(False).

## Test Plan
- `pytest tests/unit/feed/test_data_go_kr.py -q` → 41 passed (신규 a~e: ABCDEF/005930/혼합/None·int/Unicode)
- `pytest tests/unit/ -k "data_go_kr or data_pipeline or collector"` → 172 passed
- `pytest tests/unit/contracts/ -q` → 145 passed
- mypy / ruff clean