### PR TITLE
fix(feed): #2029 feed start에서 nice_value 적용 (os.setpriority, best-effort)

### DIFF
--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -165,6 +165,86 @@ def _validate_and_apply_feed_config(config: dict[str, object], fmt: object) -> N
     _validate_guard_config(config, fmt)
 
 
+# `[general].nice_value` 허용 범위. POSIX nice 값 규약(0=기본, 19=최저
+# 우선순위)을 따르며 스펙(docs/specs/data-feed/02-design-decisions.md)의
+# `nice_value = 10  # 0~19` 주석과 일치한다. 음수(우선순위 상승)는 root
+# 권한이 필요하고 수집 작업의 의도(양보)와 반대이므로 허용하지 않는다.
+_NICE_VALUE_MIN = 0
+_NICE_VALUE_MAX = 19
+_NICE_VALUE_DEFAULT = 10
+
+
+def _validate_nice_value(config: dict[str, object], fmt: object) -> int:
+    """``[general].nice_value`` 를 읽어 타입/범위를 검증하고 반환한다 (#2029).
+
+    ``feed start`` 진입 시 1회 fail-loud 검증한다. ``[general]`` 섹션은
+    ``_apply_log_level`` 이 이미 table 임을 보장하므로 여기서는 nice_value
+    자체만 본다(미지정 시 기본값 10). int 가 아니거나 ``0..19`` 범위를
+    벗어나면 구조화 에러(``CONFIG_INVALID_NICE_VALUE``) + ``SystemExit(1)``.
+
+    bool 은 파이썬에서 int 의 subclass 이지만 우선순위 값으로는 무의미하므로
+    명시적으로 거부한다.
+    """
+    general = config.get("general", {})
+    if not isinstance(general, dict):
+        # 방어적: 통상 _apply_log_level 이 먼저 거부하나, 호출 순서에
+        # 의존하지 않도록 여기서도 동일 코드로 거부한다.
+        fmt.error(  # type: ignore[attr-defined]
+            f"[general] 섹션은 table 이어야 합니다 (현재: {type(general).__name__})",
+            code="CONFIG_INVALID_GENERAL",
+        )
+        raise SystemExit(1)
+
+    nice_value = general.get("nice_value", _NICE_VALUE_DEFAULT)
+    if isinstance(nice_value, bool) or not isinstance(nice_value, int):
+        fmt.error(  # type: ignore[attr-defined]
+            f"nice_value 는 정수여야 합니다 "
+            f"(현재: {nice_value!r}, type={type(nice_value).__name__})",
+            code="CONFIG_INVALID_NICE_VALUE",
+        )
+        raise SystemExit(1)
+
+    if not (_NICE_VALUE_MIN <= nice_value <= _NICE_VALUE_MAX):
+        fmt.error(  # type: ignore[attr-defined]
+            f"nice_value 는 {_NICE_VALUE_MIN}..{_NICE_VALUE_MAX} 범위여야 합니다 "
+            f"(현재: {nice_value})",
+            code="CONFIG_INVALID_NICE_VALUE",
+        )
+        raise SystemExit(1)
+
+    return nice_value
+
+
+def _apply_process_nice(nice_value: int) -> None:
+    """현재 프로세스의 nice 값을 ``nice_value`` 절대값으로 설정한다 (#2029).
+
+    스펙(docs/specs/data-feed/08-resource-protection.md)의 "시작 시 프로세스
+    우선순위를 낮춘다" 계약을 ``feed start`` 상주 루프 진입 **전에** 적용한다.
+
+    ``os.nice(n)`` 은 현재 nice 에 ``n`` 을 더하는 누적 증분이라 부모 nice 가
+    0 이 아니면 config 의 ``nice_value`` 를 절대값으로 보장하지 못한다. 따라서
+    절대값을 직접 설정하는 ``os.setpriority(PRIO_PROCESS, 0, nice_value)`` 를
+    사용한다(POSIX). 적용은 best-effort 다 — 권한 부족/비-POSIX 등으로 실패해도
+    수집을 멈추지 않고 ``warning`` 으로 사유만 남긴다(feed start 실패 금지).
+    """
+    import os
+
+    try:
+        os.setpriority(os.PRIO_PROCESS, 0, nice_value)  # type: ignore[attr-defined]
+    except (PermissionError, OSError, AttributeError, ValueError) as exc:
+        # AttributeError: 비-POSIX(os.setpriority/PRIO_PROCESS 부재)
+        # PermissionError/OSError: 권한·플랫폼 제약. ValueError: 범위 밖
+        # (검증을 통과한 값이므로 통상 발생하지 않으나 방어).
+        logger.warning(
+            "프로세스 우선순위(nice=%d) 적용 실패 — 수집은 계속합니다: %s",
+            nice_value,
+            exc,
+        )
+        return
+
+    logger.info("프로세스 우선순위 적용: nice=%d", nice_value)
+
+
 _API_KEY_GUIDE = """\
 ──────────────────────────────────────────────────
 API 키 설정이 필요합니다.
@@ -505,6 +585,9 @@ def feed_start(ctx: click.Context, data_path: str | None) -> None:
 
     config = cfg.load_config()
     _validate_and_apply_feed_config(config, fmt)
+    # #2029: nice_value 를 fail-loud 검증한 뒤 상주 루프 진입 전에 적용한다.
+    # feed start 한정(스펙) — feed run 일회성에는 적용하지 않는다.
+    nice_value = _validate_nice_value(config, fmt)
     schedule = config.get("schedule", {})
     daily_at = (
         schedule.get("daily_at", "16:00") if isinstance(schedule, dict) else "16:00"
@@ -514,6 +597,10 @@ def feed_start(ctx: click.Context, data_path: str | None) -> None:
     )
 
     orchestrator = _build_orchestrator(cfg)
+
+    # #2029: 상주 스케줄러 루프(run_scheduler_loop) 진입 전에 OS 우선순위를
+    # 낮춰 봇이 CPU 를 필요로 할 때 양보하도록 한다. best-effort.
+    _apply_process_nice(nice_value)
 
     # #2030/#2070: 스케줄러 진입 chokepoint 에서 시간 형식을 1회 fail-fast
     # 검증해 non-padded("9:00") 등으로 인한 조용한 미실행을 차단한다.

--- a/tests/unit/feed/test_cli_feed_nice_value.py
+++ b/tests/unit/feed/test_cli_feed_nice_value.py
@@ -1,0 +1,268 @@
+"""feed start 프로세스 우선순위(nice_value) 적용 테스트 (#2029).
+
+스펙(docs/specs/data-feed/08-resource-protection.md)의 "시작 시 프로세스
+우선순위를 낮춘다" 계약을 ``feed start`` 가 상주 루프 진입 전에 적용한다.
+
+- 유효 nice_value(기본 10) → os.setpriority(PRIO_PROCESS, 0, nice_value) 호출.
+- 범위 밖(25, -1)/비-int → 구조화 config error(CONFIG_INVALID_NICE_VALUE) + exit 1.
+- 적용 실패(OSError/PermissionError) → warning + run_scheduler_loop 계속 진입.
+- 비-POSIX(AttributeError) → graceful(루프 계속 진입).
+- feed run 일회성에는 nice 를 적용하지 않는다(스펙 한정, 비목표 회귀).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx: object) -> None:
+                import click
+
+                ctx = click.get_current_context()
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+def _init_with_config(tmp_path: Path, *, nice_value: str | None = "10") -> str:
+    """주어진 nice_value 로 초기화된 데이터 경로를 만든다.
+
+    ``nice_value=None`` 이면 [general] 에 nice_value 키를 생략한다(기본값 경로).
+    """
+    data_dir = tmp_path / "data"
+    feed_dir = data_dir / ".feed"
+    feed_dir.mkdir(parents=True)
+
+    general = '[general]\nlog_level = "INFO"\n'
+    if nice_value is not None:
+        general += f"nice_value = {nice_value}\n"
+    body = (
+        general + "\n[schedule]\n"
+        'daily_at = "16:00"\n'
+        'backfill_at = "01:00"\n'
+        'backfill_since = "2024-01-01"\n\n'
+        "[guard]\n"
+        "blocked_days = []\n"
+        'blocked_hours = ["09:00-15:30"]\n'
+        "pause_during_trading = true\n"
+    )
+    (feed_dir / "config.toml").write_text(body)
+    (feed_dir / "checkpoints").mkdir()
+    (feed_dir / "reports").mkdir()
+    return str(data_dir)
+
+
+def _invoke_start(runner: CliRunner, data_path: str, *, json_fmt: bool = False):  # type: ignore[no-untyped-def]
+    """mock orchestrator + mock run_scheduler_loop 로 feed start 실행."""
+    args = ["feed", "start", "--data-path", data_path]
+    if json_fmt:
+        args = ["--format", "json", *args]
+    with (
+        patch("ante.feed.cli._build_orchestrator") as mock_build,
+        patch(
+            "ante.feed.cli_scheduler.run_scheduler_loop", new_callable=AsyncMock
+        ) as mock_loop,
+    ):
+        mock_build.return_value = AsyncMock()
+        # 상주 루프는 즉시 반환(awaitable)하도록 AsyncMock — 진입 여부만 본다.
+        mock_loop.return_value = None
+        result = runner.invoke(cli, args)
+    return result, mock_loop
+
+
+# ── (a) 유효 nice_value → setpriority 호출 ──────────────────────────────────
+
+
+class TestValidNiceApplied:
+    def test_default_ten_calls_setpriority(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """nice_value=10 → os.setpriority(PRIO_PROCESS, 0, 10) 호출 후 루프 진입."""
+        data_path = _init_with_config(tmp_path, nice_value="10")
+        with patch("os.setpriority") as mock_sp:
+            result, mock_loop = _invoke_start(runner, data_path)
+        assert result.exit_code == 0, result.output
+        mock_sp.assert_called_once_with(os.PRIO_PROCESS, 0, 10)
+        mock_loop.assert_called_once()
+
+    def test_missing_nice_value_uses_default_ten(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """nice_value 미지정 → 기본값 10 으로 setpriority 호출."""
+        data_path = _init_with_config(tmp_path, nice_value=None)
+        with patch("os.setpriority") as mock_sp:
+            result, _ = _invoke_start(runner, data_path)
+        assert result.exit_code == 0, result.output
+        mock_sp.assert_called_once_with(os.PRIO_PROCESS, 0, 10)
+
+    def test_boundary_zero_and_nineteen(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """경계값 0, 19 는 허용되어 setpriority 로 전달된다."""
+        for value in ("0", "19"):
+            data_path = _init_with_config(tmp_path / value, nice_value=value)
+            with patch("os.setpriority") as mock_sp:
+                result, _ = _invoke_start(runner, data_path)
+            assert result.exit_code == 0, result.output
+            mock_sp.assert_called_once_with(os.PRIO_PROCESS, 0, int(value))
+
+
+# ── (b) 범위 밖/비-int → config error ──────────────────────────────────────
+
+
+class TestInvalidNiceRejected:
+    @pytest.mark.parametrize("value", ["25", "20", "-1", "100"])
+    def test_out_of_range_rejected(
+        self, runner: CliRunner, tmp_path: Path, value: str
+    ) -> None:
+        """0..19 범위 밖 → CONFIG_INVALID_NICE_VALUE + exit 1, setpriority 미호출."""
+        data_path = _init_with_config(tmp_path / value.lstrip("-"), nice_value=value)
+        with patch("os.setpriority") as mock_sp:
+            result, mock_loop = _invoke_start(runner, data_path)
+        assert result.exit_code != 0
+        assert "nice_value" in result.output
+        mock_sp.assert_not_called()
+        mock_loop.assert_not_called()
+
+    def test_out_of_range_json_code(self, runner: CliRunner, tmp_path: Path) -> None:
+        """JSON 모드에서 CONFIG_INVALID_NICE_VALUE 코드를 노출한다."""
+        import json
+
+        data_path = _init_with_config(tmp_path, nice_value="25")
+        result, _ = _invoke_start(runner, data_path, json_fmt=True)
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert data["code"] == "CONFIG_INVALID_NICE_VALUE"
+
+    def test_non_int_string_rejected(self, runner: CliRunner, tmp_path: Path) -> None:
+        """nice_value='high' (str) → 거부."""
+        data_path = _init_with_config(tmp_path, nice_value='"high"')
+        with patch("os.setpriority") as mock_sp:
+            result, mock_loop = _invoke_start(runner, data_path)
+        assert result.exit_code != 0
+        assert "nice_value" in result.output
+        mock_sp.assert_not_called()
+        mock_loop.assert_not_called()
+
+    def test_float_rejected(self, runner: CliRunner, tmp_path: Path) -> None:
+        """nice_value=10.5 (float) → 거부."""
+        data_path = _init_with_config(tmp_path, nice_value="10.5")
+        with patch("os.setpriority") as mock_sp:
+            result, _ = _invoke_start(runner, data_path)
+        assert result.exit_code != 0
+        assert "nice_value" in result.output
+        mock_sp.assert_not_called()
+
+    def test_bool_rejected(self, runner: CliRunner, tmp_path: Path) -> None:
+        """nice_value=true (bool) → 거부 (int subclass 이지만 무의미)."""
+        data_path = _init_with_config(tmp_path, nice_value="true")
+        with patch("os.setpriority") as mock_sp:
+            result, _ = _invoke_start(runner, data_path)
+        assert result.exit_code != 0
+        assert "nice_value" in result.output
+        mock_sp.assert_not_called()
+
+
+# ── (c)(d) 적용 실패 best-effort → warning + 루프 계속 진입 ─────────────────
+
+
+class TestApplyBestEffort:
+    def test_oserror_warns_and_continues(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """setpriority 가 OSError → warning 후 run_scheduler_loop 진입(실패 안 함)."""
+        data_path = _init_with_config(tmp_path, nice_value="10")
+        with patch("os.setpriority", side_effect=OSError("nope")) as mock_sp:
+            result, mock_loop = _invoke_start(runner, data_path)
+        assert result.exit_code == 0, result.output
+        mock_sp.assert_called_once()
+        mock_loop.assert_called_once()
+
+    def test_permission_error_warns_and_continues(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """setpriority 가 PermissionError → graceful, 루프 진입."""
+        data_path = _init_with_config(tmp_path, nice_value="10")
+        with patch("os.setpriority", side_effect=PermissionError("denied")) as mock_sp:
+            result, mock_loop = _invoke_start(runner, data_path)
+        assert result.exit_code == 0, result.output
+        mock_sp.assert_called_once()
+        mock_loop.assert_called_once()
+
+    def test_non_posix_attribute_error_graceful(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """비-POSIX(os.setpriority 부재, AttributeError) → graceful, 루프 진입."""
+        data_path = _init_with_config(tmp_path, nice_value="10")
+        with patch(
+            "os.setpriority", side_effect=AttributeError("no setpriority")
+        ) as mock_sp:
+            result, mock_loop = _invoke_start(runner, data_path)
+        assert result.exit_code == 0, result.output
+        mock_sp.assert_called_once()
+        mock_loop.assert_called_once()
+
+
+# ── 비목표 회귀: feed run 에는 nice 미적용 ──────────────────────────────────
+
+
+class TestFeedRunNoNice:
+    def test_feed_run_backfill_does_not_apply_nice(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """feed run backfill 은 nice 를 적용하지 않는다(스펙: feed start 한정)."""
+        from ante.feed.models.result import CollectionResult
+
+        data_path = _init_with_config(tmp_path, nice_value="10")
+        with (
+            patch("ante.feed.cli._build_orchestrator") as mock_build,
+            patch("os.setpriority") as mock_sp,
+        ):
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(
+                return_value=CollectionResult(
+                    mode="backfill",
+                    started_at="2026-03-18T00:00:00Z",
+                    finished_at="2026-03-18T00:00:01Z",
+                    duration_seconds=1.0,
+                )
+            )
+            mock_build.return_value = mock_orch
+            result = runner.invoke(
+                cli, ["feed", "run", "backfill", "--data-path", data_path]
+            )
+        assert result.exit_code == 0, result.output
+        mock_sp.assert_not_called()


### PR DESCRIPTION
Closes #2029

## Summary
`ante feed start`가 `[general].nice_value`(0~19, 기본 10)를 읽어 프로세스 우선순위를 적용하도록 수정(스펙 data-feed/08-resource-protection 계약).
- `feed_start`에서 nice_value 검증(int·0~19, 위반 시 `CONFIG_INVALID_NICE_VALUE` + exit 1)
- `run_scheduler_loop` 진입 전 `os.setpriority(os.PRIO_PROCESS, 0, nice_value)` 적용 — 절대값 보장(os.nice 누적 증분 대신)
- 적용 실패(OSError/PermissionError/AttributeError 비-POSIX) → warning + 수집 계속(best-effort)
- 검증/적용을 feed_start 전용으로 분리 → 공유 chokepoint `_validate_and_apply_feed_config`(feed run도 사용) 미오염

## Scope
- `src/ante/feed/cli.py`(feed_start + 헬퍼 2개). feed run/cgroup/기본값(10) 무변경.

## Test Plan
- 신규 15건(유효/경계/무효 거부/best-effort 실패/비-POSIX/feed run 미적용)
- `pytest -k feed` 653 passed, 전체 유닛 6583 passed, ruff clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)