### PR TITLE
fix(feed): #2117 summary에 failures_total 추가 — 비-심볼(날짜/소스) 실패 표면화

### DIFF
--- a/docs/specs/data-feed/10-checkpoints-and-reports.md
+++ b/docs/specs/data-feed/10-checkpoints-and-reports.md
@@ -37,6 +37,7 @@ backfill/daily 실행 완료 시 생성되는 **운영 기록**.
     "symbols_total": 2487,
     "symbols_success": 2485,
     "symbols_failed": 2,
+    "failures_total": 2,
     "rows_written": 2485,
     "data_types": ["ohlcv", "fundamental"]
   },
@@ -66,8 +67,9 @@ backfill/daily 실행 완료 시 생성되는 **운영 기록**.
 
 | 필드 | 설명 |
 |------|------|
-| `summary` | 수집 결과 요약 (종목 수, 성공/실패, 기록 행 수) |
-| `failures` | 수집 실패 건 (종목, 날짜, 사유, 재시도 횟수) |
+| `summary` | 수집 결과 요약 (종목 수, 성공/실패, 총 실패 건수, 기록 행 수) |
+| `summary.failures_total` | 총 실패 건수(`len(failures)`). `symbols_failed`는 종목 단위 실패만 세지만, `failures`에는 날짜/소스 단위 실패(예: data.go.kr 특정 날짜 실패, DART 소스 실패)가 종목에 귀속되지 않은 채 포함될 수 있다. 따라서 `symbols_failed=0`이어도 `failures_total>0`일 수 있으며, 상세는 `failures` 배열을 참조한다. |
+| `failures` | 수집 실패 건. 종목 단위(종목, 날짜, 사유, 재시도 횟수)뿐 아니라 종목에 귀속되지 않는 날짜/소스 단위 실패도 포함한다. |
 | `warnings` | 데이터 품질 경고 (비즈니스 규칙 위반, 시계열 갭 등) |
 | `config_errors` | 설정 오류 (잘못된 routing, 누락된 API 키 등) |
 

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -744,11 +744,18 @@ def _echo_report_section(latest_report: dict | None) -> None:
     click.echo(_SEPARATOR)
     if latest_report:
         summary = latest_report.get("summary", {})
+        # 총 실패 건수: summary.failures_total(신규)을 우선하되, 구버전 리포트엔
+        # 없으므로 failures 배열 길이로 폴백한다. 날짜/소스 단위 비-심볼 실패는
+        # symbols_failed에 잡히지 않으므로 별도 병기한다(#2117).
+        failures_total = summary.get(
+            "failures_total", len(latest_report.get("failures", []))
+        )
         click.echo(f"  mode: {latest_report.get('mode', '?')}")
         click.echo(f"  date: {latest_report.get('target_date', '?')}")
         click.echo(
             f"  result: {summary.get('symbols_success', 0)} success"
             f" / {summary.get('symbols_failed', 0)} failed"
+            f" / {failures_total} total failures"
             f" / {len(latest_report.get('warnings', []))} warnings"
         )
         click.echo(f"  rows: {summary.get('rows_written', 0)}")

--- a/src/ante/feed/cli_output.py
+++ b/src/ante/feed/cli_output.py
@@ -42,6 +42,9 @@ def _backfill_result_dict(result: CollectionResult) -> dict[str, Any]:
         "symbols_total": result.symbols_total,
         "symbols_success": result.symbols_success,
         "symbols_failed": result.symbols_failed,
+        # 총 실패 건수(날짜/소스 단위 비-심볼 실패 포함). symbols_failed=0이어도
+        # >0일 수 있다(#2117). 상세는 failures 배열.
+        "failures_total": len(result.failures),
         "rows_written": result.rows_written,
         "data_types": result.data_types,
         "duration_seconds": result.duration_seconds,
@@ -59,6 +62,9 @@ def _daily_result_dict(result: CollectionResult) -> dict[str, Any]:
         "symbols_total": result.symbols_total,
         "symbols_success": result.symbols_success,
         "symbols_failed": result.symbols_failed,
