### PR TITLE
fix(bot): #2111 signal-key --rotate를 bot.signal_key.rotate IPC로 라우팅 (cold-path DB mutation 제거)

### DIFF
--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -233,7 +233,7 @@ BotManager/DB 종료 이후 lifecycle 마지막 단계에서만 호출된다.
 - **read-only**: 서버가 보유한 live adapter를 통해 상태를 조회하지만 서버/DB 상태를
   변경하지 않는 명령
 
-현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 27개가
+현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 28개가
 SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표를 함께 갱신해야 한다.
 
 | IPC 커맨드 | taxonomy | 근거 |
@@ -247,6 +247,7 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 | `bot.start` | mutating | `BotManager.start_bot()` 호출. `app_key` preflight + audit `bot.start` (#1712) |
 | `bot.stop` | mutating | `BotManager.stop_bot()` 호출. audit `bot.stop` (#1712) |
 | `bot.update` | mutating | `BotManager.update_bot()` 호출 |
+| `bot.signal_key.rotate` | mutating | `BotManager.rotate_signal_key()` 호출. 기존 signal key 폐기 + 새 key 발급, audit `bot.signal_key.rotate` (#2111) |
 | `treasury.allocate` | mutating | `Treasury.allocate()` 호출 |
 | `treasury.deallocate` | mutating | `Treasury.deallocate()` 호출 |
 | `treasury.set_balance` | mutating | `Treasury.set_account_balance()` 호출 |
@@ -271,7 +272,7 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 IPC command 분리는 별도 이슈 범위다.
 
 `account.delete`처럼 1.0 IPC 계약에서 제외되어 `CommandRegistry`에 등록되지 않는 명령은
-taxonomy 대상이 아니다. `member.update_scopes`를 제외한 `member.*`, `bot.signal_key.rotate`처럼 CLI/스펙 표에는 runtime IPC로
+taxonomy 대상이 아니다. `member.update_scopes`를 제외한 `member.*`처럼 CLI/스펙 표에는 runtime IPC로
 표현되어 있으나 현재 `register_all_handlers()`에 없는 명령의 실제 wiring은 별도 후속 이슈에서
 다룬다.
 

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -497,10 +497,13 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
                 fmt.error(text)
             raise SystemExit(1) from e
 
-        if fmt.is_json:
-            fmt.output(result)
-        else:
-            fmt.success(f"시그널 키 재발급 완료: {bot_id}", result)
+        # 출력 계약 보존 (#2111): rotate 성공은 IPC 라우팅으로 옮겼더라도
+        # 기존 standard envelope (``{status, message, data}``, json/text 공통)
+        # 을 그대로 유지한다. cli_registry signal-key 계약이 "``--rotate``
+        # 경로는 ``fmt.success`` (standard)" 로 의도적·문서화·drift-test 된
+        # mixed-branch 결정을 갖고 있으므로 raw passthrough 로 바꾸지 않는다.
+        # passthrough 일관성 개선은 별도 명시적 follow-up 범위다.
+        fmt.success(f"시그널 키 재발급 완료: {bot_id}", result)
         return
 
     async def _run_signal_key() -> dict:

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -453,8 +453,55 @@ def bot_remove(ctx: click.Context, bot_id: str, yes: bool) -> None:
 @require_auth
 @require_scope("bot:admin")
 def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
-    """봇 시그널 키 조회 또는 재발급."""
+    """봇 시그널 키 조회 또는 재발급.
+
+    ``--rotate`` 는 runtime IPC (``bot.signal_key.rotate``) 전용이다 (#2111).
+    서버가 정지되어 있으면 ``IPC_SERVER_NOT_RUNNING`` 으로 거부하며, cold-path
+    DB mutation 으로 대체하지 않는다 (runtime 경계 / audit / live 상태 정합성
+    보존). 조회(rotate 미지정)는 기존 cold-path 를 유지한다 (#2112 가 read IPC
+    라우팅 소유).
+    """
     fmt = get_formatter(ctx)
+
+    if rotate:
+        # ``--rotate`` 는 runtime IPC 전용 (#2111). ``BotManager.rotate_signal_key``
+        # 가 존재 확인 (``BotNotFoundError`` → ``BOT_NOT_FOUND``) +
+        # accepts_external_signals 게이트 (``BotNotAcceptingSignals`` →
+        # ``BOT_NOT_ACCEPTING_SIGNALS``) + ``SignalKeyManager.rotate`` 위임을
+        # 단일 chokepoint 로 수행한다. 서버 정지 시 ``ipc_send`` 가
+        # ``IPC_SERVER_NOT_RUNNING`` ClickException 으로 surface 하며, cold-path
+        # DB mutation 으로 fallback 하지 않는다.
+        actor = get_member_id(ctx)
+
+        async def _run_rotate() -> dict:
+            from ante.cli.commands.ipc_helpers import ipc_send
+
+            return await ipc_send(
+                "bot.signal_key.rotate", {"bot_id": bot_id}, actor=actor
+            )
+
+        try:
+            result = _run(_run_rotate())
+        except click.ClickException as e:
+            # ``bot start`` 형제 패턴 1:1 미러: ipc_send 가 부착한 원본
+            # code/message 를 split 없이 복원해 text/JSON 공용 envelope
+            # 안정성을 보존한다. 서버 정지(``IPC_SERVER_NOT_RUNNING``) /
+            # 타임아웃(``IPC_TIMEOUT``) / server error envelope 모두 동일
+            # 경로로 surface 되며, 직접 DB rotate 로 fallback 하지 않는다.
+            code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+            message = getattr(e, "ipc_error_message", None) or e.message
+            if fmt.is_json:
+                fmt.error(message, code=code)
+            else:
+                text = f"{code}: {message}" if code else message
+                fmt.error(text)
+            raise SystemExit(1) from e
+
+        if fmt.is_json:
+            fmt.output(result)
+        else:
+            fmt.success(f"시그널 키 재발급 완료: {bot_id}", result)
+        return
 
     async def _run_signal_key() -> dict:
         # ``_create_services`` async context manager lifecycle.
@@ -464,10 +511,9 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
             skm = SignalKeyManager(db)
             await skm.initialize()
 
-            # 미존재 bot 에 대한 signal key 발급/조회를 막기 위해
-            # rotate/get_key 호출 전에 bot 존재를 먼저 확인한다. 미존재면
-            # sentinel(``missing=True``)을 반환하여 orphan credential 발급을
-            # 차단한다. 형제 명령(`bot info`/`bot remove`/`bot positions`)과
+            # 미존재 bot 에 대한 signal key 조회를 막기 위해 get_key 호출 전에
+            # bot 존재를 먼저 확인한다. 미존재면 sentinel(``missing=True``)을
+            # 반환한다. 형제 명령(`bot info`/`bot remove`/`bot positions`)과
             # 동일하게 code 없는 에러 + exit 1 로 거부한다.
             #
             # ``status != 'deleted'`` 조건은 ``BotManager.load_from_db``
@@ -475,8 +521,7 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
             # 운영 bot 정의와 정렬한다. ``bot remove`` 는 키 폐기 후
             # soft-delete (manager.py:826 ``UPDATE bots SET status =
             # 'deleted'``) 하므로 row 가 남는다 — 이를 운영상 미존재로
-            # 취급하지 않으면 soft-deleted bot 에 ``--rotate`` 가
-            # orphan credential 을 재발급하는 버그류.
+            # 취급한다.
             #
             # ``bots`` 테이블은 ``BotManager.initialize()`` 에서 생성되며
             # 위 ``_create_services()`` 가 이를 보장하지만, 방어적으로
@@ -484,9 +529,6 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
             # 한다 (malformed db 같은 다른 ``OperationalError`` 까지
             # 삼키지 않도록 메시지로 좁힌다, 형제 패턴 동형).
             try:
-                # ``--rotate`` 게이트가 ``strategy_id`` 를 필요로 하므로
-                # 존재 확인 쿼리에서 함께 SELECT 한다. row 의 truthiness 는
-                # 보존되어 기존 미존재/소프트삭제 거부 회귀와 동일하게 동작한다.
                 bot_row = await db.fetch_one(
                     "SELECT strategy_id FROM bots "
                     "WHERE bot_id = ? AND status != 'deleted'",
@@ -499,46 +541,6 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
                     raise
             if bot_row is None:
                 return {"bot_id": bot_id, "missing": True}
-
-            if rotate:
-                # accepts_external_signals 게이트.
-                # ``BotManager.rotate_signal_key`` 가 적용하는 동일 invariant
-                # 를 CLI cold-path 에도 적용해 defense-in-depth 를 유지한다
-                # (CLI 는 BotManager 를 우회해 ``SignalKeyManager`` 를 직접
-                # 호출하므로 manager 게이트가 cover 하지 않는다).
-                from ante.bot.exceptions import BOT_NOT_ACCEPTING_SIGNALS_CODE
-                from ante.strategy.loader import StrategyLoader
-                from ante.strategy.registry import StrategyRegistry
-
-                strategy_id = bot_row["strategy_id"]
-                registry = StrategyRegistry(db)
-                await registry.initialize()
-                record = await registry.get(strategy_id)
-                if record is None:
-                    return {
-                        "bot_id": bot_id,
-                        "error": f"전략 미발견: {strategy_id}",
-                        "code": "STRATEGY_NOT_FOUND",
-                        "external_signals_disabled": True,
-                    }
-                strategy_cls = StrategyLoader.load(Path(record.filepath))
-                if not getattr(
-                    getattr(strategy_cls, "meta", None),
-                    "accepts_external_signals",
-                    False,
-                ):
-                    return {
-                        "bot_id": bot_id,
-                        "error": (
-                            "이 봇의 전략은 외부 시그널을 받지 않습니다: "
-                            f"bot_id={bot_id}, strategy_id={strategy_id}"
-                        ),
-                        "code": BOT_NOT_ACCEPTING_SIGNALS_CODE,
-                        "external_signals_disabled": True,
-                    }
-
-                new_key = await skm.rotate(bot_id)
-                return {"bot_id": bot_id, "signal_key": new_key, "rotated": True}
 
             key = await skm.get_key(bot_id)
             if not key:
@@ -566,14 +568,6 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
         fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         ctx.exit(1)
 
-    if result.get("external_signals_disabled"):
-        # ``accepts_external_signals=False`` 전략 봇에 rotate 가 새 키를
-        # 발급해 orphan credential 이 생기던 회귀를 막는다. ``signal connect``
-        # 의 동형 거부 (``ante/cli/commands/signal.py``) 와 동일한
-        # ``BOT_NOT_ACCEPTING_SIGNALS`` 코드를 stable 하게 노출한다.
-        fmt.error(result["error"], code=result.get("code", ""))
-        raise SystemExit(1)
-
     if result.get("signal_key") is None:
         # 시그널 키 미발급은 안정 코드 ``SIGNAL_KEY_NOT_SET`` 로 surface 한다.
         # 미존재 bot (``BOT_NOT_FOUND``) 분기보다 뒤에 둬서 두 의미를 envelope
@@ -586,14 +580,13 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
         )
         ctx.exit(1)
 
-    if result.get("rotated"):
-        fmt.success(f"시그널 키 재발급 완료: {bot_id}", result)
+    # read (조회) 경로 출력. ``--rotate`` 는 위 IPC 전용 분기에서 이미 return
+    # 되므로 여기 도달하는 result 는 항상 조회 결과다 (#2111: rotated 분기 제거).
+    if fmt.is_json:
+        fmt.output(result)
     else:
-        if fmt.is_json:
-            fmt.output(result)
-        else:
-            click.echo(f"  Bot ID     : {result['bot_id']}")
-            click.echo(f"  Signal Key : {result['signal_key']}")
+        click.echo(f"  Bot ID     : {result['bot_id']}")
+        click.echo(f"  Signal Key : {result['signal_key']}")
 
 
 @bot.command("positions")

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -305,6 +305,45 @@ async def _handle_bot_remove(
     return {"bot_id": bot_id, "removed": True}
 
 
+async def _handle_bot_signal_key_rotate(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """봇 시그널 키 재발급 IPC handler.
+
+    Refs #2111: ``bot signal-key --rotate`` 의 runtime IPC 경로
+    (``bot.signal_key.rotate``). CLI 가 ``SignalKeyManager.rotate()`` 를 직접
+    호출하던 cold-path DB mutation 을 제거하고 본 handler 로만 라우팅한다 —
+    runtime 경계 / audit / live 상태 정합성을 보존한다.
+
+    ``BotManager.rotate_signal_key`` 는 ``_get_bot`` 존재 확인
+    (``BotNotFoundError``) → ``accepts_external_signals`` 게이트
+    (``BotNotAcceptingSignals``) → ``SignalKeyManager.rotate`` 위임의 동일
+    invariant 를 적용한다. 두 typed exception 은 그대로 propagate 하여
+    ``server.py`` 의 ``getattr(e, "code", "EXECUTION_ERROR")`` envelope 이
+    ``BOT_NOT_FOUND`` / ``BOT_NOT_ACCEPTING_SIGNALS`` stable code 로
+    변환한다. 전략 미발견 등 그 외 ``BotError`` 는 ``EXECUTION_ERROR``
+    fallback (서버 경로 SSOT).
+
+    Refs audit.md:121: audit 호출은 ``_dispatch`` wrapper 가
+    ``CommandSpec.audit_action = "bot.signal_key.rotate"`` 기반으로 자동
+    발화하며, handler 는 ``_audit_detail`` reserved key 로
+    ``resource = "bot:{bot_id}"`` 만 전달한다 (wrapper 가 ``pop`` 으로 public
+    envelope 진입 전에 strip).
+    """
+    bot_id = args["bot_id"]
+    new_key = await svc.bot_manager.rotate_signal_key(bot_id)
+    return {
+        "bot_id": bot_id,
+        "signal_key": new_key,
+        "rotated": True,
+        "_audit_detail": {
+            "resource": f"bot:{bot_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
+
+
 async def _handle_bot_start(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
@@ -1031,6 +1070,19 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         is_mutating=True,
         result_kind="operation",
         required_services=frozenset({"bot_manager"}),
+    )
+    # bot.signal_key.rotate (#2111) — ``bot signal-key --rotate`` 의 runtime IPC
+    # 경로. ``rotated`` bool flag envelope 이므로 ``bot.remove`` 와 동형
+    # ``operation`` kind. audit_action 부여 → ``required_services`` 에
+    # ``audit_logger`` 명시 (#1849 등록 lock). read (``bot.signal_key`` 조회)
+    # 는 별개 command 로 #2112 가 소유한다.
+    registry.register(
+        "bot.signal_key.rotate",
+        _handle_bot_signal_key_rotate,
+        is_mutating=True,
+        result_kind="operation",
+        required_services=frozenset({"bot_manager", "audit_logger"}),
+        audit_action="bot.signal_key.rotate",
     )
     registry.register(
         "bot.start",

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -27,7 +27,7 @@
 #       module = dotted module path (예: ante.account.errors).
 #       class_anchor = class 이름.
 
-# bot.py 497/933/969/1003 (구 940/976/1010 → 구 924/960/994 → 구 931/967/1001
+# bot.py 497/936/972/1006 (구 940/976/1010 → 구 924/960/994 → 구 931/967/1001
 # → 구 882/918/952) 와 config.py 212/215 (구 214/217 → 구 176/179) 의
 # ``ipc_send`` ClickException text-mode 분기는 ``text = f"{code}: {message}"``
 # prefix 패턴이 의도된 영구 UX 계약이다. 회귀 lock
@@ -39,23 +39,25 @@
 # (#1870 옵션 3). #1941 commands 주석 정리로 line 번호가 7줄 위로 이동.
 # #2137 bot status positions scope 변경으로 +16줄 이동 (924/960/994 → 940/976/1010).
 # #2111 signal-key --rotate IPC 라우팅 전환: cold-path rotate mutation 제거로
-# start/stop/status 분기가 -7줄 이동 (940/976/1010 → 933/969/1003) + rotate
-# text-mode 분기 신규 callsite (497) 동일 UX prefix 패턴 추가.
+# start/stop/status 분기가 이동 (940/976/1010 → 936/972/1006) + rotate
+# text-mode 분기 신규 callsite (497) 동일 UX prefix 패턴 추가. rotate 성공
+# 출력은 standard envelope (``fmt.success``) 를 그대로 보존하므로 출력 emit
+# 분기 변경이 위 fmt.error anchor 에 추가 영향을 주지 않는다.
 intended_no_code:
   - path: src/ante/cli/commands/bot.py
     line: 497
     snippet_sha1: "03fce6e088b7"
     reason: "text-mode {code}: {message} prefix UX lock — signal-key --rotate IPC 분기 (#2111)"
   - path: src/ante/cli/commands/bot.py
-    line: 933
+    line: 936
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 969
+    line: 972
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 1003
+    line: 1006
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/config.py

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -27,27 +27,35 @@
 #       module = dotted module path (예: ante.account.errors).
 #       class_anchor = class 이름.
 
-# bot.py 940/976/1010 (구 924/960/994 → 구 931/967/1001 → 구 882/918/952) 와 config.py 212/215
-# (구 214/217 → 구 176/179) 의 ``ipc_send`` ClickException text-mode 분기는
-# ``text = f"{code}: {message}"`` prefix 패턴이 의도된 영구 UX 계약이다. 회귀
-# lock ``test_bot_start_error_text_mode_carries_code_prefix`` 와
+# bot.py 497/933/969/1003 (구 940/976/1010 → 구 924/960/994 → 구 931/967/1001
+# → 구 882/918/952) 와 config.py 212/215 (구 214/217 → 구 176/179) 의
+# ``ipc_send`` ClickException text-mode 분기는 ``text = f"{code}: {message}"``
+# prefix 패턴이 의도된 영구 UX 계약이다. 회귀 lock
+# ``test_bot_start_error_text_mode_carries_code_prefix`` 와
 # ``test_config_set_server_error`` 의 ``"STATIC_CONFIG" in result.output`` 가
 # text 모드에서 ``code: message`` prefix 톤을 명시 요구하므로 단순
 # ``fmt.error(message, code=code)`` 정렬이 UX 회귀가 된다. 따라서
 # ``known_drift`` deferred 가 아닌 ``intended_no_code`` 영구 면제로 분류한다
 # (#1870 옵션 3). #1941 commands 주석 정리로 line 번호가 7줄 위로 이동.
 # #2137 bot status positions scope 변경으로 +16줄 이동 (924/960/994 → 940/976/1010).
+# #2111 signal-key --rotate IPC 라우팅 전환: cold-path rotate mutation 제거로
+# start/stop/status 분기가 -7줄 이동 (940/976/1010 → 933/969/1003) + rotate
+# text-mode 분기 신규 callsite (497) 동일 UX prefix 패턴 추가.
 intended_no_code:
   - path: src/ante/cli/commands/bot.py
-    line: 940
+    line: 497
+    snippet_sha1: "03fce6e088b7"
+    reason: "text-mode {code}: {message} prefix UX lock — signal-key --rotate IPC 분기 (#2111)"
+  - path: src/ante/cli/commands/bot.py
+    line: 933
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 976
+    line: 969
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 1010
+    line: 1003
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/config.py

--- a/tests/unit/ipc/test_dispatch_wrapper_audit.py
+++ b/tests/unit/ipc/test_dispatch_wrapper_audit.py
@@ -621,6 +621,103 @@ async def test_account_suspend_account_id_policy_required_preflight(
         await server.stop()
 
 
+# ── bot.signal_key.rotate wrapper audit (#2111) ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bot_signal_key_rotate_audit_action_fires(socket_path: str) -> None:
+    """Refs #2111: ``bot.signal_key.rotate`` 가 wrapper 자동 audit 발화한다.
+
+    register_all_handlers 가 ``audit_action="bot.signal_key.rotate"`` 를
+    부여하므로 handler 정상 종료 후 wrapper 가 ``audit_logger.log`` 를 1회
+    호출하고 ``_audit_detail`` 의 ``resource="bot:{bot_id}"`` (audit.md:121)
+    를 전달한다.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_bot_manager = MagicMock()
+    fake_bot_manager.rotate_signal_key = AsyncMock(return_value="sk_new_rotated")
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, bot_manager=fake_bot_manager
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "bot.signal_key.rotate",
+                "args": {"bot_id": "bot-7"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "ok"
+        # public envelope 은 rotated/signal_key 를 담고 _audit_detail 은 strip.
+        assert response["result"] == {
+            "bot_id": "bot-7",
+            "signal_key": "sk_new_rotated",
+            "rotated": True,
+        }
+        assert "_audit_detail" not in response["result"]
+        # audit.md:121 SSOT: action=bot.signal_key.rotate, resource=bot:{bot_id}.
+        audit_logger.log.assert_awaited_once_with(
+            member_id="alice",
+            action="bot.signal_key.rotate",
+            resource="bot:bot-7",
+            detail="",
+            ip="",
+        )
+        fake_bot_manager.rotate_signal_key.assert_awaited_once_with("bot-7")
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_signal_key_rotate_audit_not_fired_on_failure(
+    socket_path: str,
+) -> None:
+    """Refs #2111: ``BotNotFoundError`` 등 거부 경로는 audit 발화 안 함 +
+    stable code envelope (실패 시 audit invariant)."""
+    from ante.bot.exceptions import BotNotFoundError
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_bot_manager = MagicMock()
+    fake_bot_manager.rotate_signal_key = AsyncMock(
+        side_effect=BotNotFoundError("bot-missing")
+    )
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, bot_manager=fake_bot_manager
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "bot.signal_key.rotate",
+                "args": {"bot_id": "bot-missing"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "BOT_NOT_FOUND"
+        assert audit_logger.log.await_count == 0
+    finally:
+        await server.stop()
+
+
 @pytest.mark.asyncio
 async def test_audit_action_without_audit_logger_no_crash(socket_path: str) -> None:
     """방어 케이스 — audit_action 부여되었지만 audit_logger 가 None.

--- a/tests/unit/ipc/test_docs_taxonomy_drift.py
+++ b/tests/unit/ipc/test_docs_taxonomy_drift.py
@@ -62,8 +62,6 @@ _DOCS_NON_REGISTRY_TOKENS = frozenset(
         "member.rotate_token",
         "member.reset_password",
         "member.regenerate_recovery_key",
-        # bot.signal_key.rotate 후속 wiring — ipc.md:86 / 274
-        "bot.signal_key.rotate",
         # bot.query 계열 후속 wiring — ipc.md:98 / 274
         "bot.query",
         # cold-path 전용 — ipc.md:70-74 / 193 / 273

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -65,7 +65,7 @@ def test_commands_property(registry: CommandRegistry) -> None:
 
 
 def test_register_all_handlers() -> None:
-    """register_all_handlers가 27개 핸들러를 등록 (account.delete 제외).
+    """register_all_handlers가 28개 핸들러를 등록 (account.delete 제외).
 
     `account.delete`는 1.0 IPC 계약에서 제거되어 cold-path CLI에서 직접
     AccountService를 호출한다.
@@ -79,10 +79,13 @@ def test_register_all_handlers() -> None:
     Browser/HTTP 제거 parity: retained 운영 mutation 5개를 CLI/IPC로
     이전하면서 ``bot.update``, ``treasury.set_balance``, ``rule.update``,
     ``strategy.set_status``, ``member.update_scopes``를 추가.
+
+    Refs #2111: ``bot.signal_key.rotate`` (mutating) 추가 — ``bot signal-key
+    --rotate`` 의 runtime IPC 경로.
     """
     registry = CommandRegistry()
     register_all_handlers(registry)
-    assert len(registry.commands) == 27
+    assert len(registry.commands) == 28
 
     expected = {
         "system.halt",
@@ -91,6 +94,7 @@ def test_register_all_handlers() -> None:
         "account.activate",
         "bot.create",
         "bot.remove",
+        "bot.signal_key.rotate",
         "bot.start",
         "bot.stop",
         "bot.update",
@@ -121,10 +125,12 @@ def test_register_all_handlers() -> None:
 
 
 def test_register_all_handlers_taxonomy() -> None:
-    """등록된 27개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다.
+    """등록된 28개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다.
 
     Refs #1712: ``bot.start`` / ``bot.stop`` mutating, ``bot.status``
     read-only — ``docs/specs/ipc/ipc.md`` Handler taxonomy SSOT 와 동기화.
+
+    Refs #2111: ``bot.signal_key.rotate`` mutating 추가.
     """
     registry = CommandRegistry()
     register_all_handlers(registry)
@@ -136,6 +142,7 @@ def test_register_all_handlers_taxonomy() -> None:
         "account.activate",
         "bot.create",
         "bot.remove",
+        "bot.signal_key.rotate",
         "bot.start",
         "bot.stop",
         "bot.update",
@@ -161,7 +168,7 @@ def test_register_all_handlers_taxonomy() -> None:
         "bot.status",
     }
 
-    assert len(mutating) == 23
+    assert len(mutating) == 24
     assert len(read_only) == 4
     assert mutating | read_only == set(registry.commands)
 
@@ -968,6 +975,9 @@ class TestRegisteredCommandsMetadataCompleteness:
         Refs #1853 (#1819 epic 종결): rule.update 의 audit 호출을 wrapper 로
         이전(action="account.rule.update", helper 의 기존 action 이름 보존)
         (9→10 commands).
+
+        Refs #2111: ``bot.signal_key.rotate`` 가 audit_action 부여
+        (action="bot.signal_key.rotate", audit.md:121 SSOT) (10→11 commands).
         """
         expected_actions = {
             "account.suspend",
@@ -975,6 +985,7 @@ class TestRegisteredCommandsMetadataCompleteness:
             "bot.start",
             "bot.stop",
             "bot.update",
+            "bot.signal_key.rotate",
             "treasury.set_balance",
             "strategy.set_status",
             "member.update_scopes",
@@ -1011,11 +1022,11 @@ class TestRegisteredCommandsMetadataCompleteness:
         for spec in loaded.iter_specs():
             assert spec.cross_validators == (), spec.name
 
-    def test_iter_specs_returns_all_27_specs(self, loaded: CommandRegistry) -> None:
-        """``iter_specs``가 27 commands 모두를 ``CommandSpec`` 인스턴스로
+    def test_iter_specs_returns_all_28_specs(self, loaded: CommandRegistry) -> None:
+        """``iter_specs``가 28 commands 모두를 ``CommandSpec`` 인스턴스로
         반환한다."""
         specs = loaded.iter_specs()
-        assert len(specs) == 27
+        assert len(specs) == 28
         assert all(isinstance(s, CommandSpec) for s in specs)
         # 등록 순서 보존(dict insertion order).
         assert [s.name for s in specs] == loaded.commands

--- a/tests/unit/test_bot_success_output_drift.py
+++ b/tests/unit/test_bot_success_output_drift.py
@@ -26,9 +26,12 @@ shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면 �
 4. ``create`` → ``standard`` (``fmt.success(message, data)``)
 5. ``remove`` → ``standard`` (``fmt.success(message, data)``)
 6. ``signal-key`` query (no --rotate) → ``raw_legacy`` (``{bot_id, signal_key}``)
-7. ``signal-key --rotate`` → ``raw_legacy`` (#2111: JSON 모드 IPC
-   ``bot.signal_key.rotate`` envelope passthrough — ``bot start`` 동형
-   ``fmt.output(result)``. text 모드만 ``fmt.success`` 메시지).
+7. ``signal-key --rotate`` → ``standard`` (``fmt.success(message, data)``)
+   분기 mixed lock — registry 는 raw_legacy 우선이지만 rotate 분기가
+   standard envelope 임을 별도 lock 해 분기 mixed 사실을 명시한다
+   (account ``set-credentials`` 동형 정책). #2111: rotate 는 runtime IPC
+   (``bot.signal_key.rotate``) 로 라우팅되지만 출력 계약(standard envelope)
+   은 그대로 보존된다 — 라우팅 변경이 출력-shape 변경이 아님을 lock 한다.
 8. ``positions`` empty → ``raw_legacy`` (``{message, positions}``)
 9. ``positions`` non-empty → ``raw_legacy`` (``{positions: [...]}``)
 10. ``update`` → ``raw_legacy`` (``fmt.output(result)`` 평면)
@@ -401,17 +404,24 @@ def test_bot_signal_key_query_envelope_matches_raw_legacy(
     assert payload["signal_key"] == "sig-key-abc"
 
 
-# ── 6. bot signal-key --rotate → raw_legacy (IPC envelope passthrough) ────
+# ── 6. bot signal-key --rotate → standard (mixed-branch lock) ─────────────
 
 
-def test_bot_signal_key_rotate_envelope_matches_raw_legacy(mock_ipc_send) -> None:
-    """``bot signal-key --rotate``: JSON 모드 IPC envelope passthrough (#2111).
+def test_bot_signal_key_rotate_envelope_matches_operation_standard(
+    mock_ipc_send,
+) -> None:
+    """``bot signal-key --rotate``: ``fmt.success(message, data)`` → standard.
 
-    rotate 는 runtime IPC (``bot.signal_key.rotate``) 전용으로 라우팅된다.
-    JSON 모드는 IPC 응답을 ``fmt.output(result)`` 로 그대로 dump 한다
-    (``bot start`` 동형 — feedback_cli_json_envelope_passthrough 메모 정책).
-    registry 의 ``raw_legacy`` 정책에 부합. text 모드만 ``fmt.success`` 메시지를
-    내며, 본 test 는 JSON passthrough 만 lock 한다.
+    분기 mixed lock — registry 는 raw_legacy 우선이지만 rotate 분기가
+    standard envelope 임을 별도 lock 해 분기 mixed 사실을 명시한다
+    (account ``set-credentials`` 동형 정책). registry 가 ``raw_legacy`` 우선
+    분류임은 query 분기 test 가 lock 한다.
+
+    #2111: rotate 는 runtime IPC (``bot.signal_key.rotate``) 로 라우팅되지만
+    출력 계약(standard envelope)은 그대로 보존된다. 본 test 는 (1) rotate 가
+    ``bot.signal_key.rotate`` IPC 로 라우팅되는 것과 (2) 출력이 standard
+    envelope 인 것을 함께 단언해, 라우팅 변경이 출력-shape 변경이 아님을
+    lock 한다.
     """
     mock_ipc_send.return_value = {
         "bot_id": "bot-1",
@@ -423,12 +433,15 @@ def test_bot_signal_key_rotate_envelope_matches_raw_legacy(mock_ipc_send) -> Non
     assert result.exit_code == 0, result.output
 
     payload = _load_json_payload(result.output)
-    assert _is_raw_legacy_envelope(payload), (
-        f"bot signal-key --rotate: standard envelope 아니어야 함 (IPC "
-        f"passthrough). payload={payload!r}"
+    assert _is_standard_envelope(payload), (
+        f"bot signal-key --rotate: standard envelope 이어야 함 (분기 mixed). "
+        f"payload={payload!r}"
     )
-    assert payload["signal_key"] == "new-sig-key-xyz"
-    assert payload["rotated"] is True
+    assert "시그널 키 재발급 완료" in payload["message"]
+    assert payload["data"]["signal_key"] == "new-sig-key-xyz"
+    assert payload["data"]["rotated"] is True
+
+    # rotate 는 runtime IPC (``bot.signal_key.rotate``) 로 라우팅된다 (#2111).
     mock_ipc_send.assert_awaited_once()
     call_args = mock_ipc_send.await_args
     assert call_args.args[0] == "bot.signal_key.rotate"

--- a/tests/unit/test_bot_success_output_drift.py
+++ b/tests/unit/test_bot_success_output_drift.py
@@ -26,10 +26,9 @@ shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift 하면 �
 4. ``create`` → ``standard`` (``fmt.success(message, data)``)
 5. ``remove`` → ``standard`` (``fmt.success(message, data)``)
 6. ``signal-key`` query (no --rotate) → ``raw_legacy`` (``{bot_id, signal_key}``)
-7. ``signal-key --rotate`` → ``standard`` (``fmt.success(message, data)``)
-   분기 mixed lock — registry 는 raw_legacy 우선이지만 rotate 분기가
-   standard envelope 임을 별도 lock 해 분기 mixed 사실을 명시한다
-   (account ``set-credentials`` 동형 정책).
+7. ``signal-key --rotate`` → ``raw_legacy`` (#2111: JSON 모드 IPC
+   ``bot.signal_key.rotate`` envelope passthrough — ``bot start`` 동형
+   ``fmt.output(result)``. text 모드만 ``fmt.success`` 메시지).
 8. ``positions`` empty → ``raw_legacy`` (``{message, positions}``)
 9. ``positions`` non-empty → ``raw_legacy`` (``{positions: [...]}``)
 10. ``update`` → ``raw_legacy`` (``fmt.output(result)`` 평면)
@@ -402,56 +401,38 @@ def test_bot_signal_key_query_envelope_matches_raw_legacy(
     assert payload["signal_key"] == "sig-key-abc"
 
 
-# ── 6. bot signal-key --rotate → standard (mixed-branch lock) ─────────────
+# ── 6. bot signal-key --rotate → raw_legacy (IPC envelope passthrough) ────
 
 
-def test_bot_signal_key_rotate_envelope_matches_operation_standard(
-    mock_create_services,
-) -> None:
-    """``bot signal-key --rotate``: ``fmt.success(message, data)`` → standard.
+def test_bot_signal_key_rotate_envelope_matches_raw_legacy(mock_ipc_send) -> None:
+    """``bot signal-key --rotate``: JSON 모드 IPC envelope passthrough (#2111).
 
-    분기 mixed lock — registry 는 raw_legacy 우선이지만 rotate 분기가
-    standard envelope 임을 별도 lock 해 분기 mixed 사실을 명시한다
-    (account ``set-credentials`` 동형 정책). registry 가 ``raw_legacy`` 우선
-    분류임은 query 분기 test 가 lock 한다.
+    rotate 는 runtime IPC (``bot.signal_key.rotate``) 전용으로 라우팅된다.
+    JSON 모드는 IPC 응답을 ``fmt.output(result)`` 로 그대로 dump 한다
+    (``bot start`` 동형 — feedback_cli_json_envelope_passthrough 메모 정책).
+    registry 의 ``raw_legacy`` 정책에 부합. text 모드만 ``fmt.success`` 메시지를
+    내며, 본 test 는 JSON passthrough 만 lock 한다.
     """
-    db, _, _, _ = mock_create_services
-    db.fetch_one.return_value = {"strategy_id": "strat-1"}
+    mock_ipc_send.return_value = {
+        "bot_id": "bot-1",
+        "signal_key": "new-sig-key-xyz",
+        "rotated": True,
+    }
 
-    skm = AsyncMock()
-    skm.initialize = AsyncMock()
-    skm.rotate = AsyncMock(return_value="new-sig-key-xyz")
-
-    # strategy registry / loader 도 rotate 경로에서 호출되므로 mock 한다.
-    strategy_registry = AsyncMock()
-    strategy_registry.initialize = AsyncMock()
-    record = MagicMock()
-    record.filepath = "strategies/strat-1.py"
-    strategy_registry.get = AsyncMock(return_value=record)
-
-    strategy_cls = MagicMock()
-    strategy_cls.meta = MagicMock()
-    strategy_cls.meta.accepts_external_signals = True
-
-    with (
-        patch("ante.bot.signal_key.SignalKeyManager", return_value=skm),
-        patch(
-            "ante.strategy.registry.StrategyRegistry", return_value=strategy_registry
-        ),
-        patch("ante.strategy.loader.StrategyLoader.load", return_value=strategy_cls),
-    ):
-        result = _invoke(
-            ["--format", "json", "bot", "signal-key", "bot-1", "--rotate"],
-        )
+    result = _invoke(["--format", "json", "bot", "signal-key", "bot-1", "--rotate"])
     assert result.exit_code == 0, result.output
 
     payload = _load_json_payload(result.output)
-    assert _is_standard_envelope(payload), (
-        f"bot signal-key --rotate: standard envelope 이어야 함 (분기 mixed). "
-        f"payload={payload!r}"
+    assert _is_raw_legacy_envelope(payload), (
+        f"bot signal-key --rotate: standard envelope 아니어야 함 (IPC "
+        f"passthrough). payload={payload!r}"
     )
-    assert "시그널 키 재발급 완료" in payload["message"]
-    assert payload["data"]["signal_key"] == "new-sig-key-xyz"
+    assert payload["signal_key"] == "new-sig-key-xyz"
+    assert payload["rotated"] is True
+    mock_ipc_send.assert_awaited_once()
+    call_args = mock_ipc_send.await_args
+    assert call_args.args[0] == "bot.signal_key.rotate"
+    assert call_args.args[1] == {"bot_id": "bot-1"}
 
 
 # ── 7. bot positions (empty / non-empty) → raw_legacy ─────────────────────

--- a/tests/unit/test_cli_bot_signal_key_rotate_external_gate.py
+++ b/tests/unit/test_cli_bot_signal_key_rotate_external_gate.py
@@ -141,7 +141,14 @@ class _NormalStrategy(Strategy):
 
 
 class TestRotateExternalStrategyAllowed:
-    """R1: external 전략 봇의 정상 rotate 는 IPC envelope passthrough (#2111)."""
+    """R1: external 전략 봇의 정상 rotate 는 IPC 라우팅 + standard envelope (#2111).
+
+    rotate 는 runtime IPC (``bot.signal_key.rotate``) 로 라우팅되지만 출력
+    계약(standard envelope)은 그대로 보존된다. cli_registry signal-key 계약이
+    "``--rotate`` 경로는 ``fmt.success`` (standard)" 로 문서화·drift-test 된
+    mixed-branch 결정을 갖고 있으므로 라우팅 변경이 출력-shape 변경이
+    아님을 lock 한다.
+    """
 
     def test_rotate_external_strategy_exits_zero_with_key(
         self, runner: CliRunner
@@ -167,10 +174,12 @@ class TestRotateExternalStrategyAllowed:
             )
 
         assert result.exit_code == 0, result.stdout + result.stderr
-        # JSON 모드는 IPC envelope passthrough (raw_legacy, bot start 동형).
+        # 출력 계약 보존: standard envelope (``{status, message, data}``).
         payload = json.loads(result.stdout)
-        assert payload["signal_key"] == "sk_external_rotated_42"
-        assert payload["rotated"] is True
+        assert payload["status"] == "ok"
+        assert payload["data"]["signal_key"] == "sk_external_rotated_42"
+        assert payload["data"]["rotated"] is True
+        # rotate 는 runtime IPC (``bot.signal_key.rotate``) 로 라우팅된다.
         mock_send.assert_awaited_once()
         assert mock_send.await_args.args[0] == "bot.signal_key.rotate"
         assert mock_send.await_args.args[1] == {"bot_id": "bot-ext-1"}

--- a/tests/unit/test_cli_bot_signal_key_rotate_external_gate.py
+++ b/tests/unit/test_cli_bot_signal_key_rotate_external_gate.py
@@ -22,19 +22,27 @@ Root cause (사실):
 
 ## 회귀 lock
 
-- R1 (회귀 보존 — external strategy): ``accepts_external_signals=True`` 전략의
-  봇은 ``--rotate`` 가 exit 0 + ``rotated=True`` envelope, ``skm.rotate``
-  호출됨.
-- R2 (게이트 — non-external strategy): ``accepts_external_signals=False``
-  전략의 봇은 ``--rotate`` 가 exit 1 + ``code="BOT_NOT_ACCEPTING_SIGNALS"``
-  envelope.
-- R3 (orphan 차단): R2 조건에서 ``skm.rotate`` 가 **호출되지 않는다**
-  (게이트가 키 발급 자체를 차단해 orphan credential 미발급).
+Refs #2111: ``bot signal-key --rotate`` 는 runtime IPC
+(``bot.signal_key.rotate``) 전용으로 라우팅된다. CLI cold-path 의 직접
+``SignalKeyManager.rotate`` 호출과 in-CLI accepts_external_signals 게이트는
+제거되었다. accepts_external_signals invariant 는 서버
+``BotManager.rotate_signal_key`` (R5) 가 단일 chokepoint 로 적용하며, CLI
+표면은 ``ipc_send`` 의 server envelope 을 surface 한다.
+
+- R1 (회귀 보존 — external strategy): external 전략 봇의 정상 rotate 는
+  ``ipc_send`` 가 ``{rotated:True, signal_key}`` envelope 을 반환하고 CLI 가
+  exit 0 + IPC envelope passthrough 로 surface 한다.
+- R2 (게이트 — non-external strategy): non-external 전략 봇은 서버가
+  ``BotNotAcceptingSignals`` → ``BOT_NOT_ACCEPTING_SIGNALS`` envelope 을
+  반환하고, CLI 가 exit 1 + ``code="BOT_NOT_ACCEPTING_SIGNALS"`` 로 보존한다.
+- R3 (orphan 차단): R2 조건에서 CLI 는 ``SignalKeyManager`` 를 직접 호출하지
+  않는다 (cold-path 미사용 회귀 — orphan credential 미발급은 서버 게이트
+  R5 가 책임).
 - R4 (sanity): non-rotate get 경로는 게이트 적용 대상 아님 — 기존 키 조회는
-  정상 동작 (회귀 보존).
+  정상 동작 (read cold-path 회귀 보존).
 - R5 (BotManager 게이트): ``BotManager.rotate_signal_key`` 가 동일 invariant
   를 raise ``BotNotAcceptingSignals`` (code=``BOT_NOT_ACCEPTING_SIGNALS``) 로
-  적용 — IPC / server-side 경로의 defense-in-depth.
+  적용 — runtime IPC / server-side 경로의 단일 chokepoint.
 """
 
 from __future__ import annotations
@@ -129,68 +137,23 @@ class _NormalStrategy(Strategy):
         return []
 
 
-def _make_strategy_patches(*, accepts_external_signals: bool) -> tuple:
-    """``StrategyRegistry`` + ``StrategyLoader.load`` patch tuple 을 생성한다.
-
-    rotate 게이트가 봇의 ``strategy_id`` 로 registry 조회 → ``StrategyLoader``
-    로 클래스 로드 → ``meta.accepts_external_signals`` 확인하는 경로를
-    단위 테스트에서 시뮬레이션한다.
-    """
-    mock_record = MagicMock()
-    mock_record.filepath = "/fake/path.py"
-    mock_registry = AsyncMock()
-    mock_registry.initialize = AsyncMock()
-    mock_registry.get = AsyncMock(return_value=mock_record)
-
-    mock_strategy_cls = MagicMock()
-    mock_strategy_cls.meta = StrategyMeta(
-        name="t",
-        version="1.0.0",
-        description="t",
-        accepts_external_signals=accepts_external_signals,
-    )
-
-    return (
-        patch(
-            "ante.strategy.registry.StrategyRegistry",
-            return_value=mock_registry,
-        ),
-        patch(
-            "ante.strategy.loader.StrategyLoader.load",
-            return_value=mock_strategy_cls,
-        ),
-    )
-
-
 # ── R1: 회귀 보존 ─────────────────────────────────────
 
 
 class TestRotateExternalStrategyAllowed:
-    """R1: ``accepts_external_signals=True`` 전략 봇은 rotate 정상."""
+    """R1: external 전략 봇의 정상 rotate 는 IPC envelope passthrough (#2111)."""
 
     def test_rotate_external_strategy_exits_zero_with_key(
         self, runner: CliRunner
     ) -> None:
-        mock_db = AsyncMock()
-        mock_db.close = AsyncMock()
-        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "ext-1"})
-        mock_skm = AsyncMock()
-        mock_skm.initialize = AsyncMock()
-        mock_skm.rotate = AsyncMock(return_value="sk_external_rotated_42")
-
-        reg_patch, loader_patch = _make_strategy_patches(accepts_external_signals=True)
-        with (
-            patch(
-                "ante.cli.commands.bot._create_services",
-                new=_acm_factory((mock_db, None, None, None)),
-            ),
-            patch(
-                "ante.bot.signal_key.SignalKeyManager",
-                return_value=mock_skm,
-            ),
-            reg_patch,
-            loader_patch,
-        ):
+        mock_send = AsyncMock(
+            return_value={
+                "bot_id": "bot-ext-1",
+                "signal_key": "sk_external_rotated_42",
+                "rotated": True,
+            }
+        )
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send):
             result = runner.invoke(
                 cli,
                 [
@@ -204,30 +167,48 @@ class TestRotateExternalStrategyAllowed:
             )
 
         assert result.exit_code == 0, result.stdout + result.stderr
+        # JSON 모드는 IPC envelope passthrough (raw_legacy, bot start 동형).
         payload = json.loads(result.stdout)
-        assert payload["status"] == "ok"
-        assert payload["data"]["signal_key"] == "sk_external_rotated_42"
-        assert payload["data"]["rotated"] is True
-        mock_skm.rotate.assert_awaited_once_with("bot-ext-1")
+        assert payload["signal_key"] == "sk_external_rotated_42"
+        assert payload["rotated"] is True
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args.args[0] == "bot.signal_key.rotate"
+        assert mock_send.await_args.args[1] == {"bot_id": "bot-ext-1"}
 
 
 # ── R2 + R3: 게이트 + orphan 차단 ─────────────────────
 
 
 class TestRotateNonExternalStrategyRejected:
-    """R2/R3: non-external 전략 봇은 rotate 거부 + skm.rotate 미호출."""
+    """R2/R3: non-external 전략 봇은 서버 게이트가 거부, CLI 는 envelope surface
+    + cold-path 미사용 (#2111)."""
 
-    def _gated_skm(self) -> AsyncMock:
-        """rotate 가 호출되면 즉시 실패하는 SignalKeyManager mock.
+    def _not_accepting_click_exc(self) -> object:
+        """서버 ``BotNotAcceptingSignals`` → ``BOT_NOT_ACCEPTING_SIGNALS``
+        envelope 을 ``ipc_send`` 가 변환한 ClickException 을 모사한다."""
+        import click
 
-        R3 검증의 핵심: 게이트가 ``skm.rotate`` **이전** 에 걸려야 한다.
-        ``assert_not_awaited`` 와 함께 이중으로 orphan 미발급을 lock 한다.
+        message = (
+            "이 봇의 전략은 외부 시그널을 받지 않습니다: "
+            "bot_id=bot-normal-1, strategy_id=normal-1"
+        )
+        exc = click.ClickException(f"{BOT_NOT_ACCEPTING_SIGNALS_CODE}: {message}")
+        exc.ipc_error_code = BOT_NOT_ACCEPTING_SIGNALS_CODE  # type: ignore[attr-defined]
+        exc.ipc_error_message = message  # type: ignore[attr-defined]
+        return exc
+
+    def _guard_skm(self) -> AsyncMock:
+        """직접 호출되면 즉시 실패하는 SignalKeyManager mock.
+
+        R3 회귀: rotate 는 cold-path 를 거치지 않고 IPC 로만 라우팅되므로
+        ``SignalKeyManager`` 가 CLI 에서 직접 호출되어선 안 된다 (orphan
+        credential 미발급은 서버 게이트 R5 책임).
         """
         skm = AsyncMock()
         skm.initialize = AsyncMock()
         skm.rotate = AsyncMock(
             side_effect=AssertionError(
-                "non-external 전략인데 rotate 가 호출됨 (orphan credential)"
+                "rotate cold-path 가 호출됨 (#2111: IPC 전용이어야 함)"
             )
         )
         skm.get_key = AsyncMock()
@@ -236,23 +217,18 @@ class TestRotateNonExternalStrategyRejected:
     def test_rotate_non_external_strategy_exits_one_with_code_json(
         self, runner: CliRunner
     ) -> None:
-        mock_db = AsyncMock()
-        mock_db.close = AsyncMock()
-        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "normal-1"})
-        mock_skm = self._gated_skm()
+        click_exc = self._not_accepting_click_exc()
 
-        reg_patch, loader_patch = _make_strategy_patches(accepts_external_signals=False)
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        mock_skm = self._guard_skm()
         with (
-            patch(
-                "ante.cli.commands.bot._create_services",
-                new=_acm_factory((mock_db, None, None, None)),
-            ),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
                 return_value=mock_skm,
             ),
-            reg_patch,
-            loader_patch,
         ):
             result = runner.invoke(
                 cli,
@@ -273,30 +249,25 @@ class TestRotateNonExternalStrategyRejected:
         assert payload["code"] == BOT_NOT_ACCEPTING_SIGNALS_CODE
         assert payload["code"] == "BOT_NOT_ACCEPTING_SIGNALS"
         assert "외부 시그널을 받지 않습니다" in payload["message"]
-        # R3: 게이트가 키 발급을 차단 — skm.rotate 미호출 (orphan 미발급).
+        # R3: CLI 가 SignalKeyManager 를 직접 호출하지 않는다 (cold-path 미사용).
         mock_skm.rotate.assert_not_awaited()
 
     def test_rotate_non_external_strategy_exits_one_text(
         self, runner: CliRunner
     ) -> None:
         """text 모드에서도 동일 거부 — exit 1 + stderr ``Error:``."""
-        mock_db = AsyncMock()
-        mock_db.close = AsyncMock()
-        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "normal-1"})
-        mock_skm = self._gated_skm()
+        click_exc = self._not_accepting_click_exc()
 
-        reg_patch, loader_patch = _make_strategy_patches(accepts_external_signals=False)
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        mock_skm = self._guard_skm()
         with (
-            patch(
-                "ante.cli.commands.bot._create_services",
-                new=_acm_factory((mock_db, None, None, None)),
-            ),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
                 return_value=mock_skm,
             ),
-            reg_patch,
-            loader_patch,
         ):
             result = runner.invoke(
                 cli, ["bot", "signal-key", "bot-normal-1", "--rotate"]

--- a/tests/unit/test_cli_bot_signal_key_rotate_ipc.py
+++ b/tests/unit/test_cli_bot_signal_key_rotate_ipc.py
@@ -1,0 +1,208 @@
+"""``ante bot signal-key --rotate`` runtime IPC 라우팅 회귀 lock (#2111).
+
+## 배경
+
+``bot signal-key --rotate`` 는 스펙(ipc.md:86)상 runtime IPC
+(``bot.signal_key.rotate`` → ``BotManager.rotate_signal_key()``) 로 정의되어
+있으나, CLI 가 ``SignalKeyManager.rotate()`` 를 직접 호출(cold-path DB
+mutation)해 runtime 경계 / audit / live 상태 정합성을 깼다. #2111 은 rotate 를
+IPC 전용으로 라우팅하고 cold-path mutation 을 제거한다.
+
+## 회귀 lock
+
+- L1: 서버 실행 중 ``--rotate`` → ``ipc_send("bot.signal_key.rotate",
+  {"bot_id": ...})`` 호출, ``SignalKeyManager`` 직접 미호출 (cold-path
+  미사용).
+- L2: 서버 정지(``ServerNotRunningError`` → ``IPC_SERVER_NOT_RUNNING``) →
+  에러 + exit 1, **직접 DB rotate 미수행** (fallback cold-path 없음).
+- L3: IPC timeout 등 기타 IPC 에러도 그대로 surface (별도 catch / cold-path
+  fallback 없음).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.ipc.exceptions import ServerNotRunningError
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """인증을 mock 으로 우회한 CliRunner (external_gate test 동형)."""
+    r = CliRunner(mix_stderr=False)
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+# ── L1: 서버 실행 중 → IPC 라우팅 + cold-path 미사용 ──────────────────────
+
+
+class TestRotateRoutesToIpcWhenServerRunning:
+    """L1: ``--rotate`` 는 ``ipc_send`` 로 라우팅하고 cold-path 를 쓰지 않는다."""
+
+    def test_rotate_calls_ipc_send_not_signal_key_manager(
+        self, runner: CliRunner
+    ) -> None:
+        mock_send = AsyncMock(
+            return_value={
+                "bot_id": "bot-1",
+                "signal_key": "sk_ipc_rotated",
+                "rotated": True,
+            }
+        )
+        # cold-path 가 호출되면 즉시 실패하는 가드들.
+        guard_skm_cls = patch(
+            "ante.bot.signal_key.SignalKeyManager",
+            side_effect=AssertionError(
+                "rotate 가 SignalKeyManager cold-path 를 호출함 (#2111 위반)"
+            ),
+        )
+        guard_create_services = patch(
+            "ante.cli.commands.bot._create_services",
+            side_effect=AssertionError(
+                "rotate 가 _create_services cold-path 를 호출함 (#2111 위반)"
+            ),
+        )
+
+        with (
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+            guard_skm_cls,
+            guard_create_services,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "bot", "signal-key", "bot-1", "--rotate"],
+            )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        # IPC 라우팅: command + args 정확성.
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args.args[0] == "bot.signal_key.rotate"
+        assert mock_send.await_args.args[1] == {"bot_id": "bot-1"}
+        # JSON 모드는 IPC envelope passthrough.
+        payload = json.loads(result.stdout)
+        assert payload["signal_key"] == "sk_ipc_rotated"
+        assert payload["rotated"] is True
+
+    def test_rotate_text_mode_success_message(self, runner: CliRunner) -> None:
+        """text 모드는 ``fmt.success`` 메시지로 surface (exit 0)."""
+        mock_send = AsyncMock(
+            return_value={
+                "bot_id": "bot-1",
+                "signal_key": "sk_ipc_rotated",
+                "rotated": True,
+            }
+        )
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send):
+            result = runner.invoke(cli, ["bot", "signal-key", "bot-1", "--rotate"])
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "시그널 키 재발급 완료: bot-1" in result.stdout
+        assert mock_send.await_args.args[0] == "bot.signal_key.rotate"
+
+
+# ── L2: 서버 정지 → 에러 + exit 1, cold-path fallback 없음 ────────────────
+
+
+class TestRotateNoColdPathFallbackWhenServerStopped:
+    """L2/L3: 서버 정지/IPC 에러 시 cold-path DB mutation 으로 fallback 하지
+    않는다."""
+
+    def test_server_not_running_exits_one_no_db_rotate_json(
+        self, runner: CliRunner
+    ) -> None:
+        """``ServerNotRunningError`` → ``IPC_SERVER_NOT_RUNNING`` + exit 1,
+        직접 DB rotate 미수행.
+
+        ``ipc_send`` 의 실제 변환 경로(``IPCClient.send`` 가 raise 한
+        ``ServerNotRunningError`` → ``IPC_SERVER_NOT_RUNNING`` ClickException)
+        를 타도록 ``IPCClient.send`` 와 socket 경로 resolver 만 mock 하고,
+        cold-path 진입은 가드로 막는다.
+        """
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise ServerNotRunningError("서버 미기동")
+
+        guard_skm_cls = patch(
+            "ante.bot.signal_key.SignalKeyManager",
+            side_effect=AssertionError(
+                "서버 정지 fallback 으로 cold-path rotate 가 호출됨 (#2111 위반)"
+            ),
+        )
+        guard_create_services = patch(
+            "ante.cli.commands.bot._create_services",
+            side_effect=AssertionError(
+                "서버 정지 fallback 으로 _create_services 가 호출됨 (#2111 위반)"
+            ),
+        )
+
+        with (
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/nonexistent-ante-2111.sock",
+            ),
+            patch("ante.ipc.client.IPCClient.send", new=_raise),
+            guard_skm_cls,
+            guard_create_services,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "bot", "signal-key", "bot-1", "--rotate"],
+            )
+
+        assert result.exit_code == 1, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == "IPC_SERVER_NOT_RUNNING"
+
+    def test_server_not_running_exits_one_text(self, runner: CliRunner) -> None:
+        """text 모드에서도 서버 정지 → exit 1 + stderr ``Error:``."""
+
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise ServerNotRunningError("서버 미기동")
+
+        with (
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/nonexistent-ante-2111.sock",
+            ),
+            patch("ante.ipc.client.IPCClient.send", new=_raise),
+            patch(
+                "ante.bot.signal_key.SignalKeyManager",
+                side_effect=AssertionError("cold-path 호출됨 (#2111 위반)"),
+            ),
+        ):
+            result = runner.invoke(cli, ["bot", "signal-key", "bot-1", "--rotate"])
+
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert "Error:" in result.stderr
+        # IPC_SERVER_NOT_RUNNING code 가 text envelope 에 포함.
+        assert "IPC_SERVER_NOT_RUNNING" in result.stderr

--- a/tests/unit/test_cli_bot_signal_key_rotate_ipc.py
+++ b/tests/unit/test_cli_bot_signal_key_rotate_ipc.py
@@ -107,10 +107,14 @@ class TestRotateRoutesToIpcWhenServerRunning:
         mock_send.assert_awaited_once()
         assert mock_send.await_args.args[0] == "bot.signal_key.rotate"
         assert mock_send.await_args.args[1] == {"bot_id": "bot-1"}
-        # JSON 모드는 IPC envelope passthrough.
+        # 출력 계약 보존 (#2111): 라우팅을 IPC 로 옮겨도 출력은 기존
+        # standard envelope (``{status, message, data}``, json/text 공통) 을
+        # 유지한다. cli_registry signal-key 계약의 문서화·drift-test 된
+        # mixed-branch 결정.
         payload = json.loads(result.stdout)
-        assert payload["signal_key"] == "sk_ipc_rotated"
-        assert payload["rotated"] is True
+        assert payload["status"] == "ok"
+        assert payload["data"]["signal_key"] == "sk_ipc_rotated"
+        assert payload["data"]["rotated"] is True
 
     def test_rotate_text_mode_success_message(self, runner: CliRunner) -> None:
         """text 모드는 ``fmt.success`` 메시지로 surface (exit 0)."""

--- a/tests/unit/test_cli_missing_resource_exit.py
+++ b/tests/unit/test_cli_missing_resource_exit.py
@@ -434,12 +434,13 @@ class TestBotSignalKeyMissingExit:
         assert payload["signal_key"] == "sk_test123"
 
     def test_valid_rotate_exits_zero(self, runner: CliRunner) -> None:
-        """실재 bot --rotate 재발급은 exit 0 + IPC envelope passthrough.
+        """실재 bot --rotate 재발급은 exit 0 + IPC 라우팅 + standard envelope.
 
         Refs #2111: rotate 는 runtime IPC (``bot.signal_key.rotate``) 전용으로
-        라우팅된다. CLI 는 ``ipc_send`` 가 반환한 server envelope 을 JSON 모드
-        에서 ``fmt.output(result)`` 로 그대로 dump 한다 (``bot start`` 동형).
-        존재 확인 / accepts_external_signals 게이트는 서버
+        라우팅된다. 단, 출력 계약(standard envelope ``{status, message, data}``,
+        json/text 공통)은 그대로 보존된다 — cli_registry signal-key 계약의
+        문서화·drift-test 된 mixed-branch 결정. 라우팅 변경이 출력-shape 변경이
+        아님을 lock 한다. 존재 확인 / accepts_external_signals 게이트는 서버
         ``BotManager.rotate_signal_key`` 가 단일 chokepoint 로 수행한다.
         """
         with patch(
@@ -457,10 +458,12 @@ class TestBotSignalKeyMissingExit:
             )
 
         assert result.exit_code == 0, result.stdout + result.stderr
-        # JSON 모드는 IPC envelope passthrough (raw_legacy).
+        # 출력 계약 보존: standard envelope (``{status, message, data}``).
         payload = json.loads(result.stdout)
-        assert payload["signal_key"] == "sk_rotated999"
-        assert payload["rotated"] is True
+        assert payload["status"] == "ok"
+        assert payload["data"]["signal_key"] == "sk_rotated999"
+        assert payload["data"]["rotated"] is True
+        # rotate 는 runtime IPC (``bot.signal_key.rotate``) 로 라우팅된다.
         mock_send.assert_awaited_once()
         assert mock_send.await_args.args[0] == "bot.signal_key.rotate"
         assert mock_send.await_args.args[1] == {"bot_id": "b-1"}

--- a/tests/unit/test_cli_missing_resource_exit.py
+++ b/tests/unit/test_cli_missing_resource_exit.py
@@ -55,6 +55,7 @@ import json
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -433,91 +434,72 @@ class TestBotSignalKeyMissingExit:
         assert payload["signal_key"] == "sk_test123"
 
     def test_valid_rotate_exits_zero(self, runner: CliRunner) -> None:
-        """실재 bot --rotate 재발급은 exit 0 + rotated 회귀 보존.
+        """실재 bot --rotate 재발급은 exit 0 + IPC envelope passthrough.
 
-        Refs #1761: rotate 분기가 ``strategy_id`` 를 함께 SELECT 하고
-        ``accepts_external_signals`` 게이트를 통과해야 ``skm.rotate`` 가
-        호출된다. ``StrategyRegistry``/``StrategyLoader`` 를 patch 해
-        external signals=True 전략을 시뮬레이션한다.
+        Refs #2111: rotate 는 runtime IPC (``bot.signal_key.rotate``) 전용으로
+        라우팅된다. CLI 는 ``ipc_send`` 가 반환한 server envelope 을 JSON 모드
+        에서 ``fmt.output(result)`` 로 그대로 dump 한다 (``bot start`` 동형).
+        존재 확인 / accepts_external_signals 게이트는 서버
+        ``BotManager.rotate_signal_key`` 가 단일 chokepoint 로 수행한다.
         """
-        from ante.strategy.base import StrategyMeta
-
-        mock_db = AsyncMock()
-        mock_db.close = AsyncMock()
-        mock_db.fetch_one = AsyncMock(return_value={"strategy_id": "s-1"})
-        mock_skm = AsyncMock()
-        mock_skm.initialize = AsyncMock()
-        mock_skm.rotate = AsyncMock(return_value="sk_rotated999")
-
-        mock_record = MagicMock()
-        mock_record.filepath = "/fake/path.py"
-        mock_registry = AsyncMock()
-        mock_registry.initialize = AsyncMock()
-        mock_registry.get = AsyncMock(return_value=mock_record)
-
-        mock_strategy_cls = MagicMock()
-        mock_strategy_cls.meta = StrategyMeta(
-            name="ext",
-            version="1.0.0",
-            description="external",
-            accepts_external_signals=True,
-        )
-
-        with (
-            patch(
-                "ante.cli.commands.bot._create_services",
-                new=_acm_factory((mock_db, None, None, None)),
+        with patch(
+            "ante.cli.commands.ipc_helpers.ipc_send",
+            new=AsyncMock(
+                return_value={
+                    "bot_id": "b-1",
+                    "signal_key": "sk_rotated999",
+                    "rotated": True,
+                }
             ),
-            patch(
-                "ante.bot.signal_key.SignalKeyManager",
-                return_value=mock_skm,
-            ),
-            patch(
-                "ante.strategy.registry.StrategyRegistry",
-                return_value=mock_registry,
-            ),
-            patch(
-                "ante.strategy.loader.StrategyLoader.load",
-                return_value=mock_strategy_cls,
-            ),
-        ):
+        ) as mock_send:
             result = runner.invoke(
                 cli, ["--format", "json", "bot", "signal-key", "b-1", "--rotate"]
             )
 
         assert result.exit_code == 0, result.stdout + result.stderr
-        # rotate 성공은 ``fmt.success`` envelope: {status:ok, message, data}.
+        # JSON 모드는 IPC envelope passthrough (raw_legacy).
         payload = json.loads(result.stdout)
-        assert payload["status"] == "ok"
-        assert payload["data"]["signal_key"] == "sk_rotated999"
-        assert payload["data"]["rotated"] is True
-        mock_skm.rotate.assert_awaited_once_with("b-1")
+        assert payload["signal_key"] == "sk_rotated999"
+        assert payload["rotated"] is True
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args.args[0] == "bot.signal_key.rotate"
+        assert mock_send.await_args.args[1] == {"bot_id": "b-1"}
 
 
 class TestBotSignalKeyMissingBotExit:
-    """``ante bot signal-key <missing-bot> [--rotate]`` 은 exit 1 (#1596).
+    """``ante bot signal-key <missing-bot>`` 은 exit 1 (#1596 / #2111).
 
-    미존재 bot 에 대한 signal key 발급/조회를 차단한다 (oracle A7
+    미존재 bot 에 대한 signal key 조회/재발급을 차단한다 (oracle A7
     missing-resource). 형제 명령(`bot info`/`bot remove`/`bot positions`,
-    #1558)과 동일하게 "봇을 찾을 수 없습니다: {bot_id}" + exit 1, **에러
-    코드 없음**으로 거부하고, orphan credential 을 발급하지 않는다.
+    #1558)과 동일하게 "봇을 찾을 수 없습니다: {bot_id}" + exit 1 +
+    ``BOT_NOT_FOUND`` code 로 거부하고, orphan credential 을 발급하지 않는다.
 
-    target 경로는 ``_create_services()`` 의 ``Database`` 직접 조회
-    (``SELECT 1 FROM bots WHERE bot_id = ?``) — ``SignalKeyManager``
-    자체는 미변경 (Non-Goal).
+    read (조회, rotate 미지정) 경로는 ``_create_services()`` 의 ``Database``
+    직접 조회 (``SELECT ... FROM bots WHERE bot_id = ?``) cold-path 가
+    그대로 가드한다 — ``SignalKeyManager`` 자체는 미변경 (Non-Goal).
+
+    Refs #2111: ``--rotate`` 는 runtime IPC (``bot.signal_key.rotate``)
+    전용으로 라우팅되므로, 미존재 bot 거부는 서버
+    ``BotManager.rotate_signal_key`` 의 ``BotNotFoundError`` →
+    ``BOT_NOT_FOUND`` envelope 으로 일어난다. 본 클래스의 rotate 케이스는
+    ``ipc_send`` 가 server envelope 을 surface 하는 CLI 라우팅만 lock 하고,
+    orphan 미발급 invariant 는 서버 handler/manager 테스트가 책임진다.
     """
 
     def _missing_skm(self) -> AsyncMock:
-        """rotate/get_key 가 호출되면 즉시 실패하는 SignalKeyManager mock.
+        """get_key 가 호출되면 즉시 실패하는 SignalKeyManager mock.
 
-        미존재 bot 가드가 ``skm.rotate``/``skm.get_key`` **이전**에
-        걸리므로, 이 mock 의 메서드는 호출되어선 안 된다 (orphan
-        credential 미발급 검증).
+        read 경로 미존재 bot 가드가 ``skm.get_key`` **이전**에 걸리므로,
+        이 mock 의 메서드는 호출되어선 안 된다 (orphan credential 미조회
+        검증). rotate 는 cold-path 를 거치지 않으므로 (#2111 IPC 전용)
+        ``rotate`` 도 동일하게 미호출이어야 한다.
         """
         skm = AsyncMock()
         skm.initialize = AsyncMock()
         skm.rotate = AsyncMock(
-            side_effect=AssertionError("미존재 bot 인데 rotate 가 호출됨 (orphan)")
+            side_effect=AssertionError(
+                "rotate cold-path 가 호출됨 (#2111: IPC 전용이어야 함)"
+            )
         )
         skm.get_key = AsyncMock(
             side_effect=AssertionError("미존재 bot 인데 get_key 가 호출됨")
@@ -525,16 +507,22 @@ class TestBotSignalKeyMissingBotExit:
         return skm
 
     def test_missing_bot_rotate_exits_nonzero_json(self, runner: CliRunner) -> None:
-        mock_db = AsyncMock()
-        mock_db.close = AsyncMock()
-        mock_db.fetch_one = AsyncMock(return_value=None)  # bots row 없음
-        mock_skm = self._missing_skm()
+        """#2111: 미존재 bot --rotate → 서버 ``BOT_NOT_FOUND`` envelope 을
+        ``ipc_send`` 가 surface, CLI 가 exit 1 + ``BOT_NOT_FOUND`` 로 보존."""
+        click_exc = click.ClickException(
+            "BOT_NOT_FOUND: 봇을 찾을 수 없습니다: oracle-missing-bot"
+        )
+        click_exc.ipc_error_code = "BOT_NOT_FOUND"  # type: ignore[attr-defined]
+        click_exc.ipc_error_message = (  # type: ignore[attr-defined]
+            "봇을 찾을 수 없습니다: oracle-missing-bot"
+        )
 
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        mock_skm = self._missing_skm()
         with (
-            patch(
-                "ante.cli.commands.bot._create_services",
-                new=_acm_factory((mock_db, None, None, None)),
-            ),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
                 return_value=mock_skm,
@@ -556,26 +544,28 @@ class TestBotSignalKeyMissingBotExit:
         payload = json.loads(result.stdout)
         assert payload["status"] == "error"
         assert "봇을 찾을 수 없습니다: oracle-missing-bot" in payload["message"]
-        # #1784 Group A sweep: 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로
-        # surface 한다 (CLI/IPC 일관성: ``BotNotFoundError.code`` 와 동형).
-        # 이전 #1558 의 "code 없음" 계약은 #1784 oracle A7 evidence 에서
-        # 자동화 분류 불가 결함으로 보고되어 본 sweep 에서 폐기.
+        # 서버 ``BotNotFoundError.code`` 와 동형 stable code.
         assert payload["code"] == "BOT_NOT_FOUND"
-        # orphan credential 미발급: rotate 가 호출되지 않았어야 한다.
+        # cold-path 미사용 회귀: 직접 DB rotate/get_key 미호출.
         mock_skm.rotate.assert_not_awaited()
         mock_skm.get_key.assert_not_awaited()
 
     def test_missing_bot_rotate_exits_nonzero_text(self, runner: CliRunner) -> None:
-        mock_db = AsyncMock()
-        mock_db.close = AsyncMock()
-        mock_db.fetch_one = AsyncMock(return_value=None)
-        mock_skm = self._missing_skm()
+        """#2111: text 모드에서도 서버 envelope 을 surface (exit 1 + stderr)."""
+        click_exc = click.ClickException(
+            "BOT_NOT_FOUND: 봇을 찾을 수 없습니다: oracle-missing-bot"
+        )
+        click_exc.ipc_error_code = "BOT_NOT_FOUND"  # type: ignore[attr-defined]
+        click_exc.ipc_error_message = (  # type: ignore[attr-defined]
+            "봇을 찾을 수 없습니다: oracle-missing-bot"
+        )
 
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        mock_skm = self._missing_skm()
         with (
-            patch(
-                "ante.cli.commands.bot._create_services",
-                new=_acm_factory((mock_db, None, None, None)),
-            ),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
                 return_value=mock_skm,
@@ -650,6 +640,9 @@ class TestBotSignalKeyMissingBotExit:
 
         ``no such table`` ``OperationalError`` 는 정의상 해당 bot_id 가
         존재할 수 없으므로 미존재 bot 과 동일하게 exit 1 + 거부 메시지.
+
+        Refs #2111: 본 정규화는 read (조회) cold-path 가 책임지므로 rotate
+        플래그 없이 read 경로로 lock 한다 (rotate 는 IPC 전용으로 이전).
         """
         import sqlite3
 
@@ -678,7 +671,6 @@ class TestBotSignalKeyMissingBotExit:
                     "bot",
                     "signal-key",
                     "oracle-missing-bot",
-                    "--rotate",
                 ],
             )
 
@@ -686,11 +678,15 @@ class TestBotSignalKeyMissingBotExit:
         payload = json.loads(result.stdout)
         assert payload["status"] == "error"
         assert "봇을 찾을 수 없습니다: oracle-missing-bot" in payload["message"]
-        mock_skm.rotate.assert_not_awaited()
+        mock_skm.get_key.assert_not_awaited()
 
     def test_other_operational_error_not_swallowed(self, runner: CliRunner) -> None:
         """``no such table`` 외 ``OperationalError`` 는 미존재로 정규화하지
-        않고 그대로 전파(일반 에러 경로 → exit 1, 거부 메시지 아님)."""
+        않고 그대로 전파(일반 에러 경로 → exit 1, 거부 메시지 아님).
+
+        Refs #2111: read (조회) cold-path 의 에러 정규화 회귀이므로 rotate
+        플래그 없이 lock 한다.
+        """
         import sqlite3
 
         mock_db = AsyncMock()
@@ -712,7 +708,7 @@ class TestBotSignalKeyMissingBotExit:
         ):
             result = runner.invoke(
                 cli,
-                ["--format", "json", "bot", "signal-key", "some-bot", "--rotate"],
+                ["--format", "json", "bot", "signal-key", "some-bot"],
             )
 
         # malformed db 는 미존재 bot 으로 둔갑하지 않는다 (메시지 구분).
@@ -721,7 +717,7 @@ class TestBotSignalKeyMissingBotExit:
         assert "봇을 찾을 수 없습니다" not in payload["message"]
         # non-"no such table" OperationalError 는 non-zero exit (#1596).
         assert result.exit_code != 0, result.output
-        mock_skm.rotate.assert_not_awaited()
+        mock_skm.get_key.assert_not_awaited()
 
     def test_db_error_exits_nonzero_json(self, runner: CliRunner) -> None:
         """bot 존재확인 중 non-"no such table" ``OperationalError`` (locked/
@@ -732,7 +728,10 @@ class TestBotSignalKeyMissingBotExit:
         exit code 가 0 으로 남아 자동화 호출자가 실패를 감지하지 못했다.
         형제 ``bot remove`` (raise SystemExit(1) from e)와 동일하게 non-zero
         exit 으로 정렬한다. 미존재 bot 거부 경로(exit 1 "봇을 찾을 수
-        없습니다", code 없음)는 별도 invariant 로 그대로 유지된다.
+        없습니다")는 별도 invariant 로 그대로 유지된다.
+
+        Refs #2111: read (조회) cold-path 의 DB 오류 exit-code 회귀이므로
+        rotate 플래그 없이 lock 한다 (rotate 는 IPC 전용으로 이전).
         """
         import sqlite3
 
@@ -755,7 +754,7 @@ class TestBotSignalKeyMissingBotExit:
         ):
             result = runner.invoke(
                 cli,
-                ["--format", "json", "bot", "signal-key", "some-bot", "--rotate"],
+                ["--format", "json", "bot", "signal-key", "some-bot"],
             )
 
         # 핵심 회귀 assert: DB 오류는 non-zero exit 으로 끝나야 한다.
@@ -764,8 +763,7 @@ class TestBotSignalKeyMissingBotExit:
         assert payload["status"] == "error"
         # locked DB 는 미존재 bot 으로 둔갑하지 않는다 (거부 메시지 아님).
         assert "봇을 찾을 수 없습니다" not in payload["message"]
-        # orphan credential 미발급: rotate/get_key 미호출 (가드 이전 실패).
-        mock_skm.rotate.assert_not_awaited()
+        # orphan credential 미조회: get_key 미호출 (가드 이전 실패).
         mock_skm.get_key.assert_not_awaited()
 
     def test_db_error_exits_nonzero_text(self, runner: CliRunner) -> None:
@@ -810,21 +808,30 @@ class TestBotSignalKeySoftDeletedBotExit:
     ``BotManager.load_from_db`` 의 운영 bot 정의(manager.py:212
     ``FROM bots WHERE status != 'deleted'``)와 정렬. soft-deleted bot 은
     row 없는 미존재 bot 과 동일한 missing sentinel → 동일 거부
-    ("봇을 찾을 수 없습니다" + exit 1, code 없음), orphan 미발급.
+    ("봇을 찾을 수 없습니다" + exit 1 + ``BOT_NOT_FOUND``), orphan 미발급.
+
+    Refs #2111: read (조회) cold-path 의 ``status != 'deleted'`` SELECT 가드
+    회귀는 ``test_soft_deleted_bot_lookup_*`` 가 보존한다. ``--rotate`` 는
+    runtime IPC (``bot.signal_key.rotate``) 전용으로 이전되었으므로,
+    soft-deleted bot rotate 거부는 서버 ``BotManager.rotate_signal_key`` 의
+    ``BotNotFoundError`` → ``BOT_NOT_FOUND`` envelope 으로 일어나며 (server
+    ``load_from_db`` 도 ``WHERE status != 'deleted'`` 정렬), rotate 케이스는
+    ``ipc_send`` 의 server envelope surface 만 lock 한다.
     """
 
     def _missing_skm(self) -> AsyncMock:
-        """rotate/get_key 가 호출되면 즉시 실패하는 SignalKeyManager mock.
+        """get_key 가 호출되면 즉시 실패하는 SignalKeyManager mock.
 
-        soft-deleted bot 가드가 ``skm.rotate``/``skm.get_key`` **이전**에
-        걸리므로, 이 mock 의 메서드는 호출되어선 안 된다 (orphan
-        credential 미발급 검증).
+        read 경로 soft-deleted bot 가드가 ``skm.get_key`` **이전**에 걸리므로,
+        이 mock 의 메서드는 호출되어선 안 된다 (orphan credential 미조회
+        검증). rotate 는 cold-path 를 거치지 않으므로 (#2111 IPC 전용)
+        ``rotate`` 도 동일하게 미호출이어야 한다.
         """
         skm = AsyncMock()
         skm.initialize = AsyncMock()
         skm.rotate = AsyncMock(
             side_effect=AssertionError(
-                "soft-deleted bot 인데 rotate 가 호출됨 (orphan 재발급)"
+                "rotate cold-path 가 호출됨 (#2111: IPC 전용이어야 함)"
             )
         )
         skm.get_key = AsyncMock(
@@ -854,17 +861,31 @@ class TestBotSignalKeySoftDeletedBotExit:
         mock_db.fetch_one = AsyncMock(side_effect=fetch_one)
         return mock_db
 
+    def _bot_not_found_click_exc(self) -> click.ClickException:
+        """서버 ``BotNotFoundError`` → ``BOT_NOT_FOUND`` envelope 을 ``ipc_send``
+        가 변환한 ClickException 을 모사한다."""
+        exc = click.ClickException(
+            "BOT_NOT_FOUND: 봇을 찾을 수 없습니다: soft-deleted-bot"
+        )
+        exc.ipc_error_code = "BOT_NOT_FOUND"  # type: ignore[attr-defined]
+        exc.ipc_error_message = (  # type: ignore[attr-defined]
+            "봇을 찾을 수 없습니다: soft-deleted-bot"
+        )
+        return exc
+
     def test_soft_deleted_bot_rotate_exits_nonzero_json(
         self, runner: CliRunner
     ) -> None:
-        mock_db = self._soft_deleted_db()
-        mock_skm = self._missing_skm()
+        """#2111: soft-deleted bot --rotate → 서버 ``BOT_NOT_FOUND`` envelope
+        을 ``ipc_send`` 가 surface, CLI 가 exit 1 + ``BOT_NOT_FOUND`` 로 보존."""
+        click_exc = self._bot_not_found_click_exc()
 
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        mock_skm = self._missing_skm()
         with (
-            patch(
-                "ante.cli.commands.bot._create_services",
-                new=_acm_factory((mock_db, None, None, None)),
-            ),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
                 return_value=mock_skm,
@@ -886,24 +907,24 @@ class TestBotSignalKeySoftDeletedBotExit:
         payload = json.loads(result.stdout)
         assert payload["status"] == "error"
         assert "봇을 찾을 수 없습니다: soft-deleted-bot" in payload["message"]
-        # #1784 Group A sweep: 미존재 bot 과 동일 형제 계약 — 안정 코드
-        # ``BOT_NOT_FOUND`` 로 surface (이전 #1558 의 "code 없음" 폐기).
+        # 서버 ``BotNotFoundError.code`` 와 동형 stable code.
         assert payload["code"] == "BOT_NOT_FOUND"
-        # orphan credential 미발급: rotate 가 호출되지 않았어야 한다.
+        # cold-path 미사용 회귀: 직접 DB rotate/get_key 미호출.
         mock_skm.rotate.assert_not_awaited()
         mock_skm.get_key.assert_not_awaited()
 
     def test_soft_deleted_bot_rotate_exits_nonzero_text(
         self, runner: CliRunner
     ) -> None:
-        mock_db = self._soft_deleted_db()
-        mock_skm = self._missing_skm()
+        """#2111: text 모드에서도 서버 envelope 을 surface (exit 1 + stderr)."""
+        click_exc = self._bot_not_found_click_exc()
 
+        async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click_exc
+
+        mock_skm = self._missing_skm()
         with (
-            patch(
-                "ante.cli.commands.bot._create_services",
-                new=_acm_factory((mock_db, None, None, None)),
-            ),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise),
             patch(
                 "ante.bot.signal_key.SignalKeyManager",
                 return_value=mock_skm,

--- a/tests/unit/test_ipc_bot_lifecycle.py
+++ b/tests/unit/test_ipc_bot_lifecycle.py
@@ -29,15 +29,18 @@ import pytest
 
 from ante.bot.exceptions import (
     BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE,
+    BOT_NOT_ACCEPTING_SIGNALS_CODE,
     BOT_NOT_FOUND_CODE,
     BOT_STATE_CONFLICT_CODE,
     BotAccountCredentialsNotConfigured,
     BotError,
+    BotNotAcceptingSignals,
     BotNotFoundError,
     BotStateConflict,
 )
 from ante.ipc.registry import (
     CommandRegistry,
+    _handle_bot_signal_key_rotate,
     _handle_bot_start,
     _handle_bot_status,
     _handle_bot_stop,
@@ -66,6 +69,8 @@ def _make_svc(
     account: SimpleNamespace | None = None,
     start_side_effect: Exception | None = None,
     stop_side_effect: Exception | None = None,
+    rotate_signal_key_side_effect: Exception | None = None,
+    rotate_signal_key_return: str | None = None,
     with_audit_logger: bool = True,
     strategy_registry: object | None = None,
     treasury_manager: object | None = None,
@@ -79,6 +84,12 @@ def _make_svc(
     bot_manager.get_bot = MagicMock(return_value=bot)
     bot_manager.start_bot = AsyncMock(side_effect=start_side_effect)
     bot_manager.stop_bot = AsyncMock(side_effect=stop_side_effect)
+    # #2111: rotate_signal_key 기본 stub. 각 테스트가 return_value /
+    # side_effect 를 override 한다.
+    bot_manager.rotate_signal_key = AsyncMock(
+        side_effect=rotate_signal_key_side_effect,
+        return_value=rotate_signal_key_return,
+    )
 
     account_service = MagicMock()
     if account is not None:
@@ -283,6 +294,130 @@ class TestHandleBotStop:
             },
         }
         svc.bot_manager.stop_bot.assert_awaited_once_with("bot-1")
+
+
+# ── bot.signal_key.rotate (#2111) ────────────────────
+
+
+class TestHandleBotSignalKeyRotate:
+    """``_handle_bot_signal_key_rotate`` 정상 + 거부 경로 (#2111).
+
+    ``bot signal-key --rotate`` 의 runtime IPC handler. 존재 확인 /
+    accepts_external_signals 게이트 / ``SignalKeyManager.rotate`` 위임은
+    ``BotManager.rotate_signal_key`` 가 단일 chokepoint 로 수행하며, handler 는
+    typed exception 을 그대로 propagate 한다 (``server.py`` envelope 이 stable
+    code 변환).
+    """
+
+    async def test_success_returns_rotated_envelope(self) -> None:
+        """성공 시 ``{bot_id, signal_key, rotated:True, _audit_detail}``.
+
+        handler 는 ``BotManager.rotate_signal_key`` 를 호출하고 새 키를 envelope
+        으로 반환한다. audit 발화는 ``_dispatch`` wrapper 가 수행하므로 handler
+        본문은 ``_audit_detail`` 만 채운다(#1851 동형).
+        """
+        bot = _make_bot(bot_id="bot-1")
+        svc, audit_log = _make_svc(
+            bot=bot, rotate_signal_key_return="sk_rotated_new_99"
+        )
+
+        result = await _handle_bot_signal_key_rotate(
+            svc, {"bot_id": "bot-1"}, "admin-master"
+        )
+
+        assert result == {
+            "bot_id": "bot-1",
+            "signal_key": "sk_rotated_new_99",
+            "rotated": True,
+            "_audit_detail": {
+                "resource": "bot:bot-1",
+                "detail": "",
+                "ip": "",
+            },
+        }
+        svc.bot_manager.rotate_signal_key.assert_awaited_once_with("bot-1")
+        # handler 본문은 audit 를 직접 호출하지 않는다(#1851).
+        assert audit_log is not None
+        audit_log.assert_not_awaited()
+
+    async def test_missing_bot_propagates_bot_not_found(self) -> None:
+        """미존재 봇 → ``BotNotFoundError`` (code=BOT_NOT_FOUND) propagate.
+
+        ``BotManager.rotate_signal_key`` 의 ``_get_bot`` 존재 확인이 raise 한
+        typed exception 을 handler 가 가로채지 않고 그대로 올린다.
+        """
+        bot = _make_bot(bot_id="missing")
+        svc, _ = _make_svc(
+            bot=bot,
+            rotate_signal_key_side_effect=BotNotFoundError("missing"),
+        )
+
+        with pytest.raises(BotNotFoundError) as exc:
+            await _handle_bot_signal_key_rotate(
+                svc, {"bot_id": "missing"}, "admin-master"
+            )
+
+        assert exc.value.code == BOT_NOT_FOUND_CODE
+
+    async def test_non_external_strategy_propagates_not_accepting(self) -> None:
+        """accepts_external_signals=False → ``BotNotAcceptingSignals``
+        (code=BOT_NOT_ACCEPTING_SIGNALS) propagate."""
+        bot = _make_bot(bot_id="bot-1")
+        svc, _ = _make_svc(
+            bot=bot,
+            rotate_signal_key_side_effect=BotNotAcceptingSignals(
+                "이 봇의 전략은 외부 시그널을 받지 않습니다: bot_id=bot-1"
+            ),
+        )
+
+        with pytest.raises(BotNotAcceptingSignals) as exc:
+            await _handle_bot_signal_key_rotate(
+                svc, {"bot_id": "bot-1"}, "admin-master"
+            )
+
+        assert exc.value.code == BOT_NOT_ACCEPTING_SIGNALS_CODE
+
+    async def test_strategy_missing_propagates_bot_error(self) -> None:
+        """전략 미발견 → ``BotError`` propagate (server.py 가 ``EXECUTION_ERROR``
+        fallback — error-equivalence 단언 없음, 서버 경로 SSOT, #2111).
+
+        cold-path 는 전략 미발견 시 ``STRATEGY_NOT_FOUND`` sentinel 을 냈으나,
+        runtime IPC 전용 전환 후 서버 ``rotate_signal_key`` 의 ``BotError`` 가
+        ``getattr(e, "code", "EXECUTION_ERROR")`` fallback 으로 변환된다. 이
+        known 미세차는 error-equivalence 회귀 lock 이 strategy-missing parity 를
+        단언하지 않으므로 서버 경로를 SSOT 로 수용한다.
+        """
+        bot = _make_bot(bot_id="bot-1")
+        svc, _ = _make_svc(
+            bot=bot,
+            rotate_signal_key_side_effect=BotError("전략 미발견: s-1"),
+        )
+
+        with pytest.raises(BotError):
+            await _handle_bot_signal_key_rotate(
+                svc, {"bot_id": "bot-1"}, "admin-master"
+            )
+        # BotError 는 stable ``code`` 속성이 없어 envelope 이 EXECUTION_ERROR 로
+        # fallback (회귀 명시): ``BotNotFoundError`` / ``BotNotAcceptingSignals``
+        # 와 달리 STRATEGY_NOT_FOUND 코드를 갖지 않는다.
+        assert not hasattr(BotError("x"), "code")
+
+    async def test_succeeds_when_audit_logger_is_none(self) -> None:
+        """``audit_logger=None`` 환경에서도 핸들러는 정상 성공 (#1851 동형)."""
+        bot = _make_bot(bot_id="bot-1")
+        svc, _ = _make_svc(
+            bot=bot,
+            rotate_signal_key_return="sk_rotated_2",
+            with_audit_logger=False,
+        )
+
+        result = await _handle_bot_signal_key_rotate(
+            svc, {"bot_id": "bot-1"}, "admin-master"
+        )
+
+        assert result["rotated"] is True
+        assert result["signal_key"] == "sk_rotated_2"
+        assert result["_audit_detail"]["resource"] == "bot:bot-1"
 
 
 # ── bot.status ───────────────────────────────────────
@@ -517,8 +652,9 @@ class TestRegistryRegistration:
         assert spec.is_mutating is False
         assert spec.handler is _handle_bot_status
 
-    def test_total_command_count_is_27(self) -> None:
-        """#1712 이후 CLI/IPC parity mutation 5개를 포함한다."""
+    def test_total_command_count_is_28(self) -> None:
+        """#1712 이후 CLI/IPC parity mutation 5개 + #2111
+        ``bot.signal_key.rotate`` 를 포함한다."""
         registry = CommandRegistry()
         register_all_handlers(registry)
-        assert len(registry.commands) == 27
+        assert len(registry.commands) == 28


### PR DESCRIPTION
Closes #2111

## Summary
- `ante bot signal-key <bot_id> --rotate`가 스펙(ipc.md:86)상 runtime IPC(`bot.signal_key.rotate`)인데 CLI가 `SignalKeyManager.rotate()`를 직접 호출(cold-path DB mutation)하던 것을, **서버 BotManager 경유 IPC 전용**으로 라우팅하고 cold-path mutation을 제거.
- IPC handler `_handle_bot_signal_key_rotate` 신설 → `svc.bot_manager.rotate_signal_key(bot_id)`. register `bot.signal_key.rotate`(is_mutating=True, audit_action=`bot.signal_key.rotate` — audit.md:121 정렬).
- CLI --rotate는 `ipc_send("bot.signal_key.rotate", {bot_id})`. 서버 정지 시 IPC 에러 surface(직접 DB mutation fallback 없음). **rotate 성공 JSON은 기존 standard envelope 보존**(출력 계약 무변경).
- read(non-rotate)·cli_registry 무변경 → #2112. member mutation → #2113.

## Test Plan
- 추가/갱신: handler 5케이스(존재·게이트·코드), CLI IPC 라우팅+cold-path 미사용+서버정지 no-fallback, audit 발화, output standard envelope, docs-taxonomy 등록 바인딩
- 전체 `pytest tests/unit/`: 6745 passed, 2 skipped, 0 failed
- ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (d429e35, attempt 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)