### PR TITLE
fix(backtest): #2013 비-1d 성과지표(annual_return/Sharpe)를 일별 리샘플 기준으로

### DIFF
--- a/src/ante/backtest/metrics.py
+++ b/src/ante/backtest/metrics.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import math
 from typing import Any
 
+from ante.backtest.result import resample_equity_curve_daily
+
 
 def calculate_metrics(
     trades: list[Any],
@@ -33,15 +35,25 @@ def calculate_metrics(
     )
     metrics["total_return"] = round(total_return, 4)
 
-    # 연환산 수익률
-    metrics["annual_return"] = round(_annual_return(equity_curve, total_return), 4)
-
     # ── Equity Curve 기반 지표 ────────────────────────
-    equities = [e["equity"] for e in equity_curve] if equity_curve else []
+    # annual_return / Sharpe는 "일(day)" 단위가 전제이므로, 봉 개수가 아닌
+    # 캘린더 날짜 기준으로 한 번 일별 리샘플한 뒤 헬퍼에 전달한다.
+    # (intraday 백테스트에서 bar 개수를 일수로 오인하던 왜곡 수정 — #2013)
+    # threshold=0: 비어있지 않은 모든 curve를 일별로 접는다. 기본 500은 짧은
+    # intraday(<500 bar)를 리샘플하지 않아 버그가 잔존하므로 반드시 0을 사용.
+    daily_curve = resample_equity_curve_daily(equity_curve, threshold=0)
 
-    sharpe = _sharpe_ratio(equities)
+    # 연환산 수익률 (일별 리샘플된 distinct 날짜 수를 일수로 사용)
+    metrics["annual_return"] = round(_annual_return(daily_curve, total_return), 4)
+
+    # Sharpe: 일별 리샘플(날짜당 마지막 equity) 기준 일간 수익률
+    daily_equities = [e["equity"] for e in daily_curve]
+    sharpe = _sharpe_ratio(daily_equities)
     metrics["sharpe_ratio"] = round(sharpe, 4) if sharpe is not None else None
 
+    # max_drawdown은 raw equity(전체 봉) 기준으로 유지한다.
+    # intraday 낙폭(peak-to-trough)은 일별 리샘플로 약화되어선 안 된다.
+    equities = [e["equity"] for e in equity_curve] if equity_curve else []
     mdd, mdd_duration = _max_drawdown(equities)
     metrics["max_drawdown"] = round(mdd, 4)
     metrics["max_drawdown_duration"] = mdd_duration

--- a/tests/unit/test_backtest_metrics.py
+++ b/tests/unit/test_backtest_metrics.py
@@ -14,6 +14,7 @@ from ante.backtest.metrics import (
     _sharpe_ratio,
     calculate_metrics,
 )
+from ante.backtest.result import resample_equity_curve_daily
 
 
 @dataclass(frozen=True)
@@ -252,6 +253,131 @@ class TestAnnualReturn:
         curve = [{"equity": 100 + i} for i in range(252)]
         result = _annual_return(curve, 10.0)
         assert abs(result - 10.0) < 0.5
+
+
+# ── Intraday 일별 리샘플 (#2013) ──────────────────
+#
+# annual_return / Sharpe는 "일(day)" 단위가 전제이므로 calculate_metrics가
+# equity_curve를 한 번 일별 리샘플(threshold=0)한 뒤 헬퍼에 넘긴다.
+# intraday(하루 여러 bar) 백테스트에서 bar 개수를 일수로 오인하던 왜곡을
+# 수정하면서, 1d(날짜당 1봉) 백테스트는 결과가 불변(backward compat)이어야 한다.
+
+
+class TestCalculateMetricsDailyResample:
+    def test_intraday_annual_return_uses_distinct_dates(self):
+        """intraday(5m, 2일치) → annual_return이 bar 수가 아닌 distinct 날짜 수 기준."""
+        # 하루 여러 bar, 2 캘린더 날짜
+        equity_curve = [
+            {"timestamp": "2024-01-01T09:00:00", "equity": 10_000_000},
+            {"timestamp": "2024-01-01T09:05:00", "equity": 10_010_000},
+            {"timestamp": "2024-01-01T15:30:00", "equity": 10_100_000},
+            {"timestamp": "2024-01-02T09:00:00", "equity": 10_120_000},
+            {"timestamp": "2024-01-02T09:05:00", "equity": 10_150_000},
+            {"timestamp": "2024-01-02T15:30:00", "equity": 10_200_000},
+        ]
+        metrics = calculate_metrics(
+            trades=[],
+            equity_curve=equity_curve,
+            initial_balance=10_000_000,
+            final_balance=10_200_000,
+        )
+        # total_return = 2.0% → days=2(distinct 날짜) 기준 연환산.
+        # bar 수(6)가 아니라 날짜 수(2)를 일수로 사용해야 한다.
+        # (1 + 0.02) ** (252/2) - 1) * 100 ≈ 1112.3322
+        assert metrics["annual_return"] == pytest.approx(1112.3322, abs=1e-3)
+        # bar 수(6) 기준이라면 ~129.7244 → 그 값이 아님을 확인.
+        assert metrics["annual_return"] != pytest.approx(129.7244, abs=1e-3)
+
+    def test_intraday_sharpe_uses_daily_returns(self):
+        """intraday(3일치) → Sharpe가 bar-간이 아닌 일간 수익률 기준."""
+        # 하루 여러 bar, 3 캘린더 날짜 (일별 마지막: 10.1M, 10.2M, 10.3M)
+        equity_curve = [
+            {"timestamp": "2024-01-01T09:00:00", "equity": 10_000_000},
+            {"timestamp": "2024-01-01T15:30:00", "equity": 10_100_000},
+            {"timestamp": "2024-01-02T09:00:00", "equity": 10_050_000},
+            {"timestamp": "2024-01-02T15:30:00", "equity": 10_200_000},
+            {"timestamp": "2024-01-03T09:00:00", "equity": 10_180_000},
+            {"timestamp": "2024-01-03T15:30:00", "equity": 10_300_000},
+        ]
+        metrics = calculate_metrics(
+            trades=[],
+            equity_curve=equity_curve,
+            initial_balance=10_000_000,
+            final_balance=10_300_000,
+        )
+        # 일별 종가 [10.1M, 10.2M, 10.3M] 기준 일간 수익률로 계산.
+        daily_equities = [10_100_000, 10_200_000, 10_300_000]
+        expected = _sharpe_ratio(daily_equities)
+        assert metrics["sharpe_ratio"] == pytest.approx(round(expected, 4))
+        # bar-간 수익률(6포인트) 기준이라면 ~10.7058 → 그 값이 아님.
+        assert metrics["sharpe_ratio"] != pytest.approx(10.7058, abs=1e-3)
+
+    def test_one_day_backward_compat(self):
+        """1d(날짜당 1봉) → annual_return/sharpe가 리샘플 전과 동일(회귀 락)."""
+        equity_curve = [
+            {"timestamp": "2024-01-01", "equity": 10_000_000},
+            {"timestamp": "2024-01-02", "equity": 10_050_000},
+            {"timestamp": "2024-01-03", "equity": 10_030_000},
+            {"timestamp": "2024-01-04", "equity": 10_200_000},
+        ]
+        total_return = (10_200_000 - 10_000_000) / 10_000_000 * 100
+
+        metrics = calculate_metrics(
+            trades=[],
+            equity_curve=equity_curve,
+            initial_balance=10_000_000,
+            final_balance=10_200_000,
+        )
+        # 날짜당 1봉이므로 리샘플 결과 == 원본 → 헬퍼 직접 호출과 동일해야 함.
+        expected_annual = round(_annual_return(equity_curve, total_return), 4)
+        expected_sharpe = _sharpe_ratio([e["equity"] for e in equity_curve])
+        assert metrics["annual_return"] == expected_annual
+        assert metrics["sharpe_ratio"] == pytest.approx(round(expected_sharpe, 4))
+
+    def test_single_date_intraday_sharpe_none(self):
+        """단일 날짜 intraday → daily 1포인트 → sharpe None(크래시 없음)."""
+        equity_curve = [
+            {"timestamp": "2024-01-01T09:00:00", "equity": 10_000_000},
+            {"timestamp": "2024-01-01T09:05:00", "equity": 10_010_000},
+            {"timestamp": "2024-01-01T15:30:00", "equity": 10_100_000},
+        ]
+        metrics = calculate_metrics(
+            trades=[],
+            equity_curve=equity_curve,
+            initial_balance=10_000_000,
+            final_balance=10_100_000,
+        )
+        assert metrics["sharpe_ratio"] is None
+
+    def test_same_date_points_fold_to_last(self):
+        """같은 날짜의 여러 포인트가 마지막 값으로 접힌다(chronological fold)."""
+        curve = [
+            {"timestamp": "2024-01-01T09:00", "equity": 100},
+            {"timestamp": "2024-01-01T15:00", "equity": 200},
+            {"timestamp": "2024-01-02T09:00", "equity": 300},
+            {"timestamp": "2024-01-02T15:00", "equity": 400},
+        ]
+        daily = resample_equity_curve_daily(curve, threshold=0)
+        # 날짜별 마지막 포인트만, 시간순 유지
+        assert [p["equity"] for p in daily] == [200, 400]
+
+    def test_max_drawdown_uses_raw_bars(self):
+        """max_drawdown은 raw 봉 기준 — intraday 낙폭이 일별 리샘플로 약화되지 않음."""
+        # intraday 10% 낙폭 후 종가에서 회복 → 일별 리샘플하면 MDD=0이 되어버림.
+        equity_curve = [
+            {"timestamp": "2024-01-01T09:00:00", "equity": 10_000_000},
+            {"timestamp": "2024-01-01T12:00:00", "equity": 9_000_000},
+            {"timestamp": "2024-01-01T15:30:00", "equity": 10_050_000},
+            {"timestamp": "2024-01-02T15:30:00", "equity": 10_100_000},
+        ]
+        metrics = calculate_metrics(
+            trades=[],
+            equity_curve=equity_curve,
+            initial_balance=10_000_000,
+            final_balance=10_100_000,
+        )
+        # raw 봉 peak=10.0M, trough=9.0M → MDD=10% (일별 리샘플이면 0%가 됨)
+        assert metrics["max_drawdown"] == pytest.approx(10.0)
 
 
 # ── Trade PnL Estimation ──────────────────────


### PR DESCRIPTION
Closes #2013

## Summary
- intraday(1m/5m/15m/1h) 백테스트에서 `annual_return`/`Sharpe`가 equity_curve **bar 개수**를 일수로 사용해 왜곡되던 버그
- `calculate_metrics`에서 `resample_equity_curve_daily(equity_curve, threshold=0)`(result.py SSOT)로 **항상 일별 리샘플** 후: annual_return의 days=distinct 캘린더 날짜, Sharpe는 일별 종가 수익률 기준
- `_annual_return`/`_sharpe_ratio` 시그니처·본문 불변(기존 단위테스트 보존). **max_drawdown은 raw 봉 유지**(intraday 낙폭 보존)
- 1d 백테스트는 날짜당 1봉이라 리샘플 no-op → 기존 결과 불변(backward compat)

## Test Plan
- test_backtest_metrics 29 passed, -k backtest/metrics 365 passed, contracts 145 / mypy Success / ruff clean
- 신규 TestCalculateMetricsDailyResample 6건: intraday annual(distinct dates)·sharpe(daily), 1d 회귀 락, 단일날짜 None, same-date fold, MDD raw 보존

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS