### PR TITLE
fix(strategy): #2018 StrategyValidator가 최상위 if 내부 실행코드 검사

### DIFF
--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -295,7 +295,11 @@ class StrategyValidator:
     def _find_forbidden_toplevel(self, tree: ast.Module) -> list[str]:
         """금지된 최상위 코드 탐지 (에러)."""
         errors: list[str] = []
-        for node in tree.body:
+        self._check_toplevel_body(tree.body, errors)
+        return errors
+
+    def _check_toplevel_body(self, body: list[ast.stmt], errors: list[str]) -> None:
+        for node in body:
             if isinstance(node, ast.Import | ast.ImportFrom):
                 continue
             if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
@@ -303,6 +307,11 @@ class StrategyValidator:
             if isinstance(node, ast.Pass):
                 continue
             if isinstance(node, ast.If):
+                # #2018: if/elif/else body는 import-time 실행 → 동일 규칙 재귀.
+                # If.test 조건식은 범위 밖(eval/exec/금지 import는
+                # _find_forbidden_builtins/_find_forbidden_imports의 walk가 전역 탐지).
+                self._check_toplevel_body(node.body, errors)
+                self._check_toplevel_body(node.orelse, errors)
                 continue
             # 모듈 docstring (문자열 리터럴 Expr)
             if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
@@ -318,7 +327,6 @@ class StrategyValidator:
             errors.append(
                 f"Forbidden top-level code at line {node.lineno}: {type(node).__name__}"
             )
-        return errors
 
     def _contains_call(self, node: ast.AST) -> bool:
         """AST 서브트리에 함수 호출이 포함되어 있는지 확인."""

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -511,6 +511,96 @@ class TestStrategy(Strategy):
         result = validator.validate(self._write_strategy(tmp_path, code))
         assert not any("top-level" in e.lower() for e in result.errors)
 
+    def test_toplevel_if_body_call_detected(self, validator, tmp_path):
+        """#2018: 최상위 if 본문의 실행문(함수 호출)을 검출한다.
+
+        `if True:` 등 조건이 무엇이든 if-body는 import-time에 실행되므로
+        top-level 규칙으로 재귀 검사되어야 한다. 과거에는 if 전체를 skip해
+        side effect가 우회되었다.
+        """
+        code = """
+if True:
+    foo()
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("top-level" in e.lower() for e in result.errors)
+
+    def test_toplevel_if_else_call_detected(self, validator, tmp_path):
+        """#2018: 최상위 if의 else 본문 실행문도 검출한다 (elif/else 분기)."""
+        code = """
+if SOME_FLAG:
+    pass
+else:
+    bar()
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("top-level" in e.lower() for e in result.errors)
+
+    def test_toplevel_if_elif_call_detected(self, validator, tmp_path):
+        """#2018: 최상위 if의 elif 본문(orelse에 중첩된 If)도 재귀 검출한다."""
+        code = """
+if A:
+    pass
+elif B:
+    baz()
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("top-level" in e.lower() for e in result.errors)
+
+    def test_toplevel_if_type_checking_import_allowed(self, validator, tmp_path):
+        """#2018 회귀: `if TYPE_CHECKING:` 본문의 import는 오탐 없이 통과한다.
+
+        AST 정적 검사라 TYPE_CHECKING이 정의되지 않아도 무관(실행하지 않음).
+        if-body의 import는 기존 top-level import 허용 규칙으로 통과해야 한다.
+        """
+        code = """
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.strategy import Signal
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not any("top-level" in e.lower() for e in result.errors)
+
+    def test_toplevel_if_literal_assign_allowed(self, validator, tmp_path):
+        """#2018 회귀: if 본문의 리터럴 상수 할당은 오탐 없이 통과한다."""
+        code = """
+if FLAG:
+    CONST = "a"
+else:
+    CONST = "b"
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not any("top-level" in e.lower() for e in result.errors)
+
     def test_open_error(self, validator, tmp_path):
         """open 호출은 에러."""
         code = """


### PR DESCRIPTION
Closes #2018

## Summary
- `_find_forbidden_toplevel`이 최상위 `ast.If`를 통째 skip하던 것을 `_check_toplevel_body` 재귀로 리팩터 → if/elif/else body를 동일 top-level 규칙으로 검사. `if True: <exec>` top-level side effect 우회 차단.
- import/class/func/Pass/docstring/리터럴 assign 허용 규칙은 재귀 경로에도 동일 적용(오탐 없음). If.test·while/for/with은 범위 밖(eval/exec/import는 walk 기반 검사가 전역 커버).

## Test Plan
- `pytest tests/unit/test_strategy.py` → 94 passed (if-body/elif/else 검출, TYPE_CHECKING import·리터럴 if-body 오탐 없음, 기존 회귀)
- strategy/validator 434 passed / contracts 145 / mypy·ruff clean