### PR TITLE
fix(strategy): #2017 StrategyValidator symbols/exchange 일관성 경고

### DIFF
--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ante.core.exchange import STRATEGY_EXCHANGES
+from ante.core.market_data_vocab import is_krx_symbol
 
 # 코드 레벨 SSOT(`ante.core.exchange.STRATEGY_EXCHANGES` = canonical 5종 ∪
 # {`*`})에 위임한다. 이름·타입(`set[str]`)·값·검증 결과·에러 메시지는
@@ -182,6 +183,24 @@ class StrategyValidator:
                     f"Invalid exchange value: '{exchange_value}'. "
                     f"Valid values: {sorted(VALID_EXCHANGES)}"
                 )
+
+            # 9. symbols ↔ exchange 일관성 경고 (#2017, spec 03-09 항목9).
+            # exchange == "KRX" 이고 symbols 가 정적 해석 가능한 literal list 인
+            # 경우에만, KRX 종목코드 형식(6자리 숫자)과 맞지 않는 심볼을 경고한다.
+            # warn-only — valid 는 그대로 유지(에러 아님). 비-KRX/wildcard/None
+            # exchange, 또는 symbols 가 비-literal/미지정/빈 list 면 skip
+            # (형식 정의 없음). 비-KRX 거래소 심볼 형식 검사는 1.0 비목표.
+            if exchange_value == "KRX":
+                symbols = self._extract_meta_symbols(
+                    strategy_classes[0].node, module_consts
+                )
+                if symbols is not None:
+                    for symbol in symbols:
+                        if not is_krx_symbol(symbol):
+                            warnings.append(
+                                f"Symbol '{symbol}' does not match KRX symbol "
+                                f"format (exchange=KRX)"
+                            )
 
         # 5. 금지 모듈 import
         forbidden = self._find_forbidden_imports(tree)
@@ -598,6 +617,46 @@ class StrategyValidator:
                             and kw.value.id in module_consts
                         ):
                             return module_consts[kw.value.id]
+        return None
+
+    def _extract_meta_symbols(
+        self, cls: ast.ClassDef, module_consts: dict[str, str]
+    ) -> list[str] | None:
+        """meta에서 symbols 값을 정적 해석해 추출 (#2017, _extract_meta_exchange 동형).
+
+        ``meta = StrategyMeta(..., symbols=[...])`` 의 ``symbols`` kwarg 를 찾아,
+        값이 ``ast.List`` 이고 모든 원소가 str ``ast.Constant`` 이면 ``list[str]``
+        로 반환한다. 빈 list ``[]`` 는 빈 list 로 반환한다(경고 없음).
+
+        다음은 정적 해석 불가로 보고 ``None`` 을 반환해 일관성 경고를 skip 한다:
+        symbols 미지정, 비-List(Name/계산식/Tuple/Set 등), List 이지만 비-str
+        Constant 원소나 비-Constant 원소(Name/계산식 등)를 포함하는 경우.
+        ``_module_string_constants`` 는 문자열 스칼라 상수만 담으므로 list 상수
+        이름(Name)은 정적 해석하지 않는다(literal list only, known-limitation).
+        """
+        for node in cls.body:
+            if isinstance(node, ast.Assign | ast.AnnAssign):
+                target = (
+                    node.targets[0] if isinstance(node, ast.Assign) else node.target
+                )
+                if not isinstance(target, ast.Name) or target.id != "meta":
+                    continue
+                value = node.value
+                if isinstance(value, ast.Call):
+                    for kw in value.keywords:
+                        if kw.arg != "symbols":
+                            continue
+                        if not isinstance(kw.value, ast.List):
+                            return None
+                        symbols: list[str] = []
+                        for elt in kw.value.elts:
+                            if isinstance(elt, ast.Constant) and isinstance(
+                                elt.value, str
+                            ):
+                                symbols.append(elt.value)
+                            else:
+                                return None
+                        return symbols
         return None
 
     def _has_accepts_external_signals(self, cls: ast.ClassDef) -> bool:

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -1559,6 +1559,198 @@ class TestStrategy(Strategy):
         assert not any("Invalid exchange" in e for e in result.errors)
 
 
+# ── #2017 validator: symbols ↔ exchange 일관성 경고 ──────────────────
+
+
+class TestValidatorSymbolsExchangeConsistency:
+    """#2017 — symbols 명시 시 형식이 exchange(KRX)와 맞는지 경고(warn-only).
+
+    spec 03-09 항목9. KRX 전략에 KRX 종목코드 형식(6자리 숫자)이 아닌 심볼은
+    경고하되 valid 는 유지(에러 아님). 비-KRX/wildcard/None exchange, 또는
+    symbols 가 비-literal/미지정/빈 list 면 skip.
+    """
+
+    @pytest.fixture
+    def validator(self):
+        return StrategyValidator()
+
+    def _write_strategy(self, tmp_path: Path, code: str) -> Path:
+        filepath = tmp_path / "test_strategy.py"
+        filepath.write_text(code)
+        return filepath
+
+    def test_krx_with_us_symbol_warns_but_valid(self, validator, tmp_path):
+        """exchange='KRX' + symbols=['AAPL'] → valid=True + 형식 불일치 경고(repro)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="KRX", symbols=["AAPL"],
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert any("AAPL" in w and "KRX symbol format" in w for w in result.warnings)
+
+    def test_krx_with_krx_symbol_no_warning(self, validator, tmp_path):
+        """exchange='KRX' + symbols=['005930'] → 경고 없음."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="KRX", symbols=["005930"],
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("KRX symbol format" in w for w in result.warnings)
+
+    def test_krx_mixed_symbols_only_bad_warns(self, validator, tmp_path):
+        """exchange='KRX' + symbols=['005930','AAPL'] → 'AAPL'만 경고."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="KRX", symbols=["005930", "AAPL"],
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        krx_warnings = [w for w in result.warnings if "KRX symbol format" in w]
+        assert len(krx_warnings) == 1
+        assert "AAPL" in krx_warnings[0]
+        assert not any("005930" in w for w in krx_warnings)
+
+    def test_wildcard_exchange_no_warning(self, validator, tmp_path):
+        """exchange='*'(wildcard) + symbols=['AAPL'] → 경고 없음(skip; 형식 미정의)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="*", symbols=["AAPL"],
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("KRX symbol format" in w for w in result.warnings)
+
+    def test_non_krx_exchange_no_warning(self, validator, tmp_path):
+        """exchange='NASDAQ'(비-KRX) + symbols=['AAPL'] → 경고 없음(형식 미정의)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="NASDAQ", symbols=["AAPL"],
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("KRX symbol format" in w for w in result.warnings)
+
+    def test_symbols_unspecified_no_warning(self, validator, tmp_path):
+        """symbols 미지정 → 경고 없음."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="KRX",
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("KRX symbol format" in w for w in result.warnings)
+
+    def test_symbols_non_literal_no_warning(self, validator, tmp_path):
+        """symbols 비-literal(모듈변수/계산식) → 경고 없음(정적 해석 skip)."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+SYMS = ["AAPL"]
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="KRX", symbols=SYMS,
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("KRX symbol format" in w for w in result.warnings)
+
+    def test_symbols_list_with_non_constant_element_no_warning(
+        self, validator, tmp_path
+    ):
+        """symbols list 안에 비-Constant 원소(Name) 포함 → 정적 해석 불가 skip."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+SYM = "AAPL"
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="KRX", symbols=["005930", SYM],
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("KRX symbol format" in w for w in result.warnings)
+
+    def test_symbols_empty_list_no_warning(self, validator, tmp_path):
+        """symbols=[] → 경고 없음."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="KRX", symbols=[],
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert not any("KRX symbol format" in w for w in result.warnings)
+
+
 # ── #2040 validator: async hook 계약 ──────────────────────────────────
 
 


### PR DESCRIPTION
Closes #2017

## Summary
- StrategyValidator가 spec 항목9(symbols-exchange 일관성 경고)를 미구현 → exchange="KRX" + symbols=["AAPL"]도 경고 없이 valid
- `_extract_meta_symbols`(literal list[str] 추출, _extract_meta_exchange 동형) 추가. exchange가 KRX이고 symbols가 literal이면 비-KRX-형식 symbol에 **경고**(is_krx_symbol), valid 유지
- 비-KRX/wildcard/비-literal/empty/미지정 → skip(known-limitation: 비-KRX 거래소 형식 미정의)

## Test Plan
- validator/strategy 529 passed, contracts 145 / mypy Success / ruff clean
- 신규 9: KRX bad/good/혼합 warn, wildcard/NASDAQ/non-literal/empty/미지정 skip

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS