### PR TITLE
fix(data): #2014 get_date_range가 파일 stem 대신 실제 row 날짜 반환

### DIFF
--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -93,6 +93,13 @@ def _natural_key(data_type: str, columns: list[str]) -> list[str]:
     return []
 
 
+def _date_str(value: object) -> str:
+    """Datetime/Date/str을 YYYY-MM-DD 문자열로."""
+    if hasattr(value, "isoformat"):
+        return value.isoformat()[:10]  # type: ignore[attr-defined]
+    return str(value)[:10]
+
+
 # 알려진 거래소 이름 — 마이그레이션 시 이미 exchange 디렉토리인지 판별용.
 # 코드 레벨 SSOT(`ante.core.exchange.CANONICAL_EXCHANGES`)에 위임한다.
 # 값(canonical 5종 frozenset)·`migrate_parquet_paths()` 동작은 위임
@@ -533,12 +540,24 @@ class ParquetStore:
         data_type: str = "ohlcv",
         exchange: str = "KRX",
     ) -> tuple[str, str] | None:
-        """종목의 데이터 기간 조회. (첫 파일 stem, 마지막 파일 stem) 반환."""
+        """종목의 데이터 기간 조회. (첫 row 날짜, 마지막 row 날짜) YYYY-MM-DD 반환.
+
+        파일은 월별 stem 정렬이므로 첫 파일 min(time_col) = 전역 최소,
+        마지막 파일 max(time_col) = 전역 최대. 읽기 실패/빈 컬럼 시 파일 stem fallback.
+        """
         path = self._resolve_path(symbol, timeframe, data_type, exchange)
         files = sorted(path.glob("*.parquet")) if path.exists() else []
         if not files:
             return None
-        return files[0].stem, files[-1].stem
+        time_col = _TIME_COLUMN.get(data_type, "timestamp")
+        try:
+            first_min = pl.read_parquet(files[0]).select(pl.col(time_col).min()).item()
+            last_max = pl.read_parquet(files[-1]).select(pl.col(time_col).max()).item()
+        except Exception:
+            return files[0].stem, files[-1].stem
+        if first_min is None or last_max is None:
+            return files[0].stem, files[-1].stem
+        return _date_str(first_min), _date_str(last_max)
 
     def get_row_count(
         self,

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -205,10 +205,59 @@ class TestParquetStore:
         assert store.list_symbols("1d") == []
 
     async def test_get_date_range(self, store):
+        # _make_ohlcv_df 기본: 2026-03-01 09:00~09:04(5분) → 첫/마지막 row 날짜 동일.
+        # (이슈 #2014) 월 stem "2026-03"이 아니라 실제 row 날짜 "2026-03-01"을 반환.
         store.write("005930", "1m", _make_ohlcv_df())
         result = store.get_date_range("005930", "1m")
         assert result is not None
-        assert result == ("2026-03", "2026-03")
+        assert result == ("2026-03-01", "2026-03-01")
+
+    async def test_get_date_range_actual_dates_multi_month(self, store):
+        """(이슈 #2014) 여러 월에 걸친 ohlcv → 실제 첫/마지막 row 날짜(YYYY-MM-DD).
+
+        월 stem("2026-01"/"2026-03")이 아니라 실제 row 날짜
+        ("2026-01-02"/"2026-03-15")를 반환해야 한다.
+        """
+        timestamps = pl.Series(
+            [
+                datetime(2026, 1, 2, 9, 0, tzinfo=UTC),
+                datetime(2026, 1, 20, 9, 0, tzinfo=UTC),
+                datetime(2026, 3, 15, 15, 30, tzinfo=UTC),
+            ]
+        )
+        n = len(timestamps)
+        df = pl.DataFrame(
+            {
+                "timestamp": timestamps,
+                "symbol": ["005930"] * n,
+                "open": [50000.0] * n,
+                "high": [50100.0] * n,
+                "low": [49900.0] * n,
+                "close": [50050.0] * n,
+                "volume": [1000] * n,
+                "source": ["test"] * n,
+            }
+        )
+        store.write("005930", "1d", df)
+        result = store.get_date_range("005930", "1d")
+        assert result == ("2026-01-02", "2026-03-15")
+
+    async def test_get_date_range_fundamental_actual_dates(self, store):
+        """(이슈 #2014) fundamental은 date 컬럼 기준 실제 첫/마지막 날짜."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "date": [date(2026, 2, 10), date(2026, 5, 28)],
+                "symbol": ["005930", "005930"],
+                "market_cap": [500000000000, 510000000000],
+                "per": [12.5, 12.8],
+                "source": ["dart", "dart"],
+            }
+        )
+        store.write("005930", "", df, data_type="fundamental")
+        result = store.get_date_range("005930", "", data_type="fundamental")
+        assert result == ("2026-02-10", "2026-05-28")
 
     async def test_get_date_range_none(self, store):
         assert store.get_date_range("999999", "1m") is None
@@ -1487,3 +1536,28 @@ class TestDatasetsRowCount:
         # ohlcv(005930__1m) 1건 + fundamental(005930__fundamental) 1건.
         assert result["total"] == 2
         assert len(result["items"]) == 2
+
+    def test_info_ohlcv_start_end_date_are_actual(self, store):
+        """(이슈 #2014) data info ohlcv → start/end_date 가 실제 row 날짜.
+
+        _make_ohlcv_df 기본은 2026-03-01 09:00~09:04(5분) → 첫/마지막 row 날짜
+        모두 "2026-03-01". 월 stem "2026-03" 이 아니라 실제 날짜를 반영해야 한다.
+        """
+        from ante.data.datasets import get_dataset_detail
+
+        store.write("005930", "1m", _make_ohlcv_df("005930", n=5))
+        result = get_dataset_detail(store, "005930__1m")
+        assert result["dataset"]["start_date"] == "2026-03-01"
+        assert result["dataset"]["end_date"] == "2026-03-01"
+
+    def test_info_fundamental_start_end_date_are_actual(self, store):
+        """(이슈 #2014) data info fundamental → start/end_date 가 실제 date 컬럼 값."""
+        from ante.data.datasets import get_dataset_detail
+
+        # _make_fundamental_df: date(2026,3,1)~date(2026,3,3) (n=3).
+        store.write(
+            "005930", "", _make_fundamental_df("005930", n=3), data_type="fundamental"
+        )
+        result = get_dataset_detail(store, "005930__fundamental")
+        assert result["dataset"]["start_date"] == "2026-03-01"
+        assert result["dataset"]["end_date"] == "2026-03-03"

--- a/tests/unit/test_parquet_exchange.py
+++ b/tests/unit/test_parquet_exchange.py
@@ -185,12 +185,16 @@ class TestReadWriteWithExchange:
         assert len(result) == 1
 
     def test_get_date_range_with_exchange(self, tmp_store: ParquetStore) -> None:
-        """exchange별 데이터 기간 조회."""
+        """exchange별 데이터 기간 조회.
+
+        (이슈 #2014) 월 stem "2026-01" 이 아니라 실제 row 날짜를 반환.
+        _make_ohlcv_df 기본: 2026-01-01~2026-01-03(일 단위 3건) → 첫 row "2026-01-01".
+        """
         df = _make_ohlcv_df()
         tmp_store.write("005930", "1d", df, exchange="KRX")
         result = tmp_store.get_date_range("005930", "1d", exchange="KRX")
         assert result is not None
-        assert result[0] == "2026-01"
+        assert result == ("2026-01-01", "2026-01-03")
 
     def test_get_row_count_with_exchange(self, tmp_store: ParquetStore) -> None:
         """exchange별 행 수 조회."""


### PR DESCRIPTION
Closes #2014

## Summary
- `ParquetStore.get_date_range`가 첫/마지막 파일 stem(YYYY-MM) 대신 첫 파일 min(time_col)·마지막 파일 max(time_col) → 실제 첫/마지막 row 날짜(YYYY-MM-DD) 반환. data list/info의 start_date/end_date 정확화.
- 읽기 실패/None 컬럼 시 stem fallback(견고). retention은 date_range를 존재 체크로만 사용→무영향. list는 페이지만 enrich→perf 허용.

## Test Plan
- `pytest test_data_pipeline.py test_parquet_exchange.py` → 133 passed, 2 skipped (실제 날짜 ohlcv/fundamental/info, retention 회귀, stem 기대 2건 갱신)
- data_pipeline/datasets/retention/store 228 passed / contracts 145 / mypy·ruff clean