### PR TITLE
fix(feed): #2019 RateLimiter 날짜 self-reset + #2048 token refill 시간 전진

### DIFF
--- a/src/ante/feed/sources/base.py
+++ b/src/ante/feed/sources/base.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    pass
+    from datetime import date
 
 logger = logging.getLogger(__name__)
+
+# KST(UTC+9) 캘린더 기준. cli_scheduler.KST / backfill_runner._today_kst()와
+# 동일 기준이어야 daily 한도 리셋의 "하루" 경계가 repo 전반과 정합한다.
+_KST = timezone(timedelta(hours=9))
 
 
 @runtime_checkable
@@ -39,14 +45,36 @@ class RateLimiter:
 
     data.go.kr (30 tps, 10,000건/일) 및 DART (20,000건/일)를 위한
     호출 속도 제어와 일일 한도 추적을 담당한다.
+
+    일일 카운터는 self-resetting이다. ``increment_daily`` /
+    ``is_daily_limit_reached`` 호출 시점에 KST 캘린더 날짜가 직전 기록과
+    다르면 자동으로 0으로 리셋한다. 따라서 feed start 같은 상주 프로세스가
+    자정을 넘겨도 별도 스케줄러 없이 daily_count가 새 날짜에 맞게 초기화된다
+    (#2019).
+
+    동시성: ``increment_daily`` / ``is_daily_limit_reached`` /
+    ``reset_daily`` 는 sync 메서드로 유지한다(호출부 dart.py / data_go_kr.py가
+    sync로 호출). DataFeed 소스는 단일 asyncio event loop에서 동작하고 이
+    메서드들은 내부에 await 지점이 없으므로 코루틴 간 원자적이다. 별도 lock을
+    두지 않는다. ``acquire()`` 의 ``asyncio.Lock`` 은 토큰 버킷 갱신만
+    보호하며 이 sync 메서드들과는 별개의 임계영역이다.
     """
 
-    def __init__(self, tps_limit: float, daily_limit: int) -> None:
+    def __init__(
+        self,
+        tps_limit: float,
+        daily_limit: int,
+        now_date: Callable[[], date] | None = None,
+    ) -> None:
         """RateLimiter를 초기화한다.
 
         Args:
             tps_limit: 초당 허용 트랜잭션 수.
             daily_limit: 일일 최대 호출 수.
+            now_date: 현재 날짜(KST 캘린더)를 반환하는 콜러블. 테스트에서
+                날짜 경계를 결정적으로 주입하기 위한 훅이며, 미지정 시
+                KST(UTC+9) 기준 현재 날짜를 사용한다. 기존 호출부의
+                ``RateLimiter(tps, daily)`` 시그니처와 호환된다.
         """
         self._rate = tps_limit
         self._burst = int(tps_limit)
@@ -55,6 +83,12 @@ class RateLimiter:
         self._lock = asyncio.Lock()
         self._daily_limit = daily_limit
         self._daily_count = 0
+        self._now_date: Callable[[], date] = now_date or (
+            lambda: datetime.now(tz=_KST).date()
+        )
+        # 일일 카운터가 마지막으로 귀속된 날짜. None이면 아직 미관측 상태로,
+        # 첫 increment_daily / is_daily_limit_reached 시 현재 날짜로 baseline.
+        self._daily_date: date | None = None
 
     async def acquire(self) -> None:
         """토큰 하나를 소비한다. 필요 시 대기한다."""
@@ -68,15 +102,36 @@ class RateLimiter:
                 wait_time = (1 - self._tokens) / self._rate
                 await asyncio.sleep(wait_time)
                 self._tokens = 0
+                # sleep 동안 흐른 시간을 다음 acquire의 elapsed로 재크레딧하면
+                # 설정 TPS의 약 2배가 허용된다(#2048). _last_refill을 sleep
+                # 종료 시점(now + wait_time)으로 명시 전진시켜 차단한다.
+                self._last_refill = now + wait_time
             else:
                 self._tokens -= 1
 
+    def _roll_daily_date(self) -> None:
+        """현재 날짜가 직전 기록과 다르면 일일 카운터를 리셋한다.
+
+        single event loop 가정 하에 await 없이 동작하므로 코루틴 간 atomic.
+        """
+        d = self._now_date()
+        if self._daily_date != d:
+            self._daily_count = 0
+            self._daily_date = d
+
     def increment_daily(self) -> None:
-        """일일 호출 카운터를 1 증가시킨다."""
+        """일일 호출 카운터를 1 증가시킨다.
+
+        호출 시점 KST 날짜가 직전 기록과 다르면 먼저 0으로 리셋한 뒤 증가한다.
+        """
+        self._roll_daily_date()
         self._daily_count += 1
 
     def is_daily_limit_reached(self, threshold: float = 0.9) -> bool:
         """일일 한도의 threshold 비율에 도달했는지 확인한다.
+
+        호출 시점 KST 날짜가 직전 기록과 다르면 먼저 0으로 리셋한다(증가 없이
+        자정을 넘긴 check도 새 날짜의 0을 반영).
 
         Args:
             threshold: 한도 비율 (기본값 0.9 = 90%).
@@ -84,11 +139,17 @@ class RateLimiter:
         Returns:
             한도에 도달하면 True.
         """
+        self._roll_daily_date()
         return self._daily_count >= int(self._daily_limit * threshold)
 
     def reset_daily(self) -> None:
-        """일일 카운터를 초기화한다 (자정 후 호출)."""
+        """일일 카운터를 초기화한다 (명시적 리셋).
+
+        카운터를 0으로 되돌리는 동시에 ``_daily_date`` 를 현재 KST 날짜로
+        설정해, 명시 리셋 시점을 새 날짜 baseline으로 고정한다.
+        """
         self._daily_count = 0
+        self._daily_date = self._now_date()
 
     @property
     def daily_count(self) -> int:

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -286,6 +287,168 @@ class TestRateLimiter:
         # 여러 번 acquire해도 에러 없이 동작한다
         for _ in range(5):
             await rl.acquire()
+
+    def test_backward_compat_two_positional_args(self) -> None:
+        """기존 호출부의 RateLimiter(tps, daily) 시그니처가 그대로 동작한다."""
+        rl = RateLimiter(25.0, 10_000)
+        assert rl.daily_count == 0
+        rl.increment_daily()
+        assert rl.daily_count == 1
+
+
+# ── RateLimiter: token refill 시간 전진 (#2048) ───────────────
+
+
+class TestRateLimiterTokenRefill:
+    """#2048: sleep 경로의 _last_refill 전진으로 2x TPS 허용을 차단한다."""
+
+    @pytest.mark.asyncio
+    async def test_last_refill_advances_past_sleep(self) -> None:
+        """토큰 소진 후 sleep 분기에서 _last_refill이 now + wait_time로 전진한다.
+
+        sleep 동안 흐른 시간을 다음 acquire의 elapsed로 재크레딧하면 설정 TPS의
+        약 2배가 허용된다. monotonic을 결정적으로 mock해 _last_refill이 sleep
+        종료 시점으로 명시 전진하는지 단언한다.
+        """
+        rl = RateLimiter(tps_limit=2.0, daily_limit=100)
+        # burst=2 토큰을 먼저 소진시키고, _last_refill을 mock 시계 기준으로 맞춘다.
+        rl._tokens = 0.0
+        rl._last_refill = 1000.0
+
+        clock = {"t": 1000.0}
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+            # 실제 이벤트 루프 시간 진행을 흉내내지 않아도 _last_refill 단언으로 충분.
+
+        with (
+            patch(
+                "ante.feed.sources.base.time.monotonic",
+                side_effect=lambda: clock["t"],
+            ),
+            patch(
+                "ante.feed.sources.base.asyncio.sleep",
+                side_effect=fake_sleep,
+            ),
+        ):
+            await rl.acquire()
+
+        # rate=2 → 토큰 1개 충전에 wait_time = (1 - 0) / 2 = 0.5초.
+        assert sleeps == [0.5]
+        # _last_refill은 now(1000.0) + wait_time(0.5)로 전진해야 한다.
+        assert rl._last_refill == pytest.approx(1000.5)
+        # sleep 분기 종료 후 토큰은 0으로 유지된다.
+        assert rl._tokens == 0.0
+
+    @pytest.mark.asyncio
+    async def test_throughput_not_exceed_configured_rate(self) -> None:
+        """소진 후 연속 acquire의 누적 대기가 설정 rate를 초과 허용하지 않는다.
+
+        _last_refill이 sleep만큼 전진하지 않으면 두 번째 sleep 분기가 첫
+        sleep 구간을 재크레딧해 wait_time이 0으로 줄어든다(=2x TPS). 전진
+        수정 후에는 acquire마다 1/rate초의 wait_time이 일정하게 유지된다.
+        """
+        rl = RateLimiter(tps_limit=2.0, daily_limit=100)
+        # 토큰 소진 + _last_refill을 mock 시계 시작점으로 맞춘다.
+        rl._tokens = 0.0
+        rl._last_refill = 0.0
+
+        clock = {"t": 0.0}
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+            # sleep이 실제로 시계를 진행시킨다고 가정(상주 프로세스의 실시간).
+            clock["t"] += seconds
+
+        with (
+            patch(
+                "ante.feed.sources.base.time.monotonic",
+                side_effect=lambda: clock["t"],
+            ),
+            patch(
+                "ante.feed.sources.base.asyncio.sleep",
+                side_effect=fake_sleep,
+            ),
+        ):
+            for _ in range(3):
+                await rl.acquire()
+
+        # rate=2 → 매 acquire마다 0.5초 대기가 일정하게 유지되어야 한다.
+        # _last_refill이 전진하지 않으면 2번째 이후 wait_time이 0으로 붕괴된다.
+        assert sleeps == [0.5, 0.5, 0.5]
+
+
+# ── RateLimiter: 날짜 변경 self-reset (#2019) ─────────────────
+
+
+class TestRateLimiterDailyReset:
+    """#2019: 상주 프로세스가 자정을 넘겨도 daily_count가 self-reset된다."""
+
+    def test_increment_resets_on_date_change(self) -> None:
+        """D일 N회 증가 후 D+1로 바뀌면 다음 increment에서 1로 리셋된다."""
+        current = {"d": date(2026, 6, 1)}
+        rl = RateLimiter(tps_limit=10.0, daily_limit=100, now_date=lambda: current["d"])
+
+        for _ in range(5):
+            rl.increment_daily()
+        assert rl.daily_count == 5
+
+        current["d"] = date(2026, 6, 2)
+        rl.increment_daily()
+        assert rl.daily_count == 1
+
+    def test_same_day_accumulates(self) -> None:
+        """같은 날 내에서는 누적이 유지된다."""
+        rl = RateLimiter(
+            tps_limit=10.0, daily_limit=100, now_date=lambda: date(2026, 6, 1)
+        )
+        for _ in range(7):
+            rl.increment_daily()
+        assert rl.daily_count == 7
+
+    def test_is_daily_limit_reached_resets_on_date_change(self) -> None:
+        """증가 없이 자정을 넘긴 check도 새 날짜의 0을 반영해 한도 해제된다."""
+        current = {"d": date(2026, 6, 1)}
+        rl = RateLimiter(tps_limit=10.0, daily_limit=100, now_date=lambda: current["d"])
+
+        for _ in range(90):
+            rl.increment_daily()
+        assert rl.is_daily_limit_reached() is True
+
+        # 날짜가 바뀌면 increment 없이 check만으로도 카운터가 리셋된다.
+        current["d"] = date(2026, 6, 2)
+        assert rl.is_daily_limit_reached() is False
+        assert rl.daily_count == 0
+
+    def test_reset_daily_sets_current_date_baseline(self) -> None:
+        """reset_daily는 카운터를 0으로 되돌리고 _daily_date를 현재로 갱신한다."""
+        current = {"d": date(2026, 6, 1)}
+        rl = RateLimiter(tps_limit=10.0, daily_limit=100, now_date=lambda: current["d"])
+
+        for _ in range(10):
+            rl.increment_daily()
+        assert rl.daily_count == 10
+
+        rl.reset_daily()
+        assert rl.daily_count == 0
+        assert rl._daily_date == date(2026, 6, 1)
+
+        # reset 직후 같은 날 increment는 1부터 누적된다(재리셋 없음).
+        rl.increment_daily()
+        assert rl.daily_count == 1
+
+    def test_default_now_date_uses_kst(self) -> None:
+        """now_date 미지정 시 KST 기준 현재 날짜로 동작한다(스모크)."""
+        from datetime import datetime
+
+        from ante.feed.sources.base import _KST
+
+        rl = RateLimiter(tps_limit=10.0, daily_limit=100)
+        rl.increment_daily()
+        assert rl.daily_count == 1
+        assert rl._daily_date == datetime.now(tz=_KST).date()
 
 
 # ── fetch_by_date ────────────────────────────────────────────


### PR DESCRIPTION
Closes #2019
Closes #2048

## Summary
DataFeed `RateLimiter`(feed/sources/base.py) 2건:
- **#2048(P1)**: `acquire()`가 토큰 부족 sleep 후 `_last_refill`을 전진시키지 않아 다음 acquire가 slept 구간을 재크레딧 → 설정 TPS ~2배 허용. sleep 후 `_last_refill = now + wait_time`로 전진해 차단
- **#2019(P1)**: feed start 상주 프로세스가 날짜 변경 시 reset_daily()를 호출하지 않아 daily_count가 다음 날에도 한도 도달 유지. RateLimiter를 self-resetting으로 — `_daily_date` + injectable `now_date`(default KST=UTC+9). `increment_daily`/`is_daily_limit_reached`가 날짜 변경 감지해 리셋, `reset_daily`는 `_daily_date` baseline 갱신
- 동시성: sync 메서드(single asyncio event loop, await 없어 atomic; acquire의 asyncio.Lock과 별개) — docstring 명시. backward-compat `RateLimiter(tps,daily)` 유지

## Test Plan
- ratelimit/sources 84 passed, -k feed 488, contracts 145 / mypy Success / ruff clean
- 신규: token refill 시간 전진·throughput 회귀, 날짜 변경 리셋·동일일 누적·is_daily 리셋·reset_daily baseline·default KST·backward-compat

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS