### PR TITLE
fix(account): #2131 킬스위치 suspend(CRITICAL)/activate(INFO) NotificationEvent 발행

### DIFF
--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -746,13 +746,32 @@ class AccountService:
             (AccountStatus.SUSPENDED, account.updated_at.isoformat(), account_id),
         )
 
-        from ante.eventbus.events import AccountSuspendedEvent
+        from ante.eventbus.events import AccountSuspendedEvent, NotificationEvent
 
         await self._eventbus.publish(
             AccountSuspendedEvent(
                 account_id=account_id,
                 reason=reason,
                 suspended_by=suspended_by,
+            )
+        )
+        # 킬 스위치 CRITICAL 알림 wiring (#2131): notification.md 트리거 표가
+        # "거래 상태 변경(킬 스위치)" 담당을 AccountService·레벨 CRITICAL·
+        # category system 으로 명시한다. producer 직접 발행 패턴
+        # (approval ``_publish_created``·member ``suspend`` 동형).
+        # suspend_all 은 본 메서드를 계좌별로 호출하므로 계좌별 CRITICAL 이
+        # 자동 커버된다. NotificationService 가 NotificationEvent 를 이미
+        # 구독하므로 추가 wiring 불필요.
+        await self._eventbus.publish(
+            NotificationEvent(
+                level="critical",
+                title="거래 상태 변경 (킬 스위치)",
+                message=(
+                    f"계좌 `{account_id}` 정지(SUSPENDED)\n"
+                    f"사유: {reason}\n"
+                    f"실행: `{suspended_by}`"
+                ),
+                category="system",
             )
         )
 
@@ -786,12 +805,23 @@ class AccountService:
             (AccountStatus.ACTIVE, account.updated_at.isoformat(), account_id),
         )
 
-        from ante.eventbus.events import AccountActivatedEvent
+        from ante.eventbus.events import AccountActivatedEvent, NotificationEvent
 
         await self._eventbus.publish(
             AccountActivatedEvent(
                 account_id=account_id,
                 activated_by=activated_by,
+            )
+        )
+        # 킬 스위치 해제 INFO 알림 wiring (#2131): suspend CRITICAL 의 짝.
+        # 재활성은 비긴급이므로 INFO 를 유지한다(스펙 비목표: CRITICAL 승격
+        # 금지). activate_all 은 본 메서드를 계좌별로 호출하므로 자동 커버.
+        await self._eventbus.publish(
+            NotificationEvent(
+                level="info",
+                title="거래 상태 변경 (킬 스위치 해제)",
+                message=(f"계좌 `{account_id}` 재활성(ACTIVE)\n실행: `{activated_by}`"),
+                category="system",
             )
         )
 

--- a/tests/unit/test_account_delete_events.py
+++ b/tests/unit/test_account_delete_events.py
@@ -12,7 +12,7 @@ from ante.account.models import Account, AccountStatus
 from ante.account.service import AccountService
 from ante.core.database import Database
 from ante.eventbus.bus import EventBus
-from ante.eventbus.events import AccountSuspendedEvent
+from ante.eventbus.events import AccountSuspendedEvent, NotificationEvent
 
 
 @pytest_asyncio.fixture
@@ -123,6 +123,28 @@ class TestAccountDeleteEvents:
         # AccountSuspendedEvent는 새로 발행되지 않아야 함
         # (이미 suspend 시 1회 발행되었지만 delete()에서는 추가 발행 없음)
         assert len(published) == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_does_not_publish_notification(self, service, eventbus):
+        """delete() 경로는 NotificationEvent를 발행하지 않는다 (#2131 회귀).
+
+        delete가 발행하는 ``AccountSuspendedEvent``(reason="Account deletion")는
+        구조적 삭제용 봇 중지 트리거이지 킬 스위치가 아니므로 CRITICAL 알림
+        대상이 아니다. suspend()에 추가된 NotificationEvent wiring이 delete
+        경로로 새어 들어가지 않음을 가드한다.
+        """
+        await service.create(_make_account())
+
+        notifications: list[NotificationEvent] = []
+
+        async def on_notification(event: NotificationEvent) -> None:
+            notifications.append(event)
+
+        eventbus.subscribe(NotificationEvent, on_notification)
+
+        await service.delete("main", deleted_by="admin")
+
+        assert notifications == []
 
     @pytest.mark.asyncio
     async def test_delete_sets_status_and_clears_cache(self, service):

