### PR TITLE
fix(gateway): #2044 주문 취소 완료/실패 이벤트에 symbol/side 채움 (OrderTracker record, cross-account 가드)

### DIFF
--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -413,7 +413,7 @@ Bot.on_signal()
 
 | 이벤트 타입 | 발행자 | 구독자 | 핵심 필드 |
 |------------|--------|--------|----------|
-| `OrderCancelFailedEvent` | APIGateway | Bot | `account_id`, `order_id`, `bot_id`, `strategy_id`, `error_message` |
+| `OrderCancelFailedEvent` | APIGateway | Bot | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `error_message` |
 
 #### Stop Order
 

--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -361,8 +361,8 @@ class Bot:
             update = {
                 "order_id": event.order_id,
                 "status": "cancel_failed",
-                "symbol": "",
-                "side": "",
+                "symbol": event.symbol,
+                "side": event.side,
                 "reason": event.error_message,
             }
         elif isinstance(event, OrderModifyRejectedEvent):

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -652,7 +652,13 @@ class CircuitBreakerEvent(Event):
 
 @dataclass(frozen=True)
 class OrderCancelFailedEvent(Event):
-    """주문 취소 실패."""
+    """주문 취소 실패.
+
+    Refs #2044: 전략 ``on_order_update(status="cancel_failed")`` 스펙의
+    필수 키 ``symbol``/``side`` 를 채우기 위해 ``OrderCancelledEvent`` 와
+    동형으로 필드를 보유한다. default 빈값으로 하위호환을 유지하며,
+    Gateway 핸들러가 OrderTracker record 에서 채운다.
+    """
 
     _requires_account_id: ClassVar[bool] = True
 
@@ -660,6 +666,8 @@ class OrderCancelFailedEvent(Event):
     order_id: str = ""
     bot_id: str = ""
     strategy_id: str = ""
+    symbol: str = ""
+    side: str = ""
     error_message: str = ""
 
 

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -409,6 +409,17 @@ class APIGateway:
         if not isinstance(event, OrderCancelEvent):
             return
 
+        # #2044: 전략 on_order_update(cancelled/cancel_failed) 스펙의 필수 키
+        # symbol/side 를 OrderTracker record 에서 채운다. cross-account leak
+        # 방지를 위해 record.account_id == event.account_id 일 때만 채우고,
+        # order_tracker 미주입 / record 미발견 / account 불일치 시에는 ""
+        # 로 graceful 하게 비운다 (예외 없음).
+        sym, sd = "", ""
+        if self._order_tracker is not None:
+            record = await self._order_tracker.get(event.order_id)
+            if record is not None and record.account_id == event.account_id:
+                sym, sd = record.symbol, record.side
+
         try:
             ok = await self.cancel_order(event.order_id, account_id=event.account_id)
             if not ok:
@@ -421,6 +432,8 @@ class APIGateway:
                         order_id=event.order_id,
                         bot_id=event.bot_id,
                         strategy_id=event.strategy_id,
+                        symbol=sym,
+                        side=sd,
                         error_message="브로커가 취소 실패(False)를 반환함",
                     )
                 )
@@ -431,8 +444,8 @@ class APIGateway:
                     order_id=event.order_id,
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,
-                    symbol="",
-                    side="",
+                    symbol=sym,
+                    side=sd,
                     quantity=0.0,
                     price=0.0,
                     reason=event.reason,
@@ -446,6 +459,8 @@ class APIGateway:
                     order_id=event.order_id,
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,
+                    symbol=sym,
+                    side=sd,
                     error_message=str(e),
                 )
             )

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -15,6 +15,7 @@ from ante.eventbus.events import (
     BotStopEvent,
     BotStoppedEvent,
     OrderCancelEvent,
+    OrderCancelFailedEvent,
     OrderFilledEvent,
     OrderRejectedEvent,
     OrderRequestEvent,
@@ -626,6 +627,54 @@ class TestBot:
         assert len(updates) == 1
         assert updates[0]["status"] == "rejected"
         assert updates[0]["reason"] == "insufficient funds"
+
+        await bot.stop()
+
+    async def test_on_order_update_cancel_failed_forwards_symbol_side(
+        self, eventbus, ctx, simple_config
+    ):
+        """#2044: cancel_failed 통보가 event.symbol/side 를 전략에 forward.
+
+        하드코딩 ``symbol=""``/``side=""`` 제거 회귀 잠금 — Gateway 가 채운
+        OrderCancelFailedEvent.symbol/side 가 그대로 전략 update 로 전달돼야
+        한다.
+        """
+        updates = []
+
+        class TrackStrategy(Strategy):
+            meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+            async def on_step(self, context):
+                return []
+
+            async def on_order_update(self, update):
+                updates.append(update)
+
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=TrackStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+
+        await bot.on_order_update(
+            OrderCancelFailedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                error_message="브로커가 취소 실패(False)를 반환함",
+                account_id="acc-test",
+            )
+        )
+
+        assert len(updates) == 1
+        assert updates[0]["status"] == "cancel_failed"
+        assert updates[0]["symbol"] == "005930"
+        assert updates[0]["side"] == "buy"
+        assert updates[0]["reason"] == "브로커가 취소 실패(False)를 반환함"
 
         await bot.stop()
 

--- a/tests/unit/test_gateway_cancel_failed.py
+++ b/tests/unit/test_gateway_cancel_failed.py
@@ -23,17 +23,25 @@ from ante.gateway import APIGateway
 
 
 def _order_tracker_mock(
-    *, order_id: str = "ord1", broker_order_id: str = "brk-ord1", account_id: str
+    *,
+    order_id: str = "ord1",
+    broker_order_id: str = "brk-ord1",
+    account_id: str,
+    symbol: str = "005930",
+    side: str = "buy",
 ) -> AsyncMock:
-    """#2134: cancel_order broker_order_id 변환을 통과시키는 OrderTracker mock.
+    """#2134/#2044: cancel_order broker_order_id 변환을 통과시키는 OrderTracker mock.
 
-    ``get(order_id)`` → 주어진 broker_order_id/account_id 레코드를 반환한다.
+    ``get(order_id)`` → 주어진 broker_order_id/account_id/symbol/side 레코드를
+    반환한다. ``symbol``/``side`` 는 #2044 의 취소 이벤트 채움 검증에 사용된다.
     """
     tracker = AsyncMock()
     record = MagicMock()
     record.order_id = order_id
     record.broker_order_id = broker_order_id
     record.account_id = account_id
+    record.symbol = symbol
+    record.side = side
     tracker.get = AsyncMock(return_value=record)
     return tracker
 
@@ -218,3 +226,211 @@ def test_cancel_failed_account_id_required() -> None:
             strategy_id="s1",
             error_message="boom",
         )
+
+
+# ── #2044: 취소 완료/실패 이벤트의 symbol/side 채움 ─────────────────
+
+
+async def _publish_cancel(
+    gw: APIGateway,
+    eventbus: EventBus,
+) -> tuple[list[OrderCancelledEvent], list[OrderCancelFailedEvent]]:
+    """OrderCancelEvent 를 발행하고 발행된 성공/실패 이벤트를 수집한다."""
+    cancelled: list[OrderCancelledEvent] = []
+    failed: list[OrderCancelFailedEvent] = []
+    eventbus.subscribe(OrderCancelledEvent, lambda e: cancelled.append(e))
+    eventbus.subscribe(OrderCancelFailedEvent, lambda e: failed.append(e))
+
+    await eventbus.publish(
+        OrderCancelEvent(
+            account_id="acc-test",
+            bot_id="bot1",
+            strategy_id="strategy-xyz",
+            order_id="ord1",
+            reason="test cancel",
+        )
+    )
+    return cancelled, failed
+
+
+@pytest.mark.asyncio
+async def test_cancel_success_fills_symbol_side_from_record() -> None:
+    """(a) 취소 성공 → OrderCancelledEvent.symbol/side 가 record 값으로 채워진다."""
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(return_value=True)
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        order_tracker=_order_tracker_mock(
+            account_id="acc-test", symbol="005930", side="buy"
+        ),
+    )
+    gw.start()
+
+    cancelled, failed = await _publish_cancel(gw, eventbus)
+
+    assert failed == []
+    assert len(cancelled) == 1
+    assert cancelled[0].symbol == "005930"
+    assert cancelled[0].side == "buy"
+
+
+@pytest.mark.asyncio
+async def test_cancel_broker_false_fills_symbol_side_from_record() -> None:
+    """(b) 취소 실패(broker False) → OrderCancelFailedEvent.symbol/side 채워짐."""
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(return_value=False)
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        order_tracker=_order_tracker_mock(
+            account_id="acc-test", symbol="005930", side="sell"
+        ),
+    )
+    gw.start()
+
+    cancelled, failed = await _publish_cancel(gw, eventbus)
+
+    assert cancelled == []
+    assert len(failed) == 1
+    assert failed[0].symbol == "005930"
+    assert failed[0].side == "sell"
+
+
+@pytest.mark.asyncio
+async def test_cancel_broker_exception_fills_symbol_side_from_record() -> None:
+    """(c) 취소 실패(예외) → OrderCancelFailedEvent.symbol/side 채워짐."""
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(side_effect=Exception("network error"))
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        order_tracker=_order_tracker_mock(
+            account_id="acc-test", symbol="005930", side="buy"
+        ),
+    )
+    gw.start()
+
+    cancelled, failed = await _publish_cancel(gw, eventbus)
+
+    assert cancelled == []
+    assert len(failed) == 1
+    assert failed[0].symbol == "005930"
+    assert failed[0].side == "buy"
+
+
+@pytest.mark.asyncio
+async def test_cancel_cross_account_blanks_symbol_side() -> None:
+    """(d) record.account_id != event.account_id → symbol/side leak 방지로 "".
+
+    cross-account record 는 ``cancel_order`` 가 fail-closed 로 broker 를
+    호출하지 않고 False 를 반환하므로 OrderCancelFailedEvent 가 발행되며,
+    핸들러의 account 가드가 다른 계정 record 의 symbol/side 노출을 막는다.
+    """
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(return_value=True)
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        # record 는 다른 계정 소유 — leak 되어선 안 된다.
+        order_tracker=_order_tracker_mock(
+            account_id="other-acc", symbol="005930", side="buy"
+        ),
+    )
+    gw.start()
+
+    cancelled, failed = await _publish_cancel(gw, eventbus)
+
+    # cross-account 는 broker 미호출 → 성공 이벤트 없음.
+    assert cancelled == []
+    assert len(failed) == 1
+    # 다른 계정 record 의 symbol/side 가 노출되지 않아야 한다.
+    assert failed[0].symbol == ""
+    assert failed[0].side == ""
+    # broker 는 호출되지 않았다 (fail-closed).
+    mock_broker.cancel_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancel_record_none_blanks_symbol_side_gracefully() -> None:
+    """(e-1) record None → symbol/side "" graceful, 예외 없음."""
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(return_value=True)
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    tracker = AsyncMock()
+    tracker.get = AsyncMock(return_value=None)
+
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        order_tracker=tracker,
+    )
+    gw.start()
+
+    cancelled, failed = await _publish_cancel(gw, eventbus)
+
+    # record None → cancel_order fail-closed False → 실패 이벤트.
+    assert cancelled == []
+    assert len(failed) == 1
+    assert failed[0].symbol == ""
+    assert failed[0].side == ""
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_tracker_none_blanks_symbol_side_gracefully() -> None:
+    """(e-2) order_tracker 미주입 → symbol/side "" graceful, 예외 없음."""
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(return_value=True)
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    gw = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        order_tracker=None,
+    )
+    gw.start()
+
+    cancelled, failed = await _publish_cancel(gw, eventbus)
+
+    # order_tracker None → cancel_order fail-closed False → 실패 이벤트.
+    assert cancelled == []
+    assert len(failed) == 1
+    assert failed[0].symbol == ""
+    assert failed[0].side == ""
+
+
+def test_cancel_failed_event_symbol_side_default_blank() -> None:
+    """(g) OrderCancelFailedEvent 신규 필드 default 빈값 — 기존 발행처 무회귀.
+
+    symbol/side 를 지정하지 않은 기존 호출 형태도 그대로 생성 가능해야 한다.
+    """
+    evt = OrderCancelFailedEvent(
+        account_id="acc-test",
+        order_id="ord1",
+        bot_id="bot1",
+        strategy_id="s1",
+        error_message="boom",
+    )
+    assert evt.symbol == ""
+    assert evt.side == ""


### PR DESCRIPTION
Closes #2044

## Summary
- 주문 취소 완료(OrderCancelledEvent)·실패(OrderCancelFailedEvent) 이벤트가 strategy on_order_update 스펙의 symbol/side를 빈값으로 전달하던 것을 OrderTracker record로 채움.
- events.py: OrderCancelFailedEvent에 symbol/side(default "") 추가. gateway `_on_order_cancel`: record 해석 후 성공/broker-False/예외 3경로 모두 채움. **cross-account 가드**(record.account_id != event.account_id → blanking, leak 방지). bot.py cancel_failed 매핑 하드코딩 "" → event.symbol/side. eventbus.md 행 정렬.
- record None/order_tracker None/account 불일치 → "" graceful.

## Test Plan
- cancel 성공/실패(False·예외) symbol/side 채움, cross-account blanking, record None graceful, bot cancel_failed forward, 신규 필드 무회귀
- 전체 `pytest tests/unit/`: 6821 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (589c307b)

## 비고
modify_rejected symbol/side는 #2045(별도 메커니즘).

🤖 Generated with [Claude Code](https://claude.com/claude-code)