### PR TITLE
fix(backtest): #2034 #2035 #2036 _validate_config가 exchange/date/numeric을 검증

### DIFF
--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import json
 import logging
+import math
+import re
 import sys
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +16,7 @@ from ante.backtest.data_provider import BacktestDataProvider
 from ante.backtest.exceptions import BacktestConfigError, BacktestError
 from ante.backtest.executor import BacktestExecutor
 from ante.backtest.result import BacktestResult
+from ante.core.exchange import CANONICAL_EXCHANGES, is_canonical
 from ante.core.market_data_vocab import (
     CANONICAL_TIMEFRAMES,
     is_krx_symbol,
@@ -25,6 +29,8 @@ if TYPE_CHECKING:
     from ante.eventbus.bus import EventBus
 
 logger = logging.getLogger(__name__)
+
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
 class BacktestService:
@@ -137,6 +143,31 @@ class BacktestService:
             msg = f"Missing required config keys: {missing}"
             raise BacktestConfigError(msg)
 
+        # date vocabulary 검증 (#2035). required 검사가 start_date/
+        # end_date 존재를 보장하므로 여기서는 ISO-8601(YYYY-MM-DD) shape·
+        # 실재성·순서(start <= end)만 검증한다. ``_ISO_DATE_RE`` 는
+        # ``20260510`` /``2026-W19-1`` 같은 non-canonical shape을 먼저
+        # 거부하고, ``date.fromisoformat`` 가 ``2026-13-40`` 같은 비실재
+        # 날짜를 거부한다. non-str(임의 타입)은 fullmatch 전에 차단.
+        for label in ("start_date", "end_date"):
+            value = config[label]
+            if not isinstance(value, str) or _ISO_DATE_RE.fullmatch(value) is None:
+                msg = f"Invalid {label} (expected YYYY-MM-DD): {value!r}"
+                raise BacktestConfigError(msg)
+            try:
+                datetime.date.fromisoformat(value)
+            except ValueError as e:
+                msg = f"Invalid {label}: {value!r}"
+                raise BacktestConfigError(msg) from e
+        start = datetime.date.fromisoformat(config["start_date"])
+        end = datetime.date.fromisoformat(config["end_date"])
+        if start > end:
+            msg = (
+                f"start_date {config['start_date']!r} is after "
+                f"end_date {config['end_date']!r}"
+            )
+            raise BacktestConfigError(msg)
+
         # symbol/timeframe vocabulary 검증 (#1604, core.md ``## Canonical
         # Symbol/Timeframe Vocabulary``:286 — programmatic API 행이
         # "검증 에러"를 normative로 요구). CLI(#1603)는 Click이 타입을
@@ -169,7 +200,19 @@ class BacktestService:
             msg = f"Invalid symbols (empty/blank segment): {symbols_raw!r}"
             raise BacktestConfigError(msg)
 
+        # exchange canonical 검증 (#2034, core.md ``## Canonical Exchange
+        # Vocabulary`` / D-016). CLI(#1576)는 ingress에서 거부하지만
+        # programmatic dict는 임의 값이 유입되므로 KRX-shape 블록이
+        # exchange를 읽기 **전에** canonical 5종(SSOT ``is_canonical``)을
+        # 강제한다. ``*`` 는 ``StrategyMeta.exchange`` 전용 wildcard라
+        # ``is_canonical("*") is False`` → 거부. non-str도 거부.
         exchange = config.get("exchange", "KRX")
+        if not isinstance(exchange, str) or not is_canonical(exchange):
+            msg = (
+                f"Invalid exchange: {exchange!r}. "
+                f"Allowed: {', '.join(sorted(CANONICAL_EXCHANGES))}"
+            )
+            raise BacktestConfigError(msg)
         if exchange == "KRX":
             # resolved exchange == KRX 신규 입력 한정 (core.md
             # ``### KRX symbol shape``). 비-KRX exchange의 symbol
@@ -182,6 +225,34 @@ class BacktestService:
                         "Expected 6-digit canonical KRX symbol shape."
                     )
                     raise BacktestConfigError(msg)
+
+        # numeric 검증 (#2036). config에 **존재하는** 숫자 키만 검사하고
+        # 미존재는 BacktestConfig 기본값(valid)을 따른다. bool은 int의
+        # subclass라 명시적으로 제외한다. initial_balance는 양수·유한,
+        # 각 rate는 음수가 아닌 유한값이어야 한다 (CLI
+        # validate_positive_finite_amount/validate_nonnegative_finite_amount
+        # 와 동형).
+        def _check_number(label: str, value: object, *, allow_zero: bool) -> None:
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                msg = f"Invalid {label} (expected number): {value!r}"
+                raise BacktestConfigError(msg)
+            if math.isnan(value) or math.isinf(value):
+                msg = f"Invalid {label} (NaN/Infinity not allowed): {value!r}"
+                raise BacktestConfigError(msg)
+            if allow_zero and value < 0:
+                msg = f"Invalid {label} (must be >= 0): {value!r}"
+                raise BacktestConfigError(msg)
+            if not allow_zero and value <= 0:
+                msg = f"Invalid {label} (must be > 0): {value!r}"
+                raise BacktestConfigError(msg)
+
+        if "initial_balance" in config:
+            _check_number(
+                "initial_balance", config["initial_balance"], allow_zero=False
+            )
+        for _rate in ("buy_commission_rate", "sell_commission_rate", "slippage_rate"):
+            if _rate in config:
+                _check_number(_rate, config[_rate], allow_zero=True)
 
         data_paths = config.get(
             "data_paths",

--- a/tests/unit/test_backtest_exchange_plumbing.py
+++ b/tests/unit/test_backtest_exchange_plumbing.py
@@ -59,22 +59,28 @@ class TestValidateConfigExchangeDefault:
         )
         assert validated.exchange == "NYSE"
 
