### PR TITLE
fix(feed): #2030 scheduler 시간 형식 검증 + loop 순서 backfill 우선

### DIFF
--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -397,6 +397,10 @@ def feed_start(ctx: click.Context, data_path: str | None) -> None:
 
     orchestrator = _build_orchestrator(cfg)
 
+    # #2030/#2070: 스케줄러 진입 chokepoint 에서 시간 형식을 1회 fail-fast
+    # 검증해 non-padded("9:00") 등으로 인한 조용한 미실행을 차단한다.
+    # run_scheduler_loop 진입부에도 동일 가드가 있으나(defense-in-depth),
+    # CLI 에서는 traceback 대신 구조화 에러로 변환해 출력한다.
     try:
         asyncio.run(
             run_scheduler_loop(
@@ -407,6 +411,12 @@ def feed_start(ctx: click.Context, data_path: str | None) -> None:
                 backfill_at=backfill_at,
             )
         )
+    except ValueError as exc:
+        fmt.error(  # type: ignore[attr-defined]
+            f"스케줄 시간 설정이 올바르지 않습니다: {exc}",
+            code="CLI_INVALID_SCHEDULE_TIME",
+        )
+        raise SystemExit(1) from exc
     except KeyboardInterrupt:
         click.echo("\nDataFeed 스케줄러 종료")
 

--- a/src/ante/feed/cli_scheduler.py
+++ b/src/ante/feed/cli_scheduler.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import signal
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -18,6 +19,67 @@ logger = logging.getLogger(__name__)
 
 KST = timezone(timedelta(hours=9))
 
