### PR TITLE
fix(strategy): #2023 StrategyValidator가 __builtins__ subscript/attribute 우회 검출

### DIFF
--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -284,13 +284,37 @@ class StrategyValidator:
         """금지된 내장 함수 호출 탐지 (에러)."""
         errors: list[str] = []
         for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-                if node.func.id in self.FORBIDDEN_BUILTINS:
-                    errors.append(
-                        f"Forbidden built-in call: "
-                        f"{node.func.id}() at line {node.lineno}"
-                    )
+            if not isinstance(node, ast.Call):
+                continue
+            name = self._forbidden_builtin_name(node.func)
+            if name is not None:
+                errors.append(
+                    f"Forbidden built-in call: {name}() at line {node.lineno}"
+                )
         return errors
+
+    def _forbidden_builtin_name(self, func: ast.expr) -> str | None:
+        # 1) open(...) 직접 호출
+        if isinstance(func, ast.Name) and func.id in self.FORBIDDEN_BUILTINS:
+            return func.id
+        # 2) __builtins__["open"](...)
+        if isinstance(func, ast.Subscript) and self._is_builtins_ref(func.value):
+            key = func.slice
+            if (
+                isinstance(key, ast.Constant)
+                and isinstance(key.value, str)
+                and key.value in self.FORBIDDEN_BUILTINS
+            ):
+                return key.value
+        # 3) __builtins__.open(...)
+        if isinstance(func, ast.Attribute) and self._is_builtins_ref(func.value):
+            if func.attr in self.FORBIDDEN_BUILTINS:
+                return func.attr
+        return None
+
+    @staticmethod
+    def _is_builtins_ref(node: ast.expr) -> bool:
+        return isinstance(node, ast.Name) and node.id == "__builtins__"
 
     def _find_forbidden_toplevel(self, tree: ast.Module) -> list[str]:
         """금지된 최상위 코드 탐지 (에러)."""

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -455,6 +455,82 @@ class TestStrategy(Strategy):
         assert not result.valid
         assert any("__import__" in e for e in result.errors)
 
+    def test_forbidden_builtins_subscript_open_bypass(self, validator, tmp_path):
+        """#2023 재현: __builtins__["open"](...) subscript 우회를 검출."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        f = __builtins__["open"]("/tmp/x", "w")
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("Forbidden built-in call: open()" in e for e in result.errors)
+
+    def test_forbidden_builtins_attribute_eval_bypass(self, validator, tmp_path):
+        """#2023: __builtins__.eval(...) attribute 우회를 검출."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        __builtins__.eval("1")
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("Forbidden built-in call: eval()" in e for e in result.errors)
+
+    def test_forbidden_builtins_direct_call_regression(self, validator, tmp_path):
+        """회귀: 직접 open()/eval() 호출은 기존대로 검출(메시지 포맷 불변)."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        eval("1+1")
+        open("/tmp/x", "w")
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("Forbidden built-in call: eval()" in e for e in result.errors)
+        assert any("Forbidden built-in call: open()" in e for e in result.errors)
+
+    def test_forbidden_builtins_no_false_positive(self, validator, tmp_path):
+        """오탐 없음: 정상 전략 + 비-__builtins__ subscript/attribute는 미검출."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta, Signal
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        config = {"open": "value"}
+        x = config["open"]
+        obj = context
+        obj.open()
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("Forbidden built-in call" in e for e in result.errors)
+
+    def test_forbidden_builtins_non_forbidden_subscript_key(self, validator, tmp_path):
+        """__builtins__["print"](비금지)은 FORBIDDEN_BUILTINS 한정으로 미검출."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta, Signal
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        __builtins__["print"]("hi")
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("Forbidden built-in call" in e for e in result.errors)
+
     def test_forbidden_toplevel_function_call_assign(self, validator, tmp_path):
         """최상위 함수 호출 할당은 에러."""
         code = """


### PR DESCRIPTION
Closes #2023

## Summary
- `_find_forbidden_builtins`가 `func`=Name인 Call만 검사하던 것을 `_forbidden_builtin_name` 헬퍼로 확장: `__builtins__["open"](...)`(Subscript)·`__builtins__.open(...)`(Attribute) 우회 검출. `_is_builtins_ref`로 __builtins__ 한정→일반 dict/object 접근 오탐 없음.
- 직접 호출·정상 전략·비-__builtins__·비금지 키 회귀 없음.

## Test Plan
- `pytest tests/unit/test_strategy.py` → 99 passed (subscript/attribute 우회, 직접호출 회귀, config["open"]/obj.open() 오탐 없음, print 비금지)
- strategy/validator 439 passed / contracts 145 / mypy·ruff clean