### PR TITLE
fix(cli): #2053 backtest run이 strict YYYY-MM-DD만 허용

### DIFF
--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import sqlite3
 from typing import TYPE_CHECKING, Any
 
@@ -16,6 +17,13 @@ from ante.cli.main import get_formatter
 if TYPE_CHECKING:
     from ante.backtest.result import BacktestResult
 from ante.cli.middleware import require_auth, require_scope
+
+# strict YYYY-MM-DD 가드 (feed/cli.py·backfill_runner.py 패턴 미러). Python
+# 3.11+ ``date.fromisoformat`` 은 basic ISO(``20260510``)·week date
+# (``2026-W19-1``) 까지 수락하지만 ParquetStore.read 의 Polars ``str.to_datetime``
+# 는 이를 거부한다. CLI preflight 와 실행 단계 파싱 의미를 일치시키기 위해
+# 확장 형식만 허용한다 (#2053).
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
 @click.group()
@@ -74,7 +82,14 @@ def run(
     fmt = get_formatter(ctx)
     resolved_db_path = db_path or get_db_path(ctx)
 
-    # 시작일/종료일 검증
+    # 시작일/종료일 검증 — strict YYYY-MM-DD만 허용 (basic ISO/week date 거부; #2053)
+    for label, value in (("시작일", start), ("종료일", end)):
+        if _ISO_DATE_RE.fullmatch(value) is None:
+            fmt.error(
+                f"{label} 형식이 올바르지 않습니다: '{value}' (YYYY-MM-DD 형식 필요)",
+                code="INVALID_DATE",
+            )
+            raise SystemExit(1)
     try:
         start_date = datetime.date.fromisoformat(start)
         end_date = datetime.date.fromisoformat(end)

--- a/tests/unit/contracts/factory_drift_allowlist.yaml
+++ b/tests/unit/contracts/factory_drift_allowlist.yaml
@@ -55,7 +55,7 @@ direct_database_construction:
   # `backtest history` 는 `offline` 이며 #1974 에서 `open_cli_db` (read_only)
   # 로 마이그레이션되어 직접 Database 생성 callsite 가 사라졌다 — 엔트리 제거.
   - path: src/ante/cli/commands/backtest.py
-    line: 214
+    line: 229
     reason: "backtest run — long_running (progress-bar driven, deferred migration)"
 
   # data domain — `data list` callsite. #1857 잔여로 본 사이클에서 보류.

--- a/tests/unit/test_cli_backtest_date_validation.py
+++ b/tests/unit/test_cli_backtest_date_validation.py
@@ -124,8 +124,159 @@ class TestBacktestDateValidation:
                 "2025-01-01",
             ],
         )
+        # 'not-a-date' 는 strict YYYY-MM-DD 가드(#2053)에서 INVALID_DATE 로 거부된다.
         assert result.exit_code == 1
-        assert "날짜 형식" in result.output
+        assert "형식이 올바르지 않습니다" in result.output
+
+
+class TestBacktestStrictIsoDate:
+    """backtest run --start/--end strict YYYY-MM-DD 가드 (이슈 #2053).
+
+    Python 3.11+ ``date.fromisoformat`` 이 수락하는 basic ISO(``20260510``)·
+    week date(``2026-W19-1``) 변형은 ParquetStore 의 Polars 파싱이 거부하므로
+    CLI preflight 단계에서 INVALID_DATE 로 차단되어야 한다. 정상 확장 형식은
+    날짜 검증을 통과해 이후 실행 단계로 진입한다.
+    """
+
+    def test_basic_iso_start_rejected(self, tmp_path):
+        """(a) 재현: --start 20260510 (basic ISO)는 INVALID_DATE 로 거부."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "20260510",
+                "--end",
+                "2026-05-20",
+            ],
+        )
+        assert result.exit_code == 1
+        assert '"code": "INVALID_DATE"' in result.output
+
+    def test_week_date_start_rejected(self, tmp_path):
+        """(b) --start 2026-W19-1 (ISO week date)는 INVALID_DATE 로 거부."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-W19-1",
+                "--end",
+                "2026-05-20",
+            ],
+        )
+        assert result.exit_code == 1
+        assert '"code": "INVALID_DATE"' in result.output
+
+    def test_basic_iso_end_rejected(self, tmp_path):
+        """(c) --end 20260510 (basic ISO)도 검증됨 — INVALID_DATE 로 거부."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-05-10",
+                "--end",
+                "20260510",
+            ],
+        )
+        assert result.exit_code == 1
+        assert '"code": "INVALID_DATE"' in result.output
+
+    def test_valid_extended_iso_passes_validation(self, tmp_path):
+        """(d) 회귀: 정상 YYYY-MM-DD 는 날짜 검증을 통과해 실행 단계로 진입."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        with patch("ante.backtest.service.BacktestService") as mock_service:
+            mock_service.side_effect = RuntimeError("stop after validation")
+            result = runner.invoke(
+                cli,
+                [
+                    "backtest",
+                    "run",
+                    str(strategy),
+                    "--start",
+                    "2026-05-10",
+                    "--end",
+                    "2026-05-20",
+                ],
+            )
+
+        # 날짜 검증 통과 → exchange/timeframe/symbol 검증 후 BacktestService 진입
+        mock_service.assert_called_once()
+        assert "형식이 올바르지 않습니다" not in result.output
+
+    def test_nonexistent_calendar_date_rejected(self, tmp_path):
+        """(e) 회귀: strict 형식이나 비실재 날짜(2026-13-40)는 fromisoformat 거부."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-13-40",
+                "--end",
+                "2026-05-20",
+            ],
+        )
+        assert result.exit_code == 1
+        assert '"code": "INVALID_DATE"' in result.output
+
+    def test_start_after_end_still_invalid_range(self, tmp_path):
+        """(f) 회귀: 정상 형식 역전(start > end)은 INVALID_DATE_RANGE 유지."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-05-20",
+                "--end",
+                "2026-05-10",
+            ],
+        )
+        assert result.exit_code == 1
+        assert '"code": "INVALID_DATE_RANGE"' in result.output
 
 
 class TestBacktestBalanceValidation:


### PR DESCRIPTION
Closes #2053

## Summary
- `backtest run` `--start/--end`가 `date.fromisoformat`만 써서 basic ISO(`20260510`)·week date(`2026-W19-1`)를 통과시키던 것을, 모듈 `_ISO_DATE_RE` strict fullmatch 가드로 preflight에서 INVALID_DATE 거부. ParquetStore Polars 파싱과 정합(실행 단계 BACKTEST_ERROR 방지).
- fromisoformat은 달력 유효성(2026-13-40)·INVALID_DATE_RANGE 유지. feed/cli.py·backfill_runner.py per-module regex 관례 미러.

## Test Plan
- `pytest tests/unit/test_cli_backtest_date_validation.py` → 18 passed (신규 a~f)
- `pytest -k "backtest and cli"` → 66 passed / contracts 145 / mypy·ruff clean