### PR TITLE
fix(feed): #2055 DataGoKrCollector raw 필드 schema 검증 정정 + 실패 레코드 skip·게이트

### DIFF
--- a/src/ante/data/normalizer.py
+++ b/src/ante/data/normalizer.py
@@ -253,6 +253,21 @@ class DataGoKrNormalizer(BaseNormalizer):
         return df.select(available)
 
 
+# OHLCV 필수 정규화 컬럼 집합 (선택적 amount 제외).
+_OHLCV_REQUIRED_NORMALIZED: frozenset[str] = frozenset(
+    {"timestamp", "symbol", "open", "high", "low", "close", "volume"}
+)
+
+# raw data.go.kr OHLCV 필수 필드 — DataGoKrNormalizer._OHLCV_MAPPING에서
+# 도출한 SSOT. 정규화 후 컬럼명이 OHLCV 필수 집합에 드는 raw 키만 추출하며,
+# 선택적 trPrc(→amount)는 제외된다. _OHLCV_MAPPING 삽입순을 보존한다.
+DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS: tuple[str, ...] = tuple(
+    raw
+    for raw, norm in DataGoKrNormalizer._OHLCV_MAPPING.items()
+    if norm in _OHLCV_REQUIRED_NORMALIZED
+)
+
+
 # ── DART 재무제표 Normalizer ─────────────────────────
 
 # DART 계정과목명 → FUNDAMENTAL_SCHEMA 필드 매핑

--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -51,13 +51,25 @@ class DataGoKrCollector:
 
         # (a) schema 선필터: 필수 raw 필드 누락/null 레코드를 drop & 에러 로그.
         survivors, schema_warns = self._filter_schema_invalid(raw_items, target_date)
-        # (b) survivor 검증: business 경고 수집 + 비-schema 실패 surface.
-        business_warns = self._validate(survivors, target_date)
+        # (b) survivor 검증: business 경고 수집 + passed 게이트 판정.
+        validation_passed, validation_warns = self._validate(survivors, target_date)
 
-        warns = symbol_warns + schema_warns + business_warns
+        warns = symbol_warns + schema_warns + validation_warns
         if not survivors:
             logger.warning(
                 "data.go.kr: date=%s 유효 레코드 없음(전 row drop)", target_date
+            )
+            return 0, set(), warns
+
+        # (c) 검증 게이트: survivor batch가 validate_all에서 passed=False면
+        # (transport status≠200, syntax, 또는 향후 schema 검사) 저장하지 않는다.
+        # spec(09-failure-recovery.md): schema 실패 레코드는 스킵(저장 금지).
+        if not validation_passed:
+            logger.warning(
+                "data.go.kr: date=%s survivor 검증 실패(passed=False)로 저장 차단 "
+                "(survivors=%d)",
+                target_date,
+                len(survivors),
             )
             return 0, set(), warns
 
@@ -148,16 +160,24 @@ class DataGoKrCollector:
     def _validate(
         raw_items: list[dict],
         target_date: str,
-    ) -> list[dict]:
-        """선필터를 통과한 레코드를 검증하고 경고 목록을 반환한다.
+    ) -> tuple[bool, list[dict]]:
+        """선필터를 통과한 레코드를 검증하고 (passed, 경고 목록)을 반환한다.
 
         schema 계층은 선필터(_filter_schema_invalid)에서 이미 통과했으므로
