### PR TITLE
fix(gateway): #2134 cancel_order가 OrderTracker로 broker_order_id 변환 (fail-closed+account scoping)

### DIFF
--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -47,6 +47,7 @@ class APIGateway:
         eventbus: EventBus,
         rate_config: RateLimitConfig | None = None,
         stop_order_manager: Any | None = None,
+        order_tracker: Any | None = None,
     ) -> None:
         self._account_service = account_service
         self._eventbus = eventbus
@@ -57,6 +58,7 @@ class APIGateway:
         self._cache = ResponseCache()
         self._running = False
         self._stop_order_manager = stop_order_manager
+        self._order_tracker = order_tracker
 
     async def _get_broker(self, account_id: str) -> BrokerAdapter:
         """AccountService에서 브로커 인스턴스를 획득한다."""
@@ -243,16 +245,53 @@ class APIGateway:
     async def cancel_order(self, order_id: str, *, account_id: str) -> bool:
         """주문 취소. account_id로 브로커 라우팅.
 
+        취소 대상은 **내부 order_id** 로 들어오지만 BrokerAdapter 는
+        broker_order_id(증권사 주문번호, KIS ``odno`` 등)를 요구한다. #2134:
+        OrderTracker 로 ``order_id → broker_order_id`` 를 변환한 뒤 broker 에
+        전달한다. 변환 불가/검증 실패 시 **fail-closed** 로 ``False`` 를 반환하고
+        broker 를 호출하지 않는다 (내부 order_id 를 broker 로 passthrough 하지
+        않는다 — P1 재발 방지).
+
         SPLIT-3 (#1242): ``account_id`` required (``require_account_id``).
         """
         from ante.account.scoping import require_account_id
 
         require_account_id(account_id, context="gateway.cancel_order")
 
+        # #2134: fail-closed broker_order_id 변환 — broker 호출 전에 검증.
+        if self._order_tracker is None:
+            logger.error(
+                "order_tracker 미주입 — broker_order_id 변환 불가, 취소 차단 "
+                "(order_id=%s, account=%s)",
+                order_id,
+                account_id,
+            )
+            return False
+
+        record = await self._order_tracker.get(order_id)
+        if record is None:
+            logger.warning(
+                "취소 대상 주문 미발견 — broker_order_id 변환 불가, 취소 차단 "
+                "(order_id=%s, account=%s)",
+                order_id,
+                account_id,
+            )
+            return False
+
+        if record.account_id != account_id:
+            logger.warning(
+                "cross-account 취소 시도 차단 "
+                "(order_id=%s, record.account=%s, 요청 account=%s)",
+                order_id,
+                record.account_id,
+                account_id,
+            )
+            return False
+
         rate_limiter = self._get_rate_limiter(account_id)
         await rate_limiter.acquire()
         broker = await self._get_broker(account_id)
-        return await broker.cancel_order(order_id)
+        return await broker.cancel_order(record.broker_order_id)
 
     # ── EventBus 핸들러 ──────────────────────────────
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -590,6 +590,7 @@ async def _init_gateway(s: Services) -> None:
         account_service=s.account_service,
         eventbus=s.eventbus,
         stop_order_manager=stop_order_manager,
+        order_tracker=s.order_tracker,
     )
     s.api_gateway.start()
     logger.info("APIGateway 시작 완료")

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -215,11 +215,27 @@ class TestAPIGateway:
         return EventBus()
 
     @pytest.fixture
-    async def gateway(self, account_service, eventbus):
+    def order_tracker(self):
+        """OrderTracker mock — order_id → broker_order_id 변환용 (#2134).
+
+        ``get("ORD001")`` → broker_order_id="BRK-ORD001", account_id="acc-001"
+        레코드를 반환한다.
+        """
+        tracker = AsyncMock()
+        record = MagicMock()
+        record.order_id = "ORD001"
+        record.broker_order_id = "BRK-ORD001"
+        record.account_id = "acc-001"
+        tracker.get = AsyncMock(return_value=record)
+        return tracker
+
+    @pytest.fixture
+    async def gateway(self, account_service, eventbus, order_tracker):
         gw = APIGateway(
             account_service=account_service,
             eventbus=eventbus,
             rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
+            order_tracker=order_tracker,
         )
         gw.start()
         return gw
@@ -286,10 +302,11 @@ class TestAPIGateway:
         broker.place_order.assert_called_once()
 
     async def test_cancel_order(self, gateway, broker):
-        """주문 취소 — account_id로 라우팅."""
+        """주문 취소 — account_id 라우팅 + OrderTracker broker_order_id 변환 (#2134)."""
         result = await gateway.cancel_order("ORD001", account_id="acc-001")
         assert result is True
-        broker.cancel_order.assert_called_once_with("ORD001")
+        # 내부 order_id 가 아니라 변환된 broker_order_id 로 broker 호출.
+        broker.cancel_order.assert_called_once_with("BRK-ORD001")
 
     async def test_rate_limiter_per_account(self, gateway):
         """계좌별 독립 rate limiter 생성."""
@@ -347,6 +364,51 @@ class TestAPIGateway:
         with pytest.raises(InvalidAccountIdError):
             await gateway.cancel_order("ORD001", account_id="")
 
+    async def test_cancel_order_record_not_found_fail_closed(
+        self, gateway, broker, order_tracker
+    ):
+        """#2134: OrderTracker 레코드 미발견 → False + broker 미호출."""
+        order_tracker.get = AsyncMock(return_value=None)
+
+        result = await gateway.cancel_order("UNKNOWN", account_id="acc-001")
+
+        assert result is False
+        broker.cancel_order.assert_not_called()
+
+    async def test_cancel_order_no_tracker_fail_closed(
+        self, account_service, eventbus, broker
+    ):
+        """#2134: order_tracker 미주입 → fail-closed (내부 order_id passthrough 금지).
+
+        broker 를 호출하지 않고 False 를 반환한다 (P1 재발 방지).
+        """
+        gw = APIGateway(
+            account_service=account_service,
+            eventbus=eventbus,
+            rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
+        )
+        gw.start()
+
+        result = await gw.cancel_order("ORD001", account_id="acc-001")
+
+        assert result is False
+        broker.cancel_order.assert_not_called()
+
+    async def test_cancel_order_cross_account_blocked(
+        self, gateway, broker, order_tracker
+    ):
+        """#2134: record.account_id ≠ 요청 account_id → False + broker 미호출."""
+        record = MagicMock()
+        record.order_id = "ORD001"
+        record.broker_order_id = "BRK-ORD001"
+        record.account_id = "acc-OTHER"
+        order_tracker.get = AsyncMock(return_value=record)
+
+        result = await gateway.cancel_order("ORD001", account_id="acc-001")
+
+        assert result is False
+        broker.cancel_order.assert_not_called()
+
 
 # ── APIGateway EventBus 통합 ──────────────────────
 
@@ -370,11 +432,23 @@ class TestAPIGatewayEvents:
         return EventBus()
 
     @pytest.fixture
-    async def gateway(self, account_service, eventbus):
+    def order_tracker(self):
+        """OrderTracker mock — order_id="ord1" → broker_order_id="BRK-ord1" (#2134)."""
+        tracker = AsyncMock()
+        record = MagicMock()
+        record.order_id = "ord1"
+        record.broker_order_id = "BRK-ord1"
+        record.account_id = "acc-001"
+        tracker.get = AsyncMock(return_value=record)
+        return tracker
+
+    @pytest.fixture
+    async def gateway(self, account_service, eventbus, order_tracker):
         gw = APIGateway(
             account_service=account_service,
             eventbus=eventbus,
             rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
+            order_tracker=order_tracker,
         )
         gw.start()
         return gw
@@ -473,7 +547,11 @@ class TestAPIGatewayEvents:
     async def test_order_cancel_event_with_account_id(
         self, gateway, eventbus, broker, account_service
     ):
-        """OrderCancelEvent → account_id로 브로커 선택 → OrderCancelledEvent."""
+        """OrderCancelEvent → account_id로 브로커 선택 → OrderCancelledEvent.
+
+        #2134: 이벤트 경로도 cancel_order 를 통해 OrderTracker broker_order_id
+        변환을 거친다 (내부 order_id "ord1" → broker_order_id "BRK-ord1").
+        """
         received = []
         eventbus.subscribe(OrderCancelledEvent, lambda e: received.append(e))
 
@@ -492,6 +570,8 @@ class TestAPIGatewayEvents:
         assert received[0].reason == "test cancel"
         assert received[0].account_id == "acc-001"
         account_service.get_broker.assert_called_with("acc-001")
+        # broker 에는 변환된 broker_order_id 가 전달된다 (내부 order_id 아님).
+        broker.cancel_order.assert_called_once_with("BRK-ord1")
 
     async def test_order_filled_invalidates_account_cache(
         self, gateway, eventbus, broker

--- a/tests/unit/test_gateway_cancel_failed.py
+++ b/tests/unit/test_gateway_cancel_failed.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -22,6 +22,22 @@ from ante.eventbus.events import (
 from ante.gateway import APIGateway
 
 
+def _order_tracker_mock(
+    *, order_id: str = "ord1", broker_order_id: str = "brk-ord1", account_id: str
+) -> AsyncMock:
+    """#2134: cancel_order broker_order_id 변환을 통과시키는 OrderTracker mock.
+
+    ``get(order_id)`` → 주어진 broker_order_id/account_id 레코드를 반환한다.
+    """
+    tracker = AsyncMock()
+    record = MagicMock()
+    record.order_id = order_id
+    record.broker_order_id = broker_order_id
+    record.account_id = account_id
+    tracker.get = AsyncMock(return_value=record)
+    return tracker
+
+
 @pytest.mark.asyncio
 async def test_cancel_failed_preserves_account_id() -> None:
     """브로커 cancel 예외 → 발행된 OrderCancelFailedEvent.account_id 보존."""
@@ -31,7 +47,11 @@ async def test_cancel_failed_preserves_account_id() -> None:
     mock_account_service = AsyncMock()
     mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
 
-    gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        order_tracker=_order_tracker_mock(account_id="acc-test"),
+    )
     gw.start()
 
     received: list[OrderCancelFailedEvent] = []
@@ -64,7 +84,11 @@ async def test_cancel_failed_includes_strategy_id() -> None:
     mock_account_service = AsyncMock()
     mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
 
-    gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        order_tracker=_order_tracker_mock(account_id="acc-test"),
+    )
     gw.start()
 
     received: list[OrderCancelFailedEvent] = []
@@ -99,7 +123,11 @@ async def test_cancel_broker_returns_false_emits_failed_event() -> None:
     mock_account_service = AsyncMock()
     mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
 
-    gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        order_tracker=_order_tracker_mock(account_id="acc-test"),
+    )
     gw.start()
 
     failed: list[OrderCancelFailedEvent] = []
@@ -140,7 +168,11 @@ async def test_cancel_broker_returns_true_emits_cancelled_event() -> None:
     mock_account_service = AsyncMock()
     mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
 
-    gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        order_tracker=_order_tracker_mock(account_id="acc-test"),
+    )
     gw.start()
 
     failed: list[OrderCancelFailedEvent] = []

--- a/tests/unit/test_kis_error_handling.py
+++ b/tests/unit/test_kis_error_handling.py
@@ -369,7 +369,7 @@ class TestCircuitBreakerEvent:
 class TestGatewayCancelFailed:
     async def test_cancel_failure_publishes_event(self):
         """Gateway 취소 실패 시 OrderCancelFailedEvent 발행."""
-        from unittest.mock import AsyncMock
+        from unittest.mock import AsyncMock, MagicMock
 
         from ante.eventbus.events import OrderCancelEvent
         from ante.gateway import APIGateway
@@ -380,7 +380,19 @@ class TestGatewayCancelFailed:
         mock_account_service = AsyncMock()
         mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
 
-        gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
+        # #2134: cancel_order broker_order_id 변환을 통과시키는 OrderTracker mock.
+        mock_tracker = AsyncMock()
+        record = MagicMock()
+        record.order_id = "ord1"
+        record.broker_order_id = "brk-ord1"
+        record.account_id = "acc-test"
+        mock_tracker.get = AsyncMock(return_value=record)
+
+        gw = APIGateway(
+            account_service=mock_account_service,
+            eventbus=eventbus,
+            order_tracker=mock_tracker,
+        )
         gw.start()
 
         received: list[OrderCancelFailedEvent] = []


### PR DESCRIPTION
Closes #2134

## Summary
APIGateway 취소 경로가 내부 order_id를 broker_order_id로 변환하지 않고 broker.cancel_order에 직전달해 KIS ORGN_ODNO에 내부 ID가 나가던 P1 버그 수정.
- APIGateway에 OrderTracker optional 주입(main.py L589 wiring)
- `cancel_order`: `order_tracker.get(order_id).broker_order_id`로 변환 후 broker 호출
- **fail-closed**: order_tracker None→False+broker 미호출(내부 ID passthrough 금지), record None→False, record.account_id≠account_id→False(cross-account 차단)
- `_on_order_cancel` 이벤트 경로 자동 커버, OrderCancelEvent 스키마 무변경

## Scope
- `src/ante/gateway/gateway.py`, `src/ante/main.py`. reconcile/overseas/submit 경로 무관.

## Test Plan
- 신규 5건(변환/record-None/no-tracker fail-closed/cross-account/이벤트 경로) + cancel fixture 갱신
- `pytest -k 'gateway or order_tracker or cancel'` 171 passed, 전체 유닛 6628 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)