### PR TITLE
fix(feed): #2051 config set 값 개행 거부(키 주입 차단) + #2050 inject 출력 실제 store 경로

### DIFF
--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -116,7 +116,13 @@ def config_set(ctx: click.Context, key: str, value: str, data_path: str | None) 
         raise SystemExit(1)
 
     cfg = FeedConfig(data_path)
-    env_path = cfg.set_api_key(key, value)
+    try:
+        env_path = cfg.set_api_key(key, value)
+    except ValueError as e:
+        # #2051: 개행 등 .env quoting 미지원으로 거부된 value는 구조화
+        # 에러로 표면화한다(파일 미변경). set_api_key가 쓰기 전 검증한다.
+        fmt.error(str(e), code="CONFIG_INVALID_VALUE")
+        raise SystemExit(1) from e
 
     fmt.success(
         f"Saved {key} to {env_path}",
@@ -697,10 +703,20 @@ def feed_inject(
             }
         )
     else:
+        # #2050: 하드코딩된 경로(`ohlcv/krx/{tf}/{symbol}/`)는 실제
+        # ParquetStore 레이아웃(`ohlcv/{tf}/{exchange}/{symbol}/`)과 순서·
+        # 대소문자가 어긋났다. injector가 store.write를 default exchange="KRX"
+        # 로 호출하므로 동일 인자로 store.resolve_path를 호출해 실제 저장
+        # 경로를 그대로 출력한다(drift 방지). base 상대경로로 표시한다.
+        written = store.resolve_path(symbol, timeframe, exchange="KRX")
+        try:
+            written_display = written.relative_to(_Path(data_path))
+        except ValueError:
+            written_display = written
         click.echo()
         click.echo(f"Loaded {count} rows from {filepath.name}")
         click.echo(f"Normalized: source={source}, schema=OHLCV")
         click.echo(f"Validated: {count} rows passed")
-        click.echo(f"Written to ohlcv/krx/{timeframe}/{symbol}/")
+        click.echo(f"Written to {written_display}/")
         click.echo()
         click.echo(f"Injected {count} rows for {symbol} ({timeframe})")

--- a/src/ante/feed/config.py
+++ b/src/ante/feed/config.py
@@ -118,7 +118,18 @@ class FeedConfig:
         return result
 
     def set_api_key(self, key: str, value: str) -> Path:
-        """API 키를 .env 파일에 저장한다. 파일 퍼미션을 0600으로 설정한다."""
+        """API 키를 .env 파일에 저장한다. 파일 퍼미션을 0600으로 설정한다.
+
+        Raises:
+            ValueError: value에 개행 문자(`\\n` 또는 `\\r`)가 포함된 경우.
+                _load_env_file은 quoting/escaping을 지원하지 않으므로
+                개행이 포함된 value는 후속 라인을 별도 `KEY=VALUE`로
+                재해석하게 만들어 다른 API 키를 주입할 수 있다(#2051).
+                escaping 대신 reject하며, 파일은 변경하지 않는다.
+        """
+        if "\n" in value or "\r" in value:
+            raise ValueError("API 키 값에 개행 문자를 포함할 수 없습니다")
+
         self._feed_dir.mkdir(parents=True, exist_ok=True)
 
         env_values = self._load_env_file()

--- a/tests/unit/feed/test_cli_config_set.py
+++ b/tests/unit/feed/test_cli_config_set.py
@@ -136,3 +136,60 @@ class TestFeedConfigSetSupportedKey:
         assert env_path.exists()
         assert "ANTE_DART_API_KEY=dart_value_123" in env_path.read_text()
         assert "Saved ANTE_DART_API_KEY" in result.stdout
+
+
+class TestFeedConfigSetNewlineRejection:
+    """#2051: 개행 포함 value는 키 주입 위험으로 구조화 에러로 거부한다."""
+
+    def test_json_format_rejects_newline_value(
+        self, runner: CliRunner, data_path: str
+    ) -> None:
+        """--format json: 개행 value → exit 1 + 구조화 envelope, 키 미주입."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "feed",
+                "config",
+                "set",
+                "ANTE_DATAGOKR_API_KEY",
+                "a\nANTE_DART_API_KEY=evil",
+                "--data-path",
+                data_path,
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 1, (
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        payload = json.loads(result.stdout.strip())
+        assert payload["status"] == "error"
+        assert payload["code"] == "CONFIG_INVALID_VALUE"
+        assert "개행" in payload["message"]
+        # 거부 시 .env가 생성되지 않아 DART 키가 주입되지 않는다.
+        assert not (Path(data_path) / ".feed" / ".env").exists()
+
+    def test_text_format_rejects_newline_value(
+        self, runner: CliRunner, data_path: str
+    ) -> None:
+        """--format text: 개행 value → stderr Error 라인, exit 1, 키 미주입."""
+        result = runner.invoke(
+            cli,
+            [
+                "feed",
+                "config",
+                "set",
+                "ANTE_DATAGOKR_API_KEY",
+                "a\nANTE_DART_API_KEY=evil",
+                "--data-path",
+                data_path,
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 1, (
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "개행" in result.stderr
+        assert result.stdout.strip() == ""
+        assert not (Path(data_path) / ".feed" / ".env").exists()

--- a/tests/unit/feed/test_config.py
+++ b/tests/unit/feed/test_config.py
@@ -96,6 +96,46 @@ class TestSetApiKey:
         assert "ANTE_DART_API_KEY=key2" in content
 
 
+class TestSetApiKeyNewlineRejection:
+    """#2051: 개행 포함 value는 .env 키 주입 위험으로 거부한다."""
+
+    def test_newline_value_raises_value_error(self, cfg: FeedConfig) -> None:
+        # 개행 뒤에 KEY=VALUE를 끼워 다른 키 주입을 시도하는 페이로드.
+        with pytest.raises(ValueError, match="개행"):
+            cfg.set_api_key("ANTE_DATAGOKR_API_KEY", "a\nANTE_DART_API_KEY=evil")
+
+    def test_newline_value_does_not_inject_other_key(self, cfg: FeedConfig) -> None:
+        # 거부 시 .env 자체가 생성되지 않아야 한다(쓰기 전 검증, 파일 미변경).
+        with pytest.raises(ValueError):
+            cfg.set_api_key("ANTE_DATAGOKR_API_KEY", "a\nANTE_DART_API_KEY=evil")
+        assert not cfg.env_path.exists()
+        keys = cfg.load_api_keys()
+        assert keys["ANTE_DART_API_KEY"] is None
+
+    def test_newline_value_preserves_existing_env(self, cfg: FeedConfig) -> None:
+        # 기존 .env가 있을 때 거부되면 기존 내용이 그대로 유지된다.
+        cfg.set_api_key("ANTE_DATAGOKR_API_KEY", "realkey")
+        before = cfg.env_path.read_text()
+        with pytest.raises(ValueError):
+            cfg.set_api_key("ANTE_DART_API_KEY", "x\nANTE_DATAGOKR_API_KEY=evil")
+        assert cfg.env_path.read_text() == before
+        keys = cfg.load_api_keys()
+        assert keys["ANTE_DATAGOKR_API_KEY"] == "realkey"
+        assert keys["ANTE_DART_API_KEY"] is None
+
+    def test_carriage_return_value_rejected(self, cfg: FeedConfig) -> None:
+        with pytest.raises(ValueError, match="개행"):
+            cfg.set_api_key("ANTE_DATAGOKR_API_KEY", "a\rANTE_DART_API_KEY=evil")
+        assert not cfg.env_path.exists()
+
+    def test_normal_value_still_saved(self, cfg: FeedConfig) -> None:
+        # 개행 없는 정상 value는 기존대로 저장된다.
+        result = cfg.set_api_key("ANTE_DATAGOKR_API_KEY", "realkey")
+        assert result == cfg.env_path
+        keys = cfg.load_api_keys()
+        assert keys["ANTE_DATAGOKR_API_KEY"] == "realkey"
+
+
 # ── list_api_keys ─────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_cli_feed_inject_symbol_timeframe_validation.py
