### PR TITLE
docs(rule-engine): #2152 RuleEngine 생성자 예시를 실제 시그니처에 정렬 (kw-only account_id 필수)

### DIFF
--- a/docs/specs/rule-engine/07-rule-engine-core.md
+++ b/docs/specs/rule-engine/07-rule-engine-core.md
@@ -13,10 +13,17 @@ RuleEngine은 룰을 로드하고 평가하는 메인 엔진입니다.
 ```python
 RuleEngine(
     eventbus: EventBus,
-    account_id: str = "default",
+    *,
+    account_id: str,
     account_service: AccountService | None = None,
+    bot_strategy_resolver: Callable[[str], str | None] | None = None,
+    treasury: Treasury | None = None,
+    trade_service: TradeService | None = None,
+    account: Account | None = None,
 )
 ```
+
+`eventbus`는 positional이고, 그 외 인자는 모두 keyword-only(`*,` 이후)입니다. `account_id`는 default fallback 없이 **필수**이며, 생성자 내부에서 `require_account_id(account_id, context="rule_engine.__init__")`로 즉시 검증됩니다 — 빈 값이나 `"default"` 같은 fallback은 거부됩니다.
 
 ### 의존성
 


### PR DESCRIPTION
Closes #2152

## Summary
`docs/specs/rule-engine/07-rule-engine-core.md` 생성자 예시의 `account_id: str = "default"` fallback을 실제 `__init__` 시그니처에 정렬.
- `eventbus` positional → `*,` kw-only 구분자 → `account_id: str`(default 제거, 필수) → account_service/bot_strategy_resolver/treasury/trade_service/account (모두 `| None = None`)
- account_id는 `require_account_id`로 즉시 검증(빈 값·"default" 거부) 계약 명시
- `### 의존성` 개념 핵심(EventBus/AccountService) 유지

## Scope
- 단일 파일 docs-only. 코드·generated 무변경.

## Test Plan
- `grep 'account_id: str = "default"'` → 0 매치
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)