### PR TITLE
fix(test): #2277 wall-clock 의존 테스트 결정화 (orchestrator backfill cap 중립화 + fill KST 경계-안전 타임스탬프)

### DIFF
--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -29,6 +29,23 @@ from ante.feed.sources.data_go_kr import (
 # ── Fixtures ─────────────────────────────────────────────
 
 
+@pytest.fixture(autouse=True)
+def _disable_publication_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#2015 publication cap을 이 파일 내에서만 중립화한다 (#2277).
+
+    이 파일의 backfill 테스트는 mock 소스라 실제 D+1 13:00 공시 지연과 무관하다.
+    cap이 끼면 ``backfill_since=어제`` 같은 상대 날짜가 wall-clock(KST 13:00
+    경계)에 의존해 캘린더 flaky가 된다(KST 00:00–13:00 구간에 published_end<어제로
+    range 공집합 → rows_written=0). 호출 지점인
+    ``backfill_runner._last_published_date`` 를 항등(오늘 KST)으로 대체해 backfill
+    range를 시각 무관하게 만든다. 파일-local autouse 이므로
+    ``test_backfill_last_published_cap.py`` 의 #2015 cap 검증은 마스킹하지 않는다.
+    """
+    import ante.feed.pipeline.backfill_runner as br
+
+    monkeypatch.setattr(br, "_last_published_date", lambda now_kst: now_kst.date())
+
+
 def _make_data_go_kr_records(
     date_str: str = "20240101",
     symbols: list[str] | None = None,

--- a/tests/unit/test_fill_scheduler.py
+++ b/tests/unit/test_fill_scheduler.py
@@ -14,6 +14,7 @@ import pytest
 
 from ante.broker import fill_scheduler as fill_scheduler_module
 from ante.broker.fill_scheduler import (
+    _KST,
     MIN_POLL_INTERVAL,
     CatchUpResult,
     FillReconcileScheduler,
@@ -607,8 +608,13 @@ async def test_catch_up_recovers_iso_timestamp_end_to_end(tracker, applier):
     app, ph, _eb = applier
     await _seed(tracker, broker_order_id="0001", qty=100.0)
     # Test/Mock 어댑터의 created_at.isoformat() 과 동일한 tz-aware ISO.
-    # DATE(오늘 KST) 와 같은 영업일이 되도록 오늘 정오(UTC) 를 쓴다.
-    iso_ts = datetime.now(UTC).replace(hour=3, minute=0, second=0).isoformat()
+    # DATE(영업일 YYYYMMDD)에서 파생한 KST 정오를 써서 now 비의존(완전 결정적)으로
+    # 같은 영업일을 보장한다 (#2277: UTC 저녁이면 hour=3 UTC 구성이 KST 익일로
+    # 넘어가 business_date_kst != DATE 가 되는 wall-clock flaky 제거).
+    ref = datetime.strptime(DATE, "%Y%m%d").replace(
+        hour=12, minute=0, second=0, tzinfo=_KST
+    )
+    iso_ts = ref.isoformat()
     assert business_date_kst(datetime.fromisoformat(iso_ts)) == DATE
     broker = FakeBroker(
         history=[


### PR DESCRIPTION
Closes #2277

## Summary
- KST 00:00–13:00(=15:00–24:00 UTC) 구간에 결정적 FAIL하던 테스트 8건을 wall-clock 무관하게 결정화 (main HEAD RED → 전 PR ci 차단 해소). **test-only, production 무변경.**
- 축 A (orchestrator 7건): `test_orchestrator.py`에 파일-local autouse fixture로 #2015 publication cap(`_last_published_date`)을 mock-source 테스트 한정 중립화 → backfill range `[어제,오늘]` 항상 비공집합. conftest 미승격(#2015 cap 단위테스트 마스킹 방지).
- 축 B (fill 1건): `test_catch_up_recovers_iso_timestamp_end_to_end`의 타임스탬프를 `DATE`에서 파생(KST 정오)해 UTC 저녁/KST 익일 경계 flaky 제거.

## Test Plan
- 두 파일 60 passed (TZ=UTC·TZ=Asia/Seoul 양쪽), 8 FAIL → 0
- 전체 `pytest tests/unit/`: 6723 passed, 2 skipped, 0 failed (baseline 8 failed → 0, 신규 실패 0)
- 무회귀: test_backfill_last_published_cap.py 10 passed, business_date_kst 경계 8 passed
- ruff check/format pass, `git diff --stat -- src/` 비어 있음

🤖 Generated with [Claude Code](https://claude.com/claude-code)