### PR TITLE
fix(rule): #2045 RuleEngine이 modify event symbol/side를 OrderTracker로 enrich (modify_rejected 계약 충족)

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -514,6 +514,9 @@ async def _init_trading(s: Services) -> None:
         account_service=s.account_service,
         treasury_manager=s.treasury_manager,
         trade_service=s.trade_service,
+        # #2045: modify_rejected 의 symbol/side 보강용 권위 주문 메타 소스.
+        # OrderTracker 는 상단(#1946)에서 이미 생성되어 있다.
+        order_tracker=s.order_tracker,
     )
     await s.rule_engine_manager.initialize_all(
         accounts, config=s.config, dynamic_config=s.dynamic_config

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from ante.account.models import Account
     from ante.account.service import AccountService
     from ante.eventbus.bus import EventBus
+    from ante.trade.order_tracker import OrderTracker
     from ante.trade.service import TradeService
     from ante.treasury.treasury import Treasury
 
@@ -266,6 +267,7 @@ class RuleEngine:
         treasury: Treasury | None = None,
         trade_service: TradeService | None = None,
         account: Account | None = None,
+        order_tracker: OrderTracker | None = None,
     ) -> None:
         from ante.account.scoping import require_account_id
 
@@ -277,6 +279,11 @@ class RuleEngine:
         self._bot_strategy_resolver = bot_strategy_resolver
         self._treasury = treasury
         self._trade_service = trade_service
+        # #2045: 권위 주문 메타(symbol/side) 복원용. ``ctx.modify_order()`` 경로는
+        # ``OrderAction``/``OrderModifyEvent``에 symbol/side를 채우지 못하므로
+        # ``_on_order_modify``에서 order_id 기준으로 enrich한다. optional default
+        # None — 미주입이면 graceful degrade(symbol/side "" 유지, 기존 동작).
+        self._order_tracker = order_tracker
         # Account snapshot — reload 경로(``_on_config_changed``)에서 broker_type별
         # default를 다시 merge할 때 참조한다. 생명주기 동안 broker_type 불변 가정.
         # 기존 호출자(테스트 fixture 등) 호환을 위해 ``None`` 허용 — None일 때
@@ -1128,6 +1135,31 @@ class RuleEngine:
         # account_id 필터링
         if event.account_id != self._account_id:
             return
+
+        # #2045: modify_rejected 계약(symbol/side 필수키) 충족 — 단일 chokepoint.
+        # ``ctx.modify_order()`` 경로의 ``OrderModifyEvent``는 symbol/side가 빈
+        # 값이다(OrderAction에 없음). RuleEngine은 EventBus 첫 핸들러(priority
+        # 100)이고 EventBus가 동일 event 인스턴스를 후속 구독자(Gateway,
+        # priority 50)에 그대로 전달하므로(#1331 ``_consumed`` 선례가 동일
+        # 인스턴스 공유를 증명), 여기서 한 번 enrich하면 RuleEngine 거부 +
+        # 통과 후 Gateway not-implemented 거부가 모두 채워진 symbol/side를 본다.
+        # account_id 필터 직후이므로 record는 동일 계좌로 scope된다(cross-account
+        # leak 없음). order_tracker 미주입 / record 미발견 / account 불일치는
+        # graceful degrade(symbol/side "" 유지). EventBus가 copy/fanout으로
+        # 바뀌면 이 same-instance mutation이 Gateway에 전파되지 않으므로 회귀
+        # (``_consumed``와 동일 가정).
+        if self._order_tracker is not None and not event.symbol and not event.side:
+            try:
+                record = await self._order_tracker.get(event.order_id)
+            except Exception:
+                logger.warning(
+                    "주문 정정 메타 조회 실패: order=%s — symbol/side 미보강",
+                    event.order_id,
+                )
+                record = None
+            if record is not None and record.account_id == event.account_id:
+                object.__setattr__(event, "symbol", record.symbol)
+                object.__setattr__(event, "side", record.side)
 
         # 계좌 상태 조회
         account_status = "active"

--- a/src/ante/rule/manager.py
+++ b/src/ante/rule/manager.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from ante.account.models import Account
     from ante.account.service import AccountService
     from ante.eventbus.bus import EventBus
+    from ante.trade.order_tracker import OrderTracker
     from ante.trade.service import TradeService
     from ante.treasury import TreasuryManager as TreasuryManagerType
 
@@ -27,11 +28,16 @@ class RuleEngineManager:
         account_service: AccountService,
         treasury_manager: TreasuryManagerType | None = None,
         trade_service: TradeService | None = None,
+        order_tracker: OrderTracker | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._account_service = account_service
         self._treasury_manager = treasury_manager
         self._trade_service = trade_service
+        # #2045: 생성하는 RuleEngine에 주입할 권위 주문 메타 소스. optional
+        # default None — 기존 호출자/테스트 무회귀. None이면 RuleEngine은 modify
+        # event의 symbol/side를 보강하지 않고 "" graceful degrade한다.
+        self._order_tracker = order_tracker
         self._engines: dict[str, RuleEngine] = {}
 
     def create_engine(
@@ -70,6 +76,7 @@ class RuleEngineManager:
             treasury=treasury,
             trade_service=self._trade_service,
             account=account,
+            order_tracker=self._order_tracker,
         )
 
         if rule_configs:

--- a/tests/unit/test_rule_modify_enrich.py
+++ b/tests/unit/test_rule_modify_enrich.py
@@ -1,0 +1,315 @@
+"""RuleEngine modify event symbol/side OrderTracker enrich 테스트 (#2045).
+
+``ctx.modify_order()`` 경로의 ``OrderModifyEvent``는 symbol/side가 빈 값이다
+(OrderAction에 없음). 이로 인해 RuleEngine/Gateway가 발행하는
+``OrderModifyRejectedEvent``도 빈 symbol/side를 전파해 on_order_update의
+``modify_rejected`` 필수키(order_id, status, symbol, side, reason) 계약을
+위반한다(03-01-strategy-interface.md).
+
+본 모듈은 RuleEngine이 단일 chokepoint(첫 핸들러 priority 100)에서
+OrderTracker로 event.symbol/side를 enrich하는지, 그리고 동일 인스턴스 공유로
+Gateway pass-through까지 보강이 전파되는지 잠근다:
+
+- (a) RuleEngine rule-reject → OrderModifyRejectedEvent.symbol/side == record
+- (b) RuleEngine 룰 평가 예외 거부 → 동일
+- (c) rule 통과 → Gateway not-implemented 거부도 enriched (same-instance pass-through)
+- (d) order_tracker 미주입 → "" graceful (무회귀)
+- (e) record 미발견(None) → "" graceful
+- (f) account 불일치 record → enrich 안 함(no-op)
+- (g) RuleEngine/RuleEngineManager 기존 생성자(order_tracker 미전달) 무회귀
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ante.account.models import Account, AccountStatus
+from ante.eventbus import EventBus
+from ante.eventbus.events import OrderModifyEvent, OrderModifyRejectedEvent
+from ante.gateway import APIGateway, RateLimitConfig
+from ante.rule import RuleEngine, RuleEngineManager
+from ante.rule.base import Rule, RuleAction, RuleContext, RuleEvaluation, RuleResult
+from ante.trade.order_tracker import OrderTrackerRecord
+
+
+class _RejectingRule(Rule):
+    """REJECT 결과를 반환하는 테스트 룰."""
+
+    def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        return RuleEvaluation(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            result=RuleResult.REJECT,
+            action=RuleAction.NOTIFY,
+            message="modify rejected for test",
+        )
+
+
+class _ExplodingRule(Rule):
+    """평가 시 예외를 던지는 테스트 룰."""
+
+    def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        raise RuntimeError("rule explosion for test")
+
+
+def _make_record(
+    *,
+    order_id: str = "ord-2045",
+    account_id: str = "domestic",
+    symbol: str = "005930",
+    side: str = "buy",
+) -> OrderTrackerRecord:
+    return OrderTrackerRecord(
+        order_id=order_id,
+        account_id=account_id,
+        bot_id="bot1",
+        strategy_id="s1",
+        broker_order_id="brk-1",
+        symbol=symbol,
+        side=side,
+        order_type="limit",
+        ordered_qty=10.0,
+        recorded_filled_qty=0.0,
+        avg_fill_price=0.0,
+        status="open",
+        submitted_at=None,
+        submitted_date="2026-06-01",
+    )
+
+
+def _make_tracker(record: OrderTrackerRecord | None) -> AsyncMock:
+    """``get(order_id) -> record`` 를 반환하는 OrderTracker 스텁."""
+    tracker = AsyncMock()
+    tracker.get = AsyncMock(return_value=record)
+    return tracker
+
+
+@pytest.fixture
+def mock_account_service() -> AsyncMock:
+    service = AsyncMock()
+    account = Account(
+        account_id="domestic",
+        name="국내주식",
+        exchange="KRX",
+        currency="KRW",
+        broker_type="test",
+        status=AccountStatus.ACTIVE,
+    )
+    service.get = AsyncMock(return_value=account)
+    service.suspend = AsyncMock()
+    return service
+
+
+def _make_engine(
+    account_service: AsyncMock,
+    eventbus: EventBus,
+    order_tracker: AsyncMock | None,
+) -> RuleEngine:
+    engine = RuleEngine(
+        eventbus=eventbus,
+        account_id="domestic",
+        account_service=account_service,
+        order_tracker=order_tracker,
+    )
+    engine.start()
+    return engine
+
+
+def _make_modify_event(**overrides: object) -> OrderModifyEvent:
+    """ctx.modify_order() 경로 — symbol/side 빈 값 (OrderAction에 없음)."""
+    defaults: dict[str, object] = {
+        "account_id": "domestic",
+        "bot_id": "bot1",
+        "strategy_id": "s1",
+        "order_id": "ord-2045",
+        "symbol": "",
+        "side": "",
+        "quantity": 5.0,
+        "price": 70000.0,
+        "reason": "adjust",
+    }
+    defaults.update(overrides)
+    return OrderModifyEvent(**defaults)  # type: ignore[arg-type]
+
+
+# ── (a) RuleEngine rule-reject 경로 enrich ─────────────────────────
+
+
+async def test_rule_reject_enriches_symbol_side(
+    mock_account_service: AsyncMock,
+) -> None:
+    eventbus = EventBus()
+    record = _make_record(symbol="005930", side="buy")
+    engine = _make_engine(mock_account_service, eventbus, _make_tracker(record))
+    engine.add_account_rule(_RejectingRule("rejecter", {"type": "test"}))
+
+    received: list[OrderModifyRejectedEvent] = []
+    eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].symbol == "005930"
+    assert received[0].side == "buy"
+    # 원본 event도 enrich 되어 후속 핸들러가 채워진 값을 본다.
+    assert event.symbol == "005930"
+    assert event.side == "buy"
+
+
+# ── (b) RuleEngine 예외 거부 경로 enrich ───────────────────────────
+
+
+async def test_rule_exception_enriches_symbol_side(
+    mock_account_service: AsyncMock,
+) -> None:
+    eventbus = EventBus()
+    record = _make_record(symbol="000660", side="sell")
+    engine = _make_engine(mock_account_service, eventbus, _make_tracker(record))
+    engine.add_account_rule(_ExplodingRule("boom", {"type": "test"}))
+
+    received: list[OrderModifyRejectedEvent] = []
+    eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].reason == "Rule evaluation error"
+    assert received[0].symbol == "000660"
+    assert received[0].side == "sell"
+
+
+# ── (c) rule 통과 → Gateway not-implemented 거부도 enriched ─────────
+
+
+async def test_rule_pass_then_gateway_enriched_passthrough(
+    mock_account_service: AsyncMock,
+) -> None:
+    """RuleEngine이 동일 인스턴스를 enrich → Gateway 거부도 채워진 값을 본다."""
+    eventbus = EventBus()
+    record = _make_record(symbol="035720", side="buy")
+    engine = _make_engine(mock_account_service, eventbus, _make_tracker(record))
+
+    gateway = APIGateway(
+        account_service=mock_account_service,
+        eventbus=eventbus,
+        rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
+    )
+    gateway.start()
+
+    received: list[OrderModifyRejectedEvent] = []
+    eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    # RuleEngine(p100) → Gateway(p50) 순서를 동일 인스턴스로 시뮬레이션.
+    await engine._on_order_modify(event)
+    await gateway._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].reason == "modify_not_implemented"
+    assert received[0].symbol == "035720"
+    assert received[0].side == "buy"
+
+
+# ── (d) order_tracker 미주입 → "" graceful (무회귀) ─────────────────
+
+
+async def test_no_order_tracker_keeps_empty_graceful(
+    mock_account_service: AsyncMock,
+) -> None:
+    eventbus = EventBus()
+    engine = _make_engine(mock_account_service, eventbus, order_tracker=None)
+    engine.add_account_rule(_RejectingRule("rejecter", {"type": "test"}))
+
+    received: list[OrderModifyRejectedEvent] = []
+    eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].symbol == ""
+    assert received[0].side == ""
+
+
+# ── (e) record 미발견(None) → "" graceful ──────────────────────────
+
+
+async def test_record_not_found_keeps_empty_graceful(
+    mock_account_service: AsyncMock,
+) -> None:
+    eventbus = EventBus()
+    engine = _make_engine(mock_account_service, eventbus, _make_tracker(None))
+    engine.add_account_rule(_RejectingRule("rejecter", {"type": "test"}))
+
+    received: list[OrderModifyRejectedEvent] = []
+    eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].symbol == ""
+    assert received[0].side == ""
+
+
+# ── (f) account 불일치 record → enrich 안 함 (no-op) ────────────────
+
+
+async def test_account_mismatch_record_no_enrich(
+    mock_account_service: AsyncMock,
+) -> None:
+    """다른 account의 record는 cross-account leak 방지를 위해 무시한다."""
+    eventbus = EventBus()
+    foreign = _make_record(account_id="overseas", symbol="AAPL", side="sell")
+    engine = _make_engine(mock_account_service, eventbus, _make_tracker(foreign))
+    engine.add_account_rule(_RejectingRule("rejecter", {"type": "test"}))
+
+    received: list[OrderModifyRejectedEvent] = []
+    eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].symbol == ""
+    assert received[0].side == ""
+    assert event.symbol == ""
+    assert event.side == ""
+
+
+# ── (g) 기존 생성자(order_tracker 미전달) 무회귀 ────────────────────
+
+
+def test_rule_engine_init_without_order_tracker() -> None:
+    """RuleEngine은 order_tracker 미전달로도 생성된다 (기존 호출자 무회귀)."""
+    engine = RuleEngine(eventbus=EventBus(), account_id="domestic")
+    assert engine._order_tracker is None
+
+
+def test_rule_engine_manager_init_without_order_tracker(
+    mock_account_service: AsyncMock,
+) -> None:
+    """RuleEngineManager는 order_tracker 미전달로도 생성된다 (기존 호출자 무회귀)."""
+    manager = RuleEngineManager(
+        eventbus=EventBus(),
+        account_service=mock_account_service,
+    )
+    assert manager._order_tracker is None
+
+
+async def test_rule_engine_manager_injects_order_tracker(
+    mock_account_service: AsyncMock,
+) -> None:
+    """Manager가 생성하는 RuleEngine에 order_tracker가 전달되는지 잠근다."""
+    tracker = _make_tracker(_make_record())
+    manager = RuleEngineManager(
+        eventbus=EventBus(),
+        account_service=mock_account_service,
+        order_tracker=tracker,
+    )
+    engine = manager.create_engine("domestic")
+    assert engine._order_tracker is tracker


### PR DESCRIPTION
Closes #2045

## Summary
- modify_rejected 이벤트가 symbol/side를 빈값으로 전달(OrderModifyEvent가 bot에서 빈값 발행)하던 것을, **RuleEngine 단일 chokepoint**에서 OrderTracker로 enrich해 해결.
- RuleEngine(첫 핸들러 p100)이 account 필터 직후 event.symbol/side를 record로 enrich(object.__setattr__) → EventBus 동일 인스턴스 전달(#1331 _consumed 선례)로 RuleEngine 거부 + 통과 후 gateway not-implemented 거부 **3경로 모두** enriched. gateway/bot 무변경.
- RuleEngine/RuleEngineManager에 order_tracker=None(optional, 하위호환) 주입, main.py wiring. account-scoped(cross-account 차단), order_tracker/record None graceful.

## Test Plan
- rule-reject/exception/gateway pass-through enriched, order_tracker None·record None graceful, account-mismatch no-op, 기존 생성자 무회귀(신규 9 + 484 통과)
- 전체 `pytest tests/unit/`: 6844 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (4eef9128)

🤖 Generated with [Claude Code](https://claude.com/claude-code)