### PR TITLE
docs(eventbus): #1997 BacktestCompleteEvent.status 문서를 구현(completed)에 정렬

### DIFF
--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -150,7 +150,7 @@ D-005에서 정의한 EventBus 대상 이벤트. 모든 이벤트는 `Event`를 
 
 | 이벤트 타입 | 발행자 | 구독자 | 핵심 필드 |
 |------------|--------|--------|----------|
-| `BacktestCompleteEvent` | BacktestEngine | CLI, Notification | `backtest_id`, `strategy_id`, `status` (`"success"` / `"error"`), `result_path`, `error_message` |
+| `BacktestCompleteEvent` | BacktestEngine | CLI, Notification | `backtest_id`, `strategy_id`, `status` (`"completed"`, 백테스트 성공 완료 시 발행), `result_path`, `error_message` |
 
 #### 대사 (Reconciliation)
 


### PR DESCRIPTION
Closes #1997

## Summary
- `eventbus.md` L153의 `BacktestCompleteEvent.status` 서술을 `("success"/"error")` → `("completed", 성공 완료 시 발행)`으로 정렬. 구현(`status="completed"`)·소비자(report/draft.py)·테스트가 이미 "completed" 사용, impl은 성공 경로에서만 발행(실패는 raise). doc가 유일 outlier였음(sweep로 L153 단독 확인).
- 코드/테스트 무변경(docs-only). cross-module 계약 문서 정합.

## Test Plan
- `pytest test_backtest_complete_event.py test_report_draft.py` → 14 passed (회귀, 무변경)
- contracts 145 passed / grep로 success/error 잔존 없음 확인