### PR TITLE
fix(strategy): #2043 StrategyValidator가 비리터럴 최상위 assignment 실행식 차단

### DIFF
--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -358,11 +358,12 @@ class StrategyValidator:
             # 리터럴 상수 할당
             if isinstance(node, ast.Assign | ast.AnnAssign):
                 value = node.value
-                if value is not None and not self._contains_call(value):
-                    continue
                 if value is None:
-                    # 타입 어노테이션만 있는 경우 (x: int)
-                    continue
+                    continue  # 타입 어노테이션만 (x: int)
+                if self._is_literal_assign_value(value):
+                    continue  # 리터럴/Name/리터럴 컬렉션 허용
+                # 비리터럴 실행식 (BinOp/Subscript/Comprehension/Call/...) →
+                # 아래 errors.append로
             errors.append(
                 f"Forbidden top-level code at line {node.lineno}: {type(node).__name__}"
             )
@@ -374,6 +375,25 @@ class StrategyValidator:
         for child in ast.walk(node):
             if isinstance(child, ast.Call):
                 return True
+        return False
+
+    def _is_literal_assign_value(self, node: ast.expr) -> bool:
+        """assignment 값이 부작용 없는 리터럴/참조인지 (import-time 실행식 거부)."""
+        if isinstance(node, ast.Constant):
+            return True
+        if isinstance(node, ast.Name):
+            return True  # 상수 참조(lookup) — 부작용 없음
+        if isinstance(node, ast.UnaryOp):
+            return self._is_literal_assign_value(node.operand)
+        if isinstance(node, ast.List | ast.Tuple | ast.Set):
+            return all(self._is_literal_assign_value(e) for e in node.elts)
+        if isinstance(node, ast.Dict):
+            return all(
+                k is not None
+                and self._is_literal_assign_value(k)
+                and self._is_literal_assign_value(v)
+                for k, v in zip(node.keys, node.values, strict=False)
+            )
         return False
 
     def _find_dangerous_patterns(self, tree: ast.Module) -> list[str]:

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -877,6 +877,119 @@ class TestStrategy(Strategy):
         assert result.valid
         assert not any("top-level" in e.lower() for e in result.errors)
 
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "1 / 0",  # BinOp — import-time ZeroDivisionError
+            "[1][2]",  # Subscript — import-time IndexError
+            "[x for x in [1, 2, 3]]",  # ListComp — import-time 실행식
+        ],
+    )
+    def test_toplevel_nonliteral_assign_forbidden(self, validator, tmp_path, expr):
+        """#2043 재현: 호출이 없어도 비리터럴 실행식 최상위 할당을 금지한다.
+
+        과거에는 `not self._contains_call(value)` 만 검사해 BinOp/Subscript/
+        comprehension 같은 import-time 실행식이 그대로 통과했다.
+        """
+        code = f"""
+from ante.strategy import Strategy, StrategyMeta, Signal
+
+CRASH = {expr}
+
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("top-level" in e.lower() for e in result.errors)
+
+    def test_toplevel_call_assign_still_forbidden(self, validator, tmp_path):
+        """#2043 회귀: 호출 할당은 변경 후에도 여전히 금지(불변)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta, Signal
+
+X = foo()
+
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("top-level" in e.lower() for e in result.errors)
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "5",  # Constant int
+            '"s"',  # Constant str
+            '["005930", "000660"]',  # literal list
+            '{"a": 1}',  # literal dict
+            "-1",  # UnaryOp on Constant
+            "OTHER_CONST",  # Name 참조(부작용 없는 lookup)
+            "(1, 2)",  # literal tuple
+            "{1, 2}",  # literal set
+        ],
+    )
+    def test_toplevel_literal_assign_no_false_positive(self, validator, tmp_path, expr):
+        """#2043 회귀: 리터럴/Name/리터럴 컬렉션 할당은 오탐 없이 통과한다."""
+        code = f"""
+from ante.strategy import Strategy, StrategyMeta, Signal
+
+X = {expr}
+
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not any("top-level" in e.lower() for e in result.errors)
+
+    def test_toplevel_annassign_nonliteral_forbidden(self, validator, tmp_path):
+        """#2043: AnnAssign 값이 비리터럴 실행식이면 금지한다."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta, Signal
+
+X: int = 1 / 0
+
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("top-level" in e.lower() for e in result.errors)
+
+    def test_toplevel_annassign_literal_allowed(self, validator, tmp_path):
+        """#2043 회귀: 리터럴 값 AnnAssign은 통과한다."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta, Signal
+
+X: list = [1, 2]
+
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not any("top-level" in e.lower() for e in result.errors)
+
     def test_open_error(self, validator, tmp_path):
         """open 호출은 에러."""
         code = """


### PR DESCRIPTION
Closes #2043

## Summary
- `_check_toplevel_body`의 assignment 허용을 `_contains_call` 기반에서 **literal 화이트리스트**(`_is_literal_assign_value`)로 전환: Constant/Name/UnaryOp/List·Tuple·Set/Dict(재귀)만 허용. `1/0`(BinOp)·`[1][2]`(Subscript)·comprehension 등 import-time 실행식 차단.
- `X=foo()` 여전히 금지, 리터럴/컬렉션/Name 참조·AnnAssign 회귀 없음. `_contains_call`은 #2032/#2033 default 검사용으로 보존.
- **StrategyValidator 보안 패밀리(#2022/#2018/#2023/#2032/#2033/#2043) 완료.**

## Test Plan
- `pytest tests/unit/test_strategy.py` → 121 passed (BinOp/Subscript/comprehension 거부, call 회귀, 리터럴/컬렉션/Name/AnnAssign 오탐 없음)
- strategy/validator 461 passed / contracts 145 / mypy·ruff clean