### PR TITLE
fix(feed): #2007 feed lock 원자적 획득 + PermissionError=alive 차단

### DIFF
--- a/src/ante/feed/pipeline/orchestrator.py
+++ b/src/ante/feed/pipeline/orchestrator.py
@@ -237,22 +237,65 @@ class FeedOrchestrator:
 
     @staticmethod
     def _acquire_lock(feed_dir: Path) -> bool:
-        """Lock 파일을 생성하여 동시 실행을 방지한다."""
+        """Lock 파일을 원자적으로 생성하여 동시 실행을 방지한다.
+
+        ``os.O_CREAT | os.O_EXCL`` 로 lock 파일을 생성하므로
+        ``exists()`` 확인 후 ``write_text()`` 하던 비원자 경로(check-then-write)
+        에서 동시 시작 시 둘 다 획득하던 race를 제거한다(#2007/#2057).
+        ``FileExistsError`` 일 때만 기존 lock의 liveness 를 검사한다.
+
+        liveness 분류:
+          - ``ProcessLookupError`` → 프로세스 없음(stale) → 제거 후 재시도
+          - ``PermissionError`` → 프로세스 존재(signal 권한 없음) → **alive**,
+            차단(return False) (#2006). 기존엔 stale 제거 except 에 묶여 있어
+            살아있는 프로세스의 lock 을 삭제하고 획득하던 오판이었다.
+          - PID 파싱/읽기 실패(``ValueError``/``OSError``) → malformed=stale →
+            제거 후 재시도
+
+        stale 제거 후 다른 프로세스가 그 사이 lock 을 다시 잡는 race 에 대비해
+        bounded(3회) 재시도하고, 실패 시 안전하게 ``False`` 를 반환한다.
+        """
         lock_path = feed_dir / LOCK_FILE
         feed_dir.mkdir(parents=True, exist_ok=True)
 
-        if lock_path.exists():
+        for _ in range(3):
             try:
-                pid = int(lock_path.read_text().strip())
-                os.kill(pid, 0)
-                logger.error("다른 수집 프로세스가 실행 중 (PID=%d)", pid)
-                return False
-            except (ValueError, ProcessLookupError, PermissionError, OSError):
-                logger.warning("비정상 lock 파일 감지, 제거 후 진행")
-                lock_path.unlink(missing_ok=True)
+                fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            except FileExistsError:
+                # lock 이미 존재 → liveness 검사
+                try:
+                    pid = int(lock_path.read_text().strip())
+                except (ValueError, OSError):
+                    logger.warning("비정상 lock 파일(PID 파싱 불가), 제거 후 재시도")
+                    lock_path.unlink(missing_ok=True)
+                    continue
 
-        lock_path.write_text(str(os.getpid()))
-        return True
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    logger.warning("stale lock 감지(PID=%d 없음), 제거 후 재시도", pid)
+                    lock_path.unlink(missing_ok=True)
+                    continue
+                except PermissionError:
+                    # 프로세스 존재(signal 권한 없음) → alive, 차단 (#2006)
+                    logger.error(
+                        "다른 수집 프로세스가 실행 중 (PID=%d, signal 권한 없음)", pid
+                    )
+                    return False
+                else:
+                    logger.error("다른 수집 프로세스가 실행 중 (PID=%d)", pid)
+                    return False
+            else:
+                # 원자적 생성 성공 → 획득. 기존 write_text(str(pid)) 와 동일하게
+                # 십진 문자열 PID 를 기록한다(release/다른 reader 호환).
+                try:
+                    os.write(fd, str(os.getpid()).encode())
+                finally:
+                    os.close(fd)
+                return True
+
+        logger.error("lock 획득 실패(반복 race)")
+        return False
 
     @staticmethod
     def _release_lock(feed_dir: Path) -> None:

--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -459,6 +459,107 @@ def test_acquire_lock_stale(tmp_path: Path) -> None:
     assert FeedOrchestrator._acquire_lock(feed_dir) is True
 
 
