### PR TITLE
fix(backtest): #2098 멀티심볼 백테스트 timestamp 통합 timeline + 체결 current-bar gate

### DIFF
--- a/src/ante/backtest/data_provider.py
+++ b/src/ante/backtest/data_provider.py
@@ -21,7 +21,11 @@ logger = logging.getLogger(__name__)
 class BacktestDataProvider(DataProvider):
     """백테스트용 DataProvider. 과거 데이터를 시간순으로 제공.
 
-    미래 데이터 참조를 방지하기 위해 current_idx까지만 노출한다.
+    미래 데이터 참조를 방지하기 위해 통합 timeline(전 심볼 timestamp의 union)을
+    기준으로 현재 시각까지만 노출한다(as-of 관측, #2098). 심볼별 거래 달력이
+    달라도 같은 step에서 모든 심볼이 동일한 wall-clock 시각(current_ts) 이하만
+    보므로, 공유 row-index가 유발하던 미래 데이터 노출(lookahead)이 발생하지
+    않는다.
 
     Note: DataProvider 인터페이스 준수를 위해 get_ohlcv 등은 async def를 유지한다.
     """
@@ -38,10 +42,15 @@ class BacktestDataProvider(DataProvider):
         self._end = end_date
         self._exchange = exchange
         self._cache: dict[str, pl.DataFrame] = {}
-        # 초기 커서는 첫 row 이전(-1)에 위치한다. 첫 advance()가 row 0으로
-        # 전진하여 첫 데이터 행을 처리한다(#2061). pre-advance 상태(idx=-1)에서는
+        # 초기 커서는 첫 row 이전(-1)에 위치한다. 첫 advance()가 timeline 0으로
+        # 전진하여 첫 시각을 처리한다(#2061). pre-advance 상태(idx=-1)에서는
         # OHLCV가 empty, current timestamp는 None, current price는 unavailable이다.
         self._current_idx: int = -1
+        # 전 캐시 DataFrame의 timestamp를 union·정렬·dedupe한 통합 시간축(#2098).
+        # 심볼마다 거래 달력이 다를 수 있으므로 공유 row-index 대신 wall-clock
+        # 시각을 SSOT로 삼아 as-of 관측을 한다. None이면 다음 접근 시 lazy-build.
+        # load()/reset()에서 무효화한다.
+        self._timeline: list[datetime] | None = None
         self._loaded_datasets: list[DatasetInfo] = []
 
     @property
@@ -72,6 +81,9 @@ class BacktestDataProvider(DataProvider):
             exchange=self._exchange,
         )
         self._cache[key] = df
+        # 새 데이터가 캐시에 들어오면 통합 timeline을 무효화한다(#2098). 다음
+        # advance()/get_total_steps()/get_current_timestamp() 접근 시 lazy-build.
+        self._timeline = None
 
         data_dir = self._store.resolve_path(symbol, timeframe, exchange=self._exchange)
         file_count = len(list(data_dir.glob("*.parquet"))) if data_dir.exists() else 0
@@ -88,28 +100,96 @@ class BacktestDataProvider(DataProvider):
 
         return len(df)
 
+    def _build_timeline(self) -> list[datetime]:
+        """전 캐시 DataFrame의 timestamp를 union·오름차순 정렬·dedupe한 통합 시간축.
+
+        심볼마다 거래 달력이 달라도 모든 심볼이 동일한 wall-clock 시각 기준으로
+        전진하도록, 캐시된 모든 timestamp 컬럼을 합쳐 중복 제거 후 정렬한다.
+        tz-aware datetime을 그대로 유지한다(#2098).
+        """
+        if not self._cache:
+            return []
+        seen: set[datetime] = set()
+        for df in self._cache.values():
+            if df.is_empty():
+                continue
+            for ts in df["timestamp"].to_list():
+                if isinstance(ts, datetime):
+                    seen.add(ts)
+        return sorted(seen)
+
+    def _ensure_timeline(self) -> list[datetime]:
+        """timeline이 무효화(None)되어 있으면 lazy-build 후 반환한다(#2098)."""
+        if self._timeline is None:
+            self._timeline = self._build_timeline()
+        return self._timeline
+
     async def get_ohlcv(
         self,
         symbol: str,
         timeframe: str = "1d",
         limit: int = 100,
     ) -> pl.DataFrame:
