### PR TITLE
fix(data): #2115 ParquetStore가 ohlcv 10s/30s를 일별 파티션으로 (신규 dir, legacy 월별은 #2267)

### DIFF
--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -78,6 +78,19 @@ _TIME_COLUMN: dict[str, str] = {
 # 기존 `<= end`(정확 instant) 경로로 처리된다(#2081).
 _DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
+# subminute 파티셔닝 해상도 집합(04-schema.md 파일 규격, core.md 축 B 명시값).
+# OHLCV 중 이 timeframe은 월별이 아니라 **일별**(`YYYY-MM-DD.parquet`)로
+# 파티셔닝한다. OHLCV bar timeframe vocabulary(축 A,
+# `CANONICAL_TIMEFRAMES`)와는 별개 축이며, 여기에 값을 추가/재정의하지
+# 않는다(#2115).
+_SUBMINUTE_TIMEFRAMES: frozenset[str] = frozenset({"10s", "30s"})
+
+# legacy 월별 파일(`YYYY-MM.parquet`)만 매치하는 glob 패턴. 일별 파일
+# (`YYYY-MM-DD.parquet` = `????-??-??.parquet`)은 segment 수가 달라
+# 미매치다. subminute dir이 이미 월별로 채워져 있는지(coexistence 방지)
+# 판정하는 데만 쓴다(#2115).
+_LEGACY_MONTHLY_GLOB = "????-??.parquet"
+
 
 def _natural_key(data_type: str, columns: list[str]) -> list[str]:
     """data_type별 merge/dedup용 natural key 컬럼 목록을 결정한다.
@@ -441,7 +454,17 @@ class ParquetStore:
         data_type: str = "ohlcv",
         exchange: str = "KRX",
     ) -> None:
-        """데이터를 Parquet에 기록. 월별 파티셔닝, 중복 제거(merge).
+        """데이터를 Parquet에 기록. 파티셔닝, 중복 제거(merge).
+
+        파티셔닝 해상도(04-schema.md 파일 규격, #2115):
+        - OHLCV 중 subminute(`_SUBMINUTE_TIMEFRAMES` = 10s/30s)는 **일별**
+          (`YYYY-MM-DD.parquet`). 단 해당 dir에 이미 legacy 월별 파일
+          (`_LEGACY_MONTHLY_GLOB`)이 있으면 월별-only를 유지하고 일별을
+          신규 생성하지 않는다(월별+일별 coexistence 시 read glob+concat이
+          중복 timestamp를 반환하므로 이를 원천 차단). legacy 월별→일별
+          전환 migration은 destructive하므로 별도 follow-up #2267로 분리한다.
+        - 그 외(1m+ OHLCV, fundamental/tick 등)는 기존대로 **월별**
+          (`YYYY-MM.parquet`).
 
         신규 write/append/경로 생성은 canonical exchange만 허용한다
         (core.md ``## Canonical Exchange Vocabulary``). `append()`는
@@ -471,10 +494,26 @@ class ParquetStore:
         path.mkdir(parents=True, exist_ok=True)
 
         key = _natural_key(data_type, data.columns)
-        partitioned = self._partition_by_month(data, time_col)
 
-        for month_val, group in partitioned:
-            filepath = path / f"{month_val}.parquet"
+        # 파티셔닝 해상도 결정(#2115). subminute OHLCV는 일별이 기본이나,
+        # 이미 legacy 월별 파일이 있는 dir은 월별을 유지해 coexistence(월별+
+        # 일별 혼재 → read 중복 timestamp)를 만들지 않는다.
+        use_daily = data_type == "ohlcv" and timeframe in _SUBMINUTE_TIMEFRAMES
+        if use_daily and next(path.glob(_LEGACY_MONTHLY_GLOB), None) is not None:
+            use_daily = False
+            logger.warning(
+                "legacy 월별 파티션 존재 — 일별 전환은 #2267, 월별 유지"
+                "(coexistence 미생성): %s",
+                path,
+            )
+
+        if use_daily:
+            partitioned = self._partition_by_day(data, time_col)
+        else:
+            partitioned = self._partition_by_month(data, time_col)
+
+        for part_val, group in partitioned:
+            filepath = path / f"{part_val}.parquet"
             self._persist_partition(filepath, group, key)
 
         logger.debug("Wrote %d rows for %s/%s", len(data), symbol, timeframe)
@@ -498,6 +537,32 @@ class ParquetStore:
                 data_with_month.filter(pl.col("_month") == month_val).drop("_month"),
             )
             for month_val in data_with_month["_month"].unique().to_list()
+        ]
+
+    def _partition_by_day(
+        self, data: pl.DataFrame, time_col: str
+    ) -> list[tuple[str, pl.DataFrame]]:
+        """데이터를 일별로 분할하여 (`YYYY-MM-DD`, DataFrame) 리스트 반환.
+
+        `_partition_by_month`와 동형이며 파티션 key 해상도만 일별
+        (`%Y-%m-%d` / Date면 `cast(Utf8).str.slice(0, 10)`)이다. subminute
+        OHLCV(10s/30s) 일별 파티셔닝 전용(04-schema.md, #2115).
+        """
+        if time_col in data.columns:
+            if data[time_col].dtype == pl.Date:
+                day_series = data[time_col].cast(pl.Utf8).str.slice(0, 10)
+            else:
+                day_series = data[time_col].dt.strftime("%Y-%m-%d")
+        else:
+            day_series = pl.Series(["unknown"] * len(data))
+
+        data_with_day = data.with_columns(day_series.alias("_day"))
+        return [
+            (
+                day_val,
+                data_with_day.filter(pl.col("_day") == day_val).drop("_day"),
+            )
+            for day_val in data_with_day["_day"].unique().to_list()
         ]
 
     def _persist_partition(

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -630,6 +630,199 @@ def _make_ohlcv_df_at(symbol: str, times: list[str]) -> pl.DataFrame:
     )
 
 
+def _make_subminute_ohlcv_df(
+    symbol: str,
+    days: list[str],
+    rows_per_day: int = 3,
+    interval: str = "10s",
+) -> pl.DataFrame:
+    """여러 날에 걸친 subminute OHLCV DataFrame 생성(#2115).
+
+    각 날짜의 09:00:00부터 `interval` 간격으로 `rows_per_day`개의 row를
+    만든다. day는 `YYYY-MM-DD` 문자열.
+    """
+    from datetime import timedelta
+
+    step = 30 if interval == "30s" else 10
+    frames = []
+    for day in days:
+        base = datetime.fromisoformat(f"{day}T09:00:00")
+        timestamps = pl.datetime_range(
+            base,
+            base + timedelta(seconds=(rows_per_day - 1) * step),
+            interval=interval,
+            eager=True,
+            time_zone="UTC",
+        )
+        n = len(timestamps)
+        frames.append(
+            pl.DataFrame(
+                {
+                    "timestamp": timestamps,
+                    "symbol": [symbol] * n,
+                    "open": [50000.0] * n,
+                    "high": [50100.0] * n,
+                    "low": [49900.0] * n,
+                    "close": [50050.0] * n,
+                    "volume": [1000] * n,
+                    "source": ["test"] * n,
+                }
+            )
+        )
+    return pl.concat(frames)
+
+
+class TestParquetStoreSubminuteDailyPartition:
+    """subminute OHLCV(10s/30s) 일별 파티셔닝(04-schema.md, #2115).
+
+    - 신규 dir: `YYYY-MM-DD.parquet`(일별).
+    - 1m+/fundamental/tick: `YYYY-MM.parquet`(월별, 회귀).
+    - legacy 월별 파일이 있는 subminute dir: coexistence 미생성을 위해
+      월별 유지 + warning(일별 전환은 follow-up #2267).
+    """
+
+    async def test_new_10s_dir_daily_partition(self, store, data_dir):
+        """(a) 신규 10s ohlcv dir에 여러 날 write → 일별 파일들."""
+        df = _make_subminute_ohlcv_df(
+            "005930", ["2026-03-01", "2026-03-02", "2026-03-03"], interval="10s"
+        )
+        store.write("005930", "10s", df)
+
+        dir_ = data_dir / "ohlcv" / "10s" / "KRX" / "005930"
+        files = sorted(f.name for f in dir_.glob("*.parquet"))
+        assert files == [
+            "2026-03-01.parquet",
+            "2026-03-02.parquet",
+            "2026-03-03.parquet",
+        ]
+
+    async def test_new_30s_dir_daily_partition(self, store, data_dir):
+        """(b) 신규 30s ohlcv dir도 동일하게 일별."""
+        df = _make_subminute_ohlcv_df(
+            "005930", ["2026-04-10", "2026-04-11"], interval="30s"
+        )
+        store.write("005930", "30s", df)
+
+        dir_ = data_dir / "ohlcv" / "30s" / "KRX" / "005930"
+        files = sorted(f.name for f in dir_.glob("*.parquet"))
+        assert files == ["2026-04-10.parquet", "2026-04-11.parquet"]
+
+    async def test_1m_ohlcv_monthly_regression(self, store, data_dir):
+        """(c) 1m ohlcv는 월별 유지(회귀)."""
+        df = _make_ohlcv_df("005930")  # 2026-03 1m bars
+        store.write("005930", "1m", df)
+
+        dir_ = data_dir / "ohlcv" / "1m" / "KRX" / "005930"
+        files = sorted(f.name for f in dir_.glob("*.parquet"))
+        assert files == ["2026-03.parquet"]
+
+    async def test_1d_ohlcv_monthly_regression(self, store, data_dir):
+        """(c) 1d ohlcv도 월별 유지(회귀)."""
+        df = _make_ohlcv_df("005930")
+        store.write("005930", "1d", df)
+
+        dir_ = data_dir / "ohlcv" / "1d" / "KRX" / "005930"
+        files = sorted(f.name for f in dir_.glob("*.parquet"))
+        assert files == ["2026-03.parquet"]
+
+    async def test_fundamental_monthly_regression(self, store, data_dir):
+        """(d) fundamental은 data_type gate로 월별 유지(timeframe 무관)."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "date": [date(2026, 3, 1), date(2026, 3, 2)],
+                "symbol": ["005930", "005930"],
+                "source": ["dart", "dart"],
+            }
+        )
+        store.write("005930", "", df, data_type="fundamental")
+
+        dir_ = data_dir / "fundamental" / "KRX" / "005930"
+        files = sorted(f.name for f in dir_.glob("*.parquet"))
+        assert files == ["2026-03.parquet"]
+
+    async def test_non_subminute_timeframe_gate_monthly(self, store, data_dir):
+        """(d) data_type=ohlcv여도 timeframe이 subminute가 아니면 월별.
+
+        예: 5m은 _SUBMINUTE_TIMEFRAMES에 없으므로 월별 파티션.
+        """
+        df = _make_ohlcv_df("005930")
+        store.write("005930", "5m", df)
+
+        dir_ = data_dir / "ohlcv" / "5m" / "KRX" / "005930"
+        files = sorted(f.name for f in dir_.glob("*.parquet"))
+        assert files == ["2026-03.parquet"]
+
+    async def test_daily_partition_roundtrip_with_dedup(self, store):
+        """(e) write 후 read 라운드트립 — 일별 정상 + natural-key dedup."""
+        df = _make_subminute_ohlcv_df(
+            "005930", ["2026-03-01", "2026-03-02"], rows_per_day=3, interval="10s"
+        )
+        store.write("005930", "10s", df)
+        # 같은 데이터 재write → 파일 내부 natural-key(timestamp) dedup 멱등
+        store.write("005930", "10s", df)
+
+        result = store.read("005930", "10s")
+        assert len(result) == 6  # 2일 × 3 rows, 중복 제거됨
+        # timestamp 중복 없음
+        assert result["timestamp"].n_unique() == 6
+        # 정렬됨
+        assert result["timestamp"].is_sorted()
+
+    async def test_legacy_monthly_dir_kept_monthly(self, store, data_dir, caplog):
+        """(f) legacy 월별 파일 있는 10s dir → 월별 유지, 일별 미생성, 중복 0."""
+        import logging
+
+        dir_ = data_dir / "ohlcv" / "10s" / "KRX" / "005930"
+        dir_.mkdir(parents=True, exist_ok=True)
+
+        # legacy 월별 파일 사전 생성(2026-03의 row 2개).
+        legacy = _make_subminute_ohlcv_df(
+            "005930", ["2026-03-01"], rows_per_day=2, interval="10s"
+        )
+        legacy_file = dir_ / "2026-03.parquet"
+        legacy.write_parquet(str(legacy_file))
+
+        # 같은 달의 신규 row를 추가 write → 일별 전환하지 않고 월별 유지.
+        new_df = _make_subminute_ohlcv_df(
+            "005930", ["2026-03-02"], rows_per_day=2, interval="10s"
+        )
+        with caplog.at_level(logging.WARNING, logger="ante.data.store"):
+            store.write("005930", "10s", new_df)
+
+        files = sorted(f.name for f in dir_.glob("*.parquet"))
+        # 월별만 존재 — 일별(YYYY-MM-DD) 파일이 생기지 않아야 한다.
+        assert files == ["2026-03.parquet"]
+        assert any("#2267" in rec.message for rec in caplog.records)
+
+        # read에 중복 timestamp가 없어야 한다.
+        result = store.read("005930", "10s")
+        assert result["timestamp"].n_unique() == len(result)
+        assert len(result) == 4  # legacy 2 + new 2 (서로 다른 timestamp)
+
+    async def test_legacy_glob_does_not_match_daily_files(self, store, data_dir):
+        """(g) glob `????-??.parquet`는 일별 파일을 매치하지 않는다.
+
+        이미 일별로 채워진 dir에 추가 write해도 월별로 오인되지 않고
+        일별 파티션을 계속 생성한다.
+        """
+        # 신규 일별 dir 생성
+        df1 = _make_subminute_ohlcv_df("005930", ["2026-01-15"], interval="10s")
+        store.write("005930", "10s", df1)
+
+        dir_ = data_dir / "ohlcv" / "10s" / "KRX" / "005930"
+        # 일별 파일만 존재 — 월별 glob은 0건 매치
+        assert (dir_ / "2026-01-15.parquet").exists()
+        assert list(dir_.glob("????-??.parquet")) == []
+
+        # 추가 write도 일별 유지(월별 오인 없음)
+        df2 = _make_subminute_ohlcv_df("005930", ["2026-01-16"], interval="10s")
+        store.write("005930", "10s", df2)
+        files = sorted(f.name for f in dir_.glob("*.parquet"))
+        assert files == ["2026-01-15.parquet", "2026-01-16.parquet"]
+
+
 class TestParquetStoreReadEndDateOnly:
     """`read(end=...)` date-only whole-day inclusive 동작(#2081).
 


### PR DESCRIPTION
Closes #2115

## Summary
`ParquetStore.write()`가 timeframe 무관 항상 월별 파티션이던 것을 spec(04-schema: 10s/30s 일별)에 맞게 분기.
- `data_type=="ohlcv" and timeframe in {10s,30s}` → 일별(`_partition_by_day`, YYYY-MM-DD)
- **escalation-gate 가드**: dir에 legacy 월별 파일(glob `????-??.parquet`)이 있으면 월별 유지+warn(coexistence 미생성, read 중복 0). 신규/빈 dir만 일별
- 1m+ ohlcv·fundamental·tick → 월별(회귀 없음). read/_persist_partition/migration 무변경(destructive 0)
- legacy 월별→일별 migration은 follow-up #2267(데이터-안전 설계 분리; in-write migration 손실/precedence 3회 지적 → escalation gate)

## Scope
- `src/ante/data/store.py`. read/vocab/fundamental·tick 무변경.

## Test Plan
- 신규 9건(10s/30s 일별, 1m/1d/5m·fundamental 월별 gate, 라운드트립+dedup, legacy 가드, glob 미매치)
- `pytest -k 'store or parquet or data'` 688 passed, 전체 유닛 6669 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)