### PR TITLE
fix(feed): #2047 list_reports를 started_at 기준 정렬 — 같은 날짜 daily/backfill 순서 정정

### DIFF
--- a/src/ante/feed/report/generator.py
+++ b/src/ante/feed/report/generator.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime
 from pathlib import Path
 
 from ante.feed.models.result import CollectionResult
@@ -15,6 +16,9 @@ from ante.feed.models.result import CollectionResult
 logger = logging.getLogger(__name__)
 
 REPORTS_DIR = "reports"
+
+# started_at parse 실패 시 정렬 후순위로 밀기 위한 sentinel(UTC aware).
+_MIN_STARTED_AT = datetime.min.replace(tzinfo=UTC)
 
 
 class ReportGenerator:
@@ -90,15 +94,49 @@ class ReportGenerator:
     def list_reports(self, limit: int = 10) -> list[Path]:
         """최근 리포트 목록을 반환한다.
 
+        각 리포트 JSON의 ``started_at``을 datetime으로 파싱한 값을 기준으로
+        내림차순(최신 우선) 정렬한다. 파일명(``{date}-{mode}.json``)은 같은
+        날짜의 daily/backfill 순서를 사전식으로 오판하므로 정렬 키로 쓰지
+        않는다(#2047).
+
+        ``started_at`` 누락·파싱 실패·파일 읽기 실패 시 해당 파일은 목록에서
+        제외하지 않고 정렬 키를 최소값으로 두어 뒤로 보낸다(전체 실패 방지).
+        같은 ``started_at``끼리는 파일명 역순을 보조 키로 두어 안정 정렬한다.
+
         Args:
             limit: 최대 반환 개수 (최신 순).
 
         Returns:
-            리포트 파일 경로 목록.
+            리포트 파일 경로 목록 (최신 N개).
         """
         reports_dir = self._feed_dir / REPORTS_DIR
         if not reports_dir.exists():
             return []
 
-        files = sorted(reports_dir.glob("*.json"), reverse=True)
+        files = list(reports_dir.glob("*.json"))
+        # started_at 내림차순, tie는 파일명 역순(둘 다 reverse=True와 정합).
+        files.sort(
+            key=lambda path: (self._started_at_key(path), path.name),
+            reverse=True,
+        )
         return files[:limit]
+
+    def _started_at_key(self, path: Path) -> datetime:
+        """정렬용 ``started_at`` datetime(UTC aware)을 반환한다.
+
+        읽기/파싱 실패 또는 ``started_at`` 누락 시 ``_MIN_STARTED_AT``을
+        반환하여 해당 리포트를 후순위로 밀고, 예외는 삼키되 debug 로그로 남긴다.
+        """
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            started_at = raw.get("started_at") if isinstance(raw, dict) else None
+            if not isinstance(started_at, str):
+                logger.debug("리포트 started_at 누락/비문자열: %s", path)
+                return _MIN_STARTED_AT
+            parsed = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            return parsed
+        except (OSError, json.JSONDecodeError, ValueError, TypeError) as exc:
+            logger.debug("리포트 started_at 파싱 실패: %s (%s)", path, exc)
+            return _MIN_STARTED_AT

--- a/tests/unit/feed/test_report.py
+++ b/tests/unit/feed/test_report.py
@@ -344,6 +344,109 @@ class TestReportListReports:
         assert reports[1].name == "2026-03-10-daily.json"
 
 