--- a/tests/unit/test_account_killswitch_notification.py
+++ b/tests/unit/test_account_killswitch_notification.py
@@ -1,0 +1,192 @@
+"""킬 스위치 NotificationEvent 발행 테스트 (#2131).
+
+`notification.md` 트리거 표는 "거래 상태 변경(킬 스위치)"의 담당을
+AccountService·레벨 CRITICAL·category system 으로 명시한다. AccountService.suspend
+는 도메인 이벤트(`AccountSuspendedEvent`)와 함께 CRITICAL `NotificationEvent` 를,
+activate 는 `AccountActivatedEvent` 와 함께 INFO `NotificationEvent` 를 직접
+발행해야 한다 (#2151 approval `_publish_created`·#2150 member `suspend` 동형).
+"""
+
+import pytest
+import pytest_asyncio
+
+from ante.account.errors import AccountAlreadySuspendedError
+from ante.account.models import Account, AccountStatus
+from ante.account.service import AccountService
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import (
+    AccountActivatedEvent,
+    AccountSuspendedEvent,
+    NotificationEvent,
+)
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    """테스트용 인메모리 DB."""
+    db_path = str(tmp_path / "test_account_killswitch.db")
+    database = Database(db_path)
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    """테스트용 EventBus."""
+    return EventBus()
+
+
+@pytest_asyncio.fixture
+async def service(db, eventbus):
+    """초기화된 AccountService."""
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+def _make_account(
+    account_id: str = "main",
+    name: str = "테스트",
+    exchange: str = "TEST",
+    currency: str = "KRW",
+    broker_type: str = "test",
+    **kwargs,
+) -> Account:
+    """테스트용 Account 생성 헬퍼."""
+    if "credentials" not in kwargs:
+        kwargs["credentials"] = {"app_key": "test", "app_secret": "test"}
+    return Account(
+        account_id=account_id,
+        name=name,
+        exchange=exchange,
+        currency=currency,
+        broker_type=broker_type,
+        **kwargs,
+    )
+
+
+def _capture(eventbus):
+    """모든 이벤트를 종류별 리스트로 캡처한다."""
+    suspended: list[AccountSuspendedEvent] = []
+    activated: list[AccountActivatedEvent] = []
+    notifications: list[NotificationEvent] = []
+
+    async def on_suspended(event: AccountSuspendedEvent) -> None:
+        suspended.append(event)
+
+    async def on_activated(event: AccountActivatedEvent) -> None:
+        activated.append(event)
+
+    async def on_notification(event: NotificationEvent) -> None:
+        notifications.append(event)
+
+    eventbus.subscribe(AccountSuspendedEvent, on_suspended)
+    eventbus.subscribe(AccountActivatedEvent, on_activated)
+    eventbus.subscribe(NotificationEvent, on_notification)
+    return suspended, activated, notifications
+
+
+@pytest.mark.asyncio
+async def test_suspend_publishes_domain_event_and_critical_notification(
+    service, eventbus
+):
+    """suspend()는 AccountSuspendedEvent AND CRITICAL NotificationEvent 둘 다 발행."""
+    await service.create(_make_account())
+    suspended, _activated, notifications = _capture(eventbus)
+
+    await service.suspend("main", reason="위험 감지", suspended_by="rule-engine")
+
+    # 도메인 이벤트 1회
+    assert len(suspended) == 1
+    assert suspended[0].account_id == "main"
+    assert suspended[0].reason == "위험 감지"
+    assert suspended[0].suspended_by == "rule-engine"
+
+    # CRITICAL 알림 1회
+    assert len(notifications) == 1
+    note = notifications[0]
+    assert note.level == "critical"
+    assert note.category == "system"
+    # account_id·reason·suspended_by 가 메시지에 포함
+    assert "main" in note.message
+    assert "위험 감지" in note.message
+    assert "rule-engine" in note.message
+    assert note.title
+
+
+@pytest.mark.asyncio
+async def test_activate_publishes_domain_event_and_info_notification(service, eventbus):
+    """activate()는 AccountActivatedEvent AND INFO NotificationEvent 둘 다 발행."""
+    await service.create(_make_account())
+    await service.suspend("main", reason="테스트", suspended_by="system")
+
+    _suspended, activated, notifications = _capture(eventbus)
+
+    await service.activate("main", activated_by="admin")
+
+    # 도메인 이벤트 1회
+    assert len(activated) == 1
+    assert activated[0].account_id == "main"
+    assert activated[0].activated_by == "admin"
+
+    # INFO 알림 1회 (CRITICAL 승격 금지)
+    assert len(notifications) == 1
+    note = notifications[0]
+    assert note.level == "info"
+    assert note.category == "system"
+    assert "main" in note.message
+    assert "admin" in note.message
+    assert note.title
+
+
+@pytest.mark.asyncio
+async def test_suspend_all_publishes_one_critical_per_account(service, eventbus):
+    """suspend_all(2 ACTIVE 계좌)은 계좌별 CRITICAL NotificationEvent 를 발행한다."""
+    await service.create(_make_account(account_id="acc1"))
+    await service.create(_make_account(account_id="acc2"))
+
+    _suspended, _activated, notifications = _capture(eventbus)
+
+    await service.suspend_all(reason="시스템 긴급 정지", suspended_by="system")
+
+    assert len(notifications) == 2
+    assert all(n.level == "critical" for n in notifications)
+    assert all(n.category == "system" for n in notifications)
+    # 두 계좌 각각에 대해 정확히 하나의 CRITICAL 알림이 발행되어야 한다.
+    assert any("acc1" in n.message for n in notifications)
+    assert any("acc2" in n.message for n in notifications)
+
+
+@pytest.mark.asyncio
+async def test_suspend_already_suspended_raises_and_publishes_nothing(
+    service, eventbus
+):
+    """이미 SUSPENDED면 raise하고 도메인/알림 이벤트 미발행 (기존 invariant)."""
+    await service.create(_make_account())
+    await service.suspend("main", reason="첫 정지", suspended_by="system")
+
+    suspended, _activated, notifications = _capture(eventbus)
+
+    with pytest.raises(AccountAlreadySuspendedError):
+        await service.suspend("main", reason="중복", suspended_by="system")
+
+    assert suspended == []
+    assert notifications == []
+    # 상태는 SUSPENDED 그대로
+    account = await service.get("main")
+    assert account.status == AccountStatus.SUSPENDED
+
+
+@pytest.mark.asyncio
+async def test_activate_already_active_publishes_nothing(service, eventbus):
+    """이미 ACTIVE면 early-return — 도메인/알림 이벤트를 발행하지 않는다."""
+    await service.create(_make_account())
+
+    _suspended, activated, notifications = _capture(eventbus)
+
+    await service.activate("main", activated_by="admin")
+
+    assert activated == []
+    assert notifications == []


### PR DESCRIPTION
Closes #2131

## Summary
계좌 정지/전역 kill switch·재활성이 AccountSuspended/ActivatedEvent만 발행하고 외부 알림용 NotificationEvent를 발행하지 않아 텔레그램 CRITICAL 알림이 안 나가던 P1 안전 결함 수정. AccountService가 NotificationEvent를 직접 발행(#2151/#2150 producer-emit 패턴).
- `suspend`: `NotificationEvent(level="critical", category="system")` (스펙 킬스위치 트리거)
- `activate`: `NotificationEvent(level="info", category="system")` (킬스위치 해제)
- suspend_all/activate_all은 loop가 계좌별 자동 커버, delete 경로(구조적)는 비대상

## Scope
- `src/ante/account/service.py`. notification 정책/구독·delete 알림·activate CRITICAL승격 무변경.

## Test Plan
- 신규 5건(suspend critical/activate info/suspend_all 2건/already-suspended raise/already-active no-op) + delete 무발행 회귀
- `pytest -k 'account or notification'` 920 passed, 전체 유닛 6614 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)