### PR TITLE
fix(backtest): #1990 거래 PnL 추정에 매수 수수료를 원가에 포함

### DIFF
--- a/src/ante/backtest/metrics.py
+++ b/src/ante/backtest/metrics.py
@@ -198,7 +198,9 @@ def _estimate_trade_pnl(trades: list[Any]) -> list[float]:
                 positions[symbol] = {"quantity": 0, "total_cost": 0.0}
             pos = positions[symbol]
             pos["quantity"] += trade.quantity
-            pos["total_cost"] += trade.price * trade.quantity
+            # 매수 수수료를 원가(cost basis)에 포함한다. avg_cost가 주당으로
+            # amortize되어 부분 매도에서도 일관되게 반영된다 (#1990).
+            pos["total_cost"] += trade.price * trade.quantity + trade.commission
         elif trade.side == "sell":
             pos = positions.get(symbol) or {}
             if pos and pos.get("quantity", 0) > 0:

--- a/tests/unit/test_backtest_metrics.py
+++ b/tests/unit/test_backtest_metrics.py
@@ -152,6 +152,36 @@ class TestCalculateMetrics:
         assert metrics["win_rate"] == 50.0
         assert metrics["profit_factor"] > 0
 
+    def test_buy_commission_only_classified_as_loss(self):
+        """이슈 repro(#1990): 매수 수수료만으로 손실인 거래가 losing으로 분류.
+
+        buy(price=100, qty=1, commission=10) + sell(price=100, qty=1,
+        commission=0) → pnl=-10 → losing_trades=1, winning_trades=0,
+        win_rate=0, avg_loss≈10.
+        (기존: 매수 수수료 미반영 pnl=0 → winning/losing 어느 쪽도 아님)
+        """
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 1, 100, 10),
+            FakeTrade(datetime(2024, 1, 5), "A", "sell", 1, 100, 0),
+        ]
+        equity_curve = [
+            {"timestamp": "2024-01-01", "equity": 10000},
+            {"timestamp": "2024-01-05", "equity": 9990},
+        ]
+
+        metrics = calculate_metrics(
+            trades=trades,
+            equity_curve=equity_curve,
+            initial_balance=10000,
+            final_balance=9990,
+        )
+
+        assert metrics["total_trades"] == 1
+        assert metrics["winning_trades"] == 0
+        assert metrics["losing_trades"] == 1
+        assert metrics["win_rate"] == 0.0
+        assert metrics["avg_loss"] == pytest.approx(10.0)
+
     def test_profit_factor_no_loss(self):
         """손실 없을 때 profit_factor = inf."""
         trades = [
@@ -426,6 +456,71 @@ class TestEstimateTradePnl:
         assert len(pnl) == 2
         assert pnl[0] == pytest.approx(100.0)  # A: (110-100)*10
         assert pnl[1] == pytest.approx(-50.0)  # B: (190-200)*5
+
+    def test_buy_commission_only_round_trip_is_loss(self):
+        """이슈 repro(#1990): 매수 수수료 때문에만 손실인 round-trip.
+
+        buy(price=100, qty=1, commission=10) + sell(price=100, qty=1,
+        commission=0) → 매수 수수료가 원가에 포함되어 pnl=-10.0.
+        (기존: 매수 수수료 미반영으로 pnl=0.0 → 손익 어느 쪽도 아님)
+        """
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 1, 100, 10),
+            FakeTrade(datetime(2024, 1, 5), "A", "sell", 1, 100, 0),
+        ]
+        pnl = _estimate_trade_pnl(trades)
+        assert len(pnl) == 1
+        # avg_cost = (100*1 + 10) / 1 = 110 → (100 - 110)*1 - 0 = -10
+        assert pnl[0] == pytest.approx(-10.0)
+
+    def test_both_buy_and_sell_commission(self):
+        """매수·매도 수수료 모두 반영.
+
+        buy(commission=5) + sell(commission=5), 동일가 → pnl=-10.
+        """
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 1, 100, 5),
+            FakeTrade(datetime(2024, 1, 5), "A", "sell", 1, 100, 5),
+        ]
+        pnl = _estimate_trade_pnl(trades)
+        assert len(pnl) == 1
+        # avg_cost = (100 + 5) / 1 = 105 → (100 - 105)*1 - 5 = -10
+        assert pnl[0] == pytest.approx(-10.0)
+
+    def test_profitable_trade_with_buy_commission_in_cost(self):
+        """이익 거래 — 매수 수수료가 avg_cost에 amortize.
+
+        buy(price=100, qty=1, commission=1) + sell(price=120, qty=1,
+        commission=1) → avg_cost=101 → (120-101)*1 - 1 = 18.
+        """
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 1, 100, 1),
+            FakeTrade(datetime(2024, 1, 5), "A", "sell", 1, 120, 1),
+        ]
+        pnl = _estimate_trade_pnl(trades)
+        assert len(pnl) == 1
+        assert pnl[0] == pytest.approx(18.0)
+
+    def test_partial_sell_amortizes_buy_commission(self):
+        """다중 매수 후 부분 매도 — 매수 수수료가 수량에 일관되게 amortize.
+
+        buy1(price=100, qty=10, commission=20) +
+        buy2(price=120, qty=10, commission=20) →
+          total_cost = (100*10+20) + (120*10+20) = 1020 + 1220 = 2240
+          quantity   = 20 → avg_cost = 112.0
+        sell(price=130, qty=5, commission=2) →
+          pnl = (130 - 112)*5 - 2 = 88.0
+        남은 포지션: quantity=15, total_cost = 2240 - 112*5 = 1680
+          (avg_cost가 여전히 112.0으로 일관 — 매수 수수료 포함 유지)
+        """
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 10, 100, 20),
+            FakeTrade(datetime(2024, 1, 2), "A", "buy", 10, 120, 20),
+            FakeTrade(datetime(2024, 1, 3), "A", "sell", 5, 130, 2),
+        ]
+        pnl = _estimate_trade_pnl(trades)
+        assert len(pnl) == 1
+        assert pnl[0] == pytest.approx(88.0)
 
 
 # ── CLI 지표 표시 ──────────────────────────────


### PR DESCRIPTION
Closes #1990

## Summary
- backtest `_estimate_trade_pnl`(metrics.py)가 매수 수수료를 cost basis에 미반영해, 매수 수수료 때문에만 손실인 round-trip을 pnl=0으로 분류(winning/losing 어느 쪽도 아님) → win_rate/profit_factor/avg_profit/avg_loss/winning_trades/losing_trades 왜곡
- buy 분기 `total_cost += price*qty` → `+ commission` 추가. avg_cost가 매수 수수료를 주당 amortize, 부분매도 차감 일관, 매도 수수료(pnl -= commission) 유지 → 매수·매도 수수료 모두 PnL 반영
- slippage는 executor가 trade.price에 이미 포함(별도 갭 아님)

## Test Plan
- test_backtest_metrics 34 passed(신규 5), -k backtest/metrics 379, contracts 145 / mypy Success / ruff clean
- 신규: 매수수수료-only 손실(pnl=-10)·calculate_metrics losing 분류, 이익거래(avg_cost 포함), 부분매도 amortize, 매수+매도 수수료

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS