### PR TITLE
fix(reconcile): #2119 broker.reconcile account-level 재설계 — 1봇 보정/다중봇 detect-only

### DIFF
--- a/src/ante/broker/scheduler.py
+++ b/src/ante/broker/scheduler.py
@@ -104,25 +104,61 @@ class ReconcileScheduler:
     ) -> list[dict[str, Any]]:
         """1회 대사를 수행하고 보정 내역을 반환한다.
 
-        모든 활성(running) 봇에 대해 브로커 포지션을 조회하고,
-        PositionReconciler.reconcile()을 호출하여 불일치를 보정한다.
+        이 스케줄러가 바인딩된 ``broker_account_id`` 계좌에 대해 브로커 총합을
+        1회 조회하고, **봇 귀속 ambiguity(status 무관 봇 count)** 와 **correction
+        실행 범위(running 봇)** 를 분리해 처리한다(#2118).
+
+        - 1봇-total 계좌이고 **그 봇이 running**: 기존 ``reconcile`` 보정
+          (self-check/skip_external_buy/external-buy 분류 무변경 #1946/#1950).
+        - 1봇-total 인데 그 봇이 stopped/error(미-running): correction 미실행 →
+          ``reconcile(dry_run=True)`` detect-only(기존 lifecycle 범위 보존 —
+          scheduler 가 비활성 봇을 자동 보정하지 않는다).
+        - 2+봇 계좌: ``detect_account_level`` (correct_position 미호출). 계좌
+          총합 vs 전 봇 합산 비교로 #2118/#2120 false external-buy 제거.
 
         Args:
             skip_external_buy: True 면 "외부 매수" 분류 보정을 건너뛴다(barrier,
                 #1946 Finding 1). fill 카치업 미성공 시 기동 대사에만 쓰인다.
+                1봇-total+running 보정 경로에만 적용된다.
 
         Returns:
-            각 봇별 보정 내역을 합산한 리스트.
+            각 봇별 보정 내역을 합산한 리스트. detect-only 경로는 보정이 없으므로
+            기여하지 않는다(불일치는 NotificationEvent 로 알림).
         """
         from ante.bot.config import BotStatus
 
         all_corrections: list[dict[str, Any]] = []
 
         bots = self._bot_manager.list_bots()
-        active_bots = [b for b in bots if b.get("status") == BotStatus.RUNNING]
 
-        if not active_bots:
-            logger.debug("대사 대상 활성 봇 없음")
+        # 이 스케줄러는 단일 broker(self._broker_account_id)에 바인딩돼 있다.
+        # 다른 계좌의 봇에 이 broker의 positions를 적용하면 데이터 정합성이
+        # 깨지므로(SPLIT-1 가드) 자기 계좌 봇만 다룬다. SPLIT-3 multi-broker
+        # pool 도입 시 이 가드를 제거한다.
+        account_id = self._broker_account_id
+        account_bots = []
+        for b in bots:
+            bot_account_id = b.get("account_id")
+            if not bot_account_id:
+                logger.warning(
+                    "대사 스킵: bot=%s account_id 누락 (DB 정리 필요)",
+                    b.get("bot_id"),
+                )
+                continue
+            if bot_account_id != account_id:
+                logger.warning(
+                    "대사 스킵: scheduler is bound to %s; "
+                    "bot %s belongs to %s — "
+                    "skipping until SPLIT-3 multi-broker pool",
+                    account_id,
+                    b.get("bot_id"),
+                    bot_account_id,
+                )
+                continue
+            account_bots.append(b)
+
+        if not account_bots:
+            logger.debug("대사 대상 봇 없음 (account=%s)", account_id)
             return all_corrections
 
         try:
@@ -131,50 +167,53 @@ class ReconcileScheduler:
             logger.exception("대사 중 브로커 포지션 조회 실패")
             return all_corrections
 
-        for bot_info in active_bots:
+        # ambiguity 판정 = status 무관 봇 count(#2119). correction 실행 범위는
+        # 아래에서 running 봇으로 별도 한정(#2118 v4: stopped/error 단일봇
+        # 자동보정 금지 — 기존 lifecycle 범위 보존).
+        bot_count = len(account_bots)
+
+        if bot_count == 1:
+            bot_info = account_bots[0]
             bot_id = bot_info["bot_id"]
-            account_id = bot_info.get("account_id")
-            if not account_id:
-                logger.warning(
-                    "대사 스킵: bot=%s account_id 누락 (DB 정리 필요)",
-                    bot_id,
-                )
-                continue
-            if account_id != self._broker_account_id:
-                # SPLIT-1 가드: 이 스케줄러는 단일 broker(self._broker_account_id)
-                # 에 바인딩돼 있다. 다른 계좌의 봇에 이 broker의 positions를
-                # 적용하면 데이터 정합성이 깨지므로 명시적으로 skip한다.
-                # SPLIT-3에서 multi-broker pool 도입 시 이 가드를 제거한다.
-                logger.warning(
-                    "대사 스킵: scheduler is bound to %s; "
-                    "bot %s belongs to %s — "
-                    "skipping until SPLIT-3 multi-broker pool",
-                    self._broker_account_id,
-                    bot_id,
-                    account_id,
-                )
-                continue
+            is_running = bot_info.get("status") == BotStatus.RUNNING
+            # 1봇-total + running 만 보정. stopped/error 면 dry_run detect-only
+            # (scheduler 가 비활성 봇을 자동 보정하지 않는다 — lifecycle 범위 보존).
             try:
                 corrections = await self._reconciler.reconcile(
                     bot_id=bot_id,
                     broker_positions=broker_positions,
                     account_id=account_id,
                     skip_external_buy=skip_external_buy,
+                    dry_run=not is_running,
                 )
                 all_corrections.extend(corrections)
             except Exception:
                 logger.exception("대사 실패 [%s]", bot_id)
+            if not is_running:
+                logger.debug(
+                    "주기 대사: 단일봇 %s 미-running → detect-only (보정 보류)",
+                    bot_id,
+                )
+        else:
+            # 2+봇 — 귀속 ambiguous(#2270). detect-only(correct_position 미호출).
+            try:
+                await self._reconciler.detect_account_level(
+                    broker_positions,
+                    account_id=account_id,
+                )
+            except Exception:
+                logger.exception("계좌 단위 대사 실패 [%s]", account_id)
 
         if all_corrections:
             logger.info(
-                "주기 대사 완료: 활성 봇 %d개, 보정 %d건",
-                len(active_bots),
+                "주기 대사 완료: 계좌 봇 %d개, 보정 %d건",
+                bot_count,
                 len(all_corrections),
             )
         else:
             logger.debug(
-                "주기 대사 완료: 활성 봇 %d개, 불일치 없음",
-                len(active_bots),
+                "주기 대사 완료: 계좌 봇 %d개, 보정 없음",
+                bot_count,
             )
 
         return all_corrections

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -366,16 +366,30 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
                         account_id=validated_account_id
                     )
 
-                    broker_map = {p["symbol"]: p for p in broker_positions}
-                    internal_map = {p.symbol: p for p in internal_positions}
+                    # #2120: 같은 심볼을 보유한 다중봇 internal 을 **심볼별로
+                    # 합산**한다. ``{p.symbol: p}`` dict 컴프리헨션은 동일 심볼을
+                    # 덮어써 한 봇 수량만 비교 대상이 되어 다중봇 계좌를 false
+                    # discrepancy 로 오판했다(per-bot 오판). detect-only 경로이므로
+                    # 계좌 총합 broker vs 전 봇 합산 internal 을 비교한다.
+                    broker_totals: dict[str, float] = {}
+                    for bp in broker_positions:
+                        b_qty = float(bp.get("quantity", 0) or 0)
+                        if b_qty != 0:
+                            sym = bp["symbol"]
+                            broker_totals[sym] = broker_totals.get(sym, 0.0) + b_qty
+                    internal_totals: dict[str, float] = {}
+                    for ip in internal_positions:
+                        internal_totals[ip.symbol] = (
+                            internal_totals.get(ip.symbol, 0.0) + ip.quantity
+                        )
 
-                    all_symbols = set(broker_map.keys()) | set(internal_map.keys())
+                    all_symbols = set(broker_totals.keys()) | set(
+                        internal_totals.keys()
+                    )
                     discrepancies = []
                     for symbol in sorted(all_symbols):
-                        bp = broker_map.get(symbol)
-                        ip = internal_map.get(symbol)
-                        broker_qty = float(bp.get("quantity", 0)) if bp else 0.0
-                        internal_qty = ip.quantity if ip else 0.0
+                        broker_qty = broker_totals.get(symbol, 0.0)
+                        internal_qty = internal_totals.get(symbol, 0.0)
                         if broker_qty != internal_qty:
                             discrepancies.append(
                                 {

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -832,46 +832,114 @@ async def _handle_broker_positions(
     return {"positions": await broker.get_positions()}
 
 
+def _broker_reconcile_envelope(
+    *,
+    account_id: str,
+    fix: bool,
+    bot_count: int,
+    adjustments: list[dict[str, Any]],
+    mismatches: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """``broker.reconcile`` 통일 응답 envelope 을 만든다.
+
+    account-level 신규 필드(``account_id``/``fix``/``bot_count``/``adjustments``/
+    ``mismatches``)와, CLI/agent display 호환을 위한 legacy 필드
+    (``total_symbols``/``discrepancies``/``match``/``fix_applied``/``corrections``)
+    를 함께 노출해 IPC·CLI passthrough envelope shape 를 일관 유지한다.
+    """
+    return {
+        "account_id": account_id,
+        "fix": fix,
+        "bot_count": bot_count,
+        "adjustments": adjustments,
+        "mismatches": mismatches,
+        # ── legacy display 호환 (CLI passthrough / 기존 envelope shape) ──
+        "total_symbols": len(mismatches),
+        "discrepancies": mismatches,
+        "match": len(mismatches) == 0,
+        "fix_applied": fix,
+        "corrections": len(adjustments),
+    }
+
+
 async def _handle_broker_reconcile(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    from ante.account.errors import InvalidAccountIdError
+    """``broker.reconcile`` — **account-level** 대사 (#2119/#2121/#2122/#2118/#2120).
+
+    account_id 만으로 동작한다(bot_id 불요 #2119). 서버 BrokerAdapter 가 계좌
+    총합을 직접 조회하며(caller-supplied broker_positions 무시 #2121), ``fix``
+    플래그를 준수한다(#2122). 잘못된 ``correct_position`` 이 실거래 포지션을
+    손상시키지 않도록 **correction 은 봇이 정확히 1개인 계좌에서만** 기존
+    ``reconcile`` 로직에 위임하고, 그 외(2+봇·0봇)는 detect-only 다.
+
+    봇 count 분기 (status 무관 — 수동 IPC 는 user-initiated 라 봇 상태와
+    무관하게 단일봇 귀속이 자명):
+        - 정확히 1봇: ``reconciler.reconcile(bot_id, ..., dry_run=not fix)`` —
+          기존 self-check/skip_external_buy/external-buy 분류 그대로(#1950/#1946
+          무변경). fix=True 면 보정, fix=False 면 detect-only.
+        - 2+봇: ``reconciler.detect_account_level(...)`` (correct_position 미호출).
+        - 0봇 + broker_positions 비어있지 않음: account-level detect/alert.
+    """
     from ante.account.scoping import require_account_id
 
-    # #1623 Split C / #1633 finding: ``require_account_id``를
-    # ``args["bot_id"]`` **이전**으로 둔다. 그래야 bot_id 없는
-    # invalid-account-only direct-IPC probe도 ``InvalidAccountIdError``
-    # (code="VALIDATION_ERROR", #1633 SSOT)로 raise되어 server.py:323
-    # ``getattr(e, "code", ...)``를 거쳐 VALIDATION_ERROR envelope이 된다.
-    # bot_id를 먼저 읽으면 ``KeyError``가 먼저 터져 EXECUTION_ERROR로
-    # 오분류된다. status/balance/positions handler는 이미 require_account_id
-    # 최우선이라 무변경 — reconcile만 ordering 대상.
+    # #1623 Split C / #1633 finding 유지: ``require_account_id`` 가 함수 최상단.
+    # invalid-account-only direct-IPC probe 도 ``InvalidAccountIdError``
+    # (code="VALIDATION_ERROR", #1633 SSOT)로 먼저 raise 된다.
     account_id = require_account_id(
         args.get("account_id"), context="ipc.broker.reconcile"
     )
-    bot_id = args["bot_id"]
+    fix = bool(args.get("fix", False))
 
-    # Refs #1240 review (P2-1): BotManager로부터 봇의 실제 account_id를 조회해
-    # 요청 payload의 account_id와 일치하지 않으면 거부한다. 잘못된 account_id가
-    # ``correct_position(...)`` 까지 흘러가 다른 계좌의 positions / adjustment
-    # trade가 손상되는 cross-account corruption을 차단하기 위함이다.
+    # #2121: 서버 BrokerAdapter 가 계좌 총합을 직접 조회한다. caller-supplied
+    # broker_positions(args["broker_positions"]) 는 신뢰하지 않고 무시한다 —
+    # 빈 리스트나 조작된 값이 외부청산으로 오보정되는 것을 차단한다.
+    broker = await svc.account.get_broker(account_id)
+    broker_positions = await broker.get_account_positions()
+
+    # 계좌 봇 목록 (status 무관 count — #2119 ambiguity 판정 기준).
     bot_manager = getattr(svc, "bot_manager", None)
+    account_bots: list[str] = []
     if bot_manager is not None:
-        bot = bot_manager.get_bot(bot_id)
-        if bot is not None:
-            bot_account_id = getattr(bot.config, "account_id", None)
-            if bot_account_id and bot_account_id != account_id:
-                raise InvalidAccountIdError(
-                    f"(ipc.broker.reconcile) bot_id={bot_id!r} 의 account_id는 "
-                    f"{bot_account_id!r} 인데 요청은 {account_id!r} 입니다. "
-                    "다른 계좌의 포지션을 조작할 수 없습니다."
-                )
+        for info in bot_manager.list_bots():
+            if info.get("account_id") == account_id:
+                account_bots.append(info["bot_id"])
+    bot_count = len(account_bots)
 
-    broker_positions = args.get("broker_positions", [])
-    adjustments = await svc.reconciler.reconcile(
-        bot_id, broker_positions, account_id=account_id
+    if bot_count == 1:
+        # 단일봇 — 귀속 자명. 기존 reconcile 로직 그대로 위임(self-check/external
+        # 분류 무변경). fix=True 보정 / fix=False detect-only(dry_run).
+        adjustments = await svc.reconciler.reconcile(
+            account_bots[0],
+            broker_positions,
+            account_id=account_id,
+            dry_run=not fix,
+        )
+        # display(discrepancies)는 보정 **이후** 상태로 계좌 단위 합산 비교를
+        # 재계산한다(순수, 이벤트 無). fix=True 면 보정 후 0으로 수렴, dry_run
+        # 이면 미보정 불일치가 그대로 남는다.
+        mismatches = await svc.reconciler.compute_account_diff(
+            broker_positions, account_id=account_id
+        )
+        return _broker_reconcile_envelope(
+            account_id=account_id,
+            fix=fix,
+            bot_count=bot_count,
+            adjustments=adjustments,
+            mismatches=mismatches,
+        )
+
+    # 2+봇 또는 0봇 — 귀속 ambiguous(#2270). detect-only(보정 없음).
+    mismatches = await svc.reconciler.detect_account_level(
+        broker_positions, account_id=account_id
     )
-    return {"bot_id": bot_id, "adjustments": adjustments}
+    return _broker_reconcile_envelope(
+        account_id=account_id,
+        fix=fix,
+        bot_count=bot_count,
+        adjustments=[],
+        mismatches=mismatches,
+    )
 
 
 def register_all_handlers(registry: CommandRegistry) -> None:
@@ -1103,15 +1171,18 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         result_kind="entity",
         required_services=frozenset({"approval"}),
     )
-    # broker.reconcile은 reconciler.reconcile()이 correct_position/이벤트
-    # publish를 수행하므로 일괄 mutating으로 분류한다. CLI ``--fix=False``
-    # dryrun 분리는 후속 이슈.
+    # broker.reconcile은 account-level (#2119): 서버 BrokerAdapter
+    # (svc.account.get_broker)로 계좌 총합을 조회하고, 1봇-total 계좌면
+    # reconciler.reconcile(correct_position/이벤트 publish 가능)에 위임하며,
+    # 2+봇·0봇이면 detect_account_level(알림만)을 수행한다. fix=False(dry_run)
+    # 여도 broker 조회·이벤트 발행이 있으므로 일괄 mutating으로 분류한다.
+    # required_services: account(broker 조회) + reconciler + bot_manager(count).
     registry.register(
         "broker.reconcile",
         _handle_broker_reconcile,
         is_mutating=True,
         result_kind="operation",
-        required_services=frozenset({"reconciler", "bot_manager"}),
+        required_services=frozenset({"account", "reconciler", "bot_manager"}),
         account_id_policy="required",
     )
 

--- a/src/ante/trade/reconciler.py
+++ b/src/ante/trade/reconciler.py
@@ -46,6 +46,7 @@ class PositionReconciler:
         *,
         account_id: str,
         skip_external_buy: bool = False,
+        dry_run: bool = False,
     ) -> list[dict[str, Any]]:
         """봇의 내부 포지션과 브로커 포지션을 대조하여 보정.
 
@@ -64,9 +65,15 @@ class PositionReconciler:
                 `skip_external_buy` 와 무관하게 항상 수행되며, 이 플래그는 분류
                 결과 중 "외부 매수" 보정만 억제하는 별도 계층이다. 주기
                 reconcile(`skip_external_buy=False`)에서도 self 는 보정되지 않는다.
+            dry_run: True 면 **detect-only** 모드 — 분류·로그·PositionMismatchEvent
+                /NotificationEvent 발행은 그대로 수행하되 ``correct_position`` 을
+                **호출하지 않는다**(보정 0건). 기존 external-buy/self-check 분류
+                로직은 무변경이며, 발행되는 이벤트도 동일하다. 보정만 보류한다.
+                (#2119/#2122: 다중봇 귀속 ambiguity·user-initiated detect 경로용.)
+                기본 False — 기존 호출자는 변경 없이 보정 동작 유지(무회귀).
 
         Returns:
-            보정 내역 리스트. 불일치가 없으면 빈 리스트.
+            보정 내역 리스트. 불일치가 없거나 ``dry_run=True`` 면 빈 리스트.
         """
         from ante.account.scoping import require_account_id
         from ante.eventbus.events import (
@@ -225,6 +232,22 @@ class PositionReconciler:
                 )
             )
 
+            if dry_run:
+                # detect-only: 분류·이벤트는 위에서 발행했으나 실제 보정
+                # (correct_position)은 호출하지 않는다(#2119/#2122). 다중봇
+                # 귀속이 ambiguous하거나 user-initiated 탐지 요청인 경로에서
+                # 잘못된 보정으로 실거래 포지션을 손상시키지 않기 위함이다.
+                logger.info(
+                    "포지션 불일치 [%s] %s: 내부=%.2f, 브로커=%.2f → %s "
+                    "(dry-run — 보정 보류)",
+                    bot_id,
+                    symbol,
+                    i_qty,
+                    b_qty,
+                    reason,
+                )
+                continue
+
             correction = await self._trade_service.correct_position(
                 bot_id=bot_id,
                 symbol=symbol,
@@ -251,6 +274,134 @@ class PositionReconciler:
             )
 
         return corrections
+
+    async def compute_account_diff(
+        self,
+        broker_positions: list[dict[str, Any]],
+        *,
+        account_id: str,
+    ) -> list[dict[str, Any]]:
+        """계좌 총합(broker) vs 전 봇 internal 합산 비교 — **순수(side-effect 無)**.
+
+        broker 는 계좌 **총합**만 주므로 per-bot/per-symbol 귀속이 근본적으로
+        ambiguous하다(#2270). 이 메서드는 이벤트/보정 없이 **읽기 전용으로**
+        계좌 단위 심볼별 불일치만 계산한다(display/detect 공용).
+
+        비교 기준:
+            - broker: ``get_account_positions()`` 의 심볼별 총 수량.
+            - internal: 해당 계좌의 **모든 봇(상태 무관) open 포지션을 심볼별로
+              합산**(``TradeService.get_all_positions(account_id)``). per-bot
+              비교가 같은 심볼을 보유한 다중봇을 false external-buy/청산으로
+              오판하던 것을 제거한다(#2120).
+
+        Returns:
+            불일치 내역 리스트. 일치 시 빈 리스트.
+            각 항목: {"symbol", "broker_qty", "internal_qty", "diff"}.
+        """
+        from ante.account.scoping import require_account_id
+
+        account_id = require_account_id(
+            account_id, context="reconciler.compute_account_diff"
+        )
+
+        # 전 봇(상태 무관) open 포지션을 심볼별 합산 — #2120 다중봇 합산.
+        internal = await self._trade_service.get_all_positions(account_id=account_id)
+        internal_totals: dict[str, float] = {}
+        for p in internal:
+            if p.quantity > 0:
+                internal_totals[p.symbol] = (
+                    internal_totals.get(p.symbol, 0.0) + p.quantity
+                )
+
+        broker_totals: dict[str, float] = {}
+        for bp in broker_positions:
+            qty = float(bp.get("quantity", 0.0))
+            if qty > 0:
+                symbol = bp["symbol"]
+                broker_totals[symbol] = broker_totals.get(symbol, 0.0) + qty
+
+        mismatches: list[dict[str, Any]] = []
+        all_symbols = set(internal_totals.keys()) | set(broker_totals.keys())
+        for symbol in sorted(all_symbols):
+            i_qty = internal_totals.get(symbol, 0.0)
+            b_qty = broker_totals.get(symbol, 0.0)
+            if i_qty == b_qty:
+                continue
+            mismatches.append(
+                {
+                    "symbol": symbol,
+                    "broker_qty": b_qty,
+                    "internal_qty": i_qty,
+                    "diff": b_qty - i_qty,
+                }
+            )
+        return mismatches
+
+    async def detect_account_level(
+        self,
+        broker_positions: list[dict[str, Any]],
+        *,
+        account_id: str,
+    ) -> list[dict[str, Any]]:
+        """계좌 단위 불일치 **detect-only** — 탐지 + account-scoped 알림.
+
+        다중봇(또는 0봇) 계좌에서 ``correct_position`` 을 **절대 호출하지 않고**,
+        :meth:`compute_account_diff` 로 계산한 불일치를 account-scoped
+        ``NotificationEvent`` 로 알린다(#2118/#2120). 신규 도메인 이벤트를
+        신설하지 않고 ``NotificationEvent`` 만 사용한다 — bot-scoped 인
+        ``PositionMismatchEvent``/``ReconcileEvent`` 는 다중봇 귀속이 ambiguous
+        하므로 이 경로에서 발행하지 않는다.
+
+        Args:
+            broker_positions: 서버 BrokerAdapter 가 조회한 계좌 총합.
+            account_id: 대상 계좌 ID (account-scoped 이벤트에 필수).
+
+        Returns:
+            불일치 내역 리스트(detect-only — 보정 없음). 일치 시 빈 리스트.
+        """
+        from ante.account.scoping import require_account_id
+        from ante.eventbus.events import NotificationEvent
+
+        account_id = require_account_id(
+            account_id, context="reconciler.detect_account_level"
+        )
+
+        mismatches = await self.compute_account_diff(
+            broker_positions, account_id=account_id
+        )
+        for m in mismatches:
+            symbol = m["symbol"]
+            i_qty = m["internal_qty"]
+            b_qty = m["broker_qty"]
+            logger.warning(
+                "계좌 단위 포지션 불일치 [%s] %s: 내부합산=%.2f, 브로커=%.2f "
+                "(detect-only — 다중봇 귀속 ambiguous, 보정 보류 #2270)",
+                account_id,
+                symbol,
+                i_qty,
+                b_qty,
+            )
+            await self._eventbus.publish(
+                NotificationEvent(
+                    level="critical",
+                    title="계좌 단위 포지션 불일치",
+                    message=(
+                        f"계좌: `{account_id}` · 종목: `{symbol}`\n"
+                        f"내부 합산: {i_qty:.0f}주 · 브로커: {b_qty:.0f}주\n"
+                        "사유: 계좌 단위 수량 불일치 (다중봇 귀속 ambiguous — "
+                        "자동 보정 보류, 수동 확인 필요)"
+                    ),
+                    category="broker",
+                )
+            )
+
+        if mismatches:
+            logger.info(
+                "계좌 단위 대사 완료 [%s]: 불일치 %d건 (detect-only)",
+                account_id,
+                len(mismatches),
+            )
+        return mismatches
 
     async def _is_self_submitted_fill(
         self,

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -444,123 +444,256 @@ class TestSystemKillSwitchHandlers:
         svc.bot_manager.start_all.assert_not_called()
 
 
-# ── broker.reconcile cross-account guard (Refs #1240 review P2-1) ──
+# ── broker.reconcile account-level 재설계 (#2119/2121/2122/2118/2120) ──
 
 
-class TestHandleBrokerReconcile:
-    """broker.reconcile IPC 핸들러의 account 일치 가드.
+def _make_reconcile_svc(
+    *,
+    bots: list[dict],
+    broker_positions: list[dict] | None = None,
+):
+    """account-level reconcile 핸들러용 svc mock 을 만든다.
 
-    Refs #1240 review (P2-1): 요청자가 ``bot_id`` 와 다른 ``account_id`` 를
-    보내면 잘못된 account_id 가 ``reconciler.reconcile(...)`` 으로 흘러
-    다른 계좌의 positions / adjustment trade 가 손상된다. BotManager 로
-    봇의 실제 account_id 를 조회하여 일치하지 않으면 거부한다.
+    - ``svc.account.get_broker(account_id)`` → broker mock(``get_account_positions``)
+    - ``svc.bot_manager.list_bots()`` → ``bots``
+    - ``svc.reconciler`` → reconcile/detect_account_level/compute_account_diff mock
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    broker = AsyncMock()
+    broker.get_account_positions = AsyncMock(
+        return_value=broker_positions if broker_positions is not None else []
+    )
+
+    account_svc = AsyncMock()
+    account_svc.get_broker = AsyncMock(return_value=broker)
+
+    bot_manager = MagicMock()
+    bot_manager.list_bots = MagicMock(return_value=bots)
+
+    reconciler = AsyncMock()
+    reconciler.reconcile = AsyncMock(return_value=[])
+    reconciler.detect_account_level = AsyncMock(return_value=[])
+    reconciler.compute_account_diff = AsyncMock(return_value=[])
+
+    svc = MagicMock()
+    svc.account = account_svc
+    svc.bot_manager = bot_manager
+    svc.reconciler = reconciler
+    return svc, broker, reconciler
+
+
+class TestHandleBrokerReconcileAccountLevel:
+    """``broker.reconcile`` IPC 핸들러 account-level 재설계 (#2119).
+
+    bot_id 없이 account_id 만으로 도달하고, 서버 BrokerAdapter 가 계좌 총합을
+    직접 조회하며(#2121), fix 플래그를 준수하고(#2122), 봇 count 로 보정/탐지를
+    분기한다(1봇=위임 / 2+봇·0봇=detect-only).
     """
 
     @pytest.mark.asyncio
-    async def test_broker_reconcile_rejects_account_mismatch(self):
-        from unittest.mock import AsyncMock, MagicMock
+    async def test_reaches_account_level_without_bot_id(self):
+        """(a) bot_id 없이 account_id 만으로 도달하고 서버 broker 를 조회한다."""
+        from ante.ipc.registry import _handle_broker_reconcile
 
+        svc, broker, reconciler = _make_reconcile_svc(
+            bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
+            broker_positions=[{"symbol": "005930", "quantity": 10, "avg_price": 1}],
+        )
+
+        result = await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+        )
+
+        # 서버 broker 조회 (caller-supplied 무시).
+        svc.account.get_broker.assert_awaited_once_with("acc-a")
+        broker.get_account_positions.assert_awaited_once()
+        assert result["account_id"] == "acc-a"
+        assert result["bot_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_fix_false_dry_run_no_correction(self):
+        """(b) fix=False → 단일봇 reconcile(dry_run=True) — correct_position 미호출."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler = _make_reconcile_svc(
+            bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+
+        result = await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": False}, "cli-user"
+        )
+
+        reconciler.reconcile.assert_awaited_once()
+        assert reconciler.reconcile.call_args.kwargs["dry_run"] is True
+        assert result["fix"] is False
+        assert result["fix_applied"] is False
+
+    @pytest.mark.asyncio
+    async def test_single_bot_fix_true_delegates_correction(self):
+        """(c) 1봇 계좌 fix=True → 기존 reconcile 보정(dry_run=False) 위임."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler = _make_reconcile_svc(
+            bots=[{"bot_id": "bot-1", "status": "stopped", "account_id": "acc-a"}],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+        reconciler.reconcile.return_value = [{"symbol": "005930", "corrected": True}]
+
+        result = await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+        )
+
+        reconciler.reconcile.assert_awaited_once()
+        call = reconciler.reconcile.call_args
+        assert call.args[0] == "bot-1"
+        assert call.kwargs["account_id"] == "acc-a"
+        assert call.kwargs["dry_run"] is False
+        reconciler.detect_account_level.assert_not_called()
+        assert result["corrections"] == 1
+        assert result["fix_applied"] is True
+
+    @pytest.mark.asyncio
+    async def test_multi_bot_detect_only(self):
+        """(d) 2+봇 → detect_account_level (correct_position 미호출)."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler = _make_reconcile_svc(
+            bots=[
+                {"bot_id": "bot-1", "status": "running", "account_id": "acc-a"},
+                {"bot_id": "bot-2", "status": "running", "account_id": "acc-a"},
+            ],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+        reconciler.detect_account_level.return_value = [
+            {"symbol": "005930", "broker_qty": 10, "internal_qty": 8, "diff": 2}
+        ]
+
+        result = await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+        )
+
+        reconciler.reconcile.assert_not_called()
+        reconciler.detect_account_level.assert_awaited_once()
+        assert result["bot_count"] == 2
+        assert result["adjustments"] == []
+        assert result["mismatches"][0]["symbol"] == "005930"
+        # detect-only — fix=True 여도 보정은 없다.
+        assert result["corrections"] == 0
+
+    @pytest.mark.asyncio
+    async def test_ignores_caller_supplied_broker_positions(self):
+        """(f) caller-supplied broker_positions 무시 — 서버 broker 조회값 사용."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler = _make_reconcile_svc(
+            bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+
+        await _handle_broker_reconcile(
+            svc,
+            {
+                "account_id": "acc-a",
+                "fix": True,
+                # 악의/오류 입력 — 무시되어야 한다.
+                "broker_positions": [{"symbol": "FAKE", "quantity": 9999}],
+            },
+            "cli-user",
+        )
+
+        # reconcile 에 전달된 broker_positions 는 서버 조회값이어야 한다.
+        passed = reconciler.reconcile.call_args.args[1]
+        assert passed == [{"symbol": "005930", "quantity": 10}]
+        assert all(p["symbol"] != "FAKE" for p in passed)
+
+    @pytest.mark.asyncio
+    async def test_zero_bots_with_broker_positions_detect_alert(self):
+        """(k) 0봇 + broker_positions 존재 → detect/alert (no-op 아님)."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler = _make_reconcile_svc(
+            bots=[],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+        reconciler.detect_account_level.return_value = [
+            {"symbol": "005930", "broker_qty": 10, "internal_qty": 0, "diff": 10}
+        ]
+
+        result = await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": False}, "cli-user"
+        )
+
+        reconciler.reconcile.assert_not_called()
+        reconciler.detect_account_level.assert_awaited_once()
+        assert result["bot_count"] == 0
+        assert result["mismatches"][0]["diff"] == 10
+
+    @pytest.mark.asyncio
+    async def test_bot_count_status_agnostic(self):
+        """(l) 봇 count 는 status 무관 — stopped/error 봇도 count 에 포함된다."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler = _make_reconcile_svc(
+            bots=[
+                {"bot_id": "bot-1", "status": "running", "account_id": "acc-a"},
+                {"bot_id": "bot-2", "status": "stopped", "account_id": "acc-a"},
+                {"bot_id": "bot-3", "status": "error", "account_id": "acc-a"},
+            ],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+
+        result = await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+        )
+
+        # 3봇(status 무관) → 2+봇 → detect-only.
+        assert result["bot_count"] == 3
+        reconciler.reconcile.assert_not_called()
+        reconciler.detect_account_level.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_other_account_bots_excluded_from_count(self):
+        """다른 계좌 봇은 count 에서 제외된다 (account-scoped count)."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler = _make_reconcile_svc(
+            bots=[
+                {"bot_id": "bot-1", "status": "running", "account_id": "acc-a"},
+                {"bot_id": "bot-x", "status": "running", "account_id": "acc-other"},
+            ],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+
+        result = await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+        )
+
+        # acc-a 단일봇만 count → reconcile 위임.
+        assert result["bot_count"] == 1
+        reconciler.reconcile.assert_awaited_once()
+        assert reconciler.reconcile.call_args.args[0] == "bot-1"
+
+    @pytest.mark.asyncio
+    async def test_require_account_id_rejected(self):
+        """(j) require_account_id 회귀 — invalid account_id 는 즉시 거부."""
         from ante.account.errors import InvalidAccountIdError
         from ante.ipc.registry import _handle_broker_reconcile
 
-        # 봇은 acc-a 소속인데 요청은 acc-b 로 들어옴.
-        fake_bot = MagicMock()
-        fake_bot.config = MagicMock()
-        fake_bot.config.account_id = "acc-a"
+        svc, broker, reconciler = _make_reconcile_svc(
+            bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
+        )
 
-        fake_bot_manager = MagicMock()
-        fake_bot_manager.get_bot.return_value = fake_bot
-
-        fake_reconciler = AsyncMock()
-
-        svc = MagicMock()
-        svc.bot_manager = fake_bot_manager
-        svc.reconciler = fake_reconciler
-
-        with pytest.raises(InvalidAccountIdError, match="acc-a"):
+        with pytest.raises(InvalidAccountIdError):
             await _handle_broker_reconcile(
-                svc,
-                {
-                    "bot_id": "bot-1",
-                    "account_id": "acc-b",
-                    "broker_positions": [],
-                },
-                "cli-user",
+                svc, {"account_id": "default", "fix": True}, "cli-user"
             )
 
-        # reconcile 까지 절대 도달하지 않아야 한다.
-        fake_reconciler.reconcile.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_broker_reconcile_passes_when_account_matches(self):
-        from unittest.mock import AsyncMock, MagicMock
-
-        from ante.ipc.registry import _handle_broker_reconcile
-
-        fake_bot = MagicMock()
-        fake_bot.config = MagicMock()
-        fake_bot.config.account_id = "acc-a"
-
-        fake_bot_manager = MagicMock()
-        fake_bot_manager.get_bot.return_value = fake_bot
-
-        fake_reconciler = AsyncMock()
-        fake_reconciler.reconcile.return_value = []
-
-        svc = MagicMock()
-        svc.bot_manager = fake_bot_manager
-        svc.reconciler = fake_reconciler
-
-        result = await _handle_broker_reconcile(
-            svc,
-            {
-                "bot_id": "bot-1",
-                "account_id": "acc-a",
-                "broker_positions": [],
-            },
-            "cli-user",
-        )
-
-        assert result == {"bot_id": "bot-1", "adjustments": []}
-        fake_reconciler.reconcile.assert_awaited_once_with(
-            "bot-1", [], account_id="acc-a"
-        )
-
-    @pytest.mark.asyncio
-    async def test_broker_reconcile_passes_when_bot_not_found(self):
-        """알 수 없는 ``bot_id`` 는 reconcile 단계에서 처리되도록 통과시킨다.
-
-        BotManager 에 없는 봇이라도 mismatch 검증 단계에서 false negative 로
-        막아버리면 cold-path / migration 시나리오가 깨진다. account_id 형식
-        검증은 ``require_account_id`` 가 이미 수행하므로 이 단계는 mismatch
-        만 책임진다.
-        """
-        from unittest.mock import AsyncMock, MagicMock
-
-        from ante.ipc.registry import _handle_broker_reconcile
-
-        fake_bot_manager = MagicMock()
-        fake_bot_manager.get_bot.return_value = None
-
-        fake_reconciler = AsyncMock()
-        fake_reconciler.reconcile.return_value = []
-
-        svc = MagicMock()
-        svc.bot_manager = fake_bot_manager
-        svc.reconciler = fake_reconciler
-
-        result = await _handle_broker_reconcile(
-            svc,
-            {
-                "bot_id": "unknown-bot",
-                "account_id": "acc-a",
-                "broker_positions": [],
-            },
-            "cli-user",
-        )
-
-        assert result == {"bot_id": "unknown-bot", "adjustments": []}
-        fake_reconciler.reconcile.assert_awaited_once()
+        # broker 조회/reconcile 까지 도달하지 않아야 한다.
+        svc.account.get_broker.assert_not_called()
+        reconciler.reconcile.assert_not_called()
+        reconciler.detect_account_level.assert_not_called()
 
 
 # ── #1379 oracle A7: IPC config.set 핸들러도 서비스 경계 ValueError 전파 ──

--- a/tests/unit/test_broker_reconcile_offline.py
+++ b/tests/unit/test_broker_reconcile_offline.py
@@ -43,6 +43,46 @@ def _make_click_context(*, fix: bool = False) -> MagicMock:
     return ctx
 
 
+def _offline_reconcile_result(broker_positions, internal_positions) -> dict:
+    """``broker.py`` 오프라인 폴백 합산 로직 1:1 미러 (#2120).
+
+    src ``_run_reconcile`` 와 동일하게 broker/internal 을 **심볼별 합산**한 뒤
+    비교한다. 같은 심볼을 가진 다중봇 internal 을 덮어쓰지 않고 합산해야
+    per-bot false discrepancy 가 사라진다.
+    """
+    broker_totals: dict[str, float] = {}
+    for bp in broker_positions:
+        b_qty = float(bp.get("quantity", 0) or 0)
+        if b_qty != 0:
+            sym = bp["symbol"]
+            broker_totals[sym] = broker_totals.get(sym, 0.0) + b_qty
+    internal_totals: dict[str, float] = {}
+    for ip in internal_positions:
+        internal_totals[ip.symbol] = internal_totals.get(ip.symbol, 0.0) + ip.quantity
+
+    all_symbols = set(broker_totals.keys()) | set(internal_totals.keys())
+    discrepancies = []
+    for symbol in sorted(all_symbols):
+        broker_qty = broker_totals.get(symbol, 0.0)
+        internal_qty = internal_totals.get(symbol, 0.0)
+        if broker_qty != internal_qty:
+            discrepancies.append(
+                {
+                    "symbol": symbol,
+                    "broker_qty": broker_qty,
+                    "internal_qty": internal_qty,
+                    "diff": broker_qty - internal_qty,
+                }
+            )
+    return {
+        "total_symbols": len(all_symbols),
+        "discrepancies": discrepancies,
+        "match": len(discrepancies) == 0,
+        "fix_applied": False,
+        "corrections": 0,
+    }
+
+
 class TestReconcileOfflineNoDeps:
     """오프라인 폴백 경로에서 불필요한 의존성이 제거되었는지 확인한다."""
 
@@ -111,38 +151,11 @@ class TestReconcileOfflineLogic:
                 return_value=mock_position_history,
             ),
         ):
-            # _run_reconcile 내부 로직을 직접 호출
+            # _run_reconcile 내부 로직(#2120 합산)을 직접 미러 호출
 
             broker_positions = await mock_adapter.get_account_positions()
             internal_positions = await mock_position_history.get_all_positions()
-
-            broker_map = {p["symbol"]: p for p in broker_positions}
-            internal_map = {p.symbol: p for p in internal_positions}
-
-            all_symbols = set(broker_map.keys()) | set(internal_map.keys())
-            discrepancies = []
-            for symbol in sorted(all_symbols):
-                bp = broker_map.get(symbol)
-                ip = internal_map.get(symbol)
-                broker_qty = float(bp.get("quantity", 0)) if bp else 0.0
-                internal_qty = ip.quantity if ip else 0.0
-                if broker_qty != internal_qty:
-                    discrepancies.append(
-                        {
-                            "symbol": symbol,
-                            "broker_qty": broker_qty,
-                            "internal_qty": internal_qty,
-                            "diff": broker_qty - internal_qty,
-                        }
-                    )
-
-            result = {
-                "total_symbols": len(all_symbols),
-                "discrepancies": discrepancies,
-                "match": len(discrepancies) == 0,
-                "fix_applied": False,
-                "corrections": 0,
-            }
+            result = _offline_reconcile_result(broker_positions, internal_positions)
 
             assert result["match"] is True
             assert result["total_symbols"] == 2
@@ -172,34 +185,7 @@ class TestReconcileOfflineLogic:
 
         broker_positions = await mock_adapter.get_account_positions()
         internal_positions = await mock_position_history.get_all_positions()
-
-        broker_map = {p["symbol"]: p for p in broker_positions}
-        internal_map = {p.symbol: p for p in internal_positions}
-
-        all_symbols = set(broker_map.keys()) | set(internal_map.keys())
-        discrepancies = []
-        for symbol in sorted(all_symbols):
-            bp = broker_map.get(symbol)
-            ip = internal_map.get(symbol)
-            broker_qty = float(bp.get("quantity", 0)) if bp else 0.0
-            internal_qty = ip.quantity if ip else 0.0
-            if broker_qty != internal_qty:
-                discrepancies.append(
-                    {
-                        "symbol": symbol,
-                        "broker_qty": broker_qty,
-                        "internal_qty": internal_qty,
-                        "diff": broker_qty - internal_qty,
-                    }
-                )
-
-        result = {
-            "total_symbols": len(all_symbols),
-            "discrepancies": discrepancies,
-            "match": len(discrepancies) == 0,
-            "fix_applied": False,
-            "corrections": 0,
-        }
+        result = _offline_reconcile_result(broker_positions, internal_positions)
 
         assert result["match"] is False
         assert result["total_symbols"] == 2
@@ -216,3 +202,49 @@ class TestReconcileOfflineLogic:
         assert d_035720["broker_qty"] == 20.0
         assert d_035720["internal_qty"] == 0.0
         assert d_035720["diff"] == 20.0
+
+    @pytest.mark.asyncio
+    async def test_reconcile_offline_multi_bot_same_symbol_sum(
+        self, mock_adapter: AsyncMock, mock_db: AsyncMock
+    ) -> None:
+        """(#2120) 같은 심볼을 보유한 다중봇 internal 을 합산해 비교한다.
+
+        bot1 30주 + bot2 70주 = 100주, 브로커 100주 → 합산 일치(불일치 없음).
+        이전 ``{p.symbol: p}`` 덮어쓰기는 한 봇 수량만 비교해 false discrepancy
+        를 만들었다(per-bot 오판). 합산으로 제거됨을 검증한다.
+        """
+        mock_adapter.get_account_positions = AsyncMock(
+            return_value=[{"symbol": "005930", "quantity": "100"}]
+        )
+        internal = [
+            _FakePosition(
+                bot_id="bot1", symbol="005930", quantity=30.0, avg_entry_price=70000
+            ),
+            _FakePosition(
+                bot_id="bot2", symbol="005930", quantity=70.0, avg_entry_price=70000
+            ),
+        ]
+        mock_position_history = AsyncMock()
+        mock_position_history.initialize = AsyncMock()
+        mock_position_history.get_all_positions = AsyncMock(return_value=internal)
+
+        broker_positions = await mock_adapter.get_account_positions()
+        internal_positions = await mock_position_history.get_all_positions()
+        result = _offline_reconcile_result(broker_positions, internal_positions)
+
+        # 합산 100 == 브로커 100 → 불일치 없음 (false-positive 제거).
+        assert result["match"] is True
+        assert result["discrepancies"] == []
+
+
+class TestReconcileOfflineSourceSums:
+    """오프라인 폴백 src 가 internal 을 **합산**(덮어쓰기 금지)하는지 lock (#2120)."""
+
+    def test_source_aggregates_internal_totals(self) -> None:
+        """src 에 심볼별 합산 누적 코드(``internal_totals``)가 존재한다."""
+        assert "internal_totals" in _BROKER_SOURCE
+        assert "broker_totals" in _BROKER_SOURCE
+
+    def test_source_does_not_overwrite_internal_by_symbol(self) -> None:
+        """src 가 더 이상 ``{p.symbol: p}`` 덮어쓰기 dict 컴프리헨션을 쓰지 않는다."""
+        assert "{p.symbol: p for p in internal_positions}" not in _BROKER_SOURCE

--- a/tests/unit/test_ipc_error_code_mapping.py
+++ b/tests/unit/test_ipc_error_code_mapping.py
@@ -543,18 +543,21 @@ async def test_ipc_dispatch_broker_reconcile_invalid_account_only_validation_err
 
 
 @pytest.mark.asyncio
-async def test_ipc_dispatch_broker_reconcile_missing_account_keeps_keyerror_path(
+async def test_ipc_dispatch_broker_reconcile_valid_account_no_bot_id_reaches_handler(
     socket_path: str, service_registry: ServiceRegistry
 ) -> None:
-    """#1556 회귀 유지: **valid** account_id로 reconcile하면
-    ``require_account_id``를 통과하므로 invalid-account 분기가 아니라 기존
-    경로(bot_id 부재 시 ``KeyError`` → EXECUTION_ERROR)를 그대로 탄다.
+    """#2119 account-level 재설계: **valid** account_id 면 bot_id 없이도
+    ``require_account_id`` 통과 후 account-level handler 본문에 도달한다.
 
-    #1636은 invalid-account-only를 VALIDATION_ERROR로 정렬하되,
-    valid account_id의 기존 reconcile 동작(bot_id 누락 → KeyError →
-    EXECUTION_ERROR)은 **불변**이어야 한다. require_account_id를 bot_id
-    이전으로 옮긴 ordering 변경이 valid 경로의 KeyError 계약을 깨지
-    않음을 가드한다 (narrow scope: reconcile invalid만 변경, valid 불변).
+    이전(#1636)에는 valid account_id + bot_id 누락이 ``args["bot_id"]``
+    ``KeyError`` → EXECUTION_ERROR 였으나, account-level 재설계로 bot_id 를
+    더 이상 읽지 않으므로 KeyError 가 발생하지 않는다. 본 회귀는:
+        - invalid-account-only 는 여전히 VALIDATION_ERROR (위 테스트가 가드).
+        - valid account 는 require_account_id 를 통과한 뒤 handler 본문
+          (서버 broker 조회)에 도달한다.
+    fixture 의 ``account`` 서비스가 MagicMock 이라 ``await
+    get_broker(...)`` 가 awaitable 이 아니어서 EXECUTION_ERROR(VALIDATION
+    아님)로 표면된다 — KeyError(bot_id) 가 아니라 handler 본문 도달의 증거다.
     """
     from ante.ipc.registry import register_all_handlers
 
@@ -566,15 +569,14 @@ async def test_ipc_dispatch_broker_reconcile_missing_account_keeps_keyerror_path
     try:
         client = IPCClient(socket_path, timeout=5.0)
 
-        # valid account_id + bot_id 누락 → require_account_id 통과 후
-        # args["bot_id"] KeyError → EXECUTION_ERROR (기존 계약 불변)
+        # valid account_id + bot_id 누락 → require_account_id 통과 → handler 본문
+        # (broker 조회). VALIDATION_ERROR 가 아니어야 한다(account 검증은 통과).
         response = await client.send(
             "broker.reconcile",
             {"account_id": "oracle-valid-account"},
             actor="tester",
         )
         assert response["status"] == "error"
-        assert response["error"]["code"] == "EXECUTION_ERROR", response
         assert response["error"]["code"] != "VALIDATION_ERROR", response
     finally:
         await server.stop()

--- a/tests/unit/test_reconcile_scheduler.py
+++ b/tests/unit/test_reconcile_scheduler.py
@@ -1,4 +1,11 @@
-"""ReconcileScheduler 단위 테스트."""
+"""ReconcileScheduler 단위 테스트.
+
+#2118 재설계: scheduler.run_once 는 account 별로 묶어 **봇 귀속 ambiguity(status
+무관 봇 count)** 와 **correction 실행 범위(running 봇)** 를 분리한다.
+- 1봇-total + running → 기존 reconcile 보정(skip_external_buy 적용).
+- 1봇-total + stopped/error → reconcile(dry_run=True) detect-only (lifecycle 범위 보존).
+- 2+봇 → detect_account_level (correct_position 미호출).
+"""
 
 from __future__ import annotations
 
@@ -16,6 +23,7 @@ from ante.broker.scheduler import ReconcileScheduler
 def reconciler():
     mock = AsyncMock()
     mock.reconcile = AsyncMock(return_value=[])
+    mock.detect_account_level = AsyncMock(return_value=[])
     return mock
 
 
@@ -32,11 +40,11 @@ def broker():
 
 @pytest.fixture
 def bot_manager():
+    """기본 fixture — acc-test 단일봇(running). 1봇-total + running → 보정 경로."""
     mock = MagicMock()
     mock.list_bots = MagicMock(
         return_value=[
             {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
-            {"bot_id": "bot-2", "status": "stopped", "account_id": "acc-test"},
         ]
     )
     return mock
@@ -65,14 +73,15 @@ def scheduler(reconciler, broker, bot_manager, eventbus):
 
 
 class TestRunOnce:
-    async def test_reconciles_active_bots_only(self, scheduler, reconciler, broker):
-        """running 상태인 봇만 대사한다."""
+    async def test_single_running_bot_corrects(self, scheduler, reconciler, broker):
+        """1봇-total + running → 기존 reconcile 보정(dry_run=False)."""
         await scheduler.run_once()
 
-        # bot-1만 running이므로 1회 호출
         assert reconciler.reconcile.call_count == 1
         call_args = reconciler.reconcile.call_args
         assert call_args.kwargs["bot_id"] == "bot-1"
+        assert call_args.kwargs["dry_run"] is False
+        reconciler.detect_account_level.assert_not_called()
 
     async def test_passes_broker_positions(self, scheduler, reconciler, broker):
         """브로커 포지션을 reconciler에 전달한다."""
@@ -84,7 +93,7 @@ class TestRunOnce:
         ]
 
     async def test_returns_all_corrections(self, scheduler, reconciler):
-        """보정 내역을 반환한다."""
+        """보정 내역을 반환한다 (1봇-running 경로)."""
         reconciler.reconcile.return_value = [
             {"symbol": "005930", "old_quantity": 50, "new_quantity": 100}
         ]
@@ -94,11 +103,65 @@ class TestRunOnce:
         assert len(result) == 1
         assert result[0]["symbol"] == "005930"
 
-    async def test_no_active_bots(self, scheduler, bot_manager, broker):
-        """활성 봇이 없으면 브로커 호출하지 않는다."""
+    async def test_single_stopped_bot_detect_only(
+        self, scheduler, bot_manager, reconciler, broker
+    ):
+        """1봇-total 이지만 stopped → correction 미실행(dry_run=True).
+
+        #2118 v4: status-agnostic count(=1) 로 ambiguity 는 단일봇이지만,
+        correction 실행은 running 봇으로 한정해 stopped/error 단일봇을
+        scheduler 가 자동 보정하지 않는다(lifecycle 범위 보존).
+        """
         bot_manager.list_bots.return_value = [
             {"bot_id": "bot-1", "status": "stopped", "account_id": "acc-test"},
         ]
+
+        result = await scheduler.run_once()
+
+        # 단일봇이므로 detect_account_level 가 아니라 reconcile(dry_run=True) 경로.
+        assert reconciler.reconcile.call_count == 1
+        assert reconciler.reconcile.call_args.kwargs["dry_run"] is True
+        reconciler.detect_account_level.assert_not_called()
+        # dry_run 은 보정 0 → 누적 보정 없음.
+        assert result == []
+        # 브로커는 봇이 있으므로 조회된다(과거: active 봇 없으면 미조회였음).
+        broker.get_account_positions.assert_called_once()
+
+    async def test_multi_bot_detect_only(
+        self, scheduler, bot_manager, reconciler, broker
+    ):
+        """2+봇 → detect_account_level (correct_position 미호출, #2118)."""
+        bot_manager.list_bots.return_value = [
+            {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
+            {"bot_id": "bot-2", "status": "running", "account_id": "acc-test"},
+        ]
+
+        result = await scheduler.run_once()
+
+        reconciler.reconcile.assert_not_called()
+        reconciler.detect_account_level.assert_called_once()
+        call = reconciler.detect_account_level.call_args
+        assert call.kwargs["account_id"] == "acc-test"
+        # detect-only 는 보정 0건.
+        assert result == []
+
+    async def test_multi_bot_one_running_still_detect_only(
+        self, scheduler, bot_manager, reconciler
+    ):
+        """2+봇이면 일부만 running 이어도 detect-only (귀속 ambiguous)."""
+        bot_manager.list_bots.return_value = [
+            {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
+            {"bot_id": "bot-2", "status": "stopped", "account_id": "acc-test"},
+        ]
+
+        await scheduler.run_once()
+
+        reconciler.reconcile.assert_not_called()
+        reconciler.detect_account_level.assert_called_once()
+
+    async def test_no_bots_for_account(self, scheduler, bot_manager, broker):
+        """계좌에 봇이 없으면 브로커 조회 없이 종료한다."""
+        bot_manager.list_bots.return_value = []
 
         result = await scheduler.run_once()
 
@@ -113,24 +176,31 @@ class TestRunOnce:
 
         assert result == []
         reconciler.reconcile.assert_not_called()
+        reconciler.detect_account_level.assert_not_called()
 
-    async def test_single_bot_failure_continues(
+    async def test_single_bot_reconcile_failure_swallowed(self, scheduler, reconciler):
+        """단일봇 reconcile 실패가 run_once 를 깨뜨리지 않는다."""
+        reconciler.reconcile.side_effect = Exception("bot-1 실패")
+
+        result = await scheduler.run_once()
+
+        assert result == []
+        assert reconciler.reconcile.call_count == 1
+
+    async def test_detect_account_level_failure_swallowed(
         self, scheduler, bot_manager, reconciler
     ):
-        """한 봇의 대사 실패가 다른 봇에 영향주지 않는다."""
+        """2+봇 detect_account_level 실패가 run_once 를 깨뜨리지 않는다."""
         bot_manager.list_bots.return_value = [
             {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
             {"bot_id": "bot-2", "status": "running", "account_id": "acc-test"},
         ]
-        reconciler.reconcile.side_effect = [
-            Exception("bot-1 실패"),
-            [{"symbol": "005930", "corrected": True}],
-        ]
+        reconciler.detect_account_level.side_effect = Exception("탐지 실패")
 
         result = await scheduler.run_once()
 
-        assert len(result) == 1
-        assert reconciler.reconcile.call_count == 2
+        assert result == []
+        reconciler.detect_account_level.assert_called_once()
 
 
 # ── start/stop 테스트 ────────────────────────────────
@@ -138,7 +208,7 @@ class TestRunOnce:
 
 class TestStartStop:
     async def test_start_runs_initial_reconcile(self, scheduler, reconciler):
-        """start() 시 즉시 1회 대사를 수행한다."""
+        """start() 시 즉시 1회 대사를 수행한다 (단일봇-running → reconcile)."""
         await scheduler.start()
         try:
             assert reconciler.reconcile.call_count == 1
@@ -148,8 +218,8 @@ class TestStartStop:
     async def test_start_passes_skip_external_buy_to_initial_reconcile(
         self, reconciler, broker, bot_manager, eventbus
     ):
-        """skip_initial_external_buy=True 면 기동 즉시 대사에 skip_external_buy=True
-        를 전달한다 (#1946 Finding 1 barrier).
+        """skip_initial_external_buy=True 면 기동 즉시 대사(1봇-running)에
+        skip_external_buy=True 를 전달한다 (#1946 Finding 1 barrier).
         """
         sched = ReconcileScheduler(
             reconciler=reconciler,
@@ -214,7 +284,7 @@ class TestStartStop:
         assert scheduler._task is None
 
     async def test_periodic_loop(self, scheduler, reconciler):
-        """주기적으로 대사가 반복 실행된다."""
+        """주기적으로 대사가 반복 실행된다 (단일봇-running → reconcile)."""
         await scheduler.start()
 
         # 짧은 대기로 주기 실행 확인 (interval=0.1s)
@@ -302,13 +372,17 @@ class TestConfiguration:
 
 class TestBrokerAccountScoping:
     """ReconcileScheduler가 자기 broker_account_id에 일치하는 봇만
-    reconcile하는지 확인한다 (SPLIT-1 가드).
+    대사 대상으로 삼는지 확인한다 (SPLIT-1 가드).
     """
 
     async def test_scheduler_skips_bot_from_other_account(
         self, reconciler, broker, bot_manager, eventbus, caplog
     ):
-        """scheduler가 acc-A 바인딩일 때 acc-B 봇은 reconcile되지 않는다."""
+        """scheduler가 acc-A 바인딩일 때 acc-B 봇은 대사 대상이 아니다.
+
+        acc-A 봇은 단일봇-running 이므로 reconcile(보정) 경로를 탄다. acc-B
+        봇은 다른 계좌라 skip + WARNING.
+        """
         import logging
 
         bot_manager.list_bots.return_value = [
@@ -327,11 +401,12 @@ class TestBrokerAccountScoping:
         with caplog.at_level(logging.WARNING, logger="ante.broker.scheduler"):
             await sched.run_once()
 
-        # acc-A 봇만 reconcile 호출 — acc-B 봇은 스킵
+        # acc-A 단일봇만 reconcile 호출 — acc-B 봇은 count 에서 제외.
         assert reconciler.reconcile.call_count == 1
         call_args = reconciler.reconcile.call_args
         assert call_args.kwargs["bot_id"] == "bot-a"
         assert call_args.kwargs["account_id"] == "acc-A"
+        reconciler.detect_account_level.assert_not_called()
 
         # 미일치 봇에 대한 WARNING 로그
         skip_logs = [
@@ -348,10 +423,14 @@ class TestBrokerAccountScoping:
             "WARNING 메시지에 scheduler의 broker_account_id(acc-A)가 포함돼야 한다"
         )
 
-    async def test_scheduler_processes_matching_account_bot(
+    async def test_scheduler_other_account_bots_excluded_from_count(
         self, reconciler, broker, bot_manager, eventbus
     ):
-        """일치하는 봇은 정상 reconcile 호출된다."""
+        """다른 계좌 봇은 ambiguity count 에서 제외된다.
+
+        acc-A 봇 2개(다중봇) + acc-B 봇 1개. scheduler 가 acc-A 바인딩이면
+        acc-A 봇만 count(=2) → detect-only. acc-B 봇은 count 에 포함되지 않는다.
+        """
         bot_manager.list_bots.return_value = [
             {"bot_id": "bot-a1", "status": "running", "account_id": "acc-A"},
             {"bot_id": "bot-a2", "status": "running", "account_id": "acc-A"},
@@ -368,11 +447,35 @@ class TestBrokerAccountScoping:
 
         await sched.run_once()
 
-        # acc-A 봇 두 개 모두 reconcile 호출
-        assert reconciler.reconcile.call_count == 2
-        called_bot_ids = {
-            call.kwargs["bot_id"] for call in reconciler.reconcile.call_args_list
-        }
-        assert called_bot_ids == {"bot-a1", "bot-a2"}
-        for call in reconciler.reconcile.call_args_list:
-            assert call.kwargs["account_id"] == "acc-A"
+        # acc-A 다중봇 → detect-only (correct_position 미호출).
+        reconciler.reconcile.assert_not_called()
+        reconciler.detect_account_level.assert_called_once()
+        assert reconciler.detect_account_level.call_args.kwargs["account_id"] == "acc-A"
+
+    async def test_account_id_missing_bot_skipped(
+        self, reconciler, broker, bot_manager, eventbus, caplog
+    ):
+        """account_id 누락 봇은 count 에서 제외(WARNING)된다."""
+        import logging
+
+        bot_manager.list_bots.return_value = [
+            {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
+            {"bot_id": "bot-orphan", "status": "running", "account_id": None},
+        ]
+        sched = ReconcileScheduler(
+            reconciler=reconciler,
+            broker=broker,
+            bot_manager=bot_manager,
+            eventbus=eventbus,
+            broker_account_id="acc-test",
+            interval_seconds=0.1,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ante.broker.scheduler"):
+            await sched.run_once()
+
+        # orphan 제외 → acc-test 단일봇 → reconcile 보정.
+        assert reconciler.reconcile.call_count == 1
+        assert reconciler.reconcile.call_args.kwargs["bot_id"] == "bot-1"
+        reconciler.detect_account_level.assert_not_called()
+        assert any("bot-orphan" in rec.getMessage() for rec in caplog.records)

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -811,3 +811,189 @@ class TestReconcileEventsAccountScopedMarker:
                 discrepancy_count=1,
                 corrections=[],
             )
+
+
+# ── dry_run detect-only (#2119/#2122) ────────────────
+
+
+class TestReconcileDryRun:
+    """``dry_run=True`` 는 분류·이벤트는 유지하되 correct_position 을 보류한다.
+
+    기존 external-buy/self-check 분류 로직은 무변경이며, 이벤트도 동일하게
+    발행되어야 한다 — 보정(correct_position)만 건너뛴다.
+    """
+
+    async def test_dry_run_skips_correction_keeps_events(
+        self, reconciler, position_history, eventbus
+    ):
+        """dry_run=True: 외부 청산을 탐지하나 보정은 0건. 이벤트는 발행."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+
+        mismatch_events: list = []
+        notif_events: list = []
+        reconcile_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+        eventbus.subscribe(ReconcileEvent, lambda e: reconcile_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],  # 브로커 0주 → 외부 청산 분류.
+            account_id="acc-test",
+            dry_run=True,
+        )
+
+        # 보정 0건 — correct_position 미호출.
+        assert corrections == []
+        # 포지션은 그대로 (보정 안 됨).
+        pos = await position_history.get_current("bot-1", "005930")
+        assert pos["quantity"] == 50
+        # 분류/탐지 이벤트는 그대로 발행.
+        assert len(mismatch_events) == 1
+        assert mismatch_events[0].reason == "외부 청산"
+        assert len(notif_events) == 1
+        # 보정이 0이므로 ReconcileEvent(보정 완료)는 발행 안 됨.
+        assert reconcile_events == []
+
+    async def test_dry_run_no_mismatch_no_events(
+        self, reconciler, position_history, eventbus
+    ):
+        """dry_run=True 라도 일치하면 이벤트도 보정도 없음."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        mismatch_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[{"symbol": "005930", "quantity": 50, "avg_price": 1}],
+            account_id="acc-test",
+            dry_run=True,
+        )
+
+        assert corrections == []
+        assert mismatch_events == []
+
+    async def test_default_dry_run_false_still_corrects(
+        self, reconciler, position_history
+    ):
+        """기존 호출자 무회귀: dry_run 미지정(기본 False)은 보정 동작 유지."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+        )
+
+        assert len(corrections) == 1
+        pos = await position_history.get_current("bot-1", "005930")
+        assert pos["quantity"] == 0
+
+
+# ── account-level detect-only 합산 (#2118/#2120) ─────
+
+
+class TestAccountLevelDetection:
+    """계좌 총합 broker vs 전 봇(상태 무관) open internal 합산 비교.
+
+    같은 심볼을 보유한 다중봇을 per-bot 비교가 false external-buy/청산으로
+    오판하던 것을 합산으로 제거한다(#2118/#2120). correct_position 은 절대
+    호출하지 않고 account-scoped NotificationEvent 만 발행한다.
+    """
+
+    async def test_multi_bot_same_symbol_sum_matches(
+        self, reconciler, position_history, eventbus
+    ):
+        """(e/#2118) 두 봇 internal 30+70=100, 브로커 100 → 불일치 없음."""
+        await _set_position(position_history, "bot-1", "005930", 30, 50000)
+        await _set_position(position_history, "bot-2", "005930", 70, 50000)
+
+        notif_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        mismatches = await reconciler.detect_account_level(
+            [{"symbol": "005930", "quantity": 100, "avg_price": 50000}],
+            account_id="acc-test",
+        )
+
+        # 합산 일치 → false-positive 없음.
+        assert mismatches == []
+        assert notif_events == []
+
+    async def test_multi_bot_sum_mismatch_emits_account_notification(
+        self, reconciler, position_history, eventbus
+    ):
+        """(d) 합산 80, 브로커 100 → 계좌 단위 불일치 + account NotificationEvent.
+
+        PositionMismatchEvent(bot-scoped)는 발행하지 않고 NotificationEvent 만.
+        correct_position 미호출 (반환 mismatch 만, 보정 0).
+        """
+        await _set_position(position_history, "bot-1", "005930", 30, 50000)
+        await _set_position(position_history, "bot-2", "005930", 50, 50000)
+
+        notif_events: list = []
+        mismatch_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+
+        mismatches = await reconciler.detect_account_level(
+            [{"symbol": "005930", "quantity": 100, "avg_price": 50000}],
+            account_id="acc-test",
+        )
+
+        assert len(mismatches) == 1
+        assert mismatches[0]["symbol"] == "005930"
+        assert mismatches[0]["internal_qty"] == 80
+        assert mismatches[0]["broker_qty"] == 100
+        assert mismatches[0]["diff"] == 20
+        # account-scoped: NotificationEvent 만, bot-scoped 이벤트 없음.
+        assert len(notif_events) == 1
+        assert notif_events[0].category == "broker"
+        assert mismatch_events == []
+        # 포지션은 보정되지 않음 (detect-only).
+        pos1 = await position_history.get_current("bot-1", "005930")
+        pos2 = await position_history.get_current("bot-2", "005930")
+        assert pos1["quantity"] == 30
+        assert pos2["quantity"] == 50
+
+    async def test_zero_bots_with_broker_position_detected(self, reconciler, eventbus):
+        """(k) 0봇 + broker 보유 → 계좌 단위 불일치 탐지 (no-op 아님)."""
+        notif_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        mismatches = await reconciler.detect_account_level(
+            [{"symbol": "005930", "quantity": 10, "avg_price": 50000}],
+            account_id="acc-test",
+        )
+
+        assert len(mismatches) == 1
+        assert mismatches[0]["internal_qty"] == 0
+        assert mismatches[0]["broker_qty"] == 10
+        assert len(notif_events) == 1
+
+    async def test_compute_account_diff_is_side_effect_free(
+        self, reconciler, position_history, eventbus
+    ):
+        """compute_account_diff 는 이벤트/보정 없이 diff 만 반환한다(순수)."""
+        await _set_position(position_history, "bot-1", "005930", 30, 50000)
+
+        notif_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        diff = await reconciler.compute_account_diff(
+            [{"symbol": "005930", "quantity": 100, "avg_price": 50000}],
+            account_id="acc-test",
+        )
+
+        assert len(diff) == 1
+        assert diff[0]["diff"] == 70
+        # 순수 — 이벤트 미발행.
+        assert notif_events == []
+
+    async def test_account_level_invalid_account_id_raises(self, reconciler):
+        """(j) account-level 경로도 require_account_id 회귀."""
+        with pytest.raises(InvalidAccountIdError):
+            await reconciler.detect_account_level(
+                [{"symbol": "005930", "quantity": 10}],
+                account_id="default",
+            )


### PR DESCRIPTION
Closes #2119, #2118, #2120, #2121, #2122

## Summary
broker.reconcile 경로의 다중 결함을 account-level 재설계로 안전하게 수정(safety-critical). **다중봇 correction enablement는 제품 결정 필요로 follow-up #2270 분리(Codex split-issue adjudication, 5회 plan review 수렴).**
- **#2119**: handler bot_id 필수 제거 → account-level 도달(공개 CLU `broker reconcile --account [--fix]`)
- **#2121**: caller-supplied broker_positions 금지 → 서버 BrokerAdapter `get_account_positions()` 조회
- **#2122**: fix 플래그 준수 → fix=False는 dry-run(correct_position 미호출)
- **#2118/#2120**: account-level 탐지(전 봇 status-무관 open internal 합산 vs 계좌총합 broker) → 다중봇 false external-buy 제거
- **safety**: correct_position은 **봇 정확히 1개(total) 계좌**의 기존 reconcile 위임에서만(self-check/skip_external_buy/external-buy 분류 #1950/#1946 무변경). 2+봇·0봇은 detect-only(account-scoped NotificationEvent). scheduler는 ambiguity=status-무관 count, correct 실행은 기존 running 봇 범위 한정(stopped/error 봇 자동보정 안 함)

## Scope
- reconciler.py(dry_run+account 탐지), registry.py(handler account-level), scheduler.py(run_once), broker.py(offline 합산). 다중봇/per-symbol correction routing·새 도메인 이벤트 미도입.

## Test Plan
- 신규/갱신(account-level/dry-run/1봇 위임/2+봇 detect-only/scheduler running 범위/offline 합산/0봇 alert + #1946/#1950 회귀)
- `pytest -k 'reconcil or broker or scheduler or ipc or fill'` 1039 passed, 전체 유닛 6702 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS(safety-critical 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)