### PR TITLE
fix(bot): #2112 bot list/info/positions/signal-key(read)를 runtime IPC + snapshot fallback로 라우팅

### DIFF
--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -82,6 +82,10 @@ CLI 명령 시그니처와 전체 실행 분류의 SSOT는
 | `ante bot stop <bot_id>` | `bot.stop` | `BotManager.get_bot()` + `BotManager.stop_bot()` | live 봇 존재 확인 + 실행 task 취소 + `BotStoppedEvent` 발행. 성공 시 audit `bot.stop` 기록 |
 | `ante bot update <bot_id>` | `bot.update` | `BotManager.update_bot()` | 중지 상태 봇 설정을 서버 BotManager 기준으로 갱신 |
 | `ante bot status <bot_id>` | `bot.status` | `BotManager.get_bot()` (read-only) | live 조회. 응답은 `{"bot": info}` envelope이며 `strategy_registry`/`treasury_manager`/`trade_service`가 있는 경우 strategy/budget/positions를 동적으로 보강 |
+| `ante bot list [--account]` | `bot.list` | `BotManager.list_bots()` (read-only) | live 봇 목록 조회. `--account` 필터 후 CLI 6-key(`bot_id`/`name`/`strategy_id`/`account_id`/`status`/`created_at`) projection. 서버 정지 시 snapshot DB fallback |
+| `ante bot info <bot_id>` | `bot.info` | `BotManager.get_bot()` (read-only) | live 봇 상세 조회. `{"bot": info}` envelope. 서버 정지 시 snapshot DB fallback |
+| `ante bot positions <bot_id>` | `bot.positions` | `BotManager.get_bot()` + `TradeService.get_positions()` (read-only) | live 포지션 조회. 봇 계좌로 스코핑(#2137). `trade_service` 부재(legacy registry) 시 빈 collection graceful. 서버 정지 시 snapshot DB fallback |
+| `ante bot signal-key <bot_id>` | `bot.signal_key` | `BotManager.get_signal_key()` (read-only) | live 시그널 키 조회. `{bot_id, signal_key}` (None 허용). `--rotate`(`bot.signal_key.rotate`, mutating)와 별개 read command. 서버 정지 시 snapshot DB fallback |
 | `ante bot remove` | `bot.remove` (server running) / cold-path cleanup (server stopped) | `BotManager.remove_bot()` / `cold_path_remove_bot()` | 실행 중에는 봇 중지, EventBus 구독 해제, signal key 회수, 인메모리 제거 필요. 서버 정지 중에는 persisted cleanup만 수행 |
 | `ante bot signal-key --rotate` | `bot.signal_key.rotate` | `BotManager.rotate_signal_key()` | 기존 signal channel 즉시 차단 + 새 key 발급 |
 
@@ -95,9 +99,12 @@ error code를 사용한다.
 - `BOT_STATE_CONFLICT` (신규): `bot.start`/`bot.stop`의 `BotManager.start_bot()` /
   `stop_bot()` 호출 중 `BotError`.
 
-서버 실행 중 `ante bot list/info/positions/signal-key`는 `bot.query` 계열 IPC로
-서버의 live 상태를 우선 조회한다. 서버가 정지된 상태에서는 DB에 저장된 persisted
-snapshot 조회만 허용한다. 단, `ante bot remove`는 #1161 cold-path 예외로 server stopped
+서버 실행 중 `ante bot list/info/positions/signal-key`는 각각 `bot.list` /
+`bot.info` / `bot.positions` / `bot.signal_key` IPC로 서버의 live 상태를 우선
+조회한다(#2112, read-only). 서버가 정지된 상태(`IPC_SERVER_NOT_RUNNING`)에서는
+DB에 저장된 persisted snapshot 조회로 fallback한다(runtime IPC + snapshot
+fallback). `IPC_TIMEOUT`/server-error는 stale snapshot 은폐를 막기 위해
+fallback 없이 surface한다. 단, `ante bot remove`는 #1161 cold-path 예외로 server stopped
 상태에서 `signal_keys`, 전략 스냅샷, Treasury budget, `bots.status='deleted'`만 직접
 정리할 수 있다. `handle_positions=liquidate`는 IPC runtime 경로에서만 의미가 있고,
 cold-path 삭제는 항상 keep 의미다.
@@ -233,7 +240,7 @@ BotManager/DB 종료 이후 lifecycle 마지막 단계에서만 호출된다.
 - **read-only**: 서버가 보유한 live adapter를 통해 상태를 조회하지만 서버/DB 상태를
   변경하지 않는 명령
 
-현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 28개가
+현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 32개가
 SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표를 함께 갱신해야 한다.
 
 | IPC 커맨드 | taxonomy | 근거 |
@@ -266,6 +273,10 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 | `broker.balance` | read-only | `BrokerAdapter.get_account_balance()` live 조회 |
 | `broker.positions` | read-only | `BrokerAdapter.get_positions()` live 조회 |
 | `bot.status` | read-only | `BotManager.get_bot()` live 조회. `{bot: ...}` envelope (#1712) |
+| `bot.list` | read-only | `BotManager.list_bots()` live 조회. `--account` 필터 + CLI 6-key projection, `{bots: [...]}` envelope (#2112) |
+| `bot.info` | read-only | `BotManager.get_bot()` live 조회. `{bot: info}` envelope (#2112) |
+| `bot.positions` | read-only | `BotManager.get_bot()` 존재확인 + `TradeService.get_positions()` 봇 계좌 스코핑(#2137). `{positions: [...]}` envelope (#2112) |
+| `bot.signal_key` | read-only | `BotManager.get_signal_key()` live 조회. `{bot_id, signal_key}` (None 허용). `bot.signal_key.rotate`(mutating)와 별개 read command (#2112) |
 
 `broker.reconcile`은 CLI `--fix=False` 경로에서도 같은 IPC command를 사용하지만, 한 command
 이름에 mutating/read-only 의미를 섞지 않고 일괄 mutating으로 분류한다. dry-run 전용

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -159,7 +159,10 @@ def bot_list(ctx: click.Context, account_id: str | None) -> None:
     if account_id is not None:
         account_id = reject_invalid_account_id(account_id, fmt, context="cli.bot.list")
 
-    async def _run_list() -> list[dict]:
+    actor = get_member_id(ctx)
+
+    async def _run_list_fallback() -> list[dict]:
+        # 서버 정지(``IPC_SERVER_NOT_RUNNING``) snapshot fallback (#2112).
         # ``_create_services`` async context manager lifecycle.
         # ``open_cli_db`` 가 normal/exception/cancellation 모든 경로에서
         # ``Database.close()`` 를 보장한다.
@@ -177,7 +180,37 @@ def bot_list(ctx: click.Context, account_id: str | None) -> None:
                 )
             return [dict(r) for r in rows]
 
-    result = _run(_run_list())
+    async def _run_list() -> list[dict]:
+        # 서버 실행 중이면 live ``bot.list`` IPC 우선 (#2112). ``ipc_send`` 가
+        # 서버 정지 시 ``IPC_SERVER_NOT_RUNNING`` ClickException 으로 surface 하면
+        # 기존 snapshot DB 경로로 fallback 한다(스펙: runtime IPC + snapshot
+        # fallback). ``IPC_TIMEOUT`` / server-error 는 fallback 없이 surface 한다
+        # (stale snapshot silent 반환 회귀 차단). IPC result 와 fallback 모두
+        # 6-key projection list 로 동일 shape 이다.
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        args: dict = {}
+        if account_id is not None:
+            args["account_id"] = account_id
+        try:
+            ipc_result = await ipc_send("bot.list", args, actor=actor)
+        except click.ClickException as e:
+            if getattr(e, "ipc_error_code", "") != "IPC_SERVER_NOT_RUNNING":
+                raise
+            return await _run_list_fallback()
+        return list(ipc_result.get("bots", []))
+
+    try:
+        result = _run(_run_list())
+    except click.ClickException as e:
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        if fmt.is_json:
+            fmt.error(message, code=code)
+        else:
+            text = f"{code}: {message}" if code else message
+            fmt.error(text)
+        raise SystemExit(1) from e
 
     if not result:
         fmt.output({"message": "등록된 봇이 없습니다.", "bots": []})
@@ -200,19 +233,51 @@ def bot_list(ctx: click.Context, account_id: str | None) -> None:
 def bot_info(ctx: click.Context, bot_id: str) -> None:
     """봇 상세 정보 조회."""
     fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
 
-    async def _run_info() -> dict | None:
+    async def _run_info_fallback() -> dict | None:
+        # 서버 정지(``IPC_SERVER_NOT_RUNNING``) snapshot fallback (#2112).
         # ``_create_services`` async context manager lifecycle.
         async with _create_services(ctx=ctx) as (db, _, _, _):
             row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = ?", (bot_id,))
             return dict(row) if row else None
 
-    result = _run(_run_info())
+    async def _run_info() -> dict | None:
+        # 서버 실행 중이면 live ``bot.info`` IPC 우선 (#2112). 서버 정지
+        # (``IPC_SERVER_NOT_RUNNING``) 시에만 기존 snapshot DB 경로로 fallback.
+        # IPC ``BOT_NOT_FOUND`` / ``IPC_TIMEOUT`` / server-error 는 fallback 없이
+        # surface 한다. IPC result 는 ``{"bot": info}`` envelope 이므로 inner
+        # ``bot`` dict 를 추출해 fallback 의 ``SELECT * FROM bots`` 행과 공통
+        # 핵심키(bot_id/name/status/account_id/strategy_id) parity 를 맞춘다.
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        try:
+            ipc_result = await ipc_send("bot.info", {"bot_id": bot_id}, actor=actor)
+        except click.ClickException as e:
+            if getattr(e, "ipc_error_code", "") != "IPC_SERVER_NOT_RUNNING":
+                raise
+            return await _run_info_fallback()
+        return ipc_result.get("bot")
+
+    try:
+        result = _run(_run_info())
+    except click.ClickException as e:
+        # IPC ``BOT_NOT_FOUND`` 포함 surface 경로 — fallback 의 None sentinel
+        # (``if not result``) 과 동일하게 ``BOT_NOT_FOUND`` exit 1 로 정렬된다.
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        if fmt.is_json:
+            fmt.error(message, code=code)
+        else:
+            text = f"{code}: {message}" if code else message
+            fmt.error(text)
+        raise SystemExit(1) from e
 
     if not result:
         # missing bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 해 자동화가
         # 메시지 파싱 없이 분류할 수 있도록 한다 (CLI/IPC 일관성:
-        # ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와 동형).
+        # ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와 동형). fallback 의
+        # snapshot 미존재 행이 이 분기로 들어온다(IPC 경로는 위에서 surface).
         fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         ctx.exit(1)
 
@@ -224,7 +289,10 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
         click.echo(f"  전략      : {result['strategy_id']}")
         click.echo(f"  계좌      : {result.get('account_id', 'test')}")
         click.echo(f"  상태      : {result['status']}")
-        click.echo(f"  생성일    : {result['created_at']}")
+        # ``created_at`` 은 persisted snapshot 행에만 있고 live ``get_info()``
+        # (IPC 경로) 에는 부재하므로 ``.get`` 으로 안전 접근한다 (live≠snapshot
+        # 완전 통일은 #2112 non-goal; 공통 핵심키만 parity).
+        click.echo(f"  생성일    : {result.get('created_at')}")
 
 
 def _parse_param(value: str) -> tuple[str, object]:
@@ -458,8 +526,12 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
     ``--rotate`` 는 runtime IPC (``bot.signal_key.rotate``) 전용이다 (#2111).
     서버가 정지되어 있으면 ``IPC_SERVER_NOT_RUNNING`` 으로 거부하며, cold-path
     DB mutation 으로 대체하지 않는다 (runtime 경계 / audit / live 상태 정합성
-    보존). 조회(rotate 미지정)는 기존 cold-path 를 유지한다 (#2112 가 read IPC
-    라우팅 소유).
+    보존).
+
+    조회(rotate 미지정)는 runtime IPC (``bot.signal_key`` read) 우선 + 서버
+    정지 시 snapshot DB fallback 이다 (#2112; ``--rotate`` 와 정반대로 서버
+    정지 시 기존 직접 DB 경로를 보존한다 — 스펙: runtime IPC + snapshot
+    fallback).
     """
     fmt = get_formatter(ctx)
 
@@ -506,7 +578,10 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
         fmt.success(f"시그널 키 재발급 완료: {bot_id}", result)
         return
 
-    async def _run_signal_key() -> dict:
+    actor = get_member_id(ctx)
+
+    async def _run_signal_key_fallback() -> dict:
+        # 서버 정지(``IPC_SERVER_NOT_RUNNING``) snapshot fallback (#2112).
         # ``_create_services`` async context manager lifecycle.
         from ante.bot.signal_key import SignalKeyManager
 
@@ -550,8 +625,44 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
                 return {"bot_id": bot_id, "signal_key": None}
             return {"bot_id": bot_id, "signal_key": key}
 
+    async def _run_signal_key() -> dict:
+        # 서버 실행 중이면 live ``bot.signal_key`` (read) IPC 우선 (#2112).
+        # ``--rotate`` (#2111, mutating) 와 별개 read command 다. 서버 정지
+        # (``IPC_SERVER_NOT_RUNNING``) 시에만 기존 snapshot DB 경로로 fallback.
+        # IPC ``BOT_NOT_FOUND`` 는 fallback 의 ``missing`` sentinel 과 동일하게
+        # 정규화해 후처리(``BOT_NOT_FOUND`` exit 1) 를 공통화한다.
+        # ``IPC_TIMEOUT`` / server-error 는 아래 ``except click.ClickException``
+        # 에서 fallback 없이 surface 한다(stale snapshot 은폐 차단). IPC result
+        # ``{bot_id, signal_key}`` 는 fallback 과 동일 shape 이며, signal_key
+        # None(미발급) 은 후처리(``SIGNAL_KEY_NOT_SET``) 가 공통 처리한다.
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        try:
+            return await ipc_send("bot.signal_key", {"bot_id": bot_id}, actor=actor)
+        except click.ClickException as e:
+            ipc_code = getattr(e, "ipc_error_code", "")
+            if ipc_code == "IPC_SERVER_NOT_RUNNING":
+                return await _run_signal_key_fallback()
+            if ipc_code == "BOT_NOT_FOUND":
+                # fallback 미존재 sentinel 과 동일 shape 으로 정규화 → 후처리 공통.
+                return {"bot_id": bot_id, "missing": True}
+            raise
+
     try:
         result = _run(_run_signal_key())
+    except click.ClickException as e:
+        # IPC ``IPC_TIMEOUT`` / server-error surface 경로 — fallback 없이 원본
+        # code/message 를 복원해 text/JSON 공용 envelope 안정성을 보존한다
+        # (``bot status`` 형제 패턴 1:1 미러). ``BOT_NOT_FOUND`` /
+        # ``IPC_SERVER_NOT_RUNNING`` 은 ``_run_signal_key`` 내부에서 이미 흡수.
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        if fmt.is_json:
+            fmt.error(message, code=code)
+        else:
+            text = f"{code}: {message}" if code else message
+            fmt.error(text)
+        raise SystemExit(1) from e
     except Exception as e:
         # bot 존재확인 중 non-"no such table" ``OperationalError``
         # (malformed/locked DB 등)가 재던져지면 여기로 떨어진다. JSON error를
@@ -600,8 +711,10 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
 def bot_positions(ctx: click.Context, bot_id: str) -> None:
     """봇 보유 포지션 조회."""
     fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
 
-    async def _run_positions() -> list[dict] | None:
+    async def _run_positions_fallback() -> list[dict] | None:
+        # 서버 정지(``IPC_SERVER_NOT_RUNNING``) snapshot fallback (#2112).
         # ``open_cli_db`` 헬퍼가 service ``initialize()`` /
         # ``get_positions()`` 예외 / cancellation 모든 경로에서
         # ``Database.close()`` 1회 호출을 보장한다 (cleanup invariant).
@@ -668,12 +781,47 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
                 for p in positions
             ]
 
-    result = _run(_run_positions())
+    async def _run_positions() -> list[dict] | None:
+        # 서버 실행 중이면 live ``bot.positions`` IPC 우선 (#2112). 서버 정지
+        # (``IPC_SERVER_NOT_RUNNING``) 시에만 기존 snapshot DB 경로로 fallback.
+        # IPC ``BOT_NOT_FOUND`` / ``IPC_TIMEOUT`` / server-error 는 surface 한다.
+        # IPC 서버 handler 가 봇 계좌(``bot.config.account_id``) 로 포지션을
+        # 스코핑하므로 (#2137), 타 계좌 누출 차단은 IPC·fallback 공통이다.
+        # IPC result 는 ``{"positions": [...]}`` envelope 이며 fallback list 와
+        # 동일 4-key projection 이다. None sentinel(미존재) 은 fallback 전용 —
+        # IPC 경로의 미존재는 ``BOT_NOT_FOUND`` ClickException 으로 surface 된다.
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        try:
+            ipc_result = await ipc_send(
+                "bot.positions", {"bot_id": bot_id}, actor=actor
+            )
+        except click.ClickException as e:
+            if getattr(e, "ipc_error_code", "") != "IPC_SERVER_NOT_RUNNING":
+                raise
+            return await _run_positions_fallback()
+        return list(ipc_result.get("positions", []))
+
+    try:
+        result = _run(_run_positions())
+    except click.ClickException as e:
+        # IPC ``BOT_NOT_FOUND`` 포함 surface 경로 — fallback 의 None sentinel
+        # (``if result is None``) 과 동일하게 ``BOT_NOT_FOUND`` exit 1 로
+        # 정렬된다. ``IPC_TIMEOUT`` / server-error 도 fallback 없이 surface.
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        if fmt.is_json:
+            fmt.error(message, code=code)
+        else:
+            text = f"{code}: {message}" if code else message
+            fmt.error(text)
+        raise SystemExit(1) from e
 
     if result is None:
         # 미존재 bot 은 안정 코드 ``BOT_NOT_FOUND`` 로 surface 한다
         # (CLI/IPC 일관성: ``BotNotFoundError.code = "BOT_NOT_FOUND"`` 와
-        # 동형, ``bot info`` / ``bot remove`` 형제 패턴 1:1 미러).
+        # 동형, ``bot info`` / ``bot remove`` 형제 패턴 1:1 미러). fallback 의
+        # snapshot 미존재가 이 분기로 들어온다(IPC 경로는 위에서 surface).
         fmt.error(f"봇을 찾을 수 없습니다: {bot_id}", code="BOT_NOT_FOUND")
         ctx.exit(1)
 

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -478,6 +478,139 @@ async def _handle_bot_status(
     return {"bot": info}
 
 
+# CLI ``bot list`` 출력 6-key projection (SSOT: cli/commands/bot.py:bot_list).
+# live ``Bot.get_info()`` 에는 ``created_at`` 이 없으므로(persisted DB 컬럼) None
+# 기본값으로 채워 snapshot fallback 과 동일 shape 을 보장한다 (#2112 Codex
+# condition 1: list/info 후처리 전 ``created_at=None`` 기본값).
+_BOT_LIST_KEYS = (
+    "bot_id",
+    "name",
+    "strategy_id",
+    "account_id",
+    "status",
+    "created_at",
+)
+
+
+async def _handle_bot_list(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """봇 목록 조회 IPC handler (read-only, #2112).
+
+    ``bot status`` (``_handle_bot_status``) 미러 — read-only 분류이므로 audit
+    logger 호출 없음. ``svc.bot_manager.list_bots()`` 가 반환하는 live
+    ``Bot.get_info()`` dict 들을 CLI ``bot list`` 의 6-key projection
+    (``bot_id``/``name``/``strategy_id``/``account_id``/``status``/
+    ``created_at``) 으로 좁혀 snapshot fallback 의 ``SELECT ... FROM bots``
+    행과 동일 shape 을 surface 한다.
+
+    ``--account`` 필터는 CLI ingress 에서 검증된 뒤 ``account_id`` arg 로
+    전달된다. ``None`` 이면 전체, 지정되면 해당 계좌 봇만 반환한다 (CLI SQL
+    filter 와 동형). live ``get_info()`` 에 ``created_at`` 이 없으므로 None
+    기본값으로 채운다 (snapshot 행과 key parity).
+    """
+    account_id = args.get("account_id")
+    bots = svc.bot_manager.list_bots()
+    result: list[dict[str, Any]] = []
+    for info in bots:
+        if account_id is not None and info.get("account_id") != account_id:
+            continue
+        result.append({key: info.get(key) for key in _BOT_LIST_KEYS})
+    return {"bots": result}
+
+
+async def _handle_bot_info(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """봇 상세 정보 조회 IPC handler (read-only, #2112).
+
+    ``bot status`` 미러 — read-only, audit 없음. ``get_bot(bot_id)`` 가
+    ``None`` 이면 ``BotNotFoundError`` (``BOT_NOT_FOUND`` envelope). 존재하면
+    ``Bot.get_info()`` 전체를 ``{"bot": info}`` envelope 으로 반환한다. CLI
+    fallback 의 ``SELECT * FROM bots`` 행과 공통 핵심키(``bot_id``/``name``/
+    ``status``/``account_id``/``strategy_id``) 가 일치한다 (live≠snapshot 의
+    완전 통일은 follow-up; #2112 non-goal).
+    """
+    from ante.bot.exceptions import BotNotFoundError
+
+    bot_id = args["bot_id"]
+    bot = svc.bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise BotNotFoundError(bot_id)
+    return {"bot": bot.get_info()}
+
+
+async def _handle_bot_positions(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """봇 보유 포지션 조회 IPC handler (read-only, #2112).
+
+    ``bot status`` 미러 — read-only, audit 없음. ``get_bot(bot_id)`` 존재
+    확인(``None`` → ``BotNotFoundError``) 후 ``trade_service`` 로 포지션을
+    조회한다.
+
+    ``trade_service`` 는 legacy ``ServiceRegistry`` 에서 ``None`` 일 수 있으므로
+    ``getattr`` safe-access 한다 (``_handle_bot_status`` 의 ``trade_service``
+    optional 처리 동형). **서비스 미구성(None)과 빈 포지션(0개) 을 혼동하지
+    않는다** (#2112 Codex condition 2): ``trade_service`` 가 없으면 빈 list 를
+    반환하되, 이는 "조회 불가" 가 아니라 "포지션 보강 미구성" 으로서 봇이
+    존재함은 이미 확인되었다(``BotNotFoundError`` 분기와 분리). #2137:
+    포지션 조회를 봇 계좌(``bot.config.account_id``) 로 스코핑해 타 계좌
+    stale/legacy 포지션 누출을 차단한다.
+    """
+    from ante.bot.exceptions import BotNotFoundError
+
+    bot_id = args["bot_id"]
+    bot = svc.bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise BotNotFoundError(bot_id)
+
+    trade_service = getattr(svc, "trade_service", None)
+    if trade_service is None:
+        # 서비스 미구성(legacy registry) — 봇은 존재하나 포지션 보강 경로 부재.
+        # 빈 포지션(0개) 과 동일 shape 이지만 의미상 "미구성" 이다. read-only
+        # 분류 정렬: 키 부재가 아니라 빈 collection 으로 graceful surface.
+        return {"positions": []}
+
+    positions = await trade_service.get_positions(
+        bot_id, account_id=bot.config.account_id
+    )
+    return {
+        "positions": [
+            {
+                "symbol": p.symbol,
+                "quantity": p.quantity,
+                "avg_entry_price": p.avg_entry_price,
+                "realized_pnl": p.realized_pnl,
+            }
+            for p in positions
+        ]
+    }
+
+
+async def _handle_bot_signal_key(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """봇 시그널 키 조회 IPC handler (read-only, #2112).
+
+    ``bot status`` 미러 — read-only, audit 없음. ``bot.signal_key.rotate``
+    (#2111, mutating) 와 별개의 read command 다. ``get_bot(bot_id)`` 존재
+    확인(``None`` → ``BotNotFoundError``) 후 ``get_signal_key(bot_id)`` 로
+    현재 키를 조회한다. 키 미발급이면 ``signal_key=None`` 을 반환하며, CLI
+    후처리(``SIGNAL_KEY_NOT_SET``) 가 None sentinel 을 surface 한다 (IPC·
+    fallback 공통).
+    """
+    from ante.bot.exceptions import BotNotFoundError
+
+    bot_id = args["bot_id"]
+    bot = svc.bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise BotNotFoundError(bot_id)
+
+    key = await svc.bot_manager.get_signal_key(bot_id)
+    return {"bot_id": bot_id, "signal_key": key}
+
+
 async def _handle_bot_update(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
@@ -982,9 +1115,9 @@ async def _handle_broker_reconcile(
 
 
 def register_all_handlers(registry: CommandRegistry) -> None:
-    """27개 런타임 커맨드 핸들러를 일괄 등록.
+    """32개 런타임 커맨드 핸들러를 일괄 등록.
 
-    Refs #1184: 각 핸들러는 mutating(23개) 또는 read-only(4개)로 분류된다.
+    Refs #1184: 각 핸들러는 mutating(24개) 또는 read-only(8개)로 분류된다.
     분류는 ``docs/specs/ipc/ipc.md``의 "Handler taxonomy" 섹션과 동기화되어야
     한다. mutating 명령은 ``IPCServer``가 ``SHUTTING_DOWN`` 상태일 때
     ``SERVICE_UNAVAILABLE``로 거부된다.
@@ -1014,8 +1147,13 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     ``bot.stop`` / ``bot.update`` / ``treasury.set_balance`` /
     ``strategy.set_status`` / ``member.update_scopes`` /
     ``approval.cancel_invalid`` / ``rule.update``.
+
+    Refs #2112: ``bot.list`` / ``bot.info`` / ``bot.positions`` /
+    ``bot.signal_key`` (read-only) 추가 — ``bot list/info/positions/signal-key``
+    의 runtime IPC 경로. CLI 가 서버 정지 시 snapshot DB fallback 한다. audit
+    없음(read-only). read-only 4→8, 총 28→32.
     """
-    # ── mutating (23개): 서버 상태/DB를 변경 ──────────
+    # ── mutating (24개): 서버 상태/DB를 변경 ──────────
     # system.* — account_service의 suspend_all/activate_all (collective ops).
     registry.register(
         "system.halt",
@@ -1238,7 +1376,7 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         account_id_policy="required",
     )
 
-    # ── read-only (4개): live 조회만 ──────────────────
+    # ── read-only (8개): live 조회만 ──────────────────
     # broker.* read-only — broker 객체 메서드 결과를 그대로 envelope에 surface.
     # status는 connected/healthy/exchange dict(entity), balance는 broker
     # response dict 그대로(raw passthrough), positions는 list collection.
@@ -1273,5 +1411,46 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         is_mutating=False,
         result_kind="entity",
         result_key="bot",
+        required_services=frozenset({"bot_manager"}),
+    )
+    # bot.* read-only (#2112) — ``bot list/info/positions/signal-key`` 의 runtime
+    # IPC 경로. ``bot.status`` 미러: is_mutating=False, audit_action 없음. CLI 가
+    # 서버 정지 시 ``IPC_SERVER_NOT_RUNNING`` 일 때만 기존 snapshot DB 경로로
+    # fallback 한다 (스펙: runtime IPC + snapshot fallback). bot.signal_key
+    # (read) 는 #2111 의 mutating ``bot.signal_key.rotate`` 와 별개 command 다.
+    registry.register(
+        "bot.list",
+        _handle_bot_list,
+        is_mutating=False,
+        result_kind="collection",
+        result_key="bots",
+        required_services=frozenset({"bot_manager"}),
+        account_id_policy="optional_filter",
+    )
+    registry.register(
+        "bot.info",
+        _handle_bot_info,
+        is_mutating=False,
+        result_kind="entity",
+        result_key="bot",
+        required_services=frozenset({"bot_manager"}),
+    )
+    # positions 는 ``trade_service`` optional(legacy registry None 가능)이라
+    # required_services 에서 제외하고 handler 가 graceful 처리한다. 봇 존재
+    # 확인은 ``bot_manager`` 로 수행하므로 required 에 포함.
+    registry.register(
+        "bot.positions",
+        _handle_bot_positions,
+        is_mutating=False,
+        result_kind="collection",
+        result_key="positions",
+        required_services=frozenset({"bot_manager"}),
+    )
+    registry.register(
+        "bot.signal_key",
+        _handle_bot_signal_key,
+        is_mutating=False,
+        result_kind="entity",
+        result_key="signal_key",
         required_services=frozenset({"bot_manager"}),
     )

--- a/tests/unit/contracts/error_drift_allowlist.yaml
+++ b/tests/unit/contracts/error_drift_allowlist.yaml
@@ -27,37 +27,52 @@
 #       module = dotted module path (예: ante.account.errors).
 #       class_anchor = class 이름.
 
-# bot.py 497/936/972/1006 (구 940/976/1010 → 구 924/960/994 → 구 931/967/1001
-# → 구 882/918/952) 와 config.py 212/215 (구 214/217 → 구 176/179) 의
-# ``ipc_send`` ClickException text-mode 분기는 ``text = f"{code}: {message}"``
-# prefix 패턴이 의도된 영구 UX 계약이다. 회귀 lock
+# bot.py text-mode ``ipc_send`` ClickException 분기는 ``text =
+# f"{code}: {message}"`` prefix 패턴이 의도된 영구 UX 계약이다. 회귀 lock
 # ``test_bot_start_error_text_mode_carries_code_prefix`` 와
 # ``test_config_set_server_error`` 의 ``"STATIC_CONFIG" in result.output`` 가
 # text 모드에서 ``code: message`` prefix 톤을 명시 요구하므로 단순
 # ``fmt.error(message, code=code)`` 정렬이 UX 회귀가 된다. 따라서
 # ``known_drift`` deferred 가 아닌 ``intended_no_code`` 영구 면제로 분류한다
-# (#1870 옵션 3). #1941 commands 주석 정리로 line 번호가 7줄 위로 이동.
-# #2137 bot status positions scope 변경으로 +16줄 이동 (924/960/994 → 940/976/1010).
-# #2111 signal-key --rotate IPC 라우팅 전환: cold-path rotate mutation 제거로
-# start/stop/status 분기가 이동 (940/976/1010 → 936/972/1006) + rotate
-# text-mode 분기 신규 callsite (497) 동일 UX prefix 패턴 추가. rotate 성공
-# 출력은 standard envelope (``fmt.success``) 를 그대로 보존하므로 출력 emit
-# 분기 변경이 위 fmt.error anchor 에 추가 영향을 주지 않는다.
+# (#1870 옵션 3). #1941 commands 주석 정리로 line 번호 이동, #2137/#2111 이동.
+# #2112 bot list/info/positions/signal-key(read) runtime IPC 라우팅 전환:
+# 4 read 명령에 동일 ``ipc_send`` ClickException text-mode 분기(동일 UX prefix
+# 패턴, sha 3dc4008c3fb0) 신규 추가 + start/stop/status/rotate 분기가 아래로
+# 이동. 현재 bot.py code-less text-mode fmt.error 8건: list(212)/info(273)/
+# positions(664)/signal-key-read(817)/start(1084)/stop(1120)/status(1154) +
+# rotate(569, sha 03fce6e088b7). 각 4 read 분기의 성공 출력은 기존 contract
+# (table/output/echo) 를 그대로 보존하므로 추가 fmt.error anchor 영향 없음.
 intended_no_code:
   - path: src/ante/cli/commands/bot.py
-    line: 497
+    line: 212
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "text-mode {code}: {message} prefix UX lock — bot list read IPC 분기 (#2112)"
+  - path: src/ante/cli/commands/bot.py
+    line: 273
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "text-mode {code}: {message} prefix UX lock — bot info read IPC 분기 (#2112)"
+  - path: src/ante/cli/commands/bot.py
+    line: 569
     snippet_sha1: "03fce6e088b7"
     reason: "text-mode {code}: {message} prefix UX lock — signal-key --rotate IPC 분기 (#2111)"
   - path: src/ante/cli/commands/bot.py
-    line: 936
+    line: 664
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "text-mode {code}: {message} prefix UX lock — bot positions read IPC 분기 (#2112)"
+  - path: src/ante/cli/commands/bot.py
+    line: 817
+    snippet_sha1: "3dc4008c3fb0"
+    reason: "text-mode {code}: {message} prefix UX lock — bot signal-key read IPC 분기 (#2112)"
+  - path: src/ante/cli/commands/bot.py
+    line: 1084
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 972
+    line: 1120
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/bot.py
-    line: 1006
+    line: 1154
     snippet_sha1: "3dc4008c3fb0"
     reason: "text-mode {code}: {message} prefix UX lock — intended permanent (resolves #1870)"
   - path: src/ante/cli/commands/config.py

--- a/tests/unit/ipc/test_cli_registry_ipc_cross_ref.py
+++ b/tests/unit/ipc/test_cli_registry_ipc_cross_ref.py
@@ -2,15 +2,19 @@
 
 Refs #1853 (#1819 epic 종결): ``src/ante/contracts/cli_registry.py`` 의
 ``execution="runtime_ipc"`` entries 가 가리키는 ``ipc_command`` 가 실제로
-``ante.ipc.registry.register_all_handlers()`` 에 등록된 27 commands 중
+``ante.ipc.registry.register_all_handlers()`` 에 등록된 commands 중
 하나이거나, ``EXPECTED_MISSING_IPC_COMMANDS`` baseline (후속 wiring stub —
-docs/specs/ipc/ipc.md:273-276 명시) 중 하나여야 한다.
+docs/specs/ipc/ipc.md 명시) 중 하나여야 한다.
 
 baseline 밖의 미존재 (예: 오타, 명칭 변경 누락) → 즉시 FAIL.
 
-baseline 12 entries 의 후속 wiring 은 별도 child issue 에서 점진 제거되며,
+baseline entries 의 후속 wiring 은 별도 child issue 에서 점진 제거되며,
 removal 시 본 모듈의 ``EXPECTED_MISSING_IPC_COMMANDS`` 도 함께 갱신해야 한다
 (SSOT 한쪽만 갱신되는 회귀를 본 test 가 차단).
+
+Refs #2112: ``bot.list`` / ``bot.info`` / ``bot.positions`` /
+``bot.signal_key`` (read) 4건이 ``register_all_handlers()`` 에 wiring 되어
+baseline 에서 제거되었다 (12→8). 잔여 baseline 은 member.* 8건이다.
 """
 
 from __future__ import annotations
@@ -20,13 +24,13 @@ import pytest
 from ante.contracts.cli_registry import all_contracts
 from ante.ipc.registry import CommandRegistry, register_all_handlers
 
-# ``docs/specs/ipc/ipc.md:273-276`` 명시 — ``register_all_handlers()`` 에
-# 아직 wiring 되지 않은 12 commands. CLI registry 의 ``ipc_command`` stub
-# 값은 후속 wiring 이슈로 점진 제거된다.
+# ``docs/specs/ipc/ipc.md`` 명시 — ``register_all_handlers()`` 에 아직 wiring
+# 되지 않은 8 commands. CLI registry 의 ``ipc_command`` stub 값은 후속 wiring
+# 이슈로 점진 제거된다.
 #
 # member.* 8: ipc.md:160-168 표 stub. ``member.update_scopes`` 만 현재 등록.
-# bot.* 4: ipc.md:97-103 / 274 — ``bot.list`` / ``bot.info`` / ``bot.positions`` /
-#   ``bot.signal_key`` 의 live 조회/회수 IPC 후속 wiring.
+# bot.* 4 (``bot.list`` / ``bot.info`` / ``bot.positions`` / ``bot.signal_key``)
+# 는 #2112 에서 wiring 완료되어 baseline 에서 제거되었다.
 EXPECTED_MISSING_IPC_COMMANDS: frozenset[str] = frozenset(
     {
         # member runtime IPC stub (8)
@@ -38,11 +42,6 @@ EXPECTED_MISSING_IPC_COMMANDS: frozenset[str] = frozenset(
         "member.rotate_token",
         "member.reset_password",
         "member.regenerate_recovery_key",
-        # bot query 계열 후속 wiring (4)
-        "bot.list",
-        "bot.info",
-        "bot.positions",
-        "bot.signal_key",
     }
 )
 
@@ -55,9 +54,11 @@ def loaded_registry() -> CommandRegistry:
 
 
 def test_baseline_size_locked() -> None:
-    """baseline 크기를 12 로 lock — 후속 wiring 이슈가 줄여나갈 때 본 lock 도
-    함께 갱신해야 한다 (SSOT 동기화 강제)."""
-    assert len(EXPECTED_MISSING_IPC_COMMANDS) == 12, (
+    """baseline 크기를 8 로 lock — 후속 wiring 이슈가 줄여나갈 때 본 lock 도
+    함께 갱신해야 한다 (SSOT 동기화 강제).
+
+    Refs #2112: bot.* read 4건 wiring 완료로 12→8."""
+    assert len(EXPECTED_MISSING_IPC_COMMANDS) == 8, (
         f"baseline size={len(EXPECTED_MISSING_IPC_COMMANDS)}; "
         "후속 wiring 이슈에서 baseline 항목을 제거했다면 본 lock 도 함께 갱신."
     )

--- a/tests/unit/ipc/test_docs_taxonomy_drift.py
+++ b/tests/unit/ipc/test_docs_taxonomy_drift.py
@@ -62,14 +62,16 @@ _DOCS_NON_REGISTRY_TOKENS = frozenset(
         "member.rotate_token",
         "member.reset_password",
         "member.regenerate_recovery_key",
-        # bot.query 계열 후속 wiring — ipc.md:98 / 274
-        "bot.query",
         # cold-path 전용 — ipc.md:70-74 / 193 / 273
         "account.delete",
         "account.create",
         "account.set_credentials",
     }
 )
+# Refs #2112: 종전 ``bot.query`` placeholder 토큰은 ``bot.list`` / ``bot.info`` /
+# ``bot.positions`` / ``bot.signal_key`` (read) 4건 wiring 완료로 docs/specs/
+# ipc.md 에서 제거되었고, 4건은 모두 ``register_all_handlers()`` 에 등록되므로
+# non-registry 화이트리스트에서 더 이상 필요 없다.
 
 
 def _parse_docs_taxonomy_table() -> dict[str, str]:

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -65,7 +65,7 @@ def test_commands_property(registry: CommandRegistry) -> None:
 
 
 def test_register_all_handlers() -> None:
-    """register_all_handlers가 28개 핸들러를 등록 (account.delete 제외).
+    """register_all_handlers가 32개 핸들러를 등록 (account.delete 제외).
 
     `account.delete`는 1.0 IPC 계약에서 제거되어 cold-path CLI에서 직접
     AccountService를 호출한다.
@@ -82,10 +82,14 @@ def test_register_all_handlers() -> None:
 
     Refs #2111: ``bot.signal_key.rotate`` (mutating) 추가 — ``bot signal-key
     --rotate`` 의 runtime IPC 경로.
+
+    Refs #2112: ``bot.list`` / ``bot.info`` / ``bot.positions`` /
+    ``bot.signal_key`` (read-only) 4건 추가 — ``bot list/info/positions/
+    signal-key`` 의 runtime IPC 경로 (28→32).
     """
     registry = CommandRegistry()
     register_all_handlers(registry)
-    assert len(registry.commands) == 28
+    assert len(registry.commands) == 32
 
     expected = {
         "system.halt",
@@ -99,6 +103,10 @@ def test_register_all_handlers() -> None:
         "bot.stop",
         "bot.update",
         "bot.status",
+        "bot.list",
+        "bot.info",
+        "bot.positions",
+        "bot.signal_key",
         "treasury.allocate",
         "treasury.deallocate",
         "treasury.set_balance",
@@ -125,12 +133,15 @@ def test_register_all_handlers() -> None:
 
 
 def test_register_all_handlers_taxonomy() -> None:
-    """등록된 28개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다.
+    """등록된 32개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다.
 
     Refs #1712: ``bot.start`` / ``bot.stop`` mutating, ``bot.status``
     read-only — ``docs/specs/ipc/ipc.md`` Handler taxonomy SSOT 와 동기화.
 
     Refs #2111: ``bot.signal_key.rotate`` mutating 추가.
+
+    Refs #2112: ``bot.list`` / ``bot.info`` / ``bot.positions`` /
+    ``bot.signal_key`` read-only 추가 (read-only 4→8).
     """
     registry = CommandRegistry()
     register_all_handlers(registry)
@@ -166,10 +177,14 @@ def test_register_all_handlers_taxonomy() -> None:
         "broker.balance",
         "broker.positions",
         "bot.status",
+        "bot.list",
+        "bot.info",
+        "bot.positions",
+        "bot.signal_key",
     }
 
     assert len(mutating) == 24
-    assert len(read_only) == 4
+    assert len(read_only) == 8
     assert mutating | read_only == set(registry.commands)
 
     for command in mutating:
@@ -1022,11 +1037,11 @@ class TestRegisteredCommandsMetadataCompleteness:
         for spec in loaded.iter_specs():
             assert spec.cross_validators == (), spec.name
 
-    def test_iter_specs_returns_all_28_specs(self, loaded: CommandRegistry) -> None:
-        """``iter_specs``가 28 commands 모두를 ``CommandSpec`` 인스턴스로
-        반환한다."""
+    def test_iter_specs_returns_all_32_specs(self, loaded: CommandRegistry) -> None:
+        """``iter_specs``가 32 commands 모두를 ``CommandSpec`` 인스턴스로
+        반환한다 (#2112: 28→32, bot.* read 4건 추가)."""
         specs = loaded.iter_specs()
-        assert len(specs) == 28
+        assert len(specs) == 32
         assert all(isinstance(s, CommandSpec) for s in specs)
         # 등록 순서 보존(dict insertion order).
         assert [s.name for s in specs] == loaded.commands

--- a/tests/unit/test_cli_bot_read_ipc.py
+++ b/tests/unit/test_cli_bot_read_ipc.py
@@ -1,0 +1,808 @@
+"""``ante bot list/info/positions/signal-key`` (read) runtime IPC 라우팅 lock (#2112).
+
+## 배경
+
+``bot list/info/positions/signal-key`` 는 스펙(``docs/specs/cli/03-commands.md`` /
+``cli_registry`` / ``docs/specs/ipc/ipc.md``)상 ``runtime IPC + snapshot
+fallback`` 으로 정의되어 있으나, CLI 가 IPC 를 시도하지 않고 직접 DB snapshot
+만 조회했다. #2112 는 4종을 IPC 우선 + 서버 정지(``IPC_SERVER_NOT_RUNNING``)
+시 기존 snapshot DB fallback 으로 라우팅한다.
+
+## 회귀 lock (이슈 본문 검증 (a)~(f))
+
+- (a) 서버 실행 → 각 명령 ``ipc_send`` 호출 + 직접 DB 경로
+  (``_create_services`` / ``SignalKeyManager`` / ``open_cli_db`` /
+  ``TradeService``) **미호출**.
+- (b) 서버 정지(``IPC_SERVER_NOT_RUNNING``) → fallback DB 경로 수행 + exit 0
+  (**#2111 rotate 와 정반대로 fallback 수행 lock**).
+- (c) shape parity: IPC result ↔ fallback result 공통 핵심키 동일.
+- (d) 미존재 봇 → ``BOT_NOT_FOUND`` 양쪽 exit 1; signal-key 미발급 → 양쪽
+  동일 처리.
+- (e) ``IPC_TIMEOUT`` / server-error → fallback 없이 surface exit 1.
+- (f) positions: ``trade_service`` None(미구성) vs 빈 포지션(0개) 구분;
+  account scoping(타계좌 누출 차단) 양쪽 동일.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MASTER = Member(
+    member_id="read-ipc-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Read IPC Master",
+    status="active",
+    scopes=[],
+)
+
+
+def _server_not_running_exc() -> click.ClickException:
+    """``ServerNotRunningError`` → ``ipc_send`` ClickException 대역."""
+    exc = click.ClickException(
+        "서버가 실행 중이 아닙니다. 'ante system start'로 시작하세요."
+    )
+    exc.ipc_error_code = "IPC_SERVER_NOT_RUNNING"  # type: ignore[attr-defined]
+    exc.ipc_error_message = exc.message  # type: ignore[attr-defined]
+    return exc
+
+
+def _timeout_exc() -> click.ClickException:
+    exc = click.ClickException("서버 응답 시간 초과")
+    exc.ipc_error_code = "IPC_TIMEOUT"  # type: ignore[attr-defined]
+    exc.ipc_error_message = exc.message  # type: ignore[attr-defined]
+    return exc
+
+
+def _server_error_exc(code: str, message: str) -> click.ClickException:
+    """서버 error envelope → ``ipc_send`` ClickException 대역."""
+    exc = click.ClickException(f"{code}: {message}")
+    exc.ipc_error_code = code  # type: ignore[attr-defined]
+    exc.ipc_error_message = message  # type: ignore[attr-defined]
+    return exc
+
+
+def _parse_json(stdout: str) -> dict:
+    text = stdout.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return json.loads(text.splitlines()[-1])
+
+
+def _runner() -> CliRunner:
+    return CliRunner(mix_stderr=False)
+
+
+def _invoke(args: list[str], *, patches: list):
+    """auth 우회 + 주어진 patch context 하에 CLI 호출."""
+    runner = _runner()
+
+    def _auth_set(ctx):  # noqa: ANN001, ANN202
+        ctx.obj = ctx.obj or {}
+        ctx.obj["member"] = _MASTER
+
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("ante.cli.main.authenticate_member", side_effect=_auth_set)
+        )
+        stack.enter_context(
+            patch("ante.cli.main.get_db_path", return_value="/tmp/unused-read-ipc.db")
+        )
+        for p in patches:
+            stack.enter_context(p)
+        return runner.invoke(cli, args)
+
+
+# 직접 DB cold-path 진입을 막는 가드 (서버 실행 중 IPC-only 검증용).
+def _guard_direct_db() -> list:
+    return [
+        patch(
+            "ante.cli.commands.bot._create_services",
+            side_effect=AssertionError(
+                "서버 실행 중인데 _create_services cold-path 가 호출됨 (#2112 위반)"
+            ),
+        ),
+        patch(
+            "ante.cli.commands.bot.open_cli_db",
+            side_effect=AssertionError(
+                "서버 실행 중인데 open_cli_db cold-path 가 호출됨 (#2112 위반)"
+            ),
+        ),
+        patch(
+            "ante.bot.signal_key.SignalKeyManager",
+            side_effect=AssertionError(
+                "서버 실행 중인데 SignalKeyManager cold-path 가 호출됨 (#2112 위반)"
+            ),
+        ),
+        patch(
+            "ante.trade.service.TradeService",
+            side_effect=AssertionError(
+                "서버 실행 중인데 TradeService cold-path 가 호출됨 (#2112 위반)"
+            ),
+        ),
+    ]
+
+
+# ── (a) 서버 실행 중 → IPC 라우팅 + 직접 DB 미호출 ────────────────────────────
+
+
+class TestServerRunningRoutesToIpc:
+    def test_list_routes_to_ipc(self) -> None:
+        mock_send = AsyncMock(
+            return_value={
+                "bots": [
+                    {
+                        "bot_id": "bot-1",
+                        "name": "B1",
+                        "strategy_id": "s1",
+                        "account_id": "acc-a",
+                        "status": "stopped",
+                        "created_at": None,
+                    }
+                ]
+            }
+        )
+        result = _invoke(
+            ["--format", "json", "bot", "list"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert mock_send.await_args.args[0] == "bot.list"
+        payload = _parse_json(result.stdout)
+        assert [b["bot_id"] for b in payload["bots"]] == ["bot-1"]
+
+    def test_list_account_filter_passed_to_ipc(self) -> None:
+        mock_send = AsyncMock(return_value={"bots": []})
+        result = _invoke(
+            ["--format", "json", "bot", "list", "--account", "acc-a"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert mock_send.await_args.args[0] == "bot.list"
+        assert mock_send.await_args.args[1] == {"account_id": "acc-a"}
+
+    def test_info_routes_to_ipc(self) -> None:
+        mock_send = AsyncMock(
+            return_value={
+                "bot": {
+                    "bot_id": "bot-1",
+                    "name": "B1",
+                    "status": "running",
+                    "account_id": "acc-a",
+                    "strategy_id": "s1",
+                }
+            }
+        )
+        result = _invoke(
+            ["--format", "json", "bot", "info", "bot-1"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert mock_send.await_args.args[0] == "bot.info"
+        assert mock_send.await_args.args[1] == {"bot_id": "bot-1"}
+        payload = _parse_json(result.stdout)
+        assert payload["bot_id"] == "bot-1"
+        assert payload["status"] == "running"
+
+    def test_positions_routes_to_ipc(self) -> None:
+        mock_send = AsyncMock(
+            return_value={
+                "positions": [
+                    {
+                        "symbol": "AAA",
+                        "quantity": 1.0,
+                        "avg_entry_price": 100.0,
+                        "realized_pnl": 10.0,
+                    }
+                ]
+            }
+        )
+        result = _invoke(
+            ["--format", "json", "bot", "positions", "bot-1"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert mock_send.await_args.args[0] == "bot.positions"
+        assert mock_send.await_args.args[1] == {"bot_id": "bot-1"}
+        payload = _parse_json(result.stdout)
+        assert [p["symbol"] for p in payload["positions"]] == ["AAA"]
+
+    def test_signal_key_read_routes_to_ipc(self) -> None:
+        mock_send = AsyncMock(return_value={"bot_id": "bot-1", "signal_key": "sk_live"})
+        result = _invoke(
+            ["--format", "json", "bot", "signal-key", "bot-1"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert mock_send.await_args.args[0] == "bot.signal_key"
+        assert mock_send.await_args.args[1] == {"bot_id": "bot-1"}
+        payload = _parse_json(result.stdout)
+        assert payload["signal_key"] == "sk_live"
+
+    def test_signal_key_read_does_not_use_rotate_command(self) -> None:
+        """read 경로(rotate 미지정)는 ``bot.signal_key`` (read) 만 호출하고
+        ``bot.signal_key.rotate`` (#2111 mutating) 는 호출하지 않는다."""
+        mock_send = AsyncMock(return_value={"bot_id": "bot-1", "signal_key": "sk_live"})
+        result = _invoke(
+            ["--format", "json", "bot", "signal-key", "bot-1"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        called_commands = [c.args[0] for c in mock_send.await_args_list]
+        assert "bot.signal_key.rotate" not in called_commands
+        assert called_commands == ["bot.signal_key"]
+
+
+# ── (b) 서버 정지(IPC_SERVER_NOT_RUNNING) → fallback DB 경로 수행 + exit 0 ────
+
+
+def _make_db(*, fetch_one=None, fetch_all=None) -> MagicMock:
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    if fetch_one is not None:
+        db.fetch_one = AsyncMock(side_effect=fetch_one)
+    if fetch_all is not None:
+        db.fetch_all = AsyncMock(side_effect=fetch_all)
+    return db
+
+
+def _create_services_cm(db: MagicMock):
+    """``_create_services`` async context manager 대역."""
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _cm(ctx=None):  # noqa: ANN001, ANN202
+        yield db, MagicMock(), MagicMock(), MagicMock()
+
+    return _cm
+
+
+def _open_cli_db_cm(db: MagicMock):
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _cm(ctx):  # noqa: ANN001, ANN202
+        yield db
+
+    return _cm
+
+
+class TestServerStoppedFallsBackToSnapshot:
+    """서버 정지 시 직접 DB snapshot fallback 을 수행한다 (#2111 rotate 와 정반대)."""
+
+    def test_list_falls_back_to_db(self) -> None:
+        mock_send = AsyncMock(side_effect=_server_not_running_exc())
+        rows = [
+            {
+                "bot_id": "bot-db",
+                "name": "DBBot",
+                "strategy_id": "s1",
+                "account_id": "acc-a",
+                "status": "stopped",
+                "created_at": "2026-01-01T00:00:00",
+            }
+        ]
+        db = _make_db(fetch_all=lambda *a, **k: rows)
+        result = _invoke(
+            ["--format", "json", "bot", "list"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                patch(
+                    "ante.cli.commands.bot._create_services",
+                    new=_create_services_cm(db),
+                ),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = _parse_json(result.stdout)
+        assert [b["bot_id"] for b in payload["bots"]] == ["bot-db"]
+        db.fetch_all.assert_awaited()
+
+    def test_info_falls_back_to_db(self) -> None:
+        mock_send = AsyncMock(side_effect=_server_not_running_exc())
+        row = {
+            "bot_id": "bot-db",
+            "name": "DBBot",
+            "strategy_id": "s1",
+            "account_id": "acc-a",
+            "status": "stopped",
+            "created_at": "2026-01-01T00:00:00",
+        }
+        db = _make_db(fetch_one=lambda *a, **k: row)
+        result = _invoke(
+            ["--format", "json", "bot", "info", "bot-db"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                patch(
+                    "ante.cli.commands.bot._create_services",
+                    new=_create_services_cm(db),
+                ),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = _parse_json(result.stdout)
+        assert payload["bot_id"] == "bot-db"
+        db.fetch_one.assert_awaited()
+
+    def test_signal_key_read_falls_back_to_db(self) -> None:
+        mock_send = AsyncMock(side_effect=_server_not_running_exc())
+        db = _make_db(fetch_one=lambda *a, **k: {"strategy_id": "s1"})
+        skm = MagicMock()
+        skm.initialize = AsyncMock()
+        skm.get_key = AsyncMock(return_value="sk_db")
+        result = _invoke(
+            ["--format", "json", "bot", "signal-key", "bot-db"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                patch(
+                    "ante.cli.commands.bot._create_services",
+                    new=_create_services_cm(db),
+                ),
+                patch("ante.bot.signal_key.SignalKeyManager", return_value=skm),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = _parse_json(result.stdout)
+        assert payload["signal_key"] == "sk_db"
+        skm.get_key.assert_awaited()
+
+    def test_positions_falls_back_to_db(self) -> None:
+        mock_send = AsyncMock(side_effect=_server_not_running_exc())
+        db = _make_db(fetch_one=lambda *a, **k: {"account_id": "acc-a"})
+        position = SimpleNamespace(
+            symbol="AAA", quantity=1.0, avg_entry_price=100.0, realized_pnl=10.0
+        )
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[position])
+        pos_history = MagicMock()
+        pos_history.initialize = AsyncMock()
+        recorder = MagicMock()
+        recorder.initialize = AsyncMock()
+        result = _invoke(
+            ["--format", "json", "bot", "positions", "bot-db"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                patch("ante.cli.commands.bot.open_cli_db", new=_open_cli_db_cm(db)),
+                patch("ante.trade.position.PositionHistory", return_value=pos_history),
+                patch("ante.trade.recorder.TradeRecorder", return_value=recorder),
+                patch(
+                    "ante.trade.performance.PerformanceTracker",
+                    return_value=MagicMock(),
+                ),
+                patch("ante.trade.service.TradeService", return_value=trade_service),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = _parse_json(result.stdout)
+        assert [p["symbol"] for p in payload["positions"]] == ["AAA"]
+        # account scoping 보존: 봇 계좌(acc-a) 로 스코핑.
+        trade_service.get_positions.assert_awaited_once_with(
+            "bot-db", account_id="acc-a"
+        )
+
+
+# ── (c) shape parity: IPC result ↔ fallback result 공통 핵심키 ────────────────
+
+
+class TestShapeParity:
+    def test_list_parity(self) -> None:
+        bots_payload = [
+            {
+                "bot_id": "bot-1",
+                "name": "B1",
+                "strategy_id": "s1",
+                "account_id": "acc-a",
+                "status": "stopped",
+                "created_at": None,
+            }
+        ]
+        ipc_send = AsyncMock(return_value={"bots": bots_payload})
+        ipc_res = _invoke(
+            ["--format", "json", "bot", "list"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+                *_guard_direct_db(),
+            ],
+        )
+        db_rows = [dict(b, created_at="2026-01-01") for b in bots_payload]
+        db = _make_db(fetch_all=lambda *a, **k: db_rows)
+        fb_res = _invoke(
+            ["--format", "json", "bot", "list"],
+            patches=[
+                patch(
+                    "ante.cli.commands.ipc_helpers.ipc_send",
+                    new=AsyncMock(side_effect=_server_not_running_exc()),
+                ),
+                patch(
+                    "ante.cli.commands.bot._create_services",
+                    new=_create_services_cm(db),
+                ),
+            ],
+        )
+        ipc_keys = set(_parse_json(ipc_res.stdout))
+        fb_keys = set(_parse_json(fb_res.stdout))
+        assert "bots" in ipc_keys and "bots" in fb_keys
+        ipc_bot = _parse_json(ipc_res.stdout)["bots"][0]
+        fb_bot = _parse_json(fb_res.stdout)["bots"][0]
+        common = {"bot_id", "name", "strategy_id", "account_id", "status"}
+        assert {k: ipc_bot[k] for k in common} == {k: fb_bot[k] for k in common}
+
+    def test_signal_key_parity(self) -> None:
+        ipc_send = AsyncMock(return_value={"bot_id": "bot-1", "signal_key": "sk"})
+        ipc_res = _invoke(
+            ["--format", "json", "bot", "signal-key", "bot-1"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+                *_guard_direct_db(),
+            ],
+        )
+        db = _make_db(fetch_one=lambda *a, **k: {"strategy_id": "s1"})
+        skm = MagicMock()
+        skm.initialize = AsyncMock()
+        skm.get_key = AsyncMock(return_value="sk")
+        fb_res = _invoke(
+            ["--format", "json", "bot", "signal-key", "bot-1"],
+            patches=[
+                patch(
+                    "ante.cli.commands.ipc_helpers.ipc_send",
+                    new=AsyncMock(side_effect=_server_not_running_exc()),
+                ),
+                patch(
+                    "ante.cli.commands.bot._create_services",
+                    new=_create_services_cm(db),
+                ),
+                patch("ante.bot.signal_key.SignalKeyManager", return_value=skm),
+            ],
+        )
+        ipc = _parse_json(ipc_res.stdout)
+        fb = _parse_json(fb_res.stdout)
+        assert {"bot_id", "signal_key"} <= set(ipc)
+        assert {k: ipc[k] for k in ("bot_id", "signal_key")} == {
+            k: fb[k] for k in ("bot_id", "signal_key")
+        }
+
+
+# ── (d) 미존재 봇 → BOT_NOT_FOUND 양쪽 exit 1; signal-key 미발급 동일 처리 ────
+
+
+class TestMissingResource:
+    def test_info_ipc_bot_not_found(self) -> None:
+        mock_send = AsyncMock(
+            side_effect=_server_error_exc("BOT_NOT_FOUND", "봇을 찾을 수 없습니다")
+        )
+        result = _invoke(
+            ["--format", "json", "bot", "info", "missing"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert _parse_json(result.stdout)["code"] == "BOT_NOT_FOUND"
+
+    def test_info_fallback_bot_not_found(self) -> None:
+        db = _make_db(fetch_one=lambda *a, **k: None)
+        result = _invoke(
+            ["--format", "json", "bot", "info", "missing"],
+            patches=[
+                patch(
+                    "ante.cli.commands.ipc_helpers.ipc_send",
+                    new=AsyncMock(side_effect=_server_not_running_exc()),
+                ),
+                patch(
+                    "ante.cli.commands.bot._create_services",
+                    new=_create_services_cm(db),
+                ),
+            ],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert _parse_json(result.stdout)["code"] == "BOT_NOT_FOUND"
+
+    def test_positions_ipc_bot_not_found(self) -> None:
+        mock_send = AsyncMock(
+            side_effect=_server_error_exc("BOT_NOT_FOUND", "봇을 찾을 수 없습니다")
+        )
+        result = _invoke(
+            ["--format", "json", "bot", "positions", "missing"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert _parse_json(result.stdout)["code"] == "BOT_NOT_FOUND"
+
+    def test_signal_key_ipc_bot_not_found(self) -> None:
+        mock_send = AsyncMock(
+            side_effect=_server_error_exc("BOT_NOT_FOUND", "봇을 찾을 수 없습니다")
+        )
+        result = _invoke(
+            ["--format", "json", "bot", "signal-key", "missing"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert _parse_json(result.stdout)["code"] == "BOT_NOT_FOUND"
+
+    def test_signal_key_ipc_not_set(self) -> None:
+        """IPC signal_key None → ``SIGNAL_KEY_NOT_SET`` (fallback 과 동일)."""
+        mock_send = AsyncMock(return_value={"bot_id": "bot-1", "signal_key": None})
+        result = _invoke(
+            ["--format", "json", "bot", "signal-key", "bot-1"],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert _parse_json(result.stdout)["code"] == "SIGNAL_KEY_NOT_SET"
+
+    def test_signal_key_fallback_not_set(self) -> None:
+        db = _make_db(fetch_one=lambda *a, **k: {"strategy_id": "s1"})
+        skm = MagicMock()
+        skm.initialize = AsyncMock()
+        skm.get_key = AsyncMock(return_value=None)
+        result = _invoke(
+            ["--format", "json", "bot", "signal-key", "bot-1"],
+            patches=[
+                patch(
+                    "ante.cli.commands.ipc_helpers.ipc_send",
+                    new=AsyncMock(side_effect=_server_not_running_exc()),
+                ),
+                patch(
+                    "ante.cli.commands.bot._create_services",
+                    new=_create_services_cm(db),
+                ),
+                patch("ante.bot.signal_key.SignalKeyManager", return_value=skm),
+            ],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert _parse_json(result.stdout)["code"] == "SIGNAL_KEY_NOT_SET"
+
+
+# ── (e) IPC_TIMEOUT / server-error → fallback 없이 surface exit 1 ─────────────
+
+
+class TestNonFallbackErrorsSurface:
+    @pytest.mark.parametrize(
+        "command,args",
+        [
+            ("bot.list", ["bot", "list"]),
+            ("bot.info", ["bot", "info", "bot-1"]),
+            ("bot.positions", ["bot", "positions", "bot-1"]),
+            ("bot.signal_key", ["bot", "signal-key", "bot-1"]),
+        ],
+    )
+    def test_timeout_surfaces_no_fallback(self, command: str, args: list[str]) -> None:
+        mock_send = AsyncMock(side_effect=_timeout_exc())
+        result = _invoke(
+            ["--format", "json", *args],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert _parse_json(result.stdout)["code"] == "IPC_TIMEOUT"
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["bot", "list"],
+            ["bot", "info", "bot-1"],
+            ["bot", "positions", "bot-1"],
+            ["bot", "signal-key", "bot-1"],
+        ],
+    )
+    def test_server_error_surfaces_no_fallback(self, args: list[str]) -> None:
+        mock_send = AsyncMock(
+            side_effect=_server_error_exc("EXECUTION_ERROR", "서버 내부 오류")
+        )
+        result = _invoke(
+            ["--format", "json", *args],
+            patches=[
+                patch("ante.cli.commands.ipc_helpers.ipc_send", new=mock_send),
+                *_guard_direct_db(),
+            ],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        assert _parse_json(result.stdout)["code"] == "EXECUTION_ERROR"
+
+
+# ── (f) positions: trade_service None(미구성) vs 빈 포지션(0개) 구분 ──────────
+
+
+class TestPositionsServiceMissingVsEmpty:
+    """IPC handler 가 ``trade_service`` 부재(미구성)와 빈 포지션(0개)을 모두
+    graceful 처리하되 의미가 다름을 명시 검증한다 (#2112 Codex condition 2).
+
+    두 경우 모두 CLI 출력은 ``positions=[]`` + exit 0 (빈 collection) 이지만,
+    handler 레벨에서 trade_service None 경로(서비스 미구성)와 empty positions
+    경로(0개 포지션)가 분리되어 동작함을 직접 검증한다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_handler_trade_service_none_returns_empty(self) -> None:
+        from ante.ipc.registry import _handle_bot_positions
+
+        bot = SimpleNamespace(config=SimpleNamespace(account_id="acc-a"))
+        svc = SimpleNamespace(
+            bot_manager=SimpleNamespace(get_bot=lambda _id: bot),
+            # trade_service 속성 자체가 없는 legacy registry 모사.
+        )
+        result = await _handle_bot_positions(svc, {"bot_id": "bot-1"}, "cli")
+        # 미구성 → 빈 collection graceful (조회 불가 아님; 봇은 존재).
+        assert result == {"positions": []}
+
+    @pytest.mark.asyncio
+    async def test_handler_empty_positions_distinct_from_missing_service(self) -> None:
+        from ante.ipc.registry import _handle_bot_positions
+
+        bot = SimpleNamespace(config=SimpleNamespace(account_id="acc-a"))
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[])  # 0 포지션
+        svc = SimpleNamespace(
+            bot_manager=SimpleNamespace(get_bot=lambda _id: bot),
+            trade_service=trade_service,
+        )
+        result = await _handle_bot_positions(svc, {"bot_id": "bot-1"}, "cli")
+        assert result == {"positions": []}
+        # 빈 포지션 경로는 get_positions 를 봇 계좌로 스코핑 호출했다 — 미구성
+        # 경로(get_positions 미호출)와 구분된다.
+        trade_service.get_positions.assert_awaited_once_with(
+            "bot-1", account_id="acc-a"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handler_missing_bot_raises(self) -> None:
+        from ante.bot.exceptions import BotNotFoundError
+        from ante.ipc.registry import _handle_bot_positions
+
+        svc = SimpleNamespace(
+            bot_manager=SimpleNamespace(get_bot=lambda _id: None),
+            trade_service=MagicMock(),
+        )
+        with pytest.raises(BotNotFoundError):
+            await _handle_bot_positions(svc, {"bot_id": "missing"}, "cli")
+
+    @pytest.mark.asyncio
+    async def test_handler_account_scoping_lock(self) -> None:
+        """포지션 조회가 항상 봇 계좌(account_id)로 스코핑됨 (타계좌 누출 차단)."""
+        from ante.ipc.registry import _handle_bot_positions
+
+        bot = SimpleNamespace(config=SimpleNamespace(account_id="acc-scoped"))
+        trade_service = MagicMock()
+        trade_service.get_positions = AsyncMock(return_value=[])
+        svc = SimpleNamespace(
+            bot_manager=SimpleNamespace(get_bot=lambda _id: bot),
+            trade_service=trade_service,
+        )
+        await _handle_bot_positions(svc, {"bot_id": "bot-1"}, "cli")
+        trade_service.get_positions.assert_awaited_once_with(
+            "bot-1", account_id="acc-scoped"
+        )
+
+
+# ── handler-level list/info/signal_key 직접 검증 ──────────────────────────────
+
+
+class TestReadHandlersUnit:
+    @pytest.mark.asyncio
+    async def test_list_projects_six_keys_and_defaults_created_at(self) -> None:
+        """live get_info 에 created_at 부재 → None 기본값 보장 (Codex condition 1)."""
+        from ante.ipc.registry import _handle_bot_list
+
+        live_info = {
+            "bot_id": "bot-1",
+            "name": "B1",
+            "strategy_id": "s1",
+            "account_id": "acc-a",
+            "status": "running",
+            "interval_seconds": 60,  # projection 에서 제외되는 추가 키
+        }
+        svc = SimpleNamespace(
+            bot_manager=SimpleNamespace(list_bots=lambda: [live_info])
+        )
+        result = await _handle_bot_list(svc, {}, "cli")
+        assert list(result.keys()) == ["bots"]
+        bot = result["bots"][0]
+        assert set(bot.keys()) == {
+            "bot_id",
+            "name",
+            "strategy_id",
+            "account_id",
+            "status",
+            "created_at",
+        }
+        assert bot["created_at"] is None  # live 부재 → None 기본값
+        assert "interval_seconds" not in bot  # 6-key projection 만
+
+    @pytest.mark.asyncio
+    async def test_list_account_filter(self) -> None:
+        from ante.ipc.registry import _handle_bot_list
+
+        bots = [
+            {
+                "bot_id": "b1",
+                "account_id": "acc-a",
+                "name": "",
+                "strategy_id": "",
+                "status": "",
+            },
+            {
+                "bot_id": "b2",
+                "account_id": "acc-b",
+                "name": "",
+                "strategy_id": "",
+                "status": "",
+            },
+        ]
+        svc = SimpleNamespace(bot_manager=SimpleNamespace(list_bots=lambda: bots))
+        result = await _handle_bot_list(svc, {"account_id": "acc-b"}, "cli")
+        assert [b["bot_id"] for b in result["bots"]] == ["b2"]
+
+    @pytest.mark.asyncio
+    async def test_info_missing_raises(self) -> None:
+        from ante.bot.exceptions import BotNotFoundError
+        from ante.ipc.registry import _handle_bot_info
+
+        svc = SimpleNamespace(bot_manager=SimpleNamespace(get_bot=lambda _id: None))
+        with pytest.raises(BotNotFoundError):
+            await _handle_bot_info(svc, {"bot_id": "missing"}, "cli")
+
+    @pytest.mark.asyncio
+    async def test_signal_key_read_missing_raises(self) -> None:
+        from ante.bot.exceptions import BotNotFoundError
+        from ante.ipc.registry import _handle_bot_signal_key
+
+        svc = SimpleNamespace(bot_manager=SimpleNamespace(get_bot=lambda _id: None))
+        with pytest.raises(BotNotFoundError):
+            await _handle_bot_signal_key(svc, {"bot_id": "missing"}, "cli")
+
+    @pytest.mark.asyncio
+    async def test_signal_key_read_none_allowed(self) -> None:
+        from ante.ipc.registry import _handle_bot_signal_key
+
+        bot = SimpleNamespace(config=SimpleNamespace(account_id="acc-a"))
+        svc = SimpleNamespace(
+            bot_manager=SimpleNamespace(
+                get_bot=lambda _id: bot,
+                get_signal_key=AsyncMock(return_value=None),
+            )
+        )
+        result = await _handle_bot_signal_key(svc, {"bot_id": "bot-1"}, "cli")
+        assert result == {"bot_id": "bot-1", "signal_key": None}

--- a/tests/unit/test_ipc_bot_lifecycle.py
+++ b/tests/unit/test_ipc_bot_lifecycle.py
@@ -17,7 +17,7 @@
   - 주입 시 positions 보강.
   - 부재 시 ``positions`` 키 부재(회귀 lock, #1712 cold-path 호환).
 - ``CommandRegistry`` 등록 invariant: taxonomy(start/stop=mutating,
-  status=read-only), 27 count.
+  status=read-only), 32 count (#2112 bot read 4건 포함).
 """
 
 from __future__ import annotations
@@ -652,9 +652,11 @@ class TestRegistryRegistration:
         assert spec.is_mutating is False
         assert spec.handler is _handle_bot_status
 
-    def test_total_command_count_is_28(self) -> None:
+    def test_total_command_count_is_32(self) -> None:
         """#1712 이후 CLI/IPC parity mutation 5개 + #2111
-        ``bot.signal_key.rotate`` 를 포함한다."""
+        ``bot.signal_key.rotate`` + #2112 ``bot.list`` / ``bot.info`` /
+        ``bot.positions`` / ``bot.signal_key`` (read-only) 4건을 포함한다
+        (28→32)."""
         registry = CommandRegistry()
         register_all_handlers(registry)
-        assert len(registry.commands) == 28
+        assert len(registry.commands) == 32


### PR DESCRIPTION
Closes #2112

## Summary
- `bot list/info/positions/signal-key`(read) 4종이 스펙(runtime IPC + snapshot fallback)과 달리 IPC 미시도·직접 DB snapshot만 조회하던 것을, **서버 실행 중 IPC live 조회 / 서버 정지 시 기존 snapshot fallback**으로 라우팅.
- IPC handler 4종 신설(`_handle_bot_status` 미러, read-only, audit 없음). CLI는 ipc-first + `IPC_SERVER_NOT_RUNNING`만 fallback(timeout/server-error는 surface — stale snapshot 은폐 차단). rotate(#2111) 무변경.
- positions account scoping(#2137) + trade_service 미구성 vs 빈 포지션 구분. SSOT lockstep: baseline 12→8, registry count 28→32, taxonomy read_only 4→8, ipc.md 표.

## Test Plan
- 신설 test_cli_bot_read_ipc.py 35 PASS(IPC-first/fallback/parity/BOT_NOT_FOUND/timeout surface/trade_service 구분/account scope)
- 회귀+drift SSOT(success_output_drift/missing-resource/equivalence/account-scope/contracts/ipc) PASS
- 전체 `pytest tests/unit/`: 6813 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (c4204bf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)