### PR TITLE
fix(backtest): #1998 run()이 결과 artifact 저장 + result_path 전파 (자동 리포트 초안 경로 복구)

### DIFF
--- a/src/ante/backtest/result.py
+++ b/src/ante/backtest/result.py
@@ -39,6 +39,12 @@ class BacktestResult:
     metrics: dict = field(default_factory=dict)
     config: BacktestConfig = field(default_factory=BacktestConfig)
     datasets: list[DatasetInfo] = field(default_factory=list)
+    # #1998: run() 이 결과 artifact 를 durable 하게 저장한 경로(메인 프로세스
+    # 런타임 메타데이터). BacktestCompleteEvent.result_path / backtest_runs.
+    # result_path 전파용. ``to_dict()`` 직렬화 계약에는 **포함하지 않는다** —
+    # artifact 파일 자체의 self-reference 를 막고, draft 소비 shape(result.
+    # to_dict)를 무변경으로 유지하기 위함이다. 저장 실패 시 "" fallback.
+    result_path: str = ""
 
     def to_dict(self, *, resample_equity: bool = False) -> dict:
         """결과를 딕셔너리로 변환.

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -9,6 +9,7 @@ import logging
 import math
 import re
 import sys
+import uuid
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
@@ -154,13 +155,61 @@ class BacktestService:
         result.config = effective
         result.datasets = data_provider.loaded_datasets
 
+        # #1998: 결과를 durable artifact(JSON)로 저장하고 경로를 result 에 기록한다.
+        # 이 경로가 BacktestCompleteEvent.result_path / backtest_runs.result_path
+        # 로 전파되어 ReportDraftGenerator 가 자동 리포트 초안을 생성한다. 저장
+        # 디렉토리는 effective.data_paths[0] (항상 채워짐) 하위 ``.backtest/results``
+        # 를 anchor 로 쓴다. BacktestResult 에 wall-clock timestamp 필드가 없어
+        # UUID 로 충돌 없이 네이밍한다.
+        result.result_path = self._save_result_artifact(result, effective)
+
         # BacktestCompleteEvent 발행
-        await self._publish_complete_event(result, config)
+        await self._publish_complete_event(result)
 
         return result
 
+    def _save_result_artifact(
+        self,
+        result: BacktestResult,
+        effective: BacktestConfig,
+    ) -> str:
+        """결과를 durable JSON artifact 로 저장하고 경로를 반환한다 (#1998).
+
+        저장 실패(read-only/ephemeral data dir 등)는 backtest 자체를 실패시키지
+        않는다 — warning 을 남기고 ``""`` 를 반환하여 빈 result_path 로 이벤트가
+        발행되게 한다(기존 무회귀 동작 보존, 자동 draft 만 skip). ``to_dict()``
+        의 직렬화 계약 그대로 저장하므로 ReportDraftGenerator._load_result 가
+        그대로 소비한다.
+        """
+        from pathlib import Path
+
+        try:
+            artifact_dir = Path(effective.data_paths[0]) / ".backtest" / "results"
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            name = (
+                f"{result.strategy_name}_v{result.strategy_version}_"
+                f"{uuid.uuid4().hex}.json"
+            )
+            path = artifact_dir / name
+            path.write_text(json.dumps(result.to_dict(), default=str))
+        except OSError as e:
+            logger.warning(
+                "백테스트 결과 artifact 저장 실패(자동 리포트 초안 skip): %s",
+                e,
+            )
+            return ""
+        else:
+            logger.info("백테스트 결과 artifact 저장: %s", path)
+            return str(path)
+
     async def run_subprocess(self, config: dict[str, Any]) -> dict:
-        """백테스트를 subprocess로 격리 실행 (D-004)."""
+        """백테스트를 subprocess로 격리 실행 (D-004).
+
+        #1998 비목표: 이 경로는 BacktestCompleteEvent 를 발행하지 않고 CLI 에서
+        사용되지 않으므로(critical path 밖), 결과 artifact 저장·자동 리포트 초안
+        생성을 지원하지 않는다. durable artifact + result_path 전파는 in-process
+        ``run()`` 한정이다.
+        """
         self._validate_config(config)
 
         proc = await asyncio.create_subprocess_exec(
@@ -190,7 +239,6 @@ class BacktestService:
     async def _publish_complete_event(
         self,
         result: BacktestResult,
-        config: dict[str, Any],
     ) -> None:
         """BacktestCompleteEvent 발행."""
         if not self._eventbus:
@@ -203,7 +251,9 @@ class BacktestService:
             backtest_id=strategy_id,
             strategy_id=strategy_id,
             status="completed",
-            result_path=config.get("result_path", ""),
+            # #1998: run() 이 저장한 durable artifact 경로(저장 실패 시 ""). 빈
+            # 경로면 ReportDraftGenerator 가 자동 초안을 skip 한다(무회귀).
+            result_path=result.result_path,
         )
         await self._eventbus.publish(event)
         logger.info("BacktestCompleteEvent 발행: %s", strategy_id)

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -265,7 +265,10 @@ async def _save_backtest_run(
             max_drawdown_pct=metrics.get("max_drawdown"),
             total_trades=len(result.trades),
             win_rate=metrics.get("win_rate"),
-            result_path="",
+            # #1998: service.run() 이 저장한 durable artifact 경로를 이력에 기록한다
+            # (저장 실패 시 ""). backtest_runs.result_path 와 BacktestCompleteEvent.
+            # result_path 가 동일 artifact 를 가리켜 추적성을 보장한다.
+            result_path=result.result_path,
         )
     finally:
         await db.close()

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -239,6 +239,25 @@ class TestBacktestResult:
         assert "config" in d
         assert "datasets" in d
 
+    def test_result_path_excluded_from_to_dict(self):
+        """#1998: result_path 런타임 필드는 to_dict() 직렬화 계약에 포함되지 않는다.
+
+        artifact 파일의 self-reference 를 막고 draft 소비 shape 를 무변경으로
+        유지하기 위함. dataclass 기본값은 "" 이며 set 후에도 직렬화에서 제외된다.
+        """
+        result = BacktestResult(
+            strategy_name="test",
+            strategy_version="1.0",
+            start_date="2026-01-01",
+            end_date="2026-06-30",
+            initial_balance=10_000_000,
+            final_balance=10_500_000,
+            total_return=5.0,
+        )
+        assert result.result_path == ""  # dataclass 기본값
+        result.result_path = "/data/.backtest/results/test_v1.0_abc.json"
+        assert "result_path" not in result.to_dict()
+
     def test_result_to_dict_with_trades(self):
         trade = BacktestTrade(
             timestamp=datetime(2026, 1, 2, tzinfo=UTC),

--- a/tests/unit/test_backtest_complete_event.py
+++ b/tests/unit/test_backtest_complete_event.py
@@ -1,7 +1,8 @@
-"""BacktestCompleteEvent 발행 통합 테스트."""
+"""BacktestCompleteEvent 발행 + 결과 artifact 저장(#1998) 통합 테스트."""
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from ante.backtest.config import BacktestConfig
 from ante.backtest.service import BacktestService
 from ante.eventbus.events import BacktestCompleteEvent
+from ante.report.draft import ReportDraftGenerator
 from ante.strategy.base import StrategyMeta
 from ante.strategy.validator import ValidationResult
 
@@ -37,19 +39,83 @@ def _strategy_cls_with_meta() -> MagicMock:
     return cls
 
 
+# #1998: result.to_dict() 가 json.dumps 로 직렬화되므로(durable artifact 저장),
+# mock result 는 MagicMock 이 아니라 실제 dict 를 반환해야 한다. 아래 shape 은
+# BacktestResult.to_dict()/ReportDraftGenerator._load_result 가 소비하는 계약.
+def _sample_result_dict(strategy: str) -> dict:
+    return {
+        "strategy": strategy,
+        "period": "2025-01-01 ~ 2025-12-31",
+        "initial_balance": 10_000_000,
+        "final_balance": 11_000_000,
+        "total_return_pct": 10.0,
+        "total_trades": 3,
+        "metrics": {"sharpe_ratio": 1.1, "max_drawdown": -5.0, "win_rate": 0.6},
+        "equity_curve": [],
+        "trades": [],
+        "config": {},
+        "datasets": [],
+    }
+
+
+def _mock_result(
+    *,
+    strategy_name: str,
+    strategy_version: str,
+) -> MagicMock:
+    """실제 dict 를 반환하는 to_dict 를 단 BacktestResult mock.
+
+    ``result_path`` 는 service.run() 이 저장 후 set 하므로 초기값 "" 로 둔다
+    (BacktestResult dataclass 기본값과 동일).
+    """
+    result = MagicMock()
+    result.strategy_name = strategy_name
+    result.strategy_version = strategy_version
+    result.result_path = ""
+    result.to_dict = MagicMock(
+        return_value=_sample_result_dict(f"{strategy_name}_v{strategy_version}")
+    )
+    return result
+
+
+def _patched_run(service: BacktestService, mock_result: MagicMock, data_path: str):
+    """run() 의 무거운 의존성(validator/loader/provider/executor)을 mock 한다.
+
+    ``_validate_config`` 는 data_paths 가 *data_path* 를 가리키도록 한 effective
+    BacktestConfig 를 반환해, #1998 artifact 가 격리된 디렉토리에 저장되게 한다.
+    """
+    cfg = BacktestConfig(strategy_path="strategies/test.py", data_paths=[data_path])
+
+    def _run():
+        return patch.object(service, "_validate_config", return_value=cfg)
+
+    mock_executor = MagicMock()
+    mock_executor.run = AsyncMock(return_value=mock_result)
+
+    return (
+        _run(),
+        _bypass_validator(),
+        patch(
+            "ante.backtest.service.StrategyLoader.load",
+            return_value=_strategy_cls_with_meta(),
+        ),
+        patch(
+            "ante.backtest.service.BacktestDataProvider",
+            return_value=MagicMock(),
+        ),
+        patch("ante.backtest.service.BacktestExecutor", return_value=mock_executor),
+    )
+
+
 class TestBacktestCompleteEventPublish:
     @pytest.mark.asyncio
-    async def test_run_publishes_complete_event(self):
+    async def test_run_publishes_complete_event(self, tmp_path):
         """BacktestService.run() 완료 시 BacktestCompleteEvent 발행."""
         mock_eventbus = MagicMock()
         mock_eventbus.publish = AsyncMock()
 
-        service = BacktestService(data_path="data/", eventbus=mock_eventbus)
-
-        # BacktestResult mock
-        mock_result = MagicMock()
-        mock_result.strategy_name = "momentum"
-        mock_result.strategy_version = "1.0.0"
+        service = BacktestService(data_path=str(tmp_path), eventbus=mock_eventbus)
+        mock_result = _mock_result(strategy_name="momentum", strategy_version="1.0.0")
 
         config = {
             "strategy_path": "strategies/test.py",
@@ -57,28 +123,9 @@ class TestBacktestCompleteEventPublish:
             "end_date": "2025-12-31",
         }
 
-        with patch.object(
-            service,
-            "_validate_config",
-            return_value=BacktestConfig(strategy_path="strategies/test.py"),
-        ):
-            with _bypass_validator():
-                with patch(
-                    "ante.backtest.service.StrategyLoader.load",
-                    return_value=_strategy_cls_with_meta(),
-                ):
-                    with patch(
-                        "ante.backtest.service.BacktestDataProvider",
-                        return_value=MagicMock(),
-                    ):
-                        with patch(
-                            "ante.backtest.service.BacktestExecutor"
-                        ) as mock_executor_cls:
-                            mock_executor = MagicMock()
-                            mock_executor.run = AsyncMock(return_value=mock_result)
-                            mock_executor_cls.return_value = mock_executor
-
-                            await service.run(config)
+        p1, p2, p3, p4, p5 = _patched_run(service, mock_result, str(tmp_path))
+        with p1, p2, p3, p4, p5:
+            await service.run(config)
 
         mock_eventbus.publish.assert_called_once()
         event = mock_eventbus.publish.call_args[0][0]
@@ -87,13 +134,10 @@ class TestBacktestCompleteEventPublish:
         assert event.status == "completed"
 
     @pytest.mark.asyncio
-    async def test_run_without_eventbus(self):
-        """EventBus 미설정 시 이벤트 발행 건너뜀."""
-        service = BacktestService(data_path="data/", eventbus=None)
-
-        mock_result = MagicMock()
-        mock_result.strategy_name = "test"
-        mock_result.strategy_version = "1.0.0"
+    async def test_run_saves_result_artifact(self, tmp_path):
+        """#1998: run() 이 결과를 .backtest/results/*.json 으로 저장한다."""
+        service = BacktestService(data_path=str(tmp_path), eventbus=None)
+        mock_result = _mock_result(strategy_name="momentum", strategy_version="1.0.0")
 
         config = {
             "strategy_path": "strategies/test.py",
@@ -101,27 +145,128 @@ class TestBacktestCompleteEventPublish:
             "end_date": "2025-12-31",
         }
 
-        with patch.object(
-            service,
-            "_validate_config",
-            return_value=BacktestConfig(strategy_path="strategies/test.py"),
+        p1, p2, p3, p4, p5 = _patched_run(service, mock_result, str(tmp_path))
+        with p1, p2, p3, p4, p5:
+            result = await service.run(config)
+
+        results_dir = tmp_path / ".backtest" / "results"
+        saved = list(results_dir.glob("momentum_v1.0.0_*.json"))
+        assert len(saved) == 1
+        # result.result_path 가 저장 경로로 set 되고 파일이 실제 존재
+        assert result.result_path == str(saved[0])
+        assert Path(result.result_path).exists()
+
+    @pytest.mark.asyncio
+    async def test_event_result_path_points_to_saved_artifact(self, tmp_path):
+        """#1998: event.result_path 가 비어있지 않고 실제 artifact 를 가리킨다."""
+        mock_eventbus = MagicMock()
+        mock_eventbus.publish = AsyncMock()
+
+        service = BacktestService(data_path=str(tmp_path), eventbus=mock_eventbus)
+        mock_result = _mock_result(strategy_name="momentum", strategy_version="1.0.0")
+
+        config = {
+            "strategy_path": "strategies/test.py",
+            "start_date": "2025-01-01",
+            "end_date": "2025-12-31",
+        }
+
+        p1, p2, p3, p4, p5 = _patched_run(service, mock_result, str(tmp_path))
+        with p1, p2, p3, p4, p5:
+            await service.run(config)
+
+        event = mock_eventbus.publish.call_args[0][0]
+        assert event.result_path != ""
+        assert Path(event.result_path).exists()
+
+    @pytest.mark.asyncio
+    async def test_saved_artifact_roundtrips_to_draft_loader(self, tmp_path):
+        """#1998: 저장된 artifact 를 ReportDraftGenerator._load_result 가 소비한다."""
+        mock_eventbus = MagicMock()
+        mock_eventbus.publish = AsyncMock()
+
+        service = BacktestService(data_path=str(tmp_path), eventbus=mock_eventbus)
+        mock_result = _mock_result(strategy_name="momentum", strategy_version="1.0.0")
+
+        config = {
+            "strategy_path": "strategies/test.py",
+            "start_date": "2025-01-01",
+            "end_date": "2025-12-31",
+        }
+
+        p1, p2, p3, p4, p5 = _patched_run(service, mock_result, str(tmp_path))
+        with p1, p2, p3, p4, p5:
+            await service.run(config)
+
+        event = mock_eventbus.publish.call_args[0][0]
+        loaded = ReportDraftGenerator._load_result(event.result_path)
+        assert loaded is not None
+        assert loaded["strategy"] == "momentum_v1.0.0"
+        assert loaded["total_return_pct"] == 10.0
+        # 실제 draft 생성까지 라운드트립 가능
+        report = ReportDraftGenerator.generate_draft(loaded, event.strategy_id)
+        assert report.strategy_name == "momentum"
+        assert report.total_return_pct == 10.0
+
+    @pytest.mark.asyncio
+    async def test_run_graceful_when_artifact_save_fails(self, tmp_path, caplog):
+        """#1998: 저장 실패(write_text raise) → result_path="" graceful + 이벤트 발행.
+
+        read-only/ephemeral data dir 보호: backtest 자체는 실패하지 않고, 빈
+        result_path 로 이벤트가 발행되어 자동 draft 만 skip 된다(무회귀).
+        """
+        mock_eventbus = MagicMock()
+        mock_eventbus.publish = AsyncMock()
+
+        service = BacktestService(data_path=str(tmp_path), eventbus=mock_eventbus)
+        mock_result = _mock_result(strategy_name="momentum", strategy_version="1.0.0")
+
+        config = {
+            "strategy_path": "strategies/test.py",
+            "start_date": "2025-01-01",
+            "end_date": "2025-12-31",
+        }
+
+        p1, p2, p3, p4, p5 = _patched_run(service, mock_result, str(tmp_path))
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            patch(
+                "pathlib.Path.write_text",
+                side_effect=OSError("Read-only file system"),
+            ),
+            caplog.at_level("WARNING"),
         ):
-            with _bypass_validator():
-                with patch(
-                    "ante.backtest.service.StrategyLoader.load",
-                    return_value=_strategy_cls_with_meta(),
-                ):
-                    with patch(
-                        "ante.backtest.service.BacktestDataProvider",
-                        return_value=MagicMock(),
-                    ):
-                        with patch(
-                            "ante.backtest.service.BacktestExecutor"
-                        ) as mock_executor_cls:
-                            mock_executor = MagicMock()
-                            mock_executor.run = AsyncMock(return_value=mock_result)
-                            mock_executor_cls.return_value = mock_executor
+            result = await service.run(config)
 
-                            result = await service.run(config)
+        # backtest 비실패 + 빈 result_path fallback
+        assert result is mock_result
+        assert result.result_path == ""
+        # 이벤트는 빈 경로로 정상 발행(무회귀)
+        mock_eventbus.publish.assert_called_once()
+        event = mock_eventbus.publish.call_args[0][0]
+        assert event.status == "completed"
+        assert event.result_path == ""
+        # 운영 가시성을 위한 warning 기록
+        assert any("artifact 저장 실패" in r.message for r in caplog.records)
 
-        assert result == mock_result  # 정상 반환
+    @pytest.mark.asyncio
+    async def test_run_without_eventbus(self, tmp_path):
+        """EventBus 미설정 시 이벤트 발행 건너뜀."""
+        service = BacktestService(data_path=str(tmp_path), eventbus=None)
+        mock_result = _mock_result(strategy_name="test", strategy_version="1.0.0")
+
+        config = {
+            "strategy_path": "strategies/test.py",
+            "start_date": "2025-01-01",
+            "end_date": "2025-12-31",
+        }
+
+        p1, p2, p3, p4, p5 = _patched_run(service, mock_result, str(tmp_path))
+        with p1, p2, p3, p4, p5:
+            result = await service.run(config)
+
+        assert result is mock_result  # 정상 반환

--- a/tests/unit/test_cli_backtest_result_path.py
+++ b/tests/unit/test_cli_backtest_result_path.py
@@ -1,0 +1,76 @@
+"""#1998: CLI ``_save_backtest_run`` 이 result.result_path 를 이력에 기록한다."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.backtest.result import BacktestResult
+from ante.backtest.run_store import BacktestRunStore
+from ante.cli.commands.backtest import _save_backtest_run
+from ante.core.database import Database
+
+
+@pytest.mark.asyncio
+async def test_save_backtest_run_records_result_path(tmp_path):
+    """_save_backtest_run 이 result.result_path 를 backtest_runs.result_path 로 저장."""
+    db_path = str(tmp_path / "test.db")
+    artifact_path = str(tmp_path / ".backtest" / "results" / "momentum_v1.0.0_abc.json")
+
+    result = BacktestResult(
+        strategy_name="momentum",
+        strategy_version="1.0.0",
+        start_date="2025-01-01",
+        end_date="2025-12-31",
+        initial_balance=10_000_000.0,
+        final_balance=11_000_000.0,
+        total_return=10.0,
+    )
+    result.result_path = artifact_path
+
+    config = {"start_date": "2025-01-01", "end_date": "2025-12-31"}
+    metrics = {"sharpe_ratio": 1.1, "max_drawdown": -5.0, "win_rate": 0.6}
+
+    run_id = await _save_backtest_run(db_path, result, config, metrics)
+    assert run_id
+
+    db = Database(db_path)
+    await db.connect()
+    try:
+        store = BacktestRunStore(db)
+        run = await store.get(run_id)
+    finally:
+        await db.close()
+
+    assert run is not None
+    assert run.result_path == artifact_path
+
+
+@pytest.mark.asyncio
+async def test_save_backtest_run_empty_path_on_save_failure(tmp_path):
+    """저장 실패 fallback(result_path="") 도 이력에 그대로 기록(무회귀)."""
+    db_path = str(tmp_path / "test.db")
+
+    result = BacktestResult(
+        strategy_name="momentum",
+        strategy_version="1.0.0",
+        start_date="2025-01-01",
+        end_date="2025-12-31",
+        initial_balance=10_000_000.0,
+        final_balance=11_000_000.0,
+        total_return=10.0,
+    )
+    # service.run() 저장 실패 시 result_path 는 "" fallback 으로 남는다
+    assert result.result_path == ""
+
+    run_id = await _save_backtest_run(db_path, result, {}, {})
+
+    db = Database(db_path)
+    await db.connect()
+    try:
+        store = BacktestRunStore(db)
+        run = await store.get(run_id)
+    finally:
+        await db.close()
+
+    assert run is not None
+    assert run.result_path == ""


### PR DESCRIPTION
Closes #1998

## Summary
- 표준 `BacktestService.run()`이 결과 파일을 저장 안 하고 BacktestCompleteEvent.result_path 빈값이라 자동 리포트 초안(report-store.md)이 닫혀 있던 것을, **durable result artifact 저장 + result_path 전파**로 복구.
- run()이 `{data_paths[0]}/.backtest/results/{strategy}_v{ver}_{uuid}.json`에 to_dict() JSON **guarded write**(OSError→warning+빈 경로 fallback, backtest 비실패). BacktestResult.result_path 런타임 필드(to_dict 제외). event + CLI(backtest_runs.result_path, 컬럼 기존) 전파.
- run_subprocess는 자동 draft 미지원(비목표, 주석).

## Test Plan
- artifact 저장+event.result_path 실재+ReportDraftGenerator 로드 라운드트립+CLI 기록+read-only graceful warning+to_dict 제외 계약+기존 mock to_dict() 실제 dict 갱신
- 전체 `pytest tests/unit/`: 6878 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경. 스키마 마이그레이션 불요(result_path 컬럼 기존)
- Codex 브랜치 리뷰 PASS (fc31daf8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)