### PR TITLE
fix(feed): #2099 validate_business가 tz-aware timestamp 시계열 역전 감지

### DIFF
--- a/src/ante/feed/transform/validate.py
+++ b/src/ante/feed/transform/validate.py
@@ -399,6 +399,12 @@ def _check_date_order(
 ) -> None:
     """날짜 순서 역전을 검사한다.
 
+    파싱된 datetime들이 tz-aware/naive로 혼재하면 ``<`` 비교가
+    ``TypeError``를 일으킨다. 정규화 batch는 통상 tz-awareness가 일관(전부
+    aware 또는 전부 naive)이지만, 방어적으로 인접 비교를 try/except로 감싸
+    혼재 시 해당 비교만 건너뛴다. 일관 tz(정상 케이스)에서는 역전을 정확히
+    감지한다.
+
     Args:
         symbol: 심볼 식별자.
         dates: 날짜 문자열 목록.
@@ -411,7 +417,12 @@ def _check_date_order(
             parsed_dates.append((dt, d))
 
     for j in range(1, len(parsed_dates)):
-        if parsed_dates[j][0] < parsed_dates[j - 1][0]:
+        try:
+            reversed_order = parsed_dates[j][0] < parsed_dates[j - 1][0]
+        except TypeError:
+            # tz-aware와 naive datetime 혼재 → 순서 판정 불가, 해당 비교 skip.
+            continue
+        if reversed_order:
             warnings.append(
                 f"{symbol}: 날짜 순서 역전 감지: "
                 f"{parsed_dates[j - 1][1]} -> {parsed_dates[j][1]}"
@@ -420,6 +431,12 @@ def _check_date_order(
 
 def _try_parse_date(value: str) -> datetime | None:
     """날짜 문자열을 파싱 시도한다.
+
+    먼저 고정 strptime 형식 4종을 시도하고, 모두 실패하면
+    ``datetime.fromisoformat`` 으로 fallback한다. fromisoformat은
+    timezone offset(``"2026-01-02 00:00:00+00:00"``)과 ISO ``T`` 구분자
+    offset(``"2026-01-02T00:00:00+00:00"``)을 처리하지만 ``"20260102"``
+    같은 구분자 없는 형식은 거부하므로 strptime 루프를 그대로 유지한다.
 
     Args:
         value: 날짜 문자열.
@@ -437,7 +454,11 @@ def _try_parse_date(value: str) -> datetime | None:
             return datetime.strptime(value, fmt)
         except ValueError:
             continue
-    return None
+    # strptime 4형식 모두 실패 시 ISO 8601 (tz offset 포함) fallback.
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
 
 
 def validate_all(

--- a/tests/unit/feed/test_validate.py
+++ b/tests/unit/feed/test_validate.py
@@ -6,9 +6,11 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta, timezone
 
 from ante.feed.models.result import ValidationResult
 from ante.feed.transform.validate import (
+    _try_parse_date,
     validate_all,
     validate_business,
     validate_schema,
@@ -413,6 +415,65 @@ class TestValidateBusiness:
         result = validate_business(records)
         assert any("역전" in w for w in result.warnings)
 
+    def test_tz_aware_datetime_reversal_detected(self) -> None:
+        """이슈 재현: tz-aware datetime 시계열 역전이 감지된다 (#2099).
+
+        정규화 OHLCV의 timestamp는 tz-aware datetime이며 str()로 변환하면
+        "...+00:00" offset 형식이 된다. _try_parse_date의 fromisoformat
+        fallback으로 파싱되어 역전이 감지되어야 한다(기존엔 None→미감지).
+        """
+        records = [
+            _make_ohlcv_record(timestamp=datetime(2026, 1, 2, tzinfo=UTC)),
+            _make_ohlcv_record(timestamp=datetime(2026, 1, 1, tzinfo=UTC)),
+        ]
+        result = validate_business(records)
+        assert result.passed is True
+        assert any("역전" in w for w in result.warnings)
+
+    def test_tz_aware_datetime_ascending_no_reversal(self) -> None:
+        """정상: tz-aware 오름차순은 역전 경고가 없다 (#2099)."""
+        records = [
+            _make_ohlcv_record(timestamp=datetime(2026, 1, 1, tzinfo=UTC)),
+            _make_ohlcv_record(timestamp=datetime(2026, 1, 2, tzinfo=UTC)),
+        ]
+        result = validate_business(records)
+        assert result.passed is True
+        assert not any("역전" in w for w in result.warnings)
+
+    def test_naive_str_reversal_regression(self) -> None:
+        """회귀: naive datetime 문자열 역전 감지 유지 (#2099)."""
+        records = [
+            _make_ohlcv_record(timestamp="2026-01-02 00:00:00"),
+            _make_ohlcv_record(timestamp="2026-01-01 00:00:00"),
+        ]
+        result = validate_business(records)
+        assert any("역전" in w for w in result.warnings)
+
+    def test_compact_date_format_reversal_regression(self) -> None:
+        """회귀: %Y%m%d("20260102") 형식 파싱 및 역전 감지 유지 (#2099)."""
+        records = [
+            _make_ohlcv_record(timestamp="20260102"),
+            _make_ohlcv_record(timestamp="20260101"),
+        ]
+        result = validate_business(records)
+        assert any("역전" in w for w in result.warnings)
+
+    def test_mixed_aware_naive_no_typeerror(self) -> None:
+        """mixed aware/naive 한 series는 TypeError 없이 안전 처리 (#2099).
+
+        tz-aware와 naive datetime이 섞이면 < 비교가 TypeError를 내지만,
+        _check_date_order가 해당 비교를 건너뛰어 죽지 않아야 한다.
+        """
+        records = [
+            _make_ohlcv_record(timestamp=datetime(2026, 1, 1, tzinfo=UTC)),
+            _make_ohlcv_record(timestamp=datetime(2026, 1, 2)),  # naive
+            _make_ohlcv_record(timestamp=datetime(2026, 1, 3, tzinfo=UTC)),
+        ]
+        # TypeError 없이 정상 반환되어야 함
+        result = validate_business(records)
+        assert result.passed is True
+        assert result.errors == []
+
     def test_multiple_symbols_independent(self) -> None:
         """심볼이 다르면 시계열 검증이 독립적으로 수행된다."""
         records = [
@@ -656,3 +717,47 @@ class TestValidationResult:
         result = ValidationResult(passed=True)
         assert result.warnings == []
         assert result.errors == []
+
+
+# ===========================================================================
+# 7. _try_parse_date 단위 (#2099)
+# ===========================================================================
+
+
+class TestTryParseDate:
+    """_try_parse_date 날짜 파싱 헬퍼 테스트 (#2099)."""
+
+    def test_strptime_datetime_space(self) -> None:
+        assert _try_parse_date("2026-01-02 00:00:00") == datetime(2026, 1, 2, 0, 0, 0)
+
+    def test_strptime_datetime_t(self) -> None:
+        assert _try_parse_date("2026-01-02T00:00:00") == datetime(2026, 1, 2, 0, 0, 0)
+
+    def test_strptime_date_only(self) -> None:
+        assert _try_parse_date("2026-01-02") == datetime(2026, 1, 2)
+
+    def test_strptime_compact_date(self) -> None:
+        """%Y%m%d는 fromisoformat가 거부하므로 strptime 유지가 필요하다."""
+        assert _try_parse_date("20260102") == datetime(2026, 1, 2)
+
+    def test_fromisoformat_tz_offset_space(self) -> None:
+        """tz offset 포함 space 형식(str(tz-aware datetime))을 파싱한다."""
+        parsed = _try_parse_date("2026-01-02 00:00:00+00:00")
+        assert parsed == datetime(2026, 1, 2, 0, 0, 0, tzinfo=UTC)
+        assert parsed is not None
+        assert parsed.tzinfo is not None
+
+    def test_fromisoformat_tz_offset_t(self) -> None:
+        """ISO T 구분자 + tz offset 형식을 파싱한다."""
+        parsed = _try_parse_date("2026-01-02T00:00:00+09:00")
+        assert parsed is not None
+        assert parsed.tzinfo is not None
+        assert parsed == datetime(
+            2026, 1, 2, 0, 0, 0, tzinfo=timezone(timedelta(hours=9))
+        )
+
+    def test_invalid_returns_none(self) -> None:
+        assert _try_parse_date("not-a-date") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert _try_parse_date("") is None


### PR DESCRIPTION
Closes #2099

## Summary
- `validate_business`의 `_try_parse_date`가 tz offset 형식(`2026-01-02 00:00:00+00:00`)을 strptime 4형식으로 파싱 못 해 정규화된 tz-aware OHLCV의 시계열 역전을 감지 못함
- `_try_parse_date`: strptime 4형식(%Y%m%d 포함) 먼저 시도 후 `datetime.fromisoformat` fallback(tz offset·ISO-T)
- `_check_date_order`: mixed aware/naive 비교 TypeError를 인접 비교 단위 try/except로 방어(혼재 시 skip, 일관 tz 정상 케이스는 정확히 감지)

## Test Plan
- validate/business/feed 836 passed, feed/test_validate 83, contracts 145 / mypy Success / ruff clean
- 신규: tz-aware 역전 감지/오름차순/naive 회귀/%Y%m%d 회귀/mixed-no-TypeError + _try_parse_date 단위

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS