### PR TITLE
fix(data): #2095 ParquetStore.read strict 옵션 + backtest 손상 파티션 fail-closed

### DIFF
--- a/src/ante/backtest/data_provider.py
+++ b/src/ante/backtest/data_provider.py
@@ -10,6 +10,7 @@ import polars as pl
 
 from ante.backtest.config import DatasetInfo
 from ante.backtest.exceptions import BacktestDataError
+from ante.data.store import ParquetReadError
 from ante.strategy.base import DataProvider
 
 if TYPE_CHECKING:
@@ -79,15 +80,31 @@ class BacktestDataProvider(DataProvider):
         return list(self._loaded_datasets)
 
     def load(self, symbol: str, timeframe: str) -> int:
-        """데이터를 캐시에 로드. 로드된 행 수 반환."""
+        """데이터를 캐시에 로드. 로드된 행 수 반환.
+
+        손상 파티션은 `strict=True`로 fail-closed 처리한다(#2095). store가
+        손상 파티션을 silent skip하고 부분 데이터를 반환하면 백테스트가 일부
+        기간을 빠뜨린 채 성공할 수 있으므로, `ParquetReadError`를
+        `BacktestDataError`로 wrap해 loud 실패시킨다. get_ohlcv() 등의
+        on-demand 적재 경로도 이 load()를 거치므로 동일하게 strict가 적용된다.
+
+        Raises:
+            BacktestDataError: 손상 파티션으로 데이터 로드에 실패했을 때.
+        """
         key = f"{symbol}:{timeframe}"
-        df = self._store.read(
-            symbol,
-            timeframe,
-            start=self._start,
-            end=self._end,
-            exchange=self._exchange,
-        )
+        try:
+            df = self._store.read(
+                symbol,
+                timeframe,
+                start=self._start,
+                end=self._end,
+                exchange=self._exchange,
+                strict=True,
+            )
+        except ParquetReadError as e:
+            raise BacktestDataError(
+                f"백테스트 데이터 로드 실패(손상 파티션): {symbol}: {e}"
+            ) from e
         self._cache[key] = df
         # 새 데이터가 캐시에 들어오면 통합 timeline을 무효화한다(#2098). 다음
         # advance()/get_total_steps()/get_current_timestamp() 접근 시 lazy-build.

--- a/src/ante/data/__init__.py
+++ b/src/ante/data/__init__.py
@@ -21,7 +21,7 @@ from ante.data.schemas import (
     TICK_SCHEMA,
     TIMEFRAMES,
 )
-from ante.data.store import ParquetStore, migrate_parquet_paths
+from ante.data.store import ParquetReadError, ParquetStore, migrate_parquet_paths
 
 __all__ = [
     "BaseNormalizer",
@@ -35,6 +35,7 @@ __all__ = [
     "KISNormalizer",
     "OHLCV_COLUMNS",
     "OHLCV_SCHEMA",
+    "ParquetReadError",
     "ParquetStore",
     "RetentionPolicy",
     "TICK_SCHEMA",

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -16,6 +16,20 @@ from ante.core.exchange import CANONICAL_EXCHANGES, is_canonical
 logger = logging.getLogger(__name__)
 
 
+class ParquetReadError(Exception):
+    """Parquet 파티션을 읽는 도중 손상 파일을 만났을 때 발생.
+
+    `ParquetStore.read(..., strict=True)` 경로 전용 예외다. tolerant
+    경로(`strict=False`, 기본)는 손상 파티션을 logger.warning + continue로
+    skip하므로 이 예외를 발생시키지 않는다(feed/CLI 회귀 방지). strict
+    경로(backtest data 로드 등)는 손상 파티션을 만나면 부분 데이터로
+    silent 성공하지 않고 이 예외로 즉시 실패한다(#2095).
+
+    메시지에 손상 파일 경로와 원인 예외를 포함하며, `raise ... from exc`
+    로 원인 예외 체인을 보존한다.
+    """
+
+
 def _is_safe_path_segment(seg: str) -> bool:
     """단일 path segment가 traversal-safe한지 판정.
 
@@ -324,6 +338,7 @@ class ParquetStore:
         limit: int | None = None,
         data_type: str = "ohlcv",
         exchange: str = "KRX",
+        strict: bool = False,
     ) -> pl.DataFrame:
         """Parquet에서 데이터 읽기.
 
@@ -335,6 +350,17 @@ class ParquetStore:
             limit: 최근 N건만 반환
             data_type: 데이터 타입 (ohlcv, fundamental, tick)
             exchange: 거래소 코드 (KRX, NYSE, NASDAQ 등)
+            strict: 손상 파티션 처리 정책(#2095).
+                - False(기본): tolerant. 손상 파티션을 logger.warning 후
+                  skip하고 나머지로 부분 DataFrame을 반환한다(feed/CLI 등
+                  부분-허용 공용 경로의 기존 동작 보존).
+                - True: fail-closed. 손상 파티션을 만나면 부분 데이터로
+                  silent 성공하지 않고 즉시 `ParquetReadError`를 raise한다
+                  (backtest 데이터 로드 전용). 부분 데이터로 백테스트가
+                  일부 기간을 빠뜨린 채 성공하는 버그를 차단한다.
+
+        Raises:
+            ParquetReadError: strict=True이며 손상 파티션을 만났을 때.
         """
         path = self._resolve_path(symbol, timeframe, data_type, exchange)
         if not path.exists():
@@ -348,7 +374,11 @@ class ParquetStore:
         for f in files:
             try:
                 dfs.append(pl.read_parquet(f))
-            except Exception:
+            except Exception as exc:
+                if strict:
+                    raise ParquetReadError(
+                        f"Corrupt parquet partition: {f}: {exc}"
+                    ) from exc
                 logger.warning("Failed to read parquet file: %s", f)
                 continue
 

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -131,6 +131,13 @@ pending_migration:
   - module: ante.config.exceptions
     class_anchor: ConfigError
     reason: "base — no callsite; pending_migration baseline (#1842 AccountError 동형)"
+  # #2095: store 내부 손상-파티션 예외. read(strict=True) 경로에서만 raise되며
+  # data_provider.load()가 즉시 BacktestDataError(이미 pending_migration 등록)로
+  # wrap·re-raise하므로 CLI/IPC 표면에 직접 노출되지 않는다. backtest sibling
+  # 예외(BacktestDataError 등)와 동형으로 baseline 보존.
+  - module: ante.data.store
+    class_anchor: ParquetReadError
+    reason: "internal store fault wrapped into BacktestDataError (#2095); baseline (#1842 동형)"
   - module: ante.feed.sources.dart
     class_anchor: CriticalApiError
     reason: "baseline (#1841); register in #1842/#1843"

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -420,6 +420,35 @@ class TestBacktestDataProvider:
         assert datasets1 == datasets2
         assert datasets1 is not datasets2
 
+    async def test_load_corrupt_partition_raises_data_error(
+        self, loaded_store, data_dir
+    ):
+        """손상 파티션 적재 시 load()가 BacktestDataError로 loud 실패(#2095).
+
+        정상 파티션만으로 silent 성공(부분 데이터로 일부 기간 누락)하던
+        버그의 repro. store.read(strict=True)가 ParquetReadError를 raise하면
+        load()가 BacktestDataError로 wrap·re-raise한다.
+        """
+        # 정상 1월 파티션(loaded_store) 옆에 손상 2월 파티션을 주입
+        part_dir = data_dir / "ohlcv" / "1d" / "KRX" / "005930"
+        (part_dir / "2026-02.parquet").write_text("not parquet")
+
+        provider = BacktestDataProvider(
+            store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        with pytest.raises(BacktestDataError) as exc_info:
+            provider.load("005930", "1d")
+        assert "손상 파티션" in str(exc_info.value)
+
+    async def test_load_normal_data_regression(self, loaded_store):
+        """손상 없는 store는 load()가 정상 동작(회귀, #2095)."""
+        provider = BacktestDataProvider(
+            store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        rows = provider.load("005930", "1d")
+        assert rows == 10
+        assert len(provider.loaded_datasets) == 1
+
 
 # ── BacktestStrategyContext 테스트 ─────────────────
 

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -21,7 +21,7 @@ from ante.data.schemas import (
     validate_fundamental,
     validate_ohlcv,
 )
-from ante.data.store import ParquetStore
+from ante.data.store import ParquetReadError, ParquetStore
 
 # ── Fixtures ─────────────────────────────────────────
 
@@ -556,6 +556,53 @@ class TestParquetStore:
         assert len(result) == 2
         cols = set(result.columns)
         assert {"market_cap", "shares_listed", "total_assets", "net_income"} <= cols
+
+    async def test_read_strict_raises_on_corrupt_partition(self, store, data_dir):
+        """strict=True면 손상 파티션을 만나는 즉시 ParquetReadError를 raise(#2095).
+
+        정상 파티션 + 손상 파일이 섞여 있을 때, strict 경로는 부분 데이터로
+        silent 성공하지 않고 loud 실패한다.
+        """
+        # 정상 2월 파티션 작성
+        store.write("005930", "1d", _make_ohlcv_df(n=5, start="2026-02-01T09:00:00"))
+        # 같은 디렉토리에 손상 파티션 주입(읽을 수 있으나 parquet 아님)
+        part_dir = data_dir / "ohlcv" / "1d" / "KRX" / "005930"
+        (part_dir / "2026-03.parquet").write_text("not parquet")
+
+        with pytest.raises(ParquetReadError) as exc_info:
+            store.read("005930", "1d", strict=True)
+        # 손상 파일 경로가 메시지에 포함된다
+        assert "2026-03.parquet" in str(exc_info.value)
+
+    async def test_read_tolerant_skips_corrupt_partition_regression(
+        self, store, data_dir, caplog
+    ):
+        """strict=False(기본)는 손상 파티션을 skip하고 부분 반환(현 동작 회귀, #2095).
+
+        feed/CLI 등 부분-허용 공용 경로의 기존 tolerant 동작이 불변임을 확인한다.
+        손상 파티션은 logger.warning 후 skip되고, 정상 파티션만 반환된다.
+        """
+        import logging
+
+        store.write("005930", "1d", _make_ohlcv_df(n=5, start="2026-02-01T09:00:00"))
+        part_dir = data_dir / "ohlcv" / "1d" / "KRX" / "005930"
+        (part_dir / "2026-03.parquet").write_text("not parquet")
+
+        with caplog.at_level(logging.WARNING, logger="ante.data.store"):
+            result = store.read("005930", "1d")  # strict 기본 False
+
+        # 손상 파티션은 skip되고 정상 파티션(2월 5행)만 반환된다
+        assert len(result) == 5
+        assert any(
+            "Failed to read parquet file" in rec.message for rec in caplog.records
+        )
+
+    async def test_read_strict_normal_data_regression(self, store):
+        """손상 없는 store는 strict=True여도 정상 반환(회귀, #2095)."""
+        store.write("005930", "1d", _make_ohlcv_df(n=5, start="2026-02-01T09:00:00"))
+        result = store.read("005930", "1d", strict=True)
+        assert len(result) == 5
+        assert result["symbol"][0] == "005930"
 
 
 # ── normalizer.py 테스트 ─────────────────────────────


### PR DESCRIPTION
Closes #2095

## Summary
- `ParquetStore.read()`가 손상 parquet 파티션을 warning만 남기고 부분 DataFrame 반환 → `BacktestDataProvider.load()`가 부분 데이터를 정상 수락해 백테스트가 일부 기간 누락 채 silent 성공
- store.py: `ParquetReadError` + `read(..., strict: bool=False)`. strict=False(기본)는 현 tolerant(warn+skip+부분 반환, feed/CLI 불변), strict=True는 손상 파티션에 ParquetReadError raise
- data_provider.py: `load()`가 strict=True 호출, ParquetReadError를 BacktestDataError로 wrap → 백테스트 loud 실패. on-demand get_ohlcv/get_current_bar_price load 경로도 일관
- error drift guard: ParquetReadError를 allowlist pending_migration 등록(BacktestDataError로 wrap, CLI/IPC 미노출 — sibling 패턴)

## Test Plan
- store/parquet/data_provider/backtest 587 passed, feed/data 935, contracts 145 / mypy Success / ruff clean
- 신규 5: strict raise·tolerant 회귀·정상 회귀·load BacktestDataError(repro)·load 정상 회귀

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS