### PR TITLE
fix(feed): #2026 HTTP 4xx 비재시도 + #2027 UNKNOWN(99/900) 1회 재시도 — DataFeed retry 정책

### DIFF
--- a/src/ante/feed/sources/dart.py
+++ b/src/ante/feed/sources/dart.py
@@ -34,6 +34,10 @@ DAILY_LIMIT = 20_000
 BATCH_SIZE = 100  # fnlttMultiAcnt 최대 100개 회사
 REQUEST_TIMEOUT = 60  # 다중회사 응답이 커질 수 있으므로 넉넉하게
 
+# 재시도 불가 HTTP status (spec 09-failure-recovery: 즉시 스킵/실패 로그).
+# 재시도 가능(408/429/5xx/timeout/연결 오류)은 이 집합 밖이라 기존대로 재시도된다.
+_NON_RETRYABLE_HTTP_STATUS = frozenset({400, 401, 403, 404, 422})
+
 # 보고서 코드 매핑
 REPRT_CODES: dict[str, str] = {
     "11013": "1분기보고서",
@@ -52,6 +56,7 @@ class ErrorAction(StrEnum):
     OK = "ok"
     NO_DATA = "no_data"
     RETRY = "retry"
+    RETRY_ONCE = "retry_once"
     SKIP = "skip"
     DAILY_LIMIT = "daily_limit"
     CRITICAL = "critical"
@@ -69,7 +74,7 @@ _ERROR_CODE_MAP: dict[str, ErrorAction] = {
     "100": ErrorAction.SKIP,  # 부적절한 필드 값
     "101": ErrorAction.SKIP,  # 부적절한 접근
     "800": ErrorAction.RETRY,  # 시스템 점검 중
-    "900": ErrorAction.RETRY,  # 정의되지 않은 오류
+    "900": ErrorAction.RETRY_ONCE,  # 정의되지 않은 오류 (spec: 1회 재시도 후 스킵)
     "901": ErrorAction.CRITICAL,  # 개인정보 보유기간 만료
 }
 
@@ -314,6 +319,9 @@ class DARTSource:
             # 1 attempt = 1 increment.
             self._rate_limiter.increment_daily()
 
+            # 이번 attempt의 JSON 에러 코드 분류(없으면 전송 오류 = RETRY 취급).
+            action = ErrorAction.RETRY
+
             try:
                 async with asyncio.timeout(REQUEST_TIMEOUT):
                     async with session.get(url, params=params) as resp:
@@ -353,9 +361,22 @@ class DARTSource:
                             return await resp.read()
 
             except (TimeoutError, aiohttp.ClientError) as exc:
+                # 재시도 불가 HTTP status(400/401/403/404/422)는 즉시 실패
+                # 처리한다 (spec 09-failure-recovery, #2026).
+                if (
+                    isinstance(exc, aiohttp.ClientResponseError)
+                    and exc.status in _NON_RETRYABLE_HTTP_STATUS
+                ):
+                    msg = f"DART 재시도 불가 HTTP 에러 (status={exc.status})"
+                    logger.error(msg)
+                    raise DARTError(msg) from exc
                 last_error = exc
 
-            if attempt < self._max_retries - 1:
+            # RETRY_ONCE(900 정의되지 않은 오류)는 최대 1회만 재시도한다
+            # (spec 05-data-sources: 1회 재시도 후 스킵 = 총 2회 호출, #2027).
+            # 전송 오류/일반 RETRY는 기존 max_retries를 유지한다.
+            retry_cap = 1 if action == ErrorAction.RETRY_ONCE else self._max_retries - 1
+            if attempt < retry_cap:
                 delay = self._backoff_delay(attempt)
                 logger.warning(
                     "DART corpCode 다운로드 실패 (attempt=%d/%d): %s. %.1f초 후 재시도",
@@ -365,6 +386,9 @@ class DARTSource:
                     delay,
                 )
                 await asyncio.sleep(delay)
+            elif action == ErrorAction.RETRY_ONCE:
+                # 1회 재시도 cap 도달 → 최종 실패로 즉시 종료(추가 attempt 생략).
+                break
 
         msg = "DART 고유번호 ZIP 다운로드 최종 실패"
         logger.error(msg)
@@ -447,6 +471,19 @@ class DARTSource:
                     timeout=REQUEST_TIMEOUT,
                 )
             except (TimeoutError, aiohttp.ClientError) as exc:
+                # 재시도 불가 HTTP status(400/401/403/404/422)는 즉시 실패
+                # 처리한다 (spec 09-failure-recovery, #2026). body 에러 코드의
+                # SKIP 액션과 동일하게 error 로그 + DARTError raise.
+                if (
+                    isinstance(exc, aiohttp.ClientResponseError)
+                    and exc.status in _NON_RETRYABLE_HTTP_STATUS
+                ):
+                    msg = (
+                        f"DART 재시도 불가 HTTP 에러 (status={exc.status}): "
+                        f"year={year}, reprt={reprt_code}"
+                    )
+                    logger.error(msg)
+                    raise DARTError(msg) from exc
                 last_error = exc
                 delay = self._backoff_delay(attempt)
                 logger.warning(
@@ -492,9 +529,13 @@ class DARTSource:
                 logger.error(msg)
                 raise DARTError(msg)
 
-            # RETRY
+            # RETRY / RETRY_ONCE
             last_error = DARTError(f"DART API 에러 (status={status}): {message}")
-            if attempt < self._max_retries - 1:
+            # RETRY_ONCE(900 정의되지 않은 오류)는 최대 1회만 재시도한다
+            # (spec 05-data-sources: 1회 재시도 후 스킵 = 총 2회 호출, #2027).
+            # attempt>=1이면 더 이상 재시도하지 않고 최종 실패로 떨어진다.
+            retry_cap = 1 if action == ErrorAction.RETRY_ONCE else self._max_retries - 1
+            if attempt < retry_cap:
                 delay = self._backoff_delay(attempt)
                 logger.warning(
                     "DART API 에러 (attempt=%d/%d, status=%s): %s. %.1f초 후 재시도",
@@ -505,6 +546,9 @@ class DARTSource:
                     delay,
                 )
                 await asyncio.sleep(delay)
+            elif action == ErrorAction.RETRY_ONCE:
+                # 1회 재시도 cap 도달 → 최종 실패로 즉시 종료(추가 attempt 생략).
+                break
 
         msg = f"DART fnlttMultiAcnt 요청 최종 실패: year={year}, reprt={reprt_code}"
         logger.error(msg)

--- a/src/ante/feed/sources/data_go_kr.py
+++ b/src/ante/feed/sources/data_go_kr.py
@@ -31,6 +31,10 @@ DAILY_LIMIT = 10_000
 NUM_OF_ROWS = 1000
 REQUEST_TIMEOUT = 30  # 초
 
+# 재시도 불가 HTTP status (spec 09-failure-recovery: 즉시 스킵/실패 로그).
+# 재시도 가능(408/429/5xx/timeout/연결 오류)은 이 집합 밖이라 기존대로 재시도된다.
+_NON_RETRYABLE_HTTP_STATUS = frozenset({400, 401, 403, 404, 422})
+
 
 # ── 에러 분류 ──────────────────────────────────────────────
 
@@ -40,6 +44,7 @@ class ErrorAction(StrEnum):
 
     OK = "ok"
     RETRY = "retry"
+    RETRY_ONCE = "retry_once"
     SKIP = "skip"
     DAILY_LIMIT = "daily_limit"
     CRITICAL = "critical"
@@ -56,7 +61,7 @@ _ERROR_CODE_MAP: dict[str, ErrorAction] = {
     "30": ErrorAction.CRITICAL,  # SERVICE_KEY_IS_NOT_REGISTERED_ERROR
     "31": ErrorAction.CRITICAL,  # DEADLINE_HAS_EXPIRED_ERROR
     "32": ErrorAction.SKIP,  # UNREGISTERED_IP_ERROR
-    "99": ErrorAction.RETRY,  # UNKNOWN_ERROR
+    "99": ErrorAction.RETRY_ONCE,  # UNKNOWN_ERROR (spec: 1회 재시도 후 스킵)
 }
 
 
@@ -251,6 +256,19 @@ class DataGoKrSource:
                     timeout=REQUEST_TIMEOUT,
                 )
             except (TimeoutError, aiohttp.ClientError) as exc:
+                # 재시도 불가 HTTP status(400/401/403/404/422)는 즉시 실패
+                # 처리한다 (spec 09-failure-recovery, #2026). body 에러 코드의
+                # SKIP 액션과 동일하게 error 로그 + DataGoKrError raise.
+                if (
+                    isinstance(exc, aiohttp.ClientResponseError)
+                    and exc.status in _NON_RETRYABLE_HTTP_STATUS
+                ):
+                    msg = (
+                        f"재시도 불가 HTTP 에러 (status={exc.status}): "
+                        f"basDt={bas_dt}, pageNo={page_no}"
+                    )
+                    logger.error(msg)
+                    raise DataGoKrError(msg) from exc
                 last_error = exc
                 delay = self._backoff_delay(attempt)
                 logger.warning(
@@ -285,9 +303,13 @@ class DataGoKrSource:
                 logger.error(msg)
                 raise DataGoKrError(msg)
 
-            # RETRY
+            # RETRY / RETRY_ONCE
             last_error = DataGoKrError(f"API 에러 (code={result_code}): {result_msg}")
-            if attempt < self._max_retries - 1:
+            # RETRY_ONCE(99 UNKNOWN_ERROR)는 최대 1회만 재시도한다
+            # (spec 05-data-sources: 1회 재시도 후 스킵 = 총 2회 호출, #2027).
+            # attempt>=1이면 더 이상 재시도하지 않고 최종 실패로 떨어진다.
+            retry_cap = 1 if action == ErrorAction.RETRY_ONCE else self._max_retries - 1
+            if attempt < retry_cap:
                 delay = self._backoff_delay(attempt)
                 logger.warning(
                     "data.go.kr API 에러 (attempt=%d/%d, code=%s):"
@@ -299,6 +321,9 @@ class DataGoKrSource:
                     delay,
                 )
                 await asyncio.sleep(delay)
+            elif action == ErrorAction.RETRY_ONCE:
+                # 1회 재시도 cap 도달 → 최종 실패로 즉시 종료(추가 attempt 생략).
+                break
 
         # 재시도 소진
         msg = f"data.go.kr 요청 최종 실패: basDt={bas_dt}, pageNo={page_no}"

--- a/tests/unit/feed/test_dart.py
+++ b/tests/unit/feed/test_dart.py
@@ -8,7 +8,10 @@ import zipfile
 from unittest.mock import AsyncMock, patch
 from xml.etree.ElementTree import Element, SubElement, tostring
 
+import aiohttp
 import pytest
+from multidict import CIMultiDict
+from yarl import URL
 
 from ante.feed.sources.base import RateLimiter
 from ante.feed.sources.dart import (
@@ -143,8 +146,8 @@ class TestClassifyError:
         assert classify_error("800") == ErrorAction.RETRY
 
     def test_undefined_error(self) -> None:
-        """900은 RETRY로 분류한다."""
-        assert classify_error("900") == ErrorAction.RETRY
+        """900은 RETRY_ONCE로 분류한다 (1회 재시도 후 스킵, #2027)."""
+        assert classify_error("900") == ErrorAction.RETRY_ONCE
 
     def test_expired_account(self) -> None:
         """901은 CRITICAL로 분류한다."""
@@ -500,6 +503,232 @@ class TestFetchFinancial:
 
         # 첫 번째 배치만 실행됨
         assert call_count == 1
+
+
+# -- HTTP status 재시도 분류 (#2026) -----------------------------------
+
+
+def _client_response_error(status: int) -> aiohttp.ClientResponseError:
+    """지정 status를 가진 aiohttp.ClientResponseError를 생성한다."""
+    request_info = aiohttp.RequestInfo(
+        url=URL("https://opendart.fss.or.kr/test"),
+        method="GET",
+        headers=CIMultiDict(),
+        real_url=URL("https://opendart.fss.or.kr/test"),
+    )
+    return aiohttp.ClientResponseError(
+        request_info=request_info,
+        history=(),
+        status=status,
+        message=f"HTTP {status}",
+    )
+
+
+class TestHttpStatusRetryPolicy:
+    """#2026: HTTP 4xx 비재시도 / 408·429·5xx·timeout·연결 오류 재시도."""
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+    @pytest.mark.asyncio
+    async def test_non_retryable_status_fails_immediately(
+        self, source: DARTSource, status: int
+    ) -> None:
+        """400/401/403/404/422는 재시도 없이 1회 호출 후 즉시 실패한다."""
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            raise _client_response_error(status)
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError):
+                    await source.fetch_financial(["00126380"], "2024", "11011")
+
+        assert call_count == 1
+
+    @pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+    @pytest.mark.asyncio
+    async def test_retryable_status_retries(
+        self, source: DARTSource, status: int
+    ) -> None:
+        """408/429/5xx ClientResponseError는 max_retries까지 재시도한다."""
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            raise _client_response_error(status)
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError, match="최종 실패"):
+                    await source.fetch_financial(["00126380"], "2024", "11011")
+
+        assert call_count == source._max_retries == 2
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_retries(self, source: DARTSource) -> None:
+        """TimeoutError는 재시도 대상이다."""
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            raise TimeoutError("timed out")
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError, match="최종 실패"):
+                    await source.fetch_financial(["00126380"], "2024", "11011")
+
+        assert call_count == source._max_retries == 2
+
+    @pytest.mark.asyncio
+    async def test_connection_error_without_status_retries(
+        self, source: DARTSource
+    ) -> None:
+        """status 없는 ClientConnectionError(연결 오류)는 재시도 대상이다."""
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            raise aiohttp.ClientConnectionError("Connection refused")
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError, match="최종 실패"):
+                    await source.fetch_financial(["00126380"], "2024", "11011")
+
+        assert call_count == source._max_retries == 2
+
+
+# -- UNDEFINED(900) RETRY_ONCE 1회 재시도 cap (#2027) ------------------
+
+
+class TestRetryOnceCap:
+    """#2027: status=900(정의되지 않은 오류)는 1회만 재시도(총 2회 호출) 후 스킵."""
+
+    @pytest.mark.asyncio
+    async def test_undefined_status_retries_once_then_skips(
+        self, rate_limiter: RateLimiter
+    ) -> None:
+        """900은 max_retries(=3)와 무관하게 2회 호출(1회 재시도) 후 실패한다."""
+        source = DARTSource(
+            api_key="test-dart-api-key-0123456789abcdef01",
+            rate_limiter=rate_limiter,
+            max_retries=3,
+        )
+        error_response = {"status": "900", "message": "정의되지 않은 오류"}
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            return error_response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError, match="최종 실패"):
+                    await source.fetch_financial(["00126380"], "2024", "11011")
+
+        # RETRY_ONCE → 최초 1회 + 재시도 1회 = 총 2회 (max_retries=3 미사용)
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_general_retry_status_uses_max_retries(
+        self, rate_limiter: RateLimiter
+    ) -> None:
+        """일반 RETRY status(800)는 max_retries(=3) 전체를 사용한다 (회귀)."""
+        source = DARTSource(
+            api_key="test-dart-api-key-0123456789abcdef01",
+            rate_limiter=rate_limiter,
+            max_retries=3,
+        )
+        error_response = {"status": "800", "message": "시스템 점검 중"}
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            return error_response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError, match="최종 실패"):
+                    await source.fetch_financial(["00126380"], "2024", "11011")
+
+        assert call_count == 3
+
+
+# -- corp_code 다운로드 경로 retry 정책 대칭 (#2026/#2027) ---------------
+
+
+class _FakeJsonErrorResponse:
+    """_download_corp_code_zip의 session.get(...) JSON 에러 응답 모킹."""
+
+    def __init__(self, body: str) -> None:
+        self._body = body
+        self.content_type = "application/json"
+
+    async def __aenter__(self) -> _FakeJsonErrorResponse:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def text(self) -> str:
+        return self._body
+
+
+class TestCorpCodeRetryPolicy:
+    """corp_code ZIP 다운로드 경로에도 #2026/#2027이 동형 적용된다."""
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+    @pytest.mark.asyncio
+    async def test_non_retryable_status_fails_immediately(
+        self, source: DARTSource, status: int
+    ) -> None:
+        """전송 단계 4xx는 재시도 없이 1회 호출 후 즉시 실패한다 (#2026)."""
+        call_count = 0
+
+        def fake_get(url, params=None):
+            nonlocal call_count
+            call_count += 1
+            raise _client_response_error(status)
+
+        with patch("aiohttp.ClientSession.get", side_effect=fake_get):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError):
+                    await source.fetch_corp_codes()
+
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_undefined_status_retries_once_then_skips(
+        self, rate_limiter: RateLimiter
+    ) -> None:
+        """JSON status=900은 max_retries(=3)와 무관하게 2회 호출 후 실패한다 (#2027)."""
+        source = DARTSource(
+            api_key="test-dart-api-key-0123456789abcdef01",
+            rate_limiter=rate_limiter,
+            max_retries=3,
+        )
+        body = json.dumps({"status": "900", "message": "정의되지 않은 오류"})
+        call_count = 0
+
+        def fake_get(url, params=None):
+            nonlocal call_count
+            call_count += 1
+            return _FakeJsonErrorResponse(body)
+
+        with patch("aiohttp.ClientSession.get", side_effect=fake_get):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError, match="최종 실패"):
+                    await source.fetch_corp_codes()
+
+        assert call_count == 2
 
 
 # -- daily_count attempt 기준 카운팅 (#2106) ----------------------------

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from datetime import date
 from unittest.mock import AsyncMock, patch
 
