### PR TITLE
fix(feed): #2106 RateLimiter daily_count를 request attempt 기준으로 — 실패/재시도 시도 반영

### DIFF
--- a/src/ante/feed/sources/dart.py
+++ b/src/ante/feed/sources/dart.py
@@ -200,7 +200,8 @@ class DARTSource:
             if own_session:
                 await session.close()
 
-        self._rate_limiter.increment_daily()
+        # daily_count는 _download_corp_code_zip 내부에서 각 HTTP attempt마다
+        # 카운트된다 (#2106). 여기서 성공 후 별도 increment하지 않는다.
 
         # ZIP 해제 및 XML 파싱
         corp_code_map = self._parse_corp_code_zip(zip_bytes)
@@ -308,6 +309,10 @@ class DARTSource:
 
         for attempt in range(self._max_retries):
             await self._rate_limiter.acquire()
+            # 실제 HTTP 요청(session.get) 시도 직전에 카운트한다.
+            # 성공/실패와 무관하게 모든 attempt를 반영한다 (#2106).
+            # 1 attempt = 1 increment.
+            self._rate_limiter.increment_daily()
 
             try:
                 async with asyncio.timeout(REQUEST_TIMEOUT):
@@ -431,13 +436,16 @@ class DARTSource:
 
         for attempt in range(self._max_retries):
             await self._rate_limiter.acquire()
+            # 실제 HTTP 요청 시도(_do_request) 직전에 카운트한다.
+            # 성공/실패와 무관하게 모든 attempt를 반영한다 (#2106).
+            # 1 attempt = 1 increment.
+            self._rate_limiter.increment_daily()
 
             try:
                 data = await asyncio.wait_for(
                     self._do_request(session, url, params),
                     timeout=REQUEST_TIMEOUT,
                 )
-                self._rate_limiter.increment_daily()
             except (TimeoutError, aiohttp.ClientError) as exc:
                 last_error = exc
                 delay = self._backoff_delay(attempt)

--- a/src/ante/feed/sources/data_go_kr.py
+++ b/src/ante/feed/sources/data_go_kr.py
@@ -240,13 +240,16 @@ class DataGoKrSource:
 
         for attempt in range(self._max_retries):
             await self._rate_limiter.acquire()
+            # 실제 HTTP 요청 시도(_do_request) 직전에 카운트한다.
+            # 성공/실패와 무관하게 모든 attempt를 반영하여 일일 한도 추적이
+            # 실패·재시도 시도를 누락하지 않도록 한다 (#2106). 1 attempt = 1 increment.
+            self._rate_limiter.increment_daily()
 
             try:
                 data = await asyncio.wait_for(
                     self._do_request(session, params),
                     timeout=REQUEST_TIMEOUT,
                 )
-                self._rate_limiter.increment_daily()
             except (TimeoutError, aiohttp.ClientError) as exc:
                 last_error = exc
                 delay = self._backoff_delay(attempt)

--- a/tests/unit/feed/test_dart.py
+++ b/tests/unit/feed/test_dart.py
@@ -502,6 +502,120 @@ class TestFetchFinancial:
         assert call_count == 1
 
 
+# -- daily_count attempt 기준 카운팅 (#2106) ----------------------------
+
+
+class _FakeZipResponse:
+    """_download_corp_code_zip의 session.get(...) async context manager 모킹.
+
+    ZIP 바이너리 응답을 흉내낸다 (content_type='application/zip').
+    """
+
+    def __init__(self, zip_bytes: bytes) -> None:
+        self._zip_bytes = zip_bytes
+        self.content_type = "application/zip"
+
+    async def __aenter__(self) -> _FakeZipResponse:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def read(self) -> bytes:
+        return self._zip_bytes
+
+
+class TestDailyCountAttemptCounting:
+    """모든 실제 HTTP 호출 경로에서 daily_count가 attempt 기준으로 증가한다.
+
+    실패/재시도 attempt도 카운트되고, 성공 시 1 attempt = 1 increment로
+    이중 카운트가 없어야 한다 (#2106).
+    """
+
+    # -- financial (_fetch_multi_acnt) 경로 --
+
+    @pytest.mark.asyncio
+    async def test_financial_failed_attempts_counted(self, source: DARTSource) -> None:
+        """financial: _do_request가 항상 실패해도 attempt 수만큼 카운트된다."""
+        import aiohttp
+
+        async def always_fail(session, url, params):
+            raise aiohttp.ClientConnectionError("Connection refused")
+
+        with patch.object(source, "_do_request", side_effect=always_fail):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError, match="최종 실패"):
+                    await source.fetch_financial(["00126380"], "2024", "11011")
+
+        # max_retries=2 → 실패해도 2회 카운트 (기존엔 0)
+        assert source.rate_limiter.daily_count == source._max_retries == 2
+
+    @pytest.mark.asyncio
+    async def test_financial_success_counts_once(self, source: DARTSource) -> None:
+        """financial: 단일 배치 성공 → daily_count == 1 (이중 카운트 없음)."""
+        response = _make_financial_response([_make_financial_item()])
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            await source.fetch_financial(["00126380"], "2024", "11011")
+
+        assert source.rate_limiter.daily_count == 1
+
+    @pytest.mark.asyncio
+    async def test_financial_multi_batch_counts_per_batch(
+        self, source: DARTSource
+    ) -> None:
+        """financial: 150 corp(2배치) 성공 → daily_count == 배치 수(2)."""
+        corp_codes = [f"{i:08d}" for i in range(150)]
+        response = _make_financial_response([_make_financial_item()])
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            await source.fetch_financial(corp_codes, "2024", "11011")
+
+        assert source.rate_limiter.daily_count == 2
+
+    # -- corp_code ZIP download (_download_corp_code_zip) 경로 --
+
+    @pytest.mark.asyncio
+    async def test_corp_code_success_counts_once(self, source: DARTSource) -> None:
+        """corp_code: ZIP 다운로드 성공 1회 → daily_count == 1.
+
+        성공 후 외부 increment를 제거하고 attempt 내부 카운트로 일원화했으므로
+        이중 카운트가 없어야 한다 (#2106).
+        """
+        zip_bytes = _make_corp_code_zip(
+            [{"corp_code": "00126380", "stock_code": "005930"}]
+        )
+
+        with patch(
+            "aiohttp.ClientSession.get",
+            return_value=_FakeZipResponse(zip_bytes),
+        ):
+            result = await source.fetch_corp_codes()
+
+        assert result == {"00126380": "005930"}
+        assert source.rate_limiter.daily_count == 1
+
+    @pytest.mark.asyncio
+    async def test_corp_code_failed_attempts_counted(self, source: DARTSource) -> None:
+        """corp_code: download가 항상 실패해도 attempt 수만큼 카운트된다."""
+        import aiohttp
+
+        with patch(
+            "aiohttp.ClientSession.get",
+            side_effect=aiohttp.ClientConnectionError("Connection refused"),
+        ):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError, match="최종 실패"):
+                    await source.fetch_corp_codes()
+
+        # max_retries=2 → 실패해도 2회 카운트 (기존엔 0)
+        assert source.rate_limiter.daily_count == source._max_retries == 2
+
+
 # -- fetch (DataSource 프로토콜) ----------------------------------------
 
 

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -536,6 +536,97 @@ class TestFetchByDate:
                 await source.fetch_by_date("2024-03-01")
 
     @pytest.mark.asyncio
+    async def test_failed_attempts_counted_in_daily(
+        self, source: DataGoKrSource
+    ) -> None:
+        """실패한 attempt도 daily_count에 반영된다 (#2106 repro).
+
+        _do_request가 항상 ClientError를 던지면 max_retries(=2)번 시도하고
+        최종 실패한다. 실제 HTTP 요청이 그만큼 나갔으므로 daily_count는
+        attempt 수(=max_retries)와 같아야 한다. 기존엔 성공 후에만
+        increment하여 0으로 남았다.
+        """
+        import aiohttp
+
+        async def always_fail(session, params):
+            raise aiohttp.ClientConnectionError("Connection refused")
+
+        with patch.object(source, "_do_request", side_effect=always_fail):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DataGoKrError, match="최종 실패"):
+                    await source.fetch_by_date("2024-03-01")
+
+        # max_retries=2 → 2번 시도, 모두 실패해도 2회 카운트
+        assert source.rate_limiter.daily_count == source._max_retries == 2
+
+    @pytest.mark.asyncio
+    async def test_success_counts_once_no_double(self, source: DataGoKrSource) -> None:
+        """성공 시 attempt 1회만 카운트되고 이중 카운트가 없다 (#2106).
+
+        단일 페이지 성공 → daily_count == 1.
+        """
+        response = _make_response([_make_item()], total_count=1)
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            await source.fetch_by_date("2024-03-01")
+
+        assert source.rate_limiter.daily_count == 1
+
+    @pytest.mark.asyncio
+    async def test_multi_page_count_equals_page_count(
+        self, source: DataGoKrSource
+    ) -> None:
+        """다중 페이지 수집 시 daily_count == page 수 (이중 카운트 없음, #2106)."""
+        page1_items = [_make_item(srtn_cd=f"00{i:04d}") for i in range(1000)]
+        page1 = _make_response(page1_items, total_count=1500)
+        page2_items = [_make_item(srtn_cd=f"01{i:04d}") for i in range(500)]
+        page2 = _make_response(page2_items, total_count=1500)
+
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            return page1 if call_count == 1 else page2
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            await source.fetch_by_date("2024-03-01")
+
+        # 2 페이지 = 2 attempt = 2 increment
+        assert call_count == 2
+        assert source.rate_limiter.daily_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_then_success_counts_each_attempt(
+        self, source: DataGoKrSource
+    ) -> None:
+        """재시도 후 성공 시 실패 attempt + 성공 attempt 모두 카운트된다 (#2106).
+
+        첫 시도(ClientError 실패) + 두 번째 시도(성공) → daily_count == 2.
+        실제 HTTP 요청이 2회 나갔으므로 2회 카운트가 맞다.
+        """
+        import aiohttp
+
+        success_response = _make_response([_make_item()], total_count=1)
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise aiohttp.ClientConnectionError("Connection refused")
+            return success_response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                await source.fetch_by_date("2024-03-01")
+
+        assert call_count == 2
+        assert source.rate_limiter.daily_count == 2
+
+    @pytest.mark.asyncio
     async def test_fetch_delegates_to_fetch_by_date(
         self, source: DataGoKrSource
     ) -> None:


### PR DESCRIPTION
Closes #2106

## Summary
- DataFeed RateLimiter `daily_count`가 성공 응답만 카운트하고 실패/재시도 HTTP 시도를 누락 → 네트워크/HTTP 오류 반복 시 실제 요청이 나갔는데도 일일 한도 추적이 0으로 남아 보수적 가드 무력
- `increment_daily()`를 각 request **attempt** 기준(acquire 직후·`_do_request` 직전)으로 이동. 성공-후 increment 전부 제거 → **1 attempt = 1 increment**(성공/실패 무관 카운트, 이중 카운트 없음)
- 적용: data_go_kr `_fetch_page`, dart financial(`_fetch_multi_acnt`)·corp_code(`_download_corp_code_zip`) retry 루프. base.py RateLimiter 무변경(#2019/#2048와 독립)

## Test Plan
- 병합(#2019 base.py + #2106 sources) 후 feed/sources 519 passed / mypy Success / ruff clean
- 신규: data_go_kr 실패-attempt 카운팅·성공 1회·다중페이지·retry-then-success / dart financial·corp_code 실패/성공 카운팅

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS (origin/main merge로 #2019와의 test_data_go_kr.py 자동 병합·재검증 완료)