### PR TITLE
fix(backtest): #1994 order_type 트리거/리밋 게이트 — 미충족 limit/stop 즉시 시장가 체결 차단

### DIFF
--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -255,6 +255,26 @@ class BacktestExecutor:
         로그만 남긴 뒤 skip한다(라이브 OrderRejectedEvent와 달리 backtest는
         이벤트 없음). 특히 ``hold`` 등 buy/sell 이외 side는 **절대 sell 분기로
         라우팅하지 않는다**(unknown side가 매도로 처리되던 회귀 차단).
+
+        가격 게이트 통과 후 **side 체결 분기 이전에** ``signal.order_type`` 트리거
+        게이트(``_order_triggered``)를 적용한다(#1994). limit/stop/stop_limit이
+        현재 봉가로 조건을 충족하지 않으면 미체결로 skip(``return None``)해, 기존에
+        order_type을 무시하고 모든 주문을 즉시 시장가로 체결하던 버그를 차단한다.
+        market(기본)은 항상 트리거되어 기존 시장가 체결 동작을 보존한다(회귀 방지).
+
+        체결가(``exec_price``)는 게이트 통과 후 order_type별 정책으로 산출한다:
+        market/stop(트리거→시장가)은 기존대로 슬리피지만 적용한 ``price * (1 ±
+        slippage_rate)``, limit/stop_limit은 슬리피지가 limit(``L=signal.price``)을
+        불리하게 넘지 않도록 buy는 ``min(.., L)`` sell은 ``max(.., L)`` 로 cap한다
+        (매수는 L 초과 지불 없음, 매도는 L 미만 수취 없음). slippage 필드는
+        ``abs(exec_price - price) * executed_qty`` 로 일관되게 기록한다.
+
+        known-limitation(#1994, 의도적 수용·후속 이슈 대상):
+        - per-bar 평가만 한다. 미충족 주문을 다음 봉까지 보존하는 cross-bar
+          resting order book은 모델링하지 않는다(전략이 매 step 재발행하는 모델).
+        - stop_limit은 "트리거 후 limit 대기" 2단계 상태를 보존하지 못해, **같은
+          봉에서 stop 트리거 + limit 충족이 동시에 만족**되는 단일-봉 conjunction
+          으로 근사한다. cross-bar triggered-then-resting 상태는 미모델링한다.
         """
         # ── Signal 검증 (가격 조회/분기 이전) ──────────────────────────
         # side 검증: case-sensitive로 buy/sell만 허용. hold/unknown은 skip하여
@@ -308,8 +328,15 @@ class BacktestExecutor:
             )
             return None
 
+        # ── order_type 트리거 게이트 (side 분기 이전) ───────────────────
+        # limit/stop/stop_limit이 현재 봉가로 조건을 충족하지 않으면 미체결로
+        # skip한다(#1994). market(기본)은 항상 True라 기존 시장가 체결 동작이
+        # 보존된다(회귀 방지). #2073 fill dict|None 계약과 일관되게 return None.
+        if not self._order_triggered(signal, price):
+            return None
+
         if signal.side == "buy":
-            exec_price = price * (1 + self._slippage_rate)
+            exec_price = self._apply_slippage_cap(signal, price, "buy")
             executed_qty = signal.quantity
             commission = exec_price * executed_qty * self._buy_commission_rate
             cost = exec_price * executed_qty + commission
@@ -318,7 +345,7 @@ class BacktestExecutor:
             self._balance -= cost
             self._update_position(signal.symbol, executed_qty, exec_price)
         else:
-            exec_price = price * (1 - self._slippage_rate)
+            exec_price = self._apply_slippage_cap(signal, price, "sell")
             pos = self._positions.get(signal.symbol, {})
             executed_qty = min(signal.quantity, pos.get("quantity", 0))
             if executed_qty <= 0:
@@ -354,6 +381,111 @@ class BacktestExecutor:
             "timestamp": timestamp,
             "fill_dedup_key": "",
         }
+
+    def _order_triggered(self, signal: Signal, price: float) -> bool:
+        """``signal.order_type`` 트리거가 현재 봉가(*price*)로 충족되는지 판정(#1994).
+
+        side 체결 분기 이전에 호출한다. ``True`` 면 체결 진행, ``False`` 면 호출부가
+        미체결로 skip한다. 필수 가격 필드 누락/알 수 없는 order_type은 fail-closed로
+        ``False`` + 경고를 남긴다(거래 미발행).
+
+        - ``market``(기본): 항상 True(즉시 시장가 체결). 기존 동작 보존(회귀 방지).
+        - ``limit``(``signal.price=L`` 필수): buy는 ``price <= L``, sell은
+          ``price >= L`` 이면 트리거.
+        - ``stop``(``signal.stop_price=S`` 필수): buy는 ``price >= S``, sell은
+          ``price <= S`` 이면 트리거(트리거 시 시장가로 변환되어 체결).
+        - ``stop_limit``(``S=stop_price``, ``L=price`` 둘 다 필수): buy는
+          ``price >= S and price <= L``, sell은 ``price <= S and price >= L`` 이면
+          트리거. **단일-봉 conjunction 근사**(stop 트리거 + limit 충족 동시 만족).
+          "트리거 후 limit 대기" 2단계 상태와 cross-bar triggered-then-resting은
+          모델링하지 않는다(#1994 known-limitation, 의도적 수용·후속 이슈 대상).
+
+        per-bar 평가만 하며 미충족 주문을 다음 봉까지 보존하는 cross-bar resting
+        order book은 모델링하지 않는다(전략이 매 step 재발행하는 모델, #1994).
+        """
+        order_type = signal.order_type
+        if order_type == "market":
+            return True
+
+        is_buy = signal.side == "buy"
+        limit = signal.price
+        stop = signal.stop_price
+
+        if order_type == "limit":
+            if limit is None:
+                logger.warning(
+                    "invalid limit order: missing price — symbol=%s side=%s (미체결)",
+                    signal.symbol,
+                    signal.side,
+                )
+                return False
+            triggered = price <= limit if is_buy else price >= limit
+        elif order_type == "stop":
+            if stop is None:
+                logger.warning(
+                    "invalid stop order: missing stop_price — symbol=%s side=%s "
+                    "(미체결)",
+                    signal.symbol,
+                    signal.side,
+                )
+                return False
+            triggered = price >= stop if is_buy else price <= stop
+        elif order_type == "stop_limit":
+            if stop is None or limit is None:
+                logger.warning(
+                    "invalid stop_limit order: missing price/stop_price — "
+                    "symbol=%s side=%s (미체결)",
+                    signal.symbol,
+                    signal.side,
+                )
+                return False
+            triggered = (
+                (price >= stop and price <= limit)
+                if is_buy
+                else (price <= stop and price >= limit)
+            )
+        else:
+            logger.warning(
+                "invalid order_type: unknown type=%r — symbol=%s side=%s (미체결)",
+                order_type,
+                signal.symbol,
+                signal.side,
+            )
+            return False
+
+        if not triggered:
+            logger.debug(
+                "order not triggered: type=%s side=%s price=%s limit=%s stop=%s",
+                order_type,
+                signal.side,
+                price,
+                limit,
+                stop,
+            )
+        return triggered
+
+    def _apply_slippage_cap(self, signal: Signal, price: float, side: str) -> float:
+        """게이트 통과 후 order_type별 체결가(``exec_price``)를 산출한다(#1994).
+
+        - ``market``/``stop``(트리거→시장가): 기존대로 슬리피지만 적용한
+          ``price * (1 ± slippage_rate)``.
+        - ``limit``/``stop_limit``: 슬리피지가 limit(``L=signal.price``)을 불리하게
+          넘지 않도록 cap한다 — buy는 ``min(price*(1+slip), L)``, sell은
+          ``max(price*(1-slip), L)``. 매수는 L 초과 지불 없음, 매도는 L 미만 수취
+          없음. 게이트(``_order_triggered``)를 통과한 limit/stop_limit은
+          ``signal.price`` 가 None이 아님이 보장된다.
+        """
+        limit = signal.price
+        is_capped_limit = signal.order_type in ("limit", "stop_limit")
+        if side == "buy":
+            slipped = price * (1 + self._slippage_rate)
+            if is_capped_limit and limit is not None:
+                return min(slipped, limit)
+            return slipped
+        slipped = price * (1 - self._slippage_rate)
+        if is_capped_limit and limit is not None:
+            return max(slipped, limit)
+        return slipped
 
     def _update_position(self, symbol: str, qty_delta: float, price: float) -> None:
         """포지션 업데이트."""

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -3274,3 +3274,396 @@ class TestNonDailyTimeframe:
         # datasets는 5m 기준.
         assert len(result.datasets) == 1
         assert result.datasets[0].timeframe == "5m"
+
+
+# ── order_type 트리거/리밋 게이트 (#1994) ──────────
+
+
+class TestBacktestOrderTypeGate:
+    """``Signal.order_type`` 트리거 게이트 + 체결가 limit cap 검증(#1994).
+
+    이전에는 executor가 order_type/price/stop_price를 무시하고 모든 주문을 현재
+    봉가로 즉시 시장가 체결했다. 이제 limit/stop/stop_limit은 현재 봉가로 조건을
+    충족할 때만 체결되고, limit/stop_limit 체결가는 슬리피지가 limit을 불리하게
+    넘지 않도록 cap된다. market(기본)은 항상 즉시 체결되어 기존 동작이 보존된다.
+    """
+
+    async def _run_single_signal(
+        self,
+        store,
+        signal: Signal,
+        current_close: float,
+        *,
+        slippage_rate: float = 0.0,
+    ):
+        """현재 봉 종가가 ``current_close`` 인 단일-봉 fixture에서 단일 Signal 실행.
+
+        BacktestExecutor.run은 첫 advance()가 row 0을 노출하므로(#2061), row 0
+        종가를 ``current_close`` 로 두면 첫 on_step에서 발행한 Signal이 그 가격으로
+        게이트/체결된다. 단일 봉이라 보유 포지션이 다음 봉으로 넘어가지 않는다.
+        """
+        df = _make_ohlcv_df_with_closes([current_close])
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        executor = BacktestExecutor(
+            strategy_cls=_make_one_signal_strategy(signal),
+            data_provider=provider,
+            initial_balance=10_000_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=slippage_rate,
+        )
+        result = await executor.run()
+        return executor, result
+
+    # ── limit ─────────────────────────────────────────
+
+    async def test_limit_buy_not_triggered_above(self, store):
+        """limit buy price=50, 현재가 100 → 미충족(현재가 > limit) → 미체결."""
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930", side="buy", quantity=10, order_type="limit", price=50.0
+            ),
+            current_close=100.0,
+        )
+        assert len(result.trades) == 0
+
+    async def test_limit_buy_triggered_below_caps_at_limit(self, store):
+        """limit buy price=50, 현재가 40 → 체결, exec_price ≤ 50(cap)."""
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930", side="buy", quantity=10, order_type="limit", price=50.0
+            ),
+            current_close=40.0,
+        )
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+        assert result.trades[0].price <= 50.0
+
+    async def test_limit_sell_not_triggered_below(self, store):
+        """limit sell price=150, 현재가 100 → 미충족(현재가 < limit) → 미체결."""
+        # 먼저 보유 포지션이 있어야 sell이 의미가 있으나, 트리거 게이트는 side
+        # 분기 이전이라 보유와 무관하게 미충족이면 skip된다. 보유 없이도 미체결.
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="sell",
+                quantity=10,
+                order_type="limit",
+                price=150.0,
+            ),
+            current_close=100.0,
+        )
+        assert len(result.trades) == 0
+
+    async def test_limit_sell_triggered_above_caps_at_limit(self, store):
+        """limit sell price=150, 현재가 160(보유 후) → 체결, exec_price ≥ 150(cap)."""
+        df = _make_ohlcv_df_with_closes([160.0, 160.0])
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        class BuyThenLimitSell(Strategy):
+            meta = StrategyMeta(name="buy_limit_sell", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 1:
+                    return [Signal(symbol="005930", side="buy", quantity=10)]
+                if self._step == 2:
+                    return [
+                        Signal(
+                            symbol="005930",
+                            side="sell",
+                            quantity=10,
+                            order_type="limit",
+                            price=150.0,
+                        )
+                    ]
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyThenLimitSell,
+            data_provider=provider,
+            initial_balance=10_000_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        result = await executor.run()
+        sells = [t for t in result.trades if t.side == "sell"]
+        assert len(sells) == 1
+        assert sells[0].price >= 150.0
+
+    # ── stop ──────────────────────────────────────────
+
+    async def test_stop_buy_not_triggered_below(self, store):
+        """stop buy stop_price=200, 현재가 100 → 미충족(현재가 < stop) → 미체결."""
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                order_type="stop",
+                stop_price=200.0,
+            ),
+            current_close=100.0,
+        )
+        assert len(result.trades) == 0
+
+    async def test_stop_buy_triggered_above(self, store):
+        """stop buy stop_price=200, 현재가 210 → 체결(트리거→시장가)."""
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                order_type="stop",
+                stop_price=200.0,
+            ),
+            current_close=210.0,
+        )
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+
+    async def test_stop_sell_not_triggered_above(self, store):
+        """stop sell stop_price=80, 현재가 100 → 미충족(현재가 > stop) → 미체결."""
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="sell",
+                quantity=10,
+                order_type="stop",
+                stop_price=80.0,
+            ),
+            current_close=100.0,
+        )
+        assert len(result.trades) == 0
+
+    async def test_stop_sell_triggered_below(self, store):
+        """stop sell stop_price=80, 현재가 70(보유 후) → 체결(트리거→시장가)."""
+        df = _make_ohlcv_df_with_closes([70.0, 70.0])
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        class BuyThenStopSell(Strategy):
+            meta = StrategyMeta(name="buy_stop_sell", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 1:
+                    return [Signal(symbol="005930", side="buy", quantity=10)]
+                if self._step == 2:
+                    return [
+                        Signal(
+                            symbol="005930",
+                            side="sell",
+                            quantity=10,
+                            order_type="stop",
+                            stop_price=80.0,
+                        )
+                    ]
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyThenStopSell,
+            data_provider=provider,
+            initial_balance=10_000_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=0.0,
+        )
+        result = await executor.run()
+        sells = [t for t in result.trades if t.side == "sell"]
+        assert len(sells) == 1
+
+    # ── stop_limit (단일-봉 conjunction 근사) ──────────
+
+    async def test_stop_limit_buy_triggered_within_band(self, store):
+        """stop_limit buy(S=150,L=160), 현재가 155 → 체결(stop 트리거+limit 충족)."""
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                order_type="stop_limit",
+                stop_price=150.0,
+                price=160.0,
+            ),
+            current_close=155.0,
+        )
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+        assert result.trades[0].price <= 160.0
+
+    async def test_stop_limit_buy_not_triggered_below_stop(self, store):
+        """stop_limit buy(S=150,L=160), 현재가 100 → 미체결(stop 트리거 안 됨)."""
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                order_type="stop_limit",
+                stop_price=150.0,
+                price=160.0,
+            ),
+            current_close=100.0,
+        )
+        assert len(result.trades) == 0
+
+    async def test_stop_limit_buy_not_triggered_above_limit(self, store):
+        """stop_limit buy(S=150,L=160), 현재가 170 → 미체결(limit 초과)."""
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                order_type="stop_limit",
+                stop_price=150.0,
+                price=160.0,
+            ),
+            current_close=170.0,
+        )
+        assert len(result.trades) == 0
+
+    # ── slippage cap ──────────────────────────────────
+
+    async def test_limit_buy_slippage_does_not_exceed_limit(self, store):
+        """slippage cap: limit buy L=100, 현재가 100, slippage>0 → exec_price ≤ 100.
+
+        market이면 exec_price = 100*(1+0.01)=101로 limit을 초과하지만, limit은
+        min cap으로 100을 넘지 않아야 한다.
+        """
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                order_type="limit",
+                price=100.0,
+            ),
+            current_close=100.0,
+            slippage_rate=0.01,
+        )
+        assert len(result.trades) == 1
+        # min(100*1.01, 100) = 100. 슬리피지가 limit을 불리하게 넘지 않는다.
+        assert result.trades[0].price == pytest.approx(100.0)
+        assert result.trades[0].price <= 100.0
+
+    # ── market 회귀 ────────────────────────────────────
+
+    async def test_market_order_fills_immediately(self, store):
+        """market(명시) → 현재가로 즉시 체결(회귀)."""
+        _, result = await self._run_single_signal(
+            store,
+            Signal(symbol="005930", side="buy", quantity=10, order_type="market"),
+            current_close=100.0,
+        )
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+
+    async def test_default_market_with_price_none_fills(self, store):
+        """기본 order_type(market)+price=None → 즉시 체결(회귀).
+
+        Signal 기본값(order_type="market", price=None, stop_price=None)이 게이트를
+        통과해 기존 시장가 체결 동작이 보존되는지 확인한다.
+        """
+        sig = Signal(symbol="005930", side="buy", quantity=10)
+        assert sig.order_type == "market"
+        assert sig.price is None
+        assert sig.stop_price is None
+        _, result = await self._run_single_signal(store, sig, current_close=100.0)
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+
+    # ── 필수 가격 필드 누락 / 알 수 없는 order_type ────
+
+    async def test_limit_missing_price_skipped_with_warning(self, store, caplog):
+        """limit + price=None → 미체결 skip + warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="ante.backtest.executor"):
+            _, result = await self._run_single_signal(
+                store,
+                Signal(symbol="005930", side="buy", quantity=10, order_type="limit"),
+                current_close=100.0,
+            )
+        assert len(result.trades) == 0
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("limit" in r.getMessage() for r in warnings)
+
+    async def test_stop_missing_stop_price_skipped_with_warning(self, store, caplog):
+        """stop + stop_price=None → 미체결 skip + warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="ante.backtest.executor"):
+            _, result = await self._run_single_signal(
+                store,
+                Signal(symbol="005930", side="buy", quantity=10, order_type="stop"),
+                current_close=100.0,
+            )
+        assert len(result.trades) == 0
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("stop" in r.getMessage() for r in warnings)
+
+    async def test_stop_limit_missing_field_skipped_with_warning(self, store, caplog):
+        """stop_limit + 한쪽 필드 누락(stop_price만, price=None) → 미체결 skip."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="ante.backtest.executor"):
+            _, result = await self._run_single_signal(
+                store,
+                Signal(
+                    symbol="005930",
+                    side="buy",
+                    quantity=10,
+                    order_type="stop_limit",
+                    stop_price=150.0,
+                ),
+                current_close=155.0,
+            )
+        assert len(result.trades) == 0
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("stop_limit" in r.getMessage() for r in warnings)
+
+    async def test_unknown_order_type_skipped_with_warning(self, store, caplog):
+        """알 수 없는 order_type → 미체결 skip + warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="ante.backtest.executor"):
+            _, result = await self._run_single_signal(
+                store,
+                Signal(
+                    symbol="005930", side="buy", quantity=10, order_type="trailing_stop"
+                ),
+                current_close=100.0,
+            )
+        assert len(result.trades) == 0
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("order_type" in r.getMessage() for r in warnings)

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -3319,6 +3319,59 @@ class TestBacktestOrderTypeGate:
         result = await executor.run()
         return executor, result
 
+    async def _run_buy_then_sell(
+        self,
+        store,
+        sell_signal: Signal,
+        closes: list[float],
+        *,
+        buy_quantity: float = 10,
+        slippage_rate: float = 0.0,
+    ):
+        """step 1에서 market buy로 포지션을 만든 뒤 step 2에서 *sell_signal* 평가.
+
+        보유 포지션이 필요한 sell 게이트(stop_limit sell 등)/sell-side slippage cap을
+        검증하기 위한 패턴이다(기존 ``BuyThenLimitSell``/``BuyThenStopSell`` 동형).
+        step 1 market buy는 게이트 무관하게 ``closes[0]`` 종가로 즉시 체결되고, step
+        2에서 ``closes[1]`` 종가로 *sell_signal* 트리거/체결가가 게이트된다. 봉이 2개
+        이상 필요하므로 *closes* 는 최소 2개를 준다.
+        """
+        df = _make_ohlcv_df_with_closes(closes)
+        store.write("005930", "1d", df)
+        provider = BacktestDataProvider(
+            store=store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        captured = sell_signal
+        qty = buy_quantity
+
+        class BuyThenSell(Strategy):
+            meta = StrategyMeta(name="buy_then_sell", version="1.0", description="t")
+
+            def __init__(self, ctx: Any) -> None:
+                super().__init__(ctx)
+                self._step = 0
+
+            async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+                self._step += 1
+                if self._step == 1:
+                    return [Signal(symbol="005930", side="buy", quantity=qty)]
+                if self._step == 2:
+                    return [captured]
+                return []
+
+        executor = BacktestExecutor(
+            strategy_cls=BuyThenSell,
+            data_provider=provider,
+            initial_balance=10_000_000,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
+            slippage_rate=slippage_rate,
+        )
+        result = await executor.run()
+        return executor, result
+
     # ── limit ─────────────────────────────────────────
 
     async def test_limit_buy_not_triggered_above(self, store):
@@ -3551,6 +3604,72 @@ class TestBacktestOrderTypeGate:
         )
         assert len(result.trades) == 0
 
+    async def test_stop_limit_sell_triggered_within_band(self, store):
+        """stop_limit sell(S=100,L=90), 현재가 95(보유 후) → 체결.
+
+        sell 트리거 조건은 ``현재가 <= S and 현재가 >= L``: 95 <= 100 and 95 >= 90
+        이므로 stop 트리거 + limit 충족이 동시에 만족된다(단일-봉 conjunction).
+        step 1 market buy로 보유 포지션을 만든 뒤 step 2 sell을 평가한다.
+        """
+        _, result = await self._run_buy_then_sell(
+            store,
+            Signal(
+                symbol="005930",
+                side="sell",
+                quantity=10,
+                order_type="stop_limit",
+                stop_price=100.0,
+                price=90.0,
+            ),
+            closes=[95.0, 95.0],
+        )
+        sells = [t for t in result.trades if t.side == "sell"]
+        assert len(sells) == 1
+        # limit cap: max(95*(1-slip=0), 90) = 95. exec_price ≥ limit(90).
+        assert sells[0].price >= 90.0
+
+    async def test_stop_limit_sell_not_triggered_above_stop(self, store):
+        """stop_limit sell(S=100,L=90), 현재가 110(보유 후) → 미체결(stop 트리거 안 됨).
+
+        110 > S=100 이라 sell stop(현재가 <= S)이 트리거되지 않는다. 보유 포지션이
+        있어도 게이트가 side 분기 이전이라 sell 거래가 발행되지 않는다.
+        """
+        _, result = await self._run_buy_then_sell(
+            store,
+            Signal(
+                symbol="005930",
+                side="sell",
+                quantity=10,
+                order_type="stop_limit",
+                stop_price=100.0,
+                price=90.0,
+            ),
+            closes=[110.0, 110.0],
+        )
+        sells = [t for t in result.trades if t.side == "sell"]
+        assert len(sells) == 0
+
+    async def test_stop_limit_sell_not_triggered_below_limit(self, store):
+        """stop_limit sell(S=100,L=90), 현재가 85(보유 후) → 미체결(limit 미충족).
+
+        85 <= S=100 으로 stop은 트리거되지만 85 < L=90 이라 sell limit(현재가 >= L)이
+        충족되지 않아 conjunction이 깨진다. 보유 포지션이 있어도 미체결.
+        """
+        _, result = await self._run_buy_then_sell(
+            store,
+            Signal(
+                symbol="005930",
+                side="sell",
+                quantity=10,
+                order_type="stop_limit",
+                stop_price=100.0,
+                price=90.0,
+            ),
+            closes=[85.0, 85.0],
+        )
+        sells = [t for t in result.trades if t.side == "sell"]
+        assert len(sells) == 0
+
     # ── slippage cap ──────────────────────────────────
 
     async def test_limit_buy_slippage_does_not_exceed_limit(self, store):
@@ -3575,6 +3694,32 @@ class TestBacktestOrderTypeGate:
         # min(100*1.01, 100) = 100. 슬리피지가 limit을 불리하게 넘지 않는다.
         assert result.trades[0].price == pytest.approx(100.0)
         assert result.trades[0].price <= 100.0
+
+    async def test_limit_sell_slippage_does_not_drop_below_limit(self, store):
+        """slippage cap(sell): limit sell L=100, 현재가 100, slippage>0 → exec ≥ 100.
+
+        sell 슬리피지는 ``price*(1-slip)`` 로 불리하게 내려가 market이면 99로 limit
+        미만을 수취하지만, limit은 ``max(99, 100)`` cap으로 limit(100) 미만을 수취하지
+        않아야 한다(buy의 ``min(.,L)`` 와 대칭인 sell ``max(.,L)`` 검증). step 1 market
+        buy로 보유 포지션을 확보한 뒤 step 2 limit sell을 평가한다.
+        """
+        _, result = await self._run_buy_then_sell(
+            store,
+            Signal(
+                symbol="005930",
+                side="sell",
+                quantity=10,
+                order_type="limit",
+                price=100.0,
+            ),
+            closes=[100.0, 100.0],
+            slippage_rate=0.01,
+        )
+        sells = [t for t in result.trades if t.side == "sell"]
+        assert len(sells) == 1
+        # max(100*0.99, 100) = 100. 슬리피지가 limit 아래로 내려가지 않는다.
+        assert sells[0].price == pytest.approx(100.0)
+        assert sells[0].price >= 100.0
 
     # ── market 회귀 ────────────────────────────────────
 

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -3552,6 +3552,54 @@ class TestBacktestOrderTypeGate:
         sells = [t for t in result.trades if t.side == "sell"]
         assert len(sells) == 1
 
+    async def test_stop_buy_triggered_applies_slippage_no_cap(self, store):
+        """stop buy(S=200, slip>0), 현재가 210 → 체결 + exec = price*(1+slip)(cap 없음).
+
+        stop은 트리거되면 시장가로 변환되어 limit cap 대상이 아니다. 슬리피지가 그대로
+        불리하게(매수가 상승) 반영된다(stop_limit buy의 ``min(.,L)`` cap과 대조).
+        현재가 210, slippage 0.01 → exec_price = 210*1.01 = 212.1.
+        """
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                order_type="stop",
+                stop_price=200.0,
+            ),
+            current_close=210.0,
+            slippage_rate=0.01,
+        )
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+        # stop은 트리거→시장가, cap 없음 → 210*(1+0.01) = 212.1 그대로.
+        assert result.trades[0].price == pytest.approx(212.1)
+
+    async def test_stop_sell_triggered_applies_slippage_no_cap(self, store):
+        """stop sell(S=80, slip>0), 현재가 70(보유) → exec = price*(1-slip)(cap 없음).
+
+        stop sell은 트리거되면 시장가로 변환되어 limit cap 대상이 아니다. 슬리피지가
+        그대로 불리하게(매도가 하락) 반영된다(stop_limit sell의 ``max(.,L)`` cap과
+        대조). step 2 현재가 70, slippage 0.01 → sell exec_price = 70*(1-0.01) = 69.3.
+        """
+        _, result = await self._run_buy_then_sell(
+            store,
+            Signal(
+                symbol="005930",
+                side="sell",
+                quantity=10,
+                order_type="stop",
+                stop_price=80.0,
+            ),
+            closes=[70.0, 70.0],
+            slippage_rate=0.01,
+        )
+        sells = [t for t in result.trades if t.side == "sell"]
+        assert len(sells) == 1
+        # stop은 트리거→시장가, cap 없음 → 70*(1-0.01) = 69.3 그대로.
+        assert sells[0].price == pytest.approx(69.3)
+
     # ── stop_limit (단일-봉 conjunction 근사) ──────────
 
     async def test_stop_limit_buy_triggered_within_band(self, store):
@@ -3721,6 +3769,60 @@ class TestBacktestOrderTypeGate:
         assert sells[0].price == pytest.approx(100.0)
         assert sells[0].price >= 100.0
 
+    async def test_stop_limit_buy_slippage_does_not_exceed_limit(self, store):
+        """slippage cap(stop_limit buy): S=150,L=160, 현재가 160, slip>0 → exec ≤ 160.
+
+        160 >= S=150 and 160 <= L=160 으로 stop 트리거+limit 충족(단일-봉 conjunction).
+        market이면 160*(1+0.01)=161.6으로 limit을 초과하지만, stop_limit buy도 limit과
+        동일하게 ``min(slipped, L)`` cap으로 L(160)을 넘지 않아야 한다.
+        """
+        _, result = await self._run_single_signal(
+            store,
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                order_type="stop_limit",
+                stop_price=150.0,
+                price=160.0,
+            ),
+            current_close=160.0,
+            slippage_rate=0.01,
+        )
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+        # min(160*1.01=161.6, 160) = 160. 슬리피지가 limit을 불리하게 넘지 않는다.
+        assert result.trades[0].price == pytest.approx(160.0)
+        assert result.trades[0].price <= 160.0
+
+    async def test_stop_limit_sell_slippage_does_not_drop_below_limit(self, store):
+        """slippage cap(stop_limit sell): S=100,L=90, 현재가 90(보유) slip>0 → exec≥90.
+
+        90 <= S=100 and 90 >= L=90 으로 stop 트리거+limit 충족(단일-봉 conjunction).
+        market sell이면 90*(1-0.01)=89.1로 limit 미만을 수취하지만, stop_limit sell은
+        limit과 동일하게 ``max(slipped, L)`` cap으로 L(90) 미만을 수취하지 않아야 한다
+        (buy의 ``min(.,L)`` 와 대칭). step 1 market buy로 보유 포지션을 확보한 뒤
+        step 2 stop_limit sell을 평가한다.
+        """
+        _, result = await self._run_buy_then_sell(
+            store,
+            Signal(
+                symbol="005930",
+                side="sell",
+                quantity=10,
+                order_type="stop_limit",
+                stop_price=100.0,
+                price=90.0,
+            ),
+            closes=[90.0, 90.0],
+            slippage_rate=0.01,
+        )
+        sells = [t for t in result.trades if t.side == "sell"]
+        assert len(sells) == 1
+        # max(90*0.99=89.1, 90) = 90. 슬리피지가 limit 아래로 내려가지 않는다.
+        assert sells[0].price == pytest.approx(90.0)
+        assert sells[0].price >= 90.0
+
     # ── market 회귀 ────────────────────────────────────
 
     async def test_market_order_fills_immediately(self, store):
@@ -3746,6 +3848,44 @@ class TestBacktestOrderTypeGate:
         _, result = await self._run_single_signal(store, sig, current_close=100.0)
         assert len(result.trades) == 1
         assert result.trades[0].side == "buy"
+
+    async def test_market_buy_exec_price_applies_slippage_no_cap(self, store):
+        """market buy(명시, slip>0) → 즉시 체결 + exec = price*(1+slip)(cap 없음).
+
+        market은 limit cap 대상이 아니므로 슬리피지가 그대로 불리하게(매수가 상승)
+        반영된다(limit/stop_limit의 ``min(.,L)`` cap과 대조). 단일-봉 fixture에서
+        현재가 100, slippage 0.01 → exec_price = 100*1.01 = 101.
+        """
+        _, result = await self._run_single_signal(
+            store,
+            Signal(symbol="005930", side="buy", quantity=10, order_type="market"),
+            current_close=100.0,
+            slippage_rate=0.01,
+        )
+        assert len(result.trades) == 1
+        assert result.trades[0].side == "buy"
+        # market은 cap 없음 → 100*(1+0.01) = 101 그대로.
+        assert result.trades[0].price == pytest.approx(101.0)
+
+    async def test_market_sell_fills_immediately_applies_slippage_no_cap(self, store):
+        """market sell(보유, slip>0) → 즉시 체결 + exec = price*(1-slip)(cap 없음).
+
+        market sell은 트리거 게이트 없이 즉시 체결되고(회귀: 보유 청산 보존),
+        limit cap 대상이 아니므로 슬리피지가 그대로 불리하게(매도가 하락) 반영된다
+        (limit/stop_limit sell의 ``max(.,L)`` cap과 대조). step 1 market buy로
+        보유 포지션을 확보한 뒤 step 2 market sell을 평가한다. step 2 현재가 100,
+        slippage 0.01 → sell exec_price = 100*(1-0.01) = 99.
+        """
+        _, result = await self._run_buy_then_sell(
+            store,
+            Signal(symbol="005930", side="sell", quantity=10, order_type="market"),
+            closes=[100.0, 100.0],
+            slippage_rate=0.01,
+        )
+        sells = [t for t in result.trades if t.side == "sell"]
+        assert len(sells) == 1
+        # market sell은 cap 없음 → 100*(1-0.01) = 99 그대로(limit cap 미적용 대조).
+        assert sells[0].price == pytest.approx(99.0)
 
     # ── 필수 가격 필드 누락 / 알 수 없는 order_type ────
 


### PR DESCRIPTION
Closes #1994

## Summary
- backtest `_execute_signal`이 `Signal.order_type`/`price`/`stop_price`를 무시하고 현재 봉가로 즉시 체결 → limit/stop 조건 미충족에도 시장가 체결되던 버그
- `_order_triggered` 게이트(현재 봉 기준): market 항상; limit(L) buy `price<=L`/sell `price>=L`; stop(S) buy `price>=S`/sell `price<=S`; stop_limit(S,L) buy `price>=S and price<=L`/sell `price<=S and price>=L`. 필수 가격 필드 None/unknown → 미체결+warning. 미트리거 → 미체결(return None, #2073 dict|None 일관)
- 체결가 cap: limit/stop_limit은 slippage가 limit을 불리하게 넘지 않도록 cap(buy `min(price*(1+slip),L)`, sell `max(price*(1-slip),L)`). market/stop(트리거→시장가)은 slippage 그대로
- **known-limitation(주석 명시)**: per-bar 평가, cross-bar resting order book 미모델링. stop_limit은 단일-봉 conjunction 근사(트리거-후-resting 2단계 미보존) — 후속 이슈 대상

## Test Plan
- test_backtest 148 passed, -k backtest 389, contracts 145 / mypy Success / ruff clean
- TestBacktestOrderTypeGate 28건: buy/sell × {market,limit,stop,stop_limit} × {trigger 충족/미충족, slippage cap 양방향, stop no-cap 대조} + market 회귀 + missing-field/unknown

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS (attempt 4)