### PR TITLE
fix(strategy): #2049 StrategyMeta.__hash__가 list 필드(symbols)를 tuple로 변환

### DIFF
--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -86,7 +86,12 @@ class StrategyMeta:
         )
 
     def __hash__(self) -> int:
-        return hash(tuple(getattr(self, attr) for attr in self.__slots__))
+        return hash(
+            tuple(
+                tuple(v) if isinstance(v, list) else v
+                for v in (getattr(self, attr) for attr in self.__slots__)
+            )
+        )
 
     def __repr__(self) -> str:
         fields = ", ".join(f"{a}={getattr(self, a)!r}" for a in self.__slots__)

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -98,6 +98,50 @@ class TestSignal:
         assert m.timeframe == "1d"
         assert m.exchange == "KRX"
 
+    def test_meta_hash_symbols_none(self):
+        """symbols=None인 meta는 해시 가능하다."""
+        m = StrategyMeta(name="x", version="1.0.0", description="x", symbols=None)
+        assert isinstance(hash(m), int)
+
+    def test_meta_hash_symbols_list_single(self):
+        """symbols가 단일 원소 list여도 해시 가능하다 (이슈 #2049 repro)."""
+        m = StrategyMeta(name="x", version="1.0.0", description="x", symbols=["005930"])
+        assert isinstance(hash(m), int)
+
+    def test_meta_hash_symbols_list_multi(self):
+        """symbols가 다중 원소 list여도 해시 가능하다."""
+        m = StrategyMeta(
+            name="x",
+            version="1.0.0",
+            description="x",
+            symbols=["005930", "000660"],
+        )
+        assert isinstance(hash(m), int)
+
+    def test_meta_eq_hash_consistency(self):
+        """같은 값(동일 symbols list)인 두 meta는 eq True이고 hash가 같다."""
+        m1 = StrategyMeta(
+            name="x", version="1.0.0", description="x", symbols=["005930", "000660"]
+        )
+        m2 = StrategyMeta(
+            name="x", version="1.0.0", description="x", symbols=["005930", "000660"]
+        )
+        assert m1 == m2
+        assert hash(m1) == hash(m2)
+
+    def test_meta_usable_in_set_and_dict(self):
+        """list symbols를 가진 meta가 set/dict 키로 동작한다."""
+        m1 = StrategyMeta(
+            name="x", version="1.0.0", description="x", symbols=["005930"]
+        )
+        m2 = StrategyMeta(
+            name="y", version="1.0.0", description="y", symbols=["000660"]
+        )
+        assert {m1, m2} == {m1, m2}
+        mapping = {m1: "a", m2: "b"}
+        assert mapping[m1] == "a"
+        assert mapping[m2] == "b"
+
     def test_signal_defaults(self):
         """Signal 기본값."""
         s = Signal(symbol="005930", side="buy", quantity=10.0)


### PR DESCRIPTION
Closes #2049

## Summary
- `StrategyMeta.__hash__`가 `hash(tuple(getattr(slots)))`로 모든 slot을 그대로 hash → `symbols`(list[str]|None)가 list일 때 `TypeError: unhashable type: 'list'`
- `__hash__`에서 list 값을 tuple로 변환(`tuple(v) if isinstance(v,list) else v`). symbols + 향후 list 필드 안전, None 그대로. `__eq__`(내용 비교) 불변 — 같은 값 meta는 같은 hash(eq-hash 일관)

## Test Plan
- strategy/meta/base/validator 624 passed / mypy Success / ruff clean
- 신규: symbols None/단일/다중 hash, eq-hash 일관, set/dict 키 사용

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS