### PR TITLE
fix(feed): #2068 feed run --format json에 CollectionResult failures/warnings 포함

### DIFF
--- a/src/ante/feed/cli_output.py
+++ b/src/ante/feed/cli_output.py
@@ -45,7 +45,9 @@ def _backfill_result_dict(result: CollectionResult) -> dict[str, Any]:
         "rows_written": result.rows_written,
         "data_types": result.data_types,
         "duration_seconds": result.duration_seconds,
-        "config_errors": result.config_errors,
+        "failures": list(result.failures),
+        "warnings": list(result.warnings),
+        "config_errors": list(result.config_errors),
     }
 
 
@@ -60,7 +62,9 @@ def _daily_result_dict(result: CollectionResult) -> dict[str, Any]:
         "rows_written": result.rows_written,
         "data_types": result.data_types,
         "duration_seconds": result.duration_seconds,
-        "config_errors": result.config_errors,
+        "failures": list(result.failures),
+        "warnings": list(result.warnings),
+        "config_errors": list(result.config_errors),
     }
 
 

--- a/tests/unit/feed/test_cli_output.py
+++ b/tests/unit/feed/test_cli_output.py
@@ -1,0 +1,116 @@
+"""ante feed CLI 결과 출력 포매터 단위 테스트.
+
+`_backfill_result_dict` / `_daily_result_dict`가 CollectionResult의
+failures / warnings / config_errors를 JSON 직렬화 dict에 모두 포함하는지
+회귀 검증한다 (issue #2068).
+"""
+
+from __future__ import annotations
+
+from ante.feed.cli_output import _backfill_result_dict, _daily_result_dict
+from ante.feed.models.result import CollectionResult
+
+
+def _result(**overrides: object) -> CollectionResult:
+    """공통 CollectionResult 팩토리."""
+    base: dict[str, object] = {
+        "mode": "backfill",
+        "started_at": "2026-03-18T00:00:00Z",
+        "finished_at": "2026-03-18T00:00:01Z",
+        "duration_seconds": 1.0,
+        "symbols_total": 0,
+        "symbols_success": 0,
+        "symbols_failed": 0,
+        "rows_written": 0,
+        "data_types": [],
+        "failures": [],
+        "warnings": [],
+        "config_errors": [],
+    }
+    base.update(overrides)
+    return CollectionResult(**base)  # type: ignore[arg-type]
+
+
+# ── _backfill_result_dict ────────────────────────────────────────────────
+
+
+class TestBackfillResultDict:
+    def test_includes_failures_warnings_config_errors_keys(self) -> None:
+        """세 키(failures/warnings/config_errors)가 모두 포함된다."""
+        d = _backfill_result_dict(_result())
+
+        assert "failures" in d
+        assert "warnings" in d
+        assert "config_errors" in d
+
+    def test_empty_lists_when_result_empty(self) -> None:
+        """비어 있는 경우 빈 리스트로 직렬화된다."""
+        d = _backfill_result_dict(_result())
+
+        assert d["failures"] == []
+        assert d["warnings"] == []
+        assert d["config_errors"] == []
+
+    def test_values_match_collection_result(self) -> None:
+        """항목이 있을 때 값이 CollectionResult와 일치한다."""
+        failures = [{"symbol": "005930", "error": "timeout"}]
+        warnings = [{"symbol": "000660", "warning": "gap"}]
+        config_errors = [{"error": "missing_api_key"}]
+        result = _result(
+            mode="backfill",
+            symbols_total=2,
+            symbols_success=1,
+            symbols_failed=1,
+            failures=failures,
+            warnings=warnings,
+            config_errors=config_errors,
+        )
+
+        d = _backfill_result_dict(result)
+
+        assert d["failures"] == failures
+        assert d["warnings"] == warnings
+        assert d["config_errors"] == config_errors
+
+
+# ── _daily_result_dict ───────────────────────────────────────────────────
+
+
+class TestDailyResultDict:
+    def test_includes_failures_warnings_config_errors_keys(self) -> None:
+        """세 키(failures/warnings/config_errors)가 모두 포함된다."""
+        d = _daily_result_dict(_result(mode="daily", target_date="2026-03-17"))
+
+        assert "failures" in d
+        assert "warnings" in d
+        assert "config_errors" in d
+
+    def test_empty_lists_when_result_empty(self) -> None:
+        """비어 있는 경우 빈 리스트로 직렬화된다."""
+        d = _daily_result_dict(_result(mode="daily", target_date="2026-03-17"))
+
+        assert d["failures"] == []
+        assert d["warnings"] == []
+        assert d["config_errors"] == []
+
+    def test_values_match_collection_result(self) -> None:
+        """항목이 있을 때 값이 CollectionResult와 일치한다."""
+        failures = [{"symbol": "005930", "error": "timeout"}]
+        warnings = [{"symbol": "000660", "warning": "gap"}]
+        config_errors = [{"error": "missing_api_key"}]
+        result = _result(
+            mode="daily",
+            target_date="2026-03-17",
+            symbols_total=2,
+            symbols_success=1,
+            symbols_failed=1,
+            failures=failures,
+            warnings=warnings,
+            config_errors=config_errors,
+        )
+
+        d = _daily_result_dict(result)
+
+        assert d["failures"] == failures
+        assert d["warnings"] == warnings
+        assert d["config_errors"] == config_errors


### PR DESCRIPTION
Closes #2068

## Summary
`feed run backfill/daily --format json` 출력(`_backfill_result_dict`/`_daily_result_dict`)이 `CollectionResult.failures`/`warnings`를 누락하고 config_errors만 포함하던 것을 수정. 리포트 generator(`report/generator.py`)와 동일하게 셋 다 `list(...)`로 직렬화.

## Scope
- `src/ante/feed/cli_output.py` 두 dict 빌더. text 출력/generator/result/symbols_failed(#2117) 무변경.

## Test Plan
- 신규 회귀 6건(backfill/daily × 3키 존재/빈 경우/항목 일치)
- `pytest -k feed` 638 passed, ruff clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)