### PR TITLE
fix(backtest): #2039 backtest run이 StrategyLoader.load 전 StrategyValidator로 검증 (금지 코드 import 차단)

### DIFF
--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -24,6 +24,7 @@ from ante.core.market_data_vocab import (
 )
 from ante.data.store import ParquetStore
 from ante.strategy.loader import StrategyLoader
+from ante.strategy.validator import StrategyValidator
 
 if TYPE_CHECKING:
     from ante.eventbus.bus import EventBus
@@ -60,7 +61,22 @@ class BacktestService:
 
         validated = self._validate_config(config)
 
-        strategy_cls = StrategyLoader.load(Path(validated.strategy_path))
+        # #2039: StrategyLoader.load(import)가 전략 파일을 실행하기 전에
+        #        StrategyValidator로 정적(AST) 안전성 검증을 수행한다.
+        #        validate 자체는 ast.parse 기반이라 전략 코드를 실행하지
+        #        않으므로, 금지 모듈/builtin/top-level 코드가 import 시점에
+        #        실행되는 것을 차단한다. backtest run은 public CLI에서 파일
+        #        경로를 직접 받아 in-process/subprocess 양쪽 모두 이
+        #        service.run 을 거치므로, load 직전 검증으로 모든 경로에서
+        #        우회를 막는다. valid=False면 load를 호출하지 않고 즉시
+        #        raise 하여 금지 코드가 실행되지 않는다(warnings는 비차단).
+        strategy_path = Path(validated.strategy_path)
+        val_result = StrategyValidator().validate(strategy_path)
+        if not val_result.valid:
+            msg = f"전략 검증 실패: {'; '.join(val_result.errors)}"
+            raise BacktestConfigError(msg)
+
+        strategy_cls = StrategyLoader.load(strategy_path)
 
         store = ParquetStore(
             base_path=validated.data_paths[0],

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -147,6 +147,35 @@ def _make_ohlcv_df_with_closes(
     )
 
 
+# ── Helper: 디스크 전략 파일 ─────────────────────────
+
+# StrategyValidator(#2039)가 service.run에서 load 직전 통과시키는, 금지
+# 모듈/builtin/top-level 코드가 없는 최소 유효 전략 소스. service.run은 실제
+# 파일을 read_text 하므로, load를 mock하더라도 strategy_path는 실존하는 유효
+# 파일을 가리켜야 검증을 통과한다.
+_VALID_STRATEGY_SOURCE = '''\
+"""테스트용 최소 유효 전략."""
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+
+class _DiskStrategy(Strategy):
+    meta = StrategyMeta(name="disk", version="1.0", description="t")
+
+    async def on_step(self, context):
+        return []
+'''
+
+
+def _write_valid_strategy(directory) -> str:
+    """``directory`` 에 유효 전략 파일을 쓰고 그 경로 문자열을 반환."""
+    from pathlib import Path
+
+    path = Path(directory) / "valid_strategy.py"
+    path.write_text(_VALID_STRATEGY_SOURCE)
+    return str(path)
+
+
 @pytest.fixture
 def data_dir(tmp_path):
     return tmp_path / "data"
@@ -1623,8 +1652,9 @@ class TestBacktestService:
         """run() 후 result.config=BacktestConfig, datasets=list[DatasetInfo]."""
         service = BacktestService(data_path=str(data_dir))
 
+        strategy_path = _write_valid_strategy(data_dir)
         config = {
-            "strategy_path": "dummy.py",
+            "strategy_path": strategy_path,
             "start_date": "2026-01-01",
             "end_date": "2026-12-31",
             "symbols": ["005930"],
@@ -1640,7 +1670,7 @@ class TestBacktestService:
 
         # config는 BacktestConfig 인스턴스
         assert isinstance(result.config, BacktestConfig)
-        assert result.config.strategy_path == "dummy.py"
+        assert result.config.strategy_path == strategy_path
         assert result.config.symbols == ["005930"]
         assert result.config.start_date == "2026-01-01"
         assert result.config.end_date == "2026-12-31"
@@ -1673,7 +1703,7 @@ class TestBacktestService:
 
         service = BacktestService(data_path=str(wrong))
         config = {
-            "strategy_path": "dummy.py",
+            "strategy_path": _write_valid_strategy(tmp_path),
             "start_date": "2026-01-01",
             "end_date": "2026-12-31",
             "symbols": ["005930"],
@@ -1708,7 +1738,7 @@ class TestBacktestService:
         wrong.mkdir()
         service = BacktestService(data_path=str(wrong))
         config = {
-            "strategy_path": "dummy.py",
+            "strategy_path": _write_valid_strategy(tmp_path),
             "start_date": "2026-01-01",
             "end_date": "2026-12-31",
             "symbols": ["005930"],
@@ -1735,7 +1765,7 @@ class TestBacktestService:
 
         service = BacktestService(data_path=str(default_dir))
         config = {
-            "strategy_path": "dummy.py",
+            "strategy_path": _write_valid_strategy(tmp_path),
             "start_date": "2026-01-01",
             "end_date": "2026-12-31",
             "symbols": ["005930"],
@@ -1751,6 +1781,163 @@ class TestBacktestService:
         assert len(result.datasets) == 1
         assert result.datasets[0].row_count > 0
         assert result.config.data_paths == [str(default_dir)]
+
+
+# ── service.run StrategyValidator 검증 게이트 (#2039) ─
+
+
+# import-time(top-level)에 marker 파일을 생성하는 금지 코드를 담은 전략 소스.
+# StrategyLoader.load(import)가 실행되면 marker가 생성되므로, marker 부재로
+# "금지 코드가 실행되지 않았음(=import 안 됨)"을 직접 단언할 수 있다.
+# top-level `open(...)` 는 FORBIDDEN_BUILTINS라 StrategyValidator가 거부한다.
+_FORBIDDEN_OPEN_STRATEGY_TMPL = '''\
+"""import 시점에 marker 파일을 생성하는 금지 전략."""
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+open({marker!r}, "w").write("pwned")
+
+
+class _EvilStrategy(Strategy):
+    meta = StrategyMeta(name="evil", version="1.0", description="t")
+
+    async def on_step(self, context):
+        return []
+'''
+
+
+# top-level 금지 모듈 import(`import os`)를 담은 전략 소스. import-time에
+# os.environ을 쓰진 않지만, FORBIDDEN_MODULES 위반으로 거부되어야 하며 load가
+# 호출되지 않아야 한다(검증 단계에서 차단).
+_FORBIDDEN_IMPORT_STRATEGY = '''\
+"""금지 모듈을 import 하는 전략."""
+
+import os
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+
+class _EvilImportStrategy(Strategy):
+    meta = StrategyMeta(name="evil_import", version="1.0", description="t")
+
+    async def on_step(self, context):
+        return []
+'''
+
+
+class TestBacktestServiceStrategyValidation:
+    """service.run이 StrategyLoader.load(import) 전에 StrategyValidator로
+    전략 파일을 정적 검증하여, 금지 코드가 import 시점에 실행되는 우회를
+    차단하는지 검증한다(#2039).
+
+    backtest run은 public CLI에서 파일 경로를 직접 받아 in-process(backtest.py)
+    /subprocess(runner.py) 양쪽 모두 service.run을 단일 chokepoint로 거치므로,
+    여기서 service.run을 직접 호출해 두 경로를 대표한다.
+    """
+
+    def _config(self, strategy_path: str, data_path) -> dict[str, Any]:
+        return {
+            "strategy_path": strategy_path,
+            "start_date": "2026-01-01",
+            "end_date": "2026-12-31",
+            "symbols": ["005930"],
+            "timeframe": "1d",
+            "data_path": str(data_path),
+        }
+
+    async def test_forbidden_open_blocked_before_import(self, tmp_path, data_dir):
+        """핵심(repro): top-level open() 전략 → BacktestConfigError +
+        import(load) 미실행으로 marker 파일 미생성.
+
+        검증이 load 이전에 일어나 금지 코드가 실행되지 않음을 marker 부재로
+        직접 단언한다. StrategyLoader.load는 호출조차 되지 않아야 한다.
+        """
+        from pathlib import Path
+        from unittest.mock import patch
+
+        marker = tmp_path / "pwned.txt"
+        strategy_file = tmp_path / "evil_open.py"
+        strategy_file.write_text(
+            _FORBIDDEN_OPEN_STRATEGY_TMPL.format(marker=str(marker))
+        )
+
+        service = BacktestService(data_path=str(data_dir))
+        config = self._config(str(strategy_file), data_dir)
+
+        with patch(
+            "ante.backtest.service.StrategyLoader.load",
+        ) as mock_load:
+            with pytest.raises(BacktestConfigError, match="전략 검증 실패"):
+                await service.run(config)
+
+        # (a) 금지 코드(import-time open)가 실행되지 않았다 → marker 부재.
+        assert not marker.exists(), (
+            "marker가 생성됨 = 전략이 import되어 금지 코드가 실행됨(검증 우회)"
+        )
+        # (b) 검증 실패 시 load는 호출조차 되지 않는다(import 시도 자체 차단).
+        mock_load.assert_not_called()
+        # (c) marker 경로가 Path로도 미존재(이중 단언).
+        assert not Path(marker).exists()
+
+    async def test_forbidden_import_blocked(self, tmp_path, data_dir):
+        """top-level 금지 모듈 import(`import os`) 전략 → 차단 + load 미호출."""
+        from unittest.mock import patch
+
+        strategy_file = tmp_path / "evil_import.py"
+        strategy_file.write_text(_FORBIDDEN_IMPORT_STRATEGY)
+
+        service = BacktestService(data_path=str(data_dir))
+        config = self._config(str(strategy_file), data_dir)
+
+        with patch(
+            "ante.backtest.service.StrategyLoader.load",
+        ) as mock_load:
+            with pytest.raises(BacktestConfigError, match="전략 검증 실패"):
+                await service.run(config)
+        mock_load.assert_not_called()
+
+    async def test_valid_strategy_runs_through_real_load(self, loaded_store, data_dir):
+        """회귀: 유효 전략은 검증을 통과해 실제 load·실행으로 정상 완료한다.
+
+        load를 mock하지 않고 실제 StrategyLoader.load가 디스크 전략을 import해
+        백테스트가 끝까지 수행됨을 확인한다(검증 게이트가 정상 전략을 막지 않음).
+        """
+        strategy_file = data_dir / "valid_strategy.py"
+        strategy_file.write_text(_VALID_STRATEGY_SOURCE)
+
+        service = BacktestService(data_path=str(data_dir))
+        config = self._config(str(strategy_file), data_dir)
+
+        result = await service.run(config)
+
+        assert isinstance(result.config, BacktestConfig)
+        assert result.config.strategy_path == str(strategy_file)
+        assert len(result.datasets) == 1
+        assert result.datasets[0].symbol == "005930"
+        assert len(result.equity_curve) > 0
+
+    async def test_run_subprocess_blocks_forbidden_strategy(self, tmp_path, data_dir):
+        """subprocess 경로(runner → service.run)도 금지 전략을 차단한다(#2039).
+
+        ``run_subprocess`` 는 실제 자식 프로세스에서 ``ante.backtest.runner`` 를
+        실행하고, runner는 ``service.run`` 을 호출하므로 검증 게이트를 거친다.
+        반환 코드 != 0 으로 실패하고, BacktestError로 표면화되며, marker 파일이
+        생성되지 않아야 한다(자식 프로세스에서도 금지 코드 미실행).
+        """
+        marker = tmp_path / "pwned_subprocess.txt"
+        strategy_file = tmp_path / "evil_open_sub.py"
+        strategy_file.write_text(
+            _FORBIDDEN_OPEN_STRATEGY_TMPL.format(marker=str(marker))
+        )
+
+        service = BacktestService(data_path=str(data_dir))
+        config = self._config(str(strategy_file), data_dir)
+
+        with pytest.raises(BacktestError):
+            await service.run_subprocess(config)
+
+        # 자식 프로세스에서도 금지 코드가 실행되지 않아 marker가 없어야 한다.
+        assert not marker.exists()
 
 
 # ── Exceptions 테스트 ──────────────────────────────
@@ -3508,7 +3695,7 @@ class TestNonDailyTimeframe:
 
         service = BacktestService(data_path=str(data_dir))
         config = {
-            "strategy_path": "dummy.py",
+            "strategy_path": _write_valid_strategy(tmp_path),
             "start_date": "2026-01-01",
             "end_date": "2026-12-31",
             "symbols": ["005930"],

--- a/tests/unit/test_backtest_complete_event.py
+++ b/tests/unit/test_backtest_complete_event.py
@@ -8,6 +8,20 @@ import pytest
 
 from ante.backtest.service import BacktestService
 from ante.eventbus.events import BacktestCompleteEvent
+from ante.strategy.validator import ValidationResult
+
+
+def _bypass_validator():
+    """service.run의 StrategyValidator 게이트(#2039)를 우회한다.
+
+    이 파일의 테스트는 ``_validate_config`` 와 ``StrategyLoader.load`` 를 mock해
+    실제 전략 파일 없이 run() 오케스트레이션만 검증한다. #2039에서 load 직전에
+    추가된 정적 검증도 실제 파일을 읽지 않도록 valid 결과로 대체한다.
+    """
+    return patch(
+        "ante.backtest.service.StrategyValidator.validate",
+        return_value=ValidationResult(valid=True),
+    )
 
 
 class TestBacktestCompleteEventPublish:
@@ -31,22 +45,23 @@ class TestBacktestCompleteEventPublish:
         }
 
         with patch.object(service, "_validate_config"):
-            with patch(
-                "ante.backtest.service.StrategyLoader.load",
-                return_value=MagicMock,
-            ):
+            with _bypass_validator():
                 with patch(
-                    "ante.backtest.service.BacktestDataProvider",
-                    return_value=MagicMock(),
+                    "ante.backtest.service.StrategyLoader.load",
+                    return_value=MagicMock,
                 ):
                     with patch(
-                        "ante.backtest.service.BacktestExecutor"
-                    ) as mock_executor_cls:
-                        mock_executor = MagicMock()
-                        mock_executor.run = AsyncMock(return_value=mock_result)
-                        mock_executor_cls.return_value = mock_executor
+                        "ante.backtest.service.BacktestDataProvider",
+                        return_value=MagicMock(),
+                    ):
+                        with patch(
+                            "ante.backtest.service.BacktestExecutor"
+                        ) as mock_executor_cls:
+                            mock_executor = MagicMock()
+                            mock_executor.run = AsyncMock(return_value=mock_result)
+                            mock_executor_cls.return_value = mock_executor
 
-                        await service.run(config)
+                            await service.run(config)
 
         mock_eventbus.publish.assert_called_once()
         event = mock_eventbus.publish.call_args[0][0]
@@ -70,21 +85,22 @@ class TestBacktestCompleteEventPublish:
         }
 
         with patch.object(service, "_validate_config"):
-            with patch(
-                "ante.backtest.service.StrategyLoader.load",
-                return_value=MagicMock,
-            ):
+            with _bypass_validator():
                 with patch(
-                    "ante.backtest.service.BacktestDataProvider",
-                    return_value=MagicMock(),
+                    "ante.backtest.service.StrategyLoader.load",
+                    return_value=MagicMock,
                 ):
                     with patch(
-                        "ante.backtest.service.BacktestExecutor"
-                    ) as mock_executor_cls:
-                        mock_executor = MagicMock()
-                        mock_executor.run = AsyncMock(return_value=mock_result)
-                        mock_executor_cls.return_value = mock_executor
+                        "ante.backtest.service.BacktestDataProvider",
+                        return_value=MagicMock(),
+                    ):
+                        with patch(
+                            "ante.backtest.service.BacktestExecutor"
+                        ) as mock_executor_cls:
+                            mock_executor = MagicMock()
+                            mock_executor.run = AsyncMock(return_value=mock_result)
+                            mock_executor_cls.return_value = mock_executor
 
-                        result = await service.run(config)
+                            result = await service.run(config)
 
         assert result == mock_result  # 정상 반환

--- a/tests/unit/test_backtest_exchange_plumbing.py
+++ b/tests/unit/test_backtest_exchange_plumbing.py
@@ -30,6 +30,20 @@ from ante.backtest.executor import BacktestExecutor
 from ante.backtest.result import BacktestResult, BacktestTrade
 from ante.backtest.service import BacktestService
 from ante.strategy.base import Signal, Strategy, StrategyMeta
+from ante.strategy.validator import ValidationResult
+
+
+def _bypass_validator():
+    """service.run의 StrategyValidator 게이트(#2039)를 우회한다.
+
+    이 파일의 run() exchange-plumbing 테스트는 StrategyLoader를 mock해 실제
+    전략 파일 없이 ``s.py`` 경로로 run을 구동한다. #2039에서 load 직전 추가된
+    정적 검증이 실제 파일을 읽지 않도록 valid 결과로 대체한다.
+    """
+    return patch(
+        "ante.backtest.service.StrategyValidator.validate",
+        return_value=ValidationResult(valid=True),
+    )
 
 
 class TestValidateConfigExchangeDefault:
@@ -115,6 +129,7 @@ class TestServicePassesExchangeToProvider:
         executor_instance.run = _fake_run
 
         with (
+            _bypass_validator(),
             patch("ante.backtest.service.StrategyLoader") as mock_loader,
             patch("ante.backtest.service.ParquetStore") as mock_store_cls,
             patch(
@@ -161,6 +176,7 @@ class TestServicePassesExchangeToProvider:
         executor_instance.run = _fake_run
 
         with (
+            _bypass_validator(),
             patch("ante.backtest.service.StrategyLoader") as mock_loader,
             patch("ante.backtest.service.ParquetStore"),
             patch(
@@ -330,6 +346,7 @@ class TestServicePassesExchangeToExecutor:
         executor_instance.run = _fake_run
 
         with (
+            _bypass_validator(),
             patch("ante.backtest.service.StrategyLoader") as mock_loader,
             patch("ante.backtest.service.ParquetStore"),
             patch(

--- a/tests/unit/test_backtest_programmatic_vocab_validation.py
+++ b/tests/unit/test_backtest_programmatic_vocab_validation.py
@@ -33,6 +33,22 @@ from ante.backtest.config import BacktestConfig
 from ante.backtest.exceptions import BacktestConfigError
 from ante.backtest.result import BacktestResult
 from ante.backtest.service import BACKTEST_RESULT_SENTINEL, BacktestService
+from ante.strategy.validator import ValidationResult
+
+
+def _bypass_validator():
+    """service.run의 StrategyValidator 게이트(#2039)를 우회한다.
+
+    유효 config가 data load까지 진행하는 회귀 테스트는 StrategyLoader를 mock해
+    실제 전략 파일 없이 ``s.py`` 경로로 run을 구동하므로, load 직전 추가된 정적
+    검증도 valid 결과로 대체한다. invalid-config 거부 테스트는 _validate_config
+    단계에서 더 일찍 raise되므로 이 우회의 영향을 받지 않는다.
+    """
+    return patch(
+        "ante.backtest.service.StrategyValidator.validate",
+        return_value=ValidationResult(valid=True),
+    )
+
 
 _BASE: dict = {
     "strategy_path": "s.py",
@@ -269,6 +285,7 @@ class TestServiceRunEarlyFailsBeforeDataLoad:
         """유효 config 회귀: run()이 정상적으로 data load까지 진행."""
         provider_instance, executor_instance = _patched_run_components()
         with (
+            _bypass_validator(),
             patch("ante.backtest.service.StrategyLoader") as mock_loader,
             patch("ante.backtest.service.ParquetStore"),
             patch(
@@ -292,6 +309,7 @@ class TestServiceRunEarlyFailsBeforeDataLoad:
         """[R2-F1] {"symbols": None} → run() no-symbols 정상, data load 0."""
         provider_instance, executor_instance = _patched_run_components()
         with (
+            _bypass_validator(),
             patch("ante.backtest.service.StrategyLoader") as mock_loader,
             patch("ante.backtest.service.ParquetStore"),
             patch(

--- a/tests/unit/test_backtest_progress.py
+++ b/tests/unit/test_backtest_progress.py
@@ -7,6 +7,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ante.backtest.executor import BacktestExecutor
+from ante.strategy.validator import ValidationResult
+
+
+def _bypass_validator():
+    """service.run의 StrategyValidator 게이트(#2039)를 우회한다.
+
+    이 테스트는 StrategyLoader.load를 mock해 실제 전략 파일 없이 ``test.py``
+    경로로 run을 구동하므로, load 직전 정적 검증도 valid 결과로 대체한다.
+    """
+    return patch(
+        "ante.backtest.service.StrategyValidator.validate",
+        return_value=ValidationResult(valid=True),
+    )
 
 
 class TestProgressCallback:
@@ -87,6 +100,7 @@ class TestBacktestServiceProgress:
     async def test_service_passes_callback(self):
         """BacktestService가 progress_callback을 전달한다."""
         with (
+            _bypass_validator(),
             patch("ante.backtest.service.StrategyLoader.load") as mock_load,
             patch("ante.backtest.service.BacktestDataProvider") as mock_dp_cls,
             patch("ante.backtest.service.BacktestExecutor") as mock_exec_cls,

--- a/tests/unit/test_backtest_subprocess_sentinel.py
+++ b/tests/unit/test_backtest_subprocess_sentinel.py
@@ -26,19 +26,23 @@ from ante.backtest import runner
 from ante.backtest.exceptions import BacktestError
 from ante.backtest.service import BACKTEST_RESULT_SENTINEL, BacktestService
 
+# #2039: 전략 파일은 import 시점에 코드를 실행할 수 없으므로(top-level
+# print/`import sys` 는 StrategyValidator가 거부), stdout noise는 검증을
+# 통과하는 위치인 ``on_step`` (런타임) 에서 print 한다. runner subprocess의
+# stdout에 결과 sentinel 라인 외 noise가 섞여도 run_subprocess가 sentinel
+# 라인만 파싱하는지(#2065)를 그대로 검증한다.
 _NOISE_STRATEGY = """\
-print("strategy import noise")
-import sys
-print("more stdout noise from module top", file=sys.stdout)
 from typing import Any
 
 from ante.strategy.base import Signal, Strategy, StrategyMeta
 
 
 class NoiseStrategy(Strategy):
-    meta = StrategyMeta(name="noise", version="1.0", description="noisy import")
+    meta = StrategyMeta(name="noise", version="1.0", description="noisy run")
 
     async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        print("strategy runtime stdout noise")
+        print("more stdout noise from on_step")
         return []
 """
 
@@ -71,6 +75,37 @@ def _write_strategy(tmp_path: Path, source: str) -> Path:
     return strat
 
 
+def _write_ohlcv(data_dir: Path, symbol: str, *, n: int = 5) -> None:
+    """``data_dir`` 에 ``symbol`` 1d OHLCV를 적재(런타임 step 발생용)."""
+    from datetime import UTC, datetime, timedelta
+
+    import polars as pl
+
+    from ante.data.store import ParquetStore
+
+    start = datetime(2026, 1, 2, 9, 0, tzinfo=UTC)
+    timestamps = pl.datetime_range(
+        start,
+        start + timedelta(days=n - 1),
+        interval="1d",
+        eager=True,
+        time_zone="UTC",
+    )
+    df = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": [symbol] * n,
+            "open": [50000.0 + i * 100 for i in range(n)],
+            "high": [50000.0 + i * 100 + 50 for i in range(n)],
+            "low": [50000.0 + i * 100 - 50 for i in range(n)],
+            "close": [50000.0 + i * 100 + 25 for i in range(n)],
+            "volume": [1000 + i * 10 for i in range(n)],
+            "source": ["test"] * n,
+        }
+    )
+    ParquetStore(base_path=data_dir).write(symbol, "1d", df)
+
+
 def _cfg(tmp_path: Path, strat: Path) -> dict:
     # symbols=[] (no-symbols backtest 정상) → 데이터 적재 불필요로 경량.
     return {
@@ -95,11 +130,16 @@ class TestSubprocessTolerantToStdoutNoise:
         self, tmp_path: Path
     ) -> None:
         strat = _write_strategy(tmp_path, _NOISE_STRATEGY)
+        # on_step(런타임)에서 stdout noise를 내려면 step이 실행되어야 하므로
+        # 데이터를 적재하고 symbol을 지정한다(#2039로 import-time noise 불가).
+        _write_ohlcv(tmp_path / "data", "005930")
         svc = BacktestService(data_path=str(tmp_path / "data"))
 
         # 변경 전이라면 noise 라인 때문에 json.loads(stdout) 가
         # JSONDecodeError 를 던졌다. 이제는 sentinel 라인만 파싱한다.
-        out = await svc.run_subprocess(_cfg(tmp_path, strat))
+        cfg = _cfg(tmp_path, strat)
+        cfg["symbols"] = ["005930"]
+        out = await svc.run_subprocess(cfg)
 
         assert isinstance(out, dict)
         assert _RESULT_KEYS <= set(out)


### PR DESCRIPTION
Closes #2039

## Summary
- (P1 security) `BacktestService.run()`이 StrategyValidator 없이 `StrategyLoader.load()`로 전략 파일을 import → top-level `open()`/금지 import 등이 실행되어 `strategy validate` 안전 계약 우회
- service.run()에서 `_validate_config` 후·`StrategyLoader.load()` **직전**에 `StrategyValidator().validate(path)`(AST-only, 코드 미실행). invalid면 `BacktestConfigError`로 load 없이 즉시 중단(금지 코드 import 안 됨). warnings는 비차단
- service.run()은 CLI in-process + subprocess runner 공통 chokepoint → 모든 backtest 실행 경로 import-전 검증

## Test Plan
- backtest/service/strategy 1134 passed, contracts 145 / mypy Success / ruff clean
- 신규: 금지 open/import 차단(BacktestConfigError + marker 미생성 + load 미호출), subprocess 경로 차단, 유효 전략 실제 load 회귀
- 부수: 비실존 strategy_path를 mock하던 기존 테스트 11건 + #2065 sentinel 전략을 새 검증 게이트에 정합(의도 보존)

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS