### PR TITLE
fix(cli): #1986 data list 빈 페이지 count가 total을 유지

### DIFF
--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -78,7 +78,7 @@ def data_list(
 
     datasets = result["items"]
     if not datasets:
-        fmt.output({"datasets": [], "count": 0})
+        fmt.output({"datasets": [], "count": result["total"]})
         return
 
     async def _enrich(items: list[dict]) -> list[dict]:

--- a/tests/unit/test_data_success_output_drift.py
+++ b/tests/unit/test_data_success_output_drift.py
@@ -195,6 +195,41 @@ def test_data_list_empty_envelope_matches_raw_legacy(tmp_path) -> None:
     assert payload == {"datasets": [], "count": 0}
 
 
+# ── 1b. list out-of-range page (total>0, items empty) → count==total (#1986) ─
+
+
+def test_data_list_out_of_range_page_count_preserves_total(tmp_path) -> None:
+    """``data list`` out-of-range offset: items 빈 페이지여도 count==total (#1986).
+
+    ``list_datasets`` 는 빈 items 에도 ``total`` (전체 매칭 수) 를 반환한다.
+    큰 ``--offset`` 으로 페이지가 비어도 ``count`` 는 전체 매칭 수
+    (``result["total"]``) 를 유지해야 한다 (이전엔 ``0`` 하드코딩 → 회귀).
+    """
+    with patch(
+        "ante.data.datasets.list_datasets",
+        return_value={"items": [], "total": 3129},
+    ):
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "data",
+                "list",
+                "--data-path",
+                str(tmp_path),
+                "--offset",
+                "100000",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+
+    payload = _load_json_payload(result.output)
+    assert _is_raw_legacy_payload(payload), (
+        f"data list out-of-range: standard envelope 아님. payload={payload!r}"
+    )
+    assert payload == {"datasets": [], "count": 3129}
+
+
 # ── 2. list non-empty → raw_legacy ─────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #1986

## Summary
- `data list` 빈 페이지 분기의 `count: 0` 하드코딩을 `count: result['total']`로 변경(L101 비-빈 분기와 일관). `count`가 페이지네이션과 무관히 항상 전체 매칭 수.
- 빈 store(total=0)→count:0 불변, out-of-range offset(total=N)→count:N 수정. 단일 값 교체(라인 시프트 없음).

## Test Plan
- `pytest tests/unit/test_data_success_output_drift.py` → 10 passed (빈 store 회귀 + 신규 out-of-range)
- `pytest tests/unit/cli/test_factory_drift_check.py` → 3 passed (Database anchor 무드리프트)
- contracts 145 / mypy / ruff clean