-        """현재 시점까지의 OHLCV 데이터 반환."""
+        """현재 시점(current_ts)까지의 OHLCV 데이터 반환(as-of 관측, #2098).
+
+        공유 row-index 슬라이스 대신 통합 timeline의 current_ts 이하 행만
+        노출한다. current_ts가 None(pre-advance/끝)이면 empty를 반환한다.
+        """
         key = f"{symbol}:{timeframe}"
         if key not in self._cache:
             self.load(symbol, timeframe)
 
         df = self._cache[key]
-        visible = df.head(self._current_idx + 1)
+        current_ts = self.get_current_timestamp()
+        # 데이터가 없는 심볼은 store가 컬럼 없는 빈 df를 줄 수 있으므로,
+        # timestamp 컬럼 참조 전에 empty를 먼저 가드한다(존재하지 않는 심볼).
+        if current_ts is None or df.is_empty():
+            return df.head(0)
+        visible = df.filter(pl.col("timestamp") <= current_ts)
         return visible.tail(limit)
 
     async def get_current_price(self, symbol: str) -> float:
-        """현재 시점의 종가."""
+        """현재 시점까지의 최근 종가(as-of, mark-to-market/지표/전략 관측용).
+
+        current_ts 이하의 가장 최근 봉 종가를 반환한다. 심볼이 current_ts에
+        봉이 없어도(gap day) 그 이전 최근 봉가를 쓰므로, 보유 포지션의 mark-
+        to-market 평가가 끊기지 않는다. visible이 empty면(미시작/pre-advance)
+        BacktestDataError를 raise한다.
+
+        체결 가능 가격은 ``get_current_bar_price``(현재 봉 정확 일치)를 별도로
+        쓴다. 이 메서드의 as-of 가격으로 비거래일에 체결하면 안 된다(#2098).
+        """
         df = await self.get_ohlcv(symbol, limit=1)
         if df.is_empty():
             msg = f"No data for {symbol} at step {self._current_idx}"
             raise BacktestDataError(msg)
         return float(df["close"][-1])
+
+    def get_current_bar_price(self, symbol: str, timeframe: str = "1d") -> float | None:
+        """현재 시각(current_ts)에 정확히 일치하는 봉의 종가(체결 가능가, #2098).
+
+        current_ts가 None이면 None. 심볼 df에서 ``timestamp == current_ts`` 인
+        행을 정확 일치 조회한다. 없으면(해당 심볼이 current_ts에 봉이 없음 =
+        gap day/미시작) None을 반환하고, 있으면 그 행의 close(float)를 반환한다.
+
+        as-of(get_current_price)와 달리 stale 가격을 쓰지 않으므로, 호출부는
+        None을 "이번 step에 거래 불가"로 해석해 체결을 skip해야 한다.
+        """
+        key = f"{symbol}:{timeframe}"
+        if key not in self._cache:
+            self.load(symbol, timeframe)
+
+        current_ts = self.get_current_timestamp()
+        if current_ts is None:
+            return None
+        df = self._cache[key]
+        # 데이터가 없는 심볼은 timestamp 컬럼이 없는 빈 df일 수 있으므로 가드.
+        if df.is_empty():
+            return None
+        match = df.filter(pl.col("timestamp") == current_ts)
+        if match.is_empty():
+            return None
+        return float(match["close"][-1])
 
     async def get_indicator(
         self,
@@ -130,36 +210,41 @@ class BacktestDataProvider(DataProvider):
         return IndicatorCalculator.compute(indicator, arrays, **(params or {}))
 
     def advance(self) -> bool:
-        """시뮬레이션 1스텝 전진. False면 데이터 끝."""
+        """시뮬레이션 1스텝 전진. False면 데이터 끝.
+
+        통합 timeline(전 심볼 timestamp union) 위에서 전진한다(#2098). 캐시가
+        비어 있으면 False. 그 외에는 다음 timeline 인덱스가 범위 안인지로 판정.
+        """
         self._current_idx += 1
         if not self._cache:
             return False
-        max_len = min(len(df) for df in self._cache.values())
-        return self._current_idx < max_len
+        timeline = self._ensure_timeline()
+        return self._current_idx < len(timeline)
 
     def get_current_timestamp(self) -> datetime | None:
-        """현재 시뮬레이션 시각."""
+        """현재 시뮬레이션 시각(통합 timeline의 current_idx 위치, #2098)."""
         if self._current_idx < 0:
             # pre-advance 상태(첫 advance() 이전). 음수 인덱스로 마지막 행을
             # 잘못 반환하지 않도록 명시적으로 None을 반환한다(#2061).
             return None
         if not self._cache:
             return None
-        first_df = next(iter(self._cache.values()))
-        if self._current_idx >= len(first_df):
+        timeline = self._ensure_timeline()
+        if self._current_idx >= len(timeline):
             return None
-        ts = first_df["timestamp"][self._current_idx]
-        if isinstance(ts, datetime):
-            return ts
-        return None
+        return timeline[self._current_idx]
 
     def get_total_steps(self) -> int:
-        """전체 시뮬레이션 스텝 수."""
+        """전체 시뮬레이션 스텝 수(통합 timeline의 distinct 시각 개수, #2098)."""
         if not self._cache:
             return 0
-        return min(len(df) for df in self._cache.values())
+        return len(self._ensure_timeline())
 
     def reset(self) -> None:
-        """인덱스 초기화. 커서를 첫 row 이전(-1)으로 되돌린다."""
+        """인덱스 초기화. 커서를 첫 row 이전(-1)으로 되돌린다.
+
+        통합 timeline도 무효화해 다음 접근 시 재빌드한다(#2098).
+        """
         self._current_idx = -1
+        self._timeline = None
         self._loaded_datasets.clear()

--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -73,7 +73,10 @@ class BacktestExecutor:
         strategies_dir: Path | None = None,
     ) -> None:
         self._strategy_cls = strategy_cls
-        self._data = data_provider
+        # 구체 BacktestDataProvider로 어노테이트한다(#2098). 체결가 게이트
+        # get_current_bar_price는 backtest 전용이라 base DataProvider ABC에는
+        # 없으므로, 호출이 mypy에 잡히지 않도록 구체 타입으로 좁힌다.
+        self._data: BacktestDataProvider = data_provider
         self._initial_balance = initial_balance
         self._buy_commission_rate = buy_commission_rate
         self._sell_commission_rate = sell_commission_rate
