### PR TITLE
fix(feed): #2101 DART daily 모드는 최신 분기 1개만 수집 (backfill_since 전 분기 순회 차단)

### DIFF
--- a/src/ante/feed/pipeline/daily_runner.py
+++ b/src/ante/feed/pipeline/daily_runner.py
@@ -159,12 +159,17 @@ class DailyRunner:
 
         checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
         try:
+            # daily=True: DART는 분기 공시이므로 daily-equivalent은 "최신
+            # collectable 분기 1개"만 수집한다(#2101). backfill_since 전 분기를
+            # 순회하지 않는다. 과거 미충전 분기 보정은 backfill 모드 책임이며,
+            # daily는 최신 분기 증분만 담당한다.
             written, syms, warns = await self._dart.collect(
                 data_path,
                 feed_dir,
                 checkpoint,
                 config,
                 store,
+                daily=True,
             )
             ctx.add_success(written, syms, warns)
             if written > 0:

--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -107,8 +107,23 @@ class DARTCollector:
         checkpoint: Checkpoint,
         config: dict[str, Any],
         store: ParquetStore,
+        daily: bool = False,
     ) -> tuple[int, set[str], list[dict]]:
         """DART 재무제표를 분기별로 수집한다.
+
+        Args:
+            daily: ``True``면 daily-incremental 모드로, ``backfill_since`` 범위를
+                순회하지 않고 **최신 collectable 분기 1개만** 수집한다(#2101).
+                spec 07-execution-modes의 Daily Incremental("날짜 1개")에 대응하는
+                DART daily-equivalent다. DART는 분기 단위 공시이므로 daily 실행은
+                "오늘 기준 가장 최근에 공시 가능한 분기"만 확인한다. ``False``(기본,
+                backfill 모드)면 ``_resolve_year_range``의 전 분기를 순회한다.
+
+                운영 전제: daily 모드는 과거 미충전 분기를 보정하지 않는다(최신
+                분기 1개만 본다). checkpoint가 비거나 오래되어 과거 분기가 비어
+                있으면 ``feed run backfill``(daily=False, 전 분기 순회)로 채워야
+                한다. 과거 이력 backfill 책임은 backfill 모드에 있고, daily는
+                최신 분기 증분만 담당한다.
 
         Returns:
             (기록 행 수, 수집된 심볼 집합, 경고 목록).
@@ -127,10 +142,18 @@ class DARTCollector:
             ]
             return 0, set(), warns
 
-        start_year, end_year = self._resolve_year_range(config)
         last_checkpoint = checkpoint.get_last_date()
         last_checkpoint = self._migrate_checkpoint_key(last_checkpoint)
 
+        if daily:
+            return await self._collect_latest_quarter(
+                corp_code_map,
+                store,
+                checkpoint,
+                last_checkpoint,
+            )
+
+        start_year, end_year = self._resolve_year_range(config)
         return await self._collect_quarters(
             corp_code_map,
             store,
@@ -252,6 +275,103 @@ class DARTCollector:
             rows_written,
         )
         return rows_written, symbols, warns
+
+    @staticmethod
+    def _latest_collectable_quarter(
+        today: date,
+    ) -> tuple[int, str] | None:
+        """today(KST) 기준 가장 최근에 공시 가능한 (year, reprt_code)를 반환한다.
+
+        collectable = ``_quarter_period_end(year, reprt_code) <= today``인 분기.
+        그중 period_end가 가장 최근(=가장 큰)인 분기 1개를 고른다. period_end가
+        같으면 발생하지 않지만(reprt_code→종료월 1:1), 안전하게 결정적으로
+        고른다.
+
+        연말/연초 경계: annual(Q4, 12/31)은 익년 초까지 미공시일 수 있으므로
+        period_end<=today 기준으로 정확히 판정된다. 예를 들어 2026-01-15에는
+        2025-Q4(period_end 2025-12-31)가 collectable이며 2025 annual을 고른다.
+        반대로 2026-04-01에는 2026-Q1(3/31)이 가장 최근 collectable이다.
+
+        탐색 범위는 today 연도와 직전 연도(today.year-1)면 충분하다. 직전 연도
+        Q4(period_end 전년 12/31)는 today가 연초여도 항상 <=today이므로 후보가
+        비는 경우는 없다(따라서 실질적으로 None을 반환하지 않지만, 매핑 부재
+        등 방어를 위해 Optional 시그니처를 유지한다).
+
+        Returns:
+            (year, reprt_code) 또는 collectable 분기가 없으면 None.
+        """
+        best: tuple[int, str] | None = None
+        best_end: date | None = None
+        for year in (today.year - 1, today.year):
+            for reprt_code in REPRT_CODES:
+                period_end = _quarter_period_end(year, reprt_code)
+                if period_end is None or period_end > today:
+                    continue
+                if best_end is None or period_end > best_end:
+                    best_end = period_end
+                    best = (year, reprt_code)
+        return best
+
+    async def _collect_latest_quarter(
+        self,
+        corp_code_map: dict[str, str],
+        store: ParquetStore,
+        checkpoint: Checkpoint,
+        last_checkpoint: str | None,
+    ) -> tuple[int, set[str], list[dict]]:
+        """daily 모드: 최신 collectable 분기 1개만 수집한다(#2101).
+
+        ``backfill_since`` 범위를 순회하지 않고, today(KST) 기준 가장 최근에
+        공시 가능한 분기 1개에 대해서만 ``_fetch_quarter``를 수행한다. 단일
+        분기지만 checkpoint 전진/halt/SKIP_EMPTY 판정은 backfill 경로와 동일한
+        ``_fetch_quarter``/``QuarterStatus`` 로직을 그대로 재사용한다(#2028/#2054).
+
+        운영 전제: 이 경로는 최신 분기만 본다. 과거 미충전 분기는 backfill
+        모드로 채워야 하며, daily가 과거 누락을 보정하지 않는다.
+        """
+        corp_codes_list = list(corp_code_map.keys())
+        warns: list[dict] = []
+
+        today = _today_kst()
+        latest = self._latest_collectable_quarter(today)
+        if latest is None:
+            # collectable 분기 부재(매핑 이상 등): no-op.
+            logger.info("DART daily: collectable 분기 없음")
+            return 0, set(), warns
+
+        year, reprt_code = latest
+        quarter_key = f"{year}-{REPRT_TO_QUARTER[reprt_code]}"
+
+        # 최신 분기가 이미 checkpoint done(<=last)이면 재수집하지 않는다(0 fetch).
+        if last_checkpoint and quarter_key <= last_checkpoint:
+            logger.info(
+                "DART daily: 최신 분기 %s 이미 수집됨(checkpoint=%s), skip",
+                quarter_key,
+                last_checkpoint,
+            )
+            return 0, set(), warns
+
+        written, syms, status = await self._fetch_quarter(
+            corp_codes_list,
+            corp_code_map,
+            store,
+            year,
+            reprt_code,
+            warns,
+        )
+        # SKIP_EMPTY(미공시 가능)/HALT(transient·no-storable)는 backfill과 동일하게
+        # checkpoint를 전진시키지 않는다. OK일 때만 save한다(#2028/#2054 보존).
+        if status is QuarterStatus.OK:
+            checkpoint.save(quarter_key)
+
+        logger.info(
+            "DART daily 수집 완료: quarter=%s symbols=%d rows=%d status=%s",
+            quarter_key,
+            len(syms),
+            written,
+            status.value,
+        )
+        return written, syms, warns
 
     async def _fetch_quarter(
         self,

--- a/tests/unit/feed/test_daily_runner_dart_daily_flag.py
+++ b/tests/unit/feed/test_daily_runner_dart_daily_flag.py
@@ -1,0 +1,67 @@
+"""DailyRunner가 DART collect를 daily=True로 호출하는지 검증한다(#2101).
+
+`feed run daily`는 DART를 daily-incremental("최신 분기 1개")로 수집해야 하며,
+backfill_since 전 분기를 순회해서는 안 된다. DailyRunner._collect_dart가
+DARTCollector.collect(..., daily=True)를 전달하는지 잠근다. 반대로 BackfillRunner는
+daily 인자를 넘기지 않아(기본 False) 전 분기 순회를 유지한다.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ante.data.store import ParquetStore
+from ante.feed.pipeline.checkpoint import Checkpoint
+from ante.feed.pipeline.daily_runner import DailyRunner
+
+
+class _RecordingDARTCollector:
+    """collect 호출 시 ``daily`` 인자 값을 기록하는 stub DARTCollector."""
+
+    def __init__(self) -> None:
+        self.daily_calls: list[bool] = []
+
+    async def collect(
+        self,
+        data_path: Path,
+        feed_dir: Path,
+        checkpoint: Checkpoint,
+        config: dict[str, Any],
+        store: ParquetStore,
+        daily: bool = False,
+    ) -> tuple[int, set[str], list[dict]]:
+        self.daily_calls.append(daily)
+        return 0, set(), []
+
+
+@pytest.mark.asyncio
+async def test_daily_runner_calls_dart_collect_with_daily_true(
+    tmp_path: Path,
+) -> None:
+    """DailyRunner._collect_dart가 collect(..., daily=True)를 전달한다."""
+    data_path = tmp_path / "data"
+    feed_dir = data_path / ".feed"
+    (feed_dir / "checkpoints").mkdir(parents=True)
+
+    dart = _RecordingDARTCollector()
+    store = ParquetStore(base_path=data_path)
+    runner = DailyRunner(
+        data_go_kr_collector=None,
+        dart_collector=dart,
+        store=store,
+    )
+
+    await runner.run(
+        data_path=data_path,
+        config={"schedule": {"backfill_since": "2015-01-01"}},
+        feed_dir=feed_dir,
+        started_at=datetime.now(tz=UTC),
+        is_blocked=lambda config, target_date: False,
+        target_date="2026-05-29",
+    )
+
+    assert dart.daily_calls == [True]

--- a/tests/unit/feed/test_dart_collector.py
+++ b/tests/unit/feed/test_dart_collector.py
@@ -661,6 +661,262 @@ class TestEmptyQuarterSkip:
         assert warns == []
 
 
+class TestDailyLatestQuarter:
+    """#2101: daily 모드는 최신 collectable 분기 1개만 수집한다.
+
+    수정 전 ``feed run daily``는 ``collect()``를 daily 구분 없이 호출해
+    ``_resolve_year_range``로 backfill_since(예 2015)부터 전 분기를 순회했다
+    (사실상 DART backfill 동작). daily=True는 today(KST) 기준 최신 collectable
+    분기 1개만 ``_fetch_quarter``하고, checkpoint/SKIP_EMPTY/HALT 로직(#2028/
+    #2054)은 backfill 경로와 동일하게 보존한다.
+    """
+
+    async def test_daily_collects_only_latest_quarter_ignoring_backfill_since(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """(a) daily=True + checkpoint 부재 → 최신 분기 1개만 fetch(backfill 무시).
+
+        today=2026-05-29, backfill_since=2015. backfill(daily=False)이라면 2015~2026
+        전 분기를 순회하겠지만, daily=True는 2026-05-29 기준 최신 collectable 분기
+        (2026-Q1, period_end 3/31)만 fetch한다. 2015 등 과거 분기는 fetch하지 않는다.
+        """
+        import ante.feed.pipeline.dart_collector as dc
+
+        monkeypatch.setattr(dc, "_today_kst", lambda: date(2026, 5, 29))
+
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        store = ParquetStore(base_path=tmp_path / "data")
+        checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+
+        # 최신 분기(2026-Q1)는 데이터를 반환(written>0)하도록 스크립트.
+        behaviors: dict[tuple[str, str], object] = {
+            ("2026", "11013"): [_raw_item("2026", "11013")],
+        }
+        source = _ScriptedDARTSource({"00126380": "005930"}, behaviors)
+        normalizer = _ScriptedNormalizer({("2026", "11013"): _stored_df("2026")})
+        collector = DARTCollector(source=source, normalizer=normalizer)
+
+        config = {"schedule": {"backfill_since": "2015-01-01"}}
+        rows, syms, warns = await collector.collect(
+            data_path=tmp_path / "data",
+            feed_dir=feed_dir,
+            checkpoint=checkpoint,
+            config=config,
+            store=store,
+            daily=True,
+        )
+
+        # 정확히 최신 분기 1개(2026-Q1)만 fetch. 과거/미래 분기 없음.
+        assert source.fetched == [("2026", "11013")]
+        assert rows > 0
+        assert syms == {"005930"}
+        assert warns == []
+        # 최신 분기 성공 → checkpoint가 2026-Q1로 전진.
+        assert checkpoint.get_last_date() == "2026-Q1"
+
+    async def test_daily_latest_quarter_already_done_zero_fetch(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """(b) daily=True + 최신 분기 checkpoint done → 0 fetch(skip).
+
+        today=2026-05-29 → 최신 collectable = 2026-Q1. checkpoint가 이미 2026-Q1이면
+        재수집하지 않는다(fetch 0회).
+        """
+        import ante.feed.pipeline.dart_collector as dc
+
+        monkeypatch.setattr(dc, "_today_kst", lambda: date(2026, 5, 29))
+
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        store = ParquetStore(base_path=tmp_path / "data")
+        checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+        checkpoint.save("2026-Q1")  # 최신 분기 이미 완료
+
+        source = _ScriptedDARTSource({"00126380": "005930"}, {})
+        collector = DARTCollector(source=source)
+
+        config = {"schedule": {"backfill_since": "2015-01-01"}}
+        rows, syms, warns = await collector.collect(
+            data_path=tmp_path / "data",
+            feed_dir=feed_dir,
+            checkpoint=checkpoint,
+            config=config,
+            store=store,
+            daily=True,
+        )
+
+        assert source.fetched == []  # fetch 0회
+        assert rows == 0
+        assert syms == set()
+        assert warns == []
+        # checkpoint는 변하지 않음(이미 최신).
+        assert checkpoint.get_last_date() == "2026-Q1"
+
+    async def test_daily_latest_quarter_empty_response_skip_empty(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """(e-1) daily 최신 분기 빈 응답(미공시) → SKIP_EMPTY: 미전진(checkpoint None).
+
+        분기종료 직후·공시 전 빈 응답은 SKIP_EMPTY로 처리해 checkpoint를
+        전진시키지 않는다(#2028 보존). 다음 daily run에서 재시도된다.
+        """
+        import ante.feed.pipeline.dart_collector as dc
+
+        monkeypatch.setattr(dc, "_today_kst", lambda: date(2026, 5, 29))
+
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        store = ParquetStore(base_path=tmp_path / "data")
+        checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+
+        # 최신 분기(2026-Q1) 미지정 → 빈 응답([]).
+        source = _ScriptedDARTSource({"00126380": "005930"}, {})
+        collector = DARTCollector(source=source)
+
+        config = {"schedule": {"backfill_since": "2015-01-01"}}
+        rows, _syms, warns = await collector.collect(
+            data_path=tmp_path / "data",
+            feed_dir=feed_dir,
+            checkpoint=checkpoint,
+            config=config,
+            store=store,
+            daily=True,
+        )
+
+        # 최신 분기 1개만 fetch했으나 빈 응답 → 미전진.
+        assert source.fetched == [("2026", "11013")]
+        assert rows == 0
+        assert warns == []
+        assert checkpoint.get_last_date() is None  # SKIP_EMPTY 미전진
+
+    async def test_daily_latest_quarter_transient_failure_halts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """(e-2) daily 최신 분기 transient 실패 → HALT: warn 추가 + checkpoint 미전진.
+
+        ``_fetch_quarter``의 HALT 경로(transient 예외)가 daily 경로에서도
+        동일하게 동작한다(#2054 보존). checkpoint는 전진하지 않고 warn이 표면화된다.
+        """
+        import ante.feed.pipeline.dart_collector as dc
+
+        monkeypatch.setattr(dc, "_today_kst", lambda: date(2026, 5, 29))
+
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        store = ParquetStore(base_path=tmp_path / "data")
+        checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+
+        behaviors: dict[tuple[str, str], object] = {
+            ("2026", "11013"): RuntimeError("transient upstream"),
+        }
+        source = _ScriptedDARTSource({"00126380": "005930"}, behaviors)
+        collector = DARTCollector(source=source)
+
+        config = {"schedule": {"backfill_since": "2015-01-01"}}
+        rows, _syms, warns = await collector.collect(
+            data_path=tmp_path / "data",
+            feed_dir=feed_dir,
+            checkpoint=checkpoint,
+            config=config,
+            store=store,
+            daily=True,
+        )
+
+        assert source.fetched == [("2026", "11013")]
+        assert rows == 0
+        assert checkpoint.get_last_date() is None  # HALT 미전진
+        assert len(warns) == 1
+        assert warns[0]["reprt_code"] == "11013"
+
+
+class TestLatestCollectableQuarter:
+    """#2101: ``_latest_collectable_quarter`` 산출이 period_end<=today 최대로 정확."""
+
+    def test_mid_year_picks_q1(self) -> None:
+        """(d-1) 2026-05-29 → 2026-Q1(3/31)이 최신 collectable(Q2~Q4는 미래)."""
+        result = DARTCollector._latest_collectable_quarter(date(2026, 5, 29))
+        assert result == (2026, "11013")  # 2026-Q1
+
+    def test_after_q2_period_end_picks_q2(self) -> None:
+        """(d-2) 2026-08-15 → 2026-Q2(6/30)가 최신(Q3 9/30은 미래)."""
+        result = DARTCollector._latest_collectable_quarter(date(2026, 8, 15))
+        assert result == (2026, "11012")  # 2026-Q2
+
+    def test_year_start_boundary_picks_prev_annual(self) -> None:
+        """(d-3) 연초 경계 2026-01-15 → 2025-Q4(annual, 2025-12-31)가 최신.
+
+        annual은 익년 초까지 미공시일 수 있으나 period_end<=today 기준이므로
+        2025-12-31<=2026-01-15로 collectable이다. 2026-Q1(3/31)은 미래라 제외.
+        """
+        result = DARTCollector._latest_collectable_quarter(date(2026, 1, 15))
+        assert result == (2025, "11011")  # 2025-Q4(annual)
+
+    def test_exact_period_end_is_collectable(self) -> None:
+        """(d-4) today == period_end(2026-03-31) → 그 분기(2026-Q1) collectable(<=)."""
+        result = DARTCollector._latest_collectable_quarter(date(2026, 3, 31))
+        assert result == (2026, "11013")  # 2026-Q1
+
+    def test_year_end_picks_annual(self) -> None:
+        """(d-5) 2026-12-31 → 2026-Q4(annual, 12/31)가 최신 collectable."""
+        result = DARTCollector._latest_collectable_quarter(date(2026, 12, 31))
+        assert result == (2026, "11011")  # 2026-Q4
+
+
+class TestBackfillUnchangedRegression:
+    """#2101: daily=False(기본, backfill)는 기존 전 분기 순회를 유지(회귀 락)."""
+
+    async def test_backfill_default_iterates_all_quarters(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """(c) collect(daily=False) → backfill_since~현재 전 분기 순회(무변경).
+
+        today=2016-05-29, backfill_since=2015. daily 구분 없는 기존 동작은
+        2015 전 분기(Q1~Q4) + 2016 collectable 분기(Q1)를 순회한다. daily 플래그
+        도입 후에도 기본값 False 경로는 동일하게 전 분기를 fetch한다.
+        """
+        import ante.feed.pipeline.dart_collector as dc
+
+        monkeypatch.setattr(dc, "_today_kst", lambda: date(2016, 5, 29))
+
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        store = ParquetStore(base_path=tmp_path / "data")
+        checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+
+        source = _ScriptedDARTSource({"00126380": "005930"}, {})
+        collector = DARTCollector(source=source)
+
+        config = {"schedule": {"backfill_since": "2015-01-01"}}
+        # daily 인자 생략(기본 False) → backfill 경로.
+        await collector.collect(
+            data_path=tmp_path / "data",
+            feed_dir=feed_dir,
+            checkpoint=checkpoint,
+            config=config,
+            store=store,
+        )
+
+        # 2015 전 분기 + 2016-Q1(collectable). 2016-Q2~Q4(6/30 이후)는 미래라 제외.
+        assert source.fetched == [
+            ("2015", "11013"),
+            ("2015", "11012"),
+            ("2015", "11014"),
+            ("2015", "11011"),
+            ("2016", "11013"),
+        ]
+
+
 class _CountingCorpCodeSource:
     """fetch_corp_codes 호출 횟수를 기록하고 save_path에 결과를 작성하는 스텁.
 


### PR DESCRIPTION
Closes #2101

## Summary
- `feed run daily`가 DART checkpoint 부재 시 backfill_since부터 전 분기를 수집(backfill 동작)하던 것을, daily 모드는 **최신 collectable 분기 1개**(max period_end <= today KST)만 수집하도록 수정.
- `DARTCollector.collect(..., daily: bool=False)` 추가. daily=True는 `_latest_collectable_quarter`로 산출한 1개 분기만 `_fetch_quarter`(#2028/#2054 checkpoint·QuarterStatus OK/HALT/SKIP_EMPTY 그대로 재사용). `DailyRunner._collect_dart`가 daily=True 전달.
- BackfillRunner는 daily 인자 미전달(기본 False) → 전 분기 순회 유지(회귀 락).

## Test Plan
- 추가 테스트 11건(daily 최신분기/경계 5·backfill 회귀 1·daily flag 등). 타깃 + 이전 flaky 통과
- 전체 `pytest tests/unit/` (main #2277 머지 후 baseline GREEN)
- ruff/mypy pass, generated artifact 무변경
- Codex 브랜치 리뷰 PASS (rebase 전 6268b7ff), 리베이스 후 e0ad8620

🤖 Generated with [Claude Code](https://claude.com/claude-code)