### PR TITLE
fix(bot): #2129 bots.strategy_id↔config_json 일관 갱신 + update_bot 전략 검증

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -501,14 +501,23 @@ class BotManager:
             # 비호환이면 ``StrategyNotFoundError`` / ``IncompatibleExchangeError``
             # 로 raise 하여 stale·invalid strategy_id 가 컬럼/``config_json``
             # 에 commit 되지 않도록 막는다 (create_bot L390-402 선례 재사용).
+            #
+            # account_id 는 update_bot kwargs (``updates``) 로 함께 변경될 수
+            # 있다 (아래 ``config_fields.update(updates)`` 가 account_id 컬럼을
+            # 덮어쓴다). 한 요청이 account_id 와 strategy_id 를 동시에 바꾸면
+            # 새 전략의 exchange 호환은 **옛 계좌가 아니라 새(effective) 계좌**
+            # 로 검증해야 한다. 그렇지 않으면 새 계좌에 비호환 전략이 commit
+            # 될 수 있다. effective account_id = 요청이 account_id 를 바꾸면 그
+            # 새 값, 아니면 ``old_config.account_id``.
             old_config = bot.config
+            effective_account_id = updates.get("account_id", old_config.account_id)
             new_strategy_id = updates.get("strategy_id")
             if (
                 new_strategy_id is not None
                 and new_strategy_id != old_config.strategy_id
             ):
                 await self._validate_strategy_change(
-                    account_id=old_config.account_id,
+                    account_id=effective_account_id,
                     strategy_id=new_strategy_id,
                 )
 

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -495,8 +495,24 @@ class BotManager:
             if not updates and new_budget is None:
                 return bot
 
-            # BotConfig 재생성
+            # strategy_id 변경 검증 (#2129).
+            # ``bot.config`` 교체 + DB 저장(``_save_bot_config``) 전에
+            # StrategyRegistry 존재 + 계좌 exchange 호환을 검증한다. 미등록/
+            # 비호환이면 ``StrategyNotFoundError`` / ``IncompatibleExchangeError``
+            # 로 raise 하여 stale·invalid strategy_id 가 컬럼/``config_json``
+            # 에 commit 되지 않도록 막는다 (create_bot L390-402 선례 재사용).
             old_config = bot.config
+            new_strategy_id = updates.get("strategy_id")
+            if (
+                new_strategy_id is not None
+                and new_strategy_id != old_config.strategy_id
+            ):
+                await self._validate_strategy_change(
+                    account_id=old_config.account_id,
+                    strategy_id=new_strategy_id,
+                )
+
+            # BotConfig 재생성
             config_fields = {
                 "bot_id": old_config.bot_id,
                 "strategy_id": old_config.strategy_id,
@@ -665,6 +681,12 @@ class BotManager:
 
         running 상태이면 중지 후 전략을 교체하고 재시작한다.
         stopped/created 상태이면 전략 ID만 교체한다.
+
+        전략 ID 를 ``bot.config`` (런타임) 와 DB 에 동시에 반영한다. DB
+        저장은 ``_save_bot_config(bot.config)`` 로 수행하여 ``bots.strategy_id``
+        컬럼과 ``config_json.strategy_id`` 를 항상 일관되게 갱신한다
+        (#2130). running 봇의 lifecycle 순서 (stop → old rule unload →
+        persist → new rule load → start) 는 그대로 보존한다.
         """
         bot = self._get_bot(bot_id)
         was_running = bot.status == BotStatus.RUNNING
@@ -674,7 +696,9 @@ class BotManager:
             self._remove_strategy_rules(bot.config.strategy_id)
 
         bot.config.strategy_id = strategy_id
-        await self._update_bot_strategy(bot_id, strategy_id)
+        # 컬럼만 갱신하던 ``_update_bot_strategy`` 대신 ``_save_bot_config`` 로
+        # 컬럼 + ``config_json.strategy_id`` 를 함께 persist 한다 (#2130).
+        await self._save_bot_config(bot.config)
 
         if was_running:
             self._load_strategy_rules(strategy_id)
@@ -701,7 +725,9 @@ class BotManager:
             )
 
         bot.config.strategy_id = strategy_id
-        await self._update_bot_strategy(bot_id, strategy_id)
+        # 컬럼 + ``config_json.strategy_id`` 를 함께 persist 하여 일관성 유지
+        # (#2130).
+        await self._save_bot_config(bot.config)
 
         logger.info("전략 교체: bot=%s strategy=%s", bot_id, strategy_id)
 
@@ -972,6 +998,62 @@ class BotManager:
         if bot is None:
             raise BotNotFoundError(bot_id)
         return bot
+
+    async def _validate_strategy_change(
+        self, *, account_id: str, strategy_id: str
+    ) -> None:
+        """봇 전략 변경 시 전략 존재 + 계좌 exchange 호환을 검증한다 (#2129).
+
+        ``create_bot`` (L390-402) 의 검증 선례를 ``update_bot`` 컨텍스트에서
+        재사용한다. ``create_bot`` 은 ``strategy_cls`` 를 직접 받지만
+        ``update_bot`` 은 ``strategy_id`` 만 받으므로:
+
+        - **존재 검증**: ``StrategyRegistry`` 에 ``strategy_id`` 가 등록되어
+          있는지 확인한다. 미등록이면 ``StrategyNotFoundError``
+          (code=``STRATEGY_NOT_FOUND``) 로 raise 한다.
+        - **exchange 호환 검증**: ``account_service`` 가 주입되어 있으면 계좌를
+          조회하고, ``StrategyLoader`` 로 전략 메타의 exchange 를 읽어
+          ``validate_exchange`` 로 호환성을 검증한다 (``create_bot`` 과 동일
+          하게 ``IncompatibleExchangeError`` / ``ValueError`` 로 raise). meta
+          로딩은 ``rotate_signal_key`` 의 cold-path 패턴과 동형이다.
+
+        검증 실패 시 ``bot.config`` 교체나 ``_save_bot_config`` (DB 저장) 가
+        일어나기 전에 raise 하여 invalid·stale strategy_id 가 컬럼/
+        ``config_json`` 에 commit 되지 않도록 한다.
+        """
+        from ante.strategy.registry import StrategyRegistry
+
+        registry = StrategyRegistry(self._db)
+        await registry.initialize()
+        record = await registry.get(strategy_id)
+        if record is None:
+            from ante.strategy.exceptions import StrategyNotFoundError
+
+            raise StrategyNotFoundError(f"전략 미발견: {strategy_id}")
+
+        # account_service 미주입 시 exchange 검증은 skip (create_bot 과 동일하게
+        # account 정보가 없으면 호환성 검증을 수행하지 않는다).
+        if self._account_service is None:
+            return
+
+        account = await self._account_service.get(account_id)
+
+        from ante.strategy.loader import StrategyLoader
+        from ante.strategy.validator import validate_exchange
+
+        strategy_cls = StrategyLoader.load(Path(record.filepath))
+        strategy_exchange = getattr(
+            getattr(strategy_cls, "meta", None), "exchange", "KRX"
+        )
+        strategy_name = getattr(
+            getattr(strategy_cls, "meta", None), "name", strategy_id
+        )
+        validate_exchange(
+            strategy_exchange=strategy_exchange,
+            account_exchange=account.exchange,
+            strategy_name=strategy_name,
+            account_name=account.name,
+        )
 
     # ── 전략별 룰 관리 ─────────────────────────────────
 
@@ -1336,14 +1418,6 @@ class BotManager:
 
     # ── DB ───────────────────────────────────────────
 
-    async def _update_bot_strategy(self, bot_id: str, strategy_id: str) -> None:
-        """봇의 전략 ID를 DB에 갱신."""
-        await self._db.execute(
-            "UPDATE bots SET strategy_id = ?, updated_at = datetime('now')"
-            " WHERE bot_id = ?",
-            (strategy_id, bot_id),
-        )
-
     async def _save_bot_config(self, config: BotConfig) -> None:
         """봇 설정 DB 저장.
 
@@ -1351,6 +1425,13 @@ class BotManager:
         도 함께 직렬화한다. 누락 시 ``load_from_db`` 에서 dataclass default
         로 복원되어 사용자가 PUT 으로 변경한 값이 silent 하게 default 로
         되돌아가는 회귀가 발생한다.
+
+        ``ON CONFLICT DO UPDATE`` 에서 ``strategy_id`` 컬럼도 함께 갱신한다
+        (#2129/#2130). ``config_json`` 에는 ``strategy_id`` 가 항상 포함되어
+        있었으나 과거에는 UPDATE SET 에서 ``strategy_id`` 컬럼이 제외되어
+        ``update_bot(strategy_id=...)`` 경로에서 컬럼이 stale 해졌다. 컬럼과
+        ``config_json.strategy_id`` 를 동일 INSERT/UPSERT 안에서 같은
+        ``config`` 객체로부터 쓰므로 두 store 는 항상 일관된다.
         """
         config_dict = {
             "bot_id": config.bot_id,
@@ -1370,6 +1451,7 @@ class BotManager:
                VALUES (?, ?, ?, ?, ?)
                ON CONFLICT(bot_id) DO UPDATE SET
                  name = excluded.name,
+                 strategy_id = excluded.strategy_id,
                  config_json = excluded.config_json,
                  updated_at = datetime('now')""",
             (

--- a/tests/unit/test_bot_strategy_consistency.py
+++ b/tests/unit/test_bot_strategy_consistency.py
@@ -191,6 +191,20 @@ async def _make_krx_account(account_service, account_id="acc-test"):
     return account
 
 
+async def _make_nasdaq_account(account_service, account_id="acc-nasdaq"):
+    account = Account(
+        account_id=account_id,
+        name="나스닥계좌",
+        exchange="NASDAQ",
+        currency="USD",
+        broker_type="test",
+        status=AccountStatus.ACTIVE,
+        credentials={"app_key": "test", "app_secret": "test"},
+    )
+    await account_service.create(account)
+    return account
+
+
 async def _row_strategy_ids(db, bot_id):
     """``bots`` row 의 컬럼 strategy_id 와 config_json.strategy_id 를 반환."""
     row = await db.fetch_one(
@@ -317,6 +331,114 @@ class TestUpdateBotStrategyConsistency:
         with pytest.raises(StrategyNotFoundError):
             await manager.update_bot("bot1", strategy_id="missing_v1.0.0")
         assert manager.get_bot("bot1").config.strategy_id == "s1"
+
+
+# ── account_id + strategy_id 동시 변경 → effective(새) 계좌로 검증 (브랜치 리뷰) ──
+
+
+class TestUpdateBotEffectiveAccountValidation:
+    """#2129 브랜치 리뷰: account_id 와 strategy_id 동시 변경 시 새 전략의
+    exchange 호환을 **옛 계좌가 아닌 새(effective) 계좌**로 검증한다.
+
+    수정 전에는 ``_validate_strategy_change(old_config.account_id, ...)`` 로
+    옛 계좌를 사용해, 새 계좌에 비호환 전략이 commit 될 수 있었다.
+    """
+
+    async def test_simultaneous_change_compatible_with_new_account_persists_both(
+        self, manager_with_account, account_service, ctx, db, tmp_path
+    ):
+        """(a) 새 strategy 가 **새 계좌(NASDAQ)** exchange 와 호환 → 통과·둘 다 저장.
+
+        봇은 KRX 계좌(acc-test)에서 시작하지만, 한 요청으로 account_id 를
+        NASDAQ 계좌(acc-nasdaq)로, strategy 를 NASDAQ 전략으로 동시에 바꾼다.
+        새 전략은 옛 계좌(KRX)와는 비호환이지만 effective(새, NASDAQ) 계좌와는
+        호환이므로 통과해야 한다.
+        """
+        await _make_krx_account(account_service)
+        await _make_nasdaq_account(account_service)
+        nasdaq_sid = await _register_strategy(
+            db, _NASDAQ_STRATEGY_SOURCE, "nasdaq_only", "1.0.0", tmp_path
+        )
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager_with_account.update_bot(
+            "bot1", account_id="acc-nasdaq", strategy_id=nasdaq_sid
+        )
+
+        # effective(새, NASDAQ) 계좌로 검증을 통과해 둘 다 새 값으로 commit.
+        # account_id 는 memory config 와 config_json 에 새 값으로 직렬화된다.
+        # (``bots.account_id`` 컬럼 자체는 ``_save_bot_config`` UPSERT 가
+        # 갱신하지 않는 별개의 사전 결함 — 본 브랜치 리뷰 범위 밖.)
+        assert bot.config.account_id == "acc-nasdaq"
+        assert bot.config.strategy_id == nasdaq_sid
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert col == nasdaq_sid == cfg
+        row = await db.fetch_one(
+            "SELECT config_json FROM bots WHERE bot_id = ?", ("bot1",)
+        )
+        assert json.loads(row["config_json"])["account_id"] == "acc-nasdaq"
+
+    async def test_simultaneous_change_incompatible_with_new_account_raises(
+        self, manager_with_account, account_service, ctx, db, tmp_path
+    ):
+        """(b) 새 strategy 가 **새 계좌(NASDAQ)** exchange 와 비호환 → raise·미변경.
+
+        봇은 KRX 계좌에서 시작. 한 요청으로 account_id 를 NASDAQ 계좌로,
+        strategy 를 KRX 전략으로 동시에 바꾼다. KRX 전략은 옛 계좌(KRX)와는
+        호환이지만 effective(새, NASDAQ) 계좌와는 비호환이므로, effective
+        계좌로 검증하면 raise 되어야 한다 (옛 계좌로 검증하면 잘못 통과).
+
+        검증은 swap/DB 저장 전이므로 옛·새 store 모두 미변경이어야 한다.
+        """
+        await _make_krx_account(account_service)
+        await _make_nasdaq_account(account_service)
+        krx_sid = await _register_strategy(
+            db, _KRX_STRATEGY_SOURCE, "krx_compat", "1.0.0", tmp_path
+        )
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        with pytest.raises(IncompatibleExchangeError):
+            await manager_with_account.update_bot(
+                "bot1", account_id="acc-nasdaq", strategy_id=krx_sid
+            )
+
+        # swap/저장 전 raise: memory config 와 DB(컬럼·config_json·account_id)
+        # 모두 옛 값 유지.
+        bot = manager_with_account.get_bot("bot1")
+        assert bot.config.strategy_id == "s1"
+        assert bot.config.account_id == "acc-test"
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert col == "s1" == cfg
+        row = await db.fetch_one(
+            "SELECT account_id FROM bots WHERE bot_id = ?", ("bot1",)
+        )
+        assert row["account_id"] == "acc-test"
+
+    async def test_account_only_change_does_not_trigger_validation(
+        self, manager_with_account, account_service, ctx, db
+    ):
+        """(c) account_id 만 바꾸고 strategy 동일 → 전략 검증 미트리거.
+
+        ``s1`` 은 registry 에 등록되지 않았지만, strategy_id 가 그대로이므로
+        검증이 트리거되지 않아 account_id-only update 가 성공해야 한다.
+        """
+        await _make_krx_account(account_service)
+        await _make_krx_account(account_service, account_id="acc-test2")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager_with_account.update_bot("bot1", account_id="acc-test2")
+
+        # strategy 검증 미트리거 → 미등록 ``s1`` 에도 raise 없이 성공.
+        # account_id 는 memory config + config_json 에 새 값으로 반영된다.
+        assert bot.config.account_id == "acc-test2"
+        assert bot.config.strategy_id == "s1"
+        row = await db.fetch_one(
+            "SELECT config_json FROM bots WHERE bot_id = ?", ("bot1",)
+        )
+        assert json.loads(row["config_json"])["account_id"] == "acc-test2"
 
 
 # ── (d)(e) assign_strategy / change_strategy 일관성 ──────────────

--- a/tests/unit/test_bot_strategy_consistency.py
+++ b/tests/unit/test_bot_strategy_consistency.py
@@ -1,0 +1,540 @@
+"""bots.strategy_id 컬럼 ↔ config_json.strategy_id 일관성 회귀 (#2129 + #2130).
+
+봇 전략 변경 경로(``update_bot(strategy_id=...)`` / ``assign_strategy`` /
+``change_strategy``)가 ``bots.strategy_id`` 컬럼과 ``config_json.strategy_id``
+를 항상 동일하게 갱신하는지, ``update_bot`` 의 전략 변경이 미등록/exchange
+비호환 전략을 거부하는지, lifecycle(rule load/unload·runtime config) 순서가
+보존되는지 검증한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from ante.account.models import Account, AccountStatus
+from ante.bot import BotConfig, BotManager, BotStatus
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+from ante.strategy.exceptions import IncompatibleExchangeError, StrategyNotFoundError
+from ante.strategy.registry import StrategyRegistry
+
+# ── Fake 구현체 ──────────────────────────────────
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        import polars as pl
+
+        return pl.DataFrame({"close": [100.0]})
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1000000.0, "available": 500000.0}
+
+
+class FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class SimpleStrategy(Strategy):
+    meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+
+# 실제 전략 파일 소스. ``StrategyLoader.load`` 가 파일에서 단일 Strategy
+# subclass 를 로드해 ``meta.exchange`` 를 읽으므로, registry.register 가
+# 가리키는 filepath 에 실제로 작성한다.
+_KRX_STRATEGY_SOURCE = """
+from ante.strategy import Strategy, StrategyMeta
+
+
+class KrxStrategy(Strategy):
+    meta = StrategyMeta(
+        name="krx_compat", version="1.0.0", description="krx", exchange="KRX"
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+
+_NASDAQ_STRATEGY_SOURCE = """
+from ante.strategy import Strategy, StrategyMeta
+
+
+class NasdaqStrategy(Strategy):
+    meta = StrategyMeta(
+        name="nasdaq_only", version="1.0.0", description="nasdaq", exchange="NASDAQ"
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+
+
+# ── Fixtures ─────────────────────────────────────
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def ctx():
+    return StrategyContext(
+        bot_id="bot1",
+        data_provider=FakeDataProvider(),
+        portfolio=FakePortfolioView(),
+        order_view=FakeOrderView(),
+    )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    try:
+        await asyncio.wait_for(database.close(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+async def account_service(db, eventbus):
+    from ante.account.service import AccountService
+
+    svc = AccountService(db=db, eventbus=eventbus)
+    await svc.initialize()
+    return svc
+
+
+@pytest.fixture
+async def manager(eventbus, db):
+    """account_service 미주입 manager — assign/change·일관성 코어 검증용."""
+    m = BotManager(eventbus=eventbus, db=db)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+async def manager_with_account(eventbus, db, account_service):
+    """account_service 주입 manager — update_bot exchange 검증용."""
+    m = BotManager(eventbus=eventbus, db=db, account_service=account_service)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+async def _register_strategy(db, source: str, name: str, version: str, tmp_path):
+    """전략 파일을 작성하고 ``StrategyRegistry`` 에 등록한다.
+
+    반환값은 등록된 ``strategy_id`` (``{name}_v{version}``).
+    """
+    filepath = tmp_path / f"{name}.py"
+    filepath.write_text(source, encoding="utf-8")
+    registry = StrategyRegistry(db)
+    await registry.initialize()
+    meta = StrategyMeta(name=name, version=version, description="test")
+    record = await registry.register(filepath, meta)
+    return record.strategy_id
+
+
+async def _make_krx_account(account_service, account_id="acc-test"):
+    account = Account(
+        account_id=account_id,
+        name="활성계좌",
+        exchange="KRX",
+        currency="KRW",
+        broker_type="test",
+        status=AccountStatus.ACTIVE,
+        credentials={"app_key": "test", "app_secret": "test"},
+    )
+    await account_service.create(account)
+    return account
+
+
+async def _row_strategy_ids(db, bot_id):
+    """``bots`` row 의 컬럼 strategy_id 와 config_json.strategy_id 를 반환."""
+    row = await db.fetch_one(
+        "SELECT strategy_id, config_json FROM bots WHERE bot_id = ?", (bot_id,)
+    )
+    cfg = json.loads(row["config_json"])
+    return row["strategy_id"], cfg["strategy_id"]
+
+
+# ── (a) update_bot --strategy (등록·호환) → 컬럼+config_json 둘 다 새 ID ──
+
+
+class TestUpdateBotStrategyConsistency:
+    async def test_update_strategy_updates_both_stores(
+        self, manager_with_account, account_service, ctx, db, tmp_path
+    ):
+        """#2129: update_bot --strategy(등록·호환) → 컬럼+config_json 둘 다 새 ID."""
+        await _make_krx_account(account_service)
+        new_sid = await _register_strategy(
+            db, _KRX_STRATEGY_SOURCE, "krx_compat", "1.0.0", tmp_path
+        )
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager_with_account.update_bot("bot1", strategy_id=new_sid)
+
+        assert bot.config.strategy_id == new_sid
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert col == new_sid
+        assert cfg == new_sid
+
+    async def test_update_unregistered_strategy_raises_before_persist(
+        self, manager_with_account, account_service, ctx, db
+    ):
+        """#2129 (b): update_bot 미등록 strategy → raise(저장/swap 전)."""
+        await _make_krx_account(account_service)
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        with pytest.raises(StrategyNotFoundError):
+            await manager_with_account.update_bot("bot1", strategy_id="missing_v1.0.0")
+
+        # swap 전 raise: 메모리 config 와 DB 둘 다 옛 ID 유지.
+        assert manager_with_account.get_bot("bot1").config.strategy_id == "s1"
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert col == "s1"
+        assert cfg == "s1"
+
+    async def test_update_incompatible_exchange_raises_before_persist(
+        self, manager_with_account, account_service, ctx, db, tmp_path
+    ):
+        """#2129 (c): update_bot exchange 비호환 strategy → raise(저장/swap 전)."""
+        await _make_krx_account(account_service)
+        # NASDAQ 전략 vs KRX 계좌 → 비호환.
+        bad_sid = await _register_strategy(
+            db, _NASDAQ_STRATEGY_SOURCE, "nasdaq_only", "1.0.0", tmp_path
+        )
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        with pytest.raises(IncompatibleExchangeError):
+            await manager_with_account.update_bot("bot1", strategy_id=bad_sid)
+
+        assert manager_with_account.get_bot("bot1").config.strategy_id == "s1"
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert col == "s1"
+        assert cfg == "s1"
+
+    async def test_update_non_strategy_field_skips_validation(
+        self, manager_with_account, account_service, ctx, db
+    ):
+        """strategy_id 미변경(name 만 변경)이면 registry 검증을 트리거하지 않는다.
+
+        ``s1`` 은 registry 에 등록되지 않았지만, strategy_id 가 그대로이면
+        검증을 건너뛰므로 name-only update 가 성공해야 한다.
+        """
+        await _make_krx_account(account_service)
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", name="old", account_id="acc-test"
+        )
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager_with_account.update_bot("bot1", name="new")
+        assert bot.config.name == "new"
+        assert bot.config.strategy_id == "s1"
+
+    async def test_update_same_strategy_id_skips_validation(
+        self, manager_with_account, account_service, ctx
+    ):
+        """strategy_id 를 같은 값으로 명시 전달해도 검증을 건너뛴다(no-op)."""
+        await _make_krx_account(account_service)
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager_with_account.update_bot("bot1", strategy_id="s1")
+        assert bot.config.strategy_id == "s1"
+
+    async def test_update_strategy_without_account_service_skips_exchange(
+        self, manager, ctx, db, tmp_path
+    ):
+        """account_service 미주입이면 존재 검증만 하고 exchange 검증은 skip.
+
+        create_bot 과 동일하게 account 정보가 없으면 호환성 검증을 수행하지
+        않는다. registry 존재 검증은 여전히 적용된다.
+        """
+        new_sid = await _register_strategy(
+            db, _KRX_STRATEGY_SOURCE, "krx_compat", "1.0.0", tmp_path
+        )
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager.update_bot("bot1", strategy_id=new_sid)
+        assert bot.config.strategy_id == new_sid
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert col == new_sid == cfg
+
+    async def test_update_unregistered_strategy_raises_without_account_service(
+        self, manager, ctx, db
+    ):
+        """account_service 없이도 미등록 strategy 는 거부된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        with pytest.raises(StrategyNotFoundError):
+            await manager.update_bot("bot1", strategy_id="missing_v1.0.0")
+        assert manager.get_bot("bot1").config.strategy_id == "s1"
+
+
+# ── (d)(e) assign_strategy / change_strategy 일관성 ──────────────
+
+
+class TestAssignChangeConsistency:
+    async def test_assign_strategy_updates_both_stores(self, manager, ctx, db):
+        """#2130 (d): assign_strategy → 컬럼+config_json 일관."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.assign_strategy("bot1", "s2")
+
+        assert manager.get_bot("bot1").config.strategy_id == "s2"
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert col == "s2"
+        assert cfg == "s2"
+
+    async def test_change_strategy_updates_both_stores(self, manager, ctx, db):
+        """#2130 (e): change_strategy → 컬럼+config_json 일관."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.change_strategy("bot1", "s2")
+
+        assert manager.get_bot("bot1").config.strategy_id == "s2"
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert col == "s2"
+        assert cfg == "s2"
+
+    async def test_assign_running_bot_updates_both_stores(self, manager, ctx, db):
+        """running 봇 assign 후에도 컬럼+config_json 일관 + 재시작."""
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", interval_seconds=999, account_id="acc-test"
+        )
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+
+        await manager.assign_strategy("bot1", "s2")
+
+        bot = manager.get_bot("bot1")
+        assert bot.config.strategy_id == "s2"
+        assert bot.status == BotStatus.RUNNING
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert col == "s2" == cfg
+
+
+# ── (f) lifecycle 순서 보존 (stop→unload→persist→load→start) ──────
+
+
+class _RuleEngineSpy:
+    """rule load/unload 호출을 기록하는 최소 spy."""
+
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def load_strategy_rules_from_config(self, strategy_id, rule_configs):
+        self._events.append(f"load_rules:{strategy_id}")
+
+    def remove_strategy_rules(self, strategy_id):
+        self._events.append(f"unload_rules:{strategy_id}")
+
+
+class TestLifecycleOrderPreserved:
+    async def test_assign_running_preserves_stop_unload_persist_load_start_order(
+        self, eventbus, db, ctx
+    ):
+        """#2130 (f): running 봇 assign 순서 = stop→unload→persist→load→start.
+
+        rule load/unload 와 persist(``_save_bot_config``) 호출 시퀀스를
+        기록해, Codex Plan Review 가 보존을 요구한 lifecycle 순서를 회귀
+        보호한다.
+        """
+        events: list[str] = []
+        spy = _RuleEngineSpy(events)
+        # rule_configs 가 있어야 _load_strategy_rules 가 실제 호출을 한다.
+        m = BotManager(
+            eventbus=eventbus,
+            db=db,
+            rule_engine=spy,  # type: ignore[arg-type]
+            strategy_rule_configs={
+                "s1": [{"type": "x"}],
+                "s2": [{"type": "y"}],
+            },
+        )
+        await m.initialize()
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", interval_seconds=999, account_id="acc-test"
+        )
+        await m.create_bot(config, SimpleStrategy, ctx)
+        await m.start_bot("bot1")
+        # start_bot 도 _load_strategy_rules 를 호출하므로 이전 이벤트 비운다.
+        events.clear()
+
+        # persist 시점 기록을 위해 _save_bot_config 를 wrapping.
+        original_save = m._save_bot_config
+
+        async def spy_save(cfg):
+            events.append(f"persist:{cfg.strategy_id}")
+            return await original_save(cfg)
+
+        m._save_bot_config = spy_save  # type: ignore[method-assign]
+
+        # bot.stop/start 도 시퀀스에 기록.
+        bot = m.get_bot("bot1")
+        original_stop = bot.stop
+        original_start = bot.start
+
+        async def spy_stop():
+            events.append("stop")
+            return await original_stop()
+
+        async def spy_start():
+            events.append("start")
+            return await original_start()
+
+        bot.stop = spy_stop  # type: ignore[method-assign]
+        bot.start = spy_start  # type: ignore[method-assign]
+
+        await m.assign_strategy("bot1", "s2")
+
+        # 핵심 순서: stop → old rule unload(s1) → persist(s2) → new rule load(s2)
+        # → start.
+        assert events == [
+            "stop",
+            "unload_rules:s1",
+            "persist:s2",
+            "load_rules:s2",
+            "start",
+        ]
+
+        # cleanup
+        for b in list(m._bots.values()):
+            if b._task and not b._task.done():
+                b._task.cancel()
+        try:
+            await asyncio.wait_for(m.stop_all(), timeout=5.0)
+        except TimeoutError:
+            pass
+
+    async def test_change_strategy_persists_after_runtime_update(
+        self, eventbus, db, ctx
+    ):
+        """change_strategy 는 runtime config 갱신 후 persist 한다 (stopped 봇).
+
+        stopped 봇이므로 rule load/unload 는 발생하지 않지만, runtime
+        ``bot.config.strategy_id`` 갱신 → persist 순서를 회귀 보호한다.
+        """
+        events: list[str] = []
+        m = BotManager(eventbus=eventbus, db=db)
+        await m.initialize()
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await m.create_bot(config, SimpleStrategy, ctx)
+
+        bot = m.get_bot("bot1")
+        original_save = m._save_bot_config
+
+        async def spy_save(cfg):
+            # persist 시점에 runtime config 가 이미 새 strategy_id 여야 한다.
+            events.append(f"persist:runtime={bot.config.strategy_id}")
+            return await original_save(cfg)
+
+        m._save_bot_config = spy_save  # type: ignore[method-assign]
+
+        await m.change_strategy("bot1", "s2")
+
+        assert events == ["persist:runtime=s2"]
+
+        for b in list(m._bots.values()):
+            if b._task and not b._task.done():
+                b._task.cancel()
+        try:
+            await asyncio.wait_for(m.stop_all(), timeout=5.0)
+        except TimeoutError:
+            pass
+
+
+# ── (g) load_from_db 후 재로드 일관 ──────────────────────────────
+
+
+class TestReloadConsistency:
+    async def test_assign_then_reload_consistent(self, manager, eventbus, ctx, db):
+        """#2130 (g): assign 후 새 매니저로 load_from_db → 컬럼 기반 복원이 일관.
+
+        load_from_db 는 컬럼을 읽어 BotConfig 를 만든다. assign 으로 컬럼과
+        config_json 이 모두 새 ID 이므로, 재로드된 config 와 DB 의 두 store 가
+        모두 같은 ID 를 가리켜야 한다.
+        """
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.assign_strategy("bot1", "s2")
+
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        count = await manager2.load_from_db()
+        assert count == 1
+
+        reloaded = manager2.get_bot("bot1")
+        assert reloaded.config.strategy_id == "s2"
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert reloaded.config.strategy_id == col == cfg == "s2"
+
+    async def test_update_strategy_then_reload_consistent(
+        self, manager_with_account, account_service, eventbus, ctx, db, tmp_path
+    ):
+        """#2129 (g): update_bot --strategy 후 재로드 일관."""
+        await _make_krx_account(account_service)
+        new_sid = await _register_strategy(
+            db, _KRX_STRATEGY_SOURCE, "krx_compat", "1.0.0", tmp_path
+        )
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+        await manager_with_account.update_bot("bot1", strategy_id=new_sid)
+
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        await manager2.load_from_db()
+
+        reloaded = manager2.get_bot("bot1")
+        col, cfg = await _row_strategy_ids(db, "bot1")
+        assert reloaded.config.strategy_id == col == cfg == new_sid


### PR DESCRIPTION
Closes #2129, #2130

## Summary
봇 전략 변경 경로가 `bots.strategy_id`(컬럼)과 `config_json.strategy_id`를 불일치시키던 양방향 drift 수정 + update_bot 전략 검증.
- **#2129**: `_save_bot_config` ON CONFLICT DO UPDATE SET에 `strategy_id=excluded.strategy_id` 추가(update_bot 컬럼-stale 해소). update_bot strategy 변경 시 StrategyRegistry 존재 + exchange 호환 검증(config swap/저장 전, **effective account_id** 사용 — account+strategy 동시 변경 대응)
- **#2130**: assign_strategy/change_strategy를 `_save_bot_config`(컬럼+config_json) 사용으로 전환, assign lifecycle 순서(stop→unload→persist→load→start) 보존
- `_update_bot_strategy`(컬럼-only) 제거

## Scope
- `src/ante/bot/manager.py`. schema/create_bot 검증 무변경. account_id 컬럼 stale은 동형 follow-up 분리.

## Test Plan
- 신규 17건(update valid/unregistered/incompatible/effective-account simultaneous compat·incompat / assign·change 일관 / assign 순서 spy / load_from_db 재로드)
- `pytest -k 'bot or manager or strategy'` 1184+ passed, 전체 유닛 6719 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS(2회차)

🤖 Generated with [Claude Code](https://claude.com/claude-code)