### PR TITLE
fix(feed): #2015 data.go.kr checkpoint를 written>0에만 전진 + 미공개일 backfill cap

### DIFF
--- a/src/ante/feed/pipeline/backfill_runner.py
+++ b/src/ante/feed/pipeline/backfill_runner.py
@@ -16,7 +16,7 @@ from ante.feed.pipeline.checkpoint import Checkpoint
 from ante.feed.pipeline.dart_collector import DARTCollector
 from ante.feed.pipeline.data_go_kr_collector import DataGoKrCollector
 from ante.feed.pipeline.indicator_calculator import IndicatorCalculator
-from ante.feed.pipeline.scheduler import generate_backfill_dates
+from ante.feed.pipeline.scheduler import generate_backfill_dates, is_business_day
 from ante.feed.sources.dart import (
     CriticalApiError as DARTCriticalError,
 )
@@ -105,6 +105,60 @@ def _parse_strict_backfill_since(value: str) -> date | None:
 def _today_kst() -> date:
     """오늘 날짜(KST 캘린더)를 반환한다."""
     return datetime.now(tz=_KST).date()
+
+
+# data.go.kr OHLCV는 영업일 D의 데이터가 다음 영업일 13:00 KST 이후에
+# 공개된다(스펙 docs/specs/data-feed/05-data-sources.md: "영업일 D+1,
+# 오후 1시 이후"). backfill 상한을 이 deadline이 지난 마지막 영업일로
+# capping해 미공개 날짜를 애초에 시도하지 않는다(quota 보호).
+_DATA_GO_KR_PUBLISH_HOUR_KST = 13
+
+
+def _next_business_day(d: date) -> date:
+    """``d`` 다음의 첫 영업일(주말 skip)을 반환한다.
+
+    ``is_business_day``(scheduler.py)는 weekday만 본다(KR 공휴일 미인식).
+    cap은 보조(quota 보호)일 뿐이며 데이터 무결성은 ``written > 0`` guard가
+    보장하므로, 공휴일 미인식으로 cap이 다소 낙관적이어도 데이터 손실은
+    없다(빈 응답 → checkpoint 미전진 → 재시도).
+    """
+    nxt = d + timedelta(days=1)
+    while not is_business_day(nxt.isoformat()):
+        nxt += timedelta(days=1)
+    return nxt
+
+
+def _last_published_date(now_kst: datetime) -> date:
+    """``now_kst`` 시점에 확실히 공개된 마지막 OHLCV 날짜를 반환한다.
+
+    어제부터 거꾸로 영업일 ``D`` 를 훑으며, ``D`` 의 데이터 공개 deadline
+    (``next_business_day(D)`` 의 13:00 KST)이 ``now_kst`` 이하인 첫 ``D`` 를
+    반환한다. 무한 루프 방지를 위해 최대 14일까지만 거슬러 올라간다(주말 +
+    연속 비영업 구간을 충분히 덮는 보수적 bound). 그 안에 없으면 가장 오래
+    거슬러 올라간 영업일을 반환한다(cap이 과도하게 좁아져도 무결성은 guard가
+    보장).
+
+    Args:
+        now_kst: 기준 시각(KST aware datetime). 테스트는 이 인자를 주입해
+            결정적으로 검증한다.
+
+    Returns:
+        확실히 공개된 마지막 영업일 ``date``.
+    """
+    today = now_kst.date()
+    candidate = today - timedelta(days=1)
+    # 14일 bound: 주말 + 비영업 구간을 덮는 안전 상한(무한 루프 방지).
+    for _ in range(14):
+        if is_business_day(candidate.isoformat()):
+            deadline = datetime.combine(
+                _next_business_day(candidate),
+                datetime.min.time().replace(hour=_DATA_GO_KR_PUBLISH_HOUR_KST),
+                tzinfo=_KST,
+            )
+            if deadline <= now_kst:
+                return candidate
+        candidate -= timedelta(days=1)
+    return candidate
 
 
 def validate_backfill_since(
@@ -281,9 +335,16 @@ class BackfillRunner:
         ohlcv_checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
         last_date = ohlcv_checkpoint.get_last_date()
 
+        # 상한을 KST today 대신 "확실히 공개된 마지막 날짜"로 cap한다(#2015).
+        # 미공개 최근일(D+1 13:00 KST 미도래)을 빈 응답으로 시도해 quota를
+        # 낭비하는 것을 막는다. 데이터 무결성은 written>0 checkpoint guard가
+        # 보장하므로 cap은 보조적이다.
+        published_end = _last_published_date(datetime.now(tz=_KST))
+
         return list(
             generate_backfill_dates(
                 start=backfill_since,
+                end=published_end.isoformat(),
                 last_checkpoint=last_date,
             )
         )
@@ -365,9 +426,17 @@ class BackfillRunner:
                 ctx.add_success(written, syms, warns)
                 if written > 0:
                     ctx.data_types.update(["ohlcv", "fundamental"])
-                # halt 이후에는 checkpoint를 전진시키지 않는다(#2078). 앞선
-                # 실패 날짜 너머로 last_date가 진행되면 그 날짜가 영구 skip된다.
-                if not halt:
+                # checkpoint는 데이터가 실제 저장된 날짜(written > 0)에만
+                # 전진시킨다(#2015). 빈 응답(written == 0: 미공개/지연공개/
+                # 캘린더 미인식 공휴일)에 전진하면 그 날짜가 다음 run에서
+                # last_checkpoint 이전으로 간주되어 영구 skip된다(데이터 손실).
+                # dates는 오름차순이므로 checkpoint = 마지막 written>0 날짜이며,
+                # 내부 빈 날짜는 다음 데이터 날짜에서 jump해 자연 커버(stall 없음),
+                # trailing 빈 날짜는 미전진 → 다음 실행에서 재시도(손실 없음).
+                #
+                # halt 이후에는 written 여부와 무관하게 전진시키지 않는다(#2078).
+                # 앞선 실패 날짜 너머로 last_date가 진행되면 그 날짜가 영구 skip된다.
+                if not halt and written > 0:
                     checkpoint.save(target_date)
 
             except (DataGoKrDailyLimitError, DataGoKrCriticalError) as exc:

--- a/tests/unit/feed/test_backfill_empty_response_checkpoint.py
+++ b/tests/unit/feed/test_backfill_empty_response_checkpoint.py
@@ -1,0 +1,242 @@
+"""data.go.kr backfill 빈 응답(written==0) 날짜의 checkpoint 미전진 검증 (#2015).
+
+``BackfillRunner._collect_data_go_kr`` 는 날짜를 오름차순으로 순회하며 성공
+시 ``checkpoint.save(target_date)`` 를 호출했다. ``written == 0`` 인 빈 응답
+날짜(미공개/지연공개/캘린더 미인식 공휴일)에도 checkpoint를 전진시키면, 그
+날짜가 다음 run에서 ``last_checkpoint`` 이전으로 간주되어 영구 skip된다
+(데이터 손실). 관측: checkpoint=2026-05-31인데 실제 데이터 max=2026-05-28.
+
+수정: ``if not halt and written > 0: checkpoint.save(target_date)``.
+dates는 오름차순이므로 checkpoint = 마지막으로 written>0인 날짜가 되며,
+내부 빈 날짜는 다음 데이터 날짜에서 jump해 커버(stall 없음), trailing 빈
+날짜는 미전진 → 다음 실행에서 재시도(손실 없음).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ante.feed.pipeline.backfill_runner import BackfillRunner, _RunContext
+from ante.feed.pipeline.checkpoint import Checkpoint
+
+
+class _WrittenScriptedCollector:
+    """target_date별 written 행 수를 스크립트로 지정하는 collector 스텁.
+
+    ``BackfillRunner._collect_data_go_kr`` 가 호출하는
+    ``collect(target_date, store) -> (written, syms, warns)`` 시그니처를
+    그대로 구현한다.
+
+    Args:
+        written_by_date: 날짜→written 행 수 맵. 맵에 없는 날짜는 ``default``.
+        default: 맵에 없는 날짜의 written(기본 0 = 빈 응답).
+
+    Attributes:
+        calls: ``collect`` 가 실제로 호출된 ``target_date`` 의 순서 리스트.
+    """
+
+    def __init__(
+        self,
+        written_by_date: dict[str, int],
+        default: int = 0,
+    ) -> None:
+        self._written_by_date = written_by_date
+        self._default = default
+        self.calls: list[str] = []
+
+    async def collect(
+        self,
+        target_date: str,
+        store: object,
+    ) -> tuple[int, set[str], list[dict]]:
+        self.calls.append(target_date)
+        written = self._written_by_date.get(target_date, self._default)
+        # written > 0 인 날짜만 symbol을 보고한다(빈 응답은 symbol 없음).
+        syms = {f"SYM-{target_date[-2:]}"} if written > 0 else set()
+        return written, syms, []
+
+
+async def _run_collect(
+    feed_dir: Path,
+    dates: list[str],
+    written_by_date: dict[str, int],
+) -> tuple[Checkpoint, _RunContext, _WrittenScriptedCollector]:
+    """``_collect_data_go_kr`` 를 직접 호출해 checkpoint/ctx/collector를 반환한다.
+
+    가드(is_blocked_day/is_trading_paused)는 no-op으로 두고, stop_event는
+    None(one-shot)으로 둔다. store는 스텁이 사용하지 않으므로 sentinel.
+    """
+    collector = _WrittenScriptedCollector(written_by_date=written_by_date)
+    checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+    runner = BackfillRunner(data_go_kr_collector=collector)
+    ctx = _RunContext()
+
+    await runner._collect_data_go_kr(
+        dates,
+        {},
+        object(),  # store: 스텁 collect가 사용하지 않음
+        checkpoint,
+        ctx,
+        lambda _config, _date: False,  # is_blocked_day: 항상 거래일
+        lambda _config: False,  # is_trading_paused: 대기 없음
+        None,  # stop_event: one-shot
+    )
+    return checkpoint, ctx, collector
+
+
+# ── 내부 빈 날짜(D1 < H(빈) < D2) → checkpoint = D2 (H jump 커버, 영구 skip 아님)
+
+
+@pytest.mark.asyncio
+async def test_internal_empty_date_is_jumped_not_skipped(
+    tmp_path: Path,
+) -> None:
+    """데이터 D1 < 빈 날짜 H < 데이터 D2: checkpoint=D2.
+
+    H(예: 캘린더 미인식 공휴일)는 데이터가 영원히 없으므로 checkpoint가 H에
+    멈추면 stall된다. 다음 데이터 날짜 D2에서 checkpoint가 jump해 H를 자연
+    커버하므로 stall이 없다. (H는 데이터가 없으니 영구 skip돼도 무손실.)
+    """
+    feed_dir = tmp_path / ".feed"
+    dates = ["2026-01-02", "2026-01-03", "2026-01-05"]
+    checkpoint, ctx, collector = await _run_collect(
+        feed_dir,
+        dates=dates,
+        # 2026-01-03 = 빈 응답(written 0), 양옆은 데이터 있음.
+        written_by_date={"2026-01-02": 1, "2026-01-03": 0, "2026-01-05": 1},
+    )
+
+    # checkpoint는 마지막 written>0 날짜(D2=2026-01-05)로 jump한다.
+    assert checkpoint.get_last_date() == "2026-01-05"
+    # 빈 날짜를 포함해 모든 날짜에 collect 시도됐다(skip 아님 — best-effort).
+    assert collector.calls == dates
+    # 빈 날짜는 success_symbol을 보태지 않는다.
+    assert sorted(ctx.success_symbols) == ["SYM-02", "SYM-05"]
+
+
+# ── trailing 빈 날짜(미공개/지연공개) → checkpoint 미전진(마지막 데이터 날짜 유지)
+
+
+@pytest.mark.asyncio
+async def test_trailing_empty_dates_do_not_advance_checkpoint(
+    tmp_path: Path,
+) -> None:
+    """마지막에 빈 응답 날짜가 이어지면 checkpoint는 마지막 데이터 날짜에 머문다.
+
+    이것이 이슈 #2015의 핵심: 미공개/지연공개 날짜(빈 응답)가 checkpoint를
+    전진시키면 공개 후에도 영구 skip된다. trailing 빈 날짜를 미전진시켜
+    다음 실행에서 재시도(공개되면 수집)할 수 있게 한다.
+    """
+    feed_dir = tmp_path / ".feed"
+    dates = ["2026-05-28", "2026-05-29", "2026-05-30", "2026-05-31"]
+    checkpoint, _ctx, collector = await _run_collect(
+        feed_dir,
+        dates=dates,
+        # 2026-05-28만 데이터, 이후는 미공개(빈 응답).
+        written_by_date={"2026-05-28": 1},
+    )
+
+    # checkpoint는 마지막 데이터 날짜(2026-05-28)에 고정 — 빈 날짜 미전진.
+    # 수정 전 버그에서는 checkpoint=2026-05-31(데이터 max 초과)였다.
+    assert checkpoint.get_last_date() == "2026-05-28"
+    # 빈 날짜에도 collect 시도는 됐다(다음 실행 재시도 경로 확보).
+    assert collector.calls == dates
+
+
+# ── 회귀: 이슈 관측(checkpoint > 데이터 max) 해소 ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_never_exceeds_data_max(
+    tmp_path: Path,
+) -> None:
+    """checkpoint가 실제 데이터 max를 넘지 않는다(이슈 #2015 관측 재현→해소).
+
+    관측: checkpoint=2026-05-31 vs 데이터 max=2026-05-28. written>0 guard로
+    checkpoint가 데이터 max(2026-05-28)를 넘지 못함을 직접 assert한다.
+    """
+    feed_dir = tmp_path / ".feed"
+    dates = ["2026-05-28", "2026-05-29", "2026-05-30", "2026-05-31"]
+    checkpoint, _ctx, _collector = await _run_collect(
+        feed_dir,
+        dates=dates,
+        written_by_date={"2026-05-28": 3},  # 데이터 max = 2026-05-28
+    )
+
+    last = checkpoint.get_last_date()
+    assert last is not None
+    assert last <= "2026-05-28"
+    assert last == "2026-05-28"
+
+
+# ── 빈 응답만 있는 범위 → checkpoint 무전진(손실 없음) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_all_empty_range_does_not_advance_checkpoint(
+    tmp_path: Path,
+) -> None:
+    """범위 전체가 빈 응답이면 checkpoint는 전혀 전진하지 않는다."""
+    feed_dir = tmp_path / ".feed"
+    dates = ["2026-01-02", "2026-01-03", "2026-01-05"]
+    checkpoint, _ctx, collector = await _run_collect(
+        feed_dir,
+        dates=dates,
+        written_by_date={},  # 전부 default=0 (빈 응답)
+    )
+
+    # 어떤 날짜도 written>0이 아니므로 checkpoint는 생성조차 되지 않는다.
+    assert checkpoint.get_last_date() is None
+    assert collector.calls == dates
+
+
+# ── halt 시 written>0이어도 전진 안 함(기존 #2078 가드 정합) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_halt_blocks_advance_even_when_written_positive(
+    tmp_path: Path,
+) -> None:
+    """transient 실패로 halt된 뒤에는 written>0 날짜도 checkpoint를 전진시키지 않는다.
+
+    #2078 halt 가드와 #2015 written>0 가드가 함께 동작해야 한다. 별도
+    collector로 D2 실패를 주입한다(빈 응답이 아닌 예외).
+    """
+
+    class _FailThenWrittenCollector:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def collect(
+            self,
+            target_date: str,
+            store: object,
+        ) -> tuple[int, set[str], list[dict]]:
+            self.calls.append(target_date)
+            if target_date == "2026-01-02":
+                raise RuntimeError("transient")
+            return 1, {f"SYM-{target_date[-2:]}"}, []  # written>0
+
+    feed_dir = tmp_path / ".feed"
+    collector = _FailThenWrittenCollector()
+    checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+    runner = BackfillRunner(data_go_kr_collector=collector)
+    ctx = _RunContext()
+
+    await runner._collect_data_go_kr(
+        ["2026-01-01", "2026-01-02", "2026-01-03"],
+        {},
+        object(),
+        checkpoint,
+        ctx,
+        lambda _config, _date: False,
+        lambda _config: False,
+        None,
+    )
+
+    # D2 실패 → halt. D3(written>0)는 checkpoint를 전진시키지 못함 → D1 고정.
+    assert checkpoint.get_last_date() == "2026-01-01"
+    # best-effort continue: D3도 호출됨.
+    assert collector.calls == ["2026-01-01", "2026-01-02", "2026-01-03"]

--- a/tests/unit/feed/test_backfill_last_published_cap.py
+++ b/tests/unit/feed/test_backfill_last_published_cap.py
@@ -1,0 +1,149 @@
+"""data.go.kr backfill 상한 cap (미공개 날짜 제외) 검증 (#2015).
+
+data.go.kr OHLCV는 영업일 D의 데이터가 다음 영업일 13:00 KST 이후에 공개된다
+(스펙: "영업일 D+1, 오후 1시 이후"). backfill 상한을 KST today 대신 "확실히
+공개된 마지막 날짜"(``_last_published_date``)로 cap해, 미공개 최근일을 빈
+응답으로 시도하는 quota 낭비를 막는다.
+
+cap은 보조(quota 보호)일 뿐이며 데이터 무결성은 written>0 checkpoint guard가
+보장한다. 따라서 cap의 KR 공휴일 미인식 부정확성은 데이터 손실을 유발하지
+않는다(빈 응답 → 미전진 → 재시도). 본 테스트는 cap의 deadline 산술과
+``_resolve_dates`` 의 상한 전달을 결정적으로(now 주입) 검증한다.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from ante.feed.pipeline import backfill_runner
+from ante.feed.pipeline.backfill_runner import (
+    BackfillRunner,
+    _last_published_date,
+    _next_business_day,
+)
+
+_KST = timezone(timedelta(hours=9))
+
+
+def _kst(year: int, month: int, day: int, hour: int) -> datetime:
+    return datetime(year, month, day, hour, 0, tzinfo=_KST)
+
+
+class TestNextBusinessDay:
+    """``_next_business_day`` (주말 skip, weekday만) 검증."""
+
+    def test_weekday_to_next_weekday(self) -> None:
+        # 2026-06-02(화) → 2026-06-03(수)
+        assert _next_business_day(date(2026, 6, 2)) == date(2026, 6, 3)
+
+    def test_friday_skips_weekend_to_monday(self) -> None:
+        # 2026-05-29(금) → 주말(30 토, 31 일) skip → 2026-06-01(월)
+        assert _next_business_day(date(2026, 5, 29)) == date(2026, 6, 1)
+
+    def test_saturday_to_monday(self) -> None:
+        # 2026-05-30(토) → 2026-06-01(월)
+        assert _next_business_day(date(2026, 5, 30)) == date(2026, 6, 1)
+
+
+class TestLastPublishedDate:
+    """``_last_published_date`` deadline(다음 영업일 13:00 KST) 산술 검증."""
+
+    def test_tuesday_afternoon_returns_monday(self) -> None:
+        """화 14:00 → 월.
+
+        어제=월(06-01). 월의 deadline = next_business_day(월)=화(06-02) 13:00.
+        14:00 >= 13:00 → 월(06-01)이 확실히 공개됨.
+        """
+        assert _last_published_date(_kst(2026, 6, 2, 14)) == date(2026, 6, 1)
+
+    def test_tuesday_before_deadline_returns_friday(self) -> None:
+        """화 10:00 → 월의 deadline(화 13:00) 미도래 → 직전 영업일 금.
+
+        어제=월(06-01). 월의 deadline=화(06-02) 13:00 > 10:00 → 월 제외.
+        다음 후보=일(05-31 비영업)→토(05-30 비영업)→금(05-29 영업).
+        금의 deadline = next_business_day(금)=월(06-01) 13:00 <= 화 10:00
+        → 금(05-29)이 확실히 공개됨.
+        """
+        assert _last_published_date(_kst(2026, 6, 2, 10)) == date(2026, 5, 29)
+
+    def test_monday_morning_excludes_friday(self) -> None:
+        """월 10:00 → 금요일 제외(다음 영업일 월 13:00 미도래) → 목.
+
+        어제=일(05-31 비영업)→토(05-30 비영업)→금(05-29 영업).
+        금의 deadline = next_business_day(금)=월(06-01) 13:00 > 월 10:00
+        → 금 제외. 다음 후보=목(05-28). 목의 deadline=금(05-29) 13:00 <=
+        월 10:00 → 목(2026-05-28)이 확실히 공개됨.
+        """
+        assert _last_published_date(_kst(2026, 6, 1, 10)) == date(2026, 5, 28)
+
+    def test_monday_afternoon_includes_friday(self) -> None:
+        """월 14:00 → 금(05-29)까지 공개.
+
+        금의 deadline=월(06-01) 13:00 <= 월 14:00 → 금(05-29) 포함.
+        """
+        assert _last_published_date(_kst(2026, 6, 1, 14)) == date(2026, 5, 29)
+
+    def test_deadline_at_exactly_13_is_inclusive(self) -> None:
+        """deadline 정각(13:00)은 공개된 것으로 본다(<= 비교)."""
+        # 화 13:00 정각 → 월(06-01)의 deadline(화 13:00)과 동일 → 월 포함.
+        assert _last_published_date(_kst(2026, 6, 2, 13)) == date(2026, 6, 1)
+
+
+class TestResolveDatesCap:
+    """``_resolve_dates`` 가 cap된 상한으로 미공개 날짜를 제외하는지 검증."""
+
+    def test_resolve_dates_excludes_unpublished_recent(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """checkpoint 없이 backfill 시 미공개 최근일(today/지연공개)이 제외된다.
+
+        now=화 10:00 (2026-06-02 10:00). last_published=금(2026-05-29).
+        backfill_since를 2026-05-25(월)로 두면 범위 상한이 today(06-02)가
+        아니라 2026-05-29로 cap돼야 한다(06-01 월, 06-02 화 미포함).
+        """
+
+        class _FixedDatetime(datetime):
+            @classmethod
+            def now(cls, tz: timezone | None = None) -> datetime:
+                base = _kst(2026, 6, 2, 10)
+                return base if tz is None else base.astimezone(tz)
+
+        monkeypatch.setattr(backfill_runner, "datetime", _FixedDatetime)
+
+        feed_dir = tmp_path / ".feed"
+        config = {"schedule": {"backfill_since": "2026-05-25"}}
+        dates = BackfillRunner._resolve_dates(config, feed_dir)
+
+        # 상한이 2026-05-29(금)로 cap — 미공개 06-01/06-02 미포함.
+        assert dates[-1] == "2026-05-29"
+        assert "2026-06-01" not in dates
+        assert "2026-06-02" not in dates
+        # 시작은 backfill_since(2026-05-25) 그대로.
+        assert dates[0] == "2026-05-25"
+
+    def test_backfill_since_after_last_published_yields_empty(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """backfill_since > last_published 이면 빈 목록(아직 공개된 날짜 없음)."""
+
+        class _FixedDatetime(datetime):
+            @classmethod
+            def now(cls, tz: timezone | None = None) -> datetime:
+                base = _kst(2026, 6, 2, 10)  # last_published = 2026-05-29
+                return base if tz is None else base.astimezone(tz)
+
+        monkeypatch.setattr(backfill_runner, "datetime", _FixedDatetime)
+
+        feed_dir = tmp_path / ".feed"
+        # since(2026-06-01) > last_published(2026-05-29) → start > end → empty.
+        config = {"schedule": {"backfill_since": "2026-06-01"}}
+        dates = BackfillRunner._resolve_dates(config, feed_dir)
+
+        assert dates == []


### PR DESCRIPTION
Closes #2015

## Summary
data.go.kr backfill이 빈 응답(미공개/지연공개) 날짜도 checkpoint를 전진시켜 그 구간을 영구 skip(데이터 누락)하던 P1 버그 수정.

**Primary (데이터 무결성)**: `checkpoint.save(target_date)`를 `if not halt and written > 0:`로 가드 → checkpoint=마지막 데이터 날짜. 오름차순 처리라 내부 빈 날짜(공휴일)는 다음 데이터 날짜에서 jump 커버(stall 없음), trailing 빈 날짜는 미전진→다음 실행 재시도(손실 없음). KR 캘린더 불필요.

**Secondary (quota 최적화)**: `_last_published_date`(영업일 D 중 next_business_day(D) 13:00 KST deadline 지난 마지막 D)로 backfill 상한 cap → 미공개 최근일 재시도 quota 낭비 감소. 무결성은 Primary가 보장(cap 부정확성 무관).

## Scope
- `src/ante/feed/pipeline/backfill_runner.py`(+is_business_day import). DART(#2028)/KR캘린더/#2078 halt 무변경.

## Test Plan
- 신규 테스트(interior-empty jump / trailing-empty retry / checkpoint≤데이터max(이슈 재현→해소) / cap 산술 / halt 정합)
- `pytest -k 'backfill or feed'` 673 passed, 전체 유닛 6603 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)