### PR TITLE
fix(backtest): #2060 --symbols/--timeframe 생략 시 StrategyMeta로 fallback

### DIFF
--- a/docs/specs/strategy/03-15-backtest-relationship.md
+++ b/docs/specs/strategy/03-15-backtest-relationship.md
@@ -19,6 +19,8 @@ ante backtest run strategies/universal_ma.py \
 
 `exchange="*"` 전략은 `--exchange` 옵션으로 백테스트할 시장을 자유롭게 지정할 수 있다.
 
+`backtest run`에서 `--symbols`를 생략하면(내부적으로 빈 목록) `StrategyMeta.symbols`로 fallback하고, `--timeframe`를 생략하면 `StrategyMeta.timeframe`로 fallback한다. 명시한 `--symbols`/`--timeframe`는 meta보다 우선한다. CLI와 meta 모두 종목이 없으면 에러가 아니라 경고와 함께 0-step으로 끝난다.
+
 > canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
 > backtest `--exchange` override의 목표 계약은 canonical-only·`*` 거부이나, 현재 CLI/`src/ante/backtest/`에
 > 미구현된 spec-vs-implementation gap이다. 옵션 신설 포함 정렬은 #1578에서 다룬다.

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -9,6 +9,7 @@ import logging
 import math
 import re
 import sys
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from ante.backtest.config import BacktestConfig
@@ -78,40 +79,79 @@ class BacktestService:
 
         strategy_cls = StrategyLoader.load(strategy_path)
 
+        # #2060: CLI ``--symbols``/``--timeframe`` 생략 시 ``StrategyMeta``
+        # 로 fallback 한다. ``_validate_config`` 는 load 전이라 meta 를 모르므로
+        # 여기(load 후)에서 effective 값을 resolve·재검증한다.
+        #   - symbols: 명시(validated.symbols) 우선, 비면 meta.symbols
+        #   - timeframe: 명시(config["timeframe"] 비-None) 우선, 생략(None)이면
+        #     meta.timeframe (None 은 _validate_config 가 early 검증을 deferred
+        #     했으므로 여기서 effective 값으로 재검증)
+        # meta 가 invalid timeframe/symbol 을 선언했어도 effective 재검증으로
+        # 차단한다(전략 meta 도 vocab SSOT 를 우회 못함).
+        meta = strategy_cls.meta
+        eff_symbols = validated.symbols or list(meta.symbols or [])
+        cfg_timeframe = config.get("timeframe", "1d")
+        eff_timeframe = cfg_timeframe if cfg_timeframe is not None else meta.timeframe
+
+        # effective 값 vocab 재검증 (early 검증과 동일 helper 공유). meta
+        # 선언 invalid 도 BacktestConfigError 로 차단. exchange 는 validated
+        # (이미 canonical 검증 통과) 기준으로 KRX-shape 적용.
+        self._validate_timeframe_vocab(eff_timeframe)
+        self._validate_symbols_vocab(eff_symbols, validated.exchange)
+
+        # downstream(provider/executor/data load/result.config)에는 None 이
+        # 새지 않는 effective ``BacktestConfig`` 만 흘린다(Codex 제약). validated
+        # 를 effective symbols/timeframe 으로 치환한 사본을 구성한다.
+        effective = replace(
+            validated,
+            symbols=eff_symbols,
+            timeframe=eff_timeframe,
+        )
+
+        if not effective.symbols:
+            # CLI+meta 모두 symbols 없음 → executor universe 빈 상태로 0-step
+            # 성공이 silent 하게 끝나던 사유(#2060)를 명시 기록한다.
+            logger.warning(
+                "백테스트 대상 종목이 없습니다(CLI --symbols 생략 + "
+                "StrategyMeta.symbols 미설정 '%s'): 데이터셋 0개·0-step 으로 "
+                "종료될 수 있습니다.",
+                meta.name,
+            )
+
         store = ParquetStore(
-            base_path=validated.data_paths[0],
+            base_path=effective.data_paths[0],
         )
         data_provider = BacktestDataProvider(
             store=store,
-            start_date=validated.start_date,
-            end_date=validated.end_date,
-            exchange=validated.exchange,
+            start_date=effective.start_date,
+            end_date=effective.end_date,
+            exchange=effective.exchange,
             # run timeframe을 provider에 인지시켜, 내부 read 경로
             # (체결가/equity/지표)가 ``{symbol}:{timeframe}`` 캐시 키를
             # 조회하도록 한다(#2012). 미전달 시 1d로 떨어져 비-1d run의
             # 체결가가 1d 종가로 새는 버그가 생긴다.
-            timeframe=validated.timeframe,
+            timeframe=effective.timeframe,
         )
 
-        for symbol in validated.symbols:
-            data_provider.load(symbol, validated.timeframe)
+        for symbol in effective.symbols:
+            data_provider.load(symbol, effective.timeframe)
 
         executor = BacktestExecutor(
             strategy_cls=strategy_cls,
             data_provider=data_provider,
-            initial_balance=validated.initial_balance,
-            buy_commission_rate=validated.buy_commission_rate,
-            sell_commission_rate=validated.sell_commission_rate,
-            slippage_rate=validated.slippage_rate,
-            exchange=validated.exchange,
+            initial_balance=effective.initial_balance,
+            buy_commission_rate=effective.buy_commission_rate,
+            sell_commission_rate=effective.sell_commission_rate,
+            slippage_rate=effective.slippage_rate,
+            exchange=effective.exchange,
             # config.symbols universe를 executor에 전달해, 전략이 universe 밖
             # Signal.symbol을 반환해도 거래(체결)하지 않게 한다(#2072). 빈
             # symbols(universe 미설정)는 frozenset()이 되어 거부하지 않는다.
-            symbols=validated.symbols,
+            symbols=effective.symbols,
         )
 
         result = await executor.run(progress_callback=progress_callback)
-        result.config = validated
+        result.config = effective
         result.datasets = data_provider.loaded_datasets
 
         # BacktestCompleteEvent 발행
@@ -168,6 +208,55 @@ class BacktestService:
         await self._eventbus.publish(event)
         logger.info("BacktestCompleteEvent 발행: %s", strategy_id)
 
+    def _validate_timeframe_vocab(self, timeframe: object) -> None:
+        """timeframe vocabulary 검증 (#1604). invalid → BacktestConfigError.
+
+        early(_validate_config)와 effective(run, #2060) 양쪽이 공유하는 단일
+        helper. ``str()`` 캐스팅 없이 non-str 도 ``is_valid_timeframe`` 의
+        non-str→False 가드를 통해 거부한다.
+        """
+        if not isinstance(timeframe, str) or not is_valid_timeframe(timeframe):
+            msg = (
+                f"Invalid timeframe: {timeframe!r}. "
+                f"Allowed: {', '.join(CANONICAL_TIMEFRAMES)}"
+            )
+            raise BacktestConfigError(msg)
+
+    def _validate_symbols_vocab(
+        self,
+        symbols: object,
+        exchange: str,
+        *,
+        raw: object | None = None,
+    ) -> None:
+        """symbols 구조/빈/KRX-shape 검증 (#1604/#2060 공유 helper).
+
+        early(_validate_config)와 effective(run, meta fallback) 양쪽이 동일
+        로직을 쓰도록 추출. ``raw`` 는 에러 메시지에 노출할 원본 입력값(없으면
+        ``symbols`` 자체). ``exchange == "KRX"`` 일 때만 6자리 shape 검증.
+        SSOT(`is_krx_symbol`)의 non-str→False 가드 보존 — ``str()`` 캐스팅 금지.
+        """
+        shown = symbols if raw is None else raw
+        if not isinstance(symbols, list) or not all(
+            isinstance(s, str) for s in symbols
+        ):
+            msg = f"Invalid symbols (expected list[str]): {shown!r}"
+            raise BacktestConfigError(msg)
+        if any(not s.strip() for s in symbols):
+            msg = f"Invalid symbols (empty/blank segment): {shown!r}"
+            raise BacktestConfigError(msg)
+        if exchange == "KRX":
+            # resolved exchange == KRX 신규 입력 한정 (core.md
+            # ``### KRX symbol shape``). 비-KRX exchange의 symbol shape은
+            # 미검증 (NYSE+AAPL 비거부).
+            for s in symbols:
+                if not is_krx_symbol(s):
+                    msg = (
+                        f"Invalid KRX symbol: {s!r}. "
+                        "Expected 6-digit canonical KRX symbol shape."
+                    )
+                    raise BacktestConfigError(msg)
+
     def _validate_config(self, config: dict[str, Any]) -> BacktestConfig:
         """설정 검증 후 BacktestConfig를 반환."""
         required = ["strategy_path", "start_date", "end_date"]
@@ -211,27 +300,20 @@ class BacktestService:
         # 우회하지 않도록 ``str()`` 캐스팅은 쓰지 않는다.
         # precedence: required-key → ① timeframe → ② symbols 정규화/
         # 구조/빈 → ③ KRX shape.
+        #
+        # #2060: ``timeframe`` 이 ``None`` (CLI ``--timeframe`` 생략 신호)
+        # 이면 early vocab 검증을 deferred 한다 — load 후 ``run()`` 이
+        # ``StrategyMeta.timeframe`` 로 fallback 하여 effective 값을
+        # 재검증한다. 명시적(비-None) timeframe 은 기존대로 early 검증·거부.
         timeframe = config.get("timeframe", "1d")
-        if not isinstance(timeframe, str) or not is_valid_timeframe(timeframe):
-            msg = (
-                f"Invalid timeframe: {timeframe!r}. "
-                f"Allowed: {', '.join(CANONICAL_TIMEFRAMES)}"
-            )
-            raise BacktestConfigError(msg)
+        if timeframe is not None:
+            self._validate_timeframe_vocab(timeframe)
 
         symbols_raw = config.get("symbols", [])
         # None/누락/[] → [] (no-symbols backtest 정상, 미거부). 명시적
         # ``{"symbols": None}`` 도 여기서 ``[]`` 로 정규화하여 build
         # 라인이 ``BacktestConfig.symbols=None`` 으로 새지 않게 한다.
         normalized_symbols = [] if symbols_raw is None else symbols_raw
-        if not isinstance(normalized_symbols, list) or not all(
-            isinstance(s, str) for s in normalized_symbols
-        ):
-            msg = f"Invalid symbols (expected list[str]): {symbols_raw!r}"
-            raise BacktestConfigError(msg)
-        if any(not s.strip() for s in normalized_symbols):
-            msg = f"Invalid symbols (empty/blank segment): {symbols_raw!r}"
-            raise BacktestConfigError(msg)
 
         # exchange canonical 검증 (#2034, core.md ``## Canonical Exchange
         # Vocabulary`` / D-016). CLI(#1576)는 ingress에서 거부하지만
@@ -246,18 +328,10 @@ class BacktestService:
                 f"Allowed: {', '.join(sorted(CANONICAL_EXCHANGES))}"
             )
             raise BacktestConfigError(msg)
-        if exchange == "KRX":
-            # resolved exchange == KRX 신규 입력 한정 (core.md
-            # ``### KRX symbol shape``). 비-KRX exchange의 symbol
-            # shape은 미검증 (NYSE+AAPL 비거부). 원본 str 값을 그대로
-            # 전달 — ② 에서 list[str] 보장, SSOT non-str 가드 보존.
-            for s in normalized_symbols:
-                if not is_krx_symbol(s):
-                    msg = (
-                        f"Invalid KRX symbol: {s!r}. "
-                        "Expected 6-digit canonical KRX symbol shape."
-                    )
-                    raise BacktestConfigError(msg)
+
+        # symbols 구조/빈/KRX-shape 검증 (단일 helper — #2060 effective
+        # 재검증과 동일 로직 공유). exchange == KRX 일 때만 shape 검증.
+        self._validate_symbols_vocab(normalized_symbols, exchange, raw=symbols_raw)
 
         # numeric 검증 (#2036). config에 **존재하는** 숫자 키만 검사하고
         # 미존재는 BacktestConfig 기본값(valid)을 따른다. bool은 int의
@@ -292,10 +366,17 @@ class BacktestService:
             [config.get("data_path", self._data_path)],
         )
 
+        # #2060: timeframe 이 None (CLI 생략 신호) 이면 BacktestConfig.timeframe
+        # (타입 ``str``) 에 None 이 새지 않도록 placeholder "1d" 로 채운다.
+        # 실제 effective timeframe 은 ``run()`` 이 load 후 ``StrategyMeta``
+        # 로 resolve·재검증하여 downstream(provider/executor/result.config)
+        # 에 흘릴 effective ``BacktestConfig`` 를 다시 구성한다. None 은
+        # ``run()`` 로컬에서만 "생략" 신호로 쓰이고 dataclass 로는 새지 않는다.
+        cfg_timeframe = config.get("timeframe", "1d")
         return BacktestConfig(
             strategy_path=config["strategy_path"],
             symbols=normalized_symbols,
-            timeframe=config.get("timeframe", "1d"),
+            timeframe="1d" if cfg_timeframe is None else cfg_timeframe,
             exchange=config.get("exchange", "KRX"),
             start_date=config.get("start_date", ""),
             end_date=config.get("end_date", ""),

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -43,7 +43,11 @@ def backtest() -> None:
     callback=validate_positive_finite_amount,
     help="초기 자금",
 )
-@click.option("--timeframe", default="1d", help="타임프레임")
+@click.option(
+    "--timeframe",
+    default=None,
+    help="타임프레임 (미지정 시 전략 meta)",
+)
 @click.option("--exchange", default="KRX", help="거래소 (기본: KRX)")
 @click.option(
     "--data-path",
@@ -61,7 +65,7 @@ def run(
     end: str,
     symbols: str | None,
     balance: float,
-    timeframe: str,
+    timeframe: str | None,
     exchange: str,
     data_path: str | None,
     db_path: str | None,
@@ -117,7 +121,12 @@ def run(
     # precedence: date/exchange 검증 이후 → ① timeframe → ② 빈 segment →
     # ③ KRX symbol shape. config build·BacktestService.run·_save_backtest_run
     # 이전이어야 invalid 입력 시 backtest_runs history가 생성되지 않는다.
-    if not is_valid_timeframe(timeframe):
+    #
+    # #2060: ``--timeframe`` 생략(None) 은 "전략 meta 사용" 신호이므로 CLI
+    # vocab 검증을 skip 하고 config 에 None 을 그대로 전달한다 —
+    # BacktestService.run() 이 load 후 StrategyMeta.timeframe 으로 fallback·
+    # 재검증한다. 명시값(비-None)은 기존대로 ingress 에서 거부한다.
+    if timeframe is not None and not is_valid_timeframe(timeframe):
         fmt.error(
             f"유효하지 않은 타임프레임: {timeframe!r}. "
             f"허용 값: {', '.join(CANONICAL_TIMEFRAMES)}",
@@ -152,6 +161,8 @@ def run(
         "end_date": end,
         "symbols": symbols.split(",") if symbols else [],
         "initial_balance": balance,
+        # #2060: ``--timeframe`` 생략 시 None 을 그대로 전달 — service.run()
+        # 이 StrategyMeta.timeframe 으로 fallback 한다(명시값은 그대로 전달).
         "timeframe": timeframe,
         "exchange": exchange,
         "data_path": data_path,

--- a/tests/unit/contracts/factory_drift_allowlist.yaml
+++ b/tests/unit/contracts/factory_drift_allowlist.yaml
@@ -55,7 +55,7 @@ direct_database_construction:
   # `backtest history` 는 `offline` 이며 #1974 에서 `open_cli_db` (read_only)
   # 로 마이그레이션되어 직접 Database 생성 callsite 가 사라졌다 — 엔트리 제거.
   - path: src/ante/cli/commands/backtest.py
-    line: 243
+    line: 254
     reason: "backtest run — long_running (progress-bar driven, deferred migration)"
 
   # data domain — `data list` callsite. #1857 잔여로 본 사이클에서 보류.

--- a/tests/unit/test_backtest_complete_event.py
+++ b/tests/unit/test_backtest_complete_event.py
@@ -6,8 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ante.backtest.config import BacktestConfig
 from ante.backtest.service import BacktestService
 from ante.eventbus.events import BacktestCompleteEvent
+from ante.strategy.base import StrategyMeta
 from ante.strategy.validator import ValidationResult
 
 
@@ -22,6 +24,17 @@ def _bypass_validator():
         "ante.backtest.service.StrategyValidator.validate",
         return_value=ValidationResult(valid=True),
     )
+
+
+def _strategy_cls_with_meta() -> MagicMock:
+    """``StrategyLoader.load`` 가 반환할 strategy_cls 모사 (실제 ``.meta`` 보유).
+
+    #2060 meta fallback 으로 run() 이 ``strategy_cls.meta`` 에 접근하므로 실제
+    ``StrategyMeta`` 를 단 strategy_cls 를 반환한다(symbols=[] → no-symbols).
+    """
+    cls = MagicMock()
+    cls.meta = StrategyMeta(name="s", version="1.0", description="evt")
+    return cls
 
 
 class TestBacktestCompleteEventPublish:
@@ -44,11 +57,15 @@ class TestBacktestCompleteEventPublish:
             "end_date": "2025-12-31",
         }
 
-        with patch.object(service, "_validate_config"):
+        with patch.object(
+            service,
+            "_validate_config",
+            return_value=BacktestConfig(strategy_path="strategies/test.py"),
+        ):
             with _bypass_validator():
                 with patch(
                     "ante.backtest.service.StrategyLoader.load",
-                    return_value=MagicMock,
+                    return_value=_strategy_cls_with_meta(),
                 ):
                     with patch(
                         "ante.backtest.service.BacktestDataProvider",
@@ -84,11 +101,15 @@ class TestBacktestCompleteEventPublish:
             "end_date": "2025-12-31",
         }
 
-        with patch.object(service, "_validate_config"):
+        with patch.object(
+            service,
+            "_validate_config",
+            return_value=BacktestConfig(strategy_path="strategies/test.py"),
+        ):
             with _bypass_validator():
                 with patch(
                     "ante.backtest.service.StrategyLoader.load",
-                    return_value=MagicMock,
+                    return_value=_strategy_cls_with_meta(),
                 ):
                     with patch(
                         "ante.backtest.service.BacktestDataProvider",

--- a/tests/unit/test_backtest_meta_fallback.py
+++ b/tests/unit/test_backtest_meta_fallback.py
@@ -1,0 +1,457 @@
+"""backtest run --symbols/--timeframe 생략 시 StrategyMeta fallback (#2060/#2096).
+
+`backtest run` 이 ``--symbols``/``--timeframe`` 를 생략하면 ``StrategyMeta.symbols``/
+``StrategyMeta.timeframe`` 로 fallback 하지 않아, 종목을 가진 전략도 데이터셋
+0개·0-step·0% 성공으로 끝났다(#2060). ``guide/strategy.md`` L172/174 는 이미
+기본값을 "전략 meta" 로 안내하므로, 코드를 meta fallback 하도록 고치면 가이드
+주장이 참이 되어 #2096 도 동시 해결된다.
+
+설계(effective-only):
+- ``_validate_config`` 는 load 전이라 meta 를 모름 → ``timeframe=None`` (CLI 생략
+  신호) 은 early vocab 검증을 deferred 한다. 명시값은 기존대로 early 거부.
+- ``run()`` 은 load 후 ``StrategyMeta`` 로 effective symbols/timeframe 을
+  resolve·재검증하고, downstream(provider/executor/data load/result.config) 에는
+  None 이 아닌 effective ``BacktestConfig`` 만 흘린다.
+
+검증 6축:
+- (a) --symbols 생략 + meta.symbols=["005930"] → 005930 로드.
+- (b) --timeframe 생략 + meta.timeframe="1m" → 1m 사용(provider 캐시 키 1m).
+- (c) --symbols/--timeframe 명시 → 명시값 우선(meta 무시).
+- (d) CLI+meta symbols 모두 없음 → warning + 0-step(에러 아님).
+- (e) meta invalid timeframe → BacktestConfigError.
+- (f) subprocess(runner) 동일 동작.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ante.backtest.config import BacktestConfig
+from ante.backtest.exceptions import BacktestConfigError
+from ante.backtest.result import BacktestResult
+from ante.backtest.service import BacktestService
+from ante.strategy.base import StrategyMeta
+from ante.strategy.validator import ValidationResult
+
+_BASE: dict = {
+    "strategy_path": "s.py",
+    "start_date": "2026-01-01",
+    "end_date": "2026-01-02",
+}
+
+
+def _cfg(**overrides) -> dict:
+    return {**_BASE, **overrides}
+
+
+def _bypass_validator():
+    """service.run 의 StrategyValidator 게이트(#2039)를 우회한다."""
+    return patch(
+        "ante.backtest.service.StrategyValidator.validate",
+        return_value=ValidationResult(valid=True),
+    )
+
+
+def _strategy_cls_with_meta(
+    *,
+    symbols: list[str] | None = None,
+    timeframe: str = "1d",
+) -> MagicMock:
+    """``StrategyLoader.load`` 가 반환할 strategy_cls 모사.
+
+    ``.meta`` 만 실제 ``StrategyMeta`` 로 채워 run() 의 meta fallback resolve 가
+    실 동작과 같게 한다(MagicMock 의 ``.meta.symbols`` 자동-attr 회피).
+    """
+    cls = MagicMock()
+    cls.meta = StrategyMeta(
+        name="s",
+        version="1.0",
+        description="test",
+        symbols=symbols,
+        timeframe=timeframe,
+    )
+    return cls
+
+
+def _patched_run_components():
+    """run() 내부 provider/executor 를 mock — load/effective 흐름 추적."""
+    provider_instance = MagicMock()
+    provider_instance.loaded_datasets = []
+    executor_instance = MagicMock()
+
+    async def _fake_run(progress_callback=None):
+        return BacktestResult(
+            strategy_name="S",
+            strategy_version="1",
+            start_date="2026-01-01",
+            end_date="2026-01-02",
+            initial_balance=1.0,
+            final_balance=1.0,
+            total_return=0.0,
+        )
+
+    executor_instance.run = _fake_run
+    return provider_instance, executor_instance
+
+
+@contextlib.contextmanager
+def _run_env(strategy_cls: MagicMock):
+    """provider/executor/loader patch 컨텍스트. (provider, executor) yield."""
+    provider_instance, executor_instance = _patched_run_components()
+    with (
+        _bypass_validator(),
+        patch("ante.backtest.service.StrategyLoader") as mock_loader,
+        patch("ante.backtest.service.ParquetStore"),
+        patch(
+            "ante.backtest.service.BacktestDataProvider",
+            return_value=provider_instance,
+        ) as mock_provider_cls,
+        patch(
+            "ante.backtest.service.BacktestExecutor",
+            return_value=executor_instance,
+        ) as mock_executor_cls,
+    ):
+        mock_loader.load.return_value = strategy_cls
+        yield provider_instance, mock_provider_cls, mock_executor_cls
+
+
+# ── (a) --symbols 생략 + meta.symbols=["005930"] → 005930 로드 ────────────
+
+
+class TestSymbolsOmittedFallbackToMeta:
+    """CLI ``--symbols`` 생략(=[]) → StrategyMeta.symbols 로 fallback."""
+
+    @pytest.mark.asyncio
+    async def test_symbols_empty_falls_back_to_meta_symbols(self):
+        strategy_cls = _strategy_cls_with_meta(symbols=["005930"])
+        with _run_env(strategy_cls) as (provider, _pcls, mock_executor_cls):
+            svc = BacktestService()
+            # CLI 생략은 symbols=[] (현행 유지). timeframe 도 생략(None).
+            await svc.run(_cfg(symbols=[], timeframe=None))
+
+        # meta.symbols 로 fallback 하여 005930 를 1d(meta 기본)로 로드.
+        provider.load.assert_called_once_with("005930", "1d")
+        # executor universe 도 effective symbols 로 채워진다.
+        assert mock_executor_cls.call_args.kwargs["symbols"] == ["005930"]
+
+    @pytest.mark.asyncio
+    async def test_symbols_missing_key_falls_back_to_meta_symbols(self):
+        """``symbols`` 키 자체 누락도 [] 정규화 → meta fallback."""
+        strategy_cls = _strategy_cls_with_meta(symbols=["005930", "000660"])
+        with _run_env(strategy_cls) as (provider, _pcls, _ecls):
+            svc = BacktestService()
+            await svc.run(_cfg(timeframe=None))
+
+        assert provider.load.call_count == 2
+        loaded = {c.args[0] for c in provider.load.call_args_list}
+        assert loaded == {"005930", "000660"}
+
+
+# ── (b) --timeframe 생략 + meta.timeframe="1m" → 1m 사용 ──────────────────
+
+
+class TestTimeframeOmittedFallbackToMeta:
+    """CLI ``--timeframe`` 생략(None) → StrategyMeta.timeframe 로 fallback."""
+
+    @pytest.mark.asyncio
+    async def test_timeframe_none_uses_meta_timeframe(self):
+        strategy_cls = _strategy_cls_with_meta(symbols=["005930"], timeframe="1m")
+        with _run_env(strategy_cls) as (provider, mock_provider_cls, _ecls):
+            svc = BacktestService()
+            await svc.run(_cfg(symbols=["005930"], timeframe=None))
+
+        # provider 캐시 키 timeframe 이 meta 의 1m 으로 흘러야 한다.
+        provider.load.assert_called_once_with("005930", "1m")
+        assert mock_provider_cls.call_args.kwargs["timeframe"] == "1m"
+
+    @pytest.mark.asyncio
+    async def test_timeframe_missing_key_uses_meta_timeframe(self):
+        """``timeframe`` 키 누락 시에는 _validate_config 기본 1d 가 쓰인다.
+
+        CLI 는 항상 키를 None 으로 넣으므로 이 경로는 programmatic 호환 회귀.
+        키가 아예 없으면 ``config.get("timeframe", "1d")`` 기본 1d → meta 무시.
+        """
+        strategy_cls = _strategy_cls_with_meta(symbols=["005930"], timeframe="1m")
+        with _run_env(strategy_cls) as (provider, _pcls, _ecls):
+            svc = BacktestService()
+            await svc.run(_cfg(symbols=["005930"]))  # timeframe 키 없음
+
+        provider.load.assert_called_once_with("005930", "1d")
+
+
+# ── (c) --symbols/--timeframe 명시 → 명시값 우선(meta 무시) ────────────────
+
+
+class TestExplicitValuesOverrideMeta:
+    """명시된 symbols/timeframe 은 meta 를 무시하고 우선한다."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_symbols_override_meta(self):
+        strategy_cls = _strategy_cls_with_meta(symbols=["005930"], timeframe="1m")
+        with _run_env(strategy_cls) as (provider, mock_provider_cls, _ecls):
+            svc = BacktestService()
+            await svc.run(_cfg(symbols=["000660"], timeframe="5m"))
+
+        # 명시 000660/5m 이 meta(005930/1m)를 덮어쓴다.
+        provider.load.assert_called_once_with("000660", "5m")
+        assert mock_provider_cls.call_args.kwargs["timeframe"] == "5m"
+
+    @pytest.mark.asyncio
+    async def test_explicit_timeframe_with_meta_symbols(self):
+        """timeframe 명시 + symbols 생략 → 명시 tf + meta symbols 혼합."""
+        strategy_cls = _strategy_cls_with_meta(symbols=["005930"], timeframe="1m")
+        with _run_env(strategy_cls) as (provider, _pcls, _ecls):
+            svc = BacktestService()
+            await svc.run(_cfg(symbols=[], timeframe="15m"))
+
+        provider.load.assert_called_once_with("005930", "15m")
+
+
+# ── (d) CLI+meta symbols 모두 없음 → warning + 0-step (에러 아님) ──────────
+
+
+class TestNoSymbolsAtAllWarns:
+    """CLI 생략 + meta.symbols 미설정 → warning 기록 + 0 load (에러 아님)."""
+
+    @pytest.mark.asyncio
+    async def test_no_symbols_warns_and_zero_load(self, caplog):
+        strategy_cls = _strategy_cls_with_meta(symbols=None, timeframe="1d")
+        with _run_env(strategy_cls) as (provider, _pcls, _ecls):
+            svc = BacktestService()
+            with caplog.at_level(logging.WARNING, logger="ante.backtest.service"):
+                result = await svc.run(_cfg(symbols=[], timeframe=None))
+
+        # 에러 없이 result 반환 (0-step 성공). data load 0회.
+        assert isinstance(result, BacktestResult)
+        provider.load.assert_not_called()
+        # silent 0-step 완화 — 사유 warning 기록.
+        assert any("대상 종목이 없습니다" in r.message for r in caplog.records), (
+            caplog.records
+        )
+
+
+# ── (e) meta invalid timeframe / symbol → BacktestConfigError ─────────────
+
+
+class TestMetaInvalidVocabRejected:
+    """전략 meta 가 invalid timeframe/symbol 선언 시 effective 재검증으로 차단."""
+
+    @pytest.mark.asyncio
+    async def test_meta_invalid_timeframe_rejected(self):
+        strategy_cls = _strategy_cls_with_meta(
+            symbols=["005930"], timeframe="oracle-invalid"
+        )
+        with _run_env(strategy_cls) as (provider, _pcls, _ecls):
+            svc = BacktestService()
+            with pytest.raises(BacktestConfigError, match="Invalid timeframe"):
+                await svc.run(_cfg(symbols=["005930"], timeframe=None))
+
+        # 재검증 실패 → data load 미도달.
+        provider.load.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_meta_invalid_krx_symbol_rejected(self):
+        strategy_cls = _strategy_cls_with_meta(symbols=["ABCDEF"], timeframe="1d")
+        with _run_env(strategy_cls) as (provider, _pcls, _ecls):
+            svc = BacktestService()
+            with pytest.raises(BacktestConfigError, match="Invalid KRX symbol"):
+                await svc.run(_cfg(symbols=[], timeframe=None))
+
+        provider.load.assert_not_called()
+
+
+# ── effective-only: result.config 에 None 미누수, effective 값 반영 ────────
+
+
+class TestEffectiveConfigNoNoneLeak:
+    """result.config 가 None 이 아닌 effective BacktestConfig 인지 확인."""
+
+    @pytest.mark.asyncio
+    async def test_result_config_holds_effective_values(self):
+        strategy_cls = _strategy_cls_with_meta(symbols=["005930"], timeframe="1m")
+        provider_instance, executor_instance = _patched_run_components()
+        captured: dict = {}
+
+        async def _capturing_run(progress_callback=None):
+            return BacktestResult(
+                strategy_name="S",
+                strategy_version="1",
+                start_date="2026-01-01",
+                end_date="2026-01-02",
+                initial_balance=1.0,
+                final_balance=1.0,
+                total_return=0.0,
+            )
+
+        executor_instance.run = _capturing_run
+
+        with (
+            _bypass_validator(),
+            patch("ante.backtest.service.StrategyLoader") as mock_loader,
+            patch("ante.backtest.service.ParquetStore"),
+            patch(
+                "ante.backtest.service.BacktestDataProvider",
+                return_value=provider_instance,
+            ),
+            patch(
+                "ante.backtest.service.BacktestExecutor",
+                return_value=executor_instance,
+            ),
+        ):
+            mock_loader.load.return_value = strategy_cls
+            svc = BacktestService()
+            result = await svc.run(_cfg(symbols=[], timeframe=None))
+            captured["config"] = result.config
+
+        cfg = captured["config"]
+        assert isinstance(cfg, BacktestConfig)
+        # None 미누수 — effective 값으로 채워짐.
+        assert cfg.timeframe == "1m"
+        assert cfg.symbols == ["005930"]
+
+
+# ── _validate_config: timeframe None deferred (early 검증 skip) ───────────
+
+
+class TestValidateConfigTimeframeNoneDeferred:
+    """timeframe=None 은 _validate_config 에서 early vocab 검증 deferred."""
+
+    def test_timeframe_none_does_not_early_raise(self):
+        svc = BacktestService()
+        # None 이면 early 검증을 건너뛰고 placeholder "1d" 로 BacktestConfig 빌드.
+        validated = svc._validate_config(_cfg(timeframe=None, symbols=["005930"]))
+        assert isinstance(validated, BacktestConfig)
+        assert validated.timeframe == "1d"  # None 미누수 (placeholder)
+
+    def test_explicit_invalid_timeframe_still_early_rejected(self):
+        """명시(비-None) invalid timeframe 은 기존대로 early 거부."""
+        svc = BacktestService()
+        with pytest.raises(BacktestConfigError, match="Invalid timeframe"):
+            svc._validate_config(_cfg(timeframe="oracle-invalid"))
+
+
+# ── (f) subprocess(runner) 동일 동작: 실제 데이터 + meta fallback ──────────
+
+_META_SYMBOLS_STRATEGY = """\
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+
+class MetaSymbolsStrategy(Strategy):
+    meta = StrategyMeta(
+        name="metasym",
+        version="1.0",
+        description="meta symbols fallback",
+        symbols=["005930"],
+        timeframe="1d",
+    )
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        return []
+"""
+
+
+def _write_strategy(tmp_path: Path, source: str) -> Path:
+    strat = tmp_path / "strat.py"
+    strat.write_text(source, encoding="utf-8")
+    return strat
+
+
+def _write_ohlcv(data_dir: Path, symbol: str, *, n: int = 5) -> None:
+    """``data_dir`` 에 ``symbol`` 1d OHLCV 적재 (런타임 step 발생용)."""
+    from datetime import UTC, datetime, timedelta
+
+    import polars as pl
+
+    from ante.data.store import ParquetStore
+
+    start = datetime(2026, 1, 2, 9, 0, tzinfo=UTC)
+    timestamps = pl.datetime_range(
+        start,
+        start + timedelta(days=n - 1),
+        interval="1d",
+        eager=True,
+        time_zone="UTC",
+    )
+    df = pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": [symbol] * n,
+            "open": [50000.0 + i * 100 for i in range(n)],
+            "high": [50000.0 + i * 100 + 50 for i in range(n)],
+            "low": [50000.0 + i * 100 - 50 for i in range(n)],
+            "close": [50000.0 + i * 100 + 25 for i in range(n)],
+            "volume": [1000 + i * 10 for i in range(n)],
+            "source": ["test"] * n,
+        }
+    )
+    ParquetStore(base_path=data_dir).write(symbol, "1d", df)
+
+
+class TestSubprocessMetaFallback:
+    """subprocess(runner→service.run) 도 meta fallback 동일 적용 (#2060)."""
+
+    @pytest.mark.asyncio
+    async def test_subprocess_symbols_timeframe_omitted_falls_back_to_meta(
+        self, tmp_path: Path
+    ) -> None:
+        """--symbols/--timeframe 생략(None) → meta.symbols=["005930"] 로드·≥1 step."""
+        strat = _write_strategy(tmp_path, _META_SYMBOLS_STRATEGY)
+        _write_ohlcv(tmp_path / "data", "005930")
+        svc = BacktestService(data_path=str(tmp_path / "data"))
+
+        # CLI 생략 신호 모사: symbols=[] (현행 유지), timeframe=None.
+        cfg = {
+            "strategy_path": str(strat),
+            "symbols": [],
+            "timeframe": None,
+            "exchange": "KRX",
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-08",
+            "data_path": str(tmp_path / "data"),
+        }
+        out = await svc.run_subprocess(cfg)
+
+        assert isinstance(out, dict)
+        # meta.symbols 로 fallback → 005930 데이터셋 로드(0개 아님).
+        datasets = out.get("datasets", [])
+        loaded_symbols = {d.get("symbol") for d in datasets}
+        assert "005930" in loaded_symbols, out
+        assert any(d.get("row_count", 0) >= 1 for d in datasets), out
+
+
+class TestRunInProcessMetaFallbackEndToEnd:
+    """in-process run() end-to-end: meta fallback 으로 실제 데이터 로드·≥1 step."""
+
+    @pytest.mark.asyncio
+    async def test_in_process_meta_symbols_loaded_and_stepped(
+        self, tmp_path: Path
+    ) -> None:
+        strat = _write_strategy(tmp_path, _META_SYMBOLS_STRATEGY)
+        _write_ohlcv(tmp_path / "data", "005930")
+        svc = BacktestService(data_path=str(tmp_path / "data"))
+
+        cfg = {
+            "strategy_path": str(strat),
+            "symbols": [],
+            "timeframe": None,
+            "exchange": "KRX",
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-08",
+            "data_path": str(tmp_path / "data"),
+        }
+        result = await svc.run(cfg)
+
+        # 데이터셋 1개 이상 + row_count ≥ 1 (0-step 0% 성공이 아님).
+        assert result.datasets, "meta fallback 으로 005930 가 로드되어야 함"
+        assert any(d.row_count >= 1 for d in result.datasets)
+        # result.config 는 effective 값(005930/1d) 보유, None 미누수.
+        assert isinstance(result.config, BacktestConfig)
+        assert result.config.symbols == ["005930"]
+        assert result.config.timeframe == "1d"


### PR DESCRIPTION
Closes #2060, #2096

## Summary
`backtest run`이 `--symbols`/`--timeframe` 생략 시 `StrategyMeta.symbols`/`StrategyMeta.timeframe`로 fallback하지 않아 0-step silent success로 끝나던 버그 수정. 가이드(`guide/strategy.md`)가 이미 기본값="전략 meta"로 안내하므로 코드 정합으로 #2096도 동시 해결.

- CLI `--timeframe` default None + None일 때만 ingress vocab 검증 skip(명시 invalid는 거부)
- `_validate_config`: timeframe None deferred(명시는 early 검증), vocab 검증을 `_validate_timeframe_vocab`/`_validate_symbols_vocab` helper로 추출(early/effective 공유)
- `run()`: load 후 `eff_symbols=validated.symbols or meta.symbols`, `eff_timeframe=config timeframe or meta.timeframe` resolve + effective vocab 재검증(meta 선언 invalid도 차단) + **effective BacktestConfig만 downstream 전달**(None 미누수) + eff_symbols 빈 경우 warning
- runner.py→service.run() 위임으로 in-process·subprocess 양 경로 커버
- backtest-relationship 스펙에 fallback 계약 노트 추가

## Scope
- `src/ante/backtest/service.py`, `src/ante/cli/commands/backtest.py`, 스펙 노트 1줄. guide/generated/exchange-meta 무변경.

## Test Plan
- 신규 회귀 14건(symbols/timeframe 생략→meta, 명시 우선, 양쪽 없음→warning, meta invalid→error, subprocess 동일)
- `pytest -k backtest` 421 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)