+++ b/tests/unit/test_cli_feed_inject_symbol_timeframe_validation.py
@@ -302,6 +302,65 @@ class TestFeedInjectValidationPrecedence:
         _assert_no_parquet_artifact(data_path)
 
 
+class TestFeedInjectWrittenPath:
+    """#2050: text 출력 'Written to' 경로가 실제 ParquetStore 레이아웃과 정합.
+
+    하드코딩 `ohlcv/krx/{tf}/{symbol}/`가 아니라
+    `store.resolve_path(symbol, tf, exchange="KRX")`(= `ohlcv/{tf}/KRX/{symbol}/`)
+    를 출력한다(drift 방지).
+    """
+
+    def test_written_path_matches_store_resolve_path(self, tmp_path):
+        """text 모드 'Written to' 경로 == store.resolve_path base 상대경로."""
+        from ante.data.store import ParquetStore
+
+        runner = _make_runner()
+        csv = _write_csv(tmp_path)
+        data_path = tmp_path / "data"
+
+        with patch("ante.feed.injector.FeedInjector") as mock_injector:
+            mock_injector.return_value.inject_csv.return_value = 3
+            result = runner.invoke(
+                cli,
+                _inject_args(csv, data_path, "--symbol", "005930", "--timeframe", "1d"),
+            )
+
+        assert result.exit_code == 0, result.output
+        expected = ParquetStore(base_path=data_path).resolve_path(
+            "005930", "1d", exchange="KRX"
+        )
+        expected_rel = expected.relative_to(data_path)
+        assert f"Written to {expected_rel}/" in result.output
+        # 실제 레이아웃 정합: ohlcv/{tf}/{exchange}/{symbol}/
+        assert "Written to ohlcv/1d/KRX/005930/" in result.output
+        # 기존 하드코딩 잘못된 경로(ohlcv/krx/{tf}/{symbol}/)는 더 이상 출력 안 됨.
+        assert "ohlcv/krx/1d/005930/" not in result.output
+
+    def test_written_path_not_emitted_in_json_mode(self, tmp_path):
+        """JSON 모드는 'Written to' 텍스트 라인을 출력하지 않는다(회귀 락)."""
+        runner = _make_runner()
+        csv = _write_csv(tmp_path)
+        data_path = tmp_path / "data"
+
+        with patch("ante.feed.injector.FeedInjector") as mock_injector:
+            mock_injector.return_value.inject_csv.return_value = 3
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    *_inject_args(
+                        csv, data_path, "--symbol", "005930", "--timeframe", "1d"
+                    ),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["rows"] == 3
+        assert "Written to" not in result.stdout
+
+
 class TestFeedInjectAuthDecorators:
     """@require_auth / @require_scope("data:write") 데코레이터 정상 동작."""
 


### PR DESCRIPTION
Closes #2051
Closes #2050

## Summary
- **#2051(P2 security)**: `config.set_api_key`가 raw value를 .env에 기록 → value 개행이 추가 `KEY=VALUE` 라인으로 파싱돼 다른 API 키 주입. value에 `\n`/`\r` 포함 시 파일 쓰기 전 ValueError 거부(.env 미변경). CLI config_set이 `CONFIG_INVALID_VALUE` 구조화 에러+exit1로 변환
- **#2050(P3)**: feed inject text 출력이 하드코딩 `ohlcv/krx/{timeframe}/{symbol}/`(실제와 불일치). `store.resolve_path(symbol, timeframe, exchange="KRX")` 실제 경로(`ohlcv/{timeframe}/{exchange}/{symbol}/`)로 출력. JSON 모드 불변

## Test Plan
- config/feed/inject/cli 1059 passed / mypy Success / ruff clean
- 신규: 개행/CR value 거부+.env 미주입+정상 저장+CLI 구조화 에러, inject 출력==resolve_path

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS