### PR TITLE
docs(approval): #2151 알림 wiring을 NotificationEvent 직접 발행 구조에 맞게 3파일 갱신

### DIFF
--- a/docs/specs/approval/02-design-decisions.md
+++ b/docs/specs/approval/02-design-decisions.md
@@ -32,18 +32,19 @@ Agent: 리포트 제출 (근거 자료)
 
 Notification 모듈은 양방향 통신을 지원한다. `TelegramAdapter`가 발송을, `TelegramCommandReceiver`가 getUpdates 폴링 기반 명령 수신을 담당한다.
 
-- **발송**: `ApprovalCreatedEvent` 구독 → 결재 요약 메시지 + 인라인 버튼(승인/거절) 전송
+- **발송**: `ApprovalService`가 `NotificationEvent`(category=`approval`, 승인/거절 버튼 포함)를 직접 발행하고, `NotificationService`가 `NotificationEvent`를 구독해 결재 요약 + 인라인 버튼(승인/거절)을 전송
 - **수신**: 인라인 버튼 `callback_query` 또는 `/approve <id>`, `/reject <id>` 명령어 → `ApprovalService` 호출
 
 **인라인 버튼 결재 흐름:**
 
 ```
 결재 요청 생성
-  → NotificationService가 ApprovalCreatedEvent 수신
-    → TelegramAdapter.send_with_buttons():
-      메시지: "📋 결재 요청 [budget_change]\n전략 A 예산 증액\n..."
-      버튼:  [✅ 승인] [❌ 거절]
-                ↓ callback_data: "approve:{id}" / "reject:{id}"
+  → ApprovalService가 NotificationEvent(category=approval, 버튼 포함) 발행
+    → NotificationService가 NotificationEvent 수신
+      → TelegramAdapter.send_with_buttons():
+        메시지: "📋 결재 요청 [budget_change]\n전략 A 예산 증액\n..."
+        버튼:  [✅ 승인] [❌ 거절]
+                  ↓ callback_data: "approve:{id}" / "reject:{id}"
 
 사용자가 버튼 탭
   → TelegramCommandReceiver가 callback_query 수신

--- a/docs/specs/approval/10-eventbus-integration.md
+++ b/docs/specs/approval/10-eventbus-integration.md
@@ -6,8 +6,8 @@
 
 | 이벤트 | 발행 시점 | 구독자 |
 |--------|----------|--------|
-| `ApprovalCreatedEvent` | 요청 생성 시 | Notification (사용자에게 알림) |
-| `ApprovalResolvedEvent` | 승인/거절/철회/만료 시 | Notification, 관련 모듈 |
+| `ApprovalCreatedEvent` | 요청 생성 시 | 현재 직접 구독자 없음 (발행만; 사용자 알림은 아래 `NotificationEvent` 경유) |
+| `ApprovalResolvedEvent` | 승인/거절/철회/만료 시 | 현재 직접 구독자 없음 (발행만; 사용자 알림은 아래 `NotificationEvent` 경유) |
 | `NotificationEvent` | 요청 생성 시, 처리 완료 시 | NotificationService → Telegram 어댑터 |
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조

--- a/docs/specs/approval/12-cross-module-notes.md
+++ b/docs/specs/approval/12-cross-module-notes.md
@@ -4,7 +4,7 @@
 
 # 타 모듈 설계 시 참고
 
-- **Notification**: `ApprovalCreatedEvent` 구독 시 결재 요약 + 승인/거절 버튼을 포함한 메시지 발송. 양방향 어댑터는 사용자 응답을 수신하여 `ApprovalService`를 호출한다.
+- **Notification**: `ApprovalService`가 발행하는 `NotificationEvent`(category=`approval`, 버튼 포함)를 구독해 결재 요약 + 승인/거절 버튼을 포함한 메시지를 발송. 양방향 어댑터는 사용자 응답을 수신하여 `ApprovalService`를 호출한다.
 - **Report**: 전략 채택 흐름이 Report 직접 채택 → Approval을 통한 채택으로 변경
 - **Treasury**: `budget_change` 승인 시 `update_budget()` 호출
 - **BotManager**: `bot_create`, `bot_stop` 승인 시 해당 동작 호출


### PR DESCRIPTION
Closes #2151

## Summary
approval 모듈 문서 3곳을 #487 이후 실제 구조에 정렬.
- `ApprovalService`가 `NotificationEvent`(category=approval, 버튼)를 **직접 발행**(생성=`_publish_created`, 처리완료=`_publish_resolved_notification`), `NotificationService`는 `NotificationEvent`만 구독
- `ApprovalCreatedEvent`/`ApprovalResolvedEvent`는 발행만 되고 직접 구독자 없음 → 표 구독자 열 정정
- 02-design-decisions / 10-eventbus-integration / 12-cross-module-notes 3파일

## Scope
- approval/ 3파일 docs-only. eventbus.md 중앙 표는 follow-up #2252. 코드·generated 무변경.

## Test Plan
- service.py(`_publish_created`/`_publish_resolved_notification` NotificationEvent 발행), notification service.py(NotificationEvent만 subscribe), grep 0 ApprovalCreated/Resolved subscriber와 일치
- Codex 브랜치 리뷰 PASS (2회차)

🤖 Generated with [Claude Code](https://claude.com/claude-code)