### PR TITLE
fix(feed): #2020 data.go.kr 수집 시 .feed/instruments.parquet 갱신

### DIFF
--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -289,7 +289,9 @@ class DataGoKrCollector:
 
         매핑(spec data-feed/04-schema.md INSTRUMENTS, 05-data-sources.md):
         `srtnCd`→symbol, `itmsNm`→name, `mrktCtg`→market, exchange="KRX".
-        itmsNm/mrktCtg 컬럼이 없으면 빈 문자열로 안전 처리한다.
+        itmsNm/mrktCtg 컬럼이 둘 다 없으면(메타데이터 전무) 무가치한 파일을
+        만들지 않도록 저장을 건너뛴다. 적어도 하나의 메타 컬럼이 있으면 누락 셀은
+        빈 문자열로 안전 처리한다.
 
         upsert 정책:
         - 신규 batch는 symbol 기준 1행으로 dedup한다.
@@ -306,6 +308,15 @@ class DataGoKrCollector:
         """
         # df는 survivors raw DataFrame이므로 종목코드 컬럼은 `srtnCd`다.
         if "srtnCd" not in df.columns:
+            return 0
+
+        # itmsNm/mrktCtg가 둘 다 없으면 메타데이터 전무 → 무가치 파일 생성 방지.
+        if "itmsNm" not in df.columns and "mrktCtg" not in df.columns:
+            logger.debug(
+                "data.go.kr instruments: 메타 컬럼(itmsNm/mrktCtg) 전무(rows=%d) "
+                "— 파일 미생성",
+                df.height,
+            )
             return 0
 
         height = df.height

--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -226,11 +226,19 @@ class DataGoKrCollector:
         rows_written += self._store_ohlcv(df, store, symbols)
         rows_written += self._store_fundamental(df, store, symbols)
 
+        # 종목 메타데이터(symbol/exchange/name/market)를 `.feed/instruments.parquet`에
+        # upsert한다(spec data-feed/04-schema.md INSTRUMENTS). ohlcv/fundamental과
+        # 의미가 다른(심볼 1행 마스터) 산출이라 rows_written에 합산하지 않고 별도
+        # 로그만 남긴다. 저장 실패가 ohlcv/fundamental 결과를 회귀시키지 않도록
+        # 호출은 ohlcv/fundamental 저장 뒤에 둔다.
+        instruments_written = self._store_instruments(df, store)
+
         logger.info(
-            "data.go.kr 수집 완료: date=%s symbols=%d rows=%d",
+            "data.go.kr 수집 완료: date=%s symbols=%d rows=%d instruments=%d",
             target_date,
             len(symbols),
             rows_written,
+            instruments_written,
         )
         return rows_written, symbols
 
@@ -271,3 +279,160 @@ class DataGoKrCollector:
             rows += len(sym_df)
             symbols.add(sym)
         return rows
+
+    # INSTRUMENTS 스키마 컬럼 순서(spec data-feed/04-schema.md).
+    _INSTRUMENTS_COLUMNS = ("symbol", "exchange", "name", "market")
+
+    @classmethod
+    def _store_instruments(cls, df: pl.DataFrame, store: ParquetStore) -> int:
+        """종목 메타데이터를 `.feed/instruments.parquet`에 upsert한다.
+
+        매핑(spec data-feed/04-schema.md INSTRUMENTS, 05-data-sources.md):
+        `srtnCd`→symbol, `itmsNm`→name, `mrktCtg`→market, exchange="KRX".
+        itmsNm/mrktCtg 컬럼이 없으면 빈 문자열로 안전 처리한다.
+
+        upsert 정책:
+        - 신규 batch는 symbol 기준 1행으로 dedup한다.
+        - 기존 `.feed/instruments.parquet`가 있으면 symbol을 키로 merge한다.
+          단 신규 행의 name/market가 비어있으면(누락/빈 문자열) 기존 non-empty
+          값을 덮어쓰지 않고 보존한다(Codex refinement). 신규 값이 non-empty면
+          갱신한다.
+        - 파일이 없으면 신규 생성한다.
+
+        symbol 컬럼이 없거나 결과가 비어있으면 파일을 생성/변경하지 않는다.
+
+        Returns:
+            파일에 기록된 instrument 행 수. 미기록(빈 입력)이면 0.
+        """
+        # df는 survivors raw DataFrame이므로 종목코드 컬럼은 `srtnCd`다.
+        if "srtnCd" not in df.columns:
+            return 0
+
+        height = df.height
+        symbol_expr = pl.col("srtnCd").cast(pl.Utf8)
+        name_expr = (
+            pl.col("itmsNm").cast(pl.Utf8) if "itmsNm" in df.columns else pl.lit("")
+        )
+        market_expr = (
+            pl.col("mrktCtg").cast(pl.Utf8) if "mrktCtg" in df.columns else pl.lit("")
+        )
+
+        new_df = df.select(
+            symbol_expr.alias("symbol"),
+            pl.lit("KRX").alias("exchange"),
+            name_expr.alias("name"),
+            market_expr.alias("market"),
+        )
+        # null(누락 셀)은 빈 문자열로 정규화하여 보존 로직이 일관되게 동작하게 한다.
+        new_df = new_df.with_columns(
+            pl.col("name").fill_null(""),
+            pl.col("market").fill_null(""),
+        )
+        # 유효한 symbol만 유지(빈/null symbol drop) 후 symbol 기준 dedup(1행/심볼).
+        new_df = new_df.filter(
+            pl.col("symbol").is_not_null() & (pl.col("symbol") != "")
+        ).unique(subset=["symbol"], keep="last")
+
+        if new_df.is_empty():
+            logger.debug(
+                "data.go.kr instruments: 유효 symbol 없음(rows=%d) — 파일 미변경",
+                height,
+            )
+            return 0
+
+        path = store.base_path / ".feed" / "instruments.parquet"
+        if path.exists():
+            try:
+                existing = pl.read_parquet(path)
+            except Exception as exc:
+                # 기존 파일 손상 시 신규 데이터로 덮어쓰지 않고 보존(데이터 손실 방지).
+                logger.warning(
+                    "data.go.kr instruments: 기존 파일 읽기 실패 — 보존, "
+                    "write 건너뜀 (%s)",
+                    exc,
+                )
+                return 0
+            merged = cls._merge_instruments(existing, new_df)
+        else:
+            merged = new_df
+
+        merged = merged.select(list(cls._INSTRUMENTS_COLUMNS))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        merged.write_parquet(str(path))
+        logger.info(
+            "data.go.kr instruments 갱신: path=%s rows=%d",
+            path,
+            merged.height,
+        )
+        return merged.height
+
+    @staticmethod
+    def _merge_instruments(
+        existing: pl.DataFrame, new_df: pl.DataFrame
+    ) -> pl.DataFrame:
+        """기존 instruments와 신규 행을 symbol 기준으로 merge한다.
+
+        - 신규 symbol은 그대로 추가한다.
+        - 기존 symbol은 갱신하되, 신규 name/market가 빈 문자열이면 기존
+          non-empty 값을 보존한다(빈 신규값이 기존 값을 덮어쓰지 않게).
+        - exchange는 항상 "KRX"로 유지한다.
+        """
+        # 기존 프레임을 INSTRUMENTS 컬럼으로 정규화(누락 컬럼은 빈 문자열).
+        existing = existing.with_columns(
+            *[
+                pl.lit("").alias(col)
+                for col in ("symbol", "exchange", "name", "market")
+                if col not in existing.columns
+            ]
+        )
+        existing = existing.select("symbol", "exchange", "name", "market")
+        existing = existing.with_columns(
+            pl.col("symbol").cast(pl.Utf8),
+            pl.col("exchange").cast(pl.Utf8).fill_null(""),
+            pl.col("name").cast(pl.Utf8).fill_null(""),
+            pl.col("market").cast(pl.Utf8).fill_null(""),
+        )
+
+        new_idx = {row["symbol"]: row for row in new_df.iter_rows(named=True)}
+        existing_symbols: set[str] = set()
+        merged_rows: list[dict] = []
+
+        for row in existing.iter_rows(named=True):
+            sym = row["symbol"]
+            existing_symbols.add(sym)
+            incoming = new_idx.get(sym)
+            if incoming is None:
+                merged_rows.append(row)
+                continue
+            # 신규값이 non-empty면 갱신, 빈 값이면 기존 보존.
+            merged_rows.append(
+                {
+                    "symbol": sym,
+                    "exchange": "KRX",
+                    "name": incoming["name"] or row["name"],
+                    "market": incoming["market"] or row["market"],
+                }
+            )
+
+        # 기존에 없던 신규 symbol 추가.
+        for sym, incoming in new_idx.items():
+            if sym in existing_symbols:
+                continue
+            merged_rows.append(
+                {
+                    "symbol": sym,
+                    "exchange": "KRX",
+                    "name": incoming["name"],
+                    "market": incoming["market"],
+                }
+            )
+
+        return pl.DataFrame(
+            merged_rows,
+            schema={
+                "symbol": pl.Utf8,
+                "exchange": pl.Utf8,
+                "name": pl.Utf8,
+                "market": pl.Utf8,
+            },
+        )

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -1372,7 +1372,10 @@ def _raw_inst(
 
 
 def _read_instruments(store: ParquetStore):
-    """`.feed/instruments.parquet`를 읽어 (path, DataFrame) 반환. 없으면 (path, None)."""
+    """`.feed/instruments.parquet`를 읽어 (path, DataFrame) 반환.
+
+    없으면 (path, None).
+    """
     import polars as pl
 
     path = store.base_path / ".feed" / "instruments.parquet"
@@ -1386,7 +1389,10 @@ class TestCollectorInstrumentsStore:
 
     @pytest.mark.asyncio
     async def test_instruments_written_on_collect(self, tmp_path) -> None:
-        """(a) collect → instruments.parquet 생성(symbol/exchange/name/market 채워짐)."""
+        """(a) collect → instruments.parquet 생성.
+
+        symbol/exchange/name/market 채워짐.
+        """
         store = ParquetStore(base_path=tmp_path)
         collector = DataGoKrCollector(
             source=_FakeSource([_raw_inst("005930", "삼성전자", "KOSPI")])

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -1349,3 +1349,216 @@ class TestCollectorValidationGate:
         assert len(_schema_warns(warns)) == 2
         assert store.list_symbols("1d") == []
         assert store.list_symbols(data_type="fundamental") == []
+
+
+# ── DataGoKrCollector: instruments.parquet 갱신 (#2020) ────────
+
+
+def _raw_inst(
+    srtn: str = "005930",
+    itms_nm: str | None = "삼성전자",
+    mrkt_ctg: str | None = "KOSPI",
+) -> dict:
+    """instruments 메타데이터 필드(itmsNm/mrktCtg)를 포함한 raw item.
+
+    itms_nm/mrkt_ctg를 None으로 주면 해당 키를 제거한다(컬럼 누락 모사).
+    """
+    item = _raw(srtn)
+    if itms_nm is not None:
+        item["itmsNm"] = itms_nm
+    if mrkt_ctg is not None:
+        item["mrktCtg"] = mrkt_ctg
+    return item
+
+
+def _read_instruments(store: ParquetStore):
+    """`.feed/instruments.parquet`를 읽어 (path, DataFrame) 반환. 없으면 (path, None)."""
+    import polars as pl
+
+    path = store.base_path / ".feed" / "instruments.parquet"
+    if not path.exists():
+        return path, None
+    return path, pl.read_parquet(path)
+
+
+class TestCollectorInstrumentsStore:
+    """#2020: data.go.kr 수집 시 .feed/instruments.parquet upsert."""
+
+    @pytest.mark.asyncio
+    async def test_instruments_written_on_collect(self, tmp_path) -> None:
+        """(a) collect → instruments.parquet 생성(symbol/exchange/name/market 채워짐)."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(
+            source=_FakeSource([_raw_inst("005930", "삼성전자", "KOSPI")])
+        )
+
+        await collector.collect("20260102", store)
+
+        path, df = _read_instruments(store)
+        assert path == tmp_path / ".feed" / "instruments.parquet"
+        assert df is not None
+        assert df.columns == ["symbol", "exchange", "name", "market"]
+        row = df.filter(df["symbol"] == "005930").to_dicts()[0]
+        assert row == {
+            "symbol": "005930",
+            "exchange": "KRX",
+            "name": "삼성전자",
+            "market": "KOSPI",
+        }
+
+    @pytest.mark.asyncio
+    async def test_instruments_upsert_no_duplicate_across_days(self, tmp_path) -> None:
+        """(b) 같은 심볼 2일 수집 → symbol upsert, 중복 0행."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(
+            source=_FakeSource([_raw_inst("005930", "삼성전자", "KOSPI")])
+        )
+
+        await collector.collect("20260102", store)
+        await collector.collect("20260103", store)
+
+        _, df = _read_instruments(store)
+        assert df is not None
+        assert df.height == 1
+        assert df["symbol"].to_list() == ["005930"]
+
+    @pytest.mark.asyncio
+    async def test_instruments_empty_new_values_preserve_existing(
+        self, tmp_path
+    ) -> None:
+        """(c) 신규 row의 itmsNm/mrktCtg 빈값 → 기존 non-empty 보존(덮어쓰기 안 함)."""
+        store = ParquetStore(base_path=tmp_path)
+        # 1일차: name/market 채워서 저장.
+        first = DataGoKrCollector(
+            source=_FakeSource([_raw_inst("005930", "삼성전자", "KOSPI")])
+        )
+        await first.collect("20260102", store)
+
+        # 2일차: itmsNm/mrktCtg 키 자체가 없는(누락) raw → 빈 값으로 들어옴.
+        second = DataGoKrCollector(
+            source=_FakeSource([_raw_inst("005930", itms_nm=None, mrkt_ctg=None)])
+        )
+        await second.collect("20260103", store)
+
+        _, df = _read_instruments(store)
+        assert df is not None
+        assert df.height == 1
+        row = df.filter(df["symbol"] == "005930").to_dicts()[0]
+        # 빈 신규값이 기존 non-empty를 덮어쓰지 않아야 한다.
+        assert row["name"] == "삼성전자"
+        assert row["market"] == "KOSPI"
+
+    @pytest.mark.asyncio
+    async def test_instruments_non_empty_new_values_update(self, tmp_path) -> None:
+        """신규 non-empty 값은 기존 값을 갱신한다."""
+        store = ParquetStore(base_path=tmp_path)
+        first = DataGoKrCollector(
+            source=_FakeSource([_raw_inst("005930", "구종목명", "KOSPI")])
+        )
+        await first.collect("20260102", store)
+
+        second = DataGoKrCollector(
+            source=_FakeSource([_raw_inst("005930", "삼성전자", "KOSDAQ")])
+        )
+        await second.collect("20260103", store)
+
+        _, df = _read_instruments(store)
+        assert df is not None
+        row = df.filter(df["symbol"] == "005930").to_dicts()[0]
+        assert row["name"] == "삼성전자"
+        assert row["market"] == "KOSDAQ"
+
+    @pytest.mark.asyncio
+    async def test_instruments_multiple_symbols(self, tmp_path) -> None:
+        """여러 심볼 수집 → 각 심볼 1행씩 instruments에 기록."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(
+            source=_FakeSource(
+                [
+                    _raw_inst("005930", "삼성전자", "KOSPI"),
+                    _raw_inst("000660", "SK하이닉스", "KOSPI"),
+                    _raw_inst("035720", "카카오", "KOSDAQ"),
+                ]
+            )
+        )
+
+        await collector.collect("20260102", store)
+
+        _, df = _read_instruments(store)
+        assert df is not None
+        assert df.height == 3
+        assert set(df["symbol"].to_list()) == {"005930", "000660", "035720"}
+
+    @pytest.mark.asyncio
+    async def test_ohlcv_fundamental_no_regression_with_instruments(
+        self, tmp_path
+    ) -> None:
+        """(d) instruments 저장 추가 후에도 ohlcv/fundamental 저장이 회귀 없이 유지."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(
+            source=_FakeSource([_raw_inst("005930", "삼성전자", "KOSPI")])
+        )
+
+        rows, symbols, _ = await collector.collect("20260102", store)
+
+        assert rows > 0
+        assert symbols == {"005930"}
+        assert store.list_symbols("1d") == ["005930"]
+        assert store.list_symbols(data_type="fundamental") == ["005930"]
+        # instruments도 함께 기록된다.
+        _, df = _read_instruments(store)
+        assert df is not None
+        assert df["symbol"].to_list() == ["005930"]
+
+    @pytest.mark.asyncio
+    async def test_instruments_missing_meta_columns_graceful(self, tmp_path) -> None:
+        """(e) itmsNm/mrktCtg 컬럼 전무 → graceful(파일 생성되되 빈 name/market).
+
+        symbol은 유효하므로 instruments 행은 기록되지만 name/market는 빈 문자열.
+        크래시가 발생하지 않아야 한다.
+        """
+        store = ParquetStore(base_path=tmp_path)
+        # itmsNm/mrktCtg 키가 전혀 없는 raw(=_raw 기본).
+        collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
+
+        rows, symbols, _ = await collector.collect("20260102", store)
+
+        assert rows > 0
+        assert symbols == {"005930"}
+        _, df = _read_instruments(store)
+        assert df is not None
+        row = df.filter(df["symbol"] == "005930").to_dicts()[0]
+        assert row["symbol"] == "005930"
+        assert row["exchange"] == "KRX"
+        assert row["name"] == ""
+        assert row["market"] == ""
+
+    @pytest.mark.asyncio
+    async def test_instruments_not_written_on_empty_response(self, tmp_path) -> None:
+        """(e) 빈 응답 → instruments 파일 미생성, 크래시 없음."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(source=_FakeSource([]))
+
+        rows, symbols, warns = await collector.collect("20260102", store)
+
+        assert rows == 0
+        assert symbols == set()
+        path, df = _read_instruments(store)
+        assert not path.exists()
+        assert df is None
+
+    @pytest.mark.asyncio
+    async def test_instruments_not_written_on_all_dropped(self, tmp_path) -> None:
+        """모든 레코드가 선필터 drop되어 survivors=[] → instruments 미생성."""
+        store = ParquetStore(base_path=tmp_path)
+        bad = _raw_inst("005930", "삼성전자", "KOSPI")
+        del bad["mkp"]  # 필수 필드 누락 → 선필터 drop.
+        collector = DataGoKrCollector(source=_FakeSource([bad]))
+
+        rows, symbols, _ = await collector.collect("20260102", store)
+
+        assert rows == 0
+        assert symbols == set()
+        path, df = _read_instruments(store)
+        assert not path.exists()
+        assert df is None

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -1511,11 +1511,13 @@ class TestCollectorInstrumentsStore:
         assert df["symbol"].to_list() == ["005930"]
 
     @pytest.mark.asyncio
-    async def test_instruments_missing_meta_columns_graceful(self, tmp_path) -> None:
-        """(e) itmsNm/mrktCtg 컬럼 전무 → graceful(파일 생성되되 빈 name/market).
+    async def test_instruments_not_written_on_missing_meta_columns(
+        self, tmp_path
+    ) -> None:
+        """(e) itmsNm/mrktCtg 컬럼 둘 다 전무 → 무가치 파일 미생성(크래시 없음).
 
-        symbol은 유효하므로 instruments 행은 기록되지만 name/market는 빈 문자열.
-        크래시가 발생하지 않아야 한다.
+        메타데이터가 전혀 없으면(srtnCd만 존재) instruments.parquet를 생성하지
+        않는다. ohlcv/fundamental 등 다른 저장 경로는 정상 진행한다.
         """
         store = ParquetStore(base_path=tmp_path)
         # itmsNm/mrktCtg 키가 전혀 없는 raw(=_raw 기본).
@@ -1525,13 +1527,43 @@ class TestCollectorInstrumentsStore:
 
         assert rows > 0
         assert symbols == {"005930"}
-        _, df = _read_instruments(store)
+        path, df = _read_instruments(store)
+        assert not path.exists()
+        assert df is None
+
+    @pytest.mark.asyncio
+    async def test_instruments_written_with_only_name_column(self, tmp_path) -> None:
+        """메타 컬럼이 하나만 있어도(itmsNm만) 파일 생성, 누락 컬럼은 빈 문자열."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(
+            source=_FakeSource([_raw_inst("005930", "삼성전자", mrkt_ctg=None)])
+        )
+
+        await collector.collect("20260102", store)
+
+        path, df = _read_instruments(store)
+        assert path.exists()
         assert df is not None
         row = df.filter(df["symbol"] == "005930").to_dicts()[0]
-        assert row["symbol"] == "005930"
-        assert row["exchange"] == "KRX"
-        assert row["name"] == ""
+        assert row["name"] == "삼성전자"
         assert row["market"] == ""
+
+    @pytest.mark.asyncio
+    async def test_instruments_written_with_only_market_column(self, tmp_path) -> None:
+        """메타 컬럼이 하나만 있어도(mrktCtg만) 파일 생성, 누락 컬럼은 빈 문자열."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(
+            source=_FakeSource([_raw_inst("005930", itms_nm=None, mrkt_ctg="KOSPI")])
+        )
+
+        await collector.collect("20260102", store)
+
+        path, df = _read_instruments(store)
+        assert path.exists()
+        assert df is not None
+        row = df.filter(df["symbol"] == "005930").to_dicts()[0]
+        assert row["name"] == ""
+        assert row["market"] == "KOSPI"
 
     @pytest.mark.asyncio
     async def test_instruments_not_written_on_empty_response(self, tmp_path) -> None:


### PR DESCRIPTION
Closes #2020

## Summary
DataFeed가 data.go.kr 종목 메타데이터(`srtnCd`/`itmsNm`/`mrktCtg`)를 `.feed/instruments.parquet`(symbol/exchange/name/market)로 저장하지 않던 spec gap 구현(04-schema).
- `_store_instruments`: srtnCd→symbol, itmsNm→name, mrktCtg→market, exchange=KRX; symbol dedup; `base_path/.feed/instruments.parquet` upsert
- **upsert-preserve**: 빈 신규 name/market가 기존 non-empty 덮어쓰지 않음
- **no-metadata 가드**: itmsNm/mrktCtg 컬럼 둘 다 없으면 파일 미생성
- `_normalize_and_store`에서 ohlcv/fundamental 뒤 호출(회귀 없음). InstrumentService DB(`_sync_instruments`, broker 기반)는 별개·무변경

## Scope
- `src/ante/feed/pipeline/data_go_kr_collector.py`. read/vocab/DART 무변경.

## Test Plan
- 신규 ~11건(생성·필드/2일 upsert/빈값 preserve/한쪽컬럼만/메타전무 미생성/ohlcv·fundamental 회귀/빈응답)
- `pytest -k 'data_go_kr or feed or collector or instrument'` 864 passed, 전체 유닛 6671 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS(2회차)

🤖 Generated with [Claude Code](https://claude.com/claude-code)