@@ -231,8 +234,13 @@ class BacktestExecutor:
         체결 시 라이브 bot의 ``strategy.on_fill(fill)`` dict와 동일한 shape
         (``order_id``/``symbol``/``side``/``quantity``/``price``/``timestamp``/
         ``fill_dedup_key``)의 fill dict를 반환한다(#2073). 체결되지 않은 모든
-        경로(side invalid/hold, quantity invalid, buy 잔고 부족, sell 보유 없음)는
-        ``None`` 을 반환해 호출부가 follow-up(on_fill) 경로로 진입하지 않게 한다.
+        경로(side invalid/hold, quantity invalid, **현재 봉 없음(gap day/미시작)**,
+        buy 잔고 부족, sell 보유 없음)는 ``None`` 을 반환해 호출부가 follow-up
+        (on_fill) 경로로 진입하지 않게 한다.
+
+        체결가는 ``get_current_bar_price`` (current_ts 정확 일치 봉가)로 게이트한다
+        (#2098). 심볼이 현재 step에 봉이 없으면 None이 와서 미체결 skip한다 —
+        stale as-of 가격으로 비거래일에 체결하지 않는다.
         backtest는 단발 체결이므로 ``fill_dedup_key`` 는 항상 빈 문자열이다
         (라이브와 달리 dedup이 불필요).
 
@@ -284,7 +292,21 @@ class BacktestExecutor:
             )
             return None
 
-        price = await self._data.get_current_price(signal.symbol)
+        # 체결가는 현재 봉(current_ts 정확 일치) 종가로 게이트한다(#2098).
+        # as-of(get_current_price)는 gap day에 이전 봉가를 반환하므로 그 가격으로
+        # 비거래일 체결을 하면 lookahead/stale 체결이 된다. None이면(심볼이 이
+        # step에 봉이 없음 = gap day/미시작) 미체결로 skip한다.
+        price = self._data.get_current_bar_price(signal.symbol)
+        if price is None:
+            logger.warning(
+                "Signal skip(no current bar): symbol=%s side=%r quantity=%r ts=%s — "
+                "해당 step에 봉 없음(gap day/미시작), 미체결",
+                signal.symbol,
+                signal.side,
+                signal.quantity,
+                timestamp,
+            )
+            return None
 
         if signal.side == "buy":
             exec_price = price * (1 + self._slippage_rate)

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -1218,9 +1218,12 @@ class TestBacktestMarkToMarket:
         - 루프 종료 후 advance()가 올린 미래 봉 가격을 쓰지 않음
           (final valuation에서 get_current_price를 재호출하지 않음을 lock)
         """
-        # 두 심볼: 길이가 다름(005930=4행, 000660=8행).
-        # get_total_steps/advance는 min 길이(=4)를 따르므로
-        # 시뮬레이션은 005930 idx0..3 까지만 진행된다.
+        # 두 심볼: 길이가 다름(005930=4행, 000660=8행). 두 심볼 모두 같은
+        # 시작일(2026-01-02)에서 일 단위 전진하므로 005930의 4개 timestamp는
+        # 000660의 8개 timestamp 부분집합이다. 통합 timeline은 union=8 시각이라
+        # 시뮬레이션은 idx 0..7(8 step) 진행된다(#2098: min 길이 truncation 폐기).
+        # 005930은 idx 4..7에 봉이 없지만 보유 포지션은 as-of 최근 봉가(close=130)
+        # 로 계속 mark-to-market된다.
         df_a = _make_ohlcv_df_with_closes([100.0, 110.0, 120.0, 130.0], symbol="005930")
         df_b = _make_ohlcv_df_with_closes(
             [200.0, 210.0, 220.0, 230.0, 240.0, 250.0, 260.0, 270.0],
@@ -1233,6 +1236,9 @@ class TestBacktestMarkToMarket:
         )
         provider.load("005930", "1d")
         provider.load("000660", "1d")
+
+        last_idx = provider.get_total_steps() - 1  # union timeline 마지막 step(=7)
+        assert last_idx == 7
 
         executor = BacktestExecutor(
             strategy_cls=BuyAndHoldStrategy,
@@ -1259,15 +1265,16 @@ class TestBacktestMarkToMarket:
         # final_balance는 마지막 시뮬레이션 봉 equity 재사용 (재계산 아님)
         assert result.final_balance == result.equity_curve[-1]["equity"]
 
-        # 시뮬레이션은 min 길이(4) 기준. 마지막 평가 봉은 005930 idx=3 (close=130).
-        # get_current_price는 current_idx <= 3 인 시점에서만 호출되어야 한다.
-        # (루프 종료 후 advance()로 current_idx=4가 된 뒤 재호출되면 lookahead)
+        # get_current_price는 루프 안(current_idx <= last_idx)에서만 호출되어야
+        # 한다. 루프 종료 후 advance()로 current_idx=last_idx+1이 된 뒤 재호출되면
+        # lookahead다.
         assert idx_at_call, "get_current_price가 호출되어야 함"
-        assert max(idx_at_call) <= 3, (
-            f"final valuation이 미래 봉(current_idx>3)을 참조함: {idx_at_call}"
+        assert max(idx_at_call) <= last_idx, (
+            f"final valuation이 미래 봉(current_idx>{last_idx})을 참조함: {idx_at_call}"
         )
 
-        # 005930 마지막 평가가는 idx=3 close=130 (idx=4는 데이터 없음/미래)
+        # 005930 마지막 보유 평가가는 as-of close=130 (idx 4..7엔 봉 없음 → 직전
+        # 최근 봉가 130 유지). idx 8(미래)을 보지 않는다.
         buy_trade = result.trades[0]
         qty = buy_trade.quantity
         cash = result.equity_curve[-1]["balance"]
@@ -2604,3 +2611,355 @@ class TestBacktestOnFillFollowUp:
         assert all(t.side == "buy" for t in result.trades)
         # 5주 누적 포지션.
         assert executor._positions["005930"]["quantity"] == 5
+
+
+# ── 멀티심볼 통합 timeline / as-of 관측 / 체결 게이트 (#2098, #1992) ──
+
+
+def _make_ohlcv_df_on_dates(
+    dates: list[datetime],
+    symbol: str,
+    closes: list[float] | None = None,
+) -> pl.DataFrame:
+    """명시한 거래일(tz-aware datetime) 목록으로 OHLCV DataFrame을 만든다.
+
+    심볼별 거래 달력이 다른(겹치지 않거나 부분 겹치는) 멀티심볼 시나리오를
+    구성할 때 사용한다(#2098/#1992). closes 미지정 시 기본 종가 시퀀스를 쓴다.
+    """
+    n = len(dates)
+    if closes is None:
+        closes = [50000.0 + i * 100 for i in range(n)]
+    assert len(closes) == n
+    return pl.DataFrame(
+        {
+            "timestamp": pl.Series(dates, dtype=pl.Datetime(time_zone="UTC")),
+            "symbol": [symbol] * n,
+            "open": [c - 25 for c in closes],
+            "high": [c + 50 for c in closes],
+            "low": [c - 50 for c in closes],
+            "close": list(closes),
+            "volume": [1000 + i * 10 for i in range(n)],
+            "source": ["test"] * n,
+        }
+    )
+
+
+def _d(day: int) -> datetime:
+    """2026-01-{day} 09:00 UTC tz-aware datetime 헬퍼."""
+    return datetime(2026, 1, day, 9, 0, tzinfo=UTC)
+
+
+class TestMultiSymbolTimeline:
+    """#2098/#1992: 심볼별 거래 달력이 다를 때 공유 row-index lookahead 차단.
+
+    통합 timeline(전 심볼 timestamp의 union) + as-of 관측 + 체결 current-bar
+    게이트가 올바르게 동작하는지 회귀.
+    """
+
+    async def test_2098_repro_no_future_exposure(self, store):
+        """#2098 재현: 캘린더가 어긋난 두 심볼에서 어느 step에서도 visible
+        last가 current_ts를 초과하지 않는다.
+
+        005930=[01-01,01-02], 000660=[01-02,01-03]. 기존 버그(공유 row-index)는
+        01-02 step(idx 1)에서 000660의 row 1(=01-03)을 노출해 미래를 봤다.
+        """
+        store.write("005930", "1d", _make_ohlcv_df_on_dates([_d(1), _d(2)], "005930"))
+        store.write("000660", "1d", _make_ohlcv_df_on_dates([_d(2), _d(3)], "000660"))
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        provider.load("000660", "1d")
+
+        # 통합 timeline = {01-01, 01-02, 01-03} 오름차순.
+        assert provider.get_total_steps() == 3
+
+        seen_ts: list[datetime] = []
+        while provider.advance():
+            current_ts = provider.get_current_timestamp()
+            assert current_ts is not None
+            seen_ts.append(current_ts)
+            for symbol in ("005930", "000660"):
+                df = await provider.get_ohlcv(symbol, limit=1)
+                if df.is_empty():
+                    continue
+                last_ts = df["timestamp"][-1]
+                # as-of: visible last가 current_ts보다 미래여서는 안 된다.
+                assert last_ts <= current_ts, (
+                    f"{symbol} visible last {last_ts} > current_ts {current_ts}"
+                )
+
+        # timeline은 정확히 정렬된 union이다.
+        assert seen_ts == [_d(1), _d(2), _d(3)]
+
+    async def test_2098_lagging_symbol_not_started(self, store):
+        """01-01 step에서 000660은 아직 미시작(visible empty)."""
+        store.write("005930", "1d", _make_ohlcv_df_on_dates([_d(1), _d(2)], "005930"))
+        store.write("000660", "1d", _make_ohlcv_df_on_dates([_d(2), _d(3)], "000660"))
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        provider.load("000660", "1d")
+
+        provider.advance()  # idx 0 → current_ts = 01-01
+        assert provider.get_current_timestamp() == _d(1)
+        a = await provider.get_ohlcv("005930", limit=10)
+        b = await provider.get_ohlcv("000660", limit=10)
+        assert len(a) == 1 and a["timestamp"][-1] == _d(1)
+        assert b.is_empty()  # 000660은 01-01엔 미시작
+
+    async def test_1992_repro_lagging_symbol_empty_until_start(self, store):
+        """#1992 재현: 시작이 크게 늦은 심볼은 시작 전 step에서 visible empty.
+
+        AAA001=[01-01,01-02,01-03], BBB001=[01-10,01-11,01-12]. 01-02 step에서
+        BBB visible은 empty여야 하고, 특히 BBB의 첫 봉(01-10)을 미리 노출하지
+        않는다(기존 공유 row-index 버그는 idx 1에서 BBB row 1=01-11을 노출).
+        """
+        store.write(
+            "AAA001", "1d", _make_ohlcv_df_on_dates([_d(1), _d(2), _d(3)], "AAA001")
+        )
+        store.write(
+            "BBB001", "1d", _make_ohlcv_df_on_dates([_d(10), _d(11), _d(12)], "BBB001")
+        )
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("AAA001", "1d")
+        provider.load("BBB001", "1d")
+
+        # union = {01,02,03,10,11,12} 정확 정렬.
+        assert provider.get_total_steps() == 6
+
+        # 2026-01-02 step(idx 1)으로 전진.
+        provider.advance()  # idx 0 → 01-01
+        provider.advance()  # idx 1 → 01-02
+        assert provider.get_current_timestamp() == _d(2)
+
+        bbb = await provider.get_ohlcv("BBB001", limit=100)
+        assert bbb.is_empty()  # BBB는 01-02엔 미시작, 01-10/01-11을 노출하지 않음
+
+        aaa = await provider.get_ohlcv("AAA001", limit=100)
+        assert [t for t in aaa["timestamp"]] == [_d(1), _d(2)]
+
+    async def test_total_steps_equals_distinct_union(self, store):
+        """get_total_steps == 두 심볼 distinct timestamp union 개수."""
+        store.write(
+            "AAA001", "1d", _make_ohlcv_df_on_dates([_d(1), _d(2), _d(3)], "AAA001")
+        )
+        store.write(
+            "BBB001", "1d", _make_ohlcv_df_on_dates([_d(2), _d(3), _d(4)], "BBB001")
+        )
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("AAA001", "1d")
+        provider.load("BBB001", "1d")
+        # union = {01,02,03,04} = 4.
+        assert provider.get_total_steps() == 4
+
+    async def test_get_current_bar_price_exact_match_and_gap(self, store):
+        """get_current_bar_price는 current_ts 정확 일치 봉가, 없으면 None."""
+        store.write(
+            "005930",
+            "1d",
+            _make_ohlcv_df_on_dates([_d(1), _d(3)], "005930", closes=[100.0, 130.0]),
+        )
+        store.write(
+            "000660",
+            "1d",
+            _make_ohlcv_df_on_dates([_d(2), _d(3)], "000660", closes=[200.0, 230.0]),
+        )
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        provider.load("000660", "1d")
+
+        provider.advance()  # idx 0 → 01-01
+        assert provider.get_current_bar_price("005930") == pytest.approx(100.0)
+        # 005930은 01-02에 봉이 없다(gap). 000660은 01-01에 미시작.
+        provider.advance()  # idx 1 → 01-02
+        assert provider.get_current_bar_price("005930") is None  # gap day
+        assert provider.get_current_bar_price("000660") == pytest.approx(200.0)
+        provider.advance()  # idx 2 → 01-03 (둘 다 봉 있음)
+        assert provider.get_current_bar_price("005930") == pytest.approx(130.0)
+        assert provider.get_current_bar_price("000660") == pytest.approx(230.0)
+
+    async def test_get_current_bar_price_pre_advance_none(self, store):
+        """pre-advance(current_idx=-1)에서는 None."""
+        store.write("005930", "1d", _make_ohlcv_df_on_dates([_d(1)], "005930"))
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        assert provider.get_current_bar_price("005930") is None
+
+    async def test_gap_day_buy_signal_not_filled(self, store):
+        """gap day(current_ts에 봉 없음)에 buy 신호 → 미체결(trades에 추가 안 됨)."""
+        # 005930은 01-01, 01-03에만 봉이 있고 01-02는 gap.
+        store.write(
+            "005930",
+            "1d",
+            _make_ohlcv_df_on_dates([_d(1), _d(3)], "005930", closes=[100.0, 130.0]),
+        )
+        # 000660이 01-02 봉을 만들어 timeline에 01-02를 넣는다.
+        store.write(
+            "000660",
+            "1d",
+            _make_ohlcv_df_on_dates([_d(2)], "000660", closes=[200.0]),
+        )
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        provider.load("000660", "1d")
+
+        # step 2(01-02, idx 1)에서 005930 buy 신호. 005930은 그날 봉이 없다.
+        class BuyOnGapStep(Strategy):
+            meta = StrategyMeta(name="buy_on_gap", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 2:  # 01-02 (005930 gap day)
+                    return [Signal(symbol="005930", side="buy", quantity=1)]
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyOnGapStep,
+            data_provider=provider,
+            initial_balance=1_000_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        result = await executor.run()
+
+        # gap day 신호는 미체결: 005930 거래/포지션이 없어야 한다.
+        assert all(t.symbol != "005930" for t in result.trades)
+        assert "005930" not in executor._positions
+
+    async def test_not_started_symbol_buy_skipped_no_crash(self, store):
+        """아직 미시작인 심볼에 buy 신호 → skip, 크래시 없음."""
+        store.write("005930", "1d", _make_ohlcv_df_on_dates([_d(1), _d(2)], "005930"))
+        # BBB는 01-10부터 시작.
+        store.write(
+            "BBB001",
+            "1d",
+            _make_ohlcv_df_on_dates([_d(10), _d(11)], "BBB001"),
+        )
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        provider.load("BBB001", "1d")
+
+        class BuyNotStarted(Strategy):
+            meta = StrategyMeta(name="buy_not_started", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 1:  # 01-01: BBB는 아직 미시작
+                    return [Signal(symbol="BBB001", side="buy", quantity=1)]
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyNotStarted,
+            data_provider=provider,
+            initial_balance=1_000_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        result = await executor.run()  # 크래시 없이 완료
+
+        assert all(t.symbol != "BBB001" for t in result.trades)
+        assert "BBB001" not in executor._positions
+
+    async def test_as_of_equity_preserved_on_gap_day(self, store):
+        """gap day에 보유 심볼 equity가 as-of 최근 봉가로 평가된다.
+
+        005930을 01-01에 매수 후, 005930이 봉이 없는 01-02(gap) step에서
+        005930 mark-to-market이 01-01 종가(as-of)로 유지된다.
+        """
+        store.write(
+            "005930",
+            "1d",
+            _make_ohlcv_df_on_dates([_d(1), _d(3)], "005930", closes=[100.0, 130.0]),
+        )
+        store.write(
+            "000660",
+            "1d",
+            _make_ohlcv_df_on_dates([_d(2)], "000660", closes=[200.0]),
+        )
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        provider.load("000660", "1d")
+
+        # 매 step ctx.get_positions()의 005930 current_price를 기록.
+        seen_price: list[float | None] = []
+
+        class BuyThenHold(Strategy):
+            meta = StrategyMeta(name="buy_then_hold", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._bought = False
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                signals: list[Signal] = []
+                if not self._bought:
+                    self._bought = True
+                    signals = [Signal(symbol="005930", side="buy", quantity=1)]
+                pos = self.ctx.get_positions().get("005930")
+                seen_price.append(pos["current_price"] if pos else None)
+                return signals
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyThenHold,
+            data_provider=provider,
+            initial_balance=1_000_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        await executor.run()
+
+        # step1(01-01): 매수 직전 미보유 → None.
+        assert seen_price[0] is None
+        # step2(01-02, gap): 005930 보유, as-of 최근 봉가 100.0 유지(lookahead 아님).
+        assert seen_price[1] == pytest.approx(100.0)
+        # step3(01-03): 005930 봉 있음 → 130.0.
+        assert seen_price[2] == pytest.approx(130.0)
+
+    async def test_single_symbol_timeline_unchanged(self, store):
+        """단일심볼은 timeline == 자기 timestamps라 동작 불변(회귀 락)."""
+        store.write(
+            "005930", "1d", _make_ohlcv_df_on_dates([_d(1), _d(2), _d(3)], "005930")
+        )
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        assert provider.get_total_steps() == 3
+        provider.advance()  # idx 0
+        df = await provider.get_ohlcv("005930", limit=100)
+        assert len(df) == 1
+        provider.advance()  # idx 1
+        df = await provider.get_ohlcv("005930", limit=100)
+        assert len(df) == 2
+        provider.advance()  # idx 2
+        df = await provider.get_ohlcv("005930", limit=100)
+        assert len(df) == 3
+        assert provider.advance() is False

--- a/tests/unit/test_backtest_exchange_plumbing.py
+++ b/tests/unit/test_backtest_exchange_plumbing.py
@@ -264,6 +264,13 @@ class _FakeDataProvider:
     async def get_current_price(self, symbol: str) -> float:
         return 100.0
 
+    def get_current_bar_price(self, symbol: str) -> float | None:
+        # 체결가 게이트(#2098): 현재 봉이 있으면 체결 가능가를 돌려준다.
+        # 이 fake는 모든 step에 봉이 있다고 보므로 as-of 가격과 동일하게 100.0.
+        if self.get_current_timestamp() is None:
+            return None
+        return 100.0
+
 
 def _make_executor(exchange: str | None) -> BacktestExecutor:
     kwargs = {"exchange": exchange} if exchange is not None else {}


### PR DESCRIPTION
Closes #2098
Closes #1992

## Summary
- BacktestDataProvider를 심볼 공유 row-index → **통합 timestamp 타임라인**(전 심볼 timestamp union·정렬·dedupe)으로 재설계. advance/get_current_timestamp/get_total_steps가 timeline 기반(lazy-build, load/reset 무효화)
- get_ohlcv는 **as-of 관측**(`timestamp <= current_ts`) — row-index 슬라이스 제거, 미래 노출 차단
- **신규** `get_current_bar_price(symbol)`: current_ts에 정확 일치 봉 close, gap day/미시작이면 None. executor `_execute_signal`은 이 값으로만 체결(None→미체결 skip) — stale as-of 가격으로 비거래일 체결 금지
- equity/mark-to-market은 계속 as-of(`get_current_price`). base DataProvider ABC 불변(get_current_bar_price는 BacktestDataProvider 전용)
- #1992(P2)는 동일 근본원인이라 함께 해소

## Test Plan
- 전체 회귀 6226 passed, 2 skipped / mypy src/ante/backtest Success / ruff clean
- 신규 TestMultiSymbolTimeline 10건(#2098+#1992 repro, gap-day 미체결, as-of equity 보존, total_steps union, 단일심볼 회귀 락)

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS (attempt 2)