### PR TITLE
fix(feed): #2021 DARTCollector가 존재하는 corp_code 캐시를 재사용

### DIFF
--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from calendar import monthrange
 from datetime import date, datetime, timedelta, timezone
@@ -122,8 +123,17 @@ class DARTCollector:
         self,
         feed_dir: Path,
     ) -> dict[str, str]:
-        """고유번호 매핑을 로드하거나 다운로드한다."""
+        """고유번호 매핑을 캐시에서 로드하거나 다운로드한다."""
         corp_codes_path = feed_dir / "dart_corp_codes.json"
+        if corp_codes_path.exists():
+            try:
+                data = json.loads(corp_codes_path.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning("DART: 고유번호 캐시 파싱 실패(%s), 재다운로드", e)
+            else:
+                if isinstance(data, dict) and data:
+                    return {str(k): str(v) for k, v in data.items()}
+                logger.warning("DART: 고유번호 캐시가 비정상(빈/비-dict), 재다운로드")
         return await self._source.fetch_corp_codes(save_path=corp_codes_path)
 
     @staticmethod

--- a/tests/unit/feed/test_dart_collector.py
+++ b/tests/unit/feed/test_dart_collector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import date
 from pathlib import Path
 
@@ -501,3 +502,97 @@ class TestCheckpointHaltOnFailure:
         assert checkpoint.get_last_date() is None
         assert rows == 0
         assert len(warns) == 4
+
+
+class _CountingCorpCodeSource:
+    """fetch_corp_codes 호출 횟수를 기록하고 save_path에 결과를 작성하는 스텁.
+
+    캐시 미스(다운로드) 경로가 정확히 몇 번 발동하는지 검증하기 위해
+    호출 카운터를 노출한다. save_path가 주어지면 실제 다운로드 동작을
+    흉내내 캐시 파일도 기록한다(_load_corp_codes의 save_path 갱신 계약).
+    """
+
+    def __init__(self, corp_code_map: dict[str, str]) -> None:
+        self._corp_code_map = corp_code_map
+        self.calls = 0
+
+    async def fetch_corp_codes(self, save_path: Path) -> dict[str, str]:
+        self.calls += 1
+        save_path.write_text(json.dumps(self._corp_code_map))
+        return dict(self._corp_code_map)
+
+
+class TestCorpCodeCacheReuse:
+    """#2021: 존재하는 corp_code 캐시를 재사용하고, 비정상 캐시는 재다운로드한다."""
+
+    async def test_valid_cache_hit_skips_download(self, tmp_path: Path) -> None:
+        """(a) 유효 non-empty 캐시 존재 → fetch_corp_codes 미호출, 캐시 맵 반환."""
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        cache = feed_dir / "dart_corp_codes.json"
+        cache.write_text(json.dumps({"00126380": "005930"}))
+
+        source = _CountingCorpCodeSource({"99999999": "000000"})
+        collector = DARTCollector(source=source)
+
+        result = await collector._load_corp_codes(feed_dir)
+
+        assert source.calls == 0
+        assert result == {"00126380": "005930"}
+
+    async def test_missing_cache_downloads(self, tmp_path: Path) -> None:
+        """(b) 캐시 파일 없음 → fetch_corp_codes 호출(1회), 다운로드 맵 반환."""
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+
+        source = _CountingCorpCodeSource({"00126380": "005930"})
+        collector = DARTCollector(source=source)
+
+        result = await collector._load_corp_codes(feed_dir)
+
+        assert source.calls == 1
+        assert result == {"00126380": "005930"}
+
+    async def test_corrupt_cache_falls_back_to_download(self, tmp_path: Path) -> None:
+        """(c) 손상된 JSON 캐시 → 재다운로드(1회)."""
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        (feed_dir / "dart_corp_codes.json").write_text("not json{")
+
+        source = _CountingCorpCodeSource({"00126380": "005930"})
+        collector = DARTCollector(source=source)
+
+        result = await collector._load_corp_codes(feed_dir)
+
+        assert source.calls == 1
+        assert result == {"00126380": "005930"}
+
+    async def test_empty_dict_cache_falls_back_to_download(
+        self, tmp_path: Path
+    ) -> None:
+        """(d) 빈 dict({}) 캐시 → 재다운로드(1회)."""
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        (feed_dir / "dart_corp_codes.json").write_text(json.dumps({}))
+
+        source = _CountingCorpCodeSource({"00126380": "005930"})
+        collector = DARTCollector(source=source)
+
+        result = await collector._load_corp_codes(feed_dir)
+
+        assert source.calls == 1
+        assert result == {"00126380": "005930"}
+
+    async def test_non_dict_cache_falls_back_to_download(self, tmp_path: Path) -> None:
+        """(e) 비-dict JSON([]) 캐시 → 재다운로드(1회)."""
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        (feed_dir / "dart_corp_codes.json").write_text(json.dumps([]))
+
+        source = _CountingCorpCodeSource({"00126380": "005930"})
+        collector = DARTCollector(source=source)
+
+        result = await collector._load_corp_codes(feed_dir)
+
+        assert source.calls == 1
+        assert result == {"00126380": "005930"}


### PR DESCRIPTION
Closes #2021

## Summary
- `DARTCollector._load_corp_codes`가 캐시 파일(`.feed/dart_corp_codes.json`) 존재 분기 없이 항상 다운로드하던 것을, 존재+유효 non-empty dict면 캐시 로드(다운로드 skip)로 변경. 없음/손상/빈/비-dict는 기존 다운로드 fallback.
- 스펙 명시 캐시 활성화. TTL은 비목표(스펙 미정의). #2079 빈-매핑 경로 무충돌.

## Test Plan
- `pytest tests/unit/feed/test_dart_collector.py` → 26 passed (캐시 적중/없음/손상/빈/비-dict)
- `pytest -k "dart or feed"` → 486 passed / contracts 145 / mypy·ruff clean