+def _write_report(reports_dir: Path, filename: str, started_at: str | None) -> None:
+    """started_at만 담은 최소 리포트 JSON을 기록한다(테스트 헬퍼)."""
+    payload: dict = {"mode": filename.split("-")[-1].removesuffix(".json")}
+    if started_at is not None:
+        payload["started_at"] = started_at
+    (reports_dir / filename).write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+class TestListReportsSortedByStartedAt:
+    """list_reports()가 파일명이 아닌 started_at 기준으로 정렬되는지 검증(#2047)."""
+
+    def test_same_date_backfill_after_daily_is_latest(self, feed_dir: Path) -> None:
+        """같은 날짜에서 늦게 끝난 backfill이 최신으로 선택된다.
+
+        파일명 역정렬은 daily('d') > backfill('b')라 daily를 최신으로 오판한다.
+        started_at(daily 07:00Z < backfill 08:00Z) 기준이면 backfill이 최신이다.
+        """
+        reports_dir = feed_dir / REPORTS_DIR
+        reports_dir.mkdir()
+        _write_report(reports_dir, "2026-06-01-daily.json", "2026-06-01T07:00:00Z")
+        _write_report(reports_dir, "2026-06-01-backfill.json", "2026-06-01T08:00:00Z")
+
+        gen = ReportGenerator(feed_dir)
+        reports = gen.list_reports(limit=1)
+
+        assert len(reports) == 1
+        assert reports[0].name == "2026-06-01-backfill.json"
+
+    def test_different_dates_picks_later_date(self, feed_dir: Path) -> None:
+        """날짜가 다르면 늦은 날짜의 리포트가 최신으로 선택된다."""
+        reports_dir = feed_dir / REPORTS_DIR
+        reports_dir.mkdir()
+        _write_report(reports_dir, "2026-06-01-backfill.json", "2026-06-01T08:00:00Z")
+        _write_report(reports_dir, "2026-06-02-daily.json", "2026-06-02T07:00:00Z")
+
+        gen = ReportGenerator(feed_dir)
+        reports = gen.list_reports()
+
+        assert reports[0].name == "2026-06-02-daily.json"
+        assert reports[1].name == "2026-06-01-backfill.json"
+
+    def test_missing_or_malformed_started_at_sorted_last(self, feed_dir: Path) -> None:
+        """started_at 누락/손상 리포트는 크래시 없이 후순위로 밀린다."""
+        reports_dir = feed_dir / REPORTS_DIR
+        reports_dir.mkdir()
+        # 정상 리포트.
+        _write_report(reports_dir, "2026-06-01-daily.json", "2026-06-01T07:00:00Z")
+        # started_at 누락.
+        _write_report(reports_dir, "2026-06-02-daily.json", None)
+        # started_at malformed.
+        _write_report(reports_dir, "2026-06-03-daily.json", "not-a-timestamp")
+        # JSON 자체가 손상.
+        (reports_dir / "2026-06-04-daily.json").write_text("{ broken", encoding="utf-8")
+
+        gen = ReportGenerator(feed_dir)
+        reports = gen.list_reports()
+
+        # 4개 모두 목록에 포함(전체 실패 방지).
+        assert len(reports) == 4
+        # 정상 started_at을 가진 리포트가 가장 앞(최신).
+        assert reports[0].name == "2026-06-01-daily.json"
+        # 키가 동률(min)인 나머지는 파일명 역순 보조키로 안정 정렬.
+        rest = [p.name for p in reports[1:]]
+        assert rest == [
+            "2026-06-04-daily.json",
+            "2026-06-03-daily.json",
+            "2026-06-02-daily.json",
+        ]
+
+    def test_tie_started_at_uses_filename_secondary_key(self, feed_dir: Path) -> None:
+        """동일 started_at(tie)은 파일명 역순 보조키로 안정 정렬된다."""
+        reports_dir = feed_dir / REPORTS_DIR
+        reports_dir.mkdir()
+        same = "2026-06-01T08:00:00Z"
+        _write_report(reports_dir, "2026-06-01-backfill.json", same)
+        _write_report(reports_dir, "2026-06-01-daily.json", same)
+
+        gen = ReportGenerator(feed_dir)
+        reports = gen.list_reports()
+
+        # tie면 파일명 역순: 'daily' > 'backfill'.
+        assert [p.name for p in reports] == [
+            "2026-06-01-daily.json",
+            "2026-06-01-backfill.json",
+        ]
+
+    def test_naive_started_at_is_normalized_aware(self, feed_dir: Path) -> None:
+        """tz 없는 started_at도 UTC aware로 normalize되어 비교 가능하다."""
+        reports_dir = feed_dir / REPORTS_DIR
+        reports_dir.mkdir()
+        # naive(타임존 없음) vs aware Z.
+        _write_report(reports_dir, "2026-06-01-daily.json", "2026-06-01T07:00:00")
+        _write_report(reports_dir, "2026-06-01-backfill.json", "2026-06-01T08:00:00Z")
+
+        gen = ReportGenerator(feed_dir)
+        reports = gen.list_reports(limit=1)
+
+        # naive 비교로 인한 TypeError 없이 backfill(08:00)이 최신.
+        assert reports[0].name == "2026-06-01-backfill.json"
+
+
 class _AnomalyDataGoKrCollector:
     """store merge 이상을 발생시키는 stub data.go.kr collector.
 


### PR DESCRIPTION
Closes #2047

## Summary
`ReportGenerator.list_reports()`가 파일명(`sorted(glob, reverse=True)`) 정렬이라 같은 날짜 daily/backfill이 모두 있으면 알파벳 역순(daily>backfill)으로 daily가 최신으로 잘못 선택되던 버그 수정(`feed status` limit=1 영향).
- 각 리포트의 `started_at`을 datetime parse(`fromisoformat`, Z→+00:00, naive→UTC normalize)한 값 기준 내림차순 정렬
- malformed/누락 → datetime.min(UTC) sentinel로 후순위(크래시 없음, 목록 유지), 파일명 보조키 tie-break
- writer는 UTC Z 일관(strftime %Y-%m-%dT%H:%M:%SZ from now(tz=UTC))

## Scope
- `src/ante/feed/report/generator.py::list_reports`(+helper). schema/파일명규칙/다른 메서드 무변경.

## Test Plan
- 신규 회귀 5건(같은날짜→backfill, 다른날짜, malformed 후순위, tie 파일명, naive normalize)
- `pytest -k 'feed and report'` 41 passed, 전체 유닛 6553 passed, ruff clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)