### PR TITLE
fix(feed): #2103 validate가 null required field(error)와 unparseable timestamp(warning) 검출

### DIFF
--- a/src/ante/feed/transform/validate.py
+++ b/src/ante/feed/transform/validate.py
@@ -128,6 +128,12 @@ def validate_schema(
         if missing:
             errors.append(f"레코드 {i}: 필수 필드 누락: {sorted(missing)}")
 
+        # 레코드별 필수 필드 non-null 확인 (#2103)
+        present_required = required_set & record_keys
+        null_required = sorted(f for f in present_required if record.get(f) is None)
+        if null_required:
+            errors.append(f"레코드 {i}: 필수 필드 null 값: {null_required}")
+
         # 레코드별 숫자 필드 타입 변환 가능 여부 확인
         for field_name in numeric_fields & record_keys:
             value = record.get(field_name)
@@ -179,6 +185,7 @@ def validate_business(records: list[dict[str, Any]]) -> ValidationResult:
         _check_positive_prices(record, symbol, warnings)
         _check_volume_non_negative(record, symbol, warnings)
         _check_ohlc_relationship(record, symbol, warnings)
+        _check_temporal_parseable(record, symbol, warnings)
 
     _validate_time_series(records, warnings)
 
@@ -306,6 +313,28 @@ def _check_ohlc_relationship(
         warnings.append(f"{symbol}: low > open (low={low_val}, open={o})")
     if o > h:
         warnings.append(f"{symbol}: open > high (open={o}, high={h})")
+
+
+def _check_temporal_parseable(
+    record: dict[str, Any],
+    symbol: str,
+    warnings: list[str],
+) -> None:
+    """timestamp/date가 지원 형식으로 파싱 가능한지 검증한다.
+
+    Args:
+        record: 검증할 레코드.
+        symbol: 심볼 식별자 (경고 메시지용).
+        warnings: 경고를 추가할 목록.
+    """
+    for field_name in ("timestamp", "date"):
+        value = record.get(field_name)
+        if value is None:
+            continue  # null은 schema 계층 소관
+        if not isinstance(value, str):
+            continue  # 이미 datetime 등 비문자열이면 skip(오탐 방지)
+        if _try_parse_date(value) is None:
+            warnings.append(f"{symbol}: {field_name} 파싱 불가 ({field_name}={value})")
 
 
 def _validate_time_series(records: list[dict[str, Any]], warnings: list[str]) -> None:

--- a/tests/unit/feed/test_validate.py
+++ b/tests/unit/feed/test_validate.py
@@ -222,6 +222,35 @@ class TestValidateSchema:
         assert result.passed is True
         assert result.errors == []
 
+    def test_null_required_timestamp_is_error(self) -> None:
+        """present-but-null 필수 필드(timestamp=None)는 schema error (#2103)."""
+        record = _make_ohlcv_record()
+        record["timestamp"] = None
+        result = validate_schema([record], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is False
+        assert any(
+            "레코드 0: 필수 필드 null 값" in e and "timestamp" in e
+            for e in result.errors
+        )
+
+    def test_null_required_open_is_error(self) -> None:
+        """present-but-null 필수 필드(open=None)는 schema error (#2103)."""
+        record = _make_ohlcv_record()
+        record["open"] = None
+        result = validate_schema([record], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is False
+        assert any(
+            "레코드 0: 필수 필드 null 값" in e and "open" in e for e in result.errors
+        )
+
+    def test_null_non_required_field_not_error(self) -> None:
+        """비필수 필드 null(amount=None)은 null 값 error가 아니다 (#2103)."""
+        record = _make_ohlcv_record()
+        record["amount"] = None
+        result = validate_schema([record], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is True
+        assert not any("필수 필드 null 값" in e for e in result.errors)
+
     def test_later_record_only_numeric_field_checked(self) -> None:
         """첫 레코드에 없고 이후 레코드에만 있는 숫자 필드의 비숫자 값도 검출."""
         first = {
@@ -482,6 +511,42 @@ class TestValidateBusiness:
         for substring in ("<= 0", "low > close", "open > high", "low > open"):
             assert not any(substring in w for w in result.warnings)
 
+    # --- temporal 파싱 가능성 검증 (#2103) ---------------------------------
+
+    def test_unparseable_timestamp_is_warning(self) -> None:
+        """파싱 불가 timestamp는 business 경고이며 passed=True (#2103)."""
+        record = _make_ohlcv_record(timestamp="not-a-date")
+        result = validate_business([record])
+        assert result.passed is True
+        assert result.errors == []
+        assert any("timestamp 파싱 불가" in w for w in result.warnings)
+
+    def test_parseable_timestamp_no_warning(self) -> None:
+        """회귀: 파싱 가능한 timestamp는 파싱불가 경고가 없다 (#2103)."""
+        record = _make_ohlcv_record(timestamp="2026-01-01")
+        result = validate_business([record])
+        assert result.passed is True
+        assert not any("파싱 불가" in w for w in result.warnings)
+
+    def test_datetime_timestamp_no_false_positive(self) -> None:
+        """datetime 객체 timestamp(이미 파싱됨)는 파싱불가 오탐이 없다 (#2103)."""
+        from datetime import datetime
+
+        record = _make_ohlcv_record()
+        record["timestamp"] = datetime(2026, 1, 1, 0, 0, 0)
+        result = validate_business([record])
+        assert result.passed is True
+        assert not any("파싱 불가" in w for w in result.warnings)
+
+    def test_unparseable_date_field_is_warning(self) -> None:
+        """date 필드 파싱 불가도 경고로 관측된다 (#2103)."""
+        record = _make_ohlcv_record()
+        del record["timestamp"]
+        record["date"] = "garbage"
+        result = validate_business([record])
+        assert result.passed is True
+        assert any("date 파싱 불가" in w for w in result.warnings)
+
 
 # ===========================================================================
 # 5. 통합 검증 (validate_all)
@@ -519,6 +584,38 @@ class TestValidateAll:
         records = [_make_ohlcv_record()]
         result = validate_all(records, OHLCV_REQUIRED_FIELDS)
         assert result.passed is True
+
+    def test_null_required_field_blocks_pipeline(self) -> None:
+        """null 필수 필드(timestamp=None)는 schema error로 파이프라인 차단 (#2103)."""
+        record = _make_ohlcv_record()
+        record["timestamp"] = None
+        result = validate_all([record], OHLCV_REQUIRED_FIELDS, status_code=200)
+        assert result.passed is False
+        assert any("필수 필드 null 값" in e and "timestamp" in e for e in result.errors)
+
+    def test_null_required_open_blocks_pipeline(self) -> None:
+        """null 필수 필드(open=None)는 schema error로 파이프라인 차단 (#2103)."""
+        record = _make_ohlcv_record()
+        record["open"] = None
+        result = validate_all([record], OHLCV_REQUIRED_FIELDS, status_code=200)
+        assert result.passed is False
+        assert any("필수 필드 null 값" in e and "open" in e for e in result.errors)
+
+    def test_unparseable_timestamp_passes_schema_warns_business(self) -> None:
+        """파싱 불가 timestamp: schema 통과 후 business 경고 전파 (#2103)."""
+        record = _make_ohlcv_record(timestamp="not-a-date")
+        result = validate_all([record], OHLCV_REQUIRED_FIELDS, status_code=200)
+        assert result.passed is True
+        assert result.errors == []
+        assert any("timestamp 파싱 불가" in w for w in result.warnings)
+
+    def test_valid_record_no_temporal_warning(self) -> None:
+        """회귀: 정상 레코드는 errors=[] 이고 temporal 경고도 없다 (#2103)."""
+        record = _make_ohlcv_record(timestamp="2026-01-01")
+        result = validate_all([record], OHLCV_REQUIRED_FIELDS, status_code=200)
+        assert result.passed is True
+        assert result.errors == []
+        assert not any("파싱 불가" in w for w in result.warnings)
 
 
 # ===========================================================================


### PR DESCRIPTION
Closes #2103

## Summary
- **Axis 1** `validate_schema`: required field가 present-but-null이면 schema **error**(passed=False 차단). 비필수 null(amount 등)은 미검출. numeric None-skip 불변.
- **Axis 2** `validate_business`: 신규 `_check_temporal_parseable`가 str timestamp/date를 `_try_parse_date`로 검사, 실패 시 business **warning**(passed=True). None/비문자열(datetime)은 skip.
- #2087(전레코드 존재)·#2089(NaN/inf)·#2105(timezone)와 독립 축.

## Test Plan
- `pytest tests/unit/feed/test_validate.py` → 70 passed (신규 a~f)
- `pytest -k "validate or feed or injector"` → 649 passed / contracts 145 / mypy·ruff clean