### PR TITLE
fix(data): #2011 DART CFS/OFS 선택에 bsns_year 포함 (연도별 OFS 폴백 보존)

### DIFF
--- a/src/ante/data/normalizer.py
+++ b/src/ante/data/normalizer.py
@@ -436,8 +436,10 @@ class DARTNormalizer:
     def _select_fs_div(self, df: pl.DataFrame) -> pl.DataFrame:
         """CFS(연결) 우선, 없으면 OFS(개별) 폴백.
 
-        corp_code + reprt_code 기준으로 CFS 데이터가 있으면
-        CFS만, CFS가 없는 조합은 OFS를 사용한다.
+        corp_code + reprt_code + bsns_year 기준으로 CFS 데이터가 있으면
+        CFS만, CFS가 없는 조합은 OFS를 사용한다. bsns_year를 키에 포함해야
+        연도별로 CFS 존재 여부를 판단하므로, 특정 연도에만 CFS가 있고
+        다른 연도는 OFS-only인 데이터의 OFS 폴백이 보존된다.
         """
         cfs = df.filter(pl.col("fs_div") == "CFS")
         ofs = df.filter(pl.col("fs_div") == "OFS")
@@ -447,13 +449,13 @@ class DARTNormalizer:
         if ofs.is_empty():
             return cfs
 
-        # CFS가 있는 (corp_code, reprt_code) 조합
-        cfs_keys = cfs.select("corp_code", "reprt_code").unique()
+        # CFS가 있는 (corp_code, reprt_code, bsns_year) 조합
+        cfs_keys = cfs.select("corp_code", "reprt_code", "bsns_year").unique()
 
         # OFS 중 CFS가 없는 조합만 추출
         ofs_fallback = ofs.join(
             cfs_keys,
-            on=["corp_code", "reprt_code"],
+            on=["corp_code", "reprt_code", "bsns_year"],
             how="anti",
         )
 

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -1727,6 +1727,117 @@ class TestDARTNormalizer:
         assert len(result) == 1
         assert result["revenue"][0] == 1_000_000
 
+    def test_select_fs_div_mixed_year_preserves_ofs(
+        self, dart_normalizer, corp_code_map
+    ):
+        """회귀(#2011): 연도별로 CFS/OFS 혼재 시 OFS-only 연도 보존.
+
+        2025 annual은 CFS 보유, 2024 annual은 OFS-only.
+        bsns_year를 선택 키에 포함하지 않으면 2024 OFS가
+        2025 CFS와 동일한 (corp_code, reprt_code)로 간주돼
+        anti-join에서 삭제된다 → 2024 데이터 누락 회귀.
+        """
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "corp_code": ["00126380"] * 2,
+                "account_nm": ["매출액", "매출액"],
+                "thstrm_amount": ["1,000,000", "900,000"],
+                # 2025: CFS / 2024: OFS-only
+                "fs_div": ["CFS", "OFS"],
+                "reprt_code": ["11011", "11011"],
+                "bsns_year": ["2025", "2024"],
+            }
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+
+        # 두 연도 모두 보존되어야 한다.
+        assert len(result) == 2
+        by_date = {
+            d: rev
+            for d, rev in zip(
+                result["date"].to_list(),
+                result["revenue"].to_list(),
+            )
+        }
+        assert by_date[date(2025, 12, 31)] == 1_000_000  # CFS
+        assert by_date[date(2024, 12, 31)] == 900_000  # OFS 폴백 보존
+
+    def test_select_fs_div_same_year_cfs_only(self, dart_normalizer, corp_code_map):
+        """같은 연도에 CFS/OFS 둘 다 있으면 CFS만 선택 (연도 내 우선순위 유지)."""
+        df = pl.DataFrame(
+            {
+                "corp_code": ["00126380"] * 2,
+                "account_nm": ["매출액", "매출액"],
+                "thstrm_amount": ["1,000,000", "500,000"],
+                "fs_div": ["CFS", "OFS"],
+                "reprt_code": ["11011", "11011"],
+                "bsns_year": ["2025", "2025"],
+            }
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert len(result) == 1
+        assert result["revenue"][0] == 1_000_000
+
+    def test_select_fs_div_all_years_ofs_only(self, dart_normalizer, corp_code_map):
+        """전 연도 OFS-only: 모든 연도 OFS 보존."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "corp_code": ["00126380"] * 2,
+                "account_nm": ["매출액", "매출액"],
+                "thstrm_amount": ["1,000,000", "900,000"],
+                "fs_div": ["OFS", "OFS"],
+                "reprt_code": ["11011", "11011"],
+                "bsns_year": ["2025", "2024"],
+            }
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert len(result) == 2
+        by_date = {
+            d: rev
+            for d, rev in zip(
+                result["date"].to_list(),
+                result["revenue"].to_list(),
+            )
+        }
+        assert by_date[date(2025, 12, 31)] == 1_000_000
+        assert by_date[date(2024, 12, 31)] == 900_000
+
+    def test_select_fs_div_all_years_cfs(self, dart_normalizer, corp_code_map):
+        """전 연도 CFS: 모든 연도 CFS 선택, OFS 제외."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "corp_code": ["00126380"] * 4,
+                "account_nm": ["매출액"] * 4,
+                "thstrm_amount": [
+                    "1,000,000",
+                    "111,111",
+                    "900,000",
+                    "99,999",
+                ],
+                "fs_div": ["CFS", "OFS", "CFS", "OFS"],
+                "reprt_code": ["11011"] * 4,
+                "bsns_year": ["2025", "2025", "2024", "2024"],
+            }
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert len(result) == 2
+        by_date = {
+            d: rev
+            for d, rev in zip(
+                result["date"].to_list(),
+                result["revenue"].to_list(),
+            )
+        }
+        # 두 연도 모두 CFS 값만 사용.
+        assert by_date[date(2025, 12, 31)] == 1_000_000
+        assert by_date[date(2024, 12, 31)] == 900_000
+
     def test_normalize_empty_df(self, dart_normalizer, corp_code_map):
         """빈 DataFrame 입력 시 빈 결과."""
         df = pl.DataFrame(


### PR DESCRIPTION
Closes #2011

## Summary
`DARTNormalizer._select_fs_div()`의 CFS/OFS 선택이 `(corp_code, reprt_code)`로만 anti-join해, 한 연도에 CFS·다른 연도에 OFS만 있는 정상 케이스에서 OFS-only 연도가 통째 삭제되던 버그 수정.
- cfs_keys select + anti-join 키에 `bsns_year` 추가 → CFS 존재 판단이 (corp, report, year)별 → 연도별 OFS 폴백 보존

## Scope
- `src/ante/data/normalizer.py::_select_fs_div`. DART point-in-time(#2067)·_convert_report_date·우선순위 정책 무변경.

## Test Plan
- 신규 mixed-year 회귀(2025 CFS + 2024 OFS-only → 둘 다 보존) + same-year/all-OFS/all-CFS
- `pytest -k 'normaliz or dart or fundamental'` 230 passed, 전체 유닛 6706 passed, ruff/mypy clean
- Codex 브랜치 리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)