### PR TITLE
fix(feed): #2067 fundamental as-of join을 공시 접수일(available_date) 기준으로 — lookahead 제거

### DIFF
--- a/src/ante/feed/pipeline/indicator_calculator.py
+++ b/src/ante/feed/pipeline/indicator_calculator.py
@@ -19,6 +19,28 @@ semantic(#1968, PR 명문화):
     후속 정제 이슈). 분모가 0/null이면 해당 지표는 null이다
     (``_ratio_expr`` 가드 유지). 지표는 가격 기반 지표의 자연 단위인 **일별
     행**(data.go.kr 행)에 부여하여 write-back한다.
+
+lookahead 제거(#2067):
+    as-of join 키를 분기 **period_end(date)** 가 아니라 그 재무가 실제로
+    **공시되어 알 수 있게 된 시점**(availability)로 바꾼다. period_end부터
+    분기 값을 적용하면, 예컨대 Q1(3/31) 재무가 공시(5월 중순)되기 전인 4월
+    거래일에 미래 정보를 쓰게 되어 lookahead bias가 발생한다.
+
+    분기 프레임마다 effective availability 키를 계산한다::
+
+        effective = coalesce(available_date, period_end + statutory_lag)
+
+    - ``available_date``(#2010, DART 공시 접수일 rcept_dt)가 있으면 **그대로**
+      쓴다(point-in-time 정확).
+    - 없는 legacy 행은 **자본시장법 법정 제출기한**으로 보수적 fallback한다:
+      분기/반기/3분기 보고서(period_end 월 ∈ {3,6,9})는 기말 후 45일,
+      사업보고서(period_end 월 == 12)는 기말 후 90일.
+    - 일별 거래일 ``date``(data.go.kr, point-in-time 정확)는 변경하지 않는다.
+
+    known-limitation: available_date 없는 legacy 행의 fallback은 "법정기한 내
+    공시" 가정이라 지연제출/정정공시/특수연장은 완전히 보장하지 못한다. 다만
+    fallback은 실제 공시일보다 **늦은(보수적)** 쪽이라 lookahead 측면에서는
+    안전하다(실제보다 며칠 늦게 반영될 뿐 미래 정보를 당겨쓰지 않는다).
 """
 
 from __future__ import annotations
@@ -35,6 +57,30 @@ logger = logging.getLogger(__name__)
 # source별 행 분리 기준 (normalizer가 부여하는 source 문자열 SSOT).
 _DAILY_SOURCE = "data_go_kr"
 _QUARTERLY_SOURCE = "dart"
+
+# 분기 프레임의 period-end(기말일) 컬럼. 일별 거래일 date와 동명이지만 의미가
+# 다르다(분기 행에서는 period_end, 일별 행에서는 거래일). as-of 결합은 더 이상
+# 이 컬럼을 직접 join 키로 쓰지 않는다(#2067 lookahead 제거).
+_PERIOD_END_KEY = "date"
+
+# DART 공시 접수일(point-in-time availability, #2010). nullable.
+_AVAILABLE_DATE_KEY = "available_date"
+
+# effective availability 키와 join_asof 양쪽 alias용 임시 컬럼명. write-back
+# 전 반드시 제거한다(FUNDAMENTAL 스키마 밖이므로 _FUNDAMENTAL_COLUMN_SET 필터로
+# 자연 제거되지만, 명시적으로도 drop한다).
+_EFFECTIVE_KEY = "_effective_available"
+_ASOF_KEY = "_asof_join_key"
+
+# 자본시장법 법정 제출기한(보수적 fallback). available_date가 없는 legacy 행에
+# 한해 period_end 월로 분류해 더한다:
+#   - 분기/반기/3분기 보고서(period_end 월 3/6/9) → 기말 후 45일
+#   - 사업(연간)보고서(period_end 월 12) → 기말 후 90일
+# 이 외(비표준) 월의 행은 분류 불가 → join 전 제거한다.
+_LAG_QUARTERLY_DAYS = 45
+_LAG_ANNUAL_DAYS = 90
+_QUARTERLY_PERIOD_END_MONTHS = (3, 6, 9)
+_ANNUAL_PERIOD_END_MONTH = 12
 
 # as-of join 키.
 _JOIN_KEY = "date"
@@ -151,7 +197,7 @@ class IndicatorCalculator:
         daily: pl.DataFrame,
         quarterly: pl.DataFrame,
     ) -> pl.DataFrame | None:
-        """일별 프레임에 그 날짜 기준 가장 최근 분기 재무를 as-of 결합한다.
+        """일별 거래일에 그 시점 이전 **공시된** 가장 최근 분기 재무를 결합한다.
 
         ``store.read``의 ``diagonal_relaxed`` union 때문에 daily/quarterly
         sub-frame은 동일한 컬럼 union을 보유한다(상대 소스 컬럼은 null-fill).
@@ -159,12 +205,26 @@ class IndicatorCalculator:
 
         - 일별 프레임에서 ``_QUARTERLY_FINANCIAL_COLUMNS``(일별 행에선 null)를
           **버려** join 후 분기 값이 null로 덮이지 않게 한다.
-        - 분기 프레임에서는 그 재무 컬럼만 join 키(date)와 함께 **가져온다**.
+        - 분기 프레임에서는 그 재무 컬럼만 **availability 키**와 함께 가져온다.
 
-        결합 결과는 일별 identity(date, symbol, source=data_go_kr,
-        market_cap, shares_listed 등)를 유지하면서 그 날짜 이전 가장 최근
-        분기 재무를 부여받는다. 가져올 분기 재무 컬럼이 하나도 없으면
-        ``None``을 반환한다.
+        as-of 키는 분기 period_end가 아니라 effective availability다(#2067):
+
+            effective = coalesce(available_date, period_end + statutory_lag)
+
+        - ``available_date``(#2010)가 있으면 그대로(point-in-time).
+        - 없으면 period_end 월로 법정 제출기한을 도출:
+          {3,6,9} → +45일, 12 → +90일.
+        - 비표준 period_end 월(위 4개월이 아님) 또는 effective가 끝내 null인
+          행은 정렬·결합 안정성을 위해 **join 전 제거**한다.
+
+        그 다음 일별 거래일 ``date`` ↔ 분기 ``effective``를 동일한 임시 join
+        컬럼명(``_ASOF_KEY``)으로 alias하고 ``strategy="backward"``로 결합한다
+        (backward는 inclusive — 거래일 == effective면 적용). 결합 결과는 일별
+        identity를 유지하면서, 그 거래일 **이전(또는 당일) 공시된** 가장 최근
+        분기 재무만 부여받는다. 임시 키는 결합 직후 제거한다.
+
+        가져올 분기 재무 컬럼이 하나도 없거나, effective availability를 가진
+        분기 행이 하나도 남지 않으면 ``None``을 반환한다.
         """
         financial_cols = [
             col for col in _QUARTERLY_FINANCIAL_COLUMNS if col in quarterly.columns
@@ -172,15 +232,67 @@ class IndicatorCalculator:
         if not financial_cols:
             return None
 
+        quarterly_eff = IndicatorCalculator._with_effective_availability(quarterly)
+        if quarterly_eff.is_empty():
+            return None
+
         # 일별 프레임에서 분기 재무 컬럼(null-fill된 잔재)을 제거해 충돌 차단.
         daily_identity = daily.drop([c for c in financial_cols if c in daily.columns])
-        quarterly_fin = quarterly.select([_JOIN_KEY, *financial_cols])
 
-        return daily_identity.sort(_JOIN_KEY).join_asof(
-            quarterly_fin.sort(_JOIN_KEY),
-            on=_JOIN_KEY,
+        # 양쪽을 동일한 임시 join 키로 alias: 일별=거래일 date, 분기=effective.
+        daily_keyed = daily_identity.with_columns(
+            pl.col(_JOIN_KEY).alias(_ASOF_KEY),
+        )
+        quarterly_keyed = quarterly_eff.select(
+            pl.col(_EFFECTIVE_KEY).alias(_ASOF_KEY),
+            *[pl.col(c) for c in financial_cols],
+        )
+
+        joined = daily_keyed.sort(_ASOF_KEY).join_asof(
+            quarterly_keyed.sort(_ASOF_KEY),
+            on=_ASOF_KEY,
             strategy="backward",
         )
+        # 임시 join 키 제거(스키마 밖). _EFFECTIVE_KEY는 분기 프레임에만 있었고
+        # select로 가져오지 않았으므로 결합 결과엔 없다.
+        return joined.drop(_ASOF_KEY)
+
+    @staticmethod
+    def _with_effective_availability(quarterly: pl.DataFrame) -> pl.DataFrame:
+        """분기 프레임에 effective availability 키(``_EFFECTIVE_KEY``)를 부여한다.
+
+        ``effective = coalesce(available_date, period_end + statutory_lag)``.
+        statutory_lag은 period_end 월로 분류한다(3/6/9 → +45일, 12 → +90일).
+        비표준 period_end 월이면서 available_date도 없는 행, 또는 effective가
+        끝내 null인 행은 **제거**한다(as-of 정렬 안정성 + lookahead 안전).
+
+        ``available_date`` 컬럼은 #2010 이전 legacy 파티션에는 아예 없을 수
+        있으므로(존재해도 nullable), 없으면 전 행 null(=법정기한 fallback만
+        사용)로 취급한다.
+        """
+        if _AVAILABLE_DATE_KEY in quarterly.columns:
+            available = pl.col(_AVAILABLE_DATE_KEY)
+        else:
+            available = pl.lit(None, dtype=pl.Date)
+
+        month = pl.col(_PERIOD_END_KEY).dt.month()
+        # period_end 월로 법정 제출기한(일수)을 분류. 비표준 월은 null.
+        lag_days = (
+            pl.when(month.is_in(list(_QUARTERLY_PERIOD_END_MONTHS)))
+            .then(pl.lit(_LAG_QUARTERLY_DAYS))
+            .when(month == _ANNUAL_PERIOD_END_MONTH)
+            .then(pl.lit(_LAG_ANNUAL_DAYS))
+            .otherwise(None)
+        )
+        # period_end + statutory_lag (분류 불가 월이면 lag_days null → fallback도
+        # null로 전파).
+        fallback = pl.col(_PERIOD_END_KEY) + pl.duration(days=lag_days)
+
+        with_eff = quarterly.with_columns(
+            pl.coalesce(available, fallback).cast(pl.Date).alias(_EFFECTIVE_KEY),
+        )
+        # effective가 null인 행 제거(available_date 없고 + period_end 월도 비표준).
+        return with_eff.filter(pl.col(_EFFECTIVE_KEY).is_not_null())
 
     @staticmethod
     def _build_expressions(cols: set[str]) -> list[pl.Expr]:

--- a/tests/unit/feed/test_indicator_calculator.py
+++ b/tests/unit/feed/test_indicator_calculator.py
@@ -2,8 +2,17 @@
 
 #1968: data.go.kr 일별(market_cap/shares_listed) + DART 분기(net_income/
 total_equity/total_debt)가 `(date, source)` natural key로 별도 행으로 보존된다
-(#1964). 파생지표는 일별 행에 그 날짜 기준 **가장 최근 보고된 분기 재무**를
+(#1964). 파생지표는 일별 거래일에 그 시점 이전 **공시된** 가장 최근 분기 재무를
 `join_asof(strategy="backward")`로 결합하여 계산한다.
+
+#2067 (lookahead 제거): as-of join 키를 분기 period_end가 아니라 effective
+availability(`coalesce(available_date, period_end + statutory_lag)`)로 바꾼다.
+- `available_date`(#2010, 공시 접수일)가 있으면 그대로 쓴다.
+- 없는 legacy 행은 법정 제출기한으로 fallback: period_end 월 ∈ {3,6,9} → +45일,
+  월 == 12 → +90일. 비표준 월/effective null 행은 join 전 제거한다.
+
+따라서 period_end 3/31 분기 재무는 (available_date 미지정 legacy 기준) 5/15부터
+일별 행에 적용된다 — 공시 전인 4월 거래일에는 미래 정보를 쓰지 않는다.
 
 이 모듈은 `ante.feed.pipeline.indicator_calculator.IndicatorCalculator`
 (fundamental 비율 계산기)를 검증한다 — `ante.strategy.indicators`의
@@ -50,21 +59,24 @@ def _daily_rows(store: ParquetStore) -> pl.DataFrame:
 def test_indicator_asof_join_non_null(store: ParquetStore) -> None:
     """일별+분기 혼합 fixture에서 as-of 결합 후 6종 지표가 non-null & 정확하다.
 
-    수정 전(row-wise): 일별 행에 net_income 등이 null이라 모든 지표 null → FAIL.
+    #2067: as-of 키는 공시 시점(effective availability)이다. 일별 날짜는 각
+    분기의 **공시 이후** 시점으로 둔다.
+    - Q1(period_end 3/31, available_date 5/15) → 6/15 일별이 Q1 적용.
+    - Q2(period_end 6/30, available_date 8/14) → 9/15 일별이 Q2 적용.
     """
-    # data.go.kr 일별 행: Q1 보고(3/31) 이후 두 날짜 (4월/7월).
+    # data.go.kr 일별 행: 각 분기의 공시 시점 이후 두 날짜.
     _write_daily(
         store,
         [
             {
-                "date": date(2024, 4, 15),
+                "date": date(2024, 6, 15),
                 "symbol": SYMBOL,
                 "market_cap": 420_000_000_000_000,
                 "shares_listed": 5_969_782_550,
                 "source": "data_go_kr",
             },
             {
-                "date": date(2024, 7, 15),
+                "date": date(2024, 9, 15),
                 "symbol": SYMBOL,
                 "market_cap": 440_000_000_000_000,
                 "shares_listed": 5_969_782_550,
@@ -72,12 +84,13 @@ def test_indicator_asof_join_non_null(store: ParquetStore) -> None:
             },
         ],
     )
-    # DART 분기 행: Q1(3/31), Q2(6/30).
+    # DART 분기 행: Q1(period_end 3/31, 공시 5/15), Q2(period_end 6/30, 공시 8/14).
     _write_quarterly(
         store,
         [
             {
                 "date": date(2024, 3, 31),
+                "available_date": date(2024, 5, 15),
                 "symbol": SYMBOL,
                 "net_income": 50_000_000_000_000,
                 "total_equity": 300_000_000_000_000,
@@ -86,6 +99,7 @@ def test_indicator_asof_join_non_null(store: ParquetStore) -> None:
             },
             {
                 "date": date(2024, 6, 30),
+                "available_date": date(2024, 8, 14),
                 "symbol": SYMBOL,
                 "net_income": 55_000_000_000_000,
                 "total_equity": 310_000_000_000_000,
@@ -101,43 +115,47 @@ def test_indicator_asof_join_non_null(store: ParquetStore) -> None:
     daily = _daily_rows(store)
     assert len(daily) == 2
 
-    # 4/15 → as-of Q1(3/31) 재무.
-    apr = daily.filter(pl.col("date") == date(2024, 4, 15)).row(0, named=True)
-    assert apr["per"] is not None
-    assert abs(apr["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
-    assert abs(apr["pbr"] - 420_000_000_000_000 / 300_000_000_000_000) < 1e-9
-    assert abs(apr["eps"] - 50_000_000_000_000 / 5_969_782_550) < 1e-3
-    assert abs(apr["bps"] - 300_000_000_000_000 / 5_969_782_550) < 1e-3
-    assert abs(apr["roe"] - 50_000_000_000_000 / 300_000_000_000_000) < 1e-12
+    # 6/15 → Q1 공시(5/15) 이후, Q2 공시(8/14) 이전 → Q1(3/31) 재무.
+    jun = daily.filter(pl.col("date") == date(2024, 6, 15)).row(0, named=True)
+    assert jun["per"] is not None
+    assert abs(jun["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
+    assert abs(jun["pbr"] - 420_000_000_000_000 / 300_000_000_000_000) < 1e-9
+    assert abs(jun["eps"] - 50_000_000_000_000 / 5_969_782_550) < 1e-3
+    assert abs(jun["bps"] - 300_000_000_000_000 / 5_969_782_550) < 1e-3
+    assert abs(jun["roe"] - 50_000_000_000_000 / 300_000_000_000_000) < 1e-12
     assert (
-        abs(apr["debt_to_equity"] - 100_000_000_000_000 / 300_000_000_000_000) < 1e-12
+        abs(jun["debt_to_equity"] - 100_000_000_000_000 / 300_000_000_000_000) < 1e-12
     )
 
-    # 7/15 → as-of Q2(6/30) 재무 (가장 최근 보고서).
-    jul = daily.filter(pl.col("date") == date(2024, 7, 15)).row(0, named=True)
-    assert abs(jul["per"] - 440_000_000_000_000 / 55_000_000_000_000) < 1e-6
-    assert abs(jul["pbr"] - 440_000_000_000_000 / 310_000_000_000_000) < 1e-9
-    assert abs(jul["roe"] - 55_000_000_000_000 / 310_000_000_000_000) < 1e-12
+    # 9/15 → Q2 공시(8/14) 이후 → Q2(6/30) 재무 (가장 최근 공시).
+    sep = daily.filter(pl.col("date") == date(2024, 9, 15)).row(0, named=True)
+    assert abs(sep["per"] - 440_000_000_000_000 / 55_000_000_000_000) < 1e-6
+    assert abs(sep["pbr"] - 440_000_000_000_000 / 310_000_000_000_000) < 1e-9
+    assert abs(sep["roe"] - 55_000_000_000_000 / 310_000_000_000_000) < 1e-12
     assert (
-        abs(jul["debt_to_equity"] - 105_000_000_000_000 / 310_000_000_000_000) < 1e-12
+        abs(sep["debt_to_equity"] - 105_000_000_000_000 / 310_000_000_000_000) < 1e-12
     )
 
 
-def test_indicator_asof_boundary_before_first_report_null(store: ParquetStore) -> None:
-    """첫 분기 보고 이전 일별 날짜는 결합할 재무가 없어 지표가 null이다."""
-    # 일별 행: 1/15(Q1 3/31 이전), 4/15(Q1 이후).
+def test_indicator_lookahead_blocked_until_available_date(store: ParquetStore) -> None:
+    """[#2067 lookahead 차단] period_end 이후라도 공시 전이면 재무가 null이다.
+
+    Q1 period_end 3/31, available_date(공시) 5/15. 일별 4/15는 period_end
+    이후지만 **공시 전**이라 재무 미적용(null) — period_end 기준이면 lookahead로
+    적용됐을 시점. 5/20은 공시 이후라 Q1 적용.
+    """
     _write_daily(
         store,
         [
             {
-                "date": date(2024, 1, 15),
+                "date": date(2024, 4, 15),  # period_end(3/31) 이후, 공시(5/15) 이전
                 "symbol": SYMBOL,
                 "market_cap": 400_000_000_000_000,
                 "shares_listed": 5_969_782_550,
                 "source": "data_go_kr",
             },
             {
-                "date": date(2024, 4, 15),
+                "date": date(2024, 5, 20),  # 공시(5/15) 이후
                 "symbol": SYMBOL,
                 "market_cap": 420_000_000_000_000,
                 "shares_listed": 5_969_782_550,
@@ -145,6 +163,103 @@ def test_indicator_asof_boundary_before_first_report_null(store: ParquetStore) -
             },
         ],
     )
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                "available_date": date(2024, 5, 15),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    IndicatorCalculator().compute(store, [SYMBOL])
+
+    daily = _daily_rows(store)
+
+    # 4/15: period_end 이후지만 공시(5/15) 전 → 미공시 → null (lookahead 차단).
+    apr = daily.filter(pl.col("date") == date(2024, 4, 15)).row(0, named=True)
+    assert apr["per"] is None
+    assert apr["pbr"] is None
+    assert apr["eps"] is None
+    assert apr["bps"] is None
+    assert apr["roe"] is None
+    assert apr["debt_to_equity"] is None
+
+    # 5/20: 공시 이후 → Q1 적용.
+    may = daily.filter(pl.col("date") == date(2024, 5, 20)).row(0, named=True)
+    assert may["per"] is not None
+    assert abs(may["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
+
+
+def test_indicator_available_date_boundary_inclusive(store: ParquetStore) -> None:
+    """[#2067 경계] 일별 date == available_date면 backward inclusive로 적용된다."""
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 5, 15),  # 공시일 당일
+                "symbol": SYMBOL,
+                "market_cap": 420_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                "available_date": date(2024, 5, 15),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    IndicatorCalculator().compute(store, [SYMBOL])
+
+    row = _daily_rows(store).row(0, named=True)
+    # 공시일 당일은 적용(inclusive).
+    assert row["per"] is not None
+    assert abs(row["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
+
+
+def test_indicator_legacy_fallback_statutory_lag_quarterly(store: ParquetStore) -> None:
+    """[#2067 legacy fallback] available_date null이면 period_end+45일을 쓴다.
+
+    Q1 period_end 3/31, available_date 미지정(legacy) → effective 5/15(+45일).
+    일별 5/01은 effective 전 → null, 5/20은 이후 → 적용.
+    """
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 5, 1),  # effective(5/15) 이전
+                "symbol": SYMBOL,
+                "market_cap": 400_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+            {
+                "date": date(2024, 5, 20),  # effective(5/15) 이후
+                "symbol": SYMBOL,
+                "market_cap": 420_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    # available_date 컬럼 자체를 쓰지 않는 legacy 분기 행.
     _write_quarterly(
         store,
         [
@@ -163,28 +278,174 @@ def test_indicator_asof_boundary_before_first_report_null(store: ParquetStore) -
 
     daily = _daily_rows(store)
 
-    # 1/15: 첫 분기 보고(3/31) 이전 → null.
-    jan = daily.filter(pl.col("date") == date(2024, 1, 15)).row(0, named=True)
-    assert jan["per"] is None
-    assert jan["pbr"] is None
-    assert jan["eps"] is None
-    assert jan["bps"] is None
-    assert jan["roe"] is None
-    assert jan["debt_to_equity"] is None
+    # 5/01: effective(3/31+45=5/15) 이전 → null.
+    may1 = daily.filter(pl.col("date") == date(2024, 5, 1)).row(0, named=True)
+    assert may1["per"] is None
+    assert may1["pbr"] is None
+    assert may1["roe"] is None
 
-    # 4/15: 분기 보고 이후 → non-null.
-    apr = daily.filter(pl.col("date") == date(2024, 4, 15)).row(0, named=True)
-    assert apr["per"] is not None
-    assert abs(apr["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
+    # 5/20: effective 이후 → Q1 적용.
+    may20 = daily.filter(pl.col("date") == date(2024, 5, 20)).row(0, named=True)
+    assert may20["per"] is not None
+    assert abs(may20["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
 
 
-def test_indicator_zero_denominator_null(store: ParquetStore) -> None:
-    """분모가 0이면 해당 지표가 null이다 (as-of 결합 경로)."""
+def test_indicator_legacy_fallback_statutory_lag_annual(store: ParquetStore) -> None:
+    """[#2067 연간 fallback] period_end 12/31, available null → 익년 3/31(+90일)."""
     _write_daily(
         store,
         [
             {
-                "date": date(2024, 4, 15),
+                "date": date(2025, 3, 15),  # effective(익년 3/31) 이전
+                "symbol": SYMBOL,
+                "market_cap": 400_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+            {
+                "date": date(2025, 4, 15),  # effective(2025-03-31) 이후
+                "symbol": SYMBOL,
+                "market_cap": 420_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 12, 31),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    IndicatorCalculator().compute(store, [SYMBOL])
+
+    daily = _daily_rows(store)
+
+    # 2025-03-15: effective(2024-12-31 + 90일 = 2025-03-31) 이전 → null.
+    mar = daily.filter(pl.col("date") == date(2025, 3, 15)).row(0, named=True)
+    assert mar["per"] is None
+
+    # 2025-04-15: effective 이후 → 연간 재무 적용.
+    apr = daily.filter(pl.col("date") == date(2025, 4, 15)).row(0, named=True)
+    assert apr["per"] is not None
+    assert abs(apr["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
+
+
+def test_indicator_available_date_used_over_fallback(store: ParquetStore) -> None:
+    """[#2067] available_date가 있으면 법정기한 fallback이 아니라 실제 공시일 사용.
+
+    period_end 3/31 fallback은 5/15(+45일)이지만 실제 공시(available_date)는
+    4/20으로 더 빠르다. 일별 4/25는 fallback(5/15) 기준이면 null이지만 실제
+    공시(4/20) 기준이면 적용 — available_date가 우선임을 검증한다.
+    """
+    _write_daily(
+        store,
+        [
+            {
+                # available_date(4/20) 이후, fallback(5/15) 이전.
+                "date": date(2024, 4, 25),
+                "symbol": SYMBOL,
+                "market_cap": 420_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    _write_quarterly(
+        store,
+        [
+            {
+                "date": date(2024, 3, 31),
+                # fallback(5/15)보다 빠른 실제 공시일.
+                "available_date": date(2024, 4, 20),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    IndicatorCalculator().compute(store, [SYMBOL])
+
+    row = _daily_rows(store).row(0, named=True)
+    # 실제 공시일(4/20) 기준 적용 — fallback(5/15)이면 null이었을 시점.
+    assert row["per"] is not None
+    assert abs(row["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
+
+
+def test_indicator_nonstandard_period_end_month_removed(store: ParquetStore) -> None:
+    """[#2067] 비표준 period_end 월 + available_date null 분기 행은 join 전 제거.
+
+    표준 분기 행(3/31, 공시 5/15)과 비표준 월 행(2/28, available_date null)을
+    함께 둔다. 비표준 행은 effective null로 제거되고, 표준 행만 as-of 적용된다.
+    graceful — 예외 없이 동작한다.
+    """
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 5, 20),
+                "symbol": SYMBOL,
+                "market_cap": 420_000_000_000_000,
+                "shares_listed": 5_969_782_550,
+                "source": "data_go_kr",
+            },
+        ],
+    )
+    _write_quarterly(
+        store,
+        [
+            # 비표준 period_end 월(2/28) + available_date 없음 → 제거 대상.
+            {
+                "date": date(2024, 2, 28),
+                "symbol": SYMBOL,
+                "net_income": 999_000_000_000_000,
+                "total_equity": 999_000_000_000_000,
+                "total_debt": 999_000_000_000_000,
+                "source": "dart",
+            },
+            # 표준 분기 행(3/31, 공시 5/15).
+            {
+                "date": date(2024, 3, 31),
+                "available_date": date(2024, 5, 15),
+                "symbol": SYMBOL,
+                "net_income": 50_000_000_000_000,
+                "total_equity": 300_000_000_000_000,
+                "total_debt": 100_000_000_000_000,
+                "source": "dart",
+            },
+        ],
+    )
+
+    rows = IndicatorCalculator().compute(store, [SYMBOL])
+    assert rows == 1
+
+    row = _daily_rows(store).row(0, named=True)
+    # 비표준 행이 제거되고 표준 Q1만 적용 → Q1 값으로 산출(999 값이 아님).
+    assert row["per"] is not None
+    assert abs(row["per"] - 420_000_000_000_000 / 50_000_000_000_000) < 1e-6
+
+
+def test_indicator_zero_denominator_null(store: ParquetStore) -> None:
+    """분모가 0이면 해당 지표가 null이다 (as-of 결합 경로).
+
+    재무가 실제 적용되도록 일별 날짜를 공시(available_date) 이후로 둔다.
+    """
+    _write_daily(
+        store,
+        [
+            {
+                "date": date(2024, 5, 20),  # 공시(5/15) 이후 → 재무 적용
                 "symbol": SYMBOL,
                 "market_cap": 400_000_000_000_000,
                 "shares_listed": 0,  # EPS/BPS 분모 0
@@ -197,6 +458,7 @@ def test_indicator_zero_denominator_null(store: ParquetStore) -> None:
         [
             {
                 "date": date(2024, 3, 31),
+                "available_date": date(2024, 5, 15),
                 "symbol": SYMBOL,
                 "net_income": 0,  # PER 분모 0
                 "total_equity": 0,  # PBR/ROE/부채비율 분모 0
@@ -218,12 +480,15 @@ def test_indicator_zero_denominator_null(store: ParquetStore) -> None:
 
 
 def test_indicator_null_denominator_null(store: ParquetStore) -> None:
-    """분기 재무 일부가 null이면 그 분모를 쓰는 지표만 null이 된다."""
+    """분기 재무 일부가 null이면 그 분모를 쓰는 지표만 null이 된다.
+
+    재무가 실제 적용되도록 일별 날짜를 공시(available_date) 이후로 둔다.
+    """
     _write_daily(
         store,
         [
             {
-                "date": date(2024, 4, 15),
+                "date": date(2024, 5, 20),  # 공시(5/15) 이후 → 재무 적용
                 "symbol": SYMBOL,
                 "market_cap": 400_000_000_000_000,
                 "shares_listed": 5_969_782_550,
@@ -237,6 +502,7 @@ def test_indicator_null_denominator_null(store: ParquetStore) -> None:
         [
             {
                 "date": date(2024, 3, 31),
+                "available_date": date(2024, 5, 15),
                 "symbol": SYMBOL,
                 "net_income": 50_000_000_000_000,
                 "total_equity": None,  # PBR/ROE/부채비율 분모 null
@@ -322,12 +588,14 @@ def test_indicator_writeback_within_fundamental_schema(store: ParquetStore) -> N
             },
         ],
     )
-    # 분기 행에 스키마 밖 컬럼(total_assets) 포함.
+    # 분기 행에 스키마 밖 컬럼(total_assets) 포함. 4/15 일별이 재무를 받도록
+    # available_date(공시일)를 4/1로 둔다(period_end 3/31 fallback 5/15보다 빠름).
     _write_quarterly(
         store,
         [
             {
                 "date": date(2024, 3, 31),
+                "available_date": date(2024, 4, 1),
                 "symbol": SYMBOL,
                 "net_income": 50_000_000_000_000,
                 "total_equity": 300_000_000_000_000,
@@ -340,7 +608,8 @@ def test_indicator_writeback_within_fundamental_schema(store: ParquetStore) -> N
 
     IndicatorCalculator().compute(store, [SYMBOL])
 
-    # 일별 행이 들어간 파티션 파일을 직접 검사 → 스키마 밖 컬럼 없어야 함.
+    # 일별 행이 들어간 파티션 파일을 직접 검사 → 스키마 밖 컬럼(total_assets,
+    # available_date 외 effective/temp 키 등) 없어야 함.
     daily_path = store.resolve_path(SYMBOL, "krx", data_type="fundamental")
     schema_set = set(FUNDAMENTAL_COLUMNS)
     daily_partition = daily_path / "2024-04.parquet"
@@ -350,6 +619,8 @@ def test_indicator_writeback_within_fundamental_schema(store: ParquetStore) -> N
         f"일별 write-back에 스키마 밖 컬럼 누출: {set(written.columns) - schema_set}"
     )
     assert written["source"].to_list() == ["data_go_kr"]
+    # 재무가 실제 적용됐는지(효력 있는 검증)도 함께 확인.
+    assert written["per"].to_list()[0] is not None
 
 
 def test_indicator_idempotent_recompute(store: ParquetStore) -> None:
@@ -371,6 +642,7 @@ def test_indicator_idempotent_recompute(store: ParquetStore) -> None:
         [
             {
                 "date": date(2024, 3, 31),
+                "available_date": date(2024, 4, 1),  # 4/15 일별이 재무를 받도록
                 "symbol": SYMBOL,
                 "net_income": 50_000_000_000_000,
                 "total_equity": 300_000_000_000_000,
@@ -387,7 +659,8 @@ def test_indicator_idempotent_recompute(store: ParquetStore) -> None:
     second = store.read(SYMBOL, "krx", data_type="fundamental")
 
     assert len(second) == len(first)
-    # 지표 값도 안정적.
+    # 지표 값도 안정적(non-null이며 동일).
     apr_first = first.filter(pl.col("source") == "data_go_kr").row(0, named=True)
     apr_second = second.filter(pl.col("source") == "data_go_kr").row(0, named=True)
+    assert apr_first["per"] is not None
     assert apr_first["per"] == apr_second["per"]


### PR DESCRIPTION
Closes #2067

## Summary
- `indicator_calculator._join_asof`가 DART 재무를 분기말일(period_end)부터 일별에 as-of 적용하던 것을, **공시 접수일(available_date)** 기준으로 바꿔 lookahead bias 제거. (producer #2010의 available_date 컬럼 사용 — 머지 완료.)
- effective key = `coalesce(available_date, period_end + statutory_lag)`. statutory_lag: 분기/반기/3Q(월 3/6/9)=+45일, 연간(월 12)=+90일(자본시장법 법정 제출기한, 보수적). available_date 있으면 실제 공시일 사용.
- join_asof: 일별 `date`(거래일) ↔ 분기 `effective`(임시 키 alias, backward inclusive), temp/스키마밖 컬럼 write-back 전 제거. effective null 행(available_date 없고 비표준 월)만 join 전 drop.

## known-limitation
available_date 없는 legacy 행은 '법정기한 내 공시' 가정 → 지연제출/정정공시/특수연장 미보장(보수적=실제보다 늦게라 lookahead 안전).

## Test Plan
- lookahead 차단/available_date 경계/legacy +45·연간 +90 fallback/available_date 우선/비표준 월 graceful/기존 테스트 갱신(lookahead 버그 해제)
- test_indicator_calculator + test_indicators 48 passed. 전체 `pytest tests/unit/`: 6760 passed, 2 skipped, 0 failed
- ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (56b59359)

🤖 Generated with [Claude Code](https://claude.com/claude-code)