+# zero-padded ``HH:MM`` (24시간제) 만 허용. ``strptime("%H:%M")`` 은 ``"9:00"``
+# 같은 non-padded 입력도 수락하므로, 스케줄러의 사전식(``"09:00" >= "9:00"``)
+# 문자열 비교가 조용히 오동작(daily 영원히 미실행)하지 않도록 정규식으로
+# 형태를 고정한다. (#2030/#2070)
+_HHMM_RE = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
+def _is_valid_hhmm(s: str) -> bool:
+    """``s`` 가 zero-padded ``HH:MM`` (00:00–23:59) 형식인지 검증한다.
+
+    ``"09:00"`` → True, ``"9:00"``/``"25:00"``/``"1600"``/``"24:00"`` → False.
+    """
+    return isinstance(s, str) and _HHMM_RE.fullmatch(s) is not None
+
+
+def _validate_schedule_times(
+    daily_at: str,
+    backfill_at: str,
+    blocked_hours: list[Any] | None = None,
+) -> None:
+    """스케줄러 진입 시 시간 설정을 1회 fail-fast 검증한다.
+
+    ``daily_at`` / ``backfill_at`` 은 zero-padded ``HH:MM`` 이어야 하고,
+    ``blocked_hours`` 의 각 항목은 ``"HH:MM-HH:MM"`` 형태로 양 끝점 모두
+    zero-padded ``HH:MM`` 이어야 한다. 하나라도 어긋나면 모든 위반을 모아
+    ``ValueError`` 로 즉시 실패시킨다(조용한 미실행 금지). 루프 매회가 아닌
+    진입 1회만 호출된다.
+
+    midnight-spanning window("23:00-02:00") 의 비교 의미 정정은 본 검증의
+    범위 밖이다(형식 검증만; 별도 이슈). 정상 형식의 cross-midnight 윈도우는
+    유효로 통과시킨다.
+    """
+    errors: list[str] = []
+
+    if not _is_valid_hhmm(daily_at):
+        errors.append(
+            f"잘못된 daily_at 형식: '{daily_at}' (zero-padded HH:MM 필요, 예: 16:00)"
+        )
+    if not _is_valid_hhmm(backfill_at):
+        errors.append(
+            f"잘못된 backfill_at 형식: '{backfill_at}' "
+            "(zero-padded HH:MM 필요, 예: 01:00)"
+        )
+
+    for window in blocked_hours or []:
+        if not isinstance(window, str) or "-" not in window:
+            errors.append(
+                f"잘못된 blocked_hours 항목: '{window}' "
+                "(HH:MM-HH:MM 형식 필요, 예: 09:00-15:30)"
+            )
+            continue
+        start_time, end_time = (part.strip() for part in window.split("-", 1))
+        if not _is_valid_hhmm(start_time) or not _is_valid_hhmm(end_time):
+            errors.append(
+                f"잘못된 blocked_hours 항목: '{window}' "
+                "(양 끝점 모두 zero-padded HH:MM 필요, 예: 09:00-15:30)"
+            )
+
+    if errors:
+        raise ValueError("; ".join(errors))
+
 
 async def run_scheduler_loop(
     orchestrator: Any,  # FeedOrchestrator  # noqa: ANN401
@@ -26,7 +88,22 @@ async def run_scheduler_loop(
     daily_at: str,
     backfill_at: str,
 ) -> None:
-    """스케줄 루프: daily_at / backfill_at 시각에 수집을 실행한다."""
+    """스케줄 루프: daily_at / backfill_at 시각에 수집을 실행한다.
+
+    진입 시 ``daily_at`` / ``backfill_at`` (및 config 의 ``blocked_hours``)
+    형식을 1회 fail-fast 검증한다(#2030/#2070). 모든 ``feed start`` 경로가
+    거치는 단일 chokepoint 이므로, non-padded("9:00") 등으로 인한 조용한
+    미실행을 진입 시점에 ``ValueError`` 로 차단한다. 루프 내부에서는 재검증
+    하지 않는다.
+
+    루프 내 순서는 spec(07-execution-modes)을 따라 backfill_at 체크를
+    daily_at 보다 먼저 평가한다 — 같은 틱에서 둘 다 도달하면 미완료 backfill
+    을 먼저 실행한 뒤 daily 로 넘어간다(#2031).
+    """
+    guard = config.get("guard") if isinstance(config, dict) else None
+    blocked_hours = guard.get("blocked_hours") if isinstance(guard, dict) else None
+    _validate_schedule_times(daily_at, backfill_at, blocked_hours)
+
     stop_event = _setup_signal_handlers()
 
     logger.info(
@@ -53,15 +130,18 @@ async def run_scheduler_loop(
             backfill_ran_today = False
         last_date = current_date
 
-        if not daily_ran_today and current_time >= str(daily_at):
-            await _run_daily_job(orchestrator, data_path, config, current_date)
-            daily_ran_today = True
-
+        # spec(07-execution-modes): backfill 미완료 → backfill_at 실행 후
+        # daily_at → daily. 같은 틱에서 둘 다 도달하면 backfill 을 먼저
+        # 실행한다(#2031). 하루 1회 플래그 로직은 보존한다.
         if not backfill_ran_today and current_time >= str(backfill_at):
             await _run_backfill_job(
                 orchestrator, data_path, config, current_date, stop_event
             )
             backfill_ran_today = True
+
+        if not daily_ran_today and current_time >= str(daily_at):
+            await _run_daily_job(orchestrator, data_path, config, current_date)
+            daily_ran_today = True
 
         await _wait_or_stop(stop_event, timeout=60.0)
 

--- a/tests/unit/feed/test_cli_run.py
+++ b/tests/unit/feed/test_cli_run.py
@@ -381,6 +381,85 @@ class TestFeedStart:
         assert result.exit_code == 0
         assert "스케줄러" in result.output
 
+    @staticmethod
+    def _init_with_schedule(
+        tmp_path: Path, daily_at: str, backfill_at: str, blocked_hours: str
+    ) -> str:
+        data_dir = tmp_path / "data"
+        feed_dir = data_dir / ".feed"
+        feed_dir.mkdir(parents=True)
+        (feed_dir / "config.toml").write_text(
+            "[schedule]\n"
+            f'daily_at = "{daily_at}"\n'
+            f'backfill_at = "{backfill_at}"\n'
+            'backfill_since = "2024-01-01"\n'
+            "\n"
+            "[guard]\n"
+            "blocked_days = []\n"
+            f"blocked_hours = [{blocked_hours}]\n"
+            "pause_during_trading = true\n"
+        )
+        (feed_dir / "checkpoints").mkdir()
+        (feed_dir / "reports").mkdir()
+        return str(data_dir)
+
+    def test_invalid_daily_at_fails_fast_not_silent(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """non-padded daily_at("9:00")이면 조용히 미실행이 아니라 명시 에러로 실패."""
+        data_path = self._init_with_schedule(
+            tmp_path,
+            daily_at="9:00",
+            backfill_at="01:00",
+            blocked_hours='"09:00-15:30"',
+        )
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_build.return_value = AsyncMock()
+            result = runner.invoke(
+                cli,
+                ["feed", "start", "--data-path", data_path],
+            )
+        assert result.exit_code != 0
+        assert "daily_at" in result.output
+
+    def test_invalid_blocked_hours_fails_fast(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """non-padded blocked_hours 끝점("16:00-9:00")이면 명시 에러로 실패."""
+        data_path = self._init_with_schedule(
+            tmp_path,
+            daily_at="16:00",
+            backfill_at="01:00",
+            blocked_hours='"16:00-9:00"',
+        )
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_build.return_value = AsyncMock()
+            result = runner.invoke(
+                cli,
+                ["feed", "start", "--data-path", data_path],
+            )
+        assert result.exit_code != 0
+        assert "blocked_hours" in result.output
+
+    def test_invalid_schedule_json_error_code(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """JSON 모드에서 구조화 에러 코드를 노출한다."""
+        data_path = self._init_with_schedule(
+            tmp_path,
+            daily_at="25:00",
+            backfill_at="01:00",
+            blocked_hours='"09:00-15:30"',
+        )
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_build.return_value = AsyncMock()
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "feed", "start", "--data-path", data_path],
+            )
+        assert result.exit_code != 0
+        assert "CLI_INVALID_SCHEDULE_TIME" in result.output
+
 
 # ── ante feed run --help ─────────────────────────────────────────────────
 

--- a/tests/unit/feed/test_scheduler_time_validation.py
+++ b/tests/unit/feed/test_scheduler_time_validation.py
@@ -1,0 +1,283 @@
+"""스케줄러 시간 형식 검증 + loop 순서 테스트 (#2030/#2070/#2031).
+
+- ``_is_valid_hhmm`` / ``_validate_schedule_times``: zero-padded HH:MM 만
+  허용. non-padded("9:00")/범위초과("25:00")/구분자없음("1600")/
+  "24:00" 등은 거부, 정상("16:00"/"01:00") 통과. blocked_hours 양 끝점도
+  검증.
+- ``run_scheduler_loop`` 진입 시 1회 fail-fast: 잘못된 시간이면 조용히
+  미실행하지 않고 ``ValueError`` 로 즉시 실패.
+- loop 순서: backfill_at·daily_at 둘 다 도달한 틱에서 backfill 이 daily
+  보다 먼저 실행되며(#2031), 하루 1회 플래그 로직은 보존.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ante.feed import cli_scheduler
+from ante.feed.cli_scheduler import (
+    _is_valid_hhmm,
+    _validate_schedule_times,
+    run_scheduler_loop,
+)
+
+# ── _is_valid_hhmm 단위 ──────────────────────────────────────────────────
+
+
+class TestIsValidHHMM:
+    @pytest.mark.parametrize(
+        "value",
+        ["00:00", "01:00", "09:00", "16:00", "15:30", "23:59", "12:34"],
+    )
+    def test_valid_zero_padded(self, value: str) -> None:
+        assert _is_valid_hhmm(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "9:00",  # non-padded hour — 사전식 오동작 핵심 케이스 (#2030)
+            "09:0",  # non-padded minute
+            "25:00",  # hour > 23
+            "24:00",  # 24시는 무효 (00:00 만 허용)
+            "1600",  # 구분자 없음
+            "16:60",  # minute > 59
+            "16:5",  # 1자리 minute
+            "ab:cd",  # 비숫자
+            "16:00 ",  # trailing space
+            " 16:00",  # leading space
+            "16:00:00",  # 초 포함
+            "",  # 빈 문자열
+            "-1:00",
+        ],
+    )
+    def test_invalid(self, value: str) -> None:
+        assert _is_valid_hhmm(value) is False
+
+    def test_non_string(self) -> None:
+        assert _is_valid_hhmm(None) is False  # type: ignore[arg-type]
+        assert _is_valid_hhmm(1600) is False  # type: ignore[arg-type]
+
+
+# ── _validate_schedule_times: daily_at / backfill_at ─────────────────────
+
+
+class TestValidateScheduleTimes:
+    def test_valid_passes(self) -> None:
+        # 예외가 발생하지 않으면 통과.
+        _validate_schedule_times("16:00", "01:00", ["09:00-15:30"])
+
+    @pytest.mark.parametrize("bad", ["9:00", "25:00", "1600", "24:00"])
+    def test_invalid_daily_at_raises(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="daily_at"):
+            _validate_schedule_times(bad, "01:00")
+
+    @pytest.mark.parametrize("bad", ["9:00", "25:00", "1600", "24:00"])
+    def test_invalid_backfill_at_raises(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="backfill_at"):
+            _validate_schedule_times("16:00", bad)
+
+    def test_collects_multiple_errors(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            _validate_schedule_times("9:00", "25:00")
+        msg = str(exc_info.value)
+        assert "daily_at" in msg
+        assert "backfill_at" in msg
+
+    # ── blocked_hours 형식 ──
+    def test_valid_blocked_hours_passes(self) -> None:
+        _validate_schedule_times("16:00", "01:00", ["09:00-15:30"])
+
+    def test_empty_blocked_hours_passes(self) -> None:
+        _validate_schedule_times("16:00", "01:00", [])
+        _validate_schedule_times("16:00", "01:00", None)
+
+    @pytest.mark.parametrize(
+        "window",
+        [
+            "9:00-15:30",  # non-padded start
+            "09:00-9:00",  # non-padded end (16:00-9:00 변형)
+            "16:00-9:00",  # non-padded end
+            "25:00-15:30",  # 범위초과 start
+            "09:00-24:00",  # 24:00 end
+            "0900-1530",  # 구분자 없음
+            "09:00",  # '-' 없음
+            "09:00-",  # end 누락
+            "-15:30",  # start 누락
+        ],
+    )
+    def test_invalid_blocked_hours_raises(self, window: str) -> None:
+        with pytest.raises(ValueError, match="blocked_hours"):
+            _validate_schedule_times("16:00", "01:00", [window])
+
+    def test_cross_midnight_format_is_valid(self) -> None:
+        # 자정跨ぎ window 의 비교 의미 정정은 범위 밖 — 형식만 검증하므로
+        # 정상 형식이면 통과한다(별도 이슈).
+        _validate_schedule_times("16:00", "01:00", ["23:00-02:00"])
+
+
+# ── run_scheduler_loop 진입 fail-fast ────────────────────────────────────
+
+
+class TestSchedulerLoopFailFast:
+    def test_invalid_daily_at_fails_fast_not_silent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """non-padded daily_at("9:00") → 조용한 미실행이 아니라 ValueError."""
+        ran: list[str] = []
+
+        async def _track_daily(*_a: Any, **_k: Any) -> None:
+            ran.append("daily")
+
+        async def _track_backfill(*_a: Any, **_k: Any) -> None:
+            ran.append("backfill")
+
+        monkeypatch.setattr(cli_scheduler, "_run_daily_job", _track_daily)
+        monkeypatch.setattr(cli_scheduler, "_run_backfill_job", _track_backfill)
+
+        with pytest.raises(ValueError, match="daily_at"):
+            asyncio.run(
+                run_scheduler_loop(
+                    orchestrator=MagicMock(),
+                    data_path="data/",
+                    config={},
+                    daily_at="9:00",
+                    backfill_at="01:00",
+                )
+            )
+        # 검증은 루프 진입 전이므로 작업이 실행되지 않는다.
+        assert ran == []
+
+    def test_invalid_backfill_at_fails_fast(self) -> None:
+        with pytest.raises(ValueError, match="backfill_at"):
+            asyncio.run(
+                run_scheduler_loop(
+                    orchestrator=MagicMock(),
+                    data_path="data/",
+                    config={},
+                    daily_at="16:00",
+                    backfill_at="25:00",
+                )
+            )
+
+    def test_invalid_blocked_hours_fails_fast(self) -> None:
+        with pytest.raises(ValueError, match="blocked_hours"):
+            asyncio.run(
+                run_scheduler_loop(
+                    orchestrator=MagicMock(),
+                    data_path="data/",
+                    config={"guard": {"blocked_hours": ["9:00-15:30"]}},
+                    daily_at="16:00",
+                    backfill_at="01:00",
+                )
+            )
+
+
+# ── loop 순서: backfill 우선 (#2031) ─────────────────────────────────────
+
+
+class TestSchedulerLoopOrder:
+    def test_backfill_runs_before_daily_when_both_due(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """둘 다 도달한 1틱: backfill 이 daily 보다 먼저 호출된다."""
+        call_order: list[str] = []
+
+        async def _track_daily(*_a: Any, **_k: Any) -> None:
+            call_order.append("daily")
+
+        async def _track_backfill(*_a: Any, **_k: Any) -> None:
+            call_order.append("backfill")
+
+        async def _instant_wait(stop_event: asyncio.Event, *, timeout: float) -> None:
+            # 첫 틱 이후 루프를 종료시킨다.
+            stop_event.set()
+
+        monkeypatch.setattr(cli_scheduler, "_run_daily_job", _track_daily)
+        monkeypatch.setattr(cli_scheduler, "_run_backfill_job", _track_backfill)
+        monkeypatch.setattr(cli_scheduler, "_wait_or_stop", _instant_wait)
+
+        # 둘 다 과거 시각이라 같은 틱에서 모두 도달.
+        asyncio.run(
+            run_scheduler_loop(
+                orchestrator=MagicMock(),
+                data_path="data/",
+                config={},
+                daily_at="00:00",
+                backfill_at="00:00",
+            )
+        )
+
+        assert call_order == ["backfill", "daily"]
+
+    def test_daily_at_in_future_only_backfill_runs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """daily_at 미도달이면 backfill 만 실행(daily 플래그/시각 조건 보존)."""
+        call_order: list[str] = []
+
+        async def _track_daily(*_a: Any, **_k: Any) -> None:
+            call_order.append("daily")
+
+        async def _track_backfill(*_a: Any, **_k: Any) -> None:
+            call_order.append("backfill")
+
+        async def _instant_wait(stop_event: asyncio.Event, *, timeout: float) -> None:
+            stop_event.set()
+
+        monkeypatch.setattr(cli_scheduler, "_run_daily_job", _track_daily)
+        monkeypatch.setattr(cli_scheduler, "_run_backfill_job", _track_backfill)
+        monkeypatch.setattr(cli_scheduler, "_wait_or_stop", _instant_wait)
+
+        asyncio.run(
+            run_scheduler_loop(
+                orchestrator=MagicMock(),
+                data_path="data/",
+                config={},
+                daily_at="23:59",
+                backfill_at="00:00",
+            )
+        )
+
+        assert call_order == ["backfill"]
+
+    def test_each_job_runs_once_per_day(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """하루 1회 플래그 로직 회귀: 여러 틱이어도 각 1회만 실행."""
+        call_order: list[str] = []
+
+        async def _track_daily(*_a: Any, **_k: Any) -> None:
+            call_order.append("daily")
+
+        async def _track_backfill(*_a: Any, **_k: Any) -> None:
+            call_order.append("backfill")
+
+        ticks = {"n": 0}
+
+        async def _wait_three_ticks(
+            stop_event: asyncio.Event, *, timeout: float
+        ) -> None:
+            ticks["n"] += 1
+            if ticks["n"] >= 3:
+                stop_event.set()
+
+        monkeypatch.setattr(cli_scheduler, "_run_daily_job", _track_daily)
+        monkeypatch.setattr(cli_scheduler, "_run_backfill_job", _track_backfill)
+        monkeypatch.setattr(cli_scheduler, "_wait_or_stop", _wait_three_ticks)
+
+        asyncio.run(
+            run_scheduler_loop(
+                orchestrator=MagicMock(),
+                data_path="data/",
+                config={},
+                daily_at="00:00",
+                backfill_at="00:00",
+            )
+        )
+
+        assert call_order.count("backfill") == 1
+        assert call_order.count("daily") == 1
+        # 첫 틱에서 backfill 이 daily 보다 먼저.
+        assert call_order == ["backfill", "daily"]


### PR DESCRIPTION
Closes #2030
Closes #2070
Closes #2031

## Summary
feed scheduler 시간 처리 3건:
- **#2030≈#2070**: cli_scheduler가 `daily_at`/`backfill_at`/`blocked_hours`를 HH:MM 형식 검증 없이 문자열 비교 → `9:00`(non-padded)이면 `"09:00">="9:00"`==False로 daily 조용히 미실행. `_is_valid_hhmm` 정규식(`^([01]\d|2[0-3]):[0-5]\d$`)으로 `run_scheduler_loop` 진입 chokepoint에서 1회 fail-fast 검증(ValueError→CLI 구조화 에러). blocked_hours 끝점도 검증
- **#2031**: 루프가 daily_at→backfill_at 순서였던 것을 **backfill_at→daily_at**로 정정(spec: backfill 우선 재개 후 daily). once/day 플래그 보존
- 자정跨ぎ blocked_hours 비교 정정은 범위 외(형식 검증만)

## Test Plan
- scheduler/feed/orchestrator 594 passed, contracts 145, 신규+cli 69 / mypy Success / ruff clean
- 신규: _is_valid_hhmm 유효/무효, 시작 fail-fast(작업 미실행), loop 순서 backfill-first, 플래그 회귀, CLI 에러코드

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS