### PR TITLE
fix(bot): #2274 _save_bot_config UPSERT가 account_id 컬럼도 갱신 (config_json↔컬럼 drift 제거)

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -1435,12 +1435,15 @@ class BotManager:
         로 복원되어 사용자가 PUT 으로 변경한 값이 silent 하게 default 로
         되돌아가는 회귀가 발생한다.
 
-        ``ON CONFLICT DO UPDATE`` 에서 ``strategy_id`` 컬럼도 함께 갱신한다
-        (#2129/#2130). ``config_json`` 에는 ``strategy_id`` 가 항상 포함되어
-        있었으나 과거에는 UPDATE SET 에서 ``strategy_id`` 컬럼이 제외되어
-        ``update_bot(strategy_id=...)`` 경로에서 컬럼이 stale 해졌다. 컬럼과
-        ``config_json.strategy_id`` 를 동일 INSERT/UPSERT 안에서 같은
-        ``config`` 객체로부터 쓰므로 두 store 는 항상 일관된다.
+        ``ON CONFLICT DO UPDATE`` 에서 ``strategy_id`` 컬럼과 ``account_id``
+        컬럼도 함께 갱신한다 (#2129/#2130/#2274). ``config_json`` 에는
+        ``strategy_id`` / ``account_id`` 가 항상 포함되어 있었으나 과거에는
+        UPDATE SET 에서 두 컬럼이 제외되어 ``update_bot(strategy_id=...)`` /
+        ``update_bot(account_id=...)`` 경로에서 컬럼이 stale 해졌다 (재시작 시
+        ``load_from_db`` 가 컬럼에서 읽어 옛 값으로 복원되는 drift). 컬럼과
+        ``config_json.strategy_id`` / ``config_json.account_id`` 를 동일
+        INSERT/UPSERT 안에서 같은 ``config`` 객체로부터 쓰므로 두 store 는
+        항상 일관된다.
         """
         config_dict = {
             "bot_id": config.bot_id,
@@ -1461,6 +1464,7 @@ class BotManager:
                ON CONFLICT(bot_id) DO UPDATE SET
                  name = excluded.name,
                  strategy_id = excluded.strategy_id,
+                 account_id = excluded.account_id,
                  config_json = excluded.config_json,
                  updated_at = datetime('now')""",
             (

--- a/tests/unit/test_bot_manager_update_bot_atomicity.py
+++ b/tests/unit/test_bot_manager_update_bot_atomicity.py
@@ -173,6 +173,18 @@ async def _read_db_interval(db: Database, bot_id: str) -> int:
     return int(payload["interval_seconds"])
 
 
+async def _read_db_account_ids(db: Database, bot_id: str) -> tuple[str, str]:
+    """DB ``bots.account_id`` 컬럼과 ``config_json.account_id`` 를 읽는다 (#2274)."""
+    import json
+
+    row = await db.fetch_one(
+        "SELECT account_id, config_json FROM bots WHERE bot_id = ?", (bot_id,)
+    )
+    assert row is not None
+    payload = json.loads(row["config_json"])
+    return row["account_id"], payload["account_id"]
+
+
 # ----------------------------------------------------------------------------
 # Tests
 # ----------------------------------------------------------------------------
@@ -284,6 +296,54 @@ class TestUpdateBotBudgetRollback:
         assert bot is not None
         assert bot.config.interval_seconds == 60
         assert await _read_db_interval(db, bot_id) == 60
+
+    async def test_update_bot_account_id_change_rolls_back_to_old_on_failure(
+        self, eventbus, db, ctx
+    ) -> None:
+        """#2274: account_id 를 함께 바꾼 update 가 budget 실패로 rollback 되면
+        ``bots.account_id`` 컬럼·config_json 둘 다 옛 account_id 로 복원된다.
+
+        #2274 가 UPSERT 에 ``account_id = excluded.account_id`` 를 추가한 뒤,
+        rollback 의 ``_save_bot_config(old_config)`` 가 컬럼·config_json 을 모두
+        옛 ``old_config.account_id`` 로 되돌리는지(stale 신 account_id 가 남지
+        않는지) 확인하는 회귀 가드.
+
+        treasury 는 새(effective) account_id 로 조회되므로 새 account 에 raising
+        treasury 를 등록해 ``update_budget`` 까지 진입 후 raise 시킨다.
+        """
+
+        class _BoomError(RuntimeError):
+            pass
+
+        raising_treasury = _RaisingTreasury(_BoomError("boom"))
+        # budget 처리는 new_config.account_id(='acc-new') 로 treasury 를 조회한다.
+        tm = _RaisingTreasuryManager("acc-new", raising_treasury)
+
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=tm)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-old", interval_seconds=60
+        )
+
+        # 변경 전 컬럼·config_json 모두 옛 account_id.
+        acc_col, acc_cfg = await _read_db_account_ids(db, bot_id)
+        assert acc_col == "acc-old" == acc_cfg
+
+        with pytest.raises(_BoomError):
+            await manager.update_bot(bot_id, account_id="acc-new", budget=100_000.0)
+
+        # update_budget 은 새 account_id 의 treasury 로 진입했어야 한다.
+        assert raising_treasury.update_budget_calls == [(bot_id, 100_000.0)]
+
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+        # memory rollback: 옛 account_id 로 복원.
+        assert bot.config.account_id == "acc-old"
+        # DB rollback: 컬럼·config_json 둘 다 옛 account_id 로 복원되고
+        # 신 account_id("acc-new") 가 stale 로 남지 않는다.
+        acc_col, acc_cfg = await _read_db_account_ids(db, bot_id)
+        assert acc_col == "acc-old"
+        assert acc_cfg == "acc-old"
 
     async def test_update_bot_budget_failure_cancellation(
         self, eventbus, db, ctx

--- a/tests/unit/test_bot_strategy_consistency.py
+++ b/tests/unit/test_bot_strategy_consistency.py
@@ -214,6 +214,15 @@ async def _row_strategy_ids(db, bot_id):
     return row["strategy_id"], cfg["strategy_id"]
 
 
+async def _row_account_ids(db, bot_id):
+    """``bots`` row 의 컬럼 account_id 와 config_json.account_id 를 반환 (#2274)."""
+    row = await db.fetch_one(
+        "SELECT account_id, config_json FROM bots WHERE bot_id = ?", (bot_id,)
+    )
+    cfg = json.loads(row["config_json"])
+    return row["account_id"], cfg["account_id"]
+
+
 # ── (a) update_bot --strategy (등록·호환) → 컬럼+config_json 둘 다 새 ID ──
 
 
@@ -368,16 +377,14 @@ class TestUpdateBotEffectiveAccountValidation:
 
         # effective(새, NASDAQ) 계좌로 검증을 통과해 둘 다 새 값으로 commit.
         # account_id 는 memory config 와 config_json 에 새 값으로 직렬화된다.
-        # (``bots.account_id`` 컬럼 자체는 ``_save_bot_config`` UPSERT 가
-        # 갱신하지 않는 별개의 사전 결함 — 본 브랜치 리뷰 범위 밖.)
+        # #2274 수정 이후 ``bots.account_id`` 컬럼도 UPSERT 가 함께 갱신하므로
+        # 컬럼·config_json 둘 다 새 값으로 일관된다.
         assert bot.config.account_id == "acc-nasdaq"
         assert bot.config.strategy_id == nasdaq_sid
         col, cfg = await _row_strategy_ids(db, "bot1")
         assert col == nasdaq_sid == cfg
-        row = await db.fetch_one(
-            "SELECT config_json FROM bots WHERE bot_id = ?", ("bot1",)
-        )
-        assert json.loads(row["config_json"])["account_id"] == "acc-nasdaq"
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        assert acc_col == "acc-nasdaq" == acc_cfg
 
     async def test_simultaneous_change_incompatible_with_new_account_raises(
         self, manager_with_account, account_service, ctx, db, tmp_path
@@ -432,13 +439,12 @@ class TestUpdateBotEffectiveAccountValidation:
         bot = await manager_with_account.update_bot("bot1", account_id="acc-test2")
 
         # strategy 검증 미트리거 → 미등록 ``s1`` 에도 raise 없이 성공.
-        # account_id 는 memory config + config_json 에 새 값으로 반영된다.
+        # account_id 는 memory config + config_json + 컬럼에 새 값으로 반영된다
+        # (#2274: UPSERT 가 account_id 컬럼도 갱신).
         assert bot.config.account_id == "acc-test2"
         assert bot.config.strategy_id == "s1"
-        row = await db.fetch_one(
-            "SELECT config_json FROM bots WHERE bot_id = ?", ("bot1",)
-        )
-        assert json.loads(row["config_json"])["account_id"] == "acc-test2"
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        assert acc_col == "acc-test2" == acc_cfg
 
 
 # ── (d)(e) assign_strategy / change_strategy 일관성 ──────────────
@@ -660,3 +666,114 @@ class TestReloadConsistency:
         reloaded = manager2.get_bot("bot1")
         col, cfg = await _row_strategy_ids(db, "bot1")
         assert reloaded.config.strategy_id == col == cfg == new_sid
+
+
+# ── #2274: bots.account_id 컬럼 ↔ config_json.account_id 일관성 회귀 ──────────
+
+
+class TestUpdateBotAccountConsistency:
+    """#2274 (#2129/#2130 동형): ``update_bot(account_id=...)`` 가
+    ``bots.account_id`` 컬럼과 ``config_json.account_id`` 를 항상 동일하게
+    갱신하는지, 재시작(``load_from_db``) 시 새 account_id 로 복원되는지 검증한다.
+
+    수정 전에는 ``_save_bot_config`` 의 ``ON CONFLICT DO UPDATE SET`` 에
+    ``account_id`` 컬럼이 빠져 있어, ``update_bot`` 으로 account_id 를 바꿔도
+    컬럼이 stale 하게 옛 값으로 남고, ``load_from_db`` 가 컬럼을 읽어 재시작 시
+    옛 account_id 로 복원되는 drift 가 있었다.
+    """
+
+    async def test_update_account_id_updates_column_not_stale(
+        self, manager_with_account, account_service, ctx, db
+    ):
+        """(a) update_bot(account_id=new) → 컬럼·config_json 둘 다 new(stale 아님).
+
+        strategy_id 는 그대로(미등록 ``s1``)라 전략 검증을 트리거하지 않으므로
+        account_id-only 변경만 검증한다.
+        """
+        await _make_krx_account(account_service)
+        await _make_krx_account(account_service, account_id="acc-new")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        # 생성 직후 컬럼·config_json 모두 옛 값.
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        assert acc_col == "acc-test" == acc_cfg
+
+        bot = await manager_with_account.update_bot("bot1", account_id="acc-new")
+
+        assert bot.config.account_id == "acc-new"
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        # 컬럼이 stale("acc-test") 로 남지 않고 새 값으로 갱신되어야 한다.
+        assert acc_col == "acc-new"
+        assert acc_cfg == "acc-new"
+
+    async def test_update_account_id_then_reload_restores_new(
+        self, manager_with_account, account_service, eventbus, ctx, db
+    ):
+        """(b) account_id 변경 후 새 매니저로 load_from_db → 새 account_id 복원.
+
+        ``load_from_db`` 는 ``bots.account_id`` 컬럼에서 account_id 를 읽으므로,
+        UPSERT 가 컬럼을 갱신하지 않으면 재시작 시 옛 값으로 복원되는 drift 가
+        발생한다. 컬럼이 갱신되면 재로드된 config 가 새 account_id 여야 한다.
+        """
+        await _make_krx_account(account_service)
+        await _make_krx_account(account_service, account_id="acc-new")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+        await manager_with_account.update_bot("bot1", account_id="acc-new")
+
+        # 재시작 시뮬레이션: 새 매니저로 DB 에서 재로드.
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        count = await manager2.load_from_db()
+        assert count == 1
+
+        reloaded = manager2.get_bot("bot1")
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        # 옛 account_id("acc-test") 로 복원되지 않고 새 값이어야 한다.
+        assert reloaded.config.account_id == acc_col == acc_cfg == "acc-new"
+
+    async def test_simultaneous_strategy_and_account_change_persists_both(
+        self, manager_with_account, account_service, ctx, db, tmp_path
+    ):
+        """(c) strategy_id + account_id 동시 변경 → 둘 다 컬럼·config_json persist.
+
+        #2129/#2130 회귀 보존: 새 전략은 새(effective, NASDAQ) 계좌와 호환이므로
+        검증을 통과하고, strategy_id·account_id 컬럼과 config_json 이 모두 새
+        값으로 일관되게 commit 되어야 한다.
+        """
+        await _make_krx_account(account_service)
+        await _make_nasdaq_account(account_service)
+        nasdaq_sid = await _register_strategy(
+            db, _NASDAQ_STRATEGY_SOURCE, "nasdaq_only", "1.0.0", tmp_path
+        )
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager_with_account.update_bot(
+            "bot1", account_id="acc-nasdaq", strategy_id=nasdaq_sid
+        )
+
+        assert bot.config.strategy_id == nasdaq_sid
+        assert bot.config.account_id == "acc-nasdaq"
+        sid_col, sid_cfg = await _row_strategy_ids(db, "bot1")
+        assert sid_col == nasdaq_sid == sid_cfg
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        assert acc_col == "acc-nasdaq" == acc_cfg
+
+    async def test_update_without_account_change_is_noop_on_account_column(
+        self, manager_with_account, account_service, ctx, db
+    ):
+        """(e) account_id 미변경 update(name 만 변경) → account_id 컬럼 무영향."""
+        await _make_krx_account(account_service)
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", name="old", account_id="acc-test"
+        )
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager_with_account.update_bot("bot1", name="new")
+
+        assert bot.config.name == "new"
+        assert bot.config.account_id == "acc-test"
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        assert acc_col == "acc-test" == acc_cfg


### PR DESCRIPTION
Closes #2274

## Summary
- `BotManager._save_bot_config`의 ON CONFLICT DO UPDATE SET이 `account_id` 컬럼을 제외해, update_bot의 account_id 변경이 memory·config_json엔 반영되나 `bots.account_id` 컬럼은 stale로 남아 재시작 시 옛 account_id로 복원되던 버그를 수정(#2130 strategy_id 동형).
- DO UPDATE SET에 `account_id = excluded.account_id` 1줄 추가. 컬럼·config_json을 동일 config 객체에서 써 일관.

## Test Plan
- update_bot(account_id) 후 컬럼·config_json 일관, load_from_db 새 값 복원, strategy+account 동시 변경 둘 다 persist(#2129/#2130 회귀), rollback 시 old 복원, name-only 무영향
- 전체 `pytest tests/unit/`: 6760 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (e0c8dfc6)

## 비고
account_id 변경 시 treasury 예산/broker credential 재격리는 follow-up #2282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)