### PR TITLE
fix(ipc): #2110 상태변경 명령 7개에 audit_action wiring (system/bot/approval)

### DIFF
--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -190,16 +190,42 @@ def _kill_switch_payload(status: str, accounts: list[dict[str, Any]]) -> dict:
 async def _handle_system_halt(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """전역 거래 정지(kill switch) IPC handler.
+
+    Refs #2110 (audit.md:115): audit 호출은 ``_dispatch`` wrapper 가
+    ``CommandSpec.audit_action="system.halt"`` 기반으로 자동 발화한다. handler
+    는 ``_audit_detail`` reserved key 로 ``resource="system:kill_switch"`` 를
+    전달하며, wrapper 가 ``pop`` 으로 public envelope 진입 전에 strip 한다.
+    """
     reason = args.get("reason", "IPC halt")
     accounts = await svc.account.suspend_all(reason=reason, suspended_by=actor)
-    return _kill_switch_payload("halted", accounts)
+    payload = _kill_switch_payload("halted", accounts)
+    payload["_audit_detail"] = {
+        "resource": "system:kill_switch",
+        "detail": f"reason={reason}",
+        "ip": "",
+    }
+    return payload
 
 
 async def _handle_system_clear_halt(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """전역 거래 정지 해제 IPC handler.
+
+    Refs #2110 (audit.md:116): audit 호출은 ``_dispatch`` wrapper 가
+    ``CommandSpec.audit_action="system.clear_halt"`` 기반으로 자동 발화한다.
+    handler 는 ``_audit_detail`` reserved key 로
+    ``resource="system:kill_switch"`` 를 전달한다.
+    """
     accounts = await svc.account.activate_all(activated_by=actor)
-    return _kill_switch_payload("halt_cleared", accounts)
+    payload = _kill_switch_payload("halt_cleared", accounts)
+    payload["_audit_detail"] = {
+        "resource": "system:kill_switch",
+        "detail": "",
+        "ip": "",
+    }
+    return payload
 
 
 async def _handle_account_suspend(
@@ -294,15 +320,43 @@ async def _handle_bot_create(
         strategy_cls=strategy_cls,
         source_path=Path(record.filepath),
     )
-    return {"bot_id": bot.bot_id}
+    # Refs #2110 (audit.md:117): resource 는 **생성 결과** ``bot.bot_id`` 를
+    # 사용한다 — 요청 args 의 ``bot_id`` 는 빈 문자열일 수 있어(서버가 채움)
+    # 신뢰하지 않는다. audit 호출은 ``_dispatch`` wrapper 가
+    # ``CommandSpec.audit_action="bot.create"`` 기반으로 자동 발화하며 handler
+    # 는 ``_audit_detail`` 만 전달(wrapper 가 ``pop`` 으로 strip).
+    return {
+        "bot_id": bot.bot_id,
+        "_audit_detail": {
+            "resource": f"bot:{bot.bot_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_bot_remove(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """봇 제거 IPC handler.
+
+    Refs #2110 (audit.md:120): audit 호출은 ``_dispatch`` wrapper 가
+    ``CommandSpec.audit_action="bot.delete"`` 기반으로 자동 발화한다. command
+    이름은 ``bot.remove`` 이지만 audit action 은 audit.md SSOT 에 따라
+    ``bot.delete`` 다. handler 는 ``_audit_detail`` reserved key 로
+    ``resource="bot:{bot_id}"`` 를 전달한다.
+    """
     bot_id = args["bot_id"]
     await svc.bot_manager.remove_bot(bot_id)
-    return {"bot_id": bot_id, "removed": True}
+    return {
+        "bot_id": bot_id,
+        "removed": True,
+        "_audit_detail": {
+            "resource": f"bot:{bot_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_bot_signal_key_rotate(
@@ -898,26 +952,75 @@ async def _handle_approval_request(
 async def _handle_approval_approve(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    request = await svc.approval.approve(args["id"], resolved_by=actor)
-    return {"id": request.id, "status": str(request.status)}
+    """승인 요청 승인 IPC handler.
+
+    Refs #2110 (audit.md:112): audit 호출은 ``_dispatch`` wrapper 가
+    ``CommandSpec.audit_action="approval.approve"`` 기반으로 자동 발화한다.
+    handler 는 ``_audit_detail`` reserved key 로
+    ``resource="approval:{id}"`` 를 전달한다.
+    """
+    approval_id = args["id"]
+    request = await svc.approval.approve(approval_id, resolved_by=actor)
+    return {
+        "id": request.id,
+        "status": str(request.status),
+        "_audit_detail": {
+            "resource": f"approval:{approval_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_approval_reject(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    """승인 요청 거부 IPC handler.
+
+    Refs #2110 (audit.md:113): audit 호출은 ``_dispatch`` wrapper 가
+    ``CommandSpec.audit_action="approval.reject"`` 기반으로 자동 발화한다.
+    handler 는 ``_audit_detail`` reserved key 로
+    ``resource="approval:{id}"`` 를 전달한다.
+    """
+    approval_id = args["id"]
+    reason = args.get("reason", "")
     request = await svc.approval.reject(
-        args["id"],
+        approval_id,
         resolved_by=actor,
-        reject_reason=args.get("reason", ""),
+        reject_reason=reason,
     )
-    return {"id": request.id, "status": str(request.status)}
+    return {
+        "id": request.id,
+        "status": str(request.status),
+        "_audit_detail": {
+            "resource": f"approval:{approval_id}",
+            "detail": f"reason={reason}",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_approval_cancel(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    request = await svc.approval.cancel(args["id"], requester=actor)
-    return {"id": request.id, "status": str(request.status)}
+    """승인 요청 취소 IPC handler.
+
+    Refs #2110 (audit.md:114): audit 호출은 ``_dispatch`` wrapper 가
+    ``CommandSpec.audit_action="approval.cancel"`` 기반으로 자동 발화한다.
+    handler 는 ``_audit_detail`` reserved key 로
+    ``resource="approval:{id}"`` 를 전달한다.
+    """
+    approval_id = args["id"]
+    request = await svc.approval.cancel(approval_id, requester=actor)
+    return {
+        "id": request.id,
+        "status": str(request.status),
+        "_audit_detail": {
+            "resource": f"approval:{approval_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
 
 
 async def _handle_approval_cancel_invalid(
@@ -1141,11 +1244,23 @@ def register_all_handlers(registry: CommandRegistry) -> None:
 
     Refs #1853 (#1819 epic 종결): ``rule.update`` 의 audit 호출을 wrapper 로
     이전한다(helper 의 ``audit_logger`` 인자를 IPC handler 에서 ``None`` 으로
-    전달, wrapper 가 ``audit_action="account.rule.update"`` 자동 발화). 현재
-    ``audit_action`` 부여 commands 는 10개:
-    ``account.suspend`` / ``account.activate`` / ``bot.start`` /
-    ``bot.stop`` / ``bot.update`` / ``treasury.set_balance`` /
+    전달, wrapper 가 ``audit_action="account.rule.update"`` 자동 발화).
+
+    Refs #2110 (audit.md:112-120): audit.md 가 audit 대상으로 정의했으나
+    ``audit_action`` 누락으로 audit_log 에 기록되지 않던 상태변경 명령 7개에
+    ``audit_action`` + ``audit_logger`` required 를 wiring 한다 —
+    ``system.halt`` (action ``system.halt``) / ``system.clear_halt`` /
+    ``bot.create`` (resource 는 생성 결과 ``bot.bot_id``) / ``bot.remove``
+    (action ``bot.delete``) / ``approval.approve`` / ``approval.reject`` /
+    ``approval.cancel``. 각각 account.suspend 동형으로 register 에 audit_action
+    부여 + required_services union audit_logger, handler 가 ``_audit_detail``
+    반환. 현재 ``audit_action`` 부여 commands 는 18개:
+    ``account.suspend`` / ``account.activate`` / ``system.halt`` /
+    ``system.clear_halt`` / ``bot.create`` / ``bot.remove``(→``bot.delete``) /
+    ``bot.start`` / ``bot.stop`` / ``bot.update`` /
+    ``bot.signal_key.rotate`` / ``treasury.set_balance`` /
     ``strategy.set_status`` / ``member.update_scopes`` /
+    ``approval.approve`` / ``approval.reject`` / ``approval.cancel`` /
     ``approval.cancel_invalid`` / ``rule.update``.
 
     Refs #2112: ``bot.list`` / ``bot.info`` / ``bot.positions`` /
@@ -1155,19 +1270,25 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     """
     # ── mutating (24개): 서버 상태/DB를 변경 ──────────
     # system.* — account_service의 suspend_all/activate_all (collective ops).
+    # Refs #2110 (audit.md:115/116): kill switch 토글은 audit 대상이다.
+    # audit_action 부여 + required_services 에 audit_logger 명시(account.suspend
+    # 동형) — wrapper 가 handler 성공 후 자동 발화하고 audit_logger 부재 시
+    # preflight 가 차단한다.
     registry.register(
         "system.halt",
         _handle_system_halt,
         is_mutating=True,
         result_kind="operation",
-        required_services=frozenset({"account"}),
+        required_services=frozenset({"account", "audit_logger"}),
+        audit_action="system.halt",
     )
     registry.register(
         "system.clear_halt",
         _handle_system_clear_halt,
         is_mutating=True,
         result_kind="operation",
-        required_services=frozenset({"account"}),
+        required_services=frozenset({"account", "audit_logger"}),
+        audit_action="system.clear_halt",
     )
     # account.* — Refs #1852 (#1819 epic): account_id_policy="required" 로
     # wrapper preflight 가 invalid/missing account_id 를 InvalidAccountIdError
@@ -1192,22 +1313,29 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         account_id_policy="required",
         audit_action="account.activate",
     )
-    # bot.* — bot 객체 entity 반환, audit_action은 start/stop/update만.
+    # bot.* — bot 객체 entity 반환. Refs #2110 (audit.md:117/120): create/remove
+    # 도 audit 대상이다. create 의 resource 는 생성 결과 bot.bot_id, remove 의
+    # audit action 은 command 이름과 달리 ``bot.delete`` 다(audit.md SSOT).
+    # audit_action 부여 → required_services 에 audit_logger 명시.
     registry.register(
         "bot.create",
         _handle_bot_create,
         is_mutating=True,
         result_kind="entity",
         result_key="bot_id",
-        required_services=frozenset({"strategy_registry", "bot_manager"}),
+        required_services=frozenset(
+            {"strategy_registry", "bot_manager", "audit_logger"}
+        ),
         account_id_policy="required",
+        audit_action="bot.create",
     )
     registry.register(
         "bot.remove",
         _handle_bot_remove,
         is_mutating=True,
         result_kind="operation",
-        required_services=frozenset({"bot_manager"}),
+        required_services=frozenset({"bot_manager", "audit_logger"}),
+        audit_action="bot.delete",
     )
     # bot.signal_key.rotate (#2111) — ``bot signal-key --rotate`` 의 runtime IPC
     # 경로. ``rotated`` bool flag envelope 이므로 ``bot.remove`` 와 동형
@@ -1315,9 +1443,12 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         result_kind="operation",
         required_services=frozenset({"dynamic_config"}),
     )
-    # approval.* — request/approve/reject/cancel/reopen은 audit_logger 호출이
-    # 없고(서비스 내부 history append가 fallback), cancel_invalid만 명시
-    # ``approval.cancel_invalid`` audit를 남긴다(#1418 → #1472 SPLIT-D).
+    # approval.* — request/reopen은 audit_logger 호출이 없고(서비스 내부 history
+    # append가 fallback). Refs #2110 (audit.md:112/113/114): approve/reject/
+    # cancel 은 audit 대상이다 — audit_action 부여 + required_services 에
+    # audit_logger 명시(resource="approval:{id}"). cancel_invalid 는 별개
+    # administrative path 로 ``approval.cancel_invalid`` audit를 남긴다
+    # (#1418 → #1472 SPLIT-D).
     registry.register(
         "approval.request",
         _handle_approval_request,
@@ -1330,21 +1461,24 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         _handle_approval_approve,
         is_mutating=True,
         result_kind="entity",
-        required_services=frozenset({"approval"}),
+        required_services=frozenset({"approval", "audit_logger"}),
+        audit_action="approval.approve",
     )
     registry.register(
         "approval.reject",
         _handle_approval_reject,
         is_mutating=True,
         result_kind="entity",
-        required_services=frozenset({"approval"}),
+        required_services=frozenset({"approval", "audit_logger"}),
+        audit_action="approval.reject",
     )
     registry.register(
         "approval.cancel",
         _handle_approval_cancel,
         is_mutating=True,
         result_kind="entity",
-        required_services=frozenset({"approval"}),
+        required_services=frozenset({"approval", "audit_logger"}),
+        audit_action="approval.cancel",
     )
     registry.register(
         "approval.cancel_invalid",

--- a/tests/unit/ipc/test_dispatch_wrapper_audit.py
+++ b/tests/unit/ipc/test_dispatch_wrapper_audit.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -760,5 +760,485 @@ async def test_audit_action_without_audit_logger_no_crash(socket_path: str) -> N
         # crash 없이 정상 응답 + _audit_detail strip.
         assert response["status"] == "ok"
         assert "_audit_detail" not in response["result"]
+    finally:
+        await server.stop()
+
+
+# ── #2110 audit wiring (system halt/clear-halt, bot create/remove, ───────────
+#    approval approve/reject/cancel) ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_system_halt_audit_action_fires(socket_path: str) -> None:
+    """Refs #2110 (audit.md:115): ``system.halt`` 가 wrapper 자동 audit 발화.
+
+    resource 는 ``system:kill_switch`` (audit.md SSOT). handler 성공 후
+    ``audit_logger.log`` 1회 호출 + ``_audit_detail`` strip.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_account = MagicMock()
+    fake_account.suspend_all = AsyncMock(return_value=[])
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, account=fake_account
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "system.halt",
+                "args": {"reason": "ops halt"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "ok"
+        assert "_audit_detail" not in response["result"]
+        audit_logger.log.assert_awaited_once_with(
+            member_id="alice",
+            action="system.halt",
+            resource="system:kill_switch",
+            detail="reason=ops halt",
+            ip="",
+        )
+        fake_account.suspend_all.assert_awaited_once_with(
+            reason="ops halt", suspended_by="alice"
+        )
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_system_clear_halt_audit_action_fires(socket_path: str) -> None:
+    """Refs #2110 (audit.md:116): ``system.clear_halt`` 자동 audit 발화."""
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_account = MagicMock()
+    fake_account.activate_all = AsyncMock(return_value=[])
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, account=fake_account
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "system.clear_halt",
+                "args": {},
+                "actor": "bob",
+            }
+        )
+        assert response["status"] == "ok"
+        assert "_audit_detail" not in response["result"]
+        audit_logger.log.assert_awaited_once_with(
+            member_id="bob",
+            action="system.clear_halt",
+            resource="system:kill_switch",
+            detail="",
+            ip="",
+        )
+        fake_account.activate_all.assert_awaited_once_with(activated_by="bob")
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_system_halt_audit_not_fired_on_failure(socket_path: str) -> None:
+    """Refs #2110: handler 예외(suspend_all 실패) 시 audit 미발화."""
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_account = MagicMock()
+    fake_account.suspend_all = AsyncMock(side_effect=RuntimeError("boom"))
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, account=fake_account
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "system.halt",
+                "args": {"reason": "x"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "error"
+        assert audit_logger.log.await_count == 0
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_create_audit_action_fires_with_result_bot_id(
+    socket_path: str,
+) -> None:
+    """Refs #2110 (audit.md:117): ``bot.create`` 자동 audit 발화.
+
+    resource 는 **생성 결과** ``bot.bot_id`` 를 쓴다 — 요청 args 의 ``bot_id``
+    가 비어 있어도(서버가 채움) result 의 bot_id 로 audit 한다.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_bot = MagicMock()
+    fake_bot.bot_id = "bot-generated-7"
+    fake_bot_manager = MagicMock()
+    fake_bot_manager.create_bot = AsyncMock(return_value=fake_bot)
+
+    strategy_record = MagicMock()
+    strategy_record.filepath = "/tmp/_fake_strategy.py"
+    strategy_registry = MagicMock()
+    strategy_registry.get = AsyncMock(return_value=strategy_record)
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger,
+        bot_manager=fake_bot_manager,
+        strategy_registry=strategy_registry,
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        with patch("ante.strategy.loader.StrategyLoader.load") as mock_load:
+            mock_load.return_value = MagicMock()
+            response = await server._dispatch(
+                {
+                    "id": "1",
+                    "command": "bot.create",
+                    "args": {
+                        "account_id": "acc1",
+                        "strategy_id": "s1",
+                        "name": "test",
+                        # bot_id 비움 — resource 는 result bot_id 로 채워져야 함.
+                        "bot_id": "",
+                    },
+                    "actor": "alice",
+                }
+            )
+        assert response["status"] == "ok"
+        assert response["result"] == {"bot_id": "bot-generated-7"}
+        assert "_audit_detail" not in response["result"]
+        # resource 는 요청 args 의 빈 bot_id 가 아니라 생성 결과 bot_id.
+        audit_logger.log.assert_awaited_once_with(
+            member_id="alice",
+            action="bot.create",
+            resource="bot:bot-generated-7",
+            detail="",
+            ip="",
+        )
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_remove_audit_action_is_bot_delete(socket_path: str) -> None:
+    """Refs #2110 (audit.md:120): ``bot.remove`` command 의 audit action 은
+    audit.md SSOT 에 따라 ``bot.delete`` (command 이름과 다름)."""
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_bot_manager = MagicMock()
+    fake_bot_manager.remove_bot = AsyncMock(return_value=None)
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, bot_manager=fake_bot_manager
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "bot.remove",
+                "args": {"bot_id": "bot-9"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "ok"
+        assert response["result"] == {"bot_id": "bot-9", "removed": True}
+        assert "_audit_detail" not in response["result"]
+        audit_logger.log.assert_awaited_once_with(
+            member_id="alice",
+            action="bot.delete",
+            resource="bot:bot-9",
+            detail="",
+            ip="",
+        )
+        fake_bot_manager.remove_bot.assert_awaited_once_with("bot-9")
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_remove_audit_not_fired_on_failure(socket_path: str) -> None:
+    """Refs #2110: ``BotNotFoundError`` 등 거부 경로는 audit 미발화."""
+    from ante.bot.exceptions import BotNotFoundError
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_bot_manager = MagicMock()
+    fake_bot_manager.remove_bot = AsyncMock(side_effect=BotNotFoundError("bot-missing"))
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, bot_manager=fake_bot_manager
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "bot.remove",
+                "args": {"bot_id": "bot-missing"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "BOT_NOT_FOUND"
+        assert audit_logger.log.await_count == 0
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_approval_approve_audit_action_fires(socket_path: str) -> None:
+    """Refs #2110 (audit.md:112): ``approval.approve`` 자동 audit 발화.
+
+    resource 는 ``approval:{id}`` (요청 args 의 id).
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_request = MagicMock()
+    fake_request.id = "apr-1"
+    fake_request.status = "approved"
+    fake_approval = MagicMock()
+    fake_approval.approve = AsyncMock(return_value=fake_request)
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, approval=fake_approval
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "approval.approve",
+                "args": {"id": "apr-1"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "ok"
+        assert "_audit_detail" not in response["result"]
+        audit_logger.log.assert_awaited_once_with(
+            member_id="alice",
+            action="approval.approve",
+            resource="approval:apr-1",
+            detail="",
+            ip="",
+        )
+        fake_approval.approve.assert_awaited_once_with("apr-1", resolved_by="alice")
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_approval_reject_audit_action_fires(socket_path: str) -> None:
+    """Refs #2110 (audit.md:113): ``approval.reject`` 자동 audit 발화."""
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_request = MagicMock()
+    fake_request.id = "apr-2"
+    fake_request.status = "rejected"
+    fake_approval = MagicMock()
+    fake_approval.reject = AsyncMock(return_value=fake_request)
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, approval=fake_approval
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "approval.reject",
+                "args": {"id": "apr-2", "reason": "no good"},
+                "actor": "bob",
+            }
+        )
+        assert response["status"] == "ok"
+        assert "_audit_detail" not in response["result"]
+        audit_logger.log.assert_awaited_once_with(
+            member_id="bob",
+            action="approval.reject",
+            resource="approval:apr-2",
+            detail="reason=no good",
+            ip="",
+        )
+        fake_approval.reject.assert_awaited_once_with(
+            "apr-2", resolved_by="bob", reject_reason="no good"
+        )
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_approval_cancel_audit_action_fires(socket_path: str) -> None:
+    """Refs #2110 (audit.md:114): ``approval.cancel`` 자동 audit 발화."""
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_request = MagicMock()
+    fake_request.id = "apr-3"
+    fake_request.status = "cancelled"
+    fake_approval = MagicMock()
+    fake_approval.cancel = AsyncMock(return_value=fake_request)
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, approval=fake_approval
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "approval.cancel",
+                "args": {"id": "apr-3"},
+                "actor": "carol",
+            }
+        )
+        assert response["status"] == "ok"
+        assert "_audit_detail" not in response["result"]
+        audit_logger.log.assert_awaited_once_with(
+            member_id="carol",
+            action="approval.cancel",
+            resource="approval:apr-3",
+            detail="",
+            ip="",
+        )
+        fake_approval.cancel.assert_awaited_once_with("apr-3", requester="carol")
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_approval_approve_audit_not_fired_on_failure(socket_path: str) -> None:
+    """Refs #2110: approve handler 예외 시 audit 미발화."""
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    fake_approval = MagicMock()
+    fake_approval.approve = AsyncMock(side_effect=RuntimeError("boom"))
+
+    audit_logger = _make_audit_logger_mock()
+    svc_registry = _make_service_registry(
+        audit_logger=audit_logger, approval=fake_approval
+    )
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "approval.approve",
+                "args": {"id": "apr-x"},
+                "actor": "alice",
+            }
+        )
+        assert response["status"] == "error"
+        assert audit_logger.log.await_count == 0
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_2110_commands_preflight_reject_without_audit_logger(
+    socket_path: str,
+) -> None:
+    """Refs #2110: audit_logger 미주입 시 7개 명령 모두 preflight 거부.
+
+    account.suspend 선례 동형 — required_services 에 audit_logger 가 추가됐으므로
+    legacy/미주입 환경에서는 handler 도달 전 ``SERVICE_NOT_CONFIGURED`` 로
+    차단되고 audit/상태변경이 일어나지 않는다.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    svc_registry = _make_service_registry()  # audit_logger=None (default)
+    assert svc_registry.audit_logger is None
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        for command, args in [
+            ("system.halt", {}),
+            ("system.clear_halt", {}),
+            ("bot.create", {"account_id": "acc1", "strategy_id": "s1"}),
+            ("bot.remove", {"bot_id": "b1"}),
+            ("approval.approve", {"id": "apr-1"}),
+            ("approval.reject", {"id": "apr-1"}),
+            ("approval.cancel", {"id": "apr-1"}),
+        ]:
+            spec = cmd_registry.get(command)
+            assert spec is not None
+            assert "audit_logger" in spec.required_services, command
+            response = await server._dispatch(
+                {"id": "1", "command": command, "args": args, "actor": "x"}
+            )
+            assert response["status"] == "error", command
+            assert response["error"]["code"] == "SERVICE_NOT_CONFIGURED", command
     finally:
         await server.stop()

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -247,7 +247,17 @@ class TestHandleBotCreate:
         finally:
             ante.strategy.loader.StrategyLoader.load = original_load
 
-        assert result == {"bot_id": "new-bot"}
+        # Refs #2110: bot.create 가 audit 대상이 되어 handler 가
+        # ``_audit_detail`` reserved key 를 함께 반환한다(resource 는 생성 결과
+        # bot.bot_id). public envelope 진입 전 _dispatch wrapper 가 pop 한다.
+        assert result == {
+            "bot_id": "new-bot",
+            "_audit_detail": {
+                "resource": "bot:new-bot",
+                "detail": "",
+                "ip": "",
+            },
+        }
         fake_registry.get.assert_awaited_once_with("strat-1")
         fake_bot_manager.create_bot.assert_awaited_once()
         call_kwargs = fake_bot_manager.create_bot.call_args.kwargs
@@ -993,10 +1003,22 @@ class TestRegisteredCommandsMetadataCompleteness:
 
         Refs #2111: ``bot.signal_key.rotate`` 가 audit_action 부여
         (action="bot.signal_key.rotate", audit.md:121 SSOT) (10→11 commands).
+
+        Refs #2110: audit.md 가 audit 대상으로 정의했으나 누락돼 있던 상태변경
+        명령 7개에 audit_action wiring (11→18 commands):
+        ``system.halt`` / ``system.clear_halt`` / ``bot.create`` /
+        ``bot.remove``(action ``bot.delete``) / ``approval.approve`` /
+        ``approval.reject`` / ``approval.cancel`` — audit.md:112-120 SSOT.
         """
         expected_actions = {
             "account.suspend",
             "account.activate",
+            "system.halt",
+            "system.clear_halt",
+            "bot.create",
+            # bot.remove command 의 audit action 은 audit.md SSOT 에 따라
+            # ``bot.delete`` (command 이름과 의도적으로 다름).
+            "bot.delete",
             "bot.start",
             "bot.stop",
             "bot.update",
@@ -1004,6 +1026,9 @@ class TestRegisteredCommandsMetadataCompleteness:
             "treasury.set_balance",
             "strategy.set_status",
             "member.update_scopes",
+            "approval.approve",
+            "approval.reject",
+            "approval.cancel",
             "approval.cancel_invalid",
             "account.rule.update",
         }

--- a/tests/unit/test_approval_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_approval_cli_ipc_error_equivalence.py
@@ -245,6 +245,12 @@ class TestApprovalStatusConflictEquivalence:
                 requested_action="approve",
             )
         )
+        # Refs #2110: approval.approve 가 audit 대상이 되어 required_services 에
+        # audit_logger 가 추가됐다 — preflight 통과를 위해 주입한다
+        # (account.suspend 동형). 실패 경로(ApprovalStatusConflictError)라 audit
+        # 발화는 일어나지 않지만 preflight 는 audit_logger 존재를 요구한다.
+        audit_logger = MagicMock()
+        audit_logger.log = AsyncMock(return_value=None)
         svc_registry = ServiceRegistry(
             account=MagicMock(),
             bot_manager=MagicMock(),
@@ -254,6 +260,7 @@ class TestApprovalStatusConflictEquivalence:
             reconciler=MagicMock(),
             eventbus=MagicMock(),
             member_service=MagicMock(),
+            audit_logger=audit_logger,
         )
         cmd_registry = CommandRegistry()
         register_all_handlers(cmd_registry)

--- a/tests/unit/test_bot_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_bot_cli_ipc_error_equivalence.py
@@ -364,6 +364,12 @@ class TestBotAlreadyExistsEquivalence:
         strategy_registry = MagicMock()
         strategy_registry.get = AsyncMock(return_value=strategy_record)
 
