### PR TITLE
fix(ipc): #2109 broker.reconcile --fix 실제 보정 시 조건부 audit (핸들러-레벨)

### DIFF
--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -1190,12 +1190,6 @@ async def _handle_broker_reconcile(
             account_id=account_id,
             dry_run=not fix,
         )
-        # display(discrepancies)는 보정 **이후** 상태로 계좌 단위 합산 비교를
-        # 재계산한다(순수, 이벤트 無). fix=True 면 보정 후 0으로 수렴, dry_run
-        # 이면 미보정 불일치가 그대로 남는다.
-        mismatches = await svc.reconciler.compute_account_diff(
-            broker_positions, account_id=account_id
-        )
         # #2109: 실제 포지션 보정이 발생한 경우에만 조건부 audit. audit 원칙은
         # 상태변경만 기록(docs/specs/.../audit.md L122 매핑 broker.reconcile →
         # resource=account:{id}). detect-only(fix=False)나 보정 대상 없음
@@ -1205,12 +1199,22 @@ async def _handle_broker_reconcile(
         # ``required_services`` 에 ``audit_logger`` 가 명시되어 preflight 에서
         # 부재가 차단되므로(fail-closed) 여기서는 직접 호출한다 —
         # unaudited correction 을 방지한다.
+        #
+        # 보정(상태변경) 직후 즉시 audit — 이후 post-processing
+        # (compute_account_diff) 실패가 audit 누락을 유발하지 않도록(#2109
+        # Codex). 상태변경(fix and adjustments)만 기록.
         if fix and adjustments:
             await svc.audit_logger.log(
                 member_id=actor,
                 action="broker.reconcile",
                 resource=f"account:{account_id}",
             )
+        # display(discrepancies)는 보정 **이후** 상태로 계좌 단위 합산 비교를
+        # 재계산한다(순수, 이벤트 無). fix=True 면 보정 후 0으로 수렴, dry_run
+        # 이면 미보정 불일치가 그대로 남는다.
+        mismatches = await svc.reconciler.compute_account_diff(
+            broker_positions, account_id=account_id
+        )
         return _broker_reconcile_envelope(
             account_id=account_id,
             fix=fix,

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -1196,6 +1196,21 @@ async def _handle_broker_reconcile(
         mismatches = await svc.reconciler.compute_account_diff(
             broker_positions, account_id=account_id
         )
+        # #2109: 실제 포지션 보정이 발생한 경우에만 조건부 audit. audit 원칙은
+        # 상태변경만 기록(docs/specs/.../audit.md L122 매핑 broker.reconcile →
+        # resource=account:{id}). detect-only(fix=False)나 보정 대상 없음
+        # (adjustments 빈)은 상태변경이 없어 기록하지 않는다. ``register`` 에는
+        # ``audit_action`` 을 부여하지 않으므로 ``_dispatch`` wrapper 의 무조건
+        # auto-fire 가 일어나지 않고, 조건부 발화 책임은 handler 가 소유한다.
+        # ``required_services`` 에 ``audit_logger`` 가 명시되어 preflight 에서
+        # 부재가 차단되므로(fail-closed) 여기서는 직접 호출한다 —
+        # unaudited correction 을 방지한다.
+        if fix and adjustments:
+            await svc.audit_logger.log(
+                member_id=actor,
+                action="broker.reconcile",
+                resource=f"account:{account_id}",
+            )
         return _broker_reconcile_envelope(
             account_id=account_id,
             fix=fix,
@@ -1500,13 +1515,25 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     # reconciler.reconcile(correct_position/이벤트 publish 가능)에 위임하며,
     # 2+봇·0봇이면 detect_account_level(알림만)을 수행한다. fix=False(dry_run)
     # 여도 broker 조회·이벤트 발행이 있으므로 일괄 mutating으로 분류한다.
-    # required_services: account(broker 조회) + reconciler + bot_manager(count).
+    # required_services: account(broker 조회) + reconciler + bot_manager(count)
+    # + audit_logger(#2109).
+    #
+    # Refs #2109: ``--fix`` 가 실제 포지션 보정을 일으키는 경우 audit 대상이나,
+    # detect-only(fix=False / 0봇·2+봇 / 불일치 없음) 는 상태변경이 없어
+    # 기록 대상이 아니다. 따라서 ``audit_action`` 을 부여하지 **않고**(부여 시
+    # ``_dispatch`` wrapper 가 detect-only 까지 무조건 auto-fire → 과잉감사)
+    # handler 가 실제 correction(1봇 + adjustments 비어있지 않음) 에만 직접
+    # ``svc.audit_logger.log`` 를 호출한다. ``audit_logger`` 는
+    # ``required_services`` 에만 추가해 fail-closed preflight(미주입 시 명령
+    # 거부) 로 unaudited correction 을 방지한다.
     registry.register(
         "broker.reconcile",
         _handle_broker_reconcile,
         is_mutating=True,
         result_kind="operation",
-        required_services=frozenset({"account", "reconciler", "bot_manager"}),
+        required_services=frozenset(
+            {"account", "reconciler", "bot_manager", "audit_logger"}
+        ),
         account_id_policy="required",
     )
 

--- a/tests/unit/ipc/test_dispatch_wrapper_preflight.py
+++ b/tests/unit/ipc/test_dispatch_wrapper_preflight.py
@@ -573,3 +573,45 @@ async def test_shutdown_readonly_passes_through_preflight(socket_path: str) -> N
         await server.drain_connections(timeout=0.1)
         if Path(socket_path).exists():
             server.unlink_socket()
+
+
+# ── #2109: broker.reconcile fail-closed audit_logger required ──────────────
+
+
+@pytest.mark.asyncio
+async def test_broker_reconcile_missing_audit_logger_rejected(
+    socket_path: str,
+) -> None:
+    """(e) ``broker.reconcile`` 은 ``audit_logger`` 미주입 시 preflight 거부.
+
+    Refs #2109: ``audit_logger`` 를 ``required_services`` 에 추가해 fail-closed
+    로 동작한다 — audit_logger 가 없으면 (unaudited correction 위험) 명령을
+    아예 거부한다. ``audit_logger`` 부재 검사는 account_id preflight 보다 먼저
+    이뤄지므로(required_services preflight 가 try 블록보다 앞) 유효 account_id
+    여부와 무관하게 ``SERVICE_NOT_CONFIGURED`` 다.
+    """
+    from ante.ipc.registry import register_all_handlers
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+
+    # account / reconciler / bot_manager 는 있으나 audit_logger 미주입.
+    svc_registry = _make_service_registry()
+    assert svc_registry.audit_logger is None
+
+    server = IPCServer(socket_path, svc_registry, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "broker.reconcile",
+                "args": {"account_id": "acc-a", "fix": True},
+                "actor": "cli-user",
+            }
+        )
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "SERVICE_NOT_CONFIGURED"
+        assert "audit_logger" in response["error"]["message"]
+    finally:
+        await server.stop()

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -775,6 +775,38 @@ class TestHandleBrokerReconcileConditionalAudit:
         )
 
     @pytest.mark.asyncio
+    async def test_audit_fires_before_compute_account_diff_failure(self):
+        """(a-2) compute_account_diff 실패해도 audit 는 선발화됐다 (#2109 Codex).
+
+        audit 는 correction(상태변경) **직후** 발화해야 하므로, 이후 post-processing
+        인 ``compute_account_diff`` 가 예외를 던지더라도 (이미 발생한 보정에 대한)
+        audit 누락이 일어나면 안 된다. 예외는 그대로 전파되되, 그 전에
+        ``audit_logger.log`` 가 이미 1회 호출됐음을 단언한다.
+        """
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
+            bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+        # 실제 보정 발생 (1봇 + adjustments 비어있지 않음).
+        reconciler.reconcile.return_value = [{"symbol": "005930", "corrected": True}]
+        # 보정 이후 post-processing 단계가 실패한다.
+        reconciler.compute_account_diff.side_effect = RuntimeError("diff failed")
+
+        with pytest.raises(RuntimeError, match="diff failed"):
+            await _handle_broker_reconcile(
+                svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+            )
+
+        # compute_account_diff 실패 이전에 audit 가 이미 발화됐어야 한다.
+        audit_logger.log.assert_awaited_once_with(
+            member_id="cli-user",
+            action="broker.reconcile",
+            resource="account:acc-a",
+        )
+
+    @pytest.mark.asyncio
     async def test_fix_false_detect_only_no_audit(self):
         """(b) fix=False detect-only(상태변경 없음) → audit 미발화."""
         from ante.ipc.registry import _handle_broker_reconcile

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -489,6 +489,11 @@ def _make_reconcile_svc(
     - ``svc.account.get_broker(account_id)`` → broker mock(``get_account_positions``)
     - ``svc.bot_manager.list_bots()`` → ``bots``
     - ``svc.reconciler`` → reconcile/detect_account_level/compute_account_diff mock
+    - ``svc.audit_logger`` → ``log`` AsyncMock (#2109 조건부 audit injection).
+      ``broker.reconcile`` 은 ``required_services`` 에 ``audit_logger`` 를 두고
+      실제 correction(1봇 + adjustments 비어있지 않음) 시 ``log`` 를 호출하므로,
+      handler-level 테스트도 awaitable audit_logger 를 주입한다(account.suspend
+      선례 동형).
     """
     from unittest.mock import AsyncMock, MagicMock
 
@@ -508,11 +513,15 @@ def _make_reconcile_svc(
     reconciler.detect_account_level = AsyncMock(return_value=[])
     reconciler.compute_account_diff = AsyncMock(return_value=[])
 
+    audit_logger = MagicMock()
+    audit_logger.log = AsyncMock(return_value=None)
+
     svc = MagicMock()
     svc.account = account_svc
     svc.bot_manager = bot_manager
     svc.reconciler = reconciler
-    return svc, broker, reconciler
+    svc.audit_logger = audit_logger
+    return svc, broker, reconciler, audit_logger
 
 
 class TestHandleBrokerReconcileAccountLevel:
@@ -528,7 +537,7 @@ class TestHandleBrokerReconcileAccountLevel:
         """(a) bot_id 없이 account_id 만으로 도달하고 서버 broker 를 조회한다."""
         from ante.ipc.registry import _handle_broker_reconcile
 
-        svc, broker, reconciler = _make_reconcile_svc(
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
             bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
             broker_positions=[{"symbol": "005930", "quantity": 10, "avg_price": 1}],
         )
@@ -548,7 +557,7 @@ class TestHandleBrokerReconcileAccountLevel:
         """(b) fix=False → 단일봇 reconcile(dry_run=True) — correct_position 미호출."""
         from ante.ipc.registry import _handle_broker_reconcile
 
-        svc, broker, reconciler = _make_reconcile_svc(
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
             bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
             broker_positions=[{"symbol": "005930", "quantity": 10}],
         )
@@ -567,7 +576,7 @@ class TestHandleBrokerReconcileAccountLevel:
         """(c) 1봇 계좌 fix=True → 기존 reconcile 보정(dry_run=False) 위임."""
         from ante.ipc.registry import _handle_broker_reconcile
 
-        svc, broker, reconciler = _make_reconcile_svc(
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
             bots=[{"bot_id": "bot-1", "status": "stopped", "account_id": "acc-a"}],
             broker_positions=[{"symbol": "005930", "quantity": 10}],
         )
@@ -591,7 +600,7 @@ class TestHandleBrokerReconcileAccountLevel:
         """(d) 2+봇 → detect_account_level (correct_position 미호출)."""
         from ante.ipc.registry import _handle_broker_reconcile
 
-        svc, broker, reconciler = _make_reconcile_svc(
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
             bots=[
                 {"bot_id": "bot-1", "status": "running", "account_id": "acc-a"},
                 {"bot_id": "bot-2", "status": "running", "account_id": "acc-a"},
@@ -619,7 +628,7 @@ class TestHandleBrokerReconcileAccountLevel:
         """(f) caller-supplied broker_positions 무시 — 서버 broker 조회값 사용."""
         from ante.ipc.registry import _handle_broker_reconcile
 
-        svc, broker, reconciler = _make_reconcile_svc(
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
             bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
             broker_positions=[{"symbol": "005930", "quantity": 10}],
         )
@@ -645,7 +654,7 @@ class TestHandleBrokerReconcileAccountLevel:
         """(k) 0봇 + broker_positions 존재 → detect/alert (no-op 아님)."""
         from ante.ipc.registry import _handle_broker_reconcile
 
-        svc, broker, reconciler = _make_reconcile_svc(
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
             bots=[],
             broker_positions=[{"symbol": "005930", "quantity": 10}],
         )
@@ -667,7 +676,7 @@ class TestHandleBrokerReconcileAccountLevel:
         """(l) 봇 count 는 status 무관 — stopped/error 봇도 count 에 포함된다."""
         from ante.ipc.registry import _handle_broker_reconcile
 
-        svc, broker, reconciler = _make_reconcile_svc(
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
             bots=[
                 {"bot_id": "bot-1", "status": "running", "account_id": "acc-a"},
                 {"bot_id": "bot-2", "status": "stopped", "account_id": "acc-a"},
@@ -690,7 +699,7 @@ class TestHandleBrokerReconcileAccountLevel:
         """다른 계좌 봇은 count 에서 제외된다 (account-scoped count)."""
         from ante.ipc.registry import _handle_broker_reconcile
 
-        svc, broker, reconciler = _make_reconcile_svc(
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
             bots=[
                 {"bot_id": "bot-1", "status": "running", "account_id": "acc-a"},
                 {"bot_id": "bot-x", "status": "running", "account_id": "acc-other"},
@@ -713,7 +722,7 @@ class TestHandleBrokerReconcileAccountLevel:
         from ante.account.errors import InvalidAccountIdError
         from ante.ipc.registry import _handle_broker_reconcile
 
-        svc, broker, reconciler = _make_reconcile_svc(
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
             bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
         )
 
@@ -726,6 +735,137 @@ class TestHandleBrokerReconcileAccountLevel:
         svc.account.get_broker.assert_not_called()
         reconciler.reconcile.assert_not_called()
         reconciler.detect_account_level.assert_not_called()
+
+
+# ── #2109: broker.reconcile --fix 실제 보정 시 조건부 audit (handler-level) ──
+
+
+class TestHandleBrokerReconcileConditionalAudit:
+    """``broker.reconcile`` 의 handler-level 조건부 audit (#2109).
+
+    audit 원칙은 **상태변경만 기록**(audit.md:122 → action ``broker.reconcile``,
+    resource ``account:{account_id}``). 따라서 ``--fix`` intent 만으로는 부족하고,
+    실제 correction(1봇 + ``adjustments`` 비어있지 않음) 이 발생한 경우에만
+    ``svc.audit_logger.log`` 가 1회 발화한다.
+
+    ``register`` 에 ``audit_action`` 을 부여하지 않으므로 ``_dispatch`` wrapper 의
+    무조건 auto-fire 는 일어나지 않고, 조건부 발화 책임은 handler 가 소유한다
+    (``audit_action=None`` 은 introspection 으로 lock).
+    """
+
+    @pytest.mark.asyncio
+    async def test_fix_true_single_bot_with_adjustments_audits_once(self):
+        """(a) fix=True + 1봇 + adjustments 비어있지 않음 → audit 1회 (positive)."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
+            bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+        reconciler.reconcile.return_value = [{"symbol": "005930", "corrected": True}]
+
+        await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+        )
+
+        audit_logger.log.assert_awaited_once_with(
+            member_id="cli-user",
+            action="broker.reconcile",
+            resource="account:acc-a",
+        )
+
+    @pytest.mark.asyncio
+    async def test_fix_false_detect_only_no_audit(self):
+        """(b) fix=False detect-only(상태변경 없음) → audit 미발화."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
+            bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+        # dry_run 이어도 reconcile 이 (구현상) 비어있지 않은 list 를 돌려줄 수
+        # 있으나, fix=False 면 실제 보정이 없으므로 audit 하지 않는다.
+        reconciler.reconcile.return_value = [{"symbol": "005930", "corrected": False}]
+
+        await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": False}, "cli-user"
+        )
+
+        audit_logger.log.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fix_true_multi_bot_detect_only_no_audit(self):
+        """(c-1) fix=True 이나 2+봇(detect-only 귀결) → audit 미발화."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
+            bots=[
+                {"bot_id": "bot-1", "status": "running", "account_id": "acc-a"},
+                {"bot_id": "bot-2", "status": "running", "account_id": "acc-a"},
+            ],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+        reconciler.detect_account_level.return_value = [
+            {"symbol": "005930", "broker_qty": 10, "internal_qty": 8, "diff": 2}
+        ]
+
+        await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+        )
+
+        # detect-only 경로 → adjustments 없음 → audit 미발화.
+        audit_logger.log.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fix_true_zero_bots_detect_only_no_audit(self):
+        """(c-2) fix=True 이나 0봇(detect-only 귀결) → audit 미발화."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
+            bots=[],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+        reconciler.detect_account_level.return_value = [
+            {"symbol": "005930", "broker_qty": 10, "internal_qty": 0, "diff": 10}
+        ]
+
+        await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+        )
+
+        audit_logger.log.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fix_true_single_bot_no_adjustments_no_audit(self):
+        """(d) fix=True + 1봇 이나 불일치 없음(adjustments 빈) → audit 미발화."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        svc, broker, reconciler, audit_logger = _make_reconcile_svc(
+            bots=[{"bot_id": "bot-1", "status": "running", "account_id": "acc-a"}],
+            broker_positions=[{"symbol": "005930", "quantity": 10}],
+        )
+        # 보정 대상이 없으면 reconcile 은 빈 list 를 돌려준다(상태변경 없음).
+        reconciler.reconcile.return_value = []
+
+        await _handle_broker_reconcile(
+            svc, {"account_id": "acc-a", "fix": True}, "cli-user"
+        )
+
+        audit_logger.log.assert_not_awaited()
+
+    def test_register_audit_logger_required_but_audit_action_none(self) -> None:
+        """(f) introspection: ``audit_logger`` ∈ required_services, audit_action=None.
+
+        ``audit_action=None`` 이라 ``_dispatch`` wrapper auto-fire 대상이 아니며
+        (조건부는 handler 소유), 동시에 ``audit_logger`` 가 required 라
+        fail-closed preflight(미주입 거부) 가 보장된다.
+        """
+        registry = CommandRegistry()
+        register_all_handlers(registry)
+        spec = registry.get("broker.reconcile")
+        assert spec is not None
+        assert "audit_logger" in spec.required_services
+        assert spec.audit_action is None
 
 
 # ── #1379 oracle A7: IPC config.set 핸들러도 서비스 경계 ValueError 전파 ──


### PR DESCRIPTION
Closes #2109

## Summary
- `broker reconcile --fix`가 audit 대상(audit.md L122: action broker.reconcile, resource account:{account_id})인데 IPC에 audit_action 없어 포지션 보정이 audit_log 미기록이던 것을, **실제 correction 발생 시에만 핸들러-레벨 조건부 audit**로 해결.
- register에 audit_logger required(**fail-closed**: 미주입 시 명령 거부 → unaudited correction 방지), audit_action 미부여(detect-only 과잉감사 방지). 1봇 경로에서 fix=True+adjustments 비어있지 않을 때만(=실제 상태변경) **reconcile correction 직후**(compute_account_diff 전) audit. fix=False/0·2+봇/no-adjustments → 미발화.

## Test Plan
- positive(1봇+adjustments), negatives(fix=False/2+·0봇/no-adjustments), preflight reject(audit_logger 미주입), **compute_account_diff raise 시 audit 선발화**(보정 후 audit 보장)
- 전체 `pytest tests/unit/`: 6871 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (97f9073, attempt 2)

## 비고
member.* audit=#2113(handler 선행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)