### PR TITLE
fix(broker): #2126 KIS 조회 메서드 CTX_AREA/tr_cont pagination 처리

### DIFF
--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -59,6 +59,12 @@ DEFAULT_BACKOFF_BASE = 1.0
 DEFAULT_CB_FAILURE_THRESHOLD = 5
 DEFAULT_CB_RECOVERY_TIMEOUT = 60
 
+# KIS 연속조회(CTX_AREA) 페이지네이션
+# 응답 헤더 tr_cont 값: "F"/"M" = 다음 페이지 있음, "D"/"E" = 마지막 페이지.
+_TR_CONT_HAS_NEXT = frozenset({"F", "M"})
+# 무한 루프 방지용 최대 페이지 수 안전 상한.
+DEFAULT_MAX_PAGINATION_PAGES = 100
+
 # 주문 관련 tr_id (재시도 횟수 분류용)
 _ORDER_TR_IDS = frozenset(
     {
@@ -431,8 +437,34 @@ class KISBaseAdapter(BrokerAdapter):
     ) -> dict[str, Any]:
         """API 요청 공통 래퍼 (circuit breaker + 재시도 + 타임아웃).
 
+        body dict만 반환한다. 주문 접수/취소 등 비페이지 호출자가 사용하며,
+        응답 ``tr_cont`` 헤더가 필요한 연속조회 경로는 ``_request_with_cont``
+        를 사용한다.
+
         조율만 담당하며, 에러 분류는 KISErrorClassifier,
         재시도 전략은 KISRetryHandler에 위임한다.
+        """
+        body, _ = await self._request_with_cont(
+            method, url, tr_id, params=params, json_data=json_data
+        )
+        return body
+
+    async def _request_with_cont(
+        self,
+        method: str,
+        url: str,
+        tr_id: str,
+        params: dict[str, str] | None = None,
+        json_data: dict[str, Any] | None = None,
+        cont_header: str = "",
+    ) -> tuple[dict[str, Any], str]:
+        """API 요청 공통 래퍼 (circuit breaker + 재시도 + 타임아웃).
+
+        ``(body, tr_cont)`` 튜플을 반환하는 페이지네이션 전용 저수준 변형.
+        circuit-breaker / 재시도 / rate-limit / 타임아웃 정책을 ``_request``
+        와 **동일하게 공유**한다 (로직 중복 금지). ``cont_header`` 는 KIS 연속
+        조회 요청 헤더 ``tr_cont`` 값("" 최초 / "N" 다음)이며, 반환 두 번째
+        값은 응답 헤더 ``tr_cont`` ("F"/"M"=다음 있음 / "D"/"E"=마지막)이다.
         """
         self._circuit_breaker.check()
         await self._ensure_authenticated()
@@ -441,6 +473,8 @@ class KISBaseAdapter(BrokerAdapter):
         max_retries = self._get_max_retries(url, tr_id)
         timeout = self._timeout_order if tr_id in _ORDER_TR_IDS else self._timeout_query
         headers = self._get_headers(tr_id)
+        if cont_header:
+            headers["tr_cont"] = cont_header
         last_error: Exception | None = None
 
         for attempt in range(max_retries + 1):
@@ -473,19 +507,93 @@ class KISBaseAdapter(BrokerAdapter):
         params: dict[str, str] | None,
         json_data: dict[str, Any] | None,
         timeout: float,
-    ) -> dict[str, Any]:
-        """단일 HTTP 요청 실행 (타임아웃 적용)."""
+    ) -> tuple[dict[str, Any], str]:
+        """단일 HTTP 요청 실행 (타임아웃 적용).
+
+        ``(body, tr_cont)`` 튜플을 반환한다. ``tr_cont`` 는 KIS 연속조회 응답
+        헤더이며, 헤더가 없으면 빈 문자열이다. GET/POST 양쪽 모두 헤더를
+        캡처하되 의미 있는 값은 GET 조회 경로에서만 사용된다.
+        """
         async with asyncio.timeout(timeout):
             if method == "GET":
                 async with self._session.get(
                     url, headers=headers, params=params
                 ) as resp:
