### PR TITLE
fix(strategy): #2022 StrategyValidator가 모듈 상수 invalid exchange 검출

### DIFF
--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -130,7 +130,10 @@ class StrategyValidator:
 
         # 4. exchange 유효성 검증
         if len(strategy_classes) == 1:
-            exchange_value = self._extract_meta_exchange(strategy_classes[0])
+            module_consts = self._module_string_constants(tree)
+            exchange_value = self._extract_meta_exchange(
+                strategy_classes[0], module_consts
+            )
             if exchange_value is not None and exchange_value not in VALID_EXCHANGES:
                 errors.append(
                     f"Invalid exchange value: '{exchange_value}'. "
@@ -189,8 +192,38 @@ class StrategyValidator:
                     return True
         return False
 
-    def _extract_meta_exchange(self, cls: ast.ClassDef) -> str | None:
-        """meta에서 exchange 값을 추출. 없으면 None 반환."""
+    @staticmethod
+    def _module_string_constants(tree: ast.Module) -> dict[str, str]:
+        """모듈 레벨 `NAME = "literal"` 문자열 상수 map (정적 해석용)."""
+        consts: dict[str, str] = {}
+        for node in tree.body:  # 모듈 레벨만
+            if (
+                isinstance(node, ast.Assign)
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)
+            ):
+                for t in node.targets:
+                    if isinstance(t, ast.Name):
+                        consts[t.id] = node.value.value
+            elif (
+                isinstance(node, ast.AnnAssign)
+                and node.value is not None
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)
+                and isinstance(node.target, ast.Name)
+            ):
+                consts[node.target.id] = node.value.value
+        return consts
+
+    def _extract_meta_exchange(
+        self, cls: ast.ClassDef, module_consts: dict[str, str]
+    ) -> str | None:
+        """meta에서 exchange 값을 추출. 없으면 None 반환.
+
+        exchange kwarg 가 literal(`ast.Constant`)이면 그대로,
+        모듈 레벨 문자열 상수 이름(`ast.Name`)이면 ``module_consts`` 로
+        정적 해석한다. 해석 불가(계산식/비문자열 Name)는 None(기존 동작).
+        """
         for node in cls.body:
             if isinstance(node, ast.Assign | ast.AnnAssign):
                 target = (
@@ -201,8 +234,15 @@ class StrategyValidator:
                 value = node.value
                 if isinstance(value, ast.Call):
                     for kw in value.keywords:
-                        if kw.arg == "exchange" and isinstance(kw.value, ast.Constant):
+                        if kw.arg != "exchange":
+                            continue
+                        if isinstance(kw.value, ast.Constant):
                             return str(kw.value.value)
+                        if (
+                            isinstance(kw.value, ast.Name)
+                            and kw.value.id in module_consts
+                        ):
+                            return module_consts[kw.value.id]
         return None
 
     def _has_accepts_external_signals(self, cls: ast.ClassDef) -> bool:

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -924,6 +924,111 @@ class TestStrategy(Strategy):
         result = validator.validate(self._write_strategy(tmp_path, code))
         assert result.valid
 
+    def test_invalid_exchange_via_module_constant(self, validator, tmp_path):
+        """모듈 상수로 전달된 invalid exchange도 검출한다 (#2022 재현).
+
+        `EXCHANGE = "INVALID"` 모듈 상수를 `exchange=EXCHANGE`로 전달하면
+        예전에는 literal이 아니라서 None 반환 → 검사 skip(보안 우회)이었다.
+        이제 모듈 레벨 문자열 상수를 정적 해석해 거부해야 한다.
+        """
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+EXCHANGE = "INVALID"
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange=EXCHANGE,
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("Invalid exchange value: 'INVALID'" in e for e in result.errors)
+
+    def test_invalid_exchange_literal_regression(self, validator, tmp_path):
+        """literal invalid exchange는 기존대로 거부(불변, 회귀)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="INVALID",
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("Invalid exchange value: 'INVALID'" in e for e in result.errors)
+
+    def test_valid_exchange_via_module_constant(self, validator, tmp_path):
+        """valid 모듈 상수 exchange는 통과한다(오탐 없음, 회귀)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+EX = "NYSE"
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange=EX,
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("Invalid exchange" in e for e in result.errors)
+
+    def test_valid_exchange_literal_regression(self, validator, tmp_path):
+        """literal valid exchange는 기존대로 통과(불변, 회귀)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="KRX",
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("Invalid exchange" in e for e in result.errors)
+
+    def test_unresolvable_exchange_no_error(self, validator, tmp_path):
+        """해석 불가(계산식/import 이름) exchange는 검사 skip(None, 기존 동작).
+
+        비리터럴 실행식 해석은 본 이슈 비목표(#2043). 모듈 문자열 상수가
+        아닌 Name(여기서는 함수 호출 결과)은 exchange 에러를 내지 않는다.
+        """
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+def pick():
+    return "INVALID"
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange=pick(),
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not any("Invalid exchange" in e for e in result.errors)
+
 
 # ── ante.strategy lazy attribute access 회귀 (#1463) ──────────────────
 


### PR DESCRIPTION
Closes #2022

## Summary
- `StrategyValidator._extract_meta_exchange`가 `exchange=<literal>`만 검사하던 것을, 신규 `_module_string_constants`로 모듈 레벨 문자열 상수(`EXCHANGE="INVALID"`)를 해석해 `exchange=EXCHANGE` 우회도 검출. 정적 검증 통과하던 invalid exchange 차단.
- computed/imported/비문자열 Name은 None 유지(#2043 별개). valid 상수 오탐 없음.

## Test Plan
- `pytest test_strategy.py test_exchange_vocabulary_contract.py` → 147 passed (모듈상수 invalid/valid, literal 회귀, 해석불가 미검출)
- strategy/validator/exchange 634 passed / contracts 145 / mypy·ruff clean