+        # Refs #2110: bot.create 가 audit 대상이 되어 required_services 에
+        # audit_logger 가 추가됐다 — preflight 통과를 위해 주입한다
+        # (account.suspend 동형). 실패 경로(BotAlreadyExistsError)라 audit
+        # 발화는 일어나지 않지만 preflight 는 audit_logger 존재를 요구한다.
+        audit_logger = MagicMock()
+        audit_logger.log = AsyncMock(return_value=None)
         svc_registry = ServiceRegistry(
             account=MagicMock(),
             bot_manager=bot_manager,
@@ -374,6 +380,7 @@ class TestBotAlreadyExistsEquivalence:
             eventbus=MagicMock(),
             member_service=MagicMock(),
             strategy_registry=strategy_registry,
+            audit_logger=audit_logger,
         )
         cmd_registry = CommandRegistry()
         register_all_handlers(cmd_registry)


### PR DESCRIPTION
Closes #2110

## Summary
- audit.md가 audit 대상으로 정의했으나 IPC registry에 audit_action 없이 등록돼 audit_log 미기록이던 7개 명령(system halt/clear-halt, bot create/remove, approval approve/reject/cancel)에 audit_action + resource + audit_logger required service를 wiring.
- account.suspend 선례 동형: register audit_action + audit_logger required, handler가 _audit_detail{resource} 반환, _dispatch가 성공 후 자동 발화(실패 시 미발화).
- audit.md 매핑 정확: system→system:kill_switch, approval→approval:{id}, bot.create→bot:{result.bot_id}, **bot.remove→action bot.delete**.

## Test Plan
- 7개 발화/실패 미발화/audit_logger 미주입 preflight 거부; registry audit_action set/count 11→18; bot.create result bot_id·bot.remove→bot.delete lock
- 전체 `pytest tests/unit/`: 6854 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (d353b70a)

## 비고
broker.reconcile audit=#2109(--fix 조건부), member.* audit=#2113(handler 선행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)