### PR TITLE
fix(data): #2010 DART available_date(rcept_no 접수일) 저장 — point-in-time producer

### DIFF
--- a/src/ante/data/normalizer.py
+++ b/src/ante/data/normalizer.py
@@ -321,8 +321,14 @@ class DARTNormalizer:
 
         Returns:
             FUNDAMENTAL_SCHEMA 부분 컬럼을 가진 DataFrame.
-            포함: date, symbol, revenue, net_income,
+            포함: date, available_date, symbol, revenue, net_income,
             total_equity, total_debt, total_assets, source.
+
+        ``available_date``는 point-in-time 공시 접수일(#2010)이다. DART 응답의
+        ``rcept_no``(14자리, 앞 8자리=접수일자 ``YYYYMMDD``)에서 추출한다.
+        ``date``(period_end=분기말일)와 의미가 다른 **별도 value 컬럼**이며,
+        lookahead bias를 피하려는 소비자(#2067)가 as-of join 키로 쓸 수 있다.
+        ``rcept_no``가 없거나 접수일 파싱이 실패하면 null로 강등한다(graceful).
         """
         from ante.data.schemas import FUNDAMENTAL_COLUMNS
 
@@ -370,8 +376,15 @@ class DARTNormalizer:
         if df.is_empty():
             return pl.DataFrame(schema=empty_schema)
 
-        # reprt_code + bsns_year → date 변환
+        # reprt_code + bsns_year → date(period_end) 변환
         df = self._convert_report_date(df)
+
+        # point-in-time 공시 접수일(available_date) 파생(#2010).
+        # rcept_no(14자리)의 앞 8자리가 접수일자 YYYYMMDD다. 존재하면 그
+        # 부분을 Date로 파싱하고, 컬럼이 없거나(과거 raw·data.go.kr 등) 값이
+        # 비YYYYMMDD면 strict=False로 null 강등한다(graceful). period_end(date)와
+        # 별도 value 컬럼으로 보존하며, required_cols에는 넣지 않는다.
+        df = self._derive_available_date(df)
 
         # thstrm_amount 콤마 제거 + 숫자 변환
         df = df.with_columns(
@@ -394,9 +407,17 @@ class DARTNormalizer:
             return pl.DataFrame(schema=empty_schema)
 
         # 피벗: 행(계정과목별) → 열(종목별 필드)
+        #
+        # available_date를 index에 포함해 피벗 후에도 보존한다. 같은
+        # (symbol, date=period_end)에 대해 한 응답 내 available_date는 보통
+        # 단일값이라 행이 분할되지 않는다. 단, 정정공시/재제출로 동일
+        # period_end에 후속 rcept_no가 섞이면 available_date가 달라 행이
+        # 나뉠 수 있다 — 완전한 revision history 보존은 본 이슈의 비목표이며,
+        # store의 natural key [date, source] dedup(keep="last")이 최신 1행으로
+        # 수렴시킨다(known-limitation, #2010).
         pivoted = df.pivot(
             on="field_name",
-            index=["symbol", "date"],
+            index=["symbol", "date", "available_date"],
             values="amount_value",
             aggregate_function="first",
         )
@@ -491,6 +512,45 @@ class DARTNormalizer:
 
         df = df.with_columns(pl.Series("date", dates, dtype=pl.Date))
         return df.filter(pl.col("date").is_not_null())
+
+    def _derive_available_date(self, df: pl.DataFrame) -> pl.DataFrame:
+        """rcept_no → available_date(공시 접수일) 컬럼 파생(#2010).
+
+        DART 응답의 ``rcept_no``는 14자리 접수번호이며 **앞 8자리가 접수일자
+        ``YYYYMMDD``** 다(05-data-sources.md L84·dart-openapi.md). 이 앞 8자리를
+        ``Date``로 파싱해 point-in-time ``available_date``를 만든다.
+
+        graceful 강등(required 아님):
+        - ``rcept_no`` 컬럼이 없으면(과거 raw·data.go.kr 등) ``available_date``를
+          **전부 null**(``pl.Date``)로 채운다 — 예외를 던지지 않는다.
+        - ``rcept_no``가 있어도 앞 8자리가 ``YYYYMMDD`` 형식이 아니면
+          ``strict=False`` 파싱이 그 행만 null로 강등한다(전체 실패 아님).
+
+        ``date``(period_end)와는 의미가 다른 별도 value 컬럼이므로
+        ``_convert_report_date``처럼 null 행을 필터링하지 **않는다**.
+        """
+        if "rcept_no" not in df.columns:
+            logger.debug(
+                "DART: rcept_no 컬럼 부재 — available_date를 null로 채움 "
+                "(point-in-time 접수일 미상, #2010)"
+            )
+            return df.with_columns(pl.lit(None, dtype=pl.Date).alias("available_date"))
+
+        derived = df.with_columns(
+            pl.col("rcept_no")
+            .cast(pl.Utf8)
+            .str.slice(0, 8)
+            .str.to_date("%Y%m%d", strict=False)
+            .alias("available_date")
+        )
+
+        # 비YYYYMMDD/부재로 인한 null 강등 관측성(전수 null이면 디버그 로그).
+        if bool(derived["available_date"].is_null().all()):
+            logger.debug(
+                "DART: rcept_no 앞 8자리에서 available_date를 하나도 파싱하지 "
+                "못함 — 비YYYYMMDD 형식 가능성(#2010)"
+            )
+        return derived
 
 
 # ── Normalizer 레지스트리 ────────────────────────────

--- a/src/ante/data/schemas.py
+++ b/src/ante/data/schemas.py
@@ -31,8 +31,17 @@ TICK_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
 }
 
 # 재무 데이터 스키마 (DART, data.go.kr 등)
+#
+# `date`는 보고 기간말일(period_end, 분기말 3/31·6/30·9/30·12/31)이고,
+# `available_date`는 그 데이터가 실제로 **알 수 있게 된 시점**(point-in-time,
+# DART 공시 접수일 rcept_dt)이다(#2010). lookahead bias를 피하려면 소비자가
+# `available_date` 기준 as-of join을 해야 하지만, consumer 전환은 별도 이슈
+# (#2067)이며 본 스키마는 producer가 `available_date`를 **저장**만 한다.
+# `available_date`는 nullable이다 — 소스(rcept_no)가 없거나 접수일 파싱이
+# 실패한 행은 null로 강등되고, data.go.kr 등 DART가 아닌 소스 행에서도 null이다.
 FUNDAMENTAL_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
     "date": pl.Date,
+    "available_date": pl.Date,
     "symbol": pl.Utf8,
     "market_cap": pl.Int64,
     "shares_listed": pl.Int64,

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -103,6 +103,12 @@ def _natural_key(data_type: str, columns: list[str]) -> list[str]:
       data.go.kr의 같은 거래일 일별 fundamental과 같은 월 파티션에서
       date가 충돌할 수 있다. `source`까지 키에 포함하면 두 소스의
       서로 다른(null-complementary) 행을 **모두 보존**한다(#1964).
+      `available_date`(point-in-time 공시 접수일, #2010)는 논리 행을
+      식별하는 키가 아니라 **value 속성**이므로 natural key에 넣지 않는다.
+      key는 period_end(`date`)+`source`로 한 분기·소스당 한 논리 행을
+      식별하고, 정정공시/재제출로 동일 period_end에 후속 접수가 들어오면
+      `keep="last"`가 최신 `available_date`/값으로 overwrite한다(완전한
+      revision history 보존은 비목표, known-limitation).
     - ohlcv/tick(및 기타 default): `["timestamp"]`(존재 시) 또는 `[]`.
 
     Args:

--- a/tests/unit/feed/test_dart_collector.py
+++ b/tests/unit/feed/test_dart_collector.py
@@ -1009,3 +1009,73 @@ class TestCorpCodeCacheReuse:
 
         assert source.calls == 1
         assert result == {"00126380": "005930"}
+
+
+class TestAvailableDateEndToEnd:
+    """#2010: raw_items의 rcept_no가 collector→실제 normalizer→store를 거쳐
+
+    available_date(point-in-time 접수일)로 저장되는지 end-to-end로 확인한다.
+    (collector는 raw dict를 projection 없이 normalize에 넘긴다.)
+    """
+
+    async def test_rcept_no_flows_to_store_as_available_date(
+        self, tmp_path: Path
+    ) -> None:
+        """raw_items에 rcept_no가 있으면 store에 available_date가 저장된다."""
+        store = ParquetStore(base_path=tmp_path / "data")
+        # 실제 DARTNormalizer를 쓰는 collector(normalizer 미주입 → 기본 실제 사용).
+        collector = DARTCollector(source=object())
+
+        raw_items = [
+            {
+                "rcept_no": "20250315000001",  # 앞 8자리 = 접수일 2025-03-15
+                "corp_code": "00126380",
+                "account_nm": "당기순이익",
+                "thstrm_amount": "200,000",
+                "fs_div": "CFS",
+                "reprt_code": "11013",  # 1Q → period_end 3/31
+                "bsns_year": "2025",
+            },
+        ]
+
+        written, syms = collector._normalize_and_store(
+            raw_items,
+            {"00126380": "005930"},
+            store,
+        )
+
+        assert written == 1
+        assert syms == {"005930"}
+
+        result = store.read("005930", "krx", data_type="fundamental")
+        assert len(result) == 1
+        assert "available_date" in result.columns
+        assert result["date"][0] == date(2025, 3, 31)  # period_end
+        assert result["available_date"][0] == date(2025, 3, 15)  # 접수일
+
+    async def test_no_rcept_no_stores_null_available_date(self, tmp_path: Path) -> None:
+        """raw_items에 rcept_no가 없어도 정상 저장되고 available_date=null."""
+        store = ParquetStore(base_path=tmp_path / "data")
+        collector = DARTCollector(source=object())
+
+        raw_items = [
+            {
+                "corp_code": "00126380",
+                "account_nm": "당기순이익",
+                "thstrm_amount": "200,000",
+                "fs_div": "CFS",
+                "reprt_code": "11011",
+                "bsns_year": "2025",
+            },
+        ]
+
+        written, syms = collector._normalize_and_store(
+            raw_items,
+            {"00126380": "005930"},
+            store,
+        )
+
+        assert written == 1
+        result = store.read("005930", "krx", data_type="fundamental")
+        assert "available_date" in result.columns
+        assert result["available_date"][0] is None

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -93,18 +93,22 @@ class TestSchemas:
         assert validate_ohlcv(df) is False
 
     def test_fundamental_schema_field_count(self):
-        assert len(FUNDAMENTAL_SCHEMA) == 18
+        # available_date(point-in-time 공시 접수일, #2010)를 추가해 19개.
+        assert len(FUNDAMENTAL_SCHEMA) == 19
 
     def test_fundamental_columns_list(self):
         assert "date" in FUNDAMENTAL_COLUMNS
+        assert "available_date" in FUNDAMENTAL_COLUMNS  # #2010
         assert "symbol" in FUNDAMENTAL_COLUMNS
         assert "market_cap" in FUNDAMENTAL_COLUMNS
         assert "per" in FUNDAMENTAL_COLUMNS
         assert "source" in FUNDAMENTAL_COLUMNS
-        assert len(FUNDAMENTAL_COLUMNS) == 18
+        assert len(FUNDAMENTAL_COLUMNS) == 19
 
     def test_fundamental_schema_types(self):
         assert FUNDAMENTAL_SCHEMA["date"] == pl.Date
+        # available_date도 Date 타입이며 nullable이다(#2010).
+        assert FUNDAMENTAL_SCHEMA["available_date"] == pl.Date
         assert FUNDAMENTAL_SCHEMA["symbol"] == pl.Utf8
         assert FUNDAMENTAL_SCHEMA["market_cap"] == pl.Int64
         assert FUNDAMENTAL_SCHEMA["per"] == pl.Float64
@@ -519,6 +523,76 @@ class TestParquetStore:
         # merge 이상이 없었음(silent overwrite 경로 제거 확인)
         assert store.drain_warnings() == []
 
+    async def test_store_fundamental_available_date_roundtrip(self, store):
+        """(c) available_date를 포함한 fundamental write→read 라운드트립 보존(#2010).
+
+        date(period_end)와 available_date(point-in-time 접수일)가 모두 보존되고,
+        같은 데이터 재write 시 natural key [date, source] dedup(keep="last")이
+        유지되어 행이 폭증하지 않는다(available_date는 키가 아니라 value).
+        """
+        from datetime import date
+
+        dart = pl.DataFrame(
+            {
+                "date": [date(2025, 9, 30)],
+                "available_date": [date(2025, 11, 14)],
+                "symbol": ["005930"],
+                "net_income": [300000000000],
+                "total_equity": [6000000000000],
+                "source": ["dart"],
+            }
+        )
+        store.write("005930", "krx", dart, data_type="fundamental")
+        # 동일 데이터 재write → dedup 멱등 확인.
+        store.write("005930", "krx", dart, data_type="fundamental")
+
+        result = store.read("005930", "krx", data_type="fundamental")
+
+        # [date, source] dedup으로 단일 행 유지(재write로 폭증하지 않음).
+        assert len(result) == 1
+        # 두 날짜 컬럼이 모두 보존된다.
+        assert "available_date" in result.columns
+        assert result["date"][0] == date(2025, 9, 30)
+        assert result["available_date"][0] == date(2025, 11, 14)
+        assert result.schema["available_date"] == pl.Date
+
+    async def test_store_fundamental_available_date_revision_keeps_last(self, store):
+        """known-limitation(#2010): 동일 [date, source]에 후속 available_date는
+
+        natural key가 [date, source]라 정정공시/재제출로 같은 period_end·source에
+        다른 available_date가 와도 최신값(keep="last")으로 overwrite된다(완전한
+        revision history 보존은 비목표). 두 번째 write의 available_date가 남는다.
+        """
+        from datetime import date
+
+        first = pl.DataFrame(
+            {
+                "date": [date(2025, 9, 30)],
+                "available_date": [date(2025, 11, 14)],
+                "symbol": ["005930"],
+                "net_income": [300000000000],
+                "source": ["dart"],
+            }
+        )
+        revised = pl.DataFrame(
+            {
+                "date": [date(2025, 9, 30)],
+                "available_date": [date(2025, 12, 1)],  # 정정공시 후속 접수일
+                "symbol": ["005930"],
+                "net_income": [310000000000],
+                "source": ["dart"],
+            }
+        )
+        store.write("005930", "krx", first, data_type="fundamental")
+        store.write("005930", "krx", revised, data_type="fundamental")
+
+        result = store.read("005930", "krx", data_type="fundamental")
+
+        # period_end+source가 같으므로 한 논리 행만 남고 최신값으로 overwrite.
+        assert len(result) == 1
+        assert result["available_date"][0] == date(2025, 12, 1)
+        assert result["net_income"][0] == 310000000000
+
     async def test_store_read_heterogeneous_monthly_schemas(self, store):
         """월마다 스키마가 다른 파티션을 raise 없이 합집합으로 읽는다(#1964).
 
@@ -556,6 +630,46 @@ class TestParquetStore:
         assert len(result) == 2
         cols = set(result.columns)
         assert {"market_cap", "shares_listed", "total_assets", "net_income"} <= cols
+
+    async def test_store_read_tolerates_available_date_only_in_one_source(self, store):
+        """(d) read union이 available_date를 가진 파티션과 없는 파티션을 섞어도
+
+        diagonal_relaxed가 추가 nullable 컬럼(available_date)을 null-fill로
+        tolerate한다(#2010). DART 행만 available_date를 갖고 data.go.kr 행은
+        available_date가 null로 채워진다(예외 없음).
+        """
+        from datetime import date
+
+        # data.go.kr: available_date 없음(8월 파티션)
+        dg = pl.DataFrame(
+            {
+                "date": [date(2025, 8, 14)],
+                "symbol": ["005930"],
+                "market_cap": [480000000000],
+                "source": ["data_go_kr"],
+            }
+        )
+        # DART: available_date 보유(9월 파티션)
+        dart = pl.DataFrame(
+            {
+                "date": [date(2025, 9, 30)],
+                "available_date": [date(2025, 11, 14)],
+                "symbol": ["005930"],
+                "net_income": [300000000000],
+                "source": ["dart"],
+            }
+        )
+        store.write("005930", "krx", dg, data_type="fundamental")
+        store.write("005930", "krx", dart, data_type="fundamental")
+
+        result = store.read("005930", "krx", data_type="fundamental")
+        assert len(result) == 2
+        assert "available_date" in result.columns
+        # data.go.kr 행은 available_date null, DART 행은 접수일 보유.
+        dg_row = result.filter(pl.col("source") == "data_go_kr")
+        dart_row = result.filter(pl.col("source") == "dart")
+        assert dg_row["available_date"][0] is None
+        assert dart_row["available_date"][0] == date(2025, 11, 14)
 
     async def test_read_strict_raises_on_corrupt_partition(self, store, data_dir):
         """strict=True면 손상 파티션을 만나는 즉시 ParquetReadError를 raise(#2095).
@@ -1944,6 +2058,102 @@ class TestDARTNormalizer:
 
         assert "dart" in DART_NORMALIZER_REGISTRY
         assert DART_NORMALIZER_REGISTRY["dart"] is DARTNormalizer
+
+    # ── available_date (point-in-time 공시 접수일, #2010) ──────────────
+
+    def test_available_date_from_rcept_no(self, dart_normalizer, corp_code_map):
+        """(a) rcept_no 존재 시 date=period_end + available_date=접수일 공존.
+
+        rcept_no=20250315000001(앞 8자리 20250315) + reprt=11013/year=2025 →
+        date==2025-03-31(분기말일/period_end), available_date==2025-03-15.
+        """
+        from datetime import date
+
+        df = _make_dart_df(
+            reprt_codes=["11013"] * 5,
+            bsns_years=["2025"] * 5,
+        ).with_columns(pl.lit("20250315000001").alias("rcept_no"))
+
+        result = dart_normalizer.normalize(df, corp_code_map)
+
+        assert len(result) == 1
+        # period_end(분기말일)는 무변경.
+        assert result["date"][0] == date(2025, 3, 31)
+        # point-in-time 접수일은 rcept_no 앞 8자리.
+        assert "available_date" in result.columns
+        assert result["available_date"][0] == date(2025, 3, 15)
+
+    def test_available_date_null_when_rcept_no_absent(
+        self, dart_normalizer, corp_code_map
+    ):
+        """(b) rcept_no 부재 시 available_date=null + 행 생성·예외 없음(graceful)."""
+        from datetime import date
+
+        df = _make_dart_df(
+            reprt_codes=["11011"] * 5,
+            bsns_years=["2025"] * 5,
+        )
+        assert "rcept_no" not in df.columns
+
+        result = dart_normalizer.normalize(df, corp_code_map)
+
+        # 행은 정상 생성되고 재무 값도 보존된다.
+        assert len(result) == 1
+        assert result["date"][0] == date(2025, 12, 31)
+        assert result["revenue"][0] == 1_000_000
+        # available_date 컬럼은 존재하되 null이다(Date dtype).
+        assert "available_date" in result.columns
+        assert result.schema["available_date"] == pl.Date
+        assert result["available_date"][0] is None
+
+    def test_available_date_rcept_no_14digit_prefix_format(
+        self, dart_normalizer, corp_code_map
+    ):
+        """(e) rcept_no 14자리의 앞 8자리만 YYYYMMDD로 파싱(뒤 6자리 일련번호 무시)."""
+        from datetime import date
+
+        # 14자리 접수번호: 앞 8(20231130) = 접수일, 뒤 6(000042) = 일련번호.
+        df = _make_dart_df(
+            reprt_codes=["11014"] * 5,
+            bsns_years=["2023"] * 5,
+        ).with_columns(pl.lit("20231130000042").alias("rcept_no"))
+
+        result = dart_normalizer.normalize(df, corp_code_map)
+
+        assert result["available_date"][0] == date(2023, 11, 30)
+        # period_end는 분기(3Q=9/30)말일로 별개.
+        assert result["date"][0] == date(2023, 9, 30)
+
+    def test_available_date_non_yyyymmdd_degrades_to_null(
+        self, dart_normalizer, corp_code_map
+    ):
+        """(e) 비YYYYMMDD rcept_no 앞 8자리는 strict=False로 null 강등(예외 없음)."""
+        df = _make_dart_df(
+            reprt_codes=["11011"] * 5,
+            bsns_years=["2025"] * 5,
+        ).with_columns(pl.lit("ABCDEFGH999999").alias("rcept_no"))
+
+        result = dart_normalizer.normalize(df, corp_code_map)
+
+        # 행은 생성되고 available_date만 null로 강등.
+        assert len(result) == 1
+        assert result["available_date"][0] is None
+        # period_end·재무 값은 정상.
+        assert result["revenue"][0] == 1_000_000
+
+    def test_available_date_invalid_calendar_date_degrades_to_null(
+        self, dart_normalizer, corp_code_map
+    ):
+        """(e) 8자리지만 달력상 불가능한 날짜(20251345)도 null 강등."""
+        df = _make_dart_df(
+            reprt_codes=["11011"] * 5,
+            bsns_years=["2025"] * 5,
+        ).with_columns(pl.lit("20251345000001").alias("rcept_no"))
+
+        result = dart_normalizer.normalize(df, corp_code_map)
+
+        assert len(result) == 1
+        assert result["available_date"][0] is None
 
 
 # ── datasets.py (data info / data list) row_count·file_size (#1982) ──────────


### PR DESCRIPTION
Closes #2010

## Summary
- DART 재무 행이 분기말일(period_end)로만 저장돼 lookahead 위험이 있던 것을, **공시 접수일 `available_date`**(nullable, period_end와 별도 컬럼)를 함께 저장하도록 보강. **producer 전용** — as-of join 키 변경(consumer)은 #2067.
- rcept_dt를 **이미 수신한 `fnlttMultiAcnt` 응답의 `rcept_no`(앞 8자리=YYYYMMDD)**에서 추출(스펙 05-data-sources.md L84 list.json과 동일 point-in-time 목적의 Phase-1 대체경로 — 별도 API 호출 불필요).
- schemas: `FUNDAMENTAL_SCHEMA`에 `available_date: pl.Date`(nullable, validate required 무변경). normalizer: `rcept_no[:8]→Date`(strict=False, 부재/비형식→null graceful), pivot index 포함. store: `_natural_key=[date,source]` 유지(available_date=value 컬럼, 정정공시 keep=last known-limitation).

## Test Plan
- normalizer 5(공존/부재 null/형식/비YYYYMMDD/불가능날짜), store 4(라운드트립·dedup·정정공시·union tolerate), collector 2(e2e rcept_no→available_date)
- 전체 `pytest tests/unit/`: 6744 passed, 2 skipped, 0 failed. FUNDAMENTAL_COLUMNS 18→19 단언 갱신
- ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (953b0bca)

🤖 Generated with [Claude Code](https://claude.com/claude-code)