+import aiohttp
 import pytest
+from multidict import CIMultiDict
+from yarl import URL
 
 from ante.data.store import ParquetStore
 from ante.feed.pipeline.data_go_kr_collector import DataGoKrCollector
@@ -124,8 +127,12 @@ class TestClassifyError:
         assert classify_error("31") == ErrorAction.CRITICAL
 
     def test_unknown_error(self) -> None:
-        """99는 RETRY로 분류한다."""
-        assert classify_error("99") == ErrorAction.RETRY
+        """99는 RETRY_ONCE로 분류한다 (1회 재시도 후 스킵, #2027)."""
+        assert classify_error("99") == ErrorAction.RETRY_ONCE
+
+    def test_application_error_retry(self) -> None:
+        """01은 일반 RETRY로 분류한다 (max_retries 유지, 회귀)."""
+        assert classify_error("01") == ErrorAction.RETRY
 
     def test_unmapped_code_defaults_to_retry(self) -> None:
         """매핑되지 않은 코드는 RETRY로 분류한다."""
@@ -817,6 +824,167 @@ class TestFetchByDate:
             await source.fetch_by_date("2024-03-01")
 
         assert captured_params[0]["basDt"] == "20240301"
+
+
+# ── HTTP status 재시도 분류 (#2026) ───────────────────────────
+
+
+def _client_response_error(status: int) -> aiohttp.ClientResponseError:
+    """지정 status를 가진 aiohttp.ClientResponseError를 생성한다."""
+    request_info = aiohttp.RequestInfo(
+        url=URL("https://apis.data.go.kr/test"),
+        method="GET",
+        headers=CIMultiDict(),
+        real_url=URL("https://apis.data.go.kr/test"),
+    )
+    return aiohttp.ClientResponseError(
+        request_info=request_info,
+        history=(),
+        status=status,
+        message=f"HTTP {status}",
+    )
+
+
+class TestHttpStatusRetryPolicy:
+    """#2026: HTTP 4xx 비재시도 / 408·429·5xx·timeout·연결 오류 재시도."""
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+    @pytest.mark.asyncio
+    async def test_non_retryable_status_fails_immediately(
+        self, source: DataGoKrSource, status: int
+    ) -> None:
+        """400/401/403/404/422는 재시도 없이 1회 호출 후 즉시 실패한다."""
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            raise _client_response_error(status)
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DataGoKrError):
+                    await source.fetch_by_date("2024-03-01")
+
+        # 재시도 0 → _do_request 정확히 1회 호출
+        assert call_count == 1
+
+    @pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+    @pytest.mark.asyncio
+    async def test_retryable_status_retries(
+        self, source: DataGoKrSource, status: int
+    ) -> None:
+        """408/429/5xx ClientResponseError는 max_retries까지 재시도한다."""
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            raise _client_response_error(status)
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DataGoKrError, match="최종 실패"):
+                    await source.fetch_by_date("2024-03-01")
+
+        # max_retries(=2)만큼 호출
+        assert call_count == source._max_retries == 2
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_retries(self, source: DataGoKrSource) -> None:
+        """TimeoutError는 재시도 대상이다."""
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            raise TimeoutError("timed out")
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DataGoKrError, match="최종 실패"):
+                    await source.fetch_by_date("2024-03-01")
+
+        assert call_count == source._max_retries == 2
+
+    @pytest.mark.asyncio
+    async def test_connection_error_without_status_retries(
+        self, source: DataGoKrSource
+    ) -> None:
+        """status 없는 ClientConnectionError(연결 오류)는 재시도 대상이다."""
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            raise aiohttp.ClientConnectionError("Connection refused")
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DataGoKrError, match="최종 실패"):
+                    await source.fetch_by_date("2024-03-01")
+
+        assert call_count == source._max_retries == 2
+
+
+# ── UNKNOWN(99) RETRY_ONCE 1회 재시도 cap (#2027) ─────────────
+
+
+class TestRetryOnceCap:
+    """#2027: resultCode=99(UNKNOWN)는 1회만 재시도(총 2회 호출) 후 스킵."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_code_retries_once_then_skips(
+        self, rate_limiter: RateLimiter
+    ) -> None:
+        """99는 max_retries(=3)와 무관하게 2회 호출(1회 재시도) 후 실패한다."""
+        # cap이 max_retries보다 작게 동작함을 보이려고 max_retries=3으로 둔다.
+        source = DataGoKrSource(
+            api_key="test-api-key", rate_limiter=rate_limiter, max_retries=3
+        )
+        error_response = _make_response(
+            [], result_code="99", result_msg="UNKNOWN_ERROR"
+        )
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            return error_response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DataGoKrError, match="최종 실패"):
+                    await source.fetch_by_date("2024-03-01")
+
+        # RETRY_ONCE → 최초 1회 + 재시도 1회 = 총 2회 (max_retries=3 미사용)
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_general_retry_code_uses_max_retries(
+        self, rate_limiter: RateLimiter
+    ) -> None:
+        """일반 RETRY 코드(01)는 max_retries(=3) 전체를 사용한다 (회귀)."""
+        source = DataGoKrSource(
+            api_key="test-api-key", rate_limiter=rate_limiter, max_retries=3
+        )
+        error_response = _make_response(
+            [], result_code="01", result_msg="APPLICATION_ERROR"
+        )
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            return error_response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DataGoKrError, match="최종 실패"):
+                    await source.fetch_by_date("2024-03-01")
+
+        # 일반 RETRY → max_retries(=3)회 호출
+        assert call_count == 3
 
 
 # ── DataGoKrCollector: srtnCd KRX 검증 (#2080) ────────────────


### PR DESCRIPTION
Closes #2026
Closes #2027

## Summary
DataFeed source(data_go_kr.py/dart.py) 재시도 정책 2건:
- **#2026**: retry 루프가 모든 `aiohttp.ClientError`를 재시도해 HTTP 400 등 4xx도 max_retries 반복. `_NON_RETRYABLE_HTTP_STATUS={400,401,403,404,422}` — `ClientResponseError.status`가 이에 속하면 즉시 실패(재시도 0). 408/429/5xx·timeout·연결오류는 재시도(spec 09-failure-recovery)
- **#2027**: `99`(data.go.kr)/`900`(dart)이 일반 RETRY로 max_retries(3) 사용. `ErrorAction.RETRY_ONCE` 추가, 1회 재시도(총 2회) 후 스킵(spec 05-data-sources)
- 양 source 대칭(data_go_kr _fetch_page, dart _fetch_multi_acnt + _download_corp_code_zip). increment_daily(#2106) 위치 유지

## Test Plan
- data_go_kr/dart/sources/retry/feed 636 passed, contracts 145 / mypy Success / ruff clean
- 신규: 4xx(400/401/403/404/422)→1회, 408/429/5xx·timeout·connection→재시도, 99/900→2회 후 스킵, 일반 RETRY→max_retries 회귀

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS