### PR TITLE
fix(feed): #2037 guard 타입 검증 + #2038 log_level 적용 — feed 커맨드 공통 config helper

### DIFF
--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -56,6 +56,115 @@ _SCOPE_DATA_WRITE = "data:write"
 _SCOPE_DATA_READ = "data:read"
 _SEPARATOR = "──────────────────────────────────────────────────"
 
+# `[general].log_level` 에 허용되는 logging 레벨명 (대문자). 스펙
+# (docs/specs/data-feed/02-design-decisions.md) 의 DEBUG/INFO/WARNING/ERROR 에
+# CRITICAL 을 더한 표준 logging 레벨 집합이다.
+_VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+# DataFeed 패키지 로거. log_level 은 root 가 아닌 이 로거에만 적용한다.
+_FEED_LOGGER_NAME = "ante.feed"
+
+
+def _apply_log_level(config: dict[str, object], fmt: object) -> None:
+    """``[general].log_level`` 을 ``ante.feed`` 패키지 로거에 적용한다 (#2038).
+
+    유효한 레벨명(DEBUG/INFO/WARNING/ERROR/CRITICAL)이 아니면 INFO fallback
+    없이 구조화 에러(``CONFIG_INVALID_LOG_LEVEL``)로 거부하고 ``SystemExit(1)``
+    로 종료한다(fail-loud). root 로거·logging 포맷/핸들러는 변경하지 않으며,
+    ``ante.feed`` 패키지 로거의 레벨만 설정한다.
+    """
+    general = config.get("general", {})
+    if not isinstance(general, dict):
+        fmt.error(  # type: ignore[attr-defined]
+            f"[general] 섹션은 table 이어야 합니다 (현재: {type(general).__name__})",
+            code="CONFIG_INVALID_GENERAL",
+        )
+        raise SystemExit(1)
+
+    level_name = general.get("log_level", "INFO")
+    if not isinstance(level_name, str) or level_name.upper() not in _VALID_LOG_LEVELS:
+        allowed = ", ".join(sorted(_VALID_LOG_LEVELS))
+        fmt.error(  # type: ignore[attr-defined]
+            f"유효하지 않은 log_level: {level_name!r} (허용: {allowed})",
+            code="CONFIG_INVALID_LOG_LEVEL",
+        )
+        raise SystemExit(1)
+
+    logging.getLogger(_FEED_LOGGER_NAME).setLevel(getattr(logging, level_name.upper()))
+
+
+def _validate_guard_config(config: dict[str, object], fmt: object) -> None:
+    """``[guard]`` 섹션의 타입/형식을 진입 시 1회 fail-fast 검증한다 (#2037).
+
+    - ``guard`` 는 table(dict) 이어야 한다.
+    - ``blocked_days`` 가 있으면 ``list`` 이고 각 원소는 ``str`` 이어야 한다.
+    - ``blocked_hours`` 가 있으면 ``list`` 이어야 한다. 각 window 의 형식
+      (``HH:MM-HH:MM``) 검증은 #2030 ``cli_scheduler._validate_schedule_times``
+      가 단일 책임으로 수행하므로(중복 분기 금지) 여기서는 list 여부만 본다.
+    - ``pause_during_trading`` 이 있으면 ``bool`` 이어야 한다.
+
+    무효 타입이면 구조화 에러(``CONFIG_INVALID_GUARD``)로 거부하고
+    ``SystemExit(1)`` 로 종료한다. 요일명 화이트리스트·blocked_hours 형식
+    검증은 본 함수의 범위가 아니다(비목표).
+    """
+    guard = config.get("guard", {})
+    if not isinstance(guard, dict):
+        fmt.error(  # type: ignore[attr-defined]
+            f"[guard] 섹션은 table 이어야 합니다 (현재: {type(guard).__name__})",
+            code="CONFIG_INVALID_GUARD",
+        )
+        raise SystemExit(1)
+
+    errors: list[str] = []
+
+    if "blocked_days" in guard:
+        blocked_days = guard["blocked_days"]
+        if not isinstance(blocked_days, list):
+            errors.append(
+                f"blocked_days 는 list 여야 합니다 "
+                f"(현재: {type(blocked_days).__name__})"
+            )
+        else:
+            non_str = [d for d in blocked_days if not isinstance(d, str)]
+            if non_str:
+                errors.append(
+                    f"blocked_days 의 모든 원소는 요일 문자열이어야 합니다 "
+                    f"(비-문자열 원소: {non_str!r})"
+                )
+
+    if "blocked_hours" in guard and not isinstance(guard["blocked_hours"], list):
+        errors.append(
+            f"blocked_hours 는 list 여야 합니다 "
+            f"(현재: {type(guard['blocked_hours']).__name__})"
+        )
+
+    if "pause_during_trading" in guard and not isinstance(
+        guard["pause_during_trading"], bool
+    ):
+        errors.append(
+            f"pause_during_trading 는 bool 이어야 합니다 "
+            f"(현재: {type(guard['pause_during_trading']).__name__})"
+        )
+
+    if errors:
+        fmt.error(  # type: ignore[attr-defined]
+            "잘못된 [guard] 설정: " + "; ".join(errors),
+            code="CONFIG_INVALID_GUARD",
+        )
+        raise SystemExit(1)
+
+
+def _validate_and_apply_feed_config(config: dict[str, object], fmt: object) -> None:
+    """feed 커맨드 공통 진입 검증/적용 (#2037 + #2038).
+
+    ``feed run backfill`` / ``feed run daily`` / ``feed start`` 가 config 로드
+    직후 호출하는 단일 chokepoint 다. ``[general].log_level`` 을 ``ante.feed``
+    로거에 적용(#2038)하고 ``[guard]`` 타입을 검증(#2037)한다. 무효 입력은
+    구조화 에러 + ``SystemExit(1)`` 로 fail-loud 처리한다.
+    """
+    _apply_log_level(config, fmt)
+    _validate_guard_config(config, fmt)
+
+
 _API_KEY_GUIDE = """\
 ──────────────────────────────────────────────────
 API 키 설정이 필요합니다.
@@ -289,6 +398,7 @@ def run_backfill(
             raise SystemExit(1)
 
     config = cfg.load_config()
+    _validate_and_apply_feed_config(config, fmt)
 
     # CLI 옵션으로 schedule 오버라이드
     if since is not None:
@@ -351,6 +461,7 @@ def run_daily(
         _validate_iso_date(target_date, "--date", fmt)
 
     config = cfg.load_config()
+    _validate_and_apply_feed_config(config, fmt)
 
     orchestrator = _build_orchestrator(cfg)
 
@@ -393,6 +504,7 @@ def feed_start(ctx: click.Context, data_path: str | None) -> None:
         raise SystemExit(1)
 
     config = cfg.load_config()
+    _validate_and_apply_feed_config(config, fmt)
     schedule = config.get("schedule", {})
     daily_at = (
         schedule.get("daily_at", "16:00") if isinstance(schedule, dict) else "16:00"

--- a/tests/unit/feed/test_cli_feed_config_validation.py
+++ b/tests/unit/feed/test_cli_feed_config_validation.py
@@ -1,0 +1,358 @@
+"""feed 커맨드 공통 config helper 테스트 (#2037 guard 타입 검증 + #2038 log_level).
+
+feed run backfill / feed run daily / feed start 진입에서 호출하는
+``_validate_and_apply_feed_config`` 의 동작을 검증한다.
+
+- #2038: ``[general].log_level`` 을 ``ante.feed`` 패키지 로거에 적용. 유효
+  레벨명이 아니면 INFO fallback 없이 구조화 에러(``CONFIG_INVALID_LOG_LEVEL``)
+  + exit 1 (text/JSON 모두).
+- #2037: ``[guard]`` 타입 검증 — blocked_days(list[str]) / blocked_hours(list) /
+  pause_during_trading(bool). 무효 타입은 ``CONFIG_INVALID_GUARD`` + exit 1.
+  blocked_hours 의 window 형식(HH:MM-HH:MM)은 #2030 ``_validate_schedule_times``
+  가 담당하므로 본 helper 는 list 여부만 본다(중복 검증 회피).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.feed.models.result import CollectionResult
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+_EMPTY_BACKFILL = CollectionResult(
+    mode="backfill",
+    started_at="2026-03-18T00:00:00Z",
+    finished_at="2026-03-18T00:00:01Z",
+    duration_seconds=1.0,
+)
+
+_EMPTY_DAILY = CollectionResult(
+    mode="daily",
+    started_at="2026-03-18T00:00:00Z",
+    finished_at="2026-03-18T00:00:01Z",
+    duration_seconds=1.0,
+    target_date="2026-03-17",
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx: object) -> None:
+                import click
+
+                ctx = click.get_current_context()
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+def _init_with_config(tmp_path: Path, body: str) -> str:
+    """주어진 config.toml 본문으로 초기화된 데이터 경로를 만든다."""
+    data_dir = tmp_path / "data"
+    feed_dir = data_dir / ".feed"
+    feed_dir.mkdir(parents=True)
+    (feed_dir / "config.toml").write_text(body)
+    (feed_dir / "checkpoints").mkdir()
+    (feed_dir / "reports").mkdir()
+    return str(data_dir)
+
+
+_GENERAL = '[general]\nlog_level = "{log_level}"\n\n'
+_SCHEDULE = (
+    "[schedule]\n"
+    'daily_at = "16:00"\n'
+    'backfill_at = "01:00"\n'
+    'backfill_since = "2024-01-01"\n\n'
+)
+
+
+def _config(
+    *,
+    log_level: str = "INFO",
+    guard_body: str = (
+        "[guard]\n"
+        "blocked_days = []\n"
+        'blocked_hours = ["09:00-15:30"]\n'
+        "pause_during_trading = true\n"
+    ),
+) -> str:
+    return _GENERAL.format(log_level=log_level) + _SCHEDULE + guard_body
+
+
+def _run_backfill(runner: CliRunner, data_path: str, *, json_fmt: bool = False):  # type: ignore[no-untyped-def]
+    """mock orchestrator 로 feed run backfill 실행."""
+    args = ["feed", "run", "backfill", "--data-path", data_path]
+    if json_fmt:
+        args = ["--format", "json", *args]
+    with patch("ante.feed.cli._build_orchestrator") as mock_build:
+        mock_orch = AsyncMock()
+        mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_BACKFILL)
+        mock_build.return_value = mock_orch
+        return runner.invoke(cli, args)
+
+
+def _run_daily(runner: CliRunner, data_path: str, *, json_fmt: bool = False):  # type: ignore[no-untyped-def]
+    """mock orchestrator 로 feed run daily 실행."""
+    args = ["feed", "run", "daily", "--data-path", data_path]
+    if json_fmt:
+        args = ["--format", "json", *args]
+    with patch("ante.feed.cli._build_orchestrator") as mock_build:
+        mock_orch = AsyncMock()
+        mock_orch.run_daily = AsyncMock(return_value=_EMPTY_DAILY)
+        mock_build.return_value = mock_orch
+        return runner.invoke(cli, args)
+
+
+# ── #2038: log_level 적용 ───────────────────────────────────────────────────
+
+
+class TestLogLevelApply:
+    def test_debug_applied_to_feed_logger(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """log_level=DEBUG → ante.feed 로거 레벨이 DEBUG 로 설정된다."""
+        feed_logger = logging.getLogger("ante.feed")
+        original = feed_logger.level
+        try:
+            feed_logger.setLevel(logging.WARNING)
+            data_path = _init_with_config(tmp_path, _config(log_level="DEBUG"))
+            result = _run_backfill(runner, data_path)
+            assert result.exit_code == 0
+            assert feed_logger.level == logging.DEBUG
+        finally:
+            feed_logger.setLevel(original)
+
+    def test_default_info_passes(self, runner: CliRunner, tmp_path: Path) -> None:
+        """기본 INFO 는 정상 통과(회귀)."""
+        data_path = _init_with_config(tmp_path, _config(log_level="INFO"))
+        result = _run_backfill(runner, data_path)
+        assert result.exit_code == 0
+
+    def test_root_logger_not_changed(self, runner: CliRunner, tmp_path: Path) -> None:
+        """root 로거는 변경하지 않는다 (ante.feed 패키지 로거만)."""
+        root_logger = logging.getLogger()
+        original_root = root_logger.level
+        feed_logger = logging.getLogger("ante.feed")
+        original_feed = feed_logger.level
+        try:
+            data_path = _init_with_config(tmp_path, _config(log_level="ERROR"))
+            result = _run_backfill(runner, data_path)
+            assert result.exit_code == 0
+            assert root_logger.level == original_root
+            assert feed_logger.level == logging.ERROR
+        finally:
+            feed_logger.setLevel(original_feed)
+
+    def test_invalid_log_level_rejected_text(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """무효 log_level(VERBOSE) → 거부 + exit 1 (INFO fallback 아님)."""
+        data_path = _init_with_config(tmp_path, _config(log_level="VERBOSE"))
+        result = _run_backfill(runner, data_path)
+        assert result.exit_code != 0
+        assert "log_level" in result.output
+
+    def test_invalid_log_level_rejected_json(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """JSON 모드에서 구조화 에러 코드를 노출한다."""
+        import json
+
+        data_path = _init_with_config(tmp_path, _config(log_level="VERBOSE"))
+        result = _run_backfill(runner, data_path, json_fmt=True)
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert data["code"] == "CONFIG_INVALID_LOG_LEVEL"
+
+    def test_invalid_log_level_rejected_on_daily(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """daily 경로도 동일 helper 로 무효 log_level 을 거부한다."""
+        data_path = _init_with_config(tmp_path, _config(log_level="VERBOSE"))
+        result = _run_daily(runner, data_path)
+        assert result.exit_code != 0
+        assert "log_level" in result.output
+
+
+# ── #2037: guard 타입 검증 ──────────────────────────────────────────────────
+
+
+class TestGuardTypeValidation:
+    def test_valid_guard_passes(self, runner: CliRunner, tmp_path: Path) -> None:
+        """정상 guard(blocked_days=[], blocked_hours=[...], pause=true) → 통과."""
+        data_path = _init_with_config(tmp_path, _config())
+        result = _run_backfill(runner, data_path)
+        assert result.exit_code == 0
+
+    def test_blocked_days_string_rejected(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """blocked_days='sat' (str, 비-list) → 거부."""
+        data_path = _init_with_config(
+            tmp_path,
+            _config(
+                guard_body=(
+                    "[guard]\n"
+                    'blocked_days = "sat"\n'
+                    'blocked_hours = ["09:00-15:30"]\n'
+                    "pause_during_trading = true\n"
+                )
+            ),
+        )
+        result = _run_backfill(runner, data_path)
+        assert result.exit_code != 0
+        assert "blocked_days" in result.output
+
+    def test_blocked_days_nonstring_element_rejected(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """blocked_days=[123] (비-str 원소) → 거부."""
+        data_path = _init_with_config(
+            tmp_path,
+            _config(
+                guard_body=(
+                    "[guard]\n"
+                    "blocked_days = [123]\n"
+                    'blocked_hours = ["09:00-15:30"]\n'
+                    "pause_during_trading = true\n"
+                )
+            ),
+        )
+        result = _run_backfill(runner, data_path)
+        assert result.exit_code != 0
+        assert "blocked_days" in result.output
+
+    def test_pause_during_trading_nonbool_rejected(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """pause_during_trading='yes' (비-bool) → 거부."""
+        data_path = _init_with_config(
+            tmp_path,
+            _config(
+                guard_body=(
+                    "[guard]\n"
+                    "blocked_days = []\n"
+                    'blocked_hours = ["09:00-15:30"]\n'
+                    'pause_during_trading = "yes"\n'
+                )
+            ),
+        )
+        result = _run_backfill(runner, data_path)
+        assert result.exit_code != 0
+        assert "pause_during_trading" in result.output
+
+    def test_blocked_hours_string_rejected(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """blocked_hours='09:00-15:30' (str, 비-list) → 거부."""
+        data_path = _init_with_config(
+            tmp_path,
+            _config(
+                guard_body=(
+                    "[guard]\n"
+                    "blocked_days = []\n"
+                    'blocked_hours = "09:00-15:30"\n'
+                    "pause_during_trading = true\n"
+                )
+            ),
+        )
+        result = _run_backfill(runner, data_path)
+        assert result.exit_code != 0
+        assert "blocked_hours" in result.output
+
+    def test_guard_error_json_code(self, runner: CliRunner, tmp_path: Path) -> None:
+        """JSON 모드에서 CONFIG_INVALID_GUARD 코드를 노출한다."""
+        import json
+
+        data_path = _init_with_config(
+            tmp_path,
+            _config(
+                guard_body=(
+                    '[guard]\nblocked_days = "sat"\npause_during_trading = true\n'
+                )
+            ),
+        )
+        result = _run_backfill(runner, data_path, json_fmt=True)
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert data["code"] == "CONFIG_INVALID_GUARD"
+
+    def test_guard_validation_on_daily(self, runner: CliRunner, tmp_path: Path) -> None:
+        """daily 경로도 동일 helper 로 guard 타입을 검증한다."""
+        data_path = _init_with_config(
+            tmp_path,
+            _config(guard_body=('[guard]\npause_during_trading = "yes"\n')),
+        )
+        result = _run_daily(runner, data_path)
+        assert result.exit_code != 0
+        assert "pause_during_trading" in result.output
+
+
+# ── feed start 경로도 helper 를 호출한다 ────────────────────────────────────
+
+
+class TestFeedStartCallsHelper:
+    def test_start_rejects_invalid_log_level(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """feed start 도 진입 시 무효 log_level 을 거부한다."""
+        data_path = _init_with_config(tmp_path, _config(log_level="VERBOSE"))
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_build.return_value = AsyncMock()
+            result = runner.invoke(
+                cli,
+                ["feed", "start", "--data-path", data_path],
+            )
+        assert result.exit_code != 0
+        assert "log_level" in result.output
+
+    def test_start_rejects_invalid_guard(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """feed start 도 진입 시 guard 타입을 검증한다."""
+        data_path = _init_with_config(
+            tmp_path,
+            _config(
+                guard_body=(
+                    "[guard]\nblocked_days = [123]\npause_during_trading = true\n"
+                )
+            ),
+        )
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_build.return_value = AsyncMock()
+            result = runner.invoke(
+                cli,
+                ["feed", "start", "--data-path", data_path],
+            )
+        assert result.exit_code != 0
+        assert "blocked_days" in result.output


### PR DESCRIPTION
Closes #2037
Closes #2038

## Summary
feed config 검증/적용 2건:
- **#2037(P2)**: guard 설정(blocked_days/blocked_hours/pause_during_trading)이 타입 검증 없이 사용 → traceback/조용한 오동작. cli.py 공통 helper로 타입 검증(blocked_days=list[str], blocked_hours=list, pause_during_trading=bool) fail-loud(CONFIG_INVALID_GUARD). blocked_hours window 형식은 #2030 `_validate_schedule_times`에 위임(중복 없음)
- **#2038(P3)**: general.log_level 미적용 → `logging.getLogger("ante.feed").setLevel` 적용(root 불변). 무효 레벨 → CONFIG_INVALID_LOG_LEVEL 거부(INFO fallback 아님)
- helper를 run_backfill/run_daily/feed_start의 load_config 직후 호출(3 경로 공통 chokepoint)

## Test Plan
- config/feed/guard/cli_feed/scheduler 1246 passed, contracts 145 / mypy Success / ruff clean
- 신규 15: log_level 적용/무효 거부/root 불변, guard 타입 거부, 3 커맨드 호출

## Codex 브랜치 리뷰
- `/codex:review --base main` PASS