### PR TITLE
fix(feed): #2003 scheduler 날짜 생성 헬퍼를 KST 기준으로

### DIFF
--- a/src/ante/feed/pipeline/scheduler.py
+++ b/src/ante/feed/pipeline/scheduler.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
+
+# KST(UTC+9) 캘린더 기준. backfill_runner._KST / dart_collector._KST와
+# 동일 기준이어야 한다(repo 전반 KST 정합). feed 스케줄/검증은 모두 KST today를
+# 사용하므로 OS local TZ가 아닌 KST로 기본 날짜를 산출한다.
+_KST = timezone(timedelta(hours=9))
 
 
 def generate_backfill_dates(
@@ -21,14 +26,14 @@ def generate_backfill_dates(
 
     Args:
         start: 시작 날짜 (YYYY-MM-DD, config의 backfill_since).
-        end: 종료 날짜 (YYYY-MM-DD). None이면 오늘.
+        end: 종료 날짜 (YYYY-MM-DD). None이면 KST 기준 오늘.
         last_checkpoint: 마지막 체크포인트 날짜 (YYYY-MM-DD). 있으면 그 다음 날부터.
 
     Yields:
         날짜 문자열 (YYYY-MM-DD), 오름차순.
     """
     start_date = date.fromisoformat(start)
-    end_date = date.fromisoformat(end) if end else date.today()
+    end_date = date.fromisoformat(end) if end else datetime.now(tz=_KST).date()
 
     # 체크포인트가 있으면 그 다음 날부터 시작
     if last_checkpoint:
@@ -60,12 +65,12 @@ def generate_daily_date(reference: date | None = None) -> str:
     """Daily 모드에서 수집할 날짜 (전일)를 반환한다.
 
     Args:
-        reference: 기준 날짜. None이면 오늘.
+        reference: 기준 날짜. None이면 KST 기준 오늘.
 
     Returns:
         전일 날짜 문자열 (YYYY-MM-DD).
     """
-    ref = reference or date.today()
+    ref = reference or datetime.now(tz=_KST).date()
     yesterday = ref - timedelta(days=1)
     return yesterday.isoformat()
 

--- a/tests/unit/feed/test_scheduler.py
+++ b/tests/unit/feed/test_scheduler.py
@@ -2,13 +2,32 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime, timezone
 
+import pytest
+
+from ante.feed.pipeline import scheduler
 from ante.feed.pipeline.scheduler import (
     generate_backfill_dates,
     generate_daily_date,
     is_business_day,
 )
+
+
+class _FakeDatetime:
+    """scheduler 모듈의 datetime을 대체해 now()를 고정한다.
+
+    실제 tzinfo 변환을 보존하기 위해 fixed UTC 시각에 대해 정상적인
+    astimezone 변환을 수행한다. (OS local TZ와 무관하게 결정적.)
+    """
+
+    _fixed_utc: datetime
+
+    @classmethod
+    def now(cls, tz: timezone | None = None) -> datetime:
+        if tz is None:
+            return cls._fixed_utc
+        return cls._fixed_utc.astimezone(tz)
 
 
 class TestGenerateBackfillDates:
@@ -35,11 +54,35 @@ class TestGenerateBackfillDates:
         dates = list(generate_backfill_dates("2024-01-10", "2024-01-05"))
         assert dates == []
 
-    def test_end_defaults_to_today(self) -> None:
-        """end가 None이면 오늘까지 생성한다."""
-        today = date.today().isoformat()
-        dates = list(generate_backfill_dates(today))
-        assert dates == [today]
+    def test_explicit_end_is_used_verbatim(self) -> None:
+        """명시 end 인자가 주어지면 KST today와 무관하게 그대로 사용한다(회귀)."""
+        dates = list(generate_backfill_dates("2026-01-01", end="2026-01-05"))
+        assert dates == [
+            "2026-01-01",
+            "2026-01-02",
+            "2026-01-03",
+            "2026-01-04",
+            "2026-01-05",
+        ]
+
+    def test_end_defaults_to_kst_today(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """end가 None이면 KST 기준 오늘을 종료일로 사용한다(OS TZ 무관).
+
+        UTC 2026-01-01 23:30 = KST 2026-01-02 08:30 이므로 KST today는
+        2026-01-02 여야 한다. OS local date.today()였다면 UTC 환경에서
+        2026-01-01 로 어긋난다.
+        """
+        _FakeDatetime._fixed_utc = datetime(2026, 1, 1, 23, 30, tzinfo=UTC)
+        monkeypatch.setattr(scheduler, "datetime", _FakeDatetime)
+
+        # KST today == 2026-01-02. 시작일을 그 날로 두면 end 기본값도
+        # 2026-01-02 이므로 단일 날짜만 생성된다.
+        dates = list(generate_backfill_dates("2026-01-02"))
+        assert dates == ["2026-01-02"]
+
+        # UTC today(2026-01-01)였다면 start(2026-01-02) > end(2026-01-01)로
+        # 빈 결과가 되었을 것이다. KST 적용으로 비어있지 않음을 추가 확인.
+        assert dates != []
 
     def test_includes_weekends(self) -> None:
         """영업일 필터링 없이 주말도 포함한다."""
@@ -126,12 +169,24 @@ class TestGenerateDailyDate:
         result = generate_daily_date(date(2024, 1, 1))
         assert result == "2023-12-31"
 
-    def test_default_reference_is_today(self) -> None:
-        """기준일 미지정 시 오늘 기준으로 전일을 반환한다."""
-        from datetime import timedelta
+    def test_explicit_reference_is_used_verbatim(self) -> None:
+        """명시 reference 인자가 주어지면 KST today와 무관하게 그대로 사용한다(회귀)."""
+        result = generate_daily_date(reference=date(2026, 1, 5))
+        assert result == "2026-01-04"
 
-        expected = (date.today() - timedelta(days=1)).isoformat()
-        assert generate_daily_date() == expected
+    def test_default_reference_is_kst_today(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """기준일 미지정 시 KST 기준 오늘의 전일을 반환한다(OS TZ 무관).
+
+        UTC 2026-01-01 23:30 = KST 2026-01-02 08:30 이므로 KST today는
+        2026-01-02, 전일은 2026-01-01 이다. OS local date.today()였다면
+        UTC 환경에서 today=2026-01-01, 전일=2025-12-31 로 어긋난다.
+        """
+        _FakeDatetime._fixed_utc = datetime(2026, 1, 1, 23, 30, tzinfo=UTC)
+        monkeypatch.setattr(scheduler, "datetime", _FakeDatetime)
+
+        assert generate_daily_date() == "2026-01-01"
 
     def test_return_format_is_iso(self) -> None:
         """반환값은 YYYY-MM-DD 형식이다."""


### PR DESCRIPTION
Closes #2003

## Summary
- `feed/pipeline/scheduler.py`의 `generate_backfill_dates()`/`generate_daily_date()`가 OS local `date.today()` 사용 → 서버 TZ가 UTC면 00:00-09:00 KST 구간에서 daily 대상일·backfill 종료일이 하루 어긋남
- `_KST = timezone(timedelta(hours=9))`(backfill_runner/dart_collector와 동일 기준) 추가, 두 사이트 `date.today()` → `datetime.now(tz=_KST).date()`. 명시 `end`/`reference` 인자는 그대로 우선

## Test Plan
- scheduler/feed 535 passed / mypy Success / ruff clean
- 신규: 명시 인자 우선 회귀 + KST 기본값 monkeypatch(UTC 23:30→KST 익일, OS TZ 무관)

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS