### PR TITLE
fix(ipc): #2113 member admin mutation 8개 runtime IPC wiring (IPC-first+fallback, secret 비노출)

### DIFF
--- a/docs/specs/audit/audit.md
+++ b/docs/specs/audit/audit.md
@@ -120,18 +120,27 @@ AuditLogger는 인프라(기록·조회)만 제공한다. 실제 기록은 **CLI
 | `ante bot remove <id>` | `bot.delete` | `bot:{bot_id}` |
 | `ante bot signal-key <id> --rotate` | `bot.signal_key.rotate` | `bot:{bot_id}` |
 | `ante broker reconcile --fix` | `broker.reconcile` | `account:{account_id}` |
-| `ante member register` | `member.create` | `member:{member_id}` |
+| `ante member register` | `member.register` | `member:{member_id}` |
+| `ante member set-emoji <id> <emoji>` | `member.set_emoji` | `member:{member_id}` |
+| `ante member update-scopes <id>` | `member.update_scopes` | `member:{member_id}` |
 | `ante member suspend <id>` | `member.suspend` | `member:{member_id}` |
 | `ante member reactivate <id>` | `member.reactivate` | `member:{member_id}` |
 | `ante member revoke <id>` | `member.revoke` | `member:{member_id}` |
 | `ante member rotate-token <id>` | `member.rotate_token` | `member:{member_id}` |
-| `ante member reset-password` | `member.reset_password` | `member:{member_id}` |
-| `ante member regenerate-recovery-key` | `member.regenerate_recovery_key` | `member:{member_id}` |
+| `ante member reset-password` | `member.reset_password` | `member:{master_member_id}` |
+| `ante member regenerate-recovery-key` | `member.regenerate_recovery_key` | `member:{master_member_id}` |
 
 `ante bot start`/`ante bot stop`은 audit action(`bot.start`/`bot.stop`) 이름을
 사용한다. 봇 생애주기 변경은 단일 audit action namespace로 모인다.
 `ante bot status`는 read-only live 조회이므로 audit 대상이 아니다
 (상태 변경 액션만 기록하는 audit 기록 원칙).
+
+`ante member reset-password`/`ante member regenerate-recovery-key`는 인증 불필요
+(auth-exempt) 커맨드다. 대상은 항상 master 멤버이며 그 `member_id`는 서버 handler가
+master-lookup으로 해석해 `resource`에 기록한다. 다만 audit row의 `member_id`(행위자)는
+client가 보낸 actor(스푸핑 가능)를 신뢰하지 않고 handler가 고정한 sentinel 상수
+(`recovery`)로 기록한다. recovery key, 새/현재 password 등 비밀값은 audit detail,
+audit_log, IPC error envelope, server 로그 어디에도 기록하지 않는다.
 
 ### 구현 방식
 

--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -240,7 +240,7 @@ BotManager/DB 종료 이후 lifecycle 마지막 단계에서만 호출된다.
 - **read-only**: 서버가 보유한 live adapter를 통해 상태를 조회하지만 서버/DB 상태를
   변경하지 않는 명령
 
-현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 32개가
+현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 40개가
 SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표를 함께 갱신해야 한다.
 
 | IPC 커맨드 | taxonomy | 근거 |
@@ -261,6 +261,14 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 | `rule.update` | mutating | DynamicConfig 기반 계좌 룰 수정 |
 | `strategy.set_status` | mutating | `StrategyRegistry.update_status()` 호출 |
 | `member.update_scopes` | mutating | `MemberService.update_scopes()` 호출 |
