### PR TITLE
fix(strategy): #2040 StrategyValidator/Loader validate↔load 계약 패리티 (async hook/meta 타입/실제 Strategy 상속/loader 파일정의)

### DIFF
--- a/src/ante/strategy/loader.py
+++ b/src/ante/strategy/loader.py
@@ -41,12 +41,17 @@ class StrategyLoader:
         except Exception as e:
             raise StrategyLoadError(f"Failed to execute module {filepath}: {e}") from e
 
+        # #2052: 현재 파일에서 정의된 subclass만 카운트한다.
+        # `obj.__module__ == module.__name__` 조건으로 import 된 Strategy
+        # subclass(다른 모듈 origin)를 제외하여, validator(AST 파일-scope 정의
+        # Strategy subclass 1개)와 동일한 집합을 세도록 패리티를 맞춘다(#2040).
         strategy_classes = [
             obj
             for obj in vars(module).values()
             if isinstance(obj, type)
             and issubclass(obj, Strategy)
             and obj is not Strategy
+            and obj.__module__ == module.__name__
         ]
 
         if len(strategy_classes) == 0:

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -44,6 +44,17 @@ class ValidationResult:
 class StrategyValidator:
     """AST 기반 전략 파일 정적 검증."""
 
+    # #2040 — base.py에서 `async def`이고 런타임이 await하는 hook 집합.
+    # on_step=abstract async 필수, 나머지=async default(override 시 await됨).
+    # on_start/on_stop은 sync 계약이라 의도적으로 제외.
+    ASYNC_HOOKS: set[str] = {
+        "on_step",
+        "on_fill",
+        "on_data",
+        "on_order_update",
+        "on_position_corrected",
+    }
+
     FORBIDDEN_MODULES: set[str] = {
         "os",
         "sys",
@@ -114,10 +125,18 @@ class StrategyValidator:
         # 3. 필수 요소 검사
         if len(strategy_classes) == 1:
             cls = strategy_classes[0]
+            # #2041: meta 부재 → error. 존재하지만 StrategyMeta(...) 호출이
+            # 아니면(dict/None/다른 호출 등) 타입 불일치 error.
             if not self._has_class_var(cls, "meta"):
                 errors.append("Missing 'meta' class variable (StrategyMeta)")
+            elif not self._meta_is_strategy_meta_call(cls):
+                errors.append("'meta' must be a StrategyMeta(...) instance")
             if not self._has_method(cls, "on_step"):
                 errors.append("Missing required method: on_step()")
+
+            # #2040: 런타임이 await하는 hook이 sync `def`면 await 시 TypeError.
+            # 정의된(클래스 body) async hook이 sync면 error.
+            errors.extend(self._async_hook_violations(cls))
 
             # accepts_external_signals=True인 전략에 on_data() 구현 여부 경고
             if self._has_accepts_external_signals(cls) and not self._has_method(
@@ -160,17 +179,99 @@ class StrategyValidator:
             warnings=warnings,
         )
 
+    # ante.strategy / ante.strategy.base 에서 Strategy 를 export 하는 모듈 경로.
+    _STRATEGY_MODULES: set[str] = {"ante.strategy", "ante.strategy.base"}
+
     def _find_strategy_classes(self, tree: ast.Module) -> list[ast.ClassDef]:
-        """Strategy를 상속하는 클래스 노드 탐색."""
+        """실제 ante ``Strategy`` 를 상속하는 클래스 노드 탐색 (#2042).
+
+        import alias 를 추적하여 ante.strategy(또는 .base)에서 import 된
+        ``Strategy`` 의 로컬 바인딩명, 그리고 모듈 별칭(`astg.Strategy`,
+        `ante.strategy.Strategy`)만 ante Strategy 로 인정한다. 파일 내부에
+        동일 이름의 로컬 ``class`` 정의(shadow)가 있으면 그 base 로 상속한
+        클래스는 ante Strategy 로 보지 않는다.
+
+        Known-limitation (의도된 비대칭): transitive/intermediate-base
+        (다른 파일에서 Strategy 를 상속한 중간 베이스)·다단계 재export·
+        동적 import 는 정적 인식하지 않는다. loader 의 런타임 ``issubclass``
+        가 최종 권위다(현재 validator 와 동일, 회귀 아님).
+        """
+        strategy_names, module_aliases = self._collect_strategy_bindings(tree)
+        local_class_names = {
+            node.name for node in tree.body if isinstance(node, ast.ClassDef)
+        }
+
         result: list[ast.ClassDef] = []
         for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    if isinstance(base, ast.Name) and base.id == "Strategy":
-                        result.append(node)
-                    elif isinstance(base, ast.Attribute) and base.attr == "Strategy":
-                        result.append(node)
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for base in node.bases:
+                if self._base_is_strategy(
+                    base, strategy_names, module_aliases, local_class_names
+                ):
+                    result.append(node)
+                    break
         return result
+
+    def _collect_strategy_bindings(self, tree: ast.Module) -> tuple[set[str], set[str]]:
+        """import 스캔으로 Strategy 로컬 바인딩명·모듈 별칭 집합 수집 (#2042).
+
+        Returns:
+            ``(strategy_names, module_aliases)``
+            - strategy_names: ante.strategy/.base 에서 import 된 ``Strategy``
+              의 로컬 바인딩명. ``from ante.strategy import Strategy`` →
+              {"Strategy"}, ``... import Strategy as S`` → {"S"}.
+            - module_aliases: ante.strategy(및 .base) 모듈 별칭.
+              ``import ante.strategy`` → {"ante.strategy"},
+              ``import ante.strategy as astg`` → {"astg"}.
+        """
+        strategy_names: set[str] = set()
+        module_aliases: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module in self._STRATEGY_MODULES and node.level == 0:
+                    for alias in node.names:
+                        if alias.name == "Strategy":
+                            strategy_names.add(alias.asname or alias.name)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in self._STRATEGY_MODULES:
+                        module_aliases.add(alias.asname or alias.name)
+        return strategy_names, module_aliases
+
+    def _base_is_strategy(
+        self,
+        base: ast.expr,
+        strategy_names: set[str],
+        module_aliases: set[str],
+        local_class_names: set[str],
+    ) -> bool:
+        """base 표현식이 실제 ante Strategy 를 가리키는지 판정 (#2042)."""
+        # `class X(Strategy)` / `class X(S)` — import 된 바인딩명이고
+        # 파일 내부 로컬 클래스로 shadow 되지 않은 경우만.
+        if isinstance(base, ast.Name):
+            return base.id in strategy_names and base.id not in local_class_names
+        # `class X(astg.Strategy)` / `class X(ante.strategy.Strategy)` —
+        # value 가 module_aliases 로 해석되는 경우만.
+        if isinstance(base, ast.Attribute) and base.attr == "Strategy":
+            return self._attr_value_to_str(base.value) in module_aliases
+        return False
+
+    @staticmethod
+    def _attr_value_to_str(node: ast.expr) -> str | None:
+        """`ante.strategy` / `astg` 등 dotted name 표현식을 문자열로 평탄화.
+
+        Attribute/Name 만 dotted name 으로 해석하고, 그 외(Call 등)는 None.
+        """
+        parts: list[str] = []
+        cur: ast.expr = node
+        while isinstance(cur, ast.Attribute):
+            parts.append(cur.attr)
+            cur = cur.value
+        if not isinstance(cur, ast.Name):
+            return None
+        parts.append(cur.id)
+        return ".".join(reversed(parts))
 
     def _has_class_var(self, cls: ast.ClassDef, name: str) -> bool:
         """클래스 변수 할당 존재 여부."""
@@ -190,6 +291,62 @@ class StrategyValidator:
             if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
                 if node.name == name:
                     return True
+        return False
+
+    def _method_is_async(self, cls: ast.ClassDef, name: str) -> bool | None:
+        """클래스 body 에 정의된 메서드의 async 여부 (#2040).
+
+        Returns:
+            정의돼 있고 ``async def`` → True,
+            정의돼 있고 sync ``def`` → False,
+            클래스에 정의되지 않음 → None.
+        마지막 정의를 기준으로 한다(중복 정의 시 런타임 바인딩과 동일).
+        """
+        result: bool | None = None
+        for node in cls.body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                if node.name == name:
+                    result = isinstance(node, ast.AsyncFunctionDef)
+        return result
+
+    def _async_hook_violations(self, cls: ast.ClassDef) -> list[str]:
+        """런타임 await hook 이 sync ``def`` 로 정의된 위반 목록 (#2040).
+
+        ``ASYNC_HOOKS`` 중 클래스에 정의된 hook 이 sync 면 await 시 TypeError
+        가 나므로 error. 정의되지 않은 hook(base default 상속)은 검사하지
+        않는다(on_step 부재는 별도 "Missing required method" 검사가 담당).
+        """
+        errors: list[str] = []
+        for hook in sorted(self.ASYNC_HOOKS):
+            is_async = self._method_is_async(cls, hook)
+            if is_async is False:
+                errors.append(f"{hook}() must be async (use 'async def')")
+        return errors
+
+    def _meta_is_strategy_meta_call(self, cls: ast.ClassDef) -> bool:
+        """``meta`` 할당 값이 ``StrategyMeta(...)`` 호출인지 검사 (#2041).
+
+        클래스 body 의 ``meta`` Assign/AnnAssign value 가 ``ast.Call`` 이고
+        func 가 ``Name(id="StrategyMeta")`` 또는 ``Attribute(attr="StrategyMeta")``
+        여야 True. dict/None/다른 호출 등은 False. ``meta`` 가 아예 없으면
+        (별도 부재 검사가 담당) True 를 반환하지 않도록 호출부에서 존재
+        확인 후 사용한다.
+        """
+        for node in cls.body:
+            if not isinstance(node, ast.Assign | ast.AnnAssign):
+                continue
+            target = node.targets[0] if isinstance(node, ast.Assign) else node.target
+            if not isinstance(target, ast.Name) or target.id != "meta":
+                continue
+            value = node.value
+            if not isinstance(value, ast.Call):
+                return False
+            func = value.func
+            if isinstance(func, ast.Name) and func.id == "StrategyMeta":
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == "StrategyMeta":
+                return True
+            return False
         return False
 
     @staticmethod

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -41,6 +41,26 @@ class ValidationResult:
     warnings: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class _StrategyClassMatch:
+    """ante ``Strategy`` 상속으로 인정된 module-level 클래스 + 정의 시점 바인딩 스냅샷.
+
+    ``_find_strategy_classes`` 가 후보 strategy 클래스를 찾을 때, 그 **클래스 정의
+    시점**의 ``StrategyMeta`` 바인딩(``strategymeta_binding``)과 module-alias
+    (``module_aliases``) 스냅샷을 함께 담는다. ``meta`` 가 ``StrategyMeta(...)``
+    인지 검사(``_meta_is_strategy_meta_call``)는 이 스냅샷을 import 바인딩 컨텍스트로
+    사용해 #2042(Strategy)와 동일한 order-aware import-resolution 으로 해석한다.
+    """
+
+    node: ast.ClassDef
+    strategymeta_binding: dict[str, str]
+    module_aliases: frozenset[str]
+
+    @property
+    def name(self) -> str:
+        return self.node.name
+
+
 class StrategyValidator:
     """AST 기반 전략 파일 정적 검증."""
 
@@ -124,12 +144,16 @@ class StrategyValidator:
 
         # 3. 필수 요소 검사
         if len(strategy_classes) == 1:
-            cls = strategy_classes[0]
+            match = strategy_classes[0]
+            cls = match.node
             # #2041: meta 부재 → error. 존재하지만 StrategyMeta(...) 호출이
-            # 아니면(dict/None/다른 호출 등) 타입 불일치 error.
+            # 아니면(dict/None/다른 호출 등) 타입 불일치 error. StrategyMeta 호출
+            # 여부는 클래스 정의 시점 import 바인딩 스냅샷으로 해석한다(#2042 일관).
             if not self._has_class_var(cls, "meta"):
                 errors.append("Missing 'meta' class variable (StrategyMeta)")
-            elif not self._meta_is_strategy_meta_call(cls):
+            elif not self._meta_is_strategy_meta_call(
+                cls, match.strategymeta_binding, match.module_aliases
+            ):
                 errors.append("'meta' must be a StrategyMeta(...) instance")
             if not self._has_method(cls, "on_step"):
                 errors.append("Missing required method: on_step()")
@@ -151,7 +175,7 @@ class StrategyValidator:
         if len(strategy_classes) == 1:
             module_consts = self._module_string_constants(tree)
             exchange_value = self._extract_meta_exchange(
-                strategy_classes[0], module_consts
+                strategy_classes[0].node, module_consts
             )
             if exchange_value is not None and exchange_value not in VALID_EXCHANGES:
                 errors.append(
@@ -179,19 +203,33 @@ class StrategyValidator:
             warnings=warnings,
         )
 
-    # ante.strategy / ante.strategy.base 에서 Strategy 를 export 하는 모듈 경로.
+    # ante.strategy / ante.strategy.base 에서 Strategy·StrategyMeta 를 export 하는
+    # 모듈 경로(둘은 동일 모듈에서 함께 export 된다 → module-alias 공용).
     _STRATEGY_MODULES: set[str] = {"ante.strategy", "ante.strategy.base"}
 
-    def _find_strategy_classes(self, tree: ast.Module) -> list[ast.ClassDef]:
-        """실제 ante ``Strategy`` 를 상속하는 module-level 클래스 노드 탐색 (#2042).
+    def _find_strategy_classes(self, tree: ast.Module) -> list[_StrategyClassMatch]:
+        """실제 ante ``Strategy`` 를 상속하는 module-level 클래스 + 바인딩 스냅샷 탐색.
+
+        (#2042 Strategy import-resolution + #2041 StrategyMeta 일관화)
 
         **`tree.body`(module-scope)를 정의 순서대로 위에서 아래로 한 번** 순회하며
-        이름별 "현재 바인딩"을 추적한다(`name_binding: dict[str, str]`,
-        값 ∈ {``"ante_strategy"``, ``"local_class"``, ``"other"``})와 모듈 별칭
+        이름별 "현재 바인딩"을 추적한다 — Strategy 바인딩(`name_binding:
+        dict[str, str]`, 값 ∈ {``"ante_strategy"``, ``"local_class"``, ``"other"``}),
+        StrategyMeta 바인딩(`strategymeta_binding: dict[str, str]`, 값 ∈
+        {``"ante_strategy_meta"``}; 재바인딩 시 키 제거), 그리고 두 심볼이 같은
+        모듈(`ante.strategy`/`.base`)에서 export 되므로 **공용** 모듈 별칭
         (`module_aliases: set[str]`). 각 ``ClassDef`` 를 만나면 **먼저** 그 시점의
-        바인딩으로 base 를 해석해 ante ``Strategy`` 상속 여부를 판정하고, **그
-        다음** 그 클래스 이름을 ``local_class`` 로 갱신한다(이후 등장 클래스에만
-        shadow 적용).
+        바인딩으로 base 를 해석해 ante ``Strategy`` 상속 여부를 판정하고(인정 시
+        그 시점의 ``strategymeta_binding``·``module_aliases`` 스냅샷을 함께 캡처해
+        ``_StrategyClassMatch`` 로 반환), **그 다음** 그 클래스 이름을
+        ``local_class`` 로 갱신한다(이후 등장 클래스에만 shadow 적용).
+
+        StrategyMeta 바인딩 스냅샷은 ``_meta_is_strategy_meta_call`` 이 ``meta =
+        StrategyMeta(...)`` / ``meta = astg.StrategyMeta(...)`` 호출을 **클래스 정의
+        시점 import 바인딩**으로 해석하는 데 쓰인다(#2042 Strategy 와 동일 order-
+        aware). 이로써 ``import fake; meta = fake.StrategyMeta(...)`` 같이 ante 가
+        아닌 임의 ``*.StrategyMeta`` 호출을 거부하고(false-positive 차단), submit 의
+        ``isinstance(meta, StrategyMeta)`` 런타임 검사와 정합시킨다.
 
         Python 은 이름을 **실행 시점(정의 순서)** 에 바인딩하므로, 클래스 정의
         시점의 바인딩으로 base 를 해석해야 런타임/loader 의미와 정합한다. 예:
@@ -209,34 +247,39 @@ class StrategyValidator:
         적용하면(false positive) loader 와 불일치하므로, module-scope 로 한정해
         정합시킨다.
 
-        재바인딩 무효화(`name_binding` ↔ `module_aliases` 대칭, #2042 4차):
-        ``name_binding`` 뿐 아니라 ``module_aliases`` 도 정의 순서대로 재바인딩
-        되면 무효화한다. 즉 ``import ante.strategy as astg; astg = other; class
-        X(astg.Strategy)`` 는 X 정의 시점에 ``astg`` 가 이미 다른 값으로
-        재바인딩됐으므로 미인정한다(loader 도 비카운트). 반대로 ``import
-        ante.strategy as astg; class X(astg.Strategy); astg = other`` 는 X 가
-        재바인딩 **이전**이라 인정한다. ``import ante.strategy``(dotted alias)는
-        root 이름(``ante``)이 재바인딩되면 무효화한다. 재바인딩 노드는
-        ``Assign``/value 있는 ``AnnAssign``/``ClassDef``/``Import``/``ImportFrom``
-        /``del`` 이다.
+        재바인딩 무효화(`name_binding`·`strategymeta_binding` ↔ `module_aliases`
+        대칭, #2042 4차 + #2041 5차): Strategy 바인딩(`name_binding`)·StrategyMeta
+        바인딩(`strategymeta_binding`)·module-alias(`module_aliases`) 모두 정의
+        순서대로 재바인딩되면 동일 규칙으로 무효화한다. 즉 ``import ante.strategy
+        as astg; astg = other; class X(astg.Strategy)`` 는 X 정의 시점에 ``astg``
+        가 이미 다른 값으로 재바인딩됐으므로 미인정한다(loader 도 비카운트).
+        반대로 ``import ante.strategy as astg; class X(astg.Strategy); astg =
+        other`` 는 X 가 재바인딩 **이전**이라 인정한다. ``import
+        ante.strategy``(dotted alias)는 root 이름(``ante``)이 재바인딩되면
+        무효화한다. 재바인딩 노드는 ``Assign``/value 있는 ``AnnAssign``/``ClassDef``
+        /``Import``/``ImportFrom``/``del`` 이다. StrategyMeta Name 바인딩도 동일하게
+        재바인딩되면 ``strategymeta_binding`` 에서 제거된다.
 
-        정적 name-resolution 모델 (bounded, #2042 known-limitation):
-        다음을 정확히 모델링한다 — 직접/asname import (``from ante.strategy
-        import Strategy [as S]``), ``import ante.strategy [as x]`` module-alias,
-        module-level 정의 순서 기반 local-class shadow, 그리고 Name·module-alias
-        의 재바인딩(``Assign``/``AnnAssign``/``ClassDef``/``del``/재import) 무효화.
-        그 밖의 병리적 케이스 — 조건부 import, ``from ante.strategy import *``
-        star-import, 간접 alias 체인(``x = ante.strategy; x.Strategy``), 동적
-        import 등 — 는 정적으로 모델링하지 않는다(known-limitation). validate 는
-        정적 best-effort pre-check 이며, 실제 Strategy 상속의 **authoritative
-        gate 는 loader 의 런타임 ``issubclass(obj, Strategy)``** 다. 이 비대칭은
-        의도적으로 수용한다(추가 round chase 차단). star-import 는 보수적으로
-        Strategy 를 명시 바인딩하지 않아 미인정(loader 보다 약하나 흔치 않은
-        known-limitation 범위).
+        정적 name-resolution 모델 (bounded, #2042+#2041 known-limitation):
+        Strategy·StrategyMeta **모두** 다음을 정확히 모델링한다 — 직접/asname
+        import (``from ante.strategy import Strategy [as S]`` / ``import
+        StrategyMeta [as M]``), ``import ante.strategy [as x]`` module-alias
+        attribute (``x.Strategy`` / ``x.StrategyMeta``), module-level 정의 순서
+        기반 local-class shadow, 그리고 Name·module-alias 의 재바인딩(``Assign``/
+        ``AnnAssign``/``ClassDef``/``del``/재import) 무효화. 그 밖의 병리적 케이스
+        — 조건부 import, ``from ante.strategy import *`` star-import, 간접 alias
+        체인(``x = ante.strategy; x.Strategy``), 동적 import 등 — 는 정적으로
+        모델링하지 않는다(known-limitation). validate 는 정적 best-effort
+        pre-check 이며, 실제 타입 검증의 **authoritative gate 는 loader 의 load
+        후 런타임 ``issubclass(obj, Strategy)`` + submit 의 ``isinstance(meta,
+        StrategyMeta)``** 다. 이 비대칭은 의도적으로 수용한다(추가 round chase
+        차단). star-import 는 보수적으로 Strategy/StrategyMeta 를 명시 바인딩하지
+        않아 미인정(loader 보다 약하나 흔치 않은 known-limitation 범위).
         """
         name_binding: dict[str, str] = {}
+        strategymeta_binding: dict[str, str] = {}
         module_aliases: set[str] = set()
-        result: list[ast.ClassDef] = []
+        result: list[_StrategyClassMatch] = []
 
         def _discard_module_aliases(name: str) -> None:
             """이름 재바인딩 시 그 이름이 가리키던 module-alias 를 제거.
@@ -250,9 +293,15 @@ class StrategyValidator:
                 module_aliases.discard(stale)
 
         def _invalidate(name: str) -> None:
-            """이름 재바인딩 시 ante 바인딩/module-alias 둘 다 무효화 (대칭)."""
-            # Name 바인딩: 이전이 무엇이든 ante 도 local 도 아닌 "other" 로.
+            """이름 재바인딩 시 ante Strategy/StrategyMeta 바인딩·module-alias 무효화.
+
+            Strategy(`name_binding`)·StrategyMeta(`strategymeta_binding`)·
+            module-alias(`module_aliases`) 를 대칭으로 함께 무효화한다.
+            """
+            # Strategy Name 바인딩: 이전이 무엇이든 ante 도 local 도 아닌 "other" 로.
             name_binding[name] = "other"
+            # StrategyMeta Name 바인딩: 재바인딩 시 키 제거(미바인딩으로 환원).
+            strategymeta_binding.pop(name, None)
             _discard_module_aliases(name)
 
         for node in tree.body:  # module-level 정의 순서 단일 패스 (loader 정합)
@@ -260,12 +309,15 @@ class StrategyValidator:
                 # 1) 재import 도 재바인딩 → 기존 ante 바인딩/alias 먼저 무효화.
                 for alias in node.names:
                     _invalidate(alias.asname or alias.name)
-                # 2) ante.strategy/.base 에서 module-scope import 된 ``Strategy``
-                #    (asname 포함)의 바인딩명을 ante_strategy 로 (재)기록.
+                # 2) ante.strategy/.base 에서 module-scope import 된 ``Strategy``/
+                #    ``StrategyMeta``(asname 포함)의 바인딩명을 (재)기록.
                 if node.module in self._STRATEGY_MODULES and node.level == 0:
                     for alias in node.names:
+                        bound = alias.asname or alias.name
                         if alias.name == "Strategy":
-                            name_binding[alias.asname or alias.name] = "ante_strategy"
+                            name_binding[bound] = "ante_strategy"
+                        elif alias.name == "StrategyMeta":
+                            strategymeta_binding[bound] = "ante_strategy_meta"
             elif isinstance(node, ast.Import):
                 # ante.strategy(및 .base) 모듈 별칭을 Attribute 경로 해석용으로 기록.
                 # ``import ante.strategy`` → "ante.strategy",
@@ -279,13 +331,23 @@ class StrategyValidator:
                         module_aliases.add(bound)
             elif isinstance(node, ast.ClassDef):
                 # 1) 현재 바인딩으로 base 해석 → Strategy subclass 여부 판정.
+                #    인정 시 그 시점의 StrategyMeta 바인딩·module-alias 스냅샷을
+                #    함께 캡처(meta 검사를 클래스 정의 시점 import 로 해석, #2042 일관).
                 for base in node.bases:
                     if self._base_is_strategy(base, name_binding, module_aliases):
-                        result.append(node)
+                        result.append(
+                            _StrategyClassMatch(
+                                node=node,
+                                strategymeta_binding=dict(strategymeta_binding),
+                                module_aliases=frozenset(module_aliases),
+                            )
+                        )
                         break
                 # 2) 그다음 이 클래스 이름을 로컬 클래스로 재바인딩(이후 shadow).
-                #    클래스 정의는 그 이름의 module-alias 도 무효화한다(대칭).
+                #    클래스 정의는 그 이름의 module-alias·StrategyMeta 바인딩도
+                #    무효화한다(대칭).
                 _discard_module_aliases(node.name)
+                strategymeta_binding.pop(node.name, None)
                 name_binding[node.name] = "local_class"
             elif isinstance(node, ast.Assign):
                 # 이름 재바인딩은 보수적으로 "other"(ante 도 local 도 아님) +
@@ -411,14 +473,36 @@ class StrategyValidator:
                 errors.append(f"{hook}() must be async (use 'async def')")
         return errors
 
-    def _meta_is_strategy_meta_call(self, cls: ast.ClassDef) -> bool:
-        """``meta`` 의 마지막 값-할당이 ``StrategyMeta(...)`` 호출인지 검사 (#2041).
+    def _meta_is_strategy_meta_call(
+        self,
+        cls: ast.ClassDef,
+        strategymeta_binding: dict[str, str],
+        module_aliases: frozenset[str],
+    ) -> bool:
+        """``meta`` 의 마지막 값-할당이 **ante** ``StrategyMeta(...)`` 호출인지 검사.
+
+        (#2041 last-assign + #2042 일관 import-resolution)
 
         클래스 body 를 순서대로 순회하여 ``meta`` 를 타깃으로 하는 **마지막**
         값-할당 노드를 선택한다(런타임은 마지막 할당값을 클래스 속성으로
-        쓰므로 그와 일치). 그 value 가 ``ast.Call`` 이고 func 가
-        ``Name(id="StrategyMeta")`` 또는 ``Attribute(attr="StrategyMeta")`` 여야
-        True. dict/None/다른 호출 등은 False.
+        쓰므로 그와 일치). 그 value 가 ``ast.Call`` 이고 그 func 가 **클래스 정의
+        시점 import 바인딩**으로 ante ``StrategyMeta`` 로 해석될 때만 True:
+
+        - func 가 ``ast.Name(id)`` → ``id`` 가 ``strategymeta_binding`` 에서
+          ``"ante_strategy_meta"`` 로 바인딩(``from ante.strategy import
+          StrategyMeta [as M]``)됐을 때만 통과.
+        - func 가 ``ast.Attribute(attr="StrategyMeta")`` → value 의 dotted-name
+          이 ``module_aliases``(``import ante.strategy [as astg]`` 별칭)일 때만
+          통과(예: ``astg.StrategyMeta`` / ``ante.strategy.StrategyMeta`` /
+          ``ante.strategy.base.StrategyMeta``).
+        - 그 외(``fake.StrategyMeta(...)`` 등 ante 가 아닌 임의 ``*.StrategyMeta``,
+          미바인딩 Name ``StrategyMeta(...)``, ``dict(...)``, ``None``) → False.
+
+        ``strategymeta_binding``·``module_aliases`` 는 ``_find_strategy_classes``
+        가 이 클래스 정의 시점에 캡처한 스냅샷이다(#2042 Strategy 와 동일 order-
+        aware). 이로써 ``import fake; meta = fake.StrategyMeta(...)`` 같은
+        false-positive 를 거부하고 submit 의 ``isinstance(meta, StrategyMeta)``
+        런타임 검사와 정합시킨다.
 
         값-할당 판정:
         - ``ast.Assign``: targets 에 ``Name(id="meta")`` 가 포함되면 value 가
@@ -453,10 +537,14 @@ class StrategyValidator:
         if not isinstance(last_value, ast.Call):
             return False
         func = last_value.func
-        if isinstance(func, ast.Name) and func.id == "StrategyMeta":
-            return True
+        # `meta = StrategyMeta(...)` / `meta = M(...)` — Name 이 클래스 정의
+        # 시점에 ante StrategyMeta 로 바인딩됐을 때만 통과.
+        if isinstance(func, ast.Name):
+            return strategymeta_binding.get(func.id) == "ante_strategy_meta"
+        # `meta = astg.StrategyMeta(...)` / `meta = ante.strategy.StrategyMeta(...)`
+        # — value 가 ante.strategy module-alias 로 해석되는 경우만 통과.
         if isinstance(func, ast.Attribute) and func.attr == "StrategyMeta":
-            return True
+            return self._attr_value_to_str(func.value) in module_aliases
         return False
 
     @staticmethod

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -183,13 +183,21 @@ class StrategyValidator:
     _STRATEGY_MODULES: set[str] = {"ante.strategy", "ante.strategy.base"}
 
     def _find_strategy_classes(self, tree: ast.Module) -> list[ast.ClassDef]:
-        """실제 ante ``Strategy`` 를 상속하는 클래스 노드 탐색 (#2042).
+        """실제 ante ``Strategy`` 를 상속하는 module-level 클래스 노드 탐색 (#2042).
 
-        import alias 를 추적하여 ante.strategy(또는 .base)에서 import 된
-        ``Strategy`` 의 로컬 바인딩명, 그리고 모듈 별칭(`astg.Strategy`,
-        `ante.strategy.Strategy`)만 ante Strategy 로 인정한다. 파일 내부에
-        동일 이름의 로컬 ``class`` 정의(shadow)가 있으면 그 base 로 상속한
-        클래스는 ante Strategy 로 보지 않는다.
+        import alias 를 추적하여 ante.strategy(또는 .base)에서 **module-scope**
+        로 import 된 ``Strategy`` 의 로컬 바인딩명, 그리고 모듈 별칭
+        (`astg.Strategy`, `ante.strategy.Strategy`)만 ante Strategy 로 인정한다.
+        파일 module-scope 에 동일 이름의 로컬 ``class`` 정의(shadow)가 있으면
+        그 base 로 상속한 클래스는 ante Strategy 로 보지 않는다.
+
+        탐지·바인딩 수집·shadow 판정 모두 **module-scope(`tree.body`)** 로
+        한정한다. loader 는 import·실행 후 module 네임스페이스(`vars(module)`)
+        에서 Strategy subclass 를 찾으므로, 함수/클래스 내부에 중첩된 import·
+        class 정의는 module attribute 가 아니라 loader 가 보지 못한다. validator
+        가 `ast.walk` 로 트리 전체를 보면 함수-로컬 `from ante.strategy import
+        Strategy` 같은 바인딩을 module-scope 클래스에 잘못 적용해(false
+        positive) loader 와 불일치하므로, module-scope 로 한정해 정합시킨다.
 
         Known-limitation (의도된 비대칭): transitive/intermediate-base
         (다른 파일에서 Strategy 를 상속한 중간 베이스)·다단계 재export·
@@ -202,7 +210,7 @@ class StrategyValidator:
         }
 
         result: list[ast.ClassDef] = []
-        for node in ast.walk(tree):
+        for node in tree.body:  # module-level ClassDef 만 (loader 정합)
             if not isinstance(node, ast.ClassDef):
                 continue
             for base in node.bases:
@@ -214,20 +222,28 @@ class StrategyValidator:
         return result
 
     def _collect_strategy_bindings(self, tree: ast.Module) -> tuple[set[str], set[str]]:
-        """import 스캔으로 Strategy 로컬 바인딩명·모듈 별칭 집합 수집 (#2042).
+        """module-scope import 스캔으로 Strategy 바인딩명·모듈 별칭 수집 (#2042).
+
+        **`tree.body`(모듈 최상위)만** 순회한다. 함수/클래스 내부의 중첩
+        import 는 런타임 module 네임스페이스(loader 의 `vars(module)`)에 바인딩
+        되지 않으므로 module-scope 클래스 base 해석에 쓰면 false positive 가
+        된다(함수-로컬 `from ante.strategy import Strategy` 가 있어도 module
+        네임스페이스에는 Strategy 가 없어 `class X(Strategy)` 는 런타임에
+        NameError). 따라서 module-level `Import`/`ImportFrom` 만 Strategy
+        바인딩으로 인정해 loader 와 정합시킨다.
 
         Returns:
             ``(strategy_names, module_aliases)``
-            - strategy_names: ante.strategy/.base 에서 import 된 ``Strategy``
-              의 로컬 바인딩명. ``from ante.strategy import Strategy`` →
-              {"Strategy"}, ``... import Strategy as S`` → {"S"}.
+            - strategy_names: ante.strategy/.base 에서 module-scope import 된
+              ``Strategy`` 의 로컬 바인딩명. ``from ante.strategy import
+              Strategy`` → {"Strategy"}, ``... import Strategy as S`` → {"S"}.
             - module_aliases: ante.strategy(및 .base) 모듈 별칭.
               ``import ante.strategy`` → {"ante.strategy"},
               ``import ante.strategy as astg`` → {"astg"}.
         """
         strategy_names: set[str] = set()
         module_aliases: set[str] = set()
-        for node in ast.walk(tree):
+        for node in tree.body:  # module-level import 만 (loader 네임스페이스 정합)
             if isinstance(node, ast.ImportFrom):
                 if node.module in self._STRATEGY_MODULES and node.level == 0:
                     for alias in node.names:

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -185,88 +185,86 @@ class StrategyValidator:
     def _find_strategy_classes(self, tree: ast.Module) -> list[ast.ClassDef]:
         """실제 ante ``Strategy`` 를 상속하는 module-level 클래스 노드 탐색 (#2042).
 
-        import alias 를 추적하여 ante.strategy(또는 .base)에서 **module-scope**
-        로 import 된 ``Strategy`` 의 로컬 바인딩명, 그리고 모듈 별칭
-        (`astg.Strategy`, `ante.strategy.Strategy`)만 ante Strategy 로 인정한다.
-        파일 module-scope 에 동일 이름의 로컬 ``class`` 정의(shadow)가 있으면
-        그 base 로 상속한 클래스는 ante Strategy 로 보지 않는다.
+        **`tree.body`(module-scope)를 정의 순서대로 위에서 아래로 한 번** 순회하며
+        이름별 "현재 바인딩"을 추적한다(`name_binding: dict[str, str]`,
+        값 ∈ {``"ante_strategy"``, ``"local_class"``, ``"other"``})와 모듈 별칭
+        (`module_aliases: set[str]`). 각 ``ClassDef`` 를 만나면 **먼저** 그 시점의
+        바인딩으로 base 를 해석해 ante ``Strategy`` 상속 여부를 판정하고, **그
+        다음** 그 클래스 이름을 ``local_class`` 로 갱신한다(이후 등장 클래스에만
+        shadow 적용).
 
-        탐지·바인딩 수집·shadow 판정 모두 **module-scope(`tree.body`)** 로
+        Python 은 이름을 **실행 시점(정의 순서)** 에 바인딩하므로, 클래스 정의
+        시점의 바인딩으로 base 를 해석해야 런타임/loader 의미와 정합한다. 예:
+        ``import Strategy as S; class X(S); class S`` 는 X 정의 시점에 S 가 import
+        된 ante ``Strategy`` 이므로 X 를 인정하고(loader 도 X 카운트), 그 뒤에 온
+        ``class S`` 만 로컬로 재바인딩한다. 반대로 ``import Strategy; class
+        Strategy; class X(Strategy)`` 는 X 정의 시점에 Strategy 가 이미 로컬
+        클래스로 재바인딩된 뒤이므로 미인정한다(loader 도 비카운트).
+
+        탐지·바인딩 추적·shadow 판정 모두 **module-scope(`tree.body`)** 로
         한정한다. loader 는 import·실행 후 module 네임스페이스(`vars(module)`)
         에서 Strategy subclass 를 찾으므로, 함수/클래스 내부에 중첩된 import·
-        class 정의는 module attribute 가 아니라 loader 가 보지 못한다. validator
-        가 `ast.walk` 로 트리 전체를 보면 함수-로컬 `from ante.strategy import
-        Strategy` 같은 바인딩을 module-scope 클래스에 잘못 적용해(false
-        positive) loader 와 불일치하므로, module-scope 로 한정해 정합시킨다.
+        class 정의는 module attribute 가 아니라 loader 가 보지 못한다. 함수-로컬
+        `from ante.strategy import Strategy` 같은 바인딩을 module-scope 클래스에
+        적용하면(false positive) loader 와 불일치하므로, module-scope 로 한정해
+        정합시킨다.
 
         Known-limitation (의도된 비대칭): transitive/intermediate-base
         (다른 파일에서 Strategy 를 상속한 중간 베이스)·다단계 재export·
         동적 import 는 정적 인식하지 않는다. loader 의 런타임 ``issubclass``
         가 최종 권위다(현재 validator 와 동일, 회귀 아님).
         """
-        strategy_names, module_aliases = self._collect_strategy_bindings(tree)
-        local_class_names = {
-            node.name for node in tree.body if isinstance(node, ast.ClassDef)
-        }
-
-        result: list[ast.ClassDef] = []
-        for node in tree.body:  # module-level ClassDef 만 (loader 정합)
-            if not isinstance(node, ast.ClassDef):
-                continue
-            for base in node.bases:
-                if self._base_is_strategy(
-                    base, strategy_names, module_aliases, local_class_names
-                ):
-                    result.append(node)
-                    break
-        return result
-
-    def _collect_strategy_bindings(self, tree: ast.Module) -> tuple[set[str], set[str]]:
-        """module-scope import 스캔으로 Strategy 바인딩명·모듈 별칭 수집 (#2042).
-
-        **`tree.body`(모듈 최상위)만** 순회한다. 함수/클래스 내부의 중첩
-        import 는 런타임 module 네임스페이스(loader 의 `vars(module)`)에 바인딩
-        되지 않으므로 module-scope 클래스 base 해석에 쓰면 false positive 가
-        된다(함수-로컬 `from ante.strategy import Strategy` 가 있어도 module
-        네임스페이스에는 Strategy 가 없어 `class X(Strategy)` 는 런타임에
-        NameError). 따라서 module-level `Import`/`ImportFrom` 만 Strategy
-        바인딩으로 인정해 loader 와 정합시킨다.
-
-        Returns:
-            ``(strategy_names, module_aliases)``
-            - strategy_names: ante.strategy/.base 에서 module-scope import 된
-              ``Strategy`` 의 로컬 바인딩명. ``from ante.strategy import
-              Strategy`` → {"Strategy"}, ``... import Strategy as S`` → {"S"}.
-            - module_aliases: ante.strategy(및 .base) 모듈 별칭.
-              ``import ante.strategy`` → {"ante.strategy"},
-              ``import ante.strategy as astg`` → {"astg"}.
-        """
-        strategy_names: set[str] = set()
+        name_binding: dict[str, str] = {}
         module_aliases: set[str] = set()
-        for node in tree.body:  # module-level import 만 (loader 네임스페이스 정합)
+        result: list[ast.ClassDef] = []
+
+        for node in tree.body:  # module-level 정의 순서 단일 패스 (loader 정합)
             if isinstance(node, ast.ImportFrom):
+                # ante.strategy/.base 에서 module-scope import 된 ``Strategy``
+                # (asname 포함)의 바인딩명을 ante_strategy 로 기록.
                 if node.module in self._STRATEGY_MODULES and node.level == 0:
                     for alias in node.names:
                         if alias.name == "Strategy":
-                            strategy_names.add(alias.asname or alias.name)
+                            name_binding[alias.asname or alias.name] = "ante_strategy"
             elif isinstance(node, ast.Import):
+                # ante.strategy(및 .base) 모듈 별칭을 Attribute 경로 해석용으로 기록.
+                # ``import ante.strategy`` → "ante.strategy",
+                # ``import ante.strategy as astg`` → "astg".
                 for alias in node.names:
                     if alias.name in self._STRATEGY_MODULES:
                         module_aliases.add(alias.asname or alias.name)
-        return strategy_names, module_aliases
+            elif isinstance(node, ast.ClassDef):
+                # 1) 현재 바인딩으로 base 해석 → Strategy subclass 여부 판정.
+                for base in node.bases:
+                    if self._base_is_strategy(base, name_binding, module_aliases):
+                        result.append(node)
+                        break
+                # 2) 그다음 이 클래스 이름을 로컬 클래스로 재바인딩(이후 shadow).
+                name_binding[node.name] = "local_class"
+            elif isinstance(node, ast.Assign):
+                # 이름 재바인딩은 보수적으로 "other"(ante 도 local 도 아님).
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        name_binding[target.id] = "other"
+            elif isinstance(node, ast.AnnAssign):
+                if node.value is not None and isinstance(node.target, ast.Name):
+                    name_binding[node.target.id] = "other"
+        return result
 
     def _base_is_strategy(
         self,
         base: ast.expr,
-        strategy_names: set[str],
+        name_binding: dict[str, str],
         module_aliases: set[str],
-        local_class_names: set[str],
     ) -> bool:
-        """base 표현식이 실제 ante Strategy 를 가리키는지 판정 (#2042)."""
-        # `class X(Strategy)` / `class X(S)` — import 된 바인딩명이고
-        # 파일 내부 로컬 클래스로 shadow 되지 않은 경우만.
+        """base 표현식이 (정의 시점 바인딩 기준) 실제 ante Strategy 인지 판정 (#2042).
+
+        ``name_binding`` 은 클래스 정의 시점까지의 module-level 바인딩 상태다.
+        """
+        # `class X(Strategy)` / `class X(S)` — 정의 시점에 그 이름이 ante
+        # Strategy 로 바인딩돼 있을 때만 인정. local_class/other/미바인딩이면 미인정.
         if isinstance(base, ast.Name):
-            return base.id in strategy_names and base.id not in local_class_names
+            return name_binding.get(base.id) == "ante_strategy"
         # `class X(astg.Strategy)` / `class X(ante.strategy.Strategy)` —
         # value 가 module_aliases 로 해석되는 경우만.
         if isinstance(base, ast.Attribute) and base.attr == "Strategy":

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -324,29 +324,51 @@ class StrategyValidator:
         return errors
 
     def _meta_is_strategy_meta_call(self, cls: ast.ClassDef) -> bool:
-        """``meta`` 할당 값이 ``StrategyMeta(...)`` 호출인지 검사 (#2041).
+        """``meta`` 의 마지막 값-할당이 ``StrategyMeta(...)`` 호출인지 검사 (#2041).
 
-        클래스 body 의 ``meta`` Assign/AnnAssign value 가 ``ast.Call`` 이고
-        func 가 ``Name(id="StrategyMeta")`` 또는 ``Attribute(attr="StrategyMeta")``
-        여야 True. dict/None/다른 호출 등은 False. ``meta`` 가 아예 없으면
-        (별도 부재 검사가 담당) True 를 반환하지 않도록 호출부에서 존재
-        확인 후 사용한다.
+        클래스 body 를 순서대로 순회하여 ``meta`` 를 타깃으로 하는 **마지막**
+        값-할당 노드를 선택한다(런타임은 마지막 할당값을 클래스 속성으로
+        쓰므로 그와 일치). 그 value 가 ``ast.Call`` 이고 func 가
+        ``Name(id="StrategyMeta")`` 또는 ``Attribute(attr="StrategyMeta")`` 여야
+        True. dict/None/다른 호출 등은 False.
+
+        값-할당 판정:
+        - ``ast.Assign``: targets 에 ``Name(id="meta")`` 가 포함되면 value 가
+          ``meta`` 의 런타임 속성값이 된다.
+        - ``ast.AnnAssign``: target 이 ``Name(id="meta")`` 이고 **value 가 not
+          None** 일 때만 값-할당. annotation-only(``meta: StrategyMeta``)는
+          런타임에 클래스 속성을 만들지 않으므로 값-할당으로 치지 않는다.
+
+        ``meta`` 값-할당이 하나도 없으면(annotation-only 만 있거나 부재) False.
+        부재 자체는 별도 ``_has_class_var`` 검사가 담당하고, annotation-only 는
+        StrategyMeta 인스턴스 값이 없으므로 must-be-StrategyMeta error 로 귀결돼
+        두 검사가 모순되지 않는다(부재 → Missing, 존재하나 마지막 값이
+        StrategyMeta 호출 아님 → must-be-StrategyMeta).
         """
+        last_value: ast.expr | None = None
         for node in cls.body:
-            if not isinstance(node, ast.Assign | ast.AnnAssign):
-                continue
-            target = node.targets[0] if isinstance(node, ast.Assign) else node.target
-            if not isinstance(target, ast.Name) or target.id != "meta":
-                continue
-            value = node.value
-            if not isinstance(value, ast.Call):
-                return False
-            func = value.func
-            if isinstance(func, ast.Name) and func.id == "StrategyMeta":
-                return True
-            if isinstance(func, ast.Attribute) and func.attr == "StrategyMeta":
-                return True
+            if isinstance(node, ast.Assign):
+                if any(
+                    isinstance(t, ast.Name) and t.id == "meta" for t in node.targets
+                ):
+                    last_value = node.value
+            elif isinstance(node, ast.AnnAssign):
+                target = node.target
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == "meta"
+                    and node.value is not None
+                ):
+                    last_value = node.value
+        if last_value is None:
             return False
+        if not isinstance(last_value, ast.Call):
+            return False
+        func = last_value.func
+        if isinstance(func, ast.Name) and func.id == "StrategyMeta":
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == "StrategyMeta":
+            return True
         return False
 
     @staticmethod

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -209,19 +209,59 @@ class StrategyValidator:
         적용하면(false positive) loader 와 불일치하므로, module-scope 로 한정해
         정합시킨다.
 
-        Known-limitation (의도된 비대칭): transitive/intermediate-base
-        (다른 파일에서 Strategy 를 상속한 중간 베이스)·다단계 재export·
-        동적 import 는 정적 인식하지 않는다. loader 의 런타임 ``issubclass``
-        가 최종 권위다(현재 validator 와 동일, 회귀 아님).
+        재바인딩 무효화(`name_binding` ↔ `module_aliases` 대칭, #2042 4차):
+        ``name_binding`` 뿐 아니라 ``module_aliases`` 도 정의 순서대로 재바인딩
+        되면 무효화한다. 즉 ``import ante.strategy as astg; astg = other; class
+        X(astg.Strategy)`` 는 X 정의 시점에 ``astg`` 가 이미 다른 값으로
+        재바인딩됐으므로 미인정한다(loader 도 비카운트). 반대로 ``import
+        ante.strategy as astg; class X(astg.Strategy); astg = other`` 는 X 가
+        재바인딩 **이전**이라 인정한다. ``import ante.strategy``(dotted alias)는
+        root 이름(``ante``)이 재바인딩되면 무효화한다. 재바인딩 노드는
+        ``Assign``/value 있는 ``AnnAssign``/``ClassDef``/``Import``/``ImportFrom``
+        /``del`` 이다.
+
+        정적 name-resolution 모델 (bounded, #2042 known-limitation):
+        다음을 정확히 모델링한다 — 직접/asname import (``from ante.strategy
+        import Strategy [as S]``), ``import ante.strategy [as x]`` module-alias,
+        module-level 정의 순서 기반 local-class shadow, 그리고 Name·module-alias
+        의 재바인딩(``Assign``/``AnnAssign``/``ClassDef``/``del``/재import) 무효화.
+        그 밖의 병리적 케이스 — 조건부 import, ``from ante.strategy import *``
+        star-import, 간접 alias 체인(``x = ante.strategy; x.Strategy``), 동적
+        import 등 — 는 정적으로 모델링하지 않는다(known-limitation). validate 는
+        정적 best-effort pre-check 이며, 실제 Strategy 상속의 **authoritative
+        gate 는 loader 의 런타임 ``issubclass(obj, Strategy)``** 다. 이 비대칭은
+        의도적으로 수용한다(추가 round chase 차단). star-import 는 보수적으로
+        Strategy 를 명시 바인딩하지 않아 미인정(loader 보다 약하나 흔치 않은
+        known-limitation 범위).
         """
         name_binding: dict[str, str] = {}
         module_aliases: set[str] = set()
         result: list[ast.ClassDef] = []
 
+        def _discard_module_aliases(name: str) -> None:
+            """이름 재바인딩 시 그 이름이 가리키던 module-alias 를 제거.
+
+            직접 별칭(``astg``)이거나, dotted alias(``ante.strategy``)의 root
+            이름(``ante``)이 재바인딩되면 해당 alias 들을 module_aliases 에서
+            제거한다.
+            """
+            module_aliases.discard(name)
+            for stale in {a for a in module_aliases if a.split(".", 1)[0] == name}:
+                module_aliases.discard(stale)
+
+        def _invalidate(name: str) -> None:
+            """이름 재바인딩 시 ante 바인딩/module-alias 둘 다 무효화 (대칭)."""
+            # Name 바인딩: 이전이 무엇이든 ante 도 local 도 아닌 "other" 로.
+            name_binding[name] = "other"
+            _discard_module_aliases(name)
+
         for node in tree.body:  # module-level 정의 순서 단일 패스 (loader 정합)
             if isinstance(node, ast.ImportFrom):
-                # ante.strategy/.base 에서 module-scope import 된 ``Strategy``
-                # (asname 포함)의 바인딩명을 ante_strategy 로 기록.
+                # 1) 재import 도 재바인딩 → 기존 ante 바인딩/alias 먼저 무효화.
+                for alias in node.names:
+                    _invalidate(alias.asname or alias.name)
+                # 2) ante.strategy/.base 에서 module-scope import 된 ``Strategy``
+                #    (asname 포함)의 바인딩명을 ante_strategy 로 (재)기록.
                 if node.module in self._STRATEGY_MODULES and node.level == 0:
                     for alias in node.names:
                         if alias.name == "Strategy":
@@ -231,8 +271,12 @@ class StrategyValidator:
                 # ``import ante.strategy`` → "ante.strategy",
                 # ``import ante.strategy as astg`` → "astg".
                 for alias in node.names:
+                    # 재import 도 재바인딩 → 바인딩명을 먼저 무효화한 뒤
+                    # 해당 import 가 ante module 이면 alias 로 (재)등록.
+                    bound = alias.asname or alias.name
+                    _invalidate(bound)
                     if alias.name in self._STRATEGY_MODULES:
-                        module_aliases.add(alias.asname or alias.name)
+                        module_aliases.add(bound)
             elif isinstance(node, ast.ClassDef):
                 # 1) 현재 바인딩으로 base 해석 → Strategy subclass 여부 판정.
                 for base in node.bases:
@@ -240,16 +284,46 @@ class StrategyValidator:
                         result.append(node)
                         break
                 # 2) 그다음 이 클래스 이름을 로컬 클래스로 재바인딩(이후 shadow).
+                #    클래스 정의는 그 이름의 module-alias 도 무효화한다(대칭).
+                _discard_module_aliases(node.name)
                 name_binding[node.name] = "local_class"
             elif isinstance(node, ast.Assign):
-                # 이름 재바인딩은 보수적으로 "other"(ante 도 local 도 아님).
+                # 이름 재바인딩은 보수적으로 "other"(ante 도 local 도 아님) +
+                # module-alias 무효화(대칭).
+                for target in node.targets:
+                    for name in self._assign_target_names(target):
+                        _invalidate(name)
+            elif isinstance(node, ast.AnnAssign):
+                # value 가 있는 AnnAssign 만 실제 바인딩 → 무효화.
+                if node.value is not None and isinstance(node.target, ast.Name):
+                    _invalidate(node.target.id)
+            elif isinstance(node, ast.Delete):
+                # `del astg` / `del Strategy` 도 바인딩 제거 → 무효화.
                 for target in node.targets:
                     if isinstance(target, ast.Name):
-                        name_binding[target.id] = "other"
-            elif isinstance(node, ast.AnnAssign):
-                if node.value is not None and isinstance(node.target, ast.Name):
-                    name_binding[node.target.id] = "other"
+                        _invalidate(target.id)
         return result
+
+    @staticmethod
+    def _assign_target_names(target: ast.expr) -> list[str]:
+        """Assign 타깃에서 module-level 로 재바인딩되는 Name id 들을 수집.
+
+        ``x = ...`` → ``["x"]``, ``x = y = ...`` 는 각 target 이 별도로
+        들어오므로 호출당 하나. ``x, y = ...`` (Tuple/List unpack)도 포함한다.
+        Attribute/Subscript 타깃(``obj.x = ...``)은 module-level Name 재바인딩이
+        아니므로 무시한다.
+        """
+        if isinstance(target, ast.Name):
+            return [target.id]
+        if isinstance(target, ast.Tuple | ast.List):
+            names: list[str] = []
+            for elt in target.elts:
+                if isinstance(elt, ast.Name):
+                    names.append(elt.id)
+                elif isinstance(elt, ast.Starred) and isinstance(elt.value, ast.Name):
+                    names.append(elt.value.id)
+            return names
+        return []
 
     def _base_is_strategy(
         self,

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -2070,6 +2070,105 @@ class X(Strategy):
         assert not result.valid
         assert any("No class inheriting from Strategy" in e for e in result.errors)
 
+    def test_module_alias_rebind_before_use_not_counted(self, validator, tmp_path):
+        """module-alias 재바인딩 후 사용 → 미인정 (#2042 4차 Codex FAIL 락).
+
+        `import ante.strategy as astg` 로 module-alias 등록 후 `astg = object()`
+        가 그 이름을 재바인딩한 다음 `class X(astg.Strategy)` 가 온다. X 정의
+        시점의 astg 는 ante.strategy 모듈이 아닌 다른 객체이므로 미인정해야
+        한다(loader 도 `astg.Strategy` AttributeError 로 X 정의 자체가 실패).
+        name_binding 의 재바인딩 무효화와 대칭으로 module_aliases 도 무효화돼야
+        한다. (재바인딩 값은 top-level 허용 리터럴을 써 forbidden-toplevel 검사와
+        직교하게 둔다.)
+        """
+        code = """
+import ante.strategy as astg
+from ante.strategy import StrategyMeta
+
+astg = 0
+
+class X(astg.Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+
+    def test_module_alias_used_before_rebind_passes(self, validator, tmp_path):
+        """module-alias 사용 후 재바인딩 → 인정 (정의 순서 보존).
+
+        `class X(astg.Strategy)` 시점의 astg 는 아직 ante.strategy module 이므로
+        인정(런타임 유효·loader 가 X 카운트). 그 뒤 `astg = object()` 재바인딩은
+        X 판정에 영향을 주지 않는다. 재바인딩 무효화가 order-aware 임을 락.
+        (재바인딩 값은 top-level 허용 리터럴을 써 forbidden-toplevel 검사와
+        직교하게 둔다.)
+        """
+        code = """
+import ante.strategy as astg
+from ante.strategy import StrategyMeta
+
+class X(astg.Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+
+astg = 0
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_dotted_module_root_rebind_before_use_not_counted(
+        self, validator, tmp_path
+    ):
+        """dotted alias root 이름 재바인딩 후 사용 → 미인정 (#2042).
+
+        `import ante.strategy` 로 module-alias("ante.strategy") 등록 후 root
+        이름 `ante` 를 재바인딩하면 `ante.strategy.Strategy` 경로가 더 이상 ante
+        모듈을 가리키지 않으므로 미인정해야 한다. dotted alias 무효화는 root
+        이름 기준이다. (재바인딩 값은 top-level 허용 리터럴을 써
+        forbidden-toplevel 검사와 직교하게 둔다.)
+        """
+        code = """
+import ante.strategy
+from ante.strategy import StrategyMeta
+
+ante = 0
+
+class X(ante.strategy.Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+
+    def test_star_import_strategy_not_counted(self, validator, tmp_path):
+        """`from ante.strategy import *` star-import → 미인정 (known-limitation).
+
+        star-import 는 Strategy 를 명시 바인딩명으로 추적하지 않으므로 보수적
+        으로 strategy_names 에 추가하지 않는다(미인정). loader 보다 약하지만
+        흔치 않은 의도된 known-limitation 범위다. authoritative gate 는 loader
+        의 런타임 issubclass.
+        """
+        code = """
+from ante.strategy import *
+
+class X(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+
 
 # ── #2052 loader: 파일 정의 subclass만 카운트 ────────────────────────
 

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -1936,6 +1936,69 @@ class X(SomeOtherBase):
         assert not result.valid
         assert any("No class inheriting from Strategy" in e for e in result.errors)
 
+    def test_function_local_import_not_counted(self, validator, tmp_path):
+        """함수-로컬 `from ante.strategy import Strategy` → module-scope
+        `class X(Strategy)` 를 Strategy subclass 로 인정하지 않음 (#2042 scope).
+
+        module-scope 에는 Strategy import 가 없으므로 런타임 module
+        네임스페이스에도 Strategy 가 없다(`class X(Strategy)` 는 NameError).
+        validator 가 `ast.walk` 로 함수 내부 import 까지 바인딩 수집하면
+        false positive 로 통과시켜 loader 와 불일치하므로, module-scope
+        한정으로 "No class inheriting from Strategy" 로 귀결돼야 한다.
+        """
+        code = """
+def _helper():
+    from ante.strategy import Strategy  # noqa: F401
+    return Strategy
+
+class X(Strategy):
+    meta = None
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+
+    def test_module_level_import_still_passes(self, validator, tmp_path):
+        """정상 module-level import 회귀: module-scope import + class → 통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class X(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_nested_class_not_counted_as_module_strategy(self, validator, tmp_path):
+        """함수/클래스 내부에 nested 정의된 Strategy subclass 는 module
+        attribute 가 아니므로 module strategy 로 카운트하지 않음.
+
+        module-scope 에 실제 Strategy subclass 가 없으면 nested 정의가
+        있더라도 loader(`vars(module)`)가 못 보는 것과 정합하게 "No class
+        inheriting from Strategy" 로 귀결된다.
+        """
+        code = """
+from ante.strategy import Strategy, StrategyMeta  # noqa: F401
+
+def _factory():
+    class Inner(Strategy):
+        meta = StrategyMeta(name="inner", version="1.0.0", description="i")
+
+        async def on_step(self, context):
+            return []
+
+    return Inner
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+
 
 # ── #2052 loader: 파일 정의 subclass만 카운트 ────────────────────────
 

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -357,6 +357,8 @@ class TestStrategy(Strategy):
     def test_missing_meta(self, validator, tmp_path):
         """meta 클래스 변수가 없으면 실패."""
         code = """
+from ante.strategy import Strategy
+
 class TestStrategy(Strategy):
     async def on_step(self, context):
         return []
@@ -368,8 +370,10 @@ class TestStrategy(Strategy):
     def test_missing_on_step(self, validator, tmp_path):
         """on_step 메서드가 없으면 실패."""
         code = """
+from ante.strategy import Strategy, StrategyMeta
+
 class TestStrategy(Strategy):
-    meta = None
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
 """
         result = validator.validate(self._write_strategy(tmp_path, code))
         assert not result.valid
@@ -1058,13 +1062,15 @@ class TestStrategy(Strategy):
     def test_multiple_strategy_classes(self, validator, tmp_path):
         """복수 Strategy 클래스는 실패."""
         code = """
+from ante.strategy import Strategy, StrategyMeta
+
 class A(Strategy):
-    meta = None
+    meta = StrategyMeta(name="a", version="1.0.0", description="a")
     async def on_step(self, context):
         return []
 
 class B(Strategy):
-    meta = None
+    meta = StrategyMeta(name="b", version="1.0.0", description="b")
     async def on_step(self, context):
         return []
 """
@@ -1507,6 +1513,479 @@ class TestStrategy(Strategy):
 """
         result = validator.validate(self._write_strategy(tmp_path, code))
         assert not any("Invalid exchange" in e for e in result.errors)
+
+
+# ── #2040 validator: async hook 계약 ──────────────────────────────────
+
+
+class TestValidatorAsyncHookContract:
+    """#2040 — 런타임 await hook 이 sync `def` 면 error."""
+
+    @pytest.fixture
+    def validator(self):
+        return StrategyValidator()
+
+    def _write_strategy(self, tmp_path: Path, code: str) -> Path:
+        filepath = tmp_path / "test_strategy.py"
+        filepath.write_text(code)
+        return filepath
+
+    def test_sync_on_step_rejected(self, validator, tmp_path):
+        """필수 on_step 이 sync `def` 면 'must be async' error."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "on_step() must be async (use 'async def')" in e for e in result.errors
+        )
+
+    def test_async_on_step_passes(self, validator, tmp_path):
+        """async on_step 은 통과(async 위반 없음)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("must be async" in e for e in result.errors)
+
+    def test_sync_on_fill_rejected(self, validator, tmp_path):
+        """정의된 on_fill 이 sync `def` 면 error(런타임 await 시 TypeError)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+
+    def on_fill(self, fill):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "on_fill() must be async (use 'async def')" in e for e in result.errors
+        )
+
+    def test_async_on_fill_passes(self, validator, tmp_path):
+        """async def on_fill override 는 통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+
+    async def on_fill(self, fill):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("must be async" in e for e in result.errors)
+
+    def test_sync_on_data_order_update_position_corrected_rejected(
+        self, validator, tmp_path
+    ):
+        """on_data/on_order_update/on_position_corrected sync 도 각각 error."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+
+    def on_data(self, data):
+        return []
+
+    def on_order_update(self, update):
+        return None
+
+    def on_position_corrected(self, correction):
+        return None
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("on_data() must be async" in e for e in result.errors)
+        assert any("on_order_update() must be async" in e for e in result.errors)
+        assert any("on_position_corrected() must be async" in e for e in result.errors)
+
+    def test_sync_on_start_on_stop_unaffected(self, validator, tmp_path):
+        """on_start/on_stop 은 sync 계약 → sync `def` 여도 영향 없음(통과)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    def on_start(self):
+        pass
+
+    def on_stop(self):
+        pass
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("must be async" in e for e in result.errors)
+
+
+# ── #2041 validator: meta=StrategyMeta(...) 타입 ─────────────────────
+
+
+class TestValidatorMetaTypeContract:
+    """#2041 — meta 할당 값이 StrategyMeta(...) 호출이어야 한다."""
+
+    @pytest.fixture
+    def validator(self):
+        return StrategyValidator()
+
+    def _write_strategy(self, tmp_path: Path, code: str) -> Path:
+        filepath = tmp_path / "test_strategy.py"
+        filepath.write_text(code)
+        return filepath
+
+    def test_meta_dict_rejected(self, validator, tmp_path):
+        """meta = {...} (dict) 는 타입 불일치 error."""
+        code = """
+from ante.strategy import Strategy
+
+class TestStrategy(Strategy):
+    meta = {"name": "t", "version": "1.0.0", "description": "t"}
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "'meta' must be a StrategyMeta(...) instance" in e for e in result.errors
+        )
+
+    def test_meta_none_rejected(self, validator, tmp_path):
+        """meta = None 은 타입 불일치 error."""
+        code = """
+from ante.strategy import Strategy
+
+class TestStrategy(Strategy):
+    meta = None
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "'meta' must be a StrategyMeta(...) instance" in e for e in result.errors
+        )
+
+    def test_meta_other_call_rejected(self, validator, tmp_path):
+        """다른 호출(dict(...))은 StrategyMeta 호출이 아니므로 error."""
+        code = """
+from ante.strategy import Strategy
+
+class TestStrategy(Strategy):
+    meta = dict(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "'meta' must be a StrategyMeta(...) instance" in e for e in result.errors
+        )
+
+    def test_meta_strategy_meta_call_passes(self, validator, tmp_path):
+        """meta = StrategyMeta(...) Name 호출은 통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
+    def test_meta_strategy_meta_attribute_call_passes(self, validator, tmp_path):
+        """meta = base.StrategyMeta(...) Attribute 호출도 통과."""
+        code = """
+import ante.strategy.base as base
+from ante.strategy import Strategy
+
+class TestStrategy(Strategy):
+    meta = base.StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
+
+# ── #2042 validator: 실제 ante Strategy 상속만 (import 별칭 추적) ──────
+
+
+class TestValidatorStrategyImportAware:
+    """#2042 — import alias 추적으로 실제 ante Strategy 상속만 인정."""
+
+    @pytest.fixture
+    def validator(self):
+        return StrategyValidator()
+
+    def _write_strategy(self, tmp_path: Path, code: str) -> Path:
+        filepath = tmp_path / "test_strategy.py"
+        filepath.write_text(code)
+        return filepath
+
+    def test_local_strategy_shadow_not_counted(self, validator, tmp_path):
+        """파일 내 로컬 `class Strategy` 정의 → 그 base 상속은 ante Strategy 아님."""
+        code = """
+class Strategy:
+    pass
+
+class X(Strategy):
+    meta = None
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        # 실제 ante Strategy subclass 0개 → "No class inheriting from Strategy".
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+
+    def test_direct_import_strategy_passes(self, validator, tmp_path):
+        """from ante.strategy import Strategy; class X(Strategy) → 인정·통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class X(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_import_strategy_base_passes(self, validator, tmp_path):
+        """from ante.strategy.base import Strategy 도 인정·통과."""
+        code = """
+from ante.strategy.base import Strategy, StrategyMeta
+
+class X(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_aliased_import_strategy_passes(self, validator, tmp_path):
+        """from ante.strategy import Strategy as S; class X(S) → 인정·통과."""
+        code = """
+from ante.strategy import Strategy as S, StrategyMeta
+
+class X(S):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_module_alias_attribute_strategy_passes(self, validator, tmp_path):
+        """import ante.strategy as astg; class X(astg.Strategy) → 인정·통과."""
+        code = """
+import ante.strategy as astg
+from ante.strategy import StrategyMeta
+
+class X(astg.Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_dotted_module_attribute_strategy_passes(self, validator, tmp_path):
+        """import ante.strategy; class X(ante.strategy.Strategy) → 인정·통과."""
+        code = """
+import ante.strategy
+from ante.strategy import StrategyMeta
+
+class X(ante.strategy.Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_unrelated_base_not_counted(self, validator, tmp_path):
+        """import 안 한 임의 base 이름은 ante Strategy 로 인식 안 함."""
+        code = """
+class X(SomeOtherBase):
+    meta = None
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+
+
+# ── #2052 loader: 파일 정의 subclass만 카운트 ────────────────────────
+
+
+class TestLoaderFileDefinedOnly:
+    """#2052 — import 된 Strategy subclass 제외, 파일 정의 subclass만 카운트."""
+
+    def test_imported_subclass_not_counted(self, tmp_path):
+        """helper 의 ImportedStrategy 를 import 한 main → MainStrategy 만 카운트."""
+        helper = tmp_path / "helper_mod.py"
+        helper.write_text(
+            "from ante.strategy import Strategy, StrategyMeta\n"
+            "\n"
+            "class ImportedStrategy(Strategy):\n"
+            '    meta = StrategyMeta(name="imp", version="1.0.0", description="i")\n'
+            "\n"
+            "    async def on_step(self, context):\n"
+            "        return []\n"
+        )
+        main = tmp_path / "main_strategy.py"
+        main.write_text(
+            "import sys\n"
+            f"sys.path.insert(0, {str(tmp_path)!r})\n"
+            "from helper_mod import ImportedStrategy  # noqa: F401\n"
+            "from ante.strategy import Strategy, StrategyMeta\n"
+            "\n"
+            "class MainStrategy(Strategy):\n"
+            '    meta = StrategyMeta(name="main", version="1.0.0", description="m")\n'
+            "\n"
+            "    async def on_step(self, context):\n"
+            "        return []\n"
+        )
+        cls = StrategyLoader.load(main)
+        assert cls.__name__ == "MainStrategy"
+        assert issubclass(cls, Strategy)
+
+    def test_two_local_subclasses_rejected(self, tmp_path):
+        """같은 파일에 2개 정의 → Multiple Strategy subclasses error."""
+        main = tmp_path / "two_strategy.py"
+        main.write_text(
+            "from ante.strategy import Strategy, StrategyMeta\n"
+            "\n"
+            "class AStrategy(Strategy):\n"
+            '    meta = StrategyMeta(name="a", version="1.0.0", description="a")\n'
+            "\n"
+            "    async def on_step(self, context):\n"
+            "        return []\n"
+            "\n"
+            "class BStrategy(Strategy):\n"
+            '    meta = StrategyMeta(name="b", version="1.0.0", description="b")\n'
+            "\n"
+            "    async def on_step(self, context):\n"
+            "        return []\n"
+        )
+        with pytest.raises(StrategyLoadError, match="Multiple Strategy subclasses"):
+            StrategyLoader.load(main)
+
+
+# ── validate ↔ load 패리티 (#2040 번들) ──────────────────────────────
+
+
+class TestValidateLoadParity:
+    """validate(파일 정의 실제 Strategy subclass 1개) ↔ load(module-origin 1개)."""
+
+    @pytest.fixture
+    def validator(self):
+        return StrategyValidator()
+
+    def test_imported_subclass_parity(self, tmp_path):
+        """helper import + main 1개 정의: validate 통과 ⟺ load 성공."""
+        helper = tmp_path / "helper_mod.py"
+        helper.write_text(
+            "from ante.strategy import Strategy, StrategyMeta\n"
+            "\n"
+            "class ImportedStrategy(Strategy):\n"
+            '    meta = StrategyMeta(name="imp", version="1.0.0", description="i")\n'
+            "\n"
+            "    async def on_step(self, context):\n"
+            "        return []\n"
+        )
+        # validate 대상은 main 파일만 본다(AST 파일-scope). import 된
+        # ImportedStrategy 는 main AST 에 클래스 정의가 없으므로 카운트 안 됨.
+        main = tmp_path / "main_strategy.py"
+        main.write_text(
+            "import sys\n"
+            f"sys.path.insert(0, {str(tmp_path)!r})\n"
+            "from helper_mod import ImportedStrategy  # noqa: F401\n"
+            "from ante.strategy import Strategy, StrategyMeta\n"
+            "\n"
+            "class MainStrategy(Strategy):\n"
+            '    meta = StrategyMeta(name="main", version="1.0.0", description="m")\n'
+            "\n"
+            "    async def on_step(self, context):\n"
+            "        return []\n"
+        )
+        result = StrategyValidator().validate(main)
+        # validate: 'import sys'/sys.path 호출 등 top-level 제약은 본 케이스가
+        # 패리티 집합 동형 확인 목적이므로 Strategy-count 측면만 검증한다.
+        assert not any("Multiple Strategy" in e for e in result.errors)
+        assert not any("No class inheriting" in e for e in result.errors)
+        # load: import 된 subclass 제외 → 정상 1개 로드.
+        cls = StrategyLoader.load(main)
+        assert cls.__name__ == "MainStrategy"
+
+    def test_local_shadow_parity(self, tmp_path):
+        """로컬 `class Strategy` shadow: validate 0개 ⟺ load 0개(둘 다 실패)."""
+        f = tmp_path / "shadow_strategy.py"
+        f.write_text(
+            "class Strategy:\n"
+            "    pass\n"
+            "\n"
+            "class X(Strategy):\n"
+            "    meta = None\n"
+            "\n"
+            "    async def on_step(self, context):\n"
+            "        return []\n"
+        )
+        result = StrategyValidator().validate(f)
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+        with pytest.raises(StrategyLoadError, match="No Strategy subclass"):
+            StrategyLoader.load(f)
 
 
 # ── ante.strategy lazy attribute access 회귀 (#1463) ──────────────────

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -1819,6 +1819,231 @@ class TestStrategy(Strategy):
         assert not any("StrategyMeta(...) instance" in e for e in result.errors)
 
 
+# ── #2041 (5차) validator: meta StrategyMeta 호출을 import-aware 로 해석 ──
+# #2042(Strategy)와 동일한 order-aware import-resolution 으로 ante StrategyMeta
+# 만 인정한다. ante 가 아닌 임의 `*.StrategyMeta` 호출(false-positive)을 거부.
+
+
+class TestValidatorMetaImportAware:
+    """#2041 (5차) — meta = StrategyMeta(...) 호출이 ante StrategyMeta 인지 추적."""
+
+    @pytest.fixture
+    def validator(self):
+        return StrategyValidator()
+
+    def _write_strategy(self, tmp_path: Path, code: str) -> Path:
+        filepath = tmp_path / "test_strategy.py"
+        filepath.write_text(code)
+        return filepath
+
+    def test_fake_strategy_meta_attribute_call_rejected(self, validator, tmp_path):
+        """import fake; meta = fake.StrategyMeta(...) → false-positive 차단(이번 FAIL).
+
+        ``fake`` 는 ante.strategy module-alias 가 아니므로 ``fake.StrategyMeta(...)``
+        는 ante StrategyMeta 가 아니다. submit 의 isinstance(meta, StrategyMeta)
+        가 거부하는 것과 정합하게 validate 도 거부해야 한다.
+        """
+        code = """
+import fake
+from ante.strategy import Strategy
+
+class TestStrategy(Strategy):
+    meta = fake.StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "'meta' must be a StrategyMeta(...) instance" in e for e in result.errors
+        )
+
+    def test_arbitrary_module_strategy_meta_call_rejected(self, validator, tmp_path):
+        """import some_pkg; meta = some_pkg.StrategyMeta(...) 도 거부(임의 module)."""
+        code = """
+import some_pkg
+from ante.strategy import Strategy
+
+class TestStrategy(Strategy):
+    meta = some_pkg.StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "'meta' must be a StrategyMeta(...) instance" in e for e in result.errors
+        )
+
+    def test_module_alias_strategy_meta_call_passes(self, validator, tmp_path):
+        """import ante.strategy as astg; meta = astg.StrategyMeta(...) → 통과."""
+        code = """
+import ante.strategy as astg
+
+class TestStrategy(astg.Strategy):
+    meta = astg.StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
+    def test_dotted_module_strategy_meta_call_passes(self, validator, tmp_path):
+        """import ante.strategy; meta = ante.strategy.StrategyMeta(...) → 통과."""
+        code = """
+import ante.strategy
+
+class TestStrategy(ante.strategy.Strategy):
+    meta = ante.strategy.StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
+    def test_dotted_base_module_strategy_meta_call_passes(self, validator, tmp_path):
+        """import ante.strategy.base as base; meta = base.StrategyMeta(...) → 통과."""
+        code = """
+import ante.strategy.base as base
+from ante.strategy import Strategy
+
+class TestStrategy(Strategy):
+    meta = base.StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
+    def test_direct_import_strategy_meta_name_call_passes(self, validator, tmp_path):
+        """from ante.strategy import StrategyMeta; meta = StrategyMeta(...) → 통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
+    def test_asname_import_strategy_meta_name_call_passes(self, validator, tmp_path):
+        """from ante.strategy import StrategyMeta as M; meta = M(...) → 통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta as M
+
+class TestStrategy(Strategy):
+    meta = M(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
+    def test_unimported_strategy_meta_name_call_rejected(self, validator, tmp_path):
+        """StrategyMeta 를 ante 에서 import 안 함 + meta = StrategyMeta(...) → 거부.
+
+        Strategy 만 import 하고 StrategyMeta 는 로컬 정의(ante 바인딩 아님)이므로
+        ``StrategyMeta(...)`` Name 호출은 ante StrategyMeta 가 아니다 → 거부.
+        실사용 전략은 항상 ante 에서 StrategyMeta 를 import 하므로 회귀 아님.
+        """
+        code = """
+from ante.strategy import Strategy
+
+class StrategyMeta:
+    def __init__(self, **kwargs):
+        pass
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "'meta' must be a StrategyMeta(...) instance" in e for e in result.errors
+        )
+
+    def test_alias_rebind_before_meta_call_rejected(self, validator, tmp_path):
+        """astg = other 재바인딩 후 astg.StrategyMeta(...) → 거부 (order-aware).
+
+        ``import ante.strategy as astg`` 후 ``astg = 0`` 재바인딩이 module-alias 를
+        무효화하므로, 그 다음 정의된 클래스의 ``astg.StrategyMeta(...)`` 는 ante
+        StrategyMeta 로 해석되지 않는다. (base 도 ``ante.strategy`` 직접 import 로
+        인정받아 클래스 탐지 자체는 통과시킨 뒤 meta 만 거부됨을 확인.)
+        """
+        code = """
+import ante.strategy as astg
+from ante.strategy import Strategy
+
+astg = 0
+
+class TestStrategy(Strategy):
+    meta = astg.StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "'meta' must be a StrategyMeta(...) instance" in e for e in result.errors
+        )
+
+    def test_alias_used_before_rebind_meta_call_passes(self, validator, tmp_path):
+        """클래스 정의(astg.StrategyMeta) 후 astg 재바인딩 → 정의 시점 인정·통과.
+
+        클래스 정의 시점의 ``astg`` 는 아직 ante.strategy module-alias 이므로
+        meta 통과. 그 뒤 ``astg = 0`` 재바인딩은 이미 캡처된 스냅샷에 영향 없음.
+        """
+        code = """
+import ante.strategy as astg
+
+class TestStrategy(astg.Strategy):
+    meta = astg.StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+
+astg = 0
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
+    def test_normal_strategy_fixture_regression(self, validator, tmp_path):
+        """회귀 핵심: 정상 전략(from ante.strategy import Strategy, StrategyMeta)
+        이 import-aware 강화 후에도 전부 통과.
+        """
+        code = """
+from ante.strategy import Strategy, StrategyMeta, Signal
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert result.errors == []
+
+
 # ── #2042 validator: 실제 ante Strategy 상속만 (import 별칭 추적) ──────
 
 

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -1747,6 +1747,77 @@ class TestStrategy(Strategy):
         assert result.valid
         assert not any("StrategyMeta(...) instance" in e for e in result.errors)
 
+    def test_meta_reassigned_last_strategy_meta_passes(self, validator, tmp_path):
+        """meta=None 후 meta=StrategyMeta(...) 재할당 → 마지막 값 기준 통과(핵심)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = None
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
+    def test_meta_reassigned_last_none_rejected(self, validator, tmp_path):
+        """meta=StrategyMeta(...) 후 meta=None 재할당 → 마지막이 None 이라 error."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+    meta = None
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "'meta' must be a StrategyMeta(...) instance" in e for e in result.errors
+        )
+
+    def test_meta_annotation_only_rejected(self, validator, tmp_path):
+        """annotation-only `meta: StrategyMeta`(값 없음) → 값 할당 없음 → error.
+
+        런타임에 클래스 속성을 만들지 않으므로 StrategyMeta 인스턴스가 아니다.
+        ``_has_class_var`` 는 AnnAssign 을 True 로 보지만(존재), 마지막 값-할당이
+        없으므로 must-be-StrategyMeta error 로 귀결되어 두 검사가 정합한다.
+        """
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta: StrategyMeta
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(
+            "'meta' must be a StrategyMeta(...) instance" in e for e in result.errors
+        )
+
+    def test_meta_annotated_assign_strategy_meta_passes(self, validator, tmp_path):
+        """annotated 값-할당 `meta: StrategyMeta = StrategyMeta(...)` 통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta: StrategyMeta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("StrategyMeta(...) instance" in e for e in result.errors)
+
 
 # ── #2042 validator: 실제 ante Strategy 상속만 (import 별칭 추적) ──────
 

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -1999,6 +1999,77 @@ def _factory():
         assert not result.valid
         assert any("No class inheriting from Strategy" in e for e in result.errors)
 
+    def test_import_as_used_before_local_redefine_passes(self, validator, tmp_path):
+        """import-as 후 class 사용, 그 뒤 local 재정의 → 사용 시점 바인딩으로 인정.
+
+        Python 은 정의 순서로 이름을 바인딩한다. `class X(S)` 시점의 S 는 import
+        된 ante Strategy 이므로(런타임 유효·loader 가 X 카운트) X 를 **인정**해야
+        한다. 이후 `class S` 의 local 재정의는 X 판정에 영향을 주지 않는다.
+        (3차 Codex FAIL 케이스 — 정의 순서를 무시한 false negative 회귀 락.)
+        """
+        code = """
+from ante.strategy import Strategy as S, StrategyMeta
+
+class X(S):
+    meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+    async def on_step(self, context):
+        return []
+
+class S:
+    pass
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_local_redefine_before_use_not_counted(self, validator, tmp_path):
+        """import 후 local 재정의가 사용보다 먼저 → 사용 시점엔 local shadow → 미인정.
+
+        `from ante.strategy import Strategy` 로 ante 바인딩 후, `class Strategy`
+        가 그 이름을 local 로 재바인딩한 다음 `class X(Strategy)` 가 온다. X 정의
+        시점의 Strategy 는 local 클래스이므로 미인정(loader 도 X 는 ante 비상속이라
+        비카운트, 정합).
+        """
+        code = """
+from ante.strategy import Strategy
+
+class Strategy:
+    pass
+
+class X(Strategy):
+    meta = None
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+
+    def test_original_2042_bug_strategy_meta_only_not_counted(
+        self, validator, tmp_path
+    ):
+        """원래 #2042 버그: StrategyMeta 만 import + local `class Strategy` → 미인정.
+
+        Strategy 라는 이름은 ante 로 바인딩된 적이 없고(StrategyMeta 만 import),
+        `class Strategy` 가 local 정의이므로 `class X(Strategy)` 는 미인정.
+        """
+        code = """
+from ante.strategy import StrategyMeta
+
+class Strategy:
+    pass
+
+class X(Strategy):
+    meta = None
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+
 
 # ── #2052 loader: 파일 정의 subclass만 카운트 ────────────────────────
 
@@ -2107,6 +2178,57 @@ class TestValidateLoadParity:
         """로컬 `class Strategy` shadow: validate 0개 ⟺ load 0개(둘 다 실패)."""
         f = tmp_path / "shadow_strategy.py"
         f.write_text(
+            "class Strategy:\n"
+            "    pass\n"
+            "\n"
+            "class X(Strategy):\n"
+            "    meta = None\n"
+            "\n"
+            "    async def on_step(self, context):\n"
+            "        return []\n"
+        )
+        result = StrategyValidator().validate(f)
+        assert any("No class inheriting from Strategy" in e for e in result.errors)
+        with pytest.raises(StrategyLoadError, match="No Strategy subclass"):
+            StrategyLoader.load(f)
+
+    def test_import_as_then_redefine_parity(self, tmp_path):
+        """import-as 후 사용, 그 뒤 local 재정의: validate 인정 ⟺ load 성공.
+
+        X 정의 시점의 S 는 import 된 ante Strategy 이므로 X 는 실제 ante
+        Strategy subclass(`__module__ == module.__name__`)다. 이후 `class S`
+        local 재정의는 X 의 base 에 영향을 주지 않는다. validate 가 X 를
+        인정하면 load 도 X 하나를 반환해야 한다.
+        """
+        f = tmp_path / "import_as_redefine_strategy.py"
+        f.write_text(
+            "from ante.strategy import Strategy as S, StrategyMeta\n"
+            "\n"
+            "class X(S):\n"
+            '    meta = StrategyMeta(name="t", version="1.0.0", description="t")\n'
+            "\n"
+            "    async def on_step(self, context):\n"
+            "        return []\n"
+            "\n"
+            "class S:\n"
+            "    pass\n"
+        )
+        result = StrategyValidator().validate(f)
+        assert result.valid
+        cls = StrategyLoader.load(f)
+        assert cls.__name__ == "X"
+        assert issubclass(cls, Strategy)
+
+    def test_local_redefine_before_use_parity(self, tmp_path):
+        """local 재정의가 사용보다 먼저: validate 미인정 ⟺ load 실패.
+
+        `class X(Strategy)` 시점의 Strategy 는 local 클래스로 재바인딩된 뒤이므로
+        X 는 ante 비상속. validate 가 0개로 판정하면 load 도 0개로 실패해야 한다.
+        """
+        f = tmp_path / "local_first_strategy.py"
+        f.write_text(
+            "from ante.strategy import Strategy\n"
+            "\n"
             "class Strategy:\n"
             "    pass\n"
             "\n"


### PR DESCRIPTION
Closes #2040
Closes #2041
Closes #2042
Closes #2052

## Summary
StrategyValidator와 StrategyLoader의 **validate↔load 계약 패리티** 4건:
- **#2040**: validator가 sync `def on_step`(및 정의된 async-계약 hook on_fill/on_data/on_order_update/on_position_corrected)을 통과시키던 것을 거부(런타임 await 계약). on_start/on_stop은 sync 유지
- **#2041**: `meta` 존재만 확인하던 것을 `meta = StrategyMeta(...)` 호출(마지막 할당 기준, import-aware: ante에서 바인딩된 StrategyMeta만)로 검증 — dict/None/`fake.StrategyMeta` 거부
- **#2042**: base 이름 "Strategy"만 매칭하던 것을 import-aware·정의순서 단일패스로 강화(직접/asname/module-alias, 재바인딩 무효화). 로컬 `class Strategy` 오인 차단
- **#2052**: loader가 import된 Strategy subclass까지 세던 것을 `obj.__module__ == module.__name__`(파일 정의)만 카운트
- 결과: validator(파일 정의 실제 Strategy subclass 1개) ↔ loader(module-origin 실제 subclass 1개) 동형

## 수용된 비대칭 (bounded known-limitation)
정적 name-resolution은 직접/asname import·module-alias·정의순서 local-shadow·재바인딩 무효화까지 모델링. transitive/intermediate-base, 조건부/star/간접alias/동적 import 등 병리적 케이스는 미모델링 — authoritative gate는 loader 런타임 `issubclass` + submit `isinstance(meta, StrategyMeta)`. docstring 명문화.

## Test Plan
- validator/loader/strategy 511 passed, contracts 145, 광역 회귀(strategy/backtest/submit/registry) 1007 passed / mypy clean / ruff clean
- 신규: async hook 거부, meta 타입(import-aware/마지막할당/fake 차단), Strategy import-aware(direct/alias/module-alias/local-shadow/정의순서/재바인딩/function-local/nested), loader 파일정의 카운트, validate↔load parity

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS (attempt 6)