-        여기서는 business 경고를 수집한다. transport/syntax 등 비-schema 실패가
-        나오면 폐기하지 않고 에러 로그 + schema_validation 엔트리로 surface한다.
+        실무상 survivor 검증은 거의 항상 passed=True다. 다만 transport
+        (status≠200)/syntax 또는 향후 schema 검사가 잔여 실패를 surface할 수
+        있으므로 batch 단위 게이트로 전달한다. passed=False면 호출자가 batch
+        저장을 차단한다(spec 09-failure-recovery.md: schema 실패 skip).
+
+        raw_items가 비어있으면 validate_all이 schema 빈-레코드로 passed=True를
+        반환하므로 게이트를 막지 않는다(선필터로 전 row drop된 정상 케이스).
+
+        Returns:
+            (validation.passed, 구조화 경고 목록).
         """
         warns: list[dict] = []
         if not raw_items:
-            return warns
+            return True, warns
 
         validation = validate_all(raw_items, list(DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS))
 
@@ -173,6 +193,7 @@ class DataGoKrCollector:
             )
 
         # 비-schema(transport/syntax 등) 실패는 무시하지 않고 surface한다.
+        # passed=False면 호출자가 batch 저장을 차단한다(저장 금지).
         for err in validation.errors:
             logger.error("data.go.kr: date=%s survivor 검증 실패: %s", target_date, err)
             warns.append(
@@ -183,7 +204,7 @@ class DataGoKrCollector:
                     "message": err,
                 }
             )
-        return warns
+        return validation.passed, warns
 
     @staticmethod
     def _deduplicate(df: pl.DataFrame) -> pl.DataFrame:

--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -8,22 +8,14 @@ from typing import Any
 import polars as pl
 
 from ante.core.market_data_vocab import is_krx_symbol
-from ante.data.normalizer import DataGoKrNormalizer
+from ante.data.normalizer import (
+    DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS,
+    DataGoKrNormalizer,
+)
 from ante.data.store import ParquetStore
 from ante.feed.transform.validate import validate_all
 
 logger = logging.getLogger(__name__)
-
-# OHLCV 필수 검증 필드
-OHLCV_REQUIRED_FIELDS = [
-    "timestamp",
-    "symbol",
-    "open",
-    "high",
-    "low",
-    "close",
-    "volume",
-]
 
 
 class DataGoKrCollector:
@@ -56,14 +48,20 @@ class DataGoKrCollector:
             return 0, set(), []
 
         raw_items, symbol_warns = self._filter_invalid_symbols(raw_items, target_date)
-        warns = symbol_warns + self._validate(raw_items, target_date)
-        if not raw_items:
+
+        # (a) schema 선필터: 필수 raw 필드 누락/null 레코드를 drop & 에러 로그.
+        survivors, schema_warns = self._filter_schema_invalid(raw_items, target_date)
+        # (b) survivor 검증: business 경고 수집 + 비-schema 실패 surface.
+        business_warns = self._validate(survivors, target_date)
+
+        warns = symbol_warns + schema_warns + business_warns
+        if not survivors:
             logger.warning(
-                "data.go.kr: date=%s 유효 KRX 심볼 없음(전 row drop)", target_date
+                "data.go.kr: date=%s 유효 레코드 없음(전 row drop)", target_date
             )
             return 0, set(), warns
 
-        df = pl.DataFrame(raw_items)
+        df = pl.DataFrame(survivors)
         df = self._deduplicate(df)
 
         rows_written, symbols = self._normalize_and_store(
@@ -98,13 +96,72 @@ class DataGoKrCollector:
         return valid, warns
 
     @staticmethod
+    def _filter_schema_invalid(
+        raw_items: list[dict],
+        target_date: str,
+    ) -> tuple[list[dict], list[dict]]:
+        """raw 필수 필드가 누락/null인 레코드를 drop하고 구조화 warning을 반환한다.
+
+        판정 기준은 validate_schema와 동일하다: 필수 필드의 키가 없거나(missing
+        key) 값이 None(null)이면 schema 실패로 간주한다. drop된 레코드는 에러
+        로그를 남기고 type=schema_validation 엔트리로 surface한다(저장 차단).
+        """
+        survivors: list[dict] = []
+        warns: list[dict] = []
+        for item in raw_items:
+            missing = [f for f in DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS if f not in item]
+            null_fields = [
+                f
+                for f in DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS
+                if f in item and item.get(f) is None
+            ]
+            if missing or null_fields:
+                reason = []
+                if missing:
+                    reason.append(f"누락={missing}")
+                if null_fields:
+                    reason.append(f"null={null_fields}")
+                detail = ", ".join(reason)
+                logger.error(
+                    "data.go.kr: date=%s 필수 필드 누락/null로 레코드 skip "
+                    "(srtnCd=%r, %s)",
+                    target_date,
+                    item.get("srtnCd"),
+                    detail,
+                )
+                warns.append(
+                    {
+                        "date": target_date,
+                        "source": "data_go_kr",
+                        "type": "schema_validation",
+                        "message": (
+                            f"필수 필드 누락/null로 레코드 skip: "
+                            f"srtnCd={item.get('srtnCd')!r}, {detail}"
+                        ),
+                    }
+                )
+            else:
+                survivors.append(item)
+        return survivors, warns
+
+    @staticmethod
     def _validate(
         raw_items: list[dict],
         target_date: str,
     ) -> list[dict]:
-        """데이터를 검증하고 경고 목록을 반환한다."""
-        validation = validate_all(raw_items, OHLCV_REQUIRED_FIELDS)
+        """선필터를 통과한 레코드를 검증하고 경고 목록을 반환한다.
+
+        schema 계층은 선필터(_filter_schema_invalid)에서 이미 통과했으므로
+        여기서는 business 경고를 수집한다. transport/syntax 등 비-schema 실패가
+        나오면 폐기하지 않고 에러 로그 + schema_validation 엔트리로 surface한다.
+        """
         warns: list[dict] = []
+        if not raw_items:
+            return warns
+
+        validation = validate_all(raw_items, list(DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS))
+
+        # business 계층 경고 (저장 유지)
         for w in validation.warnings:
             warns.append(
                 {
@@ -112,6 +169,18 @@ class DataGoKrCollector:
                     "source": "data_go_kr",
                     "type": "business_rule",
                     "message": w,
+                }
+            )
+
+        # 비-schema(transport/syntax 등) 실패는 무시하지 않고 surface한다.
+        for err in validation.errors:
+            logger.error("data.go.kr: date=%s survivor 검증 실패: %s", target_date, err)
+            warns.append(
+                {
+                    "date": target_date,
+                    "source": "data_go_kr",
+                    "type": "schema_validation",
+                    "message": err,
                 }
             )
         return warns

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -677,3 +677,137 @@ class TestCollectorSymbolValidation:
         assert len(_invalid_symbol_warns(warns)) == 1
         assert store.list_symbols("1d") == []
         assert store.list_symbols(data_type="fundamental") == []
+
+
+# ── DataGoKrCollector: raw schema 검증 (#2055 / #2008) ─────────
+
+
+def _schema_warns(warns: list[dict]) -> list[dict]:
+    """warns 목록에서 schema_validation 타입만 추출한다."""
+    return [w for w in warns if w.get("type") == "schema_validation"]
+
+
+class TestCollectorSchemaValidation:
+    """DataGoKrCollector가 raw 스키마 실패 레코드를 skip하고 surface한다 (#2055)."""
+
+    @pytest.mark.asyncio
+    async def test_valid_raw_no_false_schema_failure(self, tmp_path) -> None:
+        """정상 raw → 허위 schema 실패 0건, 정규화/저장 정상(rows>0)."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows > 0
+        assert symbols == {"005930"}
+        assert _schema_warns(warns) == []
+        assert store.list_symbols("1d") == ["005930"]
+
+    @pytest.mark.asyncio
+    async def test_missing_required_field_skipped(self, tmp_path) -> None:
+        """raw 필수 필드(mkp) 누락 레코드 → skip + schema_validation warning."""
+        store = ParquetStore(base_path=tmp_path)
+        item = _raw("005930")
+        del item["mkp"]
+        collector = DataGoKrCollector(source=_FakeSource([item]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows == 0
+        assert symbols == set()
+        schema = _schema_warns(warns)
+        assert len(schema) == 1
+        assert "mkp" in schema[0]["message"]
+        assert store.list_symbols("1d") == []
+
+    @pytest.mark.asyncio
+    async def test_null_required_field_skipped(self, tmp_path) -> None:
+        """raw 필수 필드(clpr) null 레코드 → missing과 동일하게 skip."""
+        store = ParquetStore(base_path=tmp_path)
+        item = _raw("005930")
+        item["clpr"] = None
+        collector = DataGoKrCollector(source=_FakeSource([item]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows == 0
+        assert symbols == set()
+        schema = _schema_warns(warns)
+        assert len(schema) == 1
+        assert "clpr" in schema[0]["message"]
+        assert store.list_symbols("1d") == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_valid_and_malformed(self, tmp_path) -> None:
+        """혼합 batch(valid + malformed) → valid만 저장, malformed surface."""
+        store = ParquetStore(base_path=tmp_path)
+        good = _raw("005930")
+        bad_missing = _raw("000660")
+        del bad_missing["hipr"]
+        bad_null = _raw("035720")
+        bad_null["trqu"] = None
+        collector = DataGoKrCollector(source=_FakeSource([good, bad_missing, bad_null]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows > 0
+        assert symbols == {"005930"}
+        assert len(_schema_warns(warns)) == 2
+        assert store.list_symbols("1d") == ["005930"]
+
+    @pytest.mark.asyncio
+    async def test_business_anomaly_record_kept(self, tmp_path) -> None:
+        """business 이상치(lopr>hipr)도 schema는 통과하므로 survivor 저장 유지(회귀).
+
+        business 계층은 비차단(경고)이므로 schema를 통과한 레코드는 값 이상치가
+        있어도 저장된다. raw 키(lopr/hipr)는 business 계층이 보는 정규화 컬럼명
+        (low/high)이 아니어서 collect 단계의 raw warns에는 잡히지 않지만,
+        핵심 회귀 불변은 'schema 통과 → 차단되지 않고 저장'이다.
+        """
+        store = ParquetStore(base_path=tmp_path)
+        # lopr(=200) > hipr(=110): 값 이상치이지만 raw 필수 필드는 모두 존재.
+        item = _raw("005930")
+        item["lopr"] = "200"
+        collector = DataGoKrCollector(source=_FakeSource([item]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows > 0
+        assert symbols == {"005930"}
+        assert _schema_warns(warns) == []
+        assert store.list_symbols("1d") == ["005930"]
+
+    def test_business_layer_warns_on_normalized_keys(self) -> None:
+        """business 계층은 정규화 컬럼명(low/high) 기준으로 warning을 낸다(회귀).
+
+        survivor 검증이 business_rule 채널을 보존하는지 직접 확인한다.
+        """
+        from ante.feed.transform.validate import validate_all
+
+        norm = {
+            "timestamp": "20260102",
+            "symbol": "005930",
+            "open": 100.0,
+            "high": 110.0,
+            "low": 200.0,  # low > high/open/close → business 위반
+            "close": 105.0,
+            "volume": 1000,
+        }
+        result = validate_all(
+            [norm],
+            ["timestamp", "symbol", "open", "high", "low", "close", "volume"],
+        )
+        assert result.passed is True  # business 위반은 차단하지 않음
+        assert result.errors == []
+        assert any("low > " in w for w in result.warnings)
+
+    def test_validate_all_passes_for_valid_raw(self) -> None:
+        """#2055/#2008 repro: 정상 raw가 도출 상수로 schema PASS."""
+        from ante.data.normalizer import DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS
+        from ante.feed.transform.validate import validate_all
+
+        result = validate_all(
+            [_raw("005930")], list(DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS)
+        )
+        assert result.passed is True
+        assert result.errors == []

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -811,3 +811,119 @@ class TestCollectorSchemaValidation:
         )
         assert result.passed is True
         assert result.errors == []
+
+
+# ── DataGoKrCollector: validate_all 실패 게이트 (#2055 Codex FAIL) ──
+
+
+class _RecordingStore:
+    """write() 호출을 기록하는 가짜 store (저장 차단 검증용)."""
+
+    def __init__(self) -> None:
+        self.writes: list[tuple] = []
+
+    def write(self, symbol, timeframe, df, data_type) -> None:
+        self.writes.append((symbol, timeframe, data_type, len(df)))
+
+
+class TestCollectorValidationGate:
+    """survivor batch가 validate_all에서 passed=False면 저장을 차단한다 (#2055).
+
+    선필터(missing/null per-record skip)가 못 잡는 잔여 실패(transport
+    status≠200, syntax, 또는 향후 schema 검사)는 비차단으로 남으면 안 된다.
+    spec(09-failure-recovery.md): schema 실패 레코드는 skip(저장 금지).
+    """
+
+    @pytest.mark.asyncio
+    async def test_validate_all_failure_blocks_store(self, monkeypatch, caplog) -> None:
+        """validate_all이 passed=False → survivor 저장 차단(write 미호출, rows=0).
+
+        warns에 schema_validation 엔트리가 surface되고 logger.error가 남는다.
+        선필터(missing/null)로는 잡히지 않는 정상 raw survivor를 쓰지만,
+        validate_all을 직접 monkeypatch하여 transport/syntax 잔여 실패를 모사한다.
+        """
+        import logging
+
+        from ante.feed.models.result import ValidationResult
+
+        store = _RecordingStore()
+        collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
+
+        def _fake_validate_all(records, required_fields, status_code=200):
+            # transport status≠200 잔여 실패를 모사: passed=False + errors.
+            return ValidationResult(
+                passed=False,
+                warnings=[],
+                errors=["HTTP 상태 코드 오류: 503"],
+            )
+
+        monkeypatch.setattr(
+            "ante.feed.pipeline.data_go_kr_collector.validate_all",
+            _fake_validate_all,
+        )
+
+        with caplog.at_level(logging.ERROR):
+            rows, symbols, warns = await collector.collect("20260102", store)
+
+        # 저장 차단: write 미호출, rows_written=0, symbols 추가 0.
+        assert rows == 0
+        assert symbols == set()
+        assert store.writes == []
+        # schema_validation 엔트리 surface.
+        schema = _schema_warns(warns)
+        assert len(schema) == 1
+        assert "503" in schema[0]["message"]
+        # logger.error 남김.
+        assert any(r.levelno >= logging.ERROR for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_validate_all_failure_does_not_raise(self, monkeypatch) -> None:
+        """passed=False여도 예외 없이 (0, set(), warns)로 정상 반환한다.
+
+        다른 날짜/소스 수집을 막지 않도록 부분 결과를 정상 반환해야 한다.
+        collect() (written, syms, warns) 시그니처는 불변이다.
+        """
+        from ante.feed.models.result import ValidationResult
+
+        store = _RecordingStore()
+        collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
+
+        monkeypatch.setattr(
+            "ante.feed.pipeline.data_go_kr_collector.validate_all",
+            lambda records, required_fields, status_code=200: ValidationResult(
+                passed=False, warnings=[], errors=["JSON 파싱 오류: mock"]
+            ),
+        )
+
+        result = await collector.collect("20260102", store)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        written, syms, warns = result
+        assert written == 0
+        assert syms == set()
+        assert isinstance(warns, list)
+
+    @pytest.mark.asyncio
+    async def test_all_records_prefiltered_empty_survivors(self, tmp_path) -> None:
+        """선필터로 모든 레코드가 drop되어 survivors=[] → 저장 0건, 크래시/에러 없음.
+
+        validate_all([])은 빈-레코드 schema로 passed=True지만, survivors가
+        비어있으면 게이트 이전에 조기 반환하여 0건 저장으로 정상 통과한다.
+        """
+        store = ParquetStore(base_path=tmp_path)
+        # 두 레코드 모두 필수 필드 누락 → 선필터가 전부 drop.
+        bad1 = _raw("005930")
+        del bad1["mkp"]
+        bad2 = _raw("000660")
+        del bad2["clpr"]
+        collector = DataGoKrCollector(source=_FakeSource([bad1, bad2]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows == 0
+        assert symbols == set()
+        # 두 레코드 모두 schema 선필터 skip warning으로 surface.
+        assert len(_schema_warns(warns)) == 2
+        assert store.list_symbols("1d") == []
+        assert store.list_symbols(data_type="fundamental") == []

--- a/tests/unit/test_normalizer_classes.py
+++ b/tests/unit/test_normalizer_classes.py
@@ -4,7 +4,9 @@ import polars as pl
 import pytest
 
 from ante.data.normalizer import (
+    DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS,
     BaseNormalizer,
+    DataGoKrNormalizer,
     DefaultNormalizer,
     KISNormalizer,
     YahooNormalizer,
@@ -198,3 +200,44 @@ def test_no_timestamp_raises():
     df = pl.DataFrame({"open": [50000.0], "close": [50050.0]})
     with pytest.raises(ValueError, match="timestamp"):
         n.normalize(df)
+
+
+# ── DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS (SSOT 도출, #2055) ──
+
+
+def test_datagokr_raw_required_fields_derived_from_mapping():
+    """raw 필수 필드는 _OHLCV_MAPPING에서 도출되며 trPrc(amount)는 제외한다.
+
+    삽입순(basDt, srtnCd, mkp, hipr, lopr, clpr, trqu)을 보존한다.
+    """
+    assert DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS == (
+        "basDt",
+        "srtnCd",
+        "mkp",
+        "hipr",
+        "lopr",
+        "clpr",
+        "trqu",
+    )
+
+
+def test_datagokr_raw_required_excludes_optional_amount():
+    """선택적 trPrc(→amount)는 필수 집합에서 제외된다."""
+    assert "trPrc" not in DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS
+    # _OHLCV_MAPPING에서 trPrc는 amount로 매핑됨을 확인 (SSOT 근거).
+    assert DataGoKrNormalizer._OHLCV_MAPPING["trPrc"] == "amount"
+
+
+def test_datagokr_raw_required_normalized_targets_are_ohlcv_set():
+    """도출된 raw 필드의 정규화 타깃이 OHLCV 필수 집합과 정확히 일치한다."""
+    mapping = DataGoKrNormalizer._OHLCV_MAPPING
+    normalized = {mapping[raw] for raw in DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS}
+    assert normalized == {
+        "timestamp",
+        "symbol",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    }


### PR DESCRIPTION
Closes #2055
Closes #2008

## Summary
- DataGoKrCollector가 **raw data.go.kr 레코드**(basDt/srtnCd/mkp/...)를 **정규화 후 필드명**(timestamp/open/...)으로 검증해 정상 raw도 schema 실패 + `validation.errors` 폐기 → 4계층 schema 검증이 무력했던 버그(P1)
- normalizer.py에 `DATAGOKR_OHLCV_RAW_REQUIRED_FIELDS`를 `_OHLCV_MAPPING`에서 **도출**(정규화값 ∈ OHLCV 필수집합인 raw 키; 선택적 trPrc/amount 제외) — SSOT, drift 차단
- 명시적 4계층 순서: (a) raw 필수필드 missing/null 레코드 선필터 skip(logger.error + warns type=schema_validation, validate_schema와 동일 기준) → (b) survivor validate_all(business 경고 + errors surface) → (c) **저장을 validation.passed로 게이트**(passed=False면 transport/syntax/잔여 schema 실패로 보고 저장 차단)
- collect() 반환 (written,syms,warns) 시그니처 불변 → daily/backfill runner 무변경
- #2008(P2)은 동일 버그라 함께 해소. business 계층의 raw/normalize 시점 불일치는 별도 latent 버그로 후속 #2222 등록

## Test Plan
- feed 165/480 passed, contracts 145 passed / mypy Success / ruff clean
- 신규: 도출 상수 3건, 선필터 skip(missing/null), mixed batch, passed=False 게이트 차단, survivors=[] no-raise, happy path 불변

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS (attempt 2)