### PR TITLE
fix(data): #2081 ParquetStore.read date-only end를 whole-day inclusive로 (intraday 당일 포함)

### DIFF
--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -73,6 +73,11 @@ _TIME_COLUMN: dict[str, str] = {
     "tick": "timestamp",
 }
 
+# `read(end=...)`에서 엄격 date-only(`YYYY-MM-DD`)를 식별하는 정규식.
+# 시간 성분/timezone suffix/basic ISO 등 그 외 형식은 매치하지 않으며
+# 기존 `<= end`(정확 instant) 경로로 처리된다(#2081).
+_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
 
 def _natural_key(data_type: str, columns: list[str]) -> list[str]:
     """data_type별 merge/dedup용 natural key 컬럼 목록을 결정한다.
@@ -346,7 +351,10 @@ class ParquetStore:
             symbol: 종목 코드
             timeframe: 타임프레임 (1m, 5m, 15m, 1h, 1d)
             start: 시작 시간 (ISO 형식, inclusive)
-            end: 종료 시간 (ISO 형식, inclusive)
+            end: 종료 시간 (ISO 형식, inclusive). date-only(`YYYY-MM-DD`)는
+                해당 날짜 whole-day inclusive(당일 23:59:59.999까지)로
+                해석되어 intraday 당일 장중 데이터가 포함된다(#2081).
+                시간 성분이 있는 형식은 그 정확 instant까지 inclusive다.
             limit: 최근 N건만 반환
             data_type: 데이터 타입 (ohlcv, fundamental, tick)
             exchange: 거래소 코드 (KRX, NYSE, NASDAQ 등)
@@ -396,9 +404,26 @@ class ParquetStore:
                 pl.col(time_col) >= pl.lit(start).str.to_datetime(time_zone="UTC")
             )
         if end and time_col in df.columns:
-            df = df.filter(
-                pl.col(time_col) <= pl.lit(end).str.to_datetime(time_zone="UTC")
-            )
+            # date-only end(`YYYY-MM-DD`)는 whole-day inclusive로 해석한다.
+            # `<= 2026-01-02 00:00 UTC`로 파싱하면 intraday(1m/5m/1h) 당일
+            # 장중 row(09:01, 15:30 등)가 모두 제외된다(#2081). 따라서
+            # date-only일 때는 자정 instant가 아니라 그 날 전체를 포함하도록
+            # `< (end_date + 1 day)`(당일 23:59:59.999까지)로 필터한다.
+            # 1d(daily) bar는 00:00이라 +1day exclusive로도 당일 bar가
+            # 그대로 포함되어 기존 동작과 동일하다(회귀 없음).
+            #
+            # 시간 성분이 있는 end(datetime, timezone suffix, basic ISO 등
+            # date-only가 아닌 모든 형식)는 기존 `<= end`(정확 instant)를
+            # 유지한다.
+            if _DATE_ONLY_RE.match(end):
+                df = df.filter(
+                    pl.col(time_col)
+                    < pl.lit(end).str.to_datetime(time_zone="UTC") + pl.duration(days=1)
+                )
+            else:
+                df = df.filter(
+                    pl.col(time_col) <= pl.lit(end).str.to_datetime(time_zone="UTC")
+                )
 
         if time_col in df.columns:
             df = df.sort(time_col)

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -605,6 +605,144 @@ class TestParquetStore:
         assert result["symbol"][0] == "005930"
 
 
+def _make_ohlcv_df_at(symbol: str, times: list[str]) -> pl.DataFrame:
+    """주어진 ISO 시각 목록으로 OHLCV DataFrame을 만든다.
+
+    `_make_ohlcv_df`는 단일 시각 내 1m 연속 row만 만들 수 있어 multi-day /
+    임의 장중 시각 경계 테스트(#2081)에 부적합하므로 별도 헬퍼를 둔다.
+    """
+    n = len(times)
+    timestamps = pl.Series(
+        "timestamp",
+        [datetime.fromisoformat(t) for t in times],
+    ).dt.replace_time_zone("UTC")
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": [symbol] * n,
+            "open": [50000.0 + i * 100 for i in range(n)],
+            "high": [50100.0 + i * 100 for i in range(n)],
+            "low": [49900.0 + i * 100 for i in range(n)],
+            "close": [50050.0 + i * 100 for i in range(n)],
+            "volume": [1000 + i * 10 for i in range(n)],
+            "source": ["test"] * n,
+        }
+    )
+
+
+class TestParquetStoreReadEndDateOnly:
+    """`read(end=...)` date-only whole-day inclusive 동작(#2081).
+
+    - date-only end는 당일 장중(intraday) row를 모두 포함해야 한다.
+    - 시간 성분이 있는 end는 그 정확 instant까지만 inclusive(기존 동작).
+    """
+
+    async def test_intraday_date_only_end_includes_whole_day(self, store):
+        """(a) 1m 데이터 read(end='2026-01-02') → 당일 장중 row 포함."""
+        store.write(
+            "005930",
+            "1m",
+            _make_ohlcv_df_at(
+                "005930",
+                [
+                    "2026-01-02T00:00:00",
+                    "2026-01-02T09:01:00",
+                    "2026-01-02T15:30:00",
+                    "2026-01-02T23:59:00",
+                ],
+            ),
+        )
+        result = store.read("005930", "1m", end="2026-01-02")
+        ts = result["timestamp"].dt.strftime("%H:%M").to_list()
+        # date-only end=2026-01-02 → 당일 자정(00:00)뿐 아니라 09:01/15:30/
+        # 23:59 등 당일 장중 row가 모두 포함되어야 한다(기존 버그는 00:00만).
+        assert ts == ["00:00", "09:01", "15:30", "23:59"]
+        assert len(result) == 4
+
+    async def test_daily_date_only_end_includes_day_bar_regression(self, store):
+        """(b) 1d 데이터 end=date-only → 당일 bar 포함(회귀 없음)."""
+        store.write(
+            "005930",
+            "1d",
+            _make_ohlcv_df_at(
+                "005930",
+                [
+                    "2026-01-01T00:00:00",
+                    "2026-01-02T00:00:00",
+                ],
+            ),
+        )
+        result = store.read("005930", "1d", end="2026-01-02")
+        dates = result["timestamp"].dt.strftime("%Y-%m-%d").to_list()
+        # 1d bar는 00:00이므로 +1day exclusive로도 당일 bar가 포함된다.
+        assert dates == ["2026-01-01", "2026-01-02"]
+        assert len(result) == 2
+
+    async def test_full_datetime_end_exact_instant_inclusive(self, store):
+        """(c) end=full datetime → 그 instant까지 inclusive, 이후 row 제외."""
+        store.write(
+            "005930",
+            "1m",
+            _make_ohlcv_df_at(
+                "005930",
+                [
+                    "2026-01-02T15:29:00",
+                    "2026-01-02T15:30:00",
+                    "2026-01-02T15:31:00",
+                ],
+            ),
+        )
+        result = store.read("005930", "1m", end="2026-01-02T15:30")
+        ts = result["timestamp"].dt.strftime("%H:%M").to_list()
+        # 시간 성분이 있는 end는 정확 instant(<= end) 유지: 15:30 포함, 15:31 제외.
+        assert ts == ["15:29", "15:30"]
+        assert len(result) == 2
+
+    async def test_start_filter_unchanged_regression(self, store):
+        """(d) start 필터 무변경 회귀."""
+        store.write(
+            "005930",
+            "1m",
+            _make_ohlcv_df_at(
+                "005930",
+                [
+                    "2026-03-01T09:00:00",
+                    "2026-03-01T09:03:00",
+                    "2026-03-01T09:07:00",
+                    "2026-03-01T09:10:00",
+                ],
+            ),
+        )
+        result = store.read(
+            "005930",
+            "1m",
+            start="2026-03-01T09:03:00",
+            end="2026-03-01T09:07:00",
+        )
+        ts = result["timestamp"].dt.strftime("%H:%M").to_list()
+        assert ts == ["09:03", "09:07"]
+
+    async def test_date_only_end_excludes_next_day(self, store):
+        """(e) end=date-only + 다음날 row → 다음날 제외(경계)."""
+        store.write(
+            "005930",
+            "1m",
+            _make_ohlcv_df_at(
+                "005930",
+                [
+                    "2026-01-02T23:59:00",
+                    "2026-01-03T00:00:00",
+                    "2026-01-03T09:01:00",
+                ],
+            ),
+        )
+        result = store.read("005930", "1m", end="2026-01-02")
+        ts = result["timestamp"].dt.strftime("%Y-%m-%d %H:%M").to_list()
+        # 다음날(2026-01-03) row는 00:00 포함 모두 제외되어야 한다.
+        assert ts == ["2026-01-02 23:59"]
+        assert len(result) == 1
+
+
 # ── normalizer.py 테스트 ─────────────────────────────
 
 


### PR DESCRIPTION
Closes #2081

## Summary
`ParquetStore.read(end="YYYY-MM-DD")`가 date-only end를 UTC 자정으로 파싱해 intraday(1m/5m/1h) 당일 장중 row(09:01/15:30 등)를 제외하던 버그 수정.
- end가 엄격 `^\d{4}-\d{2}-\d{2}$`(date-only) → `< (end + 1 day)` whole-day inclusive
- end에 시간 성분(datetime/tz-suffix/basic-iso) → 기존 `<= end`(정확 instant) 유지
- start 필터·UTC 가정 무변경. daily 1d(00:00 bar)는 계속 포함(회귀 없음)

## Scope
- `src/ante/data/store.py::read` end 필터. 파티션 로직(#2115)/data_provider/CLI 무변경.

## Test Plan
- 신규 5건(1m 당일 포함/1d 회귀/datetime 정확/start 무변경/다음날 경계)
- `pytest -k 'store or backtest or data_provider'` 572 passed, 전체 유닛 6639 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)