-                    return await self._handle_response(resp)
+                    body = await self._handle_response(resp)
+                    return body, resp.headers.get("tr_cont", "")
             else:
                 async with self._session.post(
                     url, headers=headers, json=json_data
                 ) as resp:
-                    return await self._handle_response(resp)
+                    body = await self._handle_response(resp)
+                    return body, resp.headers.get("tr_cont", "")
+
+    async def _request_paginated(
+        self,
+        method: str,
+        url: str,
+        tr_id: str,
+        base_params: dict[str, str],
+        row_key: str,
+    ) -> list[dict[str, Any]]:
+        """KIS 연속조회(CTX_AREA + tr_cont)를 따라 전 페이지 행을 누적한다.
+
+        ``base_params`` 는 첫 페이지 요청 파라미터이며 ``CTX_AREA_FK100`` /
+        ``CTX_AREA_NK100`` 은 빈 문자열로 시작한다(호출자가 전달). ``row_key``
+        로 지정한 단일 행 리스트(예: ``"output1"`` / ``"output"``)만 누적하며,
+        ``output2`` 같은 summary/metadata 는 누적하지 않는다.
+
+        연속 규약:
+            - 최초 요청: 요청 헤더 ``tr_cont`` = "" + cursor = "".
+            - 응답 헤더 ``tr_cont`` 가 "F"/"M" 이면 body 의 ``ctx_area_fk100`` /
+              ``ctx_area_nk100`` 를 다음 요청 ``CTX_AREA_FK100`` /
+              ``CTX_AREA_NK100`` 로 넣고 요청 헤더 ``tr_cont`` = "N" 로 재호출.
+            - "D"/"E"(또는 그 외) 이면 마지막 페이지로 보고 종료.
+
+        가드:
+            - "F"/"M" 인데 다음 cursor 가 비어 있으면 무한루프/누락을 막기 위해
+              ``logger.warning`` 후 중단(잔여 페이지 누락 가능성 surface).
+            - 최대 페이지 수(``DEFAULT_MAX_PAGINATION_PAGES``) 도달 시
+              ``logger.warning`` 후 중단.
+        """
+        rows: list[dict[str, Any]] = []
+        params = dict(base_params)
+        cont_header = ""
+
+        for page in range(1, DEFAULT_MAX_PAGINATION_PAGES + 1):
+            body, tr_cont = await self._request_with_cont(
+                method, url, tr_id, params=params, cont_header=cont_header
+            )
+            page_rows = body.get(row_key) or []
+            rows.extend(page_rows)
+
+            if tr_cont not in _TR_CONT_HAS_NEXT:
+                # "D"/"E" 또는 헤더 부재 → 마지막 페이지.
+                break
+
+            next_fk = str(body.get("ctx_area_fk100", "") or "").strip()
+            next_nk = str(body.get("ctx_area_nk100", "") or "").strip()
+            if not next_fk and not next_nk:
+                logger.warning(
+                    "KIS 연속조회 cursor 누락 [%s] tr_cont=%s page=%d "
+                    "(잔여 페이지 누락 가능)",
+                    tr_id,
+                    tr_cont,
+                    page,
+                )
+                break
+
+            params["CTX_AREA_FK100"] = next_fk
+            params["CTX_AREA_NK100"] = next_nk
+            cont_header = "N"
+        else:
+            logger.warning(
+                "KIS 연속조회 최대 페이지(%d) 도달 [%s] (잔여 페이지 누락 가능)",
+                DEFAULT_MAX_PAGINATION_PAGES,
+                tr_id,
+            )
+
+        return rows
 
     # ── 서브클래스 확장 포인트 ──────────────────────
 
@@ -627,13 +735,15 @@ class KISDomesticAdapter(KISBaseAdapter):
         }
 
     async def get_positions(self) -> list[dict[str, Any]]:
-        """보유 포지션 조회."""
+        """보유 포지션 조회 (CTX_AREA 연속조회로 전 페이지 누적)."""
         tr_id = "VTTC8434R" if self.is_paper else "TTTC8434R"
         url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-balance"
-        result = await self._request("GET", url, tr_id, params=self._balance_params())
+        rows = await self._request_paginated(
+            "GET", url, tr_id, self._balance_params(), row_key="output1"
+        )
 
         positions = []
-        for item in result.get("output1", []):
+        for item in rows:
             qty = float(item.get("hldg_qty", 0))
             if qty > 0:
                 positions.append(
@@ -762,7 +872,7 @@ class KISDomesticAdapter(KISBaseAdapter):
         return True
 
     async def get_order_status(self, order_id: str) -> dict[str, Any]:
-        """주문 상태 조회."""
+        """주문 상태 조회 (CTX_AREA 연속조회로 전 페이지 확보 후 검색)."""
         tr_id = "VTTC8036R" if self.is_paper else "TTTC8036R"
         url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl"
         params = {
@@ -773,9 +883,11 @@ class KISDomesticAdapter(KISBaseAdapter):
             "INQR_DVSN_1": "1",
             "INQR_DVSN_2": "0",
         }
-        result = await self._request("GET", url, tr_id, params=params)
+        orders = await self._request_paginated(
+            "GET", url, tr_id, params, row_key="output"
+        )
 
-        for order in result.get("output", []):
+        for order in orders:
             if order.get("odno") == order_id:
                 return {
                     "order_id": order["odno"],
@@ -792,7 +904,7 @@ class KISDomesticAdapter(KISBaseAdapter):
         raise OrderNotFoundError(f"Order {order_id} not found")
 
     async def get_pending_orders(self) -> list[dict[str, Any]]:
-        """미체결 주문 목록 조회."""
+        """미체결 주문 목록 조회 (CTX_AREA 연속조회로 전 페이지 누적)."""
         tr_id = "VTTC8036R" if self.is_paper else "TTTC8036R"
         url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl"
         params = {
@@ -803,10 +915,12 @@ class KISDomesticAdapter(KISBaseAdapter):
             "INQR_DVSN_1": "1",
             "INQR_DVSN_2": "0",
         }
-        result = await self._request("GET", url, tr_id, params=params)
+        rows = await self._request_paginated(
+            "GET", url, tr_id, params, row_key="output"
+        )
 
         orders = []
-        for order in result.get("output", []):
+        for order in rows:
             orders.append(
                 {
                     "order_id": order.get("odno", ""),
@@ -947,7 +1061,7 @@ class KISDomesticAdapter(KISBaseAdapter):
         from_date: str | None = None,
         to_date: str | None = None,
     ) -> list[dict[str, Any]]:
-        """주문/체결 이력 조회."""
+        """주문/체결 이력 조회 (CTX_AREA 연속조회로 전 페이지 누적 후 fold)."""
         tr_id = "VTTC8001R" if self.is_paper else "TTTC8001R"
         url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-daily-ccld"
 
@@ -969,8 +1083,10 @@ class KISDomesticAdapter(KISBaseAdapter):
             "CTX_AREA_NK100": "",
         }
 
-        result = await self._request("GET", url, tr_id, params=params)
-        return self._fold_order_history(result.get("output1", []))
+        rows = await self._request_paginated(
+            "GET", url, tr_id, params, row_key="output1"
+        )
+        return self._fold_order_history(rows)
 
     @staticmethod
     def _fold_order_history(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -218,6 +218,9 @@ class TestKISAdapterAPI:
         resp.status = status
         resp.json = AsyncMock(return_value=json_data)
         resp.text = AsyncMock(return_value="error text")
+        # 연속조회 헤더 tr_cont (#2126): 단일 페이지로 끝나도록 "D" 고정.
+        # 실제 dict 로 지정해 AsyncMock 자동 속성(미await coroutine) 경고를 막는다.
+        resp.headers = {"tr_cont": "D"}
         resp.__aenter__ = AsyncMock(return_value=resp)
         resp.__aexit__ = AsyncMock(return_value=False)
         return resp

--- a/tests/unit/test_kis_pagination.py
+++ b/tests/unit/test_kis_pagination.py
@@ -1,0 +1,442 @@
+"""KIS 조회 메서드 CTX_AREA/tr_cont 연속조회(pagination) 테스트 (#2126).
+
+KISDomesticAdapter 조회 메서드가 2페이지 이후 잔고·미체결·체결이력을 누락하지
+않도록, 응답 헤더 ``tr_cont`` 와 body ``ctx_area_fk100/nk100`` cursor 를 따라
+전 페이지를 누적하는지 검증한다.
+
+검증 축:
+    (a) 단일 페이지(tr_cont="D") → 1회 호출.
+    (b) 2페이지(F→D) → cursor 가 다음 요청 params 로 전달 + 2회 호출 + 전행 누적.
+    (c) tr_cont="F"/"M" 인데 cursor 비어 있음 → warning + 중단.
+    (d) max-page 안전 상한 도달 → warning + 중단.
+    (e) 5개 메서드 각각 다중 페이지 누적.
+    (f) 비페이지 _request 호출자(주문 등) 회귀 — body-only 보존.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ante.broker.kis import DEFAULT_MAX_PAGINATION_PAGES, KISDomesticAdapter
+
+_CONFIG = {
+    "app_key": "test-key",
+    "app_secret": "test-secret",
+    "account_no": "1234567890",
+    "is_paper": True,
+}
+
+
+def _make_adapter() -> KISDomesticAdapter:
+    """네트워크 없이 페이지 루프만 검증하기 위한 어댑터."""
+    return KISDomesticAdapter(config=_CONFIG)
+
+
+def _page(
+    rows: list[dict[str, Any]], row_key: str, *, fk: str = "", nk: str = ""
+) -> dict[str, Any]:
+    """단일 페이지 응답 body 구성."""
+    return {
+        "rt_cd": "0",
+        row_key: rows,
+        "ctx_area_fk100": fk,
+        "ctx_area_nk100": nk,
+    }
+
+
+# ── _request_paginated 코어 동작 ──────────────────────────────
+
+
+async def test_single_page_stops_after_one_call() -> None:
+    """tr_cont="D" 단일 페이지 → 1회 호출, 그 행만 누적."""
+    adapter = _make_adapter()
+    body = _page([{"id": "a"}], "output1")
+    adapter._request_with_cont = AsyncMock(return_value=(body, "D"))  # type: ignore[method-assign]
+
+    rows = await adapter._request_paginated(
+        "GET",
+        "url",
+        "TR",
+        {"CTX_AREA_FK100": "", "CTX_AREA_NK100": ""},
+        row_key="output1",
+    )
+
+    assert rows == [{"id": "a"}]
+    assert adapter._request_with_cont.call_count == 1
+    # 최초 요청 헤더 tr_cont="" (cont_header 미전달 또는 "").
+    _, kwargs = adapter._request_with_cont.call_args
+    assert kwargs.get("cont_header", "") == ""
+
+
+async def test_two_pages_passes_cursor_and_accumulates() -> None:
+    """F→D 2페이지: cursor 가 다음 요청 params 로 전달 + 2회 + 전행 누적.
+
+    ``_request_paginated`` 가 단일 ``params`` dict 를 재사용·mutate 하므로
+    ``call_args_list`` 의 dict 참조는 마지막 상태를 가리킨다. 호출 시점의
+    cursor/헤더 값을 side_effect 안에서 스냅샷해 검증한다.
+    """
+    adapter = _make_adapter()
+    page1 = _page([{"id": "a"}], "output1", fk="FK-NEXT", nk="NK-NEXT")
+    page2 = _page([{"id": "b"}], "output1")
+    responses = iter([(page1, "F"), (page2, "D")])
+    snapshots: list[tuple[str, str, str]] = []
+
+    async def fake(method, url, tr_id, params=None, json_data=None, cont_header=""):  # type: ignore[no-untyped-def]
+        snapshots.append(
+            (
+                params["CTX_AREA_FK100"],
+                params["CTX_AREA_NK100"],
+                cont_header,
+            )
+        )
+        return next(responses)
+
+    adapter._request_with_cont = fake  # type: ignore[method-assign]
+
+    rows = await adapter._request_paginated(
+        "GET",
+        "url",
+        "TR",
+        {"CTX_AREA_FK100": "", "CTX_AREA_NK100": ""},
+        row_key="output1",
+    )
+
+    assert rows == [{"id": "a"}, {"id": "b"}]
+    assert len(snapshots) == 2
+    # 1페이지: cursor 빈 값, 헤더 tr_cont="".
+    assert snapshots[0] == ("", "", "")
+    # 2페이지: 직전 body cursor 가 다음 요청 params 로 + 헤더 tr_cont="N".
+    assert snapshots[1] == ("FK-NEXT", "NK-NEXT", "N")
+
+
+async def test_first_page_params_not_mutated() -> None:
+    """호출자가 넘긴 base_params 원본은 변형되지 않는다."""
+    adapter = _make_adapter()
+    page1 = _page([{"id": "a"}], "output", fk="FK", nk="NK")
+    page2 = _page([{"id": "b"}], "output")
+    adapter._request_with_cont = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[(page1, "M"), (page2, "E")]
+    )
+    base = {"CTX_AREA_FK100": "", "CTX_AREA_NK100": "", "X": "1"}
+
+    await adapter._request_paginated("GET", "url", "TR", base, row_key="output")
+
+    assert base == {"CTX_AREA_FK100": "", "CTX_AREA_NK100": "", "X": "1"}
+
+
+async def test_has_next_but_empty_cursor_warns_and_stops(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """tr_cont="F"/"M" 인데 cursor 비어 있음 → warning + 중단(무한루프 방지)."""
+    adapter = _make_adapter()
+    body = _page([{"id": "a"}], "output1", fk="", nk="")
+    adapter._request_with_cont = AsyncMock(return_value=(body, "F"))  # type: ignore[method-assign]
+
+    with caplog.at_level("WARNING"):
+        rows = await adapter._request_paginated(
+            "GET",
+            "url",
+            "TR",
+            {"CTX_AREA_FK100": "", "CTX_AREA_NK100": ""},
+            row_key="output1",
+        )
+
+    assert rows == [{"id": "a"}]
+    assert adapter._request_with_cont.call_count == 1
+    assert any("cursor 누락" in r.message for r in caplog.records)
+
+
+async def test_max_page_cap_warns_and_stops(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """매 페이지 tr_cont="F" + cursor 유효 → max-page 상한 도달 시 warning + 중단."""
+    adapter = _make_adapter()
+    # 항상 다음 페이지가 있다고 응답 (cursor 도 항상 유효) → 상한이 유일한 종료조건.
+    adapter._request_with_cont = AsyncMock(  # type: ignore[method-assign]
+        return_value=(_page([{"id": "x"}], "output1", fk="F", nk="N"), "F")
+    )
+
+    with caplog.at_level("WARNING"):
+        rows = await adapter._request_paginated(
+            "GET",
+            "url",
+            "TR",
+            {"CTX_AREA_FK100": "", "CTX_AREA_NK100": ""},
+            row_key="output1",
+        )
+
+    assert adapter._request_with_cont.call_count == DEFAULT_MAX_PAGINATION_PAGES
+    assert len(rows) == DEFAULT_MAX_PAGINATION_PAGES
+    assert any("최대 페이지" in r.message for r in caplog.records)
+
+
+async def test_only_row_key_accumulated_not_output2() -> None:
+    """row_key 행만 누적하고 output2(summary/metadata)는 누적 금지."""
+    adapter = _make_adapter()
+    body = {
+        "rt_cd": "0",
+        "output1": [{"id": "a"}],
+        "output2": [{"summary": "should-not-accumulate"}],
+        "ctx_area_fk100": "",
+        "ctx_area_nk100": "",
+    }
+    adapter._request_with_cont = AsyncMock(return_value=(body, "D"))  # type: ignore[method-assign]
+
+    rows = await adapter._request_paginated(
+        "GET",
+        "url",
+        "TR",
+        {"CTX_AREA_FK100": "", "CTX_AREA_NK100": ""},
+        row_key="output1",
+    )
+
+    assert rows == [{"id": "a"}]
+    assert all("summary" not in r for r in rows)
+
+
+async def test_missing_row_key_yields_empty() -> None:
+    """row_key 자체가 없거나 None 이면 빈 누적으로 안전 처리."""
+    adapter = _make_adapter()
+    body = {"rt_cd": "0", "output1": None, "ctx_area_fk100": "", "ctx_area_nk100": ""}
+    adapter._request_with_cont = AsyncMock(return_value=(body, "D"))  # type: ignore[method-assign]
+
+    rows = await adapter._request_paginated("GET", "url", "TR", {}, row_key="output1")
+
+    assert rows == []
+
+
+# ── 5개 메서드 적용: 다중 페이지 누적 ───────────────────────
+
+
+async def test_get_positions_accumulates_all_pages() -> None:
+    """get_positions: output1 2페이지(F→D) → 양 페이지 포지션 모두 반환."""
+    adapter = _make_adapter()
+    p1 = _page([{"pdno": "005930", "hldg_qty": "10"}], "output1", fk="FK1", nk="NK1")
+    p2 = _page([{"pdno": "000660", "hldg_qty": "5"}], "output1")
+    adapter._request_with_cont = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[(p1, "F"), (p2, "D")]
+    )
+
+    positions = await adapter.get_positions()
+
+    symbols = {p["symbol"] for p in positions}
+    assert symbols == {"005930", "000660"}
+    assert adapter._request_with_cont.call_count == 2
+
+
+async def test_get_account_positions_accumulates_via_positions() -> None:
+    """get_account_positions 는 get_positions 에 위임 → 다중 페이지 자동 커버."""
+    adapter = _make_adapter()
+    p1 = _page([{"pdno": "005930", "hldg_qty": "10"}], "output1", fk="FK", nk="NK")
+    p2 = _page([{"pdno": "000660", "hldg_qty": "5"}], "output1")
+    adapter._request_with_cont = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[(p1, "M"), (p2, "E")]
+    )
+
+    recon = await adapter.get_account_positions()
+
+    assert {r["symbol"] for r in recon} == {"005930", "000660"}
+    assert adapter._request_with_cont.call_count == 2
+
+
+async def test_get_pending_orders_accumulates_all_pages() -> None:
+    """get_pending_orders: output 2페이지 → 양 페이지 주문 모두 반환."""
+    adapter = _make_adapter()
+    o1 = _page(
+        [{"odno": "0001", "sll_buy_dvsn_cd": "02", "ord_qty": "10"}],
+        "output",
+        fk="FK1",
+        nk="NK1",
+    )
+    o2 = _page([{"odno": "0002", "sll_buy_dvsn_cd": "01", "ord_qty": "20"}], "output")
+    adapter._request_with_cont = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[(o1, "F"), (o2, "D")]
+    )
+
+    orders = await adapter.get_pending_orders()
+
+    assert {o["order_id"] for o in orders} == {"0001", "0002"}
+    assert adapter._request_with_cont.call_count == 2
+
+
+async def test_get_order_status_finds_order_on_second_page() -> None:
+    """get_order_status: 2페이지에만 있는 주문도 전 페이지 확보 후 검색 성공."""
+    adapter = _make_adapter()
+    o1 = _page(
+        [{"odno": "0001", "sll_buy_dvsn_cd": "02"}], "output", fk="FK1", nk="NK1"
+    )
+    o2 = _page(
+        [
+            {
+                "odno": "0002",
+                "sll_buy_dvsn_cd": "01",
+                "ord_qty": "20",
+                "tot_ccld_qty": "5",
+                "rmn_qty": "15",
+                "ord_stat_cd": "20",
+            }
+        ],
+        "output",
+    )
+    adapter._request_with_cont = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[(o1, "F"), (o2, "D")]
+    )
+
+    status = await adapter.get_order_status("0002")
+
+    assert status["order_id"] == "0002"
+    assert status["status"] == "partial_filled"
+    # early-return 대신 전 페이지 확보: 2페이지 모두 조회.
+    assert adapter._request_with_cont.call_count == 2
+
+
+async def test_get_order_history_accumulates_then_folds() -> None:
+    """get_order_history: 2페이지 누적 후 _fold_order_history 1회 적용."""
+    adapter = _make_adapter()
+    h1 = _page(
+        [
+            {
+                "odno": "0001",
+                "tot_ccld_qty": "40",
+                "tot_ccld_amt": "400000",
+                "ord_dt": "20260529",
+                "sll_buy_dvsn_cd": "02",
+            }
+        ],
+        "output1",
+        fk="FK1",
+        nk="NK1",
+    )
+    # 같은 odno/영업일의 더 큰 누적 행이 다음 페이지에 → fold 가 양쪽을 합산해야.
+    h2 = _page(
+        [
+            {
+                "odno": "0001",
+                "tot_ccld_qty": "100",
+                "tot_ccld_amt": "1020000",
+                "ord_dt": "20260529",
+                "sll_buy_dvsn_cd": "02",
+            },
+            {
+                "odno": "0002",
+                "tot_ccld_qty": "10",
+                "tot_ccld_amt": "100000",
+                "ord_dt": "20260529",
+                "sll_buy_dvsn_cd": "01",
+            },
+        ],
+        "output1",
+    )
+    adapter._request_with_cont = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[(h1, "F"), (h2, "D")]
+    )
+
+    history = await adapter.get_order_history()
+
+    by_id = {h["order_id"]: h for h in history}
+    assert set(by_id) == {"0001", "0002"}
+    # fold 가 2페이지에 걸친 같은 odno 행을 max 누적으로 합산.
+    assert by_id["0001"]["filled_quantity"] == 100.0
+    assert by_id["0001"]["price"] == 10200.0
+    assert adapter._request_with_cont.call_count == 2
+
+
+async def test_get_order_status_not_found_raises_after_all_pages() -> None:
+    """전 페이지 확보 후에도 못 찾으면 OrderNotFoundError."""
+    from ante.broker.exceptions import OrderNotFoundError
+
+    adapter = _make_adapter()
+    o1 = _page([{"odno": "0001"}], "output", fk="FK1", nk="NK1")
+    o2 = _page([{"odno": "0002"}], "output")
+    adapter._request_with_cont = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[(o1, "F"), (o2, "D")]
+    )
+
+    with pytest.raises(OrderNotFoundError):
+        await adapter.get_order_status("9999")
+    assert adapter._request_with_cont.call_count == 2
+
+
+# ── _request body-only 회귀 (비페이지 호출자 보존) ──────────
+
+
+async def test_request_returns_body_only() -> None:
+    """_request 는 (body, tr_cont) 가 아닌 body dict 만 반환(주문 등 호출자 보존)."""
+    adapter = _make_adapter()
+    body = {"rt_cd": "0", "output": {"ODNO": "0001"}}
+    adapter._send_http = AsyncMock(return_value=(body, "D"))  # type: ignore[method-assign]
+    adapter._circuit_breaker = MagicMock()
+    adapter._ensure_authenticated = AsyncMock()  # type: ignore[method-assign]
+    adapter._rate_limit_wait = AsyncMock()  # type: ignore[method-assign]
+
+    result = await adapter._request("POST", "url", "TTTC0802U", json_data={"x": "1"})
+
+    assert result == body
+    assert isinstance(result, dict)
+
+
+async def test_place_order_unaffected_by_pagination_change() -> None:
+    """주문 접수는 _request(body-only) 경로 그대로 — ODNO 추출 회귀."""
+    adapter = _make_adapter()
+    body = {"rt_cd": "0", "output": {"ODNO": "BROKER-123"}}
+    with patch.object(
+        adapter, "_request", new=AsyncMock(return_value=body)
+    ) as mock_req:
+        order_id = await adapter.place_order("005930", "buy", 10, "market")
+
+    assert order_id == "BROKER-123"
+    # 주문은 단일 _request 호출 (페이지 루프 없음).
+    assert mock_req.call_count == 1
+    assert mock_req.call_args.args[0] == "POST"
+
+
+async def test_request_with_cont_sets_request_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_request_with_cont: cont_header 가 요청 헤더 tr_cont 로 주입된다."""
+    adapter = _make_adapter()
+    adapter._circuit_breaker = MagicMock()
+    adapter._ensure_authenticated = AsyncMock()  # type: ignore[method-assign]
+    adapter._rate_limit_wait = AsyncMock()  # type: ignore[method-assign]
+    adapter.access_token = "tok"
+
+    captured: dict[str, Any] = {}
+
+    async def fake_send_http(method, url, headers, params, json_data, timeout):  # type: ignore[no-untyped-def]
+        captured["headers"] = headers
+        return {"rt_cd": "0"}, "D"
+
+    adapter._send_http = fake_send_http  # type: ignore[method-assign]
+
+    body, tr_cont = await adapter._request_with_cont(
+        "GET", "url", "TR", params={}, cont_header="N"
+    )
+
+    assert body == {"rt_cd": "0"}
+    assert tr_cont == "D"
+    assert captured["headers"]["tr_cont"] == "N"
+
+
+async def test_request_with_cont_empty_header_not_injected() -> None:
+    """cont_header="" 이면 요청 헤더에 tr_cont 키를 강제로 넣지 않는다(최초 요청)."""
+    adapter = _make_adapter()
+    adapter._circuit_breaker = MagicMock()
+    adapter._ensure_authenticated = AsyncMock()  # type: ignore[method-assign]
+    adapter._rate_limit_wait = AsyncMock()  # type: ignore[method-assign]
+    adapter.access_token = "tok"
+
+    captured: dict[str, Any] = {}
+
+    async def fake_send_http(method, url, headers, params, json_data, timeout):  # type: ignore[no-untyped-def]
+        captured["headers"] = headers
+        return {"rt_cd": "0"}, "F"
+
+    adapter._send_http = fake_send_http  # type: ignore[method-assign]
+
+    await adapter._request_with_cont("GET", "url", "TR", params={}, cont_header="")
+
+    # 최초 요청: tr_cont 헤더는 빈 문자열이거나 부재(어느 쪽도 KIS 최초조회로 동작).
+    assert captured["headers"].get("tr_cont", "") == ""


### PR DESCRIPTION
Closes #2126

## Summary
`KISDomesticAdapter` 조회 메서드가 CTX pagination을 처리하지 않아 2페이지 이후 잔고·미체결·체결이력을 누락하던 P1 버그 수정(fill-recovery 백스톱 신뢰성).
- `_send_http`가 `(body, tr_cont)` 반환, `_request_with_cont`(저수준, CB/retry 재사용) 추가, `_request`(body-only)는 위임으로 보존(주문 등 비조회 호출자 무영향)
- `_request_paginated(row_key)`: 단일 row_key 누적(positions/account_positions/order_history=output1, order_status/pending_orders=output), output2 미누적; tr_cont D/E 종료·F/M cursor follow·F-M+빈cursor·max-page(100) truncation warning; base_params 비변형
- get_order_history 누적후 fold 1회, get_order_status 누적후 검색, get_account_positions는 get_positions 위임

## Scope
- `src/ante/broker/kis.py`. 해외/주문/get_current_price/CB정책 무변경.

## Test Plan
- 신규 17건(단일/2페이지 cursor 전달/truncation/max-page/5메서드 누적/비조회 회귀)
- `pytest -k 'kis or broker'` 439 passed, 전체 유닛 6620 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS(2회차, r1은 false-negative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)