+        # 총 실패 건수(날짜/소스 단위 비-심볼 실패 포함). symbols_failed=0이어도
+        # >0일 수 있다(#2117). 상세는 failures 배열.
+        "failures_total": len(result.failures),
         "rows_written": result.rows_written,
         "data_types": result.data_types,
         "duration_seconds": result.duration_seconds,

--- a/src/ante/feed/report/generator.py
+++ b/src/ante/feed/report/generator.py
@@ -51,6 +51,9 @@ class ReportGenerator:
                 "symbols_total": result.symbols_total,
                 "symbols_success": result.symbols_success,
                 "symbols_failed": result.symbols_failed,
+                # 총 실패 건수(날짜/소스 단위 비-심볼 실패 포함). symbols_failed는
+                # 종목 귀속 실패만 세므로 symbols_failed=0이어도 >0일 수 있다(#2117).
+                "failures_total": len(result.failures),
                 "rows_written": result.rows_written,
                 "data_types": list(result.data_types),
             },

--- a/tests/unit/feed/test_cli_output.py
+++ b/tests/unit/feed/test_cli_output.py
@@ -43,6 +43,12 @@ class TestBackfillResultDict:
         assert "warnings" in d
         assert "config_errors" in d
 
+    def test_includes_failures_total_key(self) -> None:
+        """failures_total 키가 포함된다(#2117)."""
+        d = _backfill_result_dict(_result())
+
+        assert "failures_total" in d
+
     def test_empty_lists_when_result_empty(self) -> None:
         """비어 있는 경우 빈 리스트로 직렬화된다."""
         d = _backfill_result_dict(_result())
@@ -50,6 +56,24 @@ class TestBackfillResultDict:
         assert d["failures"] == []
         assert d["warnings"] == []
         assert d["config_errors"] == []
+        assert d["failures_total"] == 0
+
+    def test_date_level_failure_surfaces_with_symbols_failed_zero(self) -> None:
+        """날짜/소스 단위 실패는 symbols_failed=0이어도 failures_total>0(#2117)."""
+        result = _result(
+            symbols_total=0,
+            symbols_success=0,
+            symbols_failed=0,
+            failures=[
+                {"date": "2026-03-16", "source": "data_go_kr", "reason": "HTTP 500"},
+                {"source": "dart", "reason": "연결 실패"},
+            ],
+        )
+
+        d = _backfill_result_dict(result)
+
+        assert d["symbols_failed"] == 0
+        assert d["failures_total"] == 2
 
     def test_values_match_collection_result(self) -> None:
         """항목이 있을 때 값이 CollectionResult와 일치한다."""
@@ -85,6 +109,12 @@ class TestDailyResultDict:
         assert "warnings" in d
         assert "config_errors" in d
 
+    def test_includes_failures_total_key(self) -> None:
+        """failures_total 키가 포함된다(#2117)."""
+        d = _daily_result_dict(_result(mode="daily", target_date="2026-03-17"))
+
+        assert "failures_total" in d
+
     def test_empty_lists_when_result_empty(self) -> None:
         """비어 있는 경우 빈 리스트로 직렬화된다."""
         d = _daily_result_dict(_result(mode="daily", target_date="2026-03-17"))
@@ -92,6 +122,25 @@ class TestDailyResultDict:
         assert d["failures"] == []
         assert d["warnings"] == []
         assert d["config_errors"] == []
+        assert d["failures_total"] == 0
+
+    def test_date_level_failure_surfaces_with_symbols_failed_zero(self) -> None:
+        """날짜/소스 단위 실패는 symbols_failed=0이어도 failures_total>0(#2117)."""
+        result = _result(
+            mode="daily",
+            target_date="2026-03-17",
+            symbols_total=0,
+            symbols_success=0,
+            symbols_failed=0,
+            failures=[
+                {"date": "2026-03-16", "source": "data_go_kr", "reason": "HTTP 500"},
+            ],
+        )
+
+        d = _daily_result_dict(result)
+
+        assert d["symbols_failed"] == 0
+        assert d["failures_total"] == 1
 
     def test_values_match_collection_result(self) -> None:
         """항목이 있을 때 값이 CollectionResult와 일치한다."""

--- a/tests/unit/feed/test_cli_status.py
+++ b/tests/unit/feed/test_cli_status.py
@@ -179,6 +179,51 @@ class TestFeedStatusWithReport:
         assert data["latest_report"]["mode"] == "daily"
         assert data["latest_report"]["summary"]["symbols_success"] == 2485
 
+    def test_shows_total_failures_with_non_symbol_failure(
+        self, runner: CliRunner, data_path: str
+    ) -> None:
+        """날짜/소스 단위 실패가 텍스트의 total failures로 표면화된다(#2117).
+
+        symbols_failed=0이어도 failures_total>0이면 '0 failed'와 별개로
+        'N total failures'가 표시되어 성공처럼 보이는 것을 막는다.
+        """
+        _init_feed(data_path)
+        _create_report(
+            data_path,
+            mode="daily",
+            target_date="2026-03-16",
+            success=10,
+            failed=0,
+            extra_failures=[
+                {"date": "2026-03-16", "source": "data_go_kr", "reason": "HTTP 500"},
+                {"source": "dart", "reason": "연결 실패"},
+            ],
+        )
+        result = _invoke_status(runner, data_path)
+
+        assert "0 failed" in result.output
+        assert "2 total failures" in result.output
+
+    def test_total_failures_falls_back_to_failures_len(
+        self, runner: CliRunner, data_path: str
+    ) -> None:
+        """구버전 리포트(summary.failures_total 없음)는 failures 길이로 폴백한다."""
+        _init_feed(data_path)
+        _create_report(
+            data_path,
+            mode="daily",
+            target_date="2026-03-16",
+            success=10,
+            failed=0,
+            extra_failures=[
+                {"date": "2026-03-16", "source": "data_go_kr", "reason": "HTTP 500"},
+            ],
+            include_failures_total=False,
+        )
+        result = _invoke_status(runner, data_path)
+
+        assert "1 total failures" in result.output
+
 
 class TestFeedStatusApiKeys:
     """API 키 상태 표시."""
@@ -233,24 +278,38 @@ def _create_report(
     success: int = 2485,
     failed: int = 0,
     warnings: int = 0,
+    extra_failures: list[dict] | None = None,
+    include_failures_total: bool = True,
 ) -> None:
-    """테스트용 리포트 파일을 생성한다."""
+    """테스트용 리포트 파일을 생성한다.
+
+    Args:
+        extra_failures: 종목에 귀속되지 않는 날짜/소스 단위 실패(#2117 검증용).
+        include_failures_total: summary에 failures_total을 넣을지(구버전 폴백 검증용).
+    """
     reports_dir = Path(data_path) / ".feed" / "reports"
     reports_dir.mkdir(parents=True, exist_ok=True)
+    failures: list[dict] = [
+        {"symbol": f"00{i:04d}", "reason": "test"} for i in range(failed)
+    ]
+    failures.extend(extra_failures or [])
+    summary: dict = {
+        "symbols_total": success + failed,
+        "symbols_success": success,
+        "symbols_failed": failed,
+        "rows_written": success,
+        "data_types": ["ohlcv", "fundamental"],
+    }
+    if include_failures_total:
+        summary["failures_total"] = len(failures)
     report = {
         "mode": mode,
         "started_at": f"{target_date}T16:00:12Z",
         "finished_at": f"{target_date}T16:05:34Z",
         "duration_seconds": 322,
         "target_date": target_date,
-        "summary": {
-            "symbols_total": success + failed,
-            "symbols_success": success,
-            "symbols_failed": failed,
-            "rows_written": success,
-            "data_types": ["ohlcv", "fundamental"],
-        },
-        "failures": [{"symbol": f"00{i:04d}", "reason": "test"} for i in range(failed)],
+        "summary": summary,
+        "failures": failures,
         "warnings": [
             {"symbol": f"00{i:04d}", "message": "test warning"} for i in range(warnings)
         ],

--- a/tests/unit/feed/test_report.py
+++ b/tests/unit/feed/test_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, date, datetime
 from pathlib import Path
 
@@ -134,6 +135,7 @@ class TestReportGenerate:
         assert summary["symbols_total"] == 2487
         assert summary["symbols_success"] == 2485
         assert summary["symbols_failed"] == 2
+        assert summary["failures_total"] == 1
         assert summary["rows_written"] == 2485
         assert summary["data_types"] == ["ohlcv", "fundamental"]
 
@@ -191,6 +193,14 @@ class TestReportGenerateEmpty:
         gen = ReportGenerator(feed_dir)
         report = gen.generate(empty_result)
         assert report["config_errors"] == []
+
+    def test_empty_failures_total_zero(
+        self, feed_dir: Path, empty_result: CollectionResult
+    ) -> None:
+        """failures가 비어있으면 summary.failures_total이 0이다(#2117)."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(empty_result)
+        assert report["summary"]["failures_total"] == 0
 
     def test_empty_result_has_all_keys(
         self, feed_dir: Path, empty_result: CollectionResult
@@ -518,3 +528,180 @@ class TestBackfillReportSurfacesStoreMergeWarning:
 
         # 손상 파일은 보존됨(데이터 손실 방지).
         assert (part_dir / "2025-09.parquet").read_bytes() == b"corrupt-not-parquet"
+
+
+class TestReportFailuresTotalSurfacesNonSymbolFailures:
+    """비-심볼(날짜/소스) 실패가 summary.failures_total로 표면화되는지 검증(#2117).
+
+    symbols_failed는 종목 귀속 실패만 세므로 날짜/소스 단위 실패는 0으로 남지만,
+    failures_total은 len(failures)라 정직하게 표면화된다.
+    """
+
+    def test_date_level_failure_surfaces_in_failures_total(
+        self, feed_dir: Path
+    ) -> None:
+        """data.go.kr 날짜 단위 실패는 symbols_failed=0이어도 failures_total>0."""
+        # backfill_runner가 기록하는 date-level failure 형태({date,source,reason}).
+        result = CollectionResult(
+            mode="backfill",
+            started_at="2026-03-17T16:00:12Z",
+            finished_at="2026-03-17T16:05:34Z",
+            duration_seconds=10.0,
+            symbols_total=0,
+            symbols_success=0,
+            symbols_failed=0,
+            rows_written=0,
+            data_types=[],
+            failures=[
+                {
+                    "date": "2026-03-16",
+                    "source": "data_go_kr",
+                    "reason": "HTTP 500 after 3 retries",
+                },
+            ],
+        )
+
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(result)
+        summary = report["summary"]
+
+        # 날짜 단위 실패는 종목에 귀속되지 않아 symbols_failed에 잡히지 않는다.
+        assert summary["symbols_failed"] == 0
+        # 그러나 failures_total로는 정직하게 표면화된다.
+        assert summary["failures_total"] == 1
+        assert len(report["failures"]) == 1
+
+    def test_dart_source_failure_surfaces_in_failures_total(
+        self, feed_dir: Path
+    ) -> None:
+        """DART 소스 단위 실패는 symbols_failed=0이어도 failures_total>0."""
+        # backfill_runner가 기록하는 DART source failure 형태({source,reason}).
+        result = CollectionResult(
+            mode="backfill",
+            started_at="2026-03-17T16:00:12Z",
+            finished_at="2026-03-17T16:05:34Z",
+            duration_seconds=10.0,
+            symbols_total=0,
+            symbols_success=0,
+            symbols_failed=0,
+            rows_written=0,
+            data_types=[],
+            failures=[
+                {
+                    "source": "dart",
+                    "reason": "DART API 연결 실패",
+                },
+            ],
+        )
+
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(result)
+        summary = report["summary"]
+
+        assert summary["symbols_failed"] == 0
+        assert summary["failures_total"] == 1
+
+    def test_symbol_level_failure_keeps_symbols_failed_accurate(
+        self, feed_dir: Path
+    ) -> None:
+        """심볼 단위 성공/실패는 symbols_failed가 정확히 유지된다(부풀리지 않음)."""
+        result = CollectionResult(
+            mode="daily",
+            started_at="2026-03-17T16:00:12Z",
+            finished_at="2026-03-17T16:05:34Z",
+            duration_seconds=10.0,
+            target_date="2026-03-16",
+            symbols_total=3,
+            symbols_success=2,
+            symbols_failed=1,
+            rows_written=2,
+            data_types=["ohlcv"],
+            failures=[
+                {
+                    "symbol": "003920",
+                    "date": "2026-03-16",
+                    "source": "data_go_kr",
+                    "reason": "타임아웃",
+                },
+            ],
+        )
+
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(result)
+        summary = report["summary"]
+
+        # 심볼 귀속 실패는 그대로 symbols_failed에 잡히고 failures_total과 일치.
+        assert summary["symbols_failed"] == 1
+        assert summary["failures_total"] == 1
+
+    def test_mixed_symbol_and_date_failures(self, feed_dir: Path) -> None:
+        """심볼+날짜 단위 실패 혼재 시 failures_total > symbols_failed."""
+        result = CollectionResult(
+            mode="backfill",
+            started_at="2026-03-17T16:00:12Z",
+            finished_at="2026-03-17T16:05:34Z",
+            duration_seconds=10.0,
+            symbols_total=2,
+            symbols_success=1,
+            symbols_failed=1,
+            rows_written=1,
+            data_types=["ohlcv"],
+            failures=[
+                {"symbol": "003920", "reason": "심볼 단위 실패"},
+                {"date": "2026-03-15", "source": "data_go_kr", "reason": "날짜 실패"},
+                {"source": "dart", "reason": "소스 실패"},
+            ],
+        )
+
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(result)
+        summary = report["summary"]
+
+        # symbols_failed는 심볼 귀속분만(1), failures_total은 전체(3).
+        assert summary["symbols_failed"] == 1
+        assert summary["failures_total"] == 3
+
+
+_SPEC_DOC = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "specs"
+    / "data-feed"
+    / "10-checkpoints-and-reports.md"
+)
+
+
+def _spec_report_summary_keys() -> set[str]:
+    """스펙 문서 리포트 예시 JSON의 summary 필드셋을 추출한다.
+
+    fenced ```json 블록 중 `"summary"`를 포함하는 첫 블록을 골라, 줄단위
+    `//` 주석을 제거한 뒤 파싱한다(스펙 예시는 주석을 포함하므로).
+    """
+    text = _SPEC_DOC.read_text(encoding="utf-8")
+    blocks = re.findall(r"```json\n(.*?)```", text, re.DOTALL)
+    for block in blocks:
+        if '"summary"' not in block:
+            continue
+        no_comments = "\n".join(
+            line for line in block.splitlines() if not line.strip().startswith("//")
+        )
+        payload = json.loads(no_comments)
+        return set(payload["summary"].keys())
+    raise AssertionError("스펙 문서에서 summary 예시 블록을 찾지 못함")
+
+
+class TestSpecSummaryFieldsetParity:
+    """스펙 예시의 summary 필드셋과 generate() summary 직렬화가 정합한지 검증(#2117)."""
+
+    def test_generate_summary_keys_match_spec(
+        self, feed_dir: Path, sample_result: CollectionResult
+    ) -> None:
+        """generate() summary 키 집합 == 스펙 예시 summary 필드셋."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+
+        assert set(report["summary"].keys()) == _spec_report_summary_keys()
+
+    def test_spec_contains_failures_total(self) -> None:
+        """스펙 예시 summary에 failures_total 필드가 명시돼 있다."""
+        assert "failures_total" in _spec_report_summary_keys()


### PR DESCRIPTION
Closes #2117

## Summary
- feed 결과 summary가 `symbols_failed=0`이어도 날짜단위(data.go.kr)·소스단위(DART) 실패(`ctx.failures`)가 있으면 성공처럼 보이던 문제를, summary에 **`failures_total = len(failures)`**를 추가해 정직하게 표면화.
- `symbols_failed`는 심볼 귀속 실패로 **무변경**(날짜수↔심볼수 conflate 금지). failures_total은 derived(직렬화 시점 len, stored-field 미추가).
- 4 소비자 + 스펙 동기화: `10-checkpoints-and-reports.md` summary 계약, report generator, cli_output backfill/daily, feed status 텍스트(`N total failures` 병기, 구버전 폴백).

## Test Plan
- date-level/DART 소스 실패 → failures_total>0 & symbols_failed=0; 심볼 실패 → symbols_failed; 무실패 → 0; 스펙↔직렬화 정합; feed status 텍스트
- 전체 `pytest tests/unit/`: 6773 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (2577d719)

## 비고
scheduler completion 로그가 종목 수만 표시하는 부분은 본 이슈(summary/report/feed status) 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)