+| `member.register` | mutating | `MemberService.register()` 호출. 토큰 발급 + 감사 로그. 발급 토큰은 result 에만 surface (#2113) |
+| `member.set_emoji` | mutating | `MemberService.update_emoji()` 호출 (#2113) |
+| `member.suspend` | mutating | `MemberService.suspend()` 호출. master 게이트 + 세션 무효화 (#2113) |
+| `member.reactivate` | mutating | `MemberService.reactivate()` 호출 (#2113) |
+| `member.revoke` | mutating | `MemberService.revoke()` 호출. 토큰 해시 삭제 (#2113) |
+| `member.rotate_token` | mutating | `MemberService.rotate_token()` 호출. 새 토큰은 result 에만 surface (#2113) |
+| `member.reset_password` | mutating | auth-exempt. master-lookup 을 handler 에서 수행, audit member_id 는 고정 sentinel. secret 은 result/audit/log 비노출 (#2113) |
+| `member.regenerate_recovery_key` | mutating | auth-exempt. 새 recovery key 는 result 에만 surface (#2113) |
 | `config.set` | mutating | `DynamicConfigService.set()` 호출 |
 | `approval.request` | mutating | `ApprovalService.create()` 호출 |
 | `approval.approve` | mutating | `ApprovalService.approve()` 호출 |
@@ -283,9 +291,17 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 IPC command 분리는 별도 이슈 범위다.
 
 `account.delete`처럼 1.0 IPC 계약에서 제외되어 `CommandRegistry`에 등록되지 않는 명령은
-taxonomy 대상이 아니다. `member.update_scopes`를 제외한 `member.*`처럼 CLI/스펙 표에는 runtime IPC로
-표현되어 있으나 현재 `register_all_handlers()`에 없는 명령의 실제 wiring은 별도 후속 이슈에서
-다룬다.
+taxonomy 대상이 아니다. `member.*` 9개(`member.update_scopes` + admin mutation 8개)는 모두
+`register_all_handlers()`에 wiring되어 있으며, CLI는 서버 실행 중 runtime IPC로 위임하고 서버
+정지 시 maintenance fallback으로 `MemberService`를 직접 생성한다(IPC-first + 서버 정지 fallback,
+#2113).
+
+`member.register` / `member.rotate_token`의 발급 토큰과 `member.regenerate_recovery_key`의 새
+recovery key는 사용자 표시용 result에만 담고 audit detail / audit_log / IPC error envelope /
+server 로그 어디에도 노출하지 않는다. `member.reset_password` / `member.regenerate_recovery_key`는
+auth-exempt이므로 대상 master member_id를 client가 아니라 서버 handler에서 master-lookup으로
+해석하고, audit의 member_id는 client actor(스푸핑 가능)가 아니라 handler가 고정한 sentinel 상수로
+기록한다.
 
 ## 통신 프로토콜
 

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -508,6 +508,33 @@ def member_register(
     scope_list = [s.strip() for s in scopes.split(",") if s.strip()] if scopes else []
 
     async def _run_register() -> tuple[dict, str]:
+        from ante.cli.cold_path import is_active_runtime
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        if is_active_runtime():
+            # IPC-first: 서버 실행 중이면 runtime IPC 로 위임한다. handler 가
+            # token 을 result 에 담아 반환하므로 동일 shape (fields + token) 으로
+            # 분리해 cold-path 출력 parity 를 보존한다 (#2113).
+            payload = await ipc_send(
+                "member.register",
+                {
+                    "member_id": member_id,
+                    "member_type": member_type,
+                    "org": org,
+                    "name": name,
+                    "scopes": scope_list,
+                },
+                actor=actor,
+            )
+            token = payload.get("token", "")
+            return {
+                "member_id": payload.get("member_id", member_id),
+                "type": payload.get("type", member_type),
+                "role": payload.get("role", ""),
+                "org": payload.get("org", org),
+                "name": payload.get("name", name),
+            }, token
+
         async with _create_service(ctx) as service:
             m, token = await service.register(
                 member_id=member_id,
@@ -527,6 +554,14 @@ def member_register(
 
     try:
         result, token = _run(_run_register())
+    except click.ClickException as e:
+        # IPC error envelope (서버 미기동/타임아웃 또는 server-side 거부) 를
+        # stable code 로 surface 한다 (secret 비노출 — message 는 envelope 의
+        # code/message 만 사용).
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        fmt.error(message, code=code)
+        raise SystemExit(1) from e
     except PermissionDeniedError:
         # PERMISSION_DENIED code 명시 — master 검증 위반의 안정 코드.
         # CLI surface override 보존: 사용자 친화 한국어 문구
@@ -571,12 +606,27 @@ def member_set_emoji(ctx: click.Context, member_id: str, emoji: str) -> None:
     actor = get_member_id(ctx)
 
     async def _run_set_emoji() -> dict:
+        from ante.cli.cold_path import is_active_runtime
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        if is_active_runtime():
+            return await ipc_send(
+                "member.set_emoji",
+                {"member_id": member_id, "emoji": emoji},
+                actor=actor,
+            )
+
         async with _create_service(ctx) as service:
             m = await service.update_emoji(member_id, emoji, updated_by=actor)
             return {"member_id": m.member_id, "emoji": m.emoji}
 
     try:
         result = _run(_run_set_emoji())
+    except click.ClickException as e:
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        fmt.error(message, code=code)
+        raise SystemExit(1) from e
     except MemberNotFoundError:
         # missing member 는 안정 코드 ``MEMBER_NOT_FOUND`` 로 surface 한다
         # (CLI/IPC 일관성: ``MemberNotFoundError.code`` 와 동형, ``member
@@ -666,12 +716,27 @@ def member_suspend(ctx: click.Context, member_id: str) -> None:
     actor = get_member_id(ctx)
 
     async def _run_suspend() -> dict:
+        from ante.cli.cold_path import is_active_runtime
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        if is_active_runtime():
+            return await ipc_send(
+                "member.suspend",
+                {"member_id": member_id},
+                actor=actor,
+            )
+
         async with _create_service(ctx) as service:
             m = await service.suspend(member_id, suspended_by=actor)
             return {"member_id": m.member_id, "status": m.status}
 
     try:
         result = _run(_run_suspend())
+    except click.ClickException as e:
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        fmt.error(message, code=code)
+        raise SystemExit(1) from e
     except PermissionDeniedError:
         # PERMISSION_DENIED code 명시 + CLI surface override (한국어 친화 문구).
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
@@ -706,12 +771,27 @@ def member_reactivate(ctx: click.Context, member_id: str) -> None:
     actor = get_member_id(ctx)
 
     async def _run_reactivate() -> dict:
+        from ante.cli.cold_path import is_active_runtime
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        if is_active_runtime():
+            return await ipc_send(
+                "member.reactivate",
+                {"member_id": member_id},
+                actor=actor,
+            )
+
         async with _create_service(ctx) as service:
             m = await service.reactivate(member_id, reactivated_by=actor)
             return {"member_id": m.member_id, "status": m.status}
 
     try:
         result = _run(_run_reactivate())
+    except click.ClickException as e:
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        fmt.error(message, code=code)
+        raise SystemExit(1) from e
     except PermissionDeniedError:
         # PERMISSION_DENIED code 명시 + CLI surface override (한국어 친화 문구).
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
@@ -764,12 +844,27 @@ def member_revoke(ctx: click.Context, member_id: str, yes: bool) -> None:
         raise SystemExit(1)
 
     async def _run_revoke() -> dict:
+        from ante.cli.cold_path import is_active_runtime
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        if is_active_runtime():
+            return await ipc_send(
+                "member.revoke",
+                {"member_id": member_id},
+                actor=actor,
+            )
+
         async with _create_service(ctx) as service:
             m = await service.revoke(member_id, revoked_by=actor)
             return {"member_id": m.member_id, "status": m.status}
 
     try:
         result = _run(_run_revoke())
+    except click.ClickException as e:
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        fmt.error(message, code=code)
+        raise SystemExit(1) from e
     except PermissionDeniedError:
         # PERMISSION_DENIED code 명시 + CLI surface override (한국어 친화 문구).
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
@@ -797,12 +892,32 @@ def member_rotate_token(ctx: click.Context, member_id: str) -> None:
     actor = get_member_id(ctx)
 
     async def _run_rotate() -> tuple[dict, str]:
+        from ante.cli.cold_path import is_active_runtime
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        if is_active_runtime():
+            # handler 가 token 을 result 에 담아 반환 — cold-path 출력 parity
+            # ({member_id} fields + token) 를 위해 분리한다 (#2113).
+            payload = await ipc_send(
+                "member.rotate_token",
+                {"member_id": member_id},
+                actor=actor,
+            )
+            return {"member_id": payload.get("member_id", member_id)}, payload.get(
+                "token", ""
+            )
+
         async with _create_service(ctx) as service:
             m, token = await service.rotate_token(member_id, rotated_by=actor)
             return {"member_id": m.member_id}, token
 
     try:
         result, token = _run(_run_rotate())
+    except click.ClickException as e:
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        fmt.error(message, code=code)
+        raise SystemExit(1) from e
     except PermissionDeniedError:
         # PERMISSION_DENIED code 명시 + CLI surface override (한국어 친화 문구).
         fmt.error(_MASTER_REQUIRED_MESSAGE, code="PERMISSION_DENIED")
@@ -863,6 +978,19 @@ def member_reset_password(
     )
 
     async def _run_reset() -> None:
+        from ante.cli.cold_path import is_active_runtime
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        if is_active_runtime():
+            # auth-exempt: client 는 secret 만 보내고 master-lookup 은 서버
+            # handler(chokepoint)가 수행한다. actor 는 audit member_id 로
+            # 신뢰되지 않으며 handler 가 고정 sentinel 로 기록한다 (#2113).
+            await ipc_send(
+                "member.reset_password",
+                {"recovery_key": recovery_key, "new_password": new_password},
+            )
+            return
+
         async with _create_service(ctx) as service:
             members = await service.list_members(member_type="human")
             master = next((m for m in members if m.role == "master"), None)
@@ -873,6 +1001,13 @@ def member_reset_password(
 
     try:
         _run(_run_reset())
+    except click.ClickException as e:
+        # IPC error envelope 만 surface — recovery_key/new_password 는 절대
+        # message 에 싣지 않는다 (secret 비노출).
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        fmt.error(message, code=code)
+        raise SystemExit(1) from e
     except MemberInvalidRecoveryCredentialError as e:
         # invalid recovery credential 은 안정 코드
         # ``MEMBER_INVALID_RECOVERY_CREDENTIAL`` 로 surface. ValueError
@@ -923,6 +1058,19 @@ def member_regenerate_recovery_key(
     )
 
     async def _run_regen() -> str:
+        from ante.cli.cold_path import is_active_runtime
+        from ante.cli.commands.ipc_helpers import ipc_send
+
+        if is_active_runtime():
+            # auth-exempt: client 는 secret(password) 만 보내고 master-lookup 은
+            # 서버 handler 가 수행한다. 새 recovery key 는 result 로만 surface
+            # 한다 (audit/log/envelope 비노출) (#2113).
+            payload = await ipc_send(
+                "member.regenerate_recovery_key",
+                {"password": password},
+            )
+            return payload.get("recovery_key", "")
+
         async with _create_service(ctx) as service:
             members = await service.list_members(member_type="human")
             master = next((m for m in members if m.role == "master"), None)
@@ -933,6 +1081,13 @@ def member_regenerate_recovery_key(
 
     try:
         new_key = _run(_run_regen())
+    except click.ClickException as e:
+        # IPC error envelope 만 surface — password/new recovery key 는 절대
+        # message 에 싣지 않는다 (secret 비노출).
+        code = getattr(e, "ipc_error_code", "") or "IPC_ERROR"
+        message = getattr(e, "ipc_error_message", None) or e.message
+        fmt.error(message, code=code)
+        raise SystemExit(1) from e
     except MemberInvalidRecoveryCredentialError as e:
         # invalid 현재 패스워드는 안정 코드
         # ``MEMBER_INVALID_RECOVERY_CREDENTIAL`` 로 surface. ValueError

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -924,6 +924,256 @@ async def _handle_member_update_scopes(
     }
 
 
+async def _handle_member_register(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """멤버 등록 IPC handler.
+
+    Refs #2113: ``member.update_scopes`` 미러. ``registered_by=actor`` 로
+    서버 측 master 게이트(``MemberService.register`` 내부 검증)를 보존한다.
+
+    secret 비노출: 발급 토큰은 사용자 표시용 result(``token``) 에만 담고,
+    ``_audit_detail`` (resource/detail) 이나 server logger / IPC error
+    envelope 어디에도 넘기지 않는다. ``_audit_detail`` 에는 resource 만 둔다.
+    """
+    member_id = args["member_id"]
+    member = getattr(svc, "member_service", None)
+    if member is None:
+        raise RuntimeError("member service not configured")
+    created, token = await member.register(
+        member_id=member_id,
+        member_type=args["member_type"],
+        org=args.get("org", "default"),
+        name=args.get("name", ""),
+        scopes=list(args.get("scopes") or []),
+        registered_by=actor,
+    )
+    return {
+        "member_id": created.member_id,
+        "type": created.type,
+        "role": created.role,
+        "org": created.org,
+        "name": created.name,
+        "token": token,
+        "_audit_detail": {
+            "resource": f"member:{created.member_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
+
+
+async def _handle_member_set_emoji(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """멤버 emoji 설정 IPC handler.
+
+    Refs #2113: CLI ``member set-emoji`` → ``MemberService.update_emoji``
+    (``set_emoji`` 메서드는 없음). ``updated_by=actor`` 로 호출한다.
+    """
+    member_id = args["member_id"]
+    emoji = args["emoji"]
+    member = getattr(svc, "member_service", None)
+    if member is None:
+        raise RuntimeError("member service not configured")
+    updated = await member.update_emoji(member_id, emoji, updated_by=actor)
+    return {
+        "member_id": updated.member_id,
+        "emoji": updated.emoji,
+        "_audit_detail": {
+            "resource": f"member:{member_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
+
+
+async def _handle_member_suspend(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """멤버 일시 정지 IPC handler.
+
+    Refs #2113: ``suspended_by=actor`` 로 ``MemberService.suspend`` 내부의
+    master 게이트(``_assert_master(actor)``)를 보존한다.
+    """
+    member_id = args["member_id"]
+    member = getattr(svc, "member_service", None)
+    if member is None:
+        raise RuntimeError("member service not configured")
+    updated = await member.suspend(member_id, suspended_by=actor)
+    return {
+        "member_id": updated.member_id,
+        "status": updated.status,
+        "_audit_detail": {
+            "resource": f"member:{member_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
+
+
+async def _handle_member_reactivate(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """멤버 재활성화 IPC handler.
+
+    Refs #2113: ``reactivated_by=actor`` 로 master 게이트를 보존한다.
+    """
+    member_id = args["member_id"]
+    member = getattr(svc, "member_service", None)
+    if member is None:
+        raise RuntimeError("member service not configured")
+    updated = await member.reactivate(member_id, reactivated_by=actor)
+    return {
+        "member_id": updated.member_id,
+        "status": updated.status,
+        "_audit_detail": {
+            "resource": f"member:{member_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
+
+
+async def _handle_member_revoke(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """멤버 영구 폐기 IPC handler.
+
+    Refs #2113: ``revoked_by=actor`` 로 master 게이트를 보존한다. CLI
+    ``--yes`` 게이트는 라우팅 이전 CLI 단에서 검사한다.
+    """
+    member_id = args["member_id"]
+    member = getattr(svc, "member_service", None)
+    if member is None:
+        raise RuntimeError("member service not configured")
+    updated = await member.revoke(member_id, revoked_by=actor)
+    return {
+        "member_id": updated.member_id,
+        "status": updated.status,
+        "_audit_detail": {
+            "resource": f"member:{member_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
+
+
+async def _handle_member_rotate_token(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """토큰 재발급 IPC handler.
+
+    Refs #2113: ``rotated_by=actor`` 로 master 게이트를 보존한다.
+
+    secret 비노출: 새 토큰은 사용자 표시용 result(``token``) 에만 담고
+    ``_audit_detail`` / server logger / IPC error envelope 어디에도 넘기지
+    않는다.
+    """
+    member_id = args["member_id"]
+    member = getattr(svc, "member_service", None)
+    if member is None:
+        raise RuntimeError("member service not configured")
+    updated, token = await member.rotate_token(member_id, rotated_by=actor)
+    return {
+        "member_id": updated.member_id,
+        "token": token,
+        "_audit_detail": {
+            "resource": f"member:{member_id}",
+            "detail": "",
+            "ip": "",
+        },
+    }
+
+
+# Refs #2113: auth-exempt member 명령(reset_password / regenerate_recovery_key)
+# 의 audit member_id 는 client-supplied actor(스푸핑 가능) 를 절대 쓰지 않고
+# handler 가 고정한 sentinel 상수를 ``_audit_detail["member_id"]`` 로 전달한다.
+# ``_dispatch`` wrapper 는 이 override 가 있으면 actor 대신 사용한다.
+_RECOVERY_AUDIT_MEMBER_ID = "recovery"
+
+
+async def _resolve_master_member_id(member: Any) -> str:
+    """master(human) 멤버 ID 를 서버 측에서 해석한다.
+
+    Refs #2113: reset_password / regenerate_recovery_key 는 auth-exempt 라
+    client 가 대상 member_id 를 보내지 않는다. master-lookup 을 CLI 가 아니라
+    서버 chokepoint(handler)에서 수행해 단일 경로로 일관 적용한다.
+    """
+    members = await member.list_members(member_type="human")
+    master = next((m for m in members if m.role == "master"), None)
+    if master is None:
+        msg = "master 멤버가 존재하지 않습니다"
+        raise ValueError(msg)
+    return master.member_id
+
+
+async def _handle_member_reset_password(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """recovery key 로 패스워드 리셋 IPC handler (auth-exempt).
+
+    Refs #2113: args 는 secret(``recovery_key`` / ``new_password``) 만 받는다.
+    대상 master member_id 는 서버 chokepoint 에서 ``list_members`` +
+    role filter 로 해석한다(client actor 신뢰 금지).
+
+    secret 비노출: ``recovery_key`` / ``new_password`` 는 ``_audit_detail``
+    (resource/detail) 이나 server logger / IPC error envelope 어디에도
+    넣지 않는다. ``detail`` 은 flow 표식만 둔다.
+
+    audit member_id 는 client actor(스푸핑 가능) 가 아니라 고정 sentinel
+    상수(``_RECOVERY_AUDIT_MEMBER_ID``) 로 기록한다 —
+    ``_audit_detail["member_id"]`` override 로 wrapper 에 전달한다.
+    """
+    member = getattr(svc, "member_service", None)
+    if member is None:
+        raise RuntimeError("member service not configured")
+    recovery_key = args["recovery_key"]
+    new_password = args["new_password"]
+    master_id = await _resolve_master_member_id(member)
+    await member.reset_password(master_id, recovery_key, new_password)
+    return {
+        "_audit_detail": {
+            "resource": f"member:{master_id}",
+            "detail": "password reset via recovery key",
+            "ip": "",
+            "member_id": _RECOVERY_AUDIT_MEMBER_ID,
+        },
+    }
+
+
+async def _handle_member_regenerate_recovery_key(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """recovery key 재발급 IPC handler (auth-exempt).
+
+    Refs #2113: args 는 secret(``password``) 만 받는다. 대상 master member_id 는
+    서버 chokepoint 에서 해석한다(client actor 신뢰 금지).
+
+    secret 비노출: 입력 ``password`` 와 재발급된 ``recovery_key`` 는
+    ``_audit_detail`` (resource/detail) 이나 server logger / IPC error
+    envelope 어디에도 넘기지 않는다. 새 recovery key 는 사용자 표시용
+    result(``recovery_key``) 에만 담는다.
+
+    audit member_id 는 client actor 가 아니라 고정 sentinel 상수로 기록한다.
+    """
+    member = getattr(svc, "member_service", None)
+    if member is None:
+        raise RuntimeError("member service not configured")
+    password = args["password"]
+    master_id = await _resolve_master_member_id(member)
+    new_key = await member.regenerate_recovery_key(master_id, password)
+    return {
+        "recovery_key": new_key,
+        "_audit_detail": {
+            "resource": f"member:{master_id}",
+            "detail": "recovery key regenerated",
+            "ip": "",
+            "member_id": _RECOVERY_AUDIT_MEMBER_ID,
+        },
+    }
+
+
 async def _handle_config_set(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
@@ -1237,9 +1487,9 @@ async def _handle_broker_reconcile(
 
 
 def register_all_handlers(registry: CommandRegistry) -> None:
-    """32개 런타임 커맨드 핸들러를 일괄 등록.
+    """40개 런타임 커맨드 핸들러를 일괄 등록.
 
-    Refs #1184: 각 핸들러는 mutating(24개) 또는 read-only(8개)로 분류된다.
+    Refs #1184: 각 핸들러는 mutating(32개) 또는 read-only(8개)로 분류된다.
     분류는 ``docs/specs/ipc/ipc.md``의 "Handler taxonomy" 섹션과 동기화되어야
     한다. mutating 명령은 ``IPCServer``가 ``SHUTTING_DOWN`` 상태일 때
     ``SERVICE_UNAVAILABLE``로 거부된다.
@@ -1273,12 +1523,15 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     (action ``bot.delete``) / ``approval.approve`` / ``approval.reject`` /
     ``approval.cancel``. 각각 account.suspend 동형으로 register 에 audit_action
     부여 + required_services union audit_logger, handler 가 ``_audit_detail``
-    반환. 현재 ``audit_action`` 부여 commands 는 18개:
+    반환. 현재 ``audit_action`` 부여 commands 는 26개:
     ``account.suspend`` / ``account.activate`` / ``system.halt`` /
     ``system.clear_halt`` / ``bot.create`` / ``bot.remove``(→``bot.delete``) /
     ``bot.start`` / ``bot.stop`` / ``bot.update`` /
     ``bot.signal_key.rotate`` / ``treasury.set_balance`` /
     ``strategy.set_status`` / ``member.update_scopes`` /
+    ``member.register`` / ``member.set_emoji`` / ``member.suspend`` /
+    ``member.reactivate`` / ``member.revoke`` / ``member.rotate_token`` /
+    ``member.reset_password`` / ``member.regenerate_recovery_key`` /
     ``approval.approve`` / ``approval.reject`` / ``approval.cancel`` /
     ``approval.cancel_invalid`` / ``rule.update``.
 
@@ -1286,8 +1539,19 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     ``bot.signal_key`` (read-only) 추가 — ``bot list/info/positions/signal-key``
     의 runtime IPC 경로. CLI 가 서버 정지 시 snapshot DB fallback 한다. audit
     없음(read-only). read-only 4→8, 총 28→32.
+
+    Refs #2113: member admin mutation 8개(``member.register`` /
+    ``member.set_emoji`` / ``member.suspend`` / ``member.reactivate`` /
+    ``member.revoke`` / ``member.rotate_token`` / ``member.reset_password`` /
+    ``member.regenerate_recovery_key``) 를 runtime IPC 로 wiring 한다
+    (``member.update_scopes`` 동형, IPC-first + 서버 정지 시 CLI cold-path
+    fallback). 발급 토큰/새 recovery key 는 사용자 표시용 result 에만 담고
+    audit/log/envelope 에는 노출하지 않는다. ``reset_password`` /
+    ``regenerate_recovery_key`` 는 auth-exempt 라 master-lookup 을 handler
+    (서버 chokepoint)에서 수행하고 audit member_id 를 고정 sentinel 상수로
+    기록한다. mutating 24→32, audit 18→26, 총 32→40.
     """
-    # ── mutating (24개): 서버 상태/DB를 변경 ──────────
+    # ── mutating (32개): 서버 상태/DB를 변경 ──────────
     # system.* — account_service의 suspend_all/activate_all (collective ops).
     # Refs #2110 (audit.md:115/116): kill switch 토글은 audit 대상이다.
     # audit_action 부여 + required_services 에 audit_logger 명시(account.suspend
@@ -1454,6 +1718,77 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         result_kind="entity",
         required_services=frozenset({"member_service", "audit_logger"}),
         audit_action="member.update_scopes",
+    )
+    # member.* admin mutation (#2113) — ``member.update_scopes`` 와 동형. 서버
+    # MemberService 위임 + audit_action 자동 발화. ``register`` / ``rotate_token``
+    # 은 발급 토큰을, ``regenerate_recovery_key`` 는 새 recovery key 를 사용자
+    # 표시용 result 에만 담고 audit/log/envelope 에는 절대 노출하지 않는다.
+    # ``reset_password`` / ``regenerate_recovery_key`` 는 auth-exempt 라
+    # audit member_id 를 client actor 가 아닌 고정 sentinel 상수로 기록한다.
+    # register audit_action 은 audit.md SSOT 에 따라 ``member.register`` 다.
+    registry.register(
+        "member.register",
+        _handle_member_register,
+        is_mutating=True,
+        result_kind="entity",
+        required_services=frozenset({"member_service", "audit_logger"}),
+        audit_action="member.register",
+    )
+    registry.register(
+        "member.set_emoji",
+        _handle_member_set_emoji,
+        is_mutating=True,
+        result_kind="entity",
+        required_services=frozenset({"member_service", "audit_logger"}),
+        audit_action="member.set_emoji",
+    )
+    registry.register(
+        "member.suspend",
+        _handle_member_suspend,
+        is_mutating=True,
+        result_kind="operation",
+        required_services=frozenset({"member_service", "audit_logger"}),
+        audit_action="member.suspend",
+    )
+    registry.register(
+        "member.reactivate",
+        _handle_member_reactivate,
+        is_mutating=True,
+        result_kind="operation",
+        required_services=frozenset({"member_service", "audit_logger"}),
+        audit_action="member.reactivate",
+    )
+    registry.register(
+        "member.revoke",
+        _handle_member_revoke,
+        is_mutating=True,
+        result_kind="operation",
+        required_services=frozenset({"member_service", "audit_logger"}),
+        audit_action="member.revoke",
+    )
+    registry.register(
+        "member.rotate_token",
+        _handle_member_rotate_token,
+        is_mutating=True,
+        result_kind="entity",
+        required_services=frozenset({"member_service", "audit_logger"}),
+        audit_action="member.rotate_token",
+    )
+    registry.register(
+        "member.reset_password",
+        _handle_member_reset_password,
+        is_mutating=True,
+        result_kind="operation",
+        required_services=frozenset({"member_service", "audit_logger"}),
+        audit_action="member.reset_password",
+    )
+    registry.register(
+        "member.regenerate_recovery_key",
+        _handle_member_regenerate_recovery_key,
+        is_mutating=True,
+        result_kind="entity",
+        required_services=frozenset({"member_service", "audit_logger"}),
+        audit_action="member.regenerate_recovery_key",
     )
     registry.register(
         "config.set",

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -416,8 +416,16 @@ class IPCServer:
                 if audit_logger is not None:
                     if audit_detail is None:
                         audit_detail = {}
+                    # Refs #2113: auth-exempt member 명령(reset_password /
+                    # regenerate_recovery_key)은 client 가 actor 를 임의로 보낼
+                    # 수 있으므로(스푸핑 가능) audit member_id 를 client actor 가
+                    # 아니라 handler 가 ``_audit_detail["member_id"]`` 로 고정한
+                    # sentinel 상수로 기록해야 한다. handler 가 member_id 를
+                    # 명시하지 않으면 기존 동작(``actor`` 사용)을 그대로 유지한다
+                    # (순수 additive override — 기존 audit_action 명령 회귀 없음).
+                    audit_member_id = audit_detail.get("member_id") or actor
                     await audit_logger.log(
-                        member_id=actor,
+                        member_id=audit_member_id,
                         action=spec.audit_action,
                         resource=audit_detail.get("resource") or "",
                         detail=audit_detail.get("detail") or "",

--- a/tests/unit/ipc/test_cli_registry_ipc_cross_ref.py
+++ b/tests/unit/ipc/test_cli_registry_ipc_cross_ref.py
@@ -14,7 +14,13 @@ removal 시 본 모듈의 ``EXPECTED_MISSING_IPC_COMMANDS`` 도 함께 갱신해
 
 Refs #2112: ``bot.list`` / ``bot.info`` / ``bot.positions`` /
 ``bot.signal_key`` (read) 4건이 ``register_all_handlers()`` 에 wiring 되어
-baseline 에서 제거되었다 (12→8). 잔여 baseline 은 member.* 8건이다.
+baseline 에서 제거되었다 (12→8). 잔여 baseline 은 member.* 8건이었다.
+
+Refs #2113: member admin mutation 8건(``member.register`` / ``member.set_emoji``
+/ ``member.suspend`` / ``member.reactivate`` / ``member.revoke`` /
+``member.rotate_token`` / ``member.reset_password`` /
+``member.regenerate_recovery_key``)이 ``register_all_handlers()`` 에 wiring
+되어 baseline 에서 제거되었다 (8→0). baseline 이 비었다.
 """
 
 from __future__ import annotations
@@ -25,25 +31,12 @@ from ante.contracts.cli_registry import all_contracts
 from ante.ipc.registry import CommandRegistry, register_all_handlers
 
 # ``docs/specs/ipc/ipc.md`` 명시 — ``register_all_handlers()`` 에 아직 wiring
-# 되지 않은 8 commands. CLI registry 의 ``ipc_command`` stub 값은 후속 wiring
+# 되지 않은 commands. CLI registry 의 ``ipc_command`` stub 값은 후속 wiring
 # 이슈로 점진 제거된다.
 #
-# member.* 8: ipc.md:160-168 표 stub. ``member.update_scopes`` 만 현재 등록.
-# bot.* 4 (``bot.list`` / ``bot.info`` / ``bot.positions`` / ``bot.signal_key``)
-# 는 #2112 에서 wiring 완료되어 baseline 에서 제거되었다.
-EXPECTED_MISSING_IPC_COMMANDS: frozenset[str] = frozenset(
-    {
-        # member runtime IPC stub (8)
-        "member.register",
-        "member.set_emoji",
-        "member.suspend",
-        "member.reactivate",
-        "member.revoke",
-        "member.rotate_token",
-        "member.reset_password",
-        "member.regenerate_recovery_key",
-    }
-)
+# Refs #2113: member.* 8 (ipc.md:160-168 표) 이 모두 wiring 완료되어 baseline
+# 이 비었다 (8→0). bot.* 4 는 #2112 에서, member.* 8 은 #2113 에서 제거.
+EXPECTED_MISSING_IPC_COMMANDS: frozenset[str] = frozenset()
 
 
 @pytest.fixture
@@ -57,8 +50,9 @@ def test_baseline_size_locked() -> None:
     """baseline 크기를 8 로 lock — 후속 wiring 이슈가 줄여나갈 때 본 lock 도
     함께 갱신해야 한다 (SSOT 동기화 강제).
 
-    Refs #2112: bot.* read 4건 wiring 완료로 12→8."""
-    assert len(EXPECTED_MISSING_IPC_COMMANDS) == 8, (
+    Refs #2112: bot.* read 4건 wiring 완료로 12→8.
+    Refs #2113: member.* 8건 wiring 완료로 8→0 (baseline 비었음)."""
+    assert len(EXPECTED_MISSING_IPC_COMMANDS) == 0, (
         f"baseline size={len(EXPECTED_MISSING_IPC_COMMANDS)}; "
         "후속 wiring 이슈에서 baseline 항목을 제거했다면 본 lock 도 함께 갱신."
     )

--- a/tests/unit/ipc/test_docs_taxonomy_drift.py
+++ b/tests/unit/ipc/test_docs_taxonomy_drift.py
@@ -53,15 +53,9 @@ _IPC_COMMAND_PREFIXES = (
 # 본문 prose 에서 언급된 contextual command name.
 _DOCS_NON_REGISTRY_TOKENS = frozenset(
     {
-        # member.* runtime IPC stub (CLI 표 surface, 실제 wiring 후속) — ipc.md:160-168
-        "member.register",
-        "member.set_emoji",
-        "member.suspend",
-        "member.reactivate",
-        "member.revoke",
-        "member.rotate_token",
-        "member.reset_password",
-        "member.regenerate_recovery_key",
+        # Refs #2113: member.* 8 (register/set_emoji/suspend/reactivate/revoke/
+        # rotate_token/reset_password/regenerate_recovery_key) 이 모두
+        # ``register_all_handlers()`` 에 wiring 되어 화이트리스트에서 제거됨.
         # cold-path 전용 — ipc.md:70-74 / 193 / 273
         "account.delete",
         "account.create",

--- a/tests/unit/ipc/test_member_admin_ipc_wiring.py
+++ b/tests/unit/ipc/test_member_admin_ipc_wiring.py
@@ -1,0 +1,495 @@
+"""member admin mutation 8개 runtime IPC wiring 검증 (#2113).
+
+member admin mutation 8개(``member.register`` / ``member.set_emoji`` /
+``member.suspend`` / ``member.reactivate`` / ``member.revoke`` /
+``member.rotate_token`` / ``member.reset_password`` /
+``member.regenerate_recovery_key``)를 ``member.update_scopes`` 동형으로
+runtime IPC (IPC-first + 서버 정지 fallback) 로 wiring 했음을 검증한다.
+
+핵심 invariant:
+
+(a) is_active_runtime True → 각 CLI 명령이 ``ipc_send("member.X")`` 위임 +
+    handler 가 MemberService 위임 + audit 1회 발화.
+(b) is_active_runtime False → CLI cold-path fallback (직접 MemberService).
+(c) ServerNotRunning → CLI ClickException surface (secret 비노출).
+(d) 출력 shape parity (register/rotate_token fields+token, regen recovery_key).
+(e) comprehensive secret 비노출: token / recovery_key / new_password / password
+    가 ``_audit_detail`` · audit.log detail · IPC error envelope message ·
+    server logger.exception · CLI ClickException surface · 테스트 snapshot
+    어디에도 없다.
+(f) ``_assert_master(actor)`` 게이트 보존 (suspended_by/...=actor 전달).
+(g) reset/regen audit resource=member:{resolved master_id} + audit member_id=
+    고정 sentinel 상수 (client actor 가 아님).
+(h) member.register audit_action lockstep (``member.register``).
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.core.registry import ServiceRegistry
+from ante.ipc.registry import (
+    _RECOVERY_AUDIT_MEMBER_ID,
+    CommandRegistry,
+    register_all_handlers,
+)
+from ante.ipc.server import IPCServer
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+# 테스트가 leak 여부를 검사하는 secret 토큰 sentinels. 어떤 envelope/audit/log
+# 에도 등장하면 안 된다.
+SECRET_TOKEN = "SECRET-TOKEN-aaaaaaaaaaaaaaaaaaaa"
+SECRET_RECOVERY_KEY = "SECRET-RECOVERY-bbbbbbbbbbbbbbbb"
+SECRET_NEW_PASSWORD = "SECRET-NEWPW-cccccccccccccccc"
+SECRET_PASSWORD = "SECRET-PW-dddddddddddddddddddd"
+
+_ALL_SECRETS = (
+    SECRET_TOKEN,
+    SECRET_RECOVERY_KEY,
+    SECRET_NEW_PASSWORD,
+    SECRET_PASSWORD,
+)
+
+
+def _make_member(member_id: str = "alice", **overrides: Any) -> Member:
+    base: dict[str, Any] = {
+        "member_id": member_id,
+        "type": MemberType.HUMAN,
+        "role": MemberRole.DEFAULT,
+        "org": "default",
+        "name": member_id,
+        "emoji": "",
+        "status": MemberStatus.ACTIVE,
+        "scopes": [],
+        "token_hash": "hash",
+        "password_hash": "pwhash",
+        "recovery_key_hash": "rkhash",
+        "created_at": "2026-01-01T00:00:00Z",
+        "created_by": "system",
+    }
+    base.update(overrides)
+    return Member(**base)
+
+
+def _make_audit_logger_mock() -> MagicMock:
+    logger = MagicMock()
+    logger.log = AsyncMock(return_value=None)
+    return logger
+
+
+def _make_member_service_mock() -> MagicMock:
+    svc = MagicMock()
+    svc.register = AsyncMock()
+    svc.update_emoji = AsyncMock()
+    svc.suspend = AsyncMock()
+    svc.reactivate = AsyncMock()
+    svc.revoke = AsyncMock()
+    svc.rotate_token = AsyncMock()
+    svc.reset_password = AsyncMock()
+    svc.regenerate_recovery_key = AsyncMock()
+    svc.list_members = AsyncMock()
+    return svc
+
+
+def _make_service_registry(
+    *, member_service: Any, audit_logger: Any
+) -> ServiceRegistry:
+    return ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=MagicMock(),
+        treasury_manager=MagicMock(),
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=MagicMock(),
+        audit_logger=audit_logger,
+        member_service=member_service,
+    )
+
+
+@pytest.fixture
+def socket_path() -> str:
+    td = tempfile.mkdtemp(prefix="ipc-member", dir="/tmp")
+    return str(Path(td) / "t.sock")
+
+
+def _audit_call_strings(audit_logger: MagicMock) -> str:
+    """audit_logger.log 호출의 모든 인자를 직렬화한 문자열."""
+    parts: list[str] = []
+    for call in audit_logger.log.await_args_list:
+        parts.append(repr(call.args))
+        parts.append(repr(call.kwargs))
+    return " ".join(parts)
+
+
+def _assert_no_secret(blob: str) -> None:
+    for secret in _ALL_SECRETS:
+        assert secret not in blob, f"secret {secret!r} leaked into: {blob}"
+
+
+# ── (a)+(f)+(h): authenticated member 명령 6개 IPC handler ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_handler_delegates_and_audits(socket_path: str) -> None:
+    member_service = _make_member_service_mock()
+    member_service.register.return_value = (
+        _make_member("bob", type=MemberType.AGENT, role=MemberRole.DEFAULT),
+        SECRET_TOKEN,
+    )
+    audit_logger = _make_audit_logger_mock()
+    svc = _make_service_registry(
+        member_service=member_service, audit_logger=audit_logger
+    )
+
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "member.register",
+                "args": {"member_id": "bob", "member_type": "agent"},
+                "actor": "master-1",
+            }
+        )
+    finally:
+        await server.stop()
+
+    assert response["status"] == "ok"
+    # (f) master 게이트 보존: registered_by=actor 로 위임.
+    _, kwargs = member_service.register.await_args
+    assert kwargs["registered_by"] == "master-1"
+    # (d) shape parity: token 은 result 에만.
+    assert response["result"]["token"] == SECRET_TOKEN
+    assert response["result"]["member_id"] == "bob"
+    # (a)+(h): audit 1회, action=member.register, member_id=actor.
+    audit_logger.log.assert_awaited_once()
+    _, akw = audit_logger.log.await_args
+    assert akw["action"] == "member.register"
+    assert akw["member_id"] == "master-1"
+    assert akw["resource"] == "member:bob"
+    # (e) secret 비노출: _audit_detail 은 envelope 에서 strip, audit detail
+    # 에도 token 없음.
+    assert "_audit_detail" not in response["result"]
+    _assert_no_secret(_audit_call_strings(audit_logger))
+
+
+@pytest.mark.asyncio
+async def test_set_emoji_handler_delegates_to_update_emoji(socket_path: str) -> None:
+    member_service = _make_member_service_mock()
+    member_service.update_emoji.return_value = _make_member("alice", emoji="🦊")
+    audit_logger = _make_audit_logger_mock()
+    svc = _make_service_registry(
+        member_service=member_service, audit_logger=audit_logger
+    )
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "member.set_emoji",
+                "args": {"member_id": "alice", "emoji": "🦊"},
+                "actor": "master-1",
+            }
+        )
+    finally:
+        await server.stop()
+
+    assert response["status"] == "ok"
+    # set_emoji 메서드 없음 → update_emoji 위임.
+    member_service.update_emoji.assert_awaited_once()
+    args, kwargs = member_service.update_emoji.await_args
+    assert args[0] == "alice"
+    assert kwargs["updated_by"] == "master-1"
+    assert response["result"]["emoji"] == "🦊"
+    _, akw = audit_logger.log.await_args
+    assert akw["action"] == "member.set_emoji"
+
+
+@pytest.mark.parametrize(
+    ("command", "service_attr", "by_kwarg", "action"),
+    [
+        ("member.suspend", "suspend", "suspended_by", "member.suspend"),
+        ("member.reactivate", "reactivate", "reactivated_by", "member.reactivate"),
+        ("member.revoke", "revoke", "revoked_by", "member.revoke"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_state_change_handlers_pass_actor_as_by(
+    socket_path: str,
+    command: str,
+    service_attr: str,
+    by_kwarg: str,
+    action: str,
+) -> None:
+    """(f) suspend/reactivate/revoke 가 ``*_by=actor`` 로 master 게이트 보존."""
+    member_service = _make_member_service_mock()
+    getattr(member_service, service_attr).return_value = _make_member(
+        "alice", status=MemberStatus.SUSPENDED
+    )
+    audit_logger = _make_audit_logger_mock()
+    svc = _make_service_registry(
+        member_service=member_service, audit_logger=audit_logger
+    )
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": command,
+                "args": {"member_id": "alice"},
+                "actor": "master-1",
+            }
+        )
+    finally:
+        await server.stop()
+
+    assert response["status"] == "ok"
+    _, kwargs = getattr(member_service, service_attr).await_args
+    assert kwargs[by_kwarg] == "master-1"
+    _, akw = audit_logger.log.await_args
+    assert akw["action"] == action
+    assert akw["member_id"] == "master-1"
+    assert akw["resource"] == "member:alice"
+
+
+@pytest.mark.asyncio
+async def test_rotate_token_handler_token_in_result_only(socket_path: str) -> None:
+    member_service = _make_member_service_mock()
+    member_service.rotate_token.return_value = (_make_member("alice"), SECRET_TOKEN)
+    audit_logger = _make_audit_logger_mock()
+    svc = _make_service_registry(
+        member_service=member_service, audit_logger=audit_logger
+    )
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "member.rotate_token",
+                "args": {"member_id": "alice"},
+                "actor": "master-1",
+            }
+        )
+    finally:
+        await server.stop()
+
+    assert response["status"] == "ok"
+    _, kwargs = member_service.rotate_token.await_args
+    assert kwargs["rotated_by"] == "master-1"
+    # (d) shape parity + (e) token 은 result 에만, audit detail 에 없음.
+    assert response["result"]["token"] == SECRET_TOKEN
+    _, akw = audit_logger.log.await_args
+    assert akw["action"] == "member.rotate_token"
+    _assert_no_secret(_audit_call_strings(audit_logger))
+
+
+# ── (g): auth-exempt reset/regen — sentinel member_id + master-lookup ──────
+
+
+@pytest.mark.asyncio
+async def test_reset_password_handler_master_lookup_and_sentinel(
+    socket_path: str,
+) -> None:
+    member_service = _make_member_service_mock()
+    member_service.list_members.return_value = [
+        _make_member("agent-x", type=MemberType.AGENT, role=MemberRole.DEFAULT),
+        _make_member("master-bob", role=MemberRole.MASTER),
+    ]
+    member_service.reset_password.return_value = None
+    audit_logger = _make_audit_logger_mock()
+    svc = _make_service_registry(
+        member_service=member_service, audit_logger=audit_logger
+    )
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        # client actor 를 의도적으로 스푸핑 시도(임의 값) — audit 에 반영되면 안 됨.
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "member.reset_password",
+                "args": {
+                    "recovery_key": SECRET_RECOVERY_KEY,
+                    "new_password": SECRET_NEW_PASSWORD,
+                },
+                "actor": "attacker-spoofed-actor",
+            }
+        )
+    finally:
+        await server.stop()
+
+    assert response["status"] == "ok"
+    # master-lookup 은 서버 handler 가 수행 → 해석된 master id 로 reset_password.
+    args, _ = member_service.reset_password.await_args
+    assert args[0] == "master-bob"
+    assert args[1] == SECRET_RECOVERY_KEY
+    assert args[2] == SECRET_NEW_PASSWORD
+    # (g) audit resource=member:{resolved master_id}, member_id=고정 sentinel
+    # (client actor 가 아님).
+    _, akw = audit_logger.log.await_args
+    assert akw["action"] == "member.reset_password"
+    assert akw["resource"] == "member:master-bob"
+    assert akw["member_id"] == _RECOVERY_AUDIT_MEMBER_ID
+    assert akw["member_id"] != "attacker-spoofed-actor"
+    # (e) secret 비노출: recovery_key / new_password 가 audit / envelope 에 없음.
+    _assert_no_secret(_audit_call_strings(audit_logger))
+    _assert_no_secret(repr(response))
+
+
+@pytest.mark.asyncio
+async def test_regenerate_recovery_key_handler_sentinel_and_result_only(
+    socket_path: str,
+) -> None:
+    member_service = _make_member_service_mock()
+    member_service.list_members.return_value = [
+        _make_member("master-bob", role=MemberRole.MASTER),
+    ]
+    member_service.regenerate_recovery_key.return_value = SECRET_RECOVERY_KEY
+    audit_logger = _make_audit_logger_mock()
+    svc = _make_service_registry(
+        member_service=member_service, audit_logger=audit_logger
+    )
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "member.regenerate_recovery_key",
+                "args": {"password": SECRET_PASSWORD},
+                "actor": "attacker-spoofed-actor",
+            }
+        )
+    finally:
+        await server.stop()
+
+    assert response["status"] == "ok"
+    args, _ = member_service.regenerate_recovery_key.await_args
+    assert args[0] == "master-bob"
+    assert args[1] == SECRET_PASSWORD
+    # (d) 새 recovery key 는 result 에만.
+    assert response["result"]["recovery_key"] == SECRET_RECOVERY_KEY
+    # (g) sentinel member_id.
+    _, akw = audit_logger.log.await_args
+    assert akw["action"] == "member.regenerate_recovery_key"
+    assert akw["resource"] == "member:master-bob"
+    assert akw["member_id"] == _RECOVERY_AUDIT_MEMBER_ID
+    # (e) input password 는 audit/envelope 에 없음. 새 recovery key 는 audit
+    # detail 에 없음(result 에만).
+    _assert_no_secret(_audit_call_strings(audit_logger))
+
+
+# ── (e) comprehensive secret 비노출: 실패 경로 envelope + server log ────────
+
+
+@pytest.mark.asyncio
+async def test_reset_password_failure_envelope_and_log_no_secret(
+    socket_path: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """handler 가 raise 해 IPC error envelope + server logger.exception 경로를
+    타도 secret 이 어디에도 노출되지 않는다.
+
+    ``reset_password`` 가 invalid recovery credential 로 raise 하는 메시지에
+    secret 이 들어가지 않음 + ``_dispatch`` 의 ``logger.exception`` /
+    error envelope message 에도 secret 이 없음을 검증한다.
+    """
+    from ante.member.errors import MemberInvalidRecoveryCredentialError
+
+    member_service = _make_member_service_mock()
+    member_service.list_members.return_value = [
+        _make_member("master-bob", role=MemberRole.MASTER),
+    ]
+    member_service.reset_password.side_effect = MemberInvalidRecoveryCredentialError(
+        "recovery credential 검증 실패"
+    )
+    audit_logger = _make_audit_logger_mock()
+    svc = _make_service_registry(
+        member_service=member_service, audit_logger=audit_logger
+    )
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        with caplog.at_level(logging.DEBUG):
+            response = await server._dispatch(
+                {
+                    "id": "1",
+                    "command": "member.reset_password",
+                    "args": {
+                        "recovery_key": SECRET_RECOVERY_KEY,
+                        "new_password": SECRET_NEW_PASSWORD,
+                    },
+                    "actor": "cli",
+                }
+            )
+    finally:
+        await server.stop()
+
+    assert response["status"] == "error"
+    # 실패 시 audit 미발화 invariant.
+    audit_logger.log.assert_not_awaited()
+    # IPC error envelope message 에 secret 없음.
+    _assert_no_secret(repr(response))
+    # server logger.exception 출력에 secret 없음.
+    _assert_no_secret(caplog.text)
+
+
+# ── required_services preflight: audit_logger / member_service ─────────────
+
+
+@pytest.mark.asyncio
+async def test_member_handlers_require_audit_logger(socket_path: str) -> None:
+    """audit_logger 부재 시 preflight 가 모든 member admin 명령을 거부한다."""
+    member_service = _make_member_service_mock()
+    svc = ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=MagicMock(),
+        treasury_manager=MagicMock(),
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=MagicMock(),
+        member_service=member_service,
+        # audit_logger 미주입(None).
+    )
+    cmd_registry = CommandRegistry()
+    register_all_handlers(cmd_registry)
+    server = IPCServer(socket_path, svc, cmd_registry)
+    await server.start()
+    try:
+        response = await server._dispatch(
+            {
+                "id": "1",
+                "command": "member.suspend",
+                "args": {"member_id": "alice"},
+                "actor": "master-1",
+            }
+        )
+    finally:
+        await server.stop()
+    assert response["status"] == "error"
+    member_service.suspend.assert_not_awaited()

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -65,7 +65,7 @@ def test_commands_property(registry: CommandRegistry) -> None:
 
 
 def test_register_all_handlers() -> None:
-    """register_all_handlers가 32개 핸들러를 등록 (account.delete 제외).
+    """register_all_handlers가 40개 핸들러를 등록 (account.delete 제외).
 
     `account.delete`는 1.0 IPC 계약에서 제거되어 cold-path CLI에서 직접
     AccountService를 호출한다.
@@ -86,10 +86,16 @@ def test_register_all_handlers() -> None:
     Refs #2112: ``bot.list`` / ``bot.info`` / ``bot.positions`` /
     ``bot.signal_key`` (read-only) 4건 추가 — ``bot list/info/positions/
     signal-key`` 의 runtime IPC 경로 (28→32).
+
+    Refs #2113: member admin mutation 8건(``member.register`` /
+    ``member.set_emoji`` / ``member.suspend`` / ``member.reactivate`` /
+    ``member.revoke`` / ``member.rotate_token`` / ``member.reset_password`` /
+    ``member.regenerate_recovery_key``) 추가 — ``member.update_scopes`` 동형
+    runtime IPC 경로 (32→40).
     """
     registry = CommandRegistry()
     register_all_handlers(registry)
-    assert len(registry.commands) == 32
+    assert len(registry.commands) == 40
 
     expected = {
         "system.halt",
@@ -113,6 +119,14 @@ def test_register_all_handlers() -> None:
         "rule.update",
         "strategy.set_status",
         "member.update_scopes",
+        "member.register",
+        "member.set_emoji",
+        "member.suspend",
+        "member.reactivate",
+        "member.revoke",
+        "member.rotate_token",
+        "member.reset_password",
+        "member.regenerate_recovery_key",
         "config.set",
         "approval.request",
         "approval.approve",
@@ -133,7 +147,7 @@ def test_register_all_handlers() -> None:
 
 
 def test_register_all_handlers_taxonomy() -> None:
-    """등록된 32개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다.
+    """등록된 40개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다.
 
     Refs #1712: ``bot.start`` / ``bot.stop`` mutating, ``bot.status``
     read-only — ``docs/specs/ipc/ipc.md`` Handler taxonomy SSOT 와 동기화.
@@ -142,6 +156,8 @@ def test_register_all_handlers_taxonomy() -> None:
 
     Refs #2112: ``bot.list`` / ``bot.info`` / ``bot.positions`` /
     ``bot.signal_key`` read-only 추가 (read-only 4→8).
+
+    Refs #2113: member admin mutation 8건 추가 (mutating 24→32).
     """
     registry = CommandRegistry()
     register_all_handlers(registry)
@@ -163,6 +179,14 @@ def test_register_all_handlers_taxonomy() -> None:
         "rule.update",
         "strategy.set_status",
         "member.update_scopes",
+        "member.register",
+        "member.set_emoji",
+        "member.suspend",
+        "member.reactivate",
+        "member.revoke",
+        "member.rotate_token",
+        "member.reset_password",
+        "member.regenerate_recovery_key",
         "config.set",
         "approval.request",
         "approval.approve",
@@ -183,7 +207,7 @@ def test_register_all_handlers_taxonomy() -> None:
         "bot.signal_key",
     }
 
-    assert len(mutating) == 24
+    assert len(mutating) == 32
     assert len(read_only) == 8
     assert mutating | read_only == set(registry.commands)
 
@@ -1181,6 +1205,14 @@ class TestRegisteredCommandsMetadataCompleteness:
         ``system.halt`` / ``system.clear_halt`` / ``bot.create`` /
         ``bot.remove``(action ``bot.delete``) / ``approval.approve`` /
         ``approval.reject`` / ``approval.cancel`` — audit.md:112-120 SSOT.
+
+        Refs #2113: member admin mutation 8건이 audit_action 부여
+        (18→26 commands): ``member.register`` / ``member.set_emoji`` /
+        ``member.suspend`` / ``member.reactivate`` / ``member.revoke`` /
+        ``member.rotate_token`` / ``member.reset_password`` /
+        ``member.regenerate_recovery_key`` — audit.md member rows SSOT.
+        ``member register`` 의 action 은 audit.md 정렬에 따라 ``member.register``
+        다 (종전 ``member.create`` 표기 reconcile).
         """
         expected_actions = {
             "account.suspend",
@@ -1198,6 +1230,14 @@ class TestRegisteredCommandsMetadataCompleteness:
             "treasury.set_balance",
             "strategy.set_status",
             "member.update_scopes",
+            "member.register",
+            "member.set_emoji",
+            "member.suspend",
+            "member.reactivate",
+            "member.revoke",
+            "member.rotate_token",
+            "member.reset_password",
+            "member.regenerate_recovery_key",
             "approval.approve",
             "approval.reject",
             "approval.cancel",
@@ -1234,11 +1274,12 @@ class TestRegisteredCommandsMetadataCompleteness:
         for spec in loaded.iter_specs():
             assert spec.cross_validators == (), spec.name
 
-    def test_iter_specs_returns_all_32_specs(self, loaded: CommandRegistry) -> None:
-        """``iter_specs``가 32 commands 모두를 ``CommandSpec`` 인스턴스로
-        반환한다 (#2112: 28→32, bot.* read 4건 추가)."""
+    def test_iter_specs_returns_all_40_specs(self, loaded: CommandRegistry) -> None:
+        """``iter_specs``가 40 commands 모두를 ``CommandSpec`` 인스턴스로
+        반환한다 (#2112: 28→32, bot.* read 4건; #2113: 32→40, member admin
+        mutation 8건 추가)."""
         specs = loaded.iter_specs()
-        assert len(specs) == 32
+        assert len(specs) == 40
         assert all(isinstance(s, CommandSpec) for s in specs)
         # 등록 순서 보존(dict insertion order).
         assert [s.name for s in specs] == loaded.commands

--- a/tests/unit/test_cli_member_ipc_routing.py
+++ b/tests/unit/test_cli_member_ipc_routing.py
@@ -1,0 +1,311 @@
+"""member admin CLI IPC-first 라우팅 + 서버 정지 fallback 검증 (#2113).
+
+``member.update_scopes`` 동형으로, member admin mutation 8개 CLI 명령이
+
+(a) is_active_runtime True → ``ipc_send("member.X", ...)`` 위임,
+(b) is_active_runtime False → cold-path (직접 MemberService) fallback,
+(c) ServerNotRunning(ClickException) → stable code envelope surface,
+(d) 출력 shape parity (register/rotate_token fields+token, regen recovery_key),
+(e) secret 비노출: token/recovery_key/new_password/password 가 CLI
+    ClickException surface / JSON 출력 (사용자 표시 result 제외) 어디에도
+    의도치 않게 새지 않는다,
+
+를 만족함을 lock 한다. CLI 명령은 함수 본문에서 ``ipc_send`` /
+``is_active_runtime`` 을 import 하므로 원본 모듈을 patch 한다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+SECRET_TOKEN = "SECRET-TOKEN-eeeeeeeeeeeeeeeeeeee"
+SECRET_RECOVERY_KEY = "SECRET-RECOVERY-ffffffffffffffff"
+
+
+def _master() -> Member:
+    return Member(
+        member_id="master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="master",
+        status=MemberStatus.ACTIVE,
+        scopes=[],
+    )
+
+
+def _invoke(args: list[str]):  # noqa: ANN202
+    runner = CliRunner()
+    member = _master()
+
+    def _mock_auth(ctx) -> None:  # noqa: ANN001
+        ctx.obj["member"] = member
+
+    with patch("ante.cli.main.authenticate_member", side_effect=_mock_auth):
+        return runner.invoke(
+            cli,
+            args,
+            obj={"member": member},
+            env={"ANTE_MEMBER_TOKEN": "any"},
+            catch_exceptions=False,
+        )
+
+
+def _server_not_running_exc() -> click.ClickException:
+    exc = click.ClickException(
+        "서버가 실행 중이 아닙니다. 'ante system start'로 시작하세요."
+    )
+    exc.ipc_error_code = "IPC_SERVER_NOT_RUNNING"  # type: ignore[attr-defined]
+    exc.ipc_error_message = exc.message  # type: ignore[attr-defined]
+    return exc
+
+
+# (cli_args, ipc_command, ipc_return) — authenticated 6 commands.
+_ROUTED = [
+    pytest.param(
+        ["--format", "json", "member", "suspend", "target"],
+        "member.suspend",
+        {"member_id": "target", "status": "suspended"},
+        id="suspend",
+    ),
+    pytest.param(
+        ["--format", "json", "member", "reactivate", "target"],
+        "member.reactivate",
+        {"member_id": "target", "status": "active"},
+        id="reactivate",
+    ),
+    pytest.param(
+        ["--format", "json", "member", "revoke", "target", "--yes"],
+        "member.revoke",
+        {"member_id": "target", "status": "revoked"},
+        id="revoke",
+    ),
+    pytest.param(
+        ["--format", "json", "member", "set-emoji", "target", "🤖"],
+        "member.set_emoji",
+        {"member_id": "target", "emoji": "🤖"},
+        id="set-emoji",
+    ),
+]
+
+
+# ── (a) IPC-first 위임 ─────────────────────────────────────────────────────
+
+
+class TestIpcFirstRouting:
+    @pytest.mark.parametrize("cli_args,ipc_command,ipc_return", _ROUTED)
+    def test_active_runtime_delegates_to_ipc(
+        self, cli_args: list[str], ipc_command: str, ipc_return: dict
+    ) -> None:
+        ipc_send = AsyncMock(return_value=ipc_return)
+        with (
+            patch("ante.cli.cold_path.is_active_runtime", return_value=True),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+        ):
+            result = _invoke(cli_args)
+        assert result.exit_code == 0, result.output
+        ipc_send.assert_awaited_once()
+        call = ipc_send.await_args
+        assert call.args[0] == ipc_command
+        # actor 는 master member_id (get_member_id).
+        assert call.kwargs.get("actor") == "master"
+
+    def test_register_ipc_shape_parity_token_in_output(self) -> None:
+        """(d) register IPC 경로가 {fields, token} shape 으로 출력한다."""
+        ipc_send = AsyncMock(
+            return_value={
+                "member_id": "new-agent",
+                "type": "agent",
+                "role": "default",
+                "org": "default",
+                "name": "new",
+                "token": SECRET_TOKEN,
+            }
+        )
+        with (
+            patch("ante.cli.cold_path.is_active_runtime", return_value=True),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+        ):
+            result = _invoke(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "register",
+                    "--id",
+                    "new-agent",
+                    "--type",
+                    "agent",
+                ]
+            )
+        assert result.exit_code == 0, result.output
+        ipc_send.assert_awaited_once()
+        assert ipc_send.await_args.args[0] == "member.register"
+        payload = json.loads(result.output)
+        assert payload["member_id"] == "new-agent"
+        # 발급 토큰은 사용자 표시용 result 에만 surface.
+        assert payload["token"] == SECRET_TOKEN
+
+    def test_rotate_token_ipc_shape_parity(self) -> None:
+        """(d) rotate-token IPC 경로가 {member_id, token} shape 으로 출력."""
+        ipc_send = AsyncMock(
+            return_value={"member_id": "target", "token": SECRET_TOKEN}
+        )
+        with (
+            patch("ante.cli.cold_path.is_active_runtime", return_value=True),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+        ):
+            result = _invoke(["member", "rotate-token", "target"])
+        assert result.exit_code == 0, result.output
+        assert ipc_send.await_args.args[0] == "member.rotate_token"
+        assert SECRET_TOKEN in result.output
+
+    def test_regen_ipc_shape_parity_recovery_key(self) -> None:
+        """(d) regenerate-recovery-key IPC 경로가 {recovery_key} 출력 +
+        auth-exempt 라 actor 미전달(secret 만 args 에)."""
+        ipc_send = AsyncMock(return_value={"recovery_key": SECRET_RECOVERY_KEY})
+        with (
+            patch("ante.cli.cold_path.is_active_runtime", return_value=True),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+            patch.dict("os.environ", {"ANTE_REGEN_PW": "current-pw-value"}),
+        ):
+            result = _invoke(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "regenerate-recovery-key",
+                    "--password-env",
+                    "ANTE_REGEN_PW",
+                ]
+            )
+        assert result.exit_code == 0, result.output
+        assert ipc_send.await_args.args[0] == "member.regenerate_recovery_key"
+        # auth-exempt: args 에 password(secret) 만, actor override 없음.
+        sent_args = ipc_send.await_args.args[1]
+        assert sent_args == {"password": "current-pw-value"}
+        payload = json.loads(result.output)
+        assert payload["recovery_key"] == SECRET_RECOVERY_KEY
+
+    def test_reset_password_ipc_sends_secret_only(self) -> None:
+        """(a) reset-password IPC 경로가 secret 만 보내고 master-lookup 은
+        서버가 수행(client member_id 미전송)."""
+        ipc_send = AsyncMock(return_value={})
+        with (
+            patch("ante.cli.cold_path.is_active_runtime", return_value=True),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+            patch.dict("os.environ", {"ANTE_NEW_PW": "new-pw-value"}),
+        ):
+            result = _invoke(
+                [
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "rk-value",
+                    "--new-password-env",
+                    "ANTE_NEW_PW",
+                ]
+            )
+        assert result.exit_code == 0, result.output
+        assert ipc_send.await_args.args[0] == "member.reset_password"
+        sent_args = ipc_send.await_args.args[1]
+        assert set(sent_args.keys()) == {"recovery_key", "new_password"}
+        assert "member_id" not in sent_args
+
+
+# ── (c) ServerNotRunning → ClickException surface (secret 비노출) ───────────
+
+# format_option 을 보유한 명령만 JSON envelope code 검증에 쓴다
+# (suspend/reactivate/revoke). set-emoji 는 success-only 출력이라 별도.
+_JSON_SURFACE = [p for p in _ROUTED if getattr(p, "id", None) != "set-emoji"]
+
+
+class TestServerNotRunningSurface:
+    @pytest.mark.parametrize("cli_args,ipc_command,ipc_return", _JSON_SURFACE)
+    def test_server_not_running_surfaces_stable_code(
+        self, cli_args: list[str], ipc_command: str, ipc_return: dict
+    ) -> None:
+        ipc_send = AsyncMock(side_effect=_server_not_running_exc())
+        with (
+            patch("ante.cli.cold_path.is_active_runtime", return_value=True),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+        ):
+            result = _invoke(cli_args)
+        assert result.exit_code == 1
+        # JSON envelope 에 stable code surface
+        # (formatter.error shape: {status, code, message}).
+        payload = json.loads(result.output)
+        assert payload["code"] == "IPC_SERVER_NOT_RUNNING"
+        # secret 류 토큰이 surface 에 없음(general).
+        assert SECRET_TOKEN not in result.output
+        assert SECRET_RECOVERY_KEY not in result.output
+
+    def test_reset_password_server_not_running_no_secret_in_surface(self) -> None:
+        """(c)+(e) reset-password ServerNotRunning surface 에 secret 없음."""
+        ipc_send = AsyncMock(side_effect=_server_not_running_exc())
+        with (
+            patch("ante.cli.cold_path.is_active_runtime", return_value=True),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+            patch.dict("os.environ", {"ANTE_NEW_PW": "SECRET-IN-PW-gggggg"}),
+        ):
+            result = _invoke(
+                [
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "SECRET-IN-RK-hhhhhh",
+                    "--new-password-env",
+                    "ANTE_NEW_PW",
+                ]
+            )
+        assert result.exit_code == 1
+        assert "SECRET-IN-PW-gggggg" not in result.output
+        assert "SECRET-IN-RK-hhhhhh" not in result.output
+
+
+# ── (b) 서버 정지 → cold-path fallback ─────────────────────────────────────
+
+
+class TestColdPathFallback:
+    def test_inactive_runtime_uses_cold_path(self) -> None:
+        """(b) is_active_runtime False → ipc_send 미호출 + 직접 MemberService."""
+        ipc_send = AsyncMock()
+        suspend = AsyncMock(
+            return_value=Member(
+                member_id="target",
+                type=MemberType.AGENT,
+                role=MemberRole.DEFAULT,
+                org="default",
+                name="target",
+                status=MemberStatus.SUSPENDED,
+                scopes=[],
+            )
+        )
+        service = AsyncMock()
+        service.suspend = suspend
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _fake_factory(ctx=None):  # noqa: ANN001, ANN202
+            yield service
+
+        with (
+            patch("ante.cli.cold_path.is_active_runtime", return_value=False),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=ipc_send),
+            patch("ante.cli.commands.member._create_service", new=_fake_factory),
+        ):
+            result = _invoke(["member", "suspend", "target"])
+        assert result.exit_code == 0, result.output
+        ipc_send.assert_not_awaited()
+        suspend.assert_awaited_once()
+        # cold-path 도 suspended_by=actor 로 master 게이트 보존.
+        assert suspend.await_args.kwargs["suspended_by"] == "master"

--- a/tests/unit/test_ipc_bot_lifecycle.py
+++ b/tests/unit/test_ipc_bot_lifecycle.py
@@ -652,11 +652,11 @@ class TestRegistryRegistration:
         assert spec.is_mutating is False
         assert spec.handler is _handle_bot_status
 
-    def test_total_command_count_is_32(self) -> None:
+    def test_total_command_count_is_40(self) -> None:
         """#1712 이후 CLI/IPC parity mutation 5개 + #2111
         ``bot.signal_key.rotate`` + #2112 ``bot.list`` / ``bot.info`` /
-        ``bot.positions`` / ``bot.signal_key`` (read-only) 4건을 포함한다
-        (28→32)."""
+        ``bot.positions`` / ``bot.signal_key`` (read-only) 4건 (28→32) +
+        #2113 member admin mutation 8건 (32→40)을 포함한다."""
         registry = CommandRegistry()
         register_all_handlers(registry)
-        assert len(registry.commands) == 32
+        assert len(registry.commands) == 40


### PR DESCRIPTION
Closes #2113

## Summary
- member register/set-emoji/suspend/reactivate/revoke/rotate-token/reset-password/regenerate-recovery-key 8개가 스펙(runtime_ipc)과 달리 cold-path만 있던 것을, **IPC-first + 서버정지 maintenance fallback**(ipc.md:203-209 요구)으로 wiring(member.update_scopes 모델).
- 8 IPC handler(MemberService 위임, is_mutating, audit_action=member.X, `*_by`=actor로 서버 _assert_master 게이트 보존). set-emoji→update_emoji. CLI 8 IPC-first/cold-path fallback + ClickException surface, 출력 shape parity.
- **보안**: secret(token/recovery_key/password)은 result에만 — _audit_detail·audit detail·IPC envelope message·logger.exception·CLI surface·snapshot 비노출(comprehensive 테스트). auth-exempt(reset/regen)는 master-lookup을 handler로, audit resource=member:{resolved master_id}, audit member_id=**고정 sentinel 'recovery'**(client actor spoofing 차단). server.py _dispatch member_id override는 additive(기존 audit 무회귀).
- SSOT lockstep: baseline 8→0, count 32→40, mutating 24→32, taxonomy, ipc.md 표, audit.md(member.create→member.register).

## Test Plan
- 신규 test_member_admin_ipc_wiring(10)+test_cli_member_ipc_routing(13): IPC-first/fallback/ClickException, comprehensive secret 비노출, sentinel, master-lookup, shape parity. SSOT count lock 갱신.
- 전체 `pytest tests/unit/`: 6917 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- **@code-reviewer 보안 메타리뷰 PASS**(blocking 없음, I-1/F-2 follow-up #2294/#2295). Codex 브랜치 리뷰 PASS (12709d3)

## 비고
member list/info/list-invalid-roles(read)·--recovery-key argv는 비목표.

🤖 Generated with [Claude Code](https://claude.com/claude-code)