+def test_acquire_lock_records_current_pid(tmp_path: Path) -> None:
+    """정상 획득 시 lock 파일에 현재 PID가 십진 문자열로 기록된다.
+
+    기존 ``write_text(str(pid))`` 와 동일한 형식이어야
+    release/다른 reader 호환이 유지된다(#2007).
+    """
+    import os
+
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    assert FeedOrchestrator._acquire_lock(feed_dir) is True
+    assert (feed_dir / "lock").read_text() == str(os.getpid())
+
+
+def test_acquire_lock_blocked_when_alive(tmp_path: Path) -> None:
+    """살아있는 프로세스(현재 PID)의 lock 보유 중에는 재획득이 차단된다.
+
+    원자성/이중 획득 차단: 현재 PID는 ``os.kill(pid, 0)`` 성공=alive 이므로
+    이미 lock 을 점유 중이면 두 번째 획득 시도는 ``False`` 이고 lock 파일도
+    보존된다(#2007/#2057).
+    """
+    import os
+
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    # 첫 번째 획득(현재 PID 점유)
+    assert FeedOrchestrator._acquire_lock(feed_dir) is True
+    assert (feed_dir / "lock").read_text() == str(os.getpid())
+
+    # 두 번째 획득 시도 → alive 로 판정되어 차단, lock 보존
+    assert FeedOrchestrator._acquire_lock(feed_dir) is False
+    assert (feed_dir / "lock").exists()
+    assert (feed_dir / "lock").read_text() == str(os.getpid())
+
+
+def test_acquire_lock_permission_error_is_alive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``os.kill`` PermissionError(EPERM)는 alive 로 보고 차단한다 (#2006).
+
+    EPERM 은 프로세스가 존재하나 signal 권한이 없을 때 발생한다.
+    기존엔 stale 제거 except 에 묶여 lock 을 삭제하고 획득하던 오판이었다.
+    수정 후에는 차단(``False``)하고 lock 파일을 보존해야 한다.
+    """
+    import ante.feed.pipeline.orchestrator as orch_mod
+
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    # 임의 PID 로 lock 파일 생성
+    (feed_dir / "lock").write_text("12345")
+
+    def _raise_permission(pid: int, sig: int) -> None:
+        raise PermissionError
+
+    monkeypatch.setattr(orch_mod.os, "kill", _raise_permission)
+
+    assert FeedOrchestrator._acquire_lock(feed_dir) is False
+    # alive 판정 → lock 파일을 삭제하지 않고 보존
+    assert (feed_dir / "lock").exists()
+    assert (feed_dir / "lock").read_text() == "12345"
+
+
+def test_acquire_lock_stale_process_lookup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``os.kill`` ProcessLookupError(ESRCH)는 stale 로 보고 제거 후 획득한다."""
+    import os
+
+    import ante.feed.pipeline.orchestrator as orch_mod
+
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    (feed_dir / "lock").write_text("12345")
+
+    def _raise_lookup(pid: int, sig: int) -> None:
+        raise ProcessLookupError
+
+    monkeypatch.setattr(orch_mod.os, "kill", _raise_lookup)
+
+    assert FeedOrchestrator._acquire_lock(feed_dir) is True
+    # stale 제거 후 현재 PID 로 재획득
+    assert (feed_dir / "lock").read_text() == str(os.getpid())
+
+
+def test_acquire_lock_malformed_pid(tmp_path: Path) -> None:
+    """PID 파싱이 불가능한 malformed lock 은 제거 후 획득한다."""
+    import os
+
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    (feed_dir / "lock").write_text("notapid")
+
+    assert FeedOrchestrator._acquire_lock(feed_dir) is True
+    assert (feed_dir / "lock").read_text() == str(os.getpid())
+
+
 @pytest.mark.asyncio
 async def test_concurrent_run_blocked(
     tmp_data_path: Path,


### PR DESCRIPTION
Closes #2007
Closes #2057
Closes #2006

## Summary
`FeedOrchestrator._acquire_lock` 동시 실행 방지 lock 3건:
- **#2007≈#2057**: `exists()` 확인 후 `write_text()` = check-then-write 비원자 → 동시 시작 시 둘 다 획득. `os.open(O_CREAT|O_EXCL|O_WRONLY)` 원자 생성으로 교체(하나만 성공)
- **#2006**: `os.kill(pid,0)`의 `PermissionError`(EPERM=프로세스 존재, signal 권한 없음)를 stale 제거 except에서 분리 → **alive로 차단**(return False, lock 보존). `ProcessLookupError`만 stale
- stale/malformed → unlink + bounded(3회) 재시도(제거-후-선점 race 안전, 무한루프 방지). pid는 십진 문자열(release 호환). release 경로 불변

## Test Plan
- orchestrator/lock/feed 542 passed, feed 469, contracts 145 / mypy Success / ruff clean
- 신규 5: alive 차단·PermissionError=alive(lock 보존)·stale ProcessLookupError·malformed pid·정상 획득

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS