### PR TITLE
fix(feed): #2046 feed config check API 키 네트워크 유효성 검증 (valid/invalid/unknown 3-state)

### DIFF
--- a/docs/specs/data-feed/06-cli.md
+++ b/docs/specs/data-feed/06-cli.md
@@ -126,7 +126,16 @@ $ ante feed config list
 **동작:**
 1. `.feed/.env` 및 환경변수에서 키 로드 (우선순위 적용)
 2. 각 키의 존재 여부 확인
-3. 키가 존재하면 해당 API에 경량 요청을 보내 유효성 검증
+3. 키가 존재하면 해당 API에 경량 요청을 보내 유효성을 **3-state**로 검증한다:
+   - `✓ 유효` — 키가 API에 수락됨 (DART `000`/`013`, data.go.kr `00` 등).
+   - `✗ 인증 실패` — 인증 거부 (DART `010`/`011`/`012`, data.go.kr `30`/`31`).
+   - `? 검증 불가 (네트워크)` — 네트워크 예외/타임아웃으로 검증을 완료하지
+     못함. offline 환경에서도 hang/실패 없이 graceful하게 이 상태로 떨어진다.
+4. 미설정 키는 검증을 생략한다 (`✗ 미설정`만 표시).
+
+`--format json` 출력은 각 키에 대해 `set`/`source`에 더해 `valid`(`true`/
+`false`/`null`)와 `detail`(인증 실패·검증 불가 사유, 그 외 `null`) 필드를
+포함한다. 미설정 키의 `valid`는 `null`이다.
 
 **출력 예시:**
 ```
@@ -146,6 +155,14 @@ API Key Status
   ANTE_DART_API_KEY      ✓ 설정됨 (source: .env)  ✗ 인증 실패
 ──────────────────────────────────────────────────
 설정: ante feed config set <KEY> <VALUE>
+
+$ ante feed config check   # offline / 네트워크 불가
+
+API Key Status
+──────────────────────────────────────────────────
+  ANTE_DATAGOKR_API_KEY  ✓ 설정됨 (source: .env)  ? 검증 불가 (네트워크)
+  ANTE_DART_API_KEY      ✓ 설정됨 (source: env)   ? 검증 불가 (네트워크)
+──────────────────────────────────────────────────
 ```
 
 ### `ante feed inject <path> --symbol <종목> [--timeframe <주기>] [--source <소스>]`

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -349,13 +349,20 @@ def config_list(ctx: click.Context, data_path: str | None) -> None:
 @require_auth
 @require_scope(_SCOPE_DATA_READ)
 def config_check(ctx: click.Context, data_path: str | None) -> None:
-    """API 키 존재 여부를 확인한다."""
+    """API 키 존재 여부와 유효성을 확인한다.
+
+    설정된 키는 해당 API에 경량 요청을 보내 3-state로 검증한다:
+    ✓ 유효 / ✗ 인증 실패 / ? 검증 불가(네트워크). offline/타임아웃은
+    검증 불가(unknown)로 graceful 처리한다.
+    """
+    import asyncio
+
     from ante.feed.config import FeedConfig
 
     data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
-    statuses = cfg.check_api_keys()
+    statuses = asyncio.run(cfg.check_api_keys_with_validation())
 
     if fmt.is_json:
         fmt.output({"keys": statuses})
@@ -367,7 +374,14 @@ def config_check(ctx: click.Context, data_path: str | None) -> None:
         for entry in statuses:
             if entry["set"]:
                 source_info = f"(source: {entry['source']})"
-                click.echo(f"  {entry['key']:<30} ✓ 설정됨 {source_info}")
+                valid = entry["valid"]
+                if valid is True:
+                    verdict = "✓ 유효"
+                elif valid is False:
+                    verdict = "✗ 인증 실패"
+                else:
+                    verdict = "? 검증 불가 (네트워크)"
+                click.echo(f"  {entry['key']:<30} ✓ 설정됨 {source_info}  {verdict}")
             else:
                 click.echo(f"  {entry['key']:<30} ✗ 미설정")
                 all_set = False

--- a/src/ante/feed/config.py
+++ b/src/ante/feed/config.py
@@ -174,9 +174,11 @@ class FeedConfig:
         return result
 
     def check_api_keys(self) -> list[dict[str, str | bool]]:
-        """API 키 존재 여부를 확인한다.
+        """API 키 존재 여부를 확인한다(동기, 네트워크 호출 없음).
 
-        유효성 검증은 네트워크 호출이 필요하므로 스텁.
+        존재여부만 반환하는 경량 경로다. ``feed status`` 등 네트워크
+        검증이 필요 없는 호출자가 사용한다. 유효성 검증이 필요하면
+        :meth:`check_api_keys_with_validation` 을 사용한다.
         """
         keys = self.load_api_keys()
         result: list[dict[str, str | bool]] = []
@@ -194,6 +196,63 @@ class FeedConfig:
                 }
             )
         return result
+
+    async def check_api_keys_with_validation(
+        self,
+    ) -> list[dict[str, str | bool | None]]:
+        """API 키 존재 여부 + 네트워크 유효성을 확인한다 (#2046).
+
+        존재여부는 :meth:`check_api_keys` 와 동일하게 판정하고, 설정된
+        키에 한해 해당 source의 경량 요청으로 유효성을 검증한다.
+
+        각 항목은 ``{key, set, source, valid, detail}`` 형태다.
+            * ``valid``  — ``True``(유효) / ``False``(인증 실패) /
+              ``None``(검증 불가 또는 미설정 → 검증 생략).
+            * ``detail`` — 인증 실패/검증 불가 시의 사유 문자열, 그 외 None.
+
+        미설정 키는 검증을 생략하며 ``valid``/``detail`` 은 None이다.
+        네트워크 예외/타임아웃(offline 포함)은 source 단에서 unknown으로
+        흡수되어 예외가 전파되지 않는다.
+        """
+        keys = self.load_api_keys()
+        result: list[dict[str, str | bool | None]] = []
+        for key in API_KEYS:
+            val = keys.get(key)
+            source = ""
+            valid: bool | None = None
+            detail: str | None = None
+            if val:
+                env_val = os.environ.get(key)
+                source = "env" if env_val else ".env"
+                valid, detail = await self._validate_key(key, val)
+            result.append(
+                {
+                    "key": key,
+                    "set": bool(val),
+                    "source": source,
+                    "valid": valid,
+                    "detail": detail,
+                }
+            )
+        return result
+
+    @staticmethod
+    async def _validate_key(key: str, value: str) -> tuple[bool | None, str | None]:
+        """단일 API 키를 해당 source의 경량 검증으로 평가한다 (#2046).
+
+        지원하지 않는 키는 검증을 생략한다(unknown=None). source의
+        validate_credentials는 네트워크 예외를 unknown으로 흡수하므로
+        여기서 추가 예외 처리는 하지 않는다.
+        """
+        if key == "ANTE_DART_API_KEY":
+            from ante.feed.sources.dart import DARTSource
+
+            return await DARTSource(api_key=value).validate_credentials()
+        if key == "ANTE_DATAGOKR_API_KEY":
+            from ante.feed.sources.data_go_kr import DataGoKrSource
+
+            return await DataGoKrSource(api_key=value).validate_credentials()
+        return None, None
 
     def _load_env_file(self) -> dict[str, str]:
         """.env 파일을 파싱하여 딕셔너리로 반환한다."""

--- a/src/ante/feed/sources/dart.py
+++ b/src/ante/feed/sources/dart.py
@@ -293,6 +293,62 @@ class DARTSource:
         )
         return all_items
 
+    async def validate_credentials(self) -> tuple[bool | None, str | None]:
+        """API 키 유효성을 경량 요청 1회로 검증한다 (#2046).
+
+        가장 싼 기존 요청 패턴(fnlttMultiAcnt.json)을 더미 파라미터로 1회
+        호출한다. DART는 인증키를 파라미터 유효성보다 먼저 평가하므로,
+        키가 유효하면 ``000``(정상) 또는 ``013``(조회된 데이터 없음)이
+        돌아오고, 키가 잘못되면 ``010/011/012`` 인증 에러(CRITICAL)가
+        돌아온다.
+
+        3-state를 반환한다:
+            * ``(True, None)``  — 유효 (키가 수락됨).
+            * ``(False, 사유)`` — 인증 실패 (CRITICAL 에러 코드).
+            * ``(None, 사유)``  — 검증 불가 (네트워크 예외/타임아웃).
+
+        offline·타임아웃 등 네트워크 예외는 unknown으로 흡수하며 예외를
+        전파하지 않는다. config check가 오프라인에서도 hang/실패 없이
+        graceful하게 동작하도록 보장한다.
+
+        Returns:
+            (valid, reason) 튜플. valid는 True/False/None.
+        """
+        url = f"{self._base_url}/fnlttMultiAcnt.json"
+        # 인증 평가만을 위한 최소 더미 파라미터(키 검증이 우선 수행됨).
+        params = {
+            "crtfc_key": self._api_key,
+            "corp_code": "00000000",
+            "bsns_year": "2024",
+            "reprt_code": "11011",
+        }
+
+        own_session = self._session is None
+        session = self._session or aiohttp.ClientSession()
+
+        try:
+            await self._rate_limiter.acquire()
+            self._rate_limiter.increment_daily()
+            data = await asyncio.wait_for(
+                self._do_request(session, url, params),
+                timeout=REQUEST_TIMEOUT,
+            )
+        except (TimeoutError, aiohttp.ClientError) as exc:
+            logger.info("DART 키 검증 불가 (네트워크): %s", exc)
+            return None, f"검증 불가 (네트워크): {exc}"
+        finally:
+            if own_session:
+                await session.close()
+
+        status = str(data.get("status", "900"))
+        message = str(data.get("message", ""))
+        action = classify_error(status)
+
+        if action == ErrorAction.CRITICAL:
+            return False, f"인증 실패 (status={status}): {message}"
+        # OK / NO_DATA / 그 외(키는 수락됨) → 유효.
+        return True, None
+
     # -- 내부 메서드 ---------------------------------------------------
 
     async def _download_corp_code_zip(

--- a/src/ante/feed/sources/data_go_kr.py
+++ b/src/ante/feed/sources/data_go_kr.py
@@ -212,6 +212,61 @@ class DataGoKrSource:
         logger.info("data.go.kr 수집 완료: date=%s records=%d", date, len(all_items))
         return all_items
 
+    async def validate_credentials(self) -> tuple[bool | None, str | None]:
+        """서비스키 유효성을 경량 요청 1회로 검증한다 (#2046).
+
+        가장 싼 기존 요청 패턴(getStockPriceInfo 1페이지, numOfRows=1)을
+        더미 기준일자로 1회 호출한다. data.go.kr은 서비스키를 우선
+        평가하므로, 키가 유효하면 ``00``(정상) 또는 다른 비인증 에러가
+        돌아오고, 키가 미등록/만료면 ``30/31`` 인증 에러(CRITICAL)가
+        돌아온다.
+
+        3-state를 반환한다:
+            * ``(True, None)``  — 유효 (키가 수락됨).
+            * ``(False, 사유)`` — 인증 실패 (CRITICAL 에러 코드).
+            * ``(None, 사유)``  — 검증 불가 (네트워크 예외/타임아웃).
+
+        offline·타임아웃 등 네트워크 예외는 unknown으로 흡수하며 예외를
+        전파하지 않는다. config check가 오프라인에서도 hang/실패 없이
+        graceful하게 동작하도록 보장한다.
+
+        Returns:
+            (valid, reason) 튜플. valid는 True/False/None.
+        """
+        # 인증 평가만을 위한 최소 더미 파라미터(서비스키 검증이 우선 수행됨).
+        params = {
+            "serviceKey": self._api_key,
+            "numOfRows": "1",
+            "pageNo": "1",
+            "resultType": "json",
+            "basDt": "20240102",
+        }
+
+        own_session = self._session is None
+        session = self._session or aiohttp.ClientSession()
+
+        try:
+            await self._rate_limiter.acquire()
+            self._rate_limiter.increment_daily()
+            data = await asyncio.wait_for(
+                self._do_request(session, params),
+                timeout=REQUEST_TIMEOUT,
+            )
+        except (TimeoutError, aiohttp.ClientError) as exc:
+            logger.info("data.go.kr 키 검증 불가 (네트워크): %s", exc)
+            return None, f"검증 불가 (네트워크): {exc}"
+        finally:
+            if own_session:
+                await session.close()
+
+        result_code, result_msg = self._extract_result_code(data)
+        action = classify_error(result_code)
+
+        if action == ErrorAction.CRITICAL:
+            return False, f"인증 실패 (code={result_code}): {result_msg}"
+        # OK / 그 외(키는 수락됨) → 유효.
+        return True, None
+
     async def _fetch_page(
         self,
         session: aiohttp.ClientSession,

--- a/tests/unit/feed/test_cli_config_check.py
+++ b/tests/unit/feed/test_cli_config_check.py
@@ -1,0 +1,223 @@
+"""ante feed config check CLI 커맨드 테스트 (#2046).
+
+API 키 네트워크 유효성 3-state(valid/invalid/unknown) 출력을 검증한다.
+실 네트워크 호출 없이 source.validate_credentials를 mock한다.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner — stdout/stderr 분리."""
+    r = CliRunner(mix_stderr=False)
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx: object) -> None:
+                import click
+
+                ctx = click.get_current_context()
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+@pytest.fixture
+def data_path(tmp_path: Path) -> str:
+    """임시 데이터 디렉토리 경로 (문자열)."""
+    return str(tmp_path / "data")
+
+
+def _set_dart_key(data_path: str) -> None:
+    """DART 키만 .env에 설정한다 (DATAGOKR는 미설정)."""
+    from ante.feed.config import FeedConfig
+
+    cfg = FeedConfig(data_path)
+    cfg.set_api_key("ANTE_DART_API_KEY", "dart-key-value")
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """환경변수 키가 .env를 가리지 않도록 제거한다."""
+    monkeypatch.delenv("ANTE_DART_API_KEY", raising=False)
+    monkeypatch.delenv("ANTE_DATAGOKR_API_KEY", raising=False)
+
+
+class TestConfigCheckValid:
+    """유효 키 3-state: ✓ 유효."""
+
+    def test_text_shows_valid(
+        self, runner: CliRunner, data_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_dart_key(data_path)
+        from ante.feed.sources import dart as dart_mod
+
+        async def _ok(self: object) -> tuple[bool, None]:
+            return True, None
+
+        monkeypatch.setattr(dart_mod.DARTSource, "validate_credentials", _ok)
+        result = runner.invoke(
+            cli, ["feed", "config", "check", "--data-path", data_path]
+        )
+        assert result.exit_code == 0
+        assert "✓ 유효" in result.stdout
+        # DATAGOKR는 미설정 → 검증 표시 생략.
+        assert "✗ 미설정" in result.stdout
+
+    def test_json_valid_field(
+        self, runner: CliRunner, data_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_dart_key(data_path)
+        from ante.feed.sources import dart as dart_mod
+
+        async def _ok(self: object) -> tuple[bool, None]:
+            return True, None
+
+        monkeypatch.setattr(dart_mod.DARTSource, "validate_credentials", _ok)
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "feed", "config", "check", "--data-path", data_path],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        keys = {k["key"]: k for k in payload["keys"]}
+        dart = keys["ANTE_DART_API_KEY"]
+        assert dart["set"] is True
+        assert dart["valid"] is True
+        assert dart["detail"] is None
+        # 미설정 키는 검증 생략 → valid=None.
+        dg = keys["ANTE_DATAGOKR_API_KEY"]
+        assert dg["set"] is False
+        assert dg["valid"] is None
+
+
+class TestConfigCheckInvalid:
+    """인증 실패 3-state: ✗ 인증 실패."""
+
+    def test_text_shows_auth_fail(
+        self, runner: CliRunner, data_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_dart_key(data_path)
+        from ante.feed.sources import dart as dart_mod
+
+        async def _invalid(self: object) -> tuple[bool, str]:
+            return False, "인증 실패 (status=010): 등록되지 않은 키"
+
+        monkeypatch.setattr(dart_mod.DARTSource, "validate_credentials", _invalid)
+        result = runner.invoke(
+            cli, ["feed", "config", "check", "--data-path", data_path]
+        )
+        assert result.exit_code == 0
+        assert "✗ 인증 실패" in result.stdout
+
+    def test_json_invalid_field(
+        self, runner: CliRunner, data_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_dart_key(data_path)
+        from ante.feed.sources import dart as dart_mod
+
+        async def _invalid(self: object) -> tuple[bool, str]:
+            return False, "인증 실패 (status=010): 등록되지 않은 키"
+
+        monkeypatch.setattr(dart_mod.DARTSource, "validate_credentials", _invalid)
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "feed", "config", "check", "--data-path", data_path],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        keys = {k["key"]: k for k in payload["keys"]}
+        dart = keys["ANTE_DART_API_KEY"]
+        assert dart["valid"] is False
+        assert "010" in dart["detail"]
+
+
+class TestConfigCheckUnknown:
+    """검증 불가(네트워크) 3-state: ? 검증 불가."""
+
+    def test_text_shows_unknown(
+        self, runner: CliRunner, data_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_dart_key(data_path)
+        from ante.feed.sources import dart as dart_mod
+
+        async def _unknown(self: object) -> tuple[None, str]:
+            return None, "검증 불가 (네트워크): offline"
+
+        monkeypatch.setattr(dart_mod.DARTSource, "validate_credentials", _unknown)
+        result = runner.invoke(
+            cli, ["feed", "config", "check", "--data-path", data_path]
+        )
+        assert result.exit_code == 0
+        assert "? 검증 불가 (네트워크)" in result.stdout
+
+    def test_json_unknown_field(
+        self, runner: CliRunner, data_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_dart_key(data_path)
+        from ante.feed.sources import dart as dart_mod
+
+        async def _unknown(self: object) -> tuple[None, str]:
+            return None, "검증 불가 (네트워크): offline"
+
+        monkeypatch.setattr(dart_mod.DARTSource, "validate_credentials", _unknown)
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "feed", "config", "check", "--data-path", data_path],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        keys = {k["key"]: k for k in payload["keys"]}
+        dart = keys["ANTE_DART_API_KEY"]
+        assert dart["valid"] is None
+        assert dart["detail"] is not None
+        assert "네트워크" in dart["detail"]
+
+
+class TestConfigCheckOfflineGraceful:
+    """offline: source.validate_credentials가 unknown으로 흡수 → 예외 미전파."""
+
+    def test_offline_no_exception_propagation(
+        self, runner: CliRunner, data_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """validate_credentials가 unknown 반환 시 명령은 exit 0으로 graceful."""
+        _set_dart_key(data_path)
+        from ante.feed.sources import dart as dart_mod
+
+        async def _offline(self: object) -> tuple[None, str]:
+            return None, "검증 불가 (네트워크): Cannot connect to host"
+
+        monkeypatch.setattr(dart_mod.DARTSource, "validate_credentials", _offline)
+        result = runner.invoke(
+            cli, ["feed", "config", "check", "--data-path", data_path]
+        )
+        assert result.exit_code == 0
+        assert result.exception is None

--- a/tests/unit/feed/test_config.py
+++ b/tests/unit/feed/test_config.py
@@ -303,6 +303,90 @@ class TestCheckApiKeys:
                 assert entry["source"] == ""
 
 
+# ── check_api_keys_with_validation (#2046) ────────────────────────────────────
+
+
+class TestCheckApiKeysWithValidation:
+    """네트워크 유효성 3-state 경로 (source.validate_credentials mock)."""
+
+    @pytest.mark.asyncio
+    async def test_unset_keys_skip_validation(
+        self, cfg: FeedConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """미설정 키는 검증을 생략한다 (valid/detail=None, set=False)."""
+        for key in API_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        statuses = await cfg.check_api_keys_with_validation()
+        for entry in statuses:
+            assert entry["set"] is False
+            assert entry["valid"] is None
+            assert entry["detail"] is None
+
+    @pytest.mark.asyncio
+    async def test_set_key_validates_valid(
+        self, cfg: FeedConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """설정된 키가 유효하면 valid=True/detail=None."""
+        for key in API_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        cfg.set_api_key("ANTE_DART_API_KEY", "dart-key-value")
+
+        from ante.feed.sources import dart as dart_mod
+
+        async def _ok(self: object) -> tuple[bool, None]:
+            return True, None
+
+        monkeypatch.setattr(dart_mod.DARTSource, "validate_credentials", _ok)
+        statuses = await cfg.check_api_keys_with_validation()
+        dart = next(s for s in statuses if s["key"] == "ANTE_DART_API_KEY")
+        assert dart["set"] is True
+        assert dart["source"] == ".env"
+        assert dart["valid"] is True
+        assert dart["detail"] is None
+
+    @pytest.mark.asyncio
+    async def test_set_key_validates_invalid(
+        self, cfg: FeedConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """인증 실패 키는 valid=False + detail 사유."""
+        for key in API_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        cfg.set_api_key("ANTE_DATAGOKR_API_KEY", "datagokr-key")
+
+        from ante.feed.sources import data_go_kr as dg_mod
+
+        async def _invalid(self: object) -> tuple[bool, str]:
+            return False, "인증 실패 (code=30): not registered"
+
+        monkeypatch.setattr(dg_mod.DataGoKrSource, "validate_credentials", _invalid)
+        statuses = await cfg.check_api_keys_with_validation()
+        dg = next(s for s in statuses if s["key"] == "ANTE_DATAGOKR_API_KEY")
+        assert dg["valid"] is False
+        assert dg["detail"] is not None
+        assert "30" in dg["detail"]
+
+    @pytest.mark.asyncio
+    async def test_set_key_validation_unknown(
+        self, cfg: FeedConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """검증 불가(네트워크)는 valid=None + detail 사유, 예외 미전파."""
+        for key in API_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        cfg.set_api_key("ANTE_DART_API_KEY", "dart-key-value")
+
+        from ante.feed.sources import dart as dart_mod
+
+        async def _unknown(self: object) -> tuple[None, str]:
+            return None, "검증 불가 (네트워크): offline"
+
+        monkeypatch.setattr(dart_mod.DARTSource, "validate_credentials", _unknown)
+        statuses = await cfg.check_api_keys_with_validation()
+        dart = next(s for s in statuses if s["key"] == "ANTE_DART_API_KEY")
+        assert dart["valid"] is None
+        assert dart["detail"] is not None
+        assert "네트워크" in dart["detail"]
+
+
 # ── _mask_value ───────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/feed/test_dart.py
+++ b/tests/unit/feed/test_dart.py
@@ -879,3 +879,84 @@ class TestFetch:
         """일부 kwargs만 있으면 빈 리스트를 반환한다."""
         result = await source.fetch("2024-12-31", corp_codes=["00126380"])
         assert result == []
+
+
+# -- validate_credentials (#2046) --------------------------------------
+
+
+class TestValidateCredentials:
+    """DART 키 유효성 3-state 검증 (mock HTTP, 실 네트워크 없음)."""
+
+    @pytest.mark.asyncio
+    async def test_valid_key_ok(self, source: DARTSource) -> None:
+        """정상 응답(000) → valid=True."""
+        response = _make_financial_response([_make_financial_item()], status="000")
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            valid, detail = await source.validate_credentials()
+        assert valid is True
+        assert detail is None
+
+    @pytest.mark.asyncio
+    async def test_valid_key_no_data(self, source: DARTSource) -> None:
+        """데이터 없음(013)도 키는 수락된 것 → valid=True."""
+        response = _make_financial_response([], status="013", message="데이터 없음")
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            valid, detail = await source.validate_credentials()
+        assert valid is True
+        assert detail is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_key_010(self, source: DARTSource) -> None:
+        """미등록 키(010) → valid=False, 사유 포함."""
+        response = _make_financial_response(
+            [], status="010", message="등록되지 않은 키입니다"
+        )
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            valid, detail = await source.validate_credentials()
+        assert valid is False
+        assert detail is not None
+        assert "010" in detail
+
+    @pytest.mark.asyncio
+    async def test_invalid_key_011_unusable(self, source: DARTSource) -> None:
+        """사용 불가 키(011)도 인증 실패 → valid=False."""
+        response = _make_financial_response(
+            [], status="011", message="사용할 수 없는 키"
+        )
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            valid, _ = await source.validate_credentials()
+        assert valid is False
+
+    @pytest.mark.asyncio
+    async def test_network_error_unknown(self, source: DARTSource) -> None:
+        """네트워크 예외 → valid=None(검증 불가), 예외 미전파."""
+        with patch.object(
+            source,
+            "_do_request",
+            new_callable=AsyncMock,
+            side_effect=aiohttp.ClientError("connection refused"),
+        ):
+            valid, detail = await source.validate_credentials()
+        assert valid is None
+        assert detail is not None
+        assert "네트워크" in detail
+
+    @pytest.mark.asyncio
+    async def test_timeout_unknown(self, source: DARTSource) -> None:
+        """타임아웃 → valid=None(검증 불가), 예외 미전파."""
+
+        async def _slow(*args: object, **kwargs: object) -> dict:
+            raise TimeoutError
+
+        with patch.object(source, "_do_request", side_effect=_slow):
+            valid, detail = await source.validate_credentials()
+        assert valid is None
+        assert detail is not None

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -1600,3 +1600,79 @@ class TestCollectorInstrumentsStore:
         path, df = _read_instruments(store)
         assert not path.exists()
         assert df is None
+
+
+# ── validate_credentials (#2046) ──────────────────────────────
+
+
+class TestValidateCredentials:
+    """data.go.kr 서비스키 유효성 3-state 검증 (mock HTTP, 실 네트워크 없음)."""
+
+    @pytest.mark.asyncio
+    async def test_valid_key_ok(self, source: DataGoKrSource) -> None:
+        """정상 응답(00) → valid=True."""
+        response = _make_response([_make_item()], total_count=1)
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            valid, detail = await source.validate_credentials()
+        assert valid is True
+        assert detail is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_key_30(self, source: DataGoKrSource) -> None:
+        """서비스키 미등록(30) → valid=False, 사유 포함."""
+        response = _make_response(
+            [],
+            total_count=0,
+            result_code="30",
+            result_msg="SERVICE_KEY_IS_NOT_REGISTERED_ERROR",
+        )
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            valid, detail = await source.validate_credentials()
+        assert valid is False
+        assert detail is not None
+        assert "30" in detail
+
+    @pytest.mark.asyncio
+    async def test_invalid_key_31_expired(self, source: DataGoKrSource) -> None:
+        """기한 만료(31)도 인증 실패 → valid=False."""
+        response = _make_response(
+            [],
+            total_count=0,
+            result_code="31",
+            result_msg="DEADLINE_HAS_EXPIRED_ERROR",
+        )
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            valid, _ = await source.validate_credentials()
+        assert valid is False
+
+    @pytest.mark.asyncio
+    async def test_network_error_unknown(self, source: DataGoKrSource) -> None:
+        """네트워크 예외 → valid=None(검증 불가), 예외 미전파."""
+        with patch.object(
+            source,
+            "_do_request",
+            new_callable=AsyncMock,
+            side_effect=aiohttp.ClientError("connection refused"),
+        ):
+            valid, detail = await source.validate_credentials()
+        assert valid is None
+        assert detail is not None
+        assert "네트워크" in detail
+
+    @pytest.mark.asyncio
+    async def test_timeout_unknown(self, source: DataGoKrSource) -> None:
+        """타임아웃 → valid=None(검증 불가), 예외 미전파."""
+
+        async def _slow(*args: object, **kwargs: object) -> dict:
+            raise TimeoutError
+
+        with patch.object(source, "_do_request", side_effect=_slow):
+            valid, detail = await source.validate_credentials()
+        assert valid is None
+        assert detail is not None


### PR DESCRIPTION
Closes #2046

## Summary
- `ante feed config check`가 스펙(06-cli.md)과 달리 키 존재여부만 표시하던 것을, **경량 네트워크 요청으로 유효성 검증**하도록 구현(✓유효/✗인증실패/?검증불가 3-state).
- DARTSource/DataGoKrSource `validate_credentials()` — 기존 요청 헬퍼+에러분류 재사용(DART 010 등→invalid, 정상→valid, 네트워크 예외→unknown 비전파). 기존 동기 `check_api_keys()`(존재여부) 보존, 별도 async 검증 경로 추가.
- CLI 3-state 출력(text+JSON valid/detail), 미설정 키 검증 생략, offline graceful(exit 0). 스펙 06-cli.md에 unknown 상태 추가.

## Test Plan
- mock/fake transport(실 네트워크 0): valid/invalid(010/30)/network-error(unknown); config_check 3-state; 미설정 생략; offline 비전파; 기존 check_api_keys 호출자(feed status) 무회귀
- 전체 `pytest tests/unit/`: 6800 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (31982260)

🤖 Generated with [Claude Code](https://claude.com/claude-code)