### PR TITLE
fix(cli): #2108 data validate --fix에 data:write scope 조건부 검증 + data scope 문서 정렬

### DIFF
--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -492,17 +492,34 @@ account-scoped CLI 명령의 invalid `account_id`( `None`/빈 문자열/`default
 
 ### `ante data` — 데이터 관리
 
-모든 data 커맨드는 `@require_auth`와 `@require_scope("data:read")` 데코레이터 적용.
+모든 data 커맨드는 `@require_auth`를 적용해 인증을 요구한다. scope 경계는
+명령의 동작이 read-only인지 mutating인지에 따라 다르다:
+
+- read 전용(`list` / `info` / `schema` / `storage`, 그리고 `--fix` 없는
+  `validate`)은 `@require_scope("data:read")` 만 요구한다.
+- mutating 명령은 write 권한을 추가로 요구한다. `delete` 는
+  `@require_scope("data:write")`. `validate --fix` 는 손상 파일을
+  `.corrupted` 로 격리(rename)하는 mutating 경로이므로, 순수 검증의
+  `@require_scope("data:read")` 데코레이터에 더해 명령 본문에서
+  `enforce_scope(ctx, "data:write")` 로 write 권한을 조건부 검증한다(어떤
+  파일 mutation보다 먼저 발화).
+
+scope vocabulary(`src/ante/member/scopes.py` SSOT)는 flat frozenset으로
+계층이 없다 — `data:write` 가 `data:read` 를 함의하지 않는다. 따라서
+`validate --fix` 는 `data:read` 와 `data:write` 를 **모두** 보유한 토큰만
+실행할 수 있다(검증 read + 격리 write). Human(master/admin) 멤버는 scope
+제한 없이 모든 data 명령을 통과한다.
+
 `--data-path`를 생략하면 Config resolver가 정규화한 `data.path`를 사용한다.
 명시적 `--data-path`는 해당 커맨드의 작업 대상만 바꾸며 인스턴스 경계를 바꾸지 않는다.
 
 ```bash
-ante data list [--data-path <경로>] [--db-path <경로>]            # 보유 데이터셋 목록 (종목명 병기, InstrumentService 연동)
-ante data info <dataset_id> [--data-path <경로>] [--format text|json]  # 데이터셋 상세 조회
-ante data schema [--data-path <경로>]                             # OHLCV 데이터 스키마 조회
-ante data storage [--data-path <경로>]                            # 저장 용량 현황 (MB 단위, timeframe별)
-ante data validate [--symbol <종목>] [--timeframe <주기>] [--fix] [--data-path <경로>]  # Parquet 파일 무결성 검증
-ante data delete <dataset_id> --type ohlcv|fundamental --yes [--data-path <경로>] [--format text|json]  # 데이터셋 삭제 (위험 명령, --yes 필수)
+ante data list [--data-path <경로>] [--db-path <경로>]            # 보유 데이터셋 목록 (종목명 병기, InstrumentService 연동) (scope: data:read)
+ante data info <dataset_id> [--data-path <경로>] [--format text|json]  # 데이터셋 상세 조회 (scope: data:read)
+ante data schema [--data-path <경로>]                             # OHLCV 데이터 스키마 조회 (scope: data:read)
+ante data storage [--data-path <경로>]                            # 저장 용량 현황 (MB 단위, timeframe별) (scope: data:read)
+ante data validate [--symbol <종목>] [--timeframe <주기>] [--fix] [--data-path <경로>]  # Parquet 파일 무결성 검증 (scope: data:read, --fix 시 data:write 추가)
+ante data delete <dataset_id> --type ohlcv|fundamental --yes [--data-path <경로>] [--format text|json]  # 데이터셋 삭제 (위험 명령, --yes 필수) (scope: data:write)
 ```
 
 ### `ante backtest` — 백테스트

--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -7,7 +7,7 @@ import click
 from ante.cli._data_path import resolve_data_path
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
-from ante.cli.middleware import require_auth, require_scope
+from ante.cli.middleware import enforce_scope, require_auth, require_scope
 
 
 @click.group()
@@ -331,6 +331,14 @@ def validate(
             code="DATA_VALIDATE_INVALID_SYMBOL",
         )
         raise SystemExit(1)
+
+    # 조건부 권한 경계: `--fix` 는 손상 파일을 `.corrupted` 로 격리(rename)하는
+    # mutating 경로다. flat scope 모델(`member/scopes.py` SSOT — 계층 없음)에서
+    # `data:write` 는 `data:read` 를 함의하지 않으므로, `@require_scope("data:read")`
+    # 데코레이터에 더해 write 권한을 조건부로 검증한다. 어떤 파일 mutation
+    # (store.validate(..., fix=True) 의 rename)보다 **먼저** 발화해야 한다.
+    if fix:
+        enforce_scope(ctx, "data:write")
 
     store = ParquetStore(base_path=data_path)
 

--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -306,6 +306,19 @@ def validate(
     )
     from ante.data.store import ParquetStore
 
+    # 조건부 권한 경계: `--fix` 는 손상 파일을 `.corrupted` 로 격리(rename)하는
+    # mutating 경로다. flat scope 모델(`member/scopes.py` SSOT — 계층 없음)에서
+    # `data:write` 는 `data:read` 를 함의하지 않으므로, `@require_scope("data:read")`
+    # 데코레이터에 더해 write 권한을 조건부로 검증한다. 어떤 입력검증·경로
+    # resolution·파일 mutation(store.validate(..., fix=True) 의 rename)보다
+    # **먼저** 발화한다. 미인가(read-only) 토큰은 입력 유효성·경로 resolution과
+    # 무관하게 즉시 permission_denied 여야 하므로(정보 노출 순서 정리 + 어떤
+    # side effect보다 우선) 함수 본문 최상단에서 fail-fast 한다. enforce_scope 는
+    # ctx 만 필요하고 _emit_auth_error 는 get_formatter 선행이 불필요하다
+    # (require_scope 데코레이터도 본문 진입 전 발화한다).
+    if fix:
+        enforce_scope(ctx, "data:write")
+
     data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
 
@@ -331,14 +344,6 @@ def validate(
             code="DATA_VALIDATE_INVALID_SYMBOL",
         )
         raise SystemExit(1)
-
-    # 조건부 권한 경계: `--fix` 는 손상 파일을 `.corrupted` 로 격리(rename)하는
-    # mutating 경로다. flat scope 모델(`member/scopes.py` SSOT — 계층 없음)에서
-    # `data:write` 는 `data:read` 를 함의하지 않으므로, `@require_scope("data:read")`
-    # 데코레이터에 더해 write 권한을 조건부로 검증한다. 어떤 파일 mutation
-    # (store.validate(..., fix=True) 의 rename)보다 **먼저** 발화해야 한다.
-    if fix:
-        enforce_scope(ctx, "data:write")
 
     store = ParquetStore(base_path=data_path)
 

--- a/src/ante/cli/middleware.py
+++ b/src/ante/cli/middleware.py
@@ -350,6 +350,55 @@ def require_scope(*scopes: str) -> Callable:
     return decorator
 
 
+def enforce_scope(ctx: click.Context, *scopes: str) -> None:
+    """명령 내부에서 조건부로 scope를 검증한다(imperative).
+
+    ``require_scope`` 데코레이터는 명령 진입 시점에 고정 scope를 강제하지만,
+    일부 명령은 입력 옵션에 따라 mutating 경로로 분기한다(예:
+    ``data validate --fix`` 는 손상 파일을 ``.corrupted`` 로 격리하므로 read
+    검증에 더해 write 권한이 필요하다). 이런 조건부 권한 경계를 데코레이터로
+    표현할 수 없으므로, 명령 본문에서 mutation 직전에 호출하는 imperative
+    헬퍼를 제공한다.
+
+    ``require_scope`` 데코레이터와 동일 규칙을 적용한다:
+
+    - ``ctx.obj["member"]`` 가 ``None`` 이면 ``auth_required`` emit 후
+      ``SystemExit(1)``.
+    - Human(master, admin) 멤버는 scope 제한 없이 통과.
+    - Agent 멤버는 ``scopes`` 를 모두 보유해야 한다. 부족 시
+      ``permission_denied`` 를 부족 scope와 함께 emit 후 ``SystemExit(1)``.
+
+    SCOPE_VOCABULARY 는 flat frozenset(계층 없음)이므로 ``data:write`` 가
+    ``data:read`` 를 함의하지 않는다. 따라서 ``@require_scope("data:read")`` 데코
+    레이터와 본 헬퍼의 ``enforce_scope(ctx, "data:write")`` 호출이 결합되면
+    Agent는 두 scope를 모두 보유한 토큰만 통과한다(검증 read + 격리 write).
+    """
+    from ante.member.models import MemberType
+
+    member: Member | None = ctx.obj.get("member")
+    if member is None:
+        _emit_auth_error(
+            ctx,
+            "auth_required",
+            "인증이 필요합니다. ANTE_MEMBER_TOKEN 환경변수를 설정해 주세요.",
+        )
+        raise SystemExit(1)
+
+    # Human(master, admin)은 scope 무제한 — require_scope 와 동일.
+    if member.type == MemberType.HUMAN:
+        return
+
+    # Agent는 scope 검증 — require_scope 와 동일 규칙/메시지.
+    missing = [s for s in scopes if s not in member.scopes]
+    if missing:
+        _emit_auth_error(
+            ctx,
+            "permission_denied",
+            f"권한이 부족합니다. 필요 권한: {', '.join(missing)}",
+        )
+        raise SystemExit(1)
+
+
 def get_member_id(ctx: click.Context) -> str:
     """인증된 멤버 ID를 반환. 미인증 시 'unknown'."""
     member: Member | None = ctx.obj.get("member")

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -339,6 +339,65 @@ class TestLeafNameCollisionNotExempt:
         assert path == ("member", "reset-password")
 
 
+class TestEnforceScope:
+    """enforce_scope 헬퍼 단위 테스트 (#2108).
+
+    명령 내부에서 조건부로 scope 를 검증하는 imperative 헬퍼다.
+    require_scope 데코레이터와 동일 규칙/메시지를 따른다:
+    - member None → auth_required + SystemExit(1).
+    - Human → 무제한 통과.
+    - Agent missing → permission_denied(부족 scope) + SystemExit(1).
+    - Agent ok → 통과(반환 None).
+    """
+
+    def _ctx_with_member(self, member):  # noqa: ANN001, ANN202
+        ctx = click.Context(cli)
+        ctx.obj = {"member": member}
+        return ctx
+
+    def test_member_none_raises_auth_required(self):
+        """member 가 None 이면 auth_required + SystemExit(1)."""
+        from ante.cli.middleware import enforce_scope
+
+        ctx = self._ctx_with_member(None)
+        with patch("ante.cli.middleware._emit_auth_error") as mock_emit:
+            with pytest.raises(SystemExit) as exc:
+                enforce_scope(ctx, "data:write")
+        assert exc.value.code == 1
+        mock_emit.assert_called_once()
+        assert mock_emit.call_args.args[1] == "auth_required"
+
+    def test_human_bypasses_scope(self):
+        """Human(master) 은 scope 무관 통과 (예외 없음)."""
+        from ante.cli.middleware import enforce_scope
+
+        ctx = self._ctx_with_member(_MOCK_MASTER)
+        # 보유하지 않은 scope 라도 통과해야 한다.
+        assert enforce_scope(ctx, "data:write") is None
+
+    def test_agent_missing_scope_raises_permission_denied(self):
+        """Agent 가 필요 scope 를 보유하지 않으면 permission_denied + SystemExit(1)."""
+        from ante.cli.middleware import enforce_scope
+
+        # _MOCK_AGENT 는 scopes=["strategy:read", "data:read"] — data:write 없음.
+        ctx = self._ctx_with_member(_MOCK_AGENT)
+        with patch("ante.cli.middleware._emit_auth_error") as mock_emit:
+            with pytest.raises(SystemExit) as exc:
+                enforce_scope(ctx, "data:write")
+        assert exc.value.code == 1
+        mock_emit.assert_called_once()
+        assert mock_emit.call_args.args[1] == "permission_denied"
+        assert "data:write" in mock_emit.call_args.args[2]
+
+    def test_agent_with_scope_passes(self):
+        """Agent 가 필요 scope 를 모두 보유하면 통과 (예외 없음)."""
+        from ante.cli.middleware import enforce_scope
+
+        # _MOCK_AGENT 는 data:read 보유 → enforce_scope(ctx, "data:read") 통과.
+        ctx = self._ctx_with_member(_MOCK_AGENT)
+        assert enforce_scope(ctx, "data:read") is None
+
+
 class TestGetMemberId:
     """get_member_id 유틸리티 테스트."""
 

--- a/tests/unit/test_cli_data_validate_fix_scope.py
+++ b/tests/unit/test_cli_data_validate_fix_scope.py
@@ -128,6 +128,71 @@ class TestValidateFixScopeDenied:
         mock_store.assert_not_called()
 
 
+class TestValidateFixScopeFailFast:
+    """권한 체크가 입력검증·경로 resolution 보다 먼저 발화하는지 (fail-fast).
+
+    #2108 Codex 브랜치 리뷰 후속: `enforce_scope` 를 함수 본문 최상단(입력검증·
+    경로 resolution 이전)으로 이동했다. 미인가(read-only) 토큰은 입력 유효성과
+    무관하게 즉시 `permission_denied` 여야 하며, invalid timeframe/symbol 을
+    함께 줘도 `DATA_VALIDATE_INVALID_*` 가 아니라 `permission_denied` 가 먼저
+    나와야 한다(정보 노출 순서 정리 + 어떤 side effect 보다 우선).
+    """
+
+    def test_read_only_agent_fix_invalid_timeframe_denied_first(self):
+        """read-only Agent + --fix + invalid timeframe → permission_denied 우선."""
+        runner = _runner_for(_AGENT_READ_ONLY)
+        with patch("ante.data.store.ParquetStore") as mock_store:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    *_validate_args(
+                        "--symbol",
+                        "005930",
+                        "--timeframe",
+                        "9z",
+                        "--fix",
+                    ),
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        # 권한 거부가 invalid timeframe 검증보다 먼저 발화한다.
+        assert payload["code"] == "permission_denied"
+        assert payload["code"] != "DATA_VALIDATE_INVALID_TIMEFRAME"
+        assert "data:write" in payload["message"]
+        mock_store.assert_not_called()
+
+    def test_read_only_agent_fix_invalid_symbol_denied_first(self):
+        """read-only Agent + --fix + invalid symbol → permission_denied 우선."""
+        runner = _runner_for(_AGENT_READ_ONLY)
+        with patch("ante.data.store.ParquetStore") as mock_store:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    *_validate_args(
+                        "--symbol",
+                        "BAD",
+                        "--timeframe",
+                        "1d",
+                        "--fix",
+                    ),
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        # 권한 거부가 invalid symbol 검증보다 먼저 발화한다.
+        assert payload["code"] == "permission_denied"
+        assert payload["code"] != "DATA_VALIDATE_INVALID_SYMBOL"
+        assert "data:write" in payload["message"]
+        mock_store.assert_not_called()
+
+
 class TestValidateFixScopeAllowed:
     """write 권한 보유/Human 의 `--fix` 통과."""
 

--- a/tests/unit/test_cli_data_validate_fix_scope.py
+++ b/tests/unit/test_cli_data_validate_fix_scope.py
@@ -1,0 +1,225 @@
+"""`ante data validate --fix` 의 data:write scope 조건부 검증 테스트 (#2108).
+
+`data validate` 데코레이터는 `@require_scope("data:read")` 로 순수 검증 권한을
+요구하지만, `--fix` 는 손상 파일을 `.corrupted` 로 격리(rename)하는 mutating
+경로다. flat scope 모델(`src/ante/member/scopes.py` SSOT — 계층 없음)에서
+`data:write` 는 `data:read` 를 함의하지 않으므로, 명령 본문에서
+`enforce_scope(ctx, "data:write")` 로 write 권한을 조건부 검증한다.
+
+검증 행렬:
+- data:read 만 가진 Agent + `--fix` → permission_denied(exit 1, 필요 권한
+  data:write). 실제 파일 mutation(store.validate) 미도달.
+- {data:read, data:write} Agent + `--fix` → 통과(store.validate(..., fix=True)
+  도달).
+- data:read Agent + `--fix` 없는 `validate` → 통과(read 유지, 회귀 없음).
+- Human(master) + `--fix` → scope 무관 통과.
+- write-only(data:write만, data:read 없음) Agent + `--fix` →
+  `@require_scope("data:read")` 데코레이터가 먼저 data:read 부족으로 거부
+  (둘 다 필요 모델 검증).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+_AGENT_READ_ONLY = Member(
+    member_id="agent-read",
+    type=MemberType.AGENT,
+    role=MemberRole.DEFAULT,
+    org="default",
+    name="Read-only Agent",
+    status="active",
+    scopes=["data:read"],
+)
+
+_AGENT_READ_WRITE = Member(
+    member_id="agent-readwrite",
+    type=MemberType.AGENT,
+    role=MemberRole.DEFAULT,
+    org="default",
+    name="Read+Write Agent",
+    status="active",
+    scopes=["data:read", "data:write"],
+)
+
+_AGENT_WRITE_ONLY = Member(
+    member_id="agent-write",
+    type=MemberType.AGENT,
+    role=MemberRole.DEFAULT,
+    org="default",
+    name="Write-only Agent",
+    status="active",
+    scopes=["data:write"],
+)
+
+
+def _runner_for(member: Member) -> CliRunner:
+    """지정 멤버로 인증되는 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_member(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001, ANN202
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = member
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_member
+    return r
+
+
+def _validate_args(*extra: str) -> list[str]:
+    return ["data", "validate", *extra]
+
+
+class TestValidateFixScopeDenied:
+    """data:read 만 가진 Agent 의 `--fix` 거부 + 파일 mutation 미도달."""
+
+    def test_read_only_agent_fix_denied_text(self):
+        """data:read Agent + --fix → permission_denied(exit 1, data:write)."""
+        runner = _runner_for(_AGENT_READ_ONLY)
+        with patch("ante.data.store.ParquetStore") as mock_store:
+            result = runner.invoke(
+                cli, _validate_args("--symbol", "005930", "--timeframe", "1d", "--fix")
+            )
+        assert result.exit_code == 1, result.output
+        assert "권한이 부족합니다" in result.output
+        assert "data:write" in result.output
+        # 권한 거부가 어떤 파일 mutation(ParquetStore 사용)보다 먼저 발화.
+        mock_store.assert_not_called()
+
+    def test_read_only_agent_fix_denied_json(self):
+        """--format json: permission_denied 구조화 envelope."""
+        runner = _runner_for(_AGENT_READ_ONLY)
+        with patch("ante.data.store.ParquetStore") as mock_store:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    *_validate_args("--symbol", "005930", "--timeframe", "1d", "--fix"),
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == "permission_denied"
+        assert "data:write" in payload["message"]
+        mock_store.assert_not_called()
+
+
+class TestValidateFixScopeAllowed:
+    """write 권한 보유/Human 의 `--fix` 통과."""
+
+    def test_read_write_agent_fix_passes(self):
+        """{data:read, data:write} Agent + --fix → store.validate(fix=True) 도달."""
+        runner = _runner_for(_AGENT_READ_WRITE)
+        with patch("ante.data.store.ParquetStore") as mock_store:
+            instance = mock_store.return_value
+            instance.validate.return_value = {
+                "symbol": "005930",
+                "timeframe": "1d",
+                "total": 1,
+                "valid": 1,
+                "corrupted": 0,
+                "corrupted_files": [],
+            }
+            result = runner.invoke(
+                cli, _validate_args("--symbol", "005930", "--timeframe", "1d", "--fix")
+            )
+        assert result.exit_code == 0, result.output
+        assert "권한이 부족합니다" not in result.output
+        instance.validate.assert_called_once_with("005930", "1d", fix=True)
+
+    def test_master_fix_passes_regardless_of_scope(self):
+        """Human(master) + --fix → scope 무관 통과."""
+        runner = _runner_for(_MOCK_MASTER)
+        with patch("ante.data.store.ParquetStore") as mock_store:
+            instance = mock_store.return_value
+            instance.validate.return_value = {
+                "symbol": "005930",
+                "timeframe": "1d",
+                "total": 1,
+                "valid": 1,
+                "corrupted": 0,
+                "corrupted_files": [],
+            }
+            result = runner.invoke(
+                cli, _validate_args("--symbol", "005930", "--timeframe", "1d", "--fix")
+            )
+        assert result.exit_code == 0, result.output
+        assert "권한이 부족합니다" not in result.output
+        instance.validate.assert_called_once_with("005930", "1d", fix=True)
+
+
+class TestValidateReadNoRegression:
+    """`--fix` 없는 read-only 경로 회귀 방지."""
+
+    def test_read_only_agent_validate_without_fix_passes(self):
+        """data:read Agent + (no --fix) → 통과(read 유지). store.validate(fix=False)."""
+        runner = _runner_for(_AGENT_READ_ONLY)
+        with patch("ante.data.store.ParquetStore") as mock_store:
+            instance = mock_store.return_value
+            instance.validate.return_value = {
+                "symbol": "005930",
+                "timeframe": "1d",
+                "total": 1,
+                "valid": 1,
+                "corrupted": 0,
+                "corrupted_files": [],
+            }
+            result = runner.invoke(
+                cli, _validate_args("--symbol", "005930", "--timeframe", "1d")
+            )
+        assert result.exit_code == 0, result.output
+        assert "권한이 부족합니다" not in result.output
+        instance.validate.assert_called_once_with("005930", "1d", fix=False)
+
+
+class TestValidateFixWriteOnlyDeniedByReadDecorator:
+    """write-only Agent 는 `@require_scope("data:read")` 데코레이터가 먼저 거부.
+
+    flat scope 모델에서 `validate --fix` 는 data:read 와 data:write 를 모두
+    요구한다. data:read 가 없으면 본문 `enforce_scope` 에 도달하기 전에
+    데코레이터에서 거부된다.
+    """
+
+    def test_write_only_agent_fix_denied_by_read_decorator(self):
+        """data:write만 가진 Agent + --fix → data:read 부족으로 데코레이터 거부."""
+        runner = _runner_for(_AGENT_WRITE_ONLY)
+        with patch("ante.data.store.ParquetStore") as mock_store:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    *_validate_args("--symbol", "005930", "--timeframe", "1d", "--fix"),
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == "permission_denied"
+        # 데코레이터가 먼저 data:read 부족을 보고한다(enforce_scope 미도달).
+        assert "data:read" in payload["message"]
+        mock_store.assert_not_called()


### PR DESCRIPTION
Closes #2108
Closes #1996
Closes #2154

## Summary
- `ante data validate --fix`는 손상 파일을 `.corrupted`로 rename하는 mutating 경로인데 `@require_scope("data:read")`만 요구 → read-only 토큰이 데이터 파일 변경 가능(P1 권한 경계)
- middleware에 standalone `enforce_scope(ctx, *scopes)` 헬퍼 추가(require_scope 데코레이터·센티널 마커 불변). `validate()` 본문 최상단에서 `fix=True`면 `data:write` 조건부 검증(입력검증·경로 resolution 이전 fail-fast)
- flat scope 모델(SCOPE_VOCABULARY 계층 없음)이라 `--fix`는 {data:read+data:write} 둘 다 필요
- spec doc `docs/specs/cli/03-commands.md` data scope 계약 정렬(read/write 명령 분리, validate --fix=read+write, delete=write) → #2154 동시 해소
- #1996(P2)은 동일 버그라 함께 해소. data:read 명령 중 mutating은 validate --fix 단 하나(audit 완료)

## Test Plan
- 신규 test_cli_data_validate_fix_scope.py(deny/allow/human/no-fix/write-only-거부/fail-fast) + test_cli_auth.py::TestEnforceScope
- pytest cli 96 passed, contracts 145 passed, 광역 회귀 1258 passed / mypy Success / ruff clean / generated cli.md drift 0
- click --fix help 미변경(생성물 영향 없음)

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS (attempt 2)