-    def test_validate_config_does_not_canonical_validate(self):
-        """_validate_config는 canonical 검증을 하지 않는다 (CLI 경계 단일 검증).
+    def test_validate_config_rejects_non_canonical_exchange(self):
+        """_validate_config가 non-canonical exchange를 거부한다 (#2034 supersede).
 
-        서비스/config 이중검증 금지 — 비-canonical 값도 plumbing은 그대로
-        통과시킨다 (게이트는 CLI ingress).
+        #1585 당시에는 "게이트는 CLI ingress, 서비스 이중검증 금지"였으나,
+        #2034가 programmatic dict 경로의 fake-success(invalid exchange가
+        그대로 통과)를 닫기 위해 ``_validate_config`` 단일 chokepoint에
+        canonical 검증(SSOT ``is_canonical``)을 추가하면서 이 정책을
+        supersede했다 (timeframe/symbol #1604와 동형). CLI는 ingress에서
+        별도 거부하지만 programmatic 직접 호출의 fake-success를 닫는다.
         """
+        from ante.backtest.exceptions import BacktestConfigError
+
         svc = BacktestService()
-        validated = svc._validate_config(
-            {
-                "strategy_path": "s.py",
-                "start_date": "2026-01-01",
-                "end_date": "2026-01-02",
-                "exchange": "ORACLE_INVALID_EXCHANGE",
-            }
-        )
-        assert validated.exchange == "ORACLE_INVALID_EXCHANGE"
+        with pytest.raises(BacktestConfigError, match="Invalid exchange"):
+            svc._validate_config(
+                {
+                    "strategy_path": "s.py",
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-01-02",
+                    "exchange": "ORACLE_INVALID_EXCHANGE",
+                }
+            )
 
 
 class TestServicePassesExchangeToProvider:

--- a/tests/unit/test_backtest_programmatic_vocab_validation.py
+++ b/tests/unit/test_backtest_programmatic_vocab_validation.py
@@ -383,3 +383,204 @@ class TestRunnerForwardsToValidateConfig:
     async def test_invalid_timeframe_rejected_via_runner(self):
         with pytest.raises(BacktestConfigError, match="Invalid timeframe"):
             await runner.run_backtest(_cfg(timeframe="oracle-invalid"))
+
+
+# ── exchange canonical 검증 (#2034) ──────────────────────────────────────
+
+
+class TestValidateConfigRejectsInvalidExchange:
+    """``_validate_config`` 가 canonical 아닌 exchange를 BacktestConfigError로.
+
+    core.md ``## Canonical Exchange Vocabulary`` / D-016. programmatic dict는
+    임의 값이 유입되므로 KRX-shape 블록이 읽기 전에 SSOT ``is_canonical`` 로
+    canonical 5종을 강제한다. ``*`` 는 strategy 전용 wildcard라 거부.
+    """
+
+    @pytest.mark.parametrize("bad", ["INVALID", "*", "krx", "nyse"])
+    def test_non_canonical_str_exchange_rejected(self, bad):
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match="Invalid exchange"):
+            svc._validate_config(_cfg(exchange=bad))
+
+    @pytest.mark.parametrize("bad", [123, None, ["KRX"], 1.5])
+    def test_non_str_exchange_rejected(self, bad):
+        """non-str(임의 타입)도 BacktestConfigError (TypeError 아님)."""
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match="Invalid exchange"):
+            svc._validate_config(_cfg(exchange=bad))
+
+    @pytest.mark.parametrize("good", ["NYSE", "NASDAQ", "AMEX", "TEST"])
+    def test_canonical_non_krx_exchange_passes(self, good):
+        """canonical 5종 중 비-KRX → 통과 (symbol shape 미검증)."""
+        svc = BacktestService()
+        validated = svc._validate_config(_cfg(exchange=good, symbols=["AAPL"]))
+        assert isinstance(validated, BacktestConfig)
+        assert validated.exchange == good
+
+    def test_canonical_krx_exchange_passes_with_valid_symbol(self):
+        """KRX → 통과(회귀; 기존 KRX symbol shape 검증 유지되게 valid 6자리)."""
+        svc = BacktestService()
+        validated = svc._validate_config(_cfg(exchange="KRX", symbols=["005930"]))
+        assert isinstance(validated, BacktestConfig)
+        assert validated.exchange == "KRX"
+        assert validated.symbols == ["005930"]
+
+
+# ── date vocabulary 검증 (#2035) ─────────────────────────────────────────
+
+
+class TestValidateConfigRejectsInvalidDate:
+    """``_validate_config`` 가 invalid start_date/end_date를 BacktestConfigError로.
+
+    required 검사가 존재를 보장하므로 shape(YYYY-MM-DD)·실재성·순서만 검증한다.
+    """
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "20260510",  # 구분자 없음
+            "2026-W19-1",  # ISO week shape (non-canonical)
+            "2026/05/10",  # 잘못된 구분자
+            "2026-5-1",  # zero-pad 안됨
+            "2026-13-40",  # shape은 맞지만 비실재 월/일
+        ],
+    )
+    def test_invalid_start_date_shape_rejected(self, bad):
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match="Invalid start_date"):
+            svc._validate_config(_cfg(start_date=bad))
+
+    @pytest.mark.parametrize("bad", [123, None, ["2026-01-01"]])
+    def test_non_str_start_date_rejected(self, bad):
+        """non-str(임의 타입)도 BacktestConfigError (TypeError 아님)."""
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match="Invalid start_date"):
+            svc._validate_config(_cfg(start_date=bad))
+
+    def test_invalid_end_date_rejected(self):
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match="Invalid end_date"):
+            svc._validate_config(_cfg(end_date="2026-13-40"))
+
+    def test_start_after_end_rejected(self):
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match="is after"):
+            svc._validate_config(_cfg(start_date="2026-05-20", end_date="2026-05-10"))
+
+    def test_valid_date_range_passes(self):
+        svc = BacktestService()
+        validated = svc._validate_config(
+            _cfg(start_date="2026-05-10", end_date="2026-05-20", symbols=["005930"])
+        )
+        assert validated.start_date == "2026-05-10"
+        assert validated.end_date == "2026-05-20"
+
+    def test_same_start_end_date_passes(self):
+        """start == end 는 허용 (단일 날짜 백테스트)."""
+        svc = BacktestService()
+        validated = svc._validate_config(
+            _cfg(start_date="2026-05-10", end_date="2026-05-10")
+        )
+        assert validated.start_date == "2026-05-10"
+
+
+# ── numeric 검증 (#2036) ─────────────────────────────────────────────────
+
+
+class TestValidateConfigRejectsInvalidNumeric:
+    """``_validate_config`` 가 invalid 숫자 필드를 BacktestConfigError로.
+
+    config에 **존재하는** 숫자 키만 검사하고 미존재는 BacktestConfig
+    기본값(valid)을 따른다. bool은 int subclass라 명시 제외.
+    """
+
+    @pytest.mark.parametrize(
+        "bad",
+        [float("nan"), float("inf"), float("-inf"), 0, -1, "x", None, True],
+    )
+    def test_invalid_initial_balance_rejected(self, bad):
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match="initial_balance"):
+            svc._validate_config(_cfg(initial_balance=bad))
+
+    def test_valid_initial_balance_passes(self):
+        svc = BacktestService()
+        validated = svc._validate_config(_cfg(initial_balance=5_000_000.0))
+        assert validated.initial_balance == 5_000_000.0
+
+    @pytest.mark.parametrize(
+        "bad",
+        [-0.1, float("nan"), float("inf"), "x", None, True],
+    )
+    def test_invalid_buy_commission_rate_rejected(self, bad):
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match="buy_commission_rate"):
+            svc._validate_config(_cfg(buy_commission_rate=bad))
+
+    @pytest.mark.parametrize(
+        "rate_key",
+        ["buy_commission_rate", "sell_commission_rate", "slippage_rate"],
+    )
+    def test_zero_rate_passes(self, rate_key):
+        """rate=0 은 허용 (allow_zero=True)."""
+        svc = BacktestService()
+        validated = svc._validate_config(_cfg(**{rate_key: 0}))
+        assert getattr(validated, rate_key) == 0
+
+    @pytest.mark.parametrize(
+        "rate_key",
+        ["sell_commission_rate", "slippage_rate"],
+    )
+    def test_negative_rate_rejected(self, rate_key):
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match=rate_key):
+            svc._validate_config(_cfg(**{rate_key: -0.1}))
+
+    def test_missing_numeric_keys_use_defaults(self):
+        """숫자 키 미존재 → BacktestConfig 기본값(valid) → 통과."""
+        svc = BacktestService()
+        validated = svc._validate_config(_cfg())
+        assert validated.initial_balance == 10_000_000.0
+        assert validated.buy_commission_rate == 0.00015
+        assert validated.sell_commission_rate == 0.00195
+        assert validated.slippage_rate == 0.001
+
+
+# ── run_subprocess: invalid 3축 → subprocess 미기동 (#2034/#2035/#2036) ──
+
+
+class TestRunSubprocessEarlyFailsOnNewAxes:
+    """run_subprocess(): 신규 3축 invalid → BacktestConfigError, subprocess 미기동."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_exchange_no_subprocess(self):
+        with patch(
+            "ante.backtest.service.asyncio.create_subprocess_exec"
+        ) as mock_spawn:
+            svc = BacktestService()
+            with pytest.raises(BacktestConfigError, match="Invalid exchange"):
+                await svc.run_subprocess(_cfg(exchange="INVALID"))
+
+        mock_spawn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_date_no_subprocess(self):
+        with patch(
+            "ante.backtest.service.asyncio.create_subprocess_exec"
+        ) as mock_spawn:
+            svc = BacktestService()
+            with pytest.raises(BacktestConfigError, match="Invalid start_date"):
+                await svc.run_subprocess(_cfg(start_date="20260510"))
+
+        mock_spawn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_initial_balance_no_subprocess(self):
+        with patch(
+            "ante.backtest.service.asyncio.create_subprocess_exec"
+        ) as mock_spawn:
+            svc = BacktestService()
+            with pytest.raises(BacktestConfigError, match="initial_balance"):
+                await svc.run_subprocess(_cfg(initial_balance=float("nan")))
+
+        mock_spawn.assert_not_called()


### PR DESCRIPTION
Closes #2034
Closes #2035
Closes #2036

## Summary
`BacktestService._validate_config()`(run/run_subprocess/runner 공유 chokepoint, 기존 symbol/timeframe만 검증)에 3축 검증 추가. 모든 invalid → `BacktestConfigError` early-fail. CLI를 우회한 programmatic 경로의 fake-success를 닫음.
- **#2034 exchange**: `is_canonical` 검증(non-canonical/`*`/non-str 거부). `*`는 core.md D-016상 StrategyMeta 단독.
- **#2035 date**: strict `YYYY-MM-DD`(`\d{4}-\d{2}-\d{2}` + `date.fromisoformat` 실재성) + `start<=end`.
- **#2036 numeric**: present-only — initial_balance>0 finite, commission/slippage rates>=0 finite, bool 제외, NaN/inf/non-number 거부.

## 정책 전환 (#1585 supersede)
`test_validate_config_does_not_canonical_validate`(#1585, '서비스 exchange 미검증·CLI 단일 게이트')를 거부 단정으로 갱신. 근거: #2034 oracle 요구 + #1604(timeframe/symbol 동일 chokepoint 검증) + AccountService service-layer canonical 선례(core.md L155). Codex 브랜치 리뷰에서 supersede 정당성 adversarial 검증 완료.

## Test Plan
- `pytest tests/unit/test_backtest_programmatic_vocab_validation.py` → 79 passed (exchange/date/numeric/run_subprocess 미기동)
- `pytest -k backtest` → 310 passed / contracts 145 / mypy·ruff clean