### PR TITLE
fix(feed): #2002 daily_runner가 store_merge 경고를 CollectionResult.warnings로 drain

### DIFF
--- a/src/ante/feed/pipeline/daily_runner.py
+++ b/src/ante/feed/pipeline/daily_runner.py
@@ -79,7 +79,13 @@ class DailyRunner:
         ctx = _RunContext()
         store = self._store or ParquetStore(base_path=data_path)
 
+        # 각 store 쓰기 단계 직후 store의 merge 이상 경고를 drain하여
+        # CollectionResult.warnings(→ daily report `warnings`)로 표면화한다.
+        # backfill_runner.run()의 drain 지점(data.go.kr/DART/지표 후)을
+        # 정확히 미러한다(#2002). collector 미주입(None) skip 경로에서도
+        # drain은 빈 경고를 반환해 안전하다.
         await self._collect_data_go_kr(target_date, store, ctx)
+        ctx.warnings.extend(store.drain_warnings())
         await self._collect_dart(
             data_path,
             feed_dir,
@@ -87,7 +93,9 @@ class DailyRunner:
             store,
             ctx,
         )
+        ctx.warnings.extend(store.drain_warnings())
         self._compute_indicators(store, ctx)
+        ctx.warnings.extend(store.drain_warnings())
 
         return ctx.to_result("daily", started_at, target_date=target_date)
 

--- a/tests/unit/feed/test_daily_runner_store_merge_drain.py
+++ b/tests/unit/feed/test_daily_runner_store_merge_drain.py
@@ -1,0 +1,145 @@
+"""DailyRunner의 store_merge 경고 drain 회귀 테스트(#2002).
+
+backfill_runner는 각 store 쓰기 단계(data.go.kr/DART/지표) 직후
+``ctx.warnings.extend(store.drain_warnings())`` 를 호출해 store의 merge 이상
+경고를 ``CollectionResult.warnings`` (→ daily report ``warnings``)로 표면화한다.
+daily_runner에는 이 drain 경로가 없어 store merge 경고가 store 내부
+``_pending_warnings`` 버퍼에만 남고 ``.feed/reports/*-daily.json`` 에 안 나타났다.
+
+이 테스트는 backfill 회귀 테스트
+(``test_report.py::TestBackfillReportSurfacesStoreMergeWarning``)와 동형으로,
+daily 경로에서도 store_merge 경고가 결과 warnings에 표면화되고 store pending이
+비워지는지를 잠근다.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from ante.data.store import ParquetStore
+from ante.feed.pipeline.daily_runner import DailyRunner
+
+
+class _AnomalyDataGoKrCollector:
+    """store merge 이상을 발생시키는 stub data.go.kr collector.
+
+    `.collect()`가 호출되면, 사전에 손상시켜 둔(읽기 불가) 파티션 위로
+    fundamental write를 시도한다. ParquetStore는 기존 파일을 덮어쓰지 않고
+    `store_merge` 이상 경고만 버퍼에 적재한다(#1964 silent-overwrite 제거).
+    """
+
+    async def collect(
+        self,
+        target_date: str,
+        store: ParquetStore,
+    ) -> tuple[int, set[str], list[dict]]:
+        df = pl.DataFrame(
+            {
+                "date": [date(2025, 9, 30)],
+                "symbol": ["005930"],
+                "market_cap": [510000000000],
+                "source": ["data_go_kr"],
+            }
+        )
+        store.write("005930", "krx", df, data_type="fundamental")
+        return 1, {"005930"}, []
+
+
+@pytest.mark.asyncio
+async def test_daily_run_surfaces_store_merge_warning(tmp_path: Path) -> None:
+    """store merge anomaly가 daily 결과의 warnings에 등장하고 pending이 비워진다.
+
+    수정 전에는 store 덮어쓰기가 stderr 로그/내부 버퍼로만 남고
+    CollectionResult.warnings는 비어 있었다(#2002).
+    """
+    data_path = tmp_path / "data"
+    feed_dir = data_path / ".feed"
+    (feed_dir / "checkpoints").mkdir(parents=True)
+
+    # 손상된(읽기 불가) 파티션을 사전 배치 → 다음 write에서 merge 실패 유발.
+    part_dir = data_path / "fundamental" / "KRX" / "005930"
+    part_dir.mkdir(parents=True)
+    (part_dir / "2025-09.parquet").write_bytes(b"corrupt-not-parquet")
+
+    store = ParquetStore(base_path=data_path)
+    runner = DailyRunner(
+        data_go_kr_collector=_AnomalyDataGoKrCollector(),
+        dart_collector=None,
+        store=store,
+    )
+
+    result = await runner.run(
+        data_path=data_path,
+        config={},
+        feed_dir=feed_dir,
+        started_at=datetime.now(tz=UTC),
+        is_blocked=lambda config, target_date: False,
+        target_date="2025-09-30",
+    )
+
+    store_merge_warnings = [
+        w for w in result.warnings if w.get("type") == "store_merge"
+    ]
+    assert store_merge_warnings, (
+        f"store_merge 경고가 result.warnings에 없음: {result.warnings}"
+    )
+    assert "2025-09.parquet" in store_merge_warnings[0]["path"]
+
+    # drain 후 store 내부 버퍼는 비워져 중복 전파되지 않는다.
+    assert store.drain_warnings() == []
+
+    # 손상 파일은 보존됨(데이터 손실 방지).
+    assert (part_dir / "2025-09.parquet").read_bytes() == b"corrupt-not-parquet"
+
+
+@pytest.mark.asyncio
+async def test_daily_run_no_store_warnings_when_clean(tmp_path: Path) -> None:
+    """store 이상이 없으면 daily 결과 warnings에 store_merge가 없다.
+
+    drain 추가가 정상 경로에 store_merge 잡음을 만들지 않음을 확인한다.
+    """
+    data_path = tmp_path / "data"
+    feed_dir = data_path / ".feed"
+    (feed_dir / "checkpoints").mkdir(parents=True)
+
+    class _CleanCollector:
+        async def collect(
+            self,
+            target_date: str,
+            store: ParquetStore,
+        ) -> tuple[int, set[str], list[dict]]:
+            df = pl.DataFrame(
+                {
+                    "date": [date(2025, 9, 30)],
+                    "symbol": ["005930"],
+                    "market_cap": [510000000000],
+                    "source": ["data_go_kr"],
+                }
+            )
+            store.write("005930", "krx", df, data_type="fundamental")
+            return 1, {"005930"}, []
+
+    store = ParquetStore(base_path=data_path)
+    runner = DailyRunner(
+        data_go_kr_collector=_CleanCollector(),
+        dart_collector=None,
+        store=store,
+    )
+
+    result = await runner.run(
+        data_path=data_path,
+        config={},
+        feed_dir=feed_dir,
+        started_at=datetime.now(tz=UTC),
+        is_blocked=lambda config, target_date: False,
+        target_date="2025-09-30",
+    )
+
+    store_merge_warnings = [
+        w for w in result.warnings if w.get("type") == "store_merge"
+    ]
+    assert store_merge_warnings == []


### PR DESCRIPTION
Closes #2002

## Summary
- `backfill_runner`는 data.go.kr/DART/지표 단계 후 각각 `ctx.warnings.extend(store.drain_warnings())`로 store_merge 경고를 표면화하나, `daily_runner`는 누락 → daily 수집 중 merge 이상 경고가 store 버퍼에만 남고 daily report.warnings에 미표면
- daily_runner `run()`의 data.go.kr/DART/지표 단계 직후 3개 drain 호출 추가(backfill 패턴 미러). backfill_runner/store.py 불변
- collector-None skip 경로도 빈 drain으로 안전

## Test Plan
- feed daily/report/runner/store 104 passed, -k feed 499, contracts 145 / mypy Success / ruff clean
- 신규: 실제 corrupt parquet merge anomaly로 daily CollectionResult.warnings 표면화+pending drain 검증(프록시 아님), clean path 무잡음 락

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS