### PR TITLE
fix(cli): #1984 data list를 read-only DB artifact 조회로 확대 (load_readonly 캐시 워밍)

### DIFF
--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 
 from ante.cli._data_path import resolve_data_path
+from ante.cli.db_context import open_cli_db
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import enforce_scope, require_auth, require_scope
@@ -50,14 +51,12 @@ def data_list(
     """보유 데이터셋 목록."""
     import asyncio
 
-    from ante.cli.main import get_db_path
     from ante.data.datasets import list_datasets, validate_dataset_filters
     from ante.data.store import ParquetStore
 
     data_path = resolve_data_path(ctx, data_path)
     fmt = get_formatter(ctx)
     store = ParquetStore(base_path=data_path)
-    resolved_db_path = db_path or get_db_path(ctx)
 
     try:
         normalized_type = validate_dataset_filters(
@@ -82,21 +81,40 @@ def data_list(
         return
 
     async def _enrich(items: list[dict]) -> list[dict]:
-        from ante.core.database import Database
         from ante.instrument.service import InstrumentService
 
-        db = Database(resolved_db_path)
-        await db.connect()
-        try:
+        # ``data list`` 는 ParquetStore (파일) 에서 datasets 를 읽는 offline read
+        # 명령이며, DB 는 종목명 보강 (``get_name``) 에만 쓰인다. read-only DB
+        # artifact (``--db-path`` 로 지정된 0444 파일 / 0555 부모 디렉터리) 에서
+        # ``InstrumentService.initialize()`` (CREATE TABLE instruments DDL) 나
+        # ``Database(read_only=False)`` (WAL PRAGMA writer 연결) 를 발화하면
+        # read-only fs 에서 실패한다. 따라서 ``backtest history`` (#1974) 와 동형
+        # 으로 ``open_cli_db(read_only=True)`` + ``svc.load_readonly()`` (DDL 없는
+        # 캐시 워밍) 를 사용한다 (offline-factory.md §2 옵션 A). ``--db-path``
+        # 원시 값 (None 가능) 을 그대로 ``db_path_override`` 로 전달하면
+        # ``open_cli_db`` 가 None 일 때 ``get_db_path(ctx)`` 로 해석하므로 기존
+        # ``--db-path`` 동작과 동치다 (approval.py / backtest.py 패턴).
+        async with open_cli_db(ctx, read_only=True, db_path_override=db_path) as db:
             svc = InstrumentService(db)
-            await svc.initialize()
+            # initialize() 대신 load_readonly(): schema DDL 없이 캐시만 워밍한다.
+            # instruments 테이블이 부재하면 빈 캐시로 정규화되어 ``get_name`` 이
+            # symbol fallback 을 반환한다 (malformed/locked 등 다른
+            # OperationalError 는 재전파 → 아래 DATA_ERROR 로 변환).
+            await svc.load_readonly()
             for item in items:
                 item["name"] = svc.get_name(item["symbol"])
             return items
-        finally:
-            await db.close()
 
-    datasets = asyncio.run(_enrich(datasets))
+    try:
+        datasets = asyncio.run(_enrich(datasets))
+    except Exception as e:
+        # malformed/locked DB 등 종목명 보강 단계의 DB 에러는 traceback 을
+        # JSON 으로 노출하지 않고 public error code 로 변환한다 (#1984 —
+        # ``backtest history`` 의 BACKTEST_ERROR 분류 동형). read-only 성공
+        # 경로 (테이블 존재/부재 graceful) 는 본 분기에 들어오지 않는다.
+        fmt.error(str(e), code="DATA_ERROR")
+        raise SystemExit(1) from e
+
     if fmt.is_json:
         fmt.output({"datasets": datasets, "count": result["total"]})
     else:

--- a/src/ante/cli/db_context.py
+++ b/src/ante/cli/db_context.py
@@ -21,7 +21,8 @@ Codex Plan Review v2 lock:
    ``read_only=False``이면 기존 ``Database(db_path)`` 호출을 byte-for-byte
    유지한다(kwarg 미전달 — #1856/#1857 patch 호환 및 모든 write 소비자 무영향
    invariant). read-only 모드는 기존 스키마를 부트스트랩 없이 읽는 offline read
-   명령(현재 ``backtest history``)에만 적용된다 — §4 예외 service
+   명령(현재 ``backtest history``, ``data list`` 의 종목명 보강 — #1984)에만
+   적용된다 — §4 예외 service
    (`AccountService`/`MemberService`/`ApprovalService`/`AuditLogger`/
    `DynamicConfigService`)는 ``initialize()``가 schema DDL을 발화해야 read가
    가능하므로 schema 분리 전까지 ``read_only=True`` 대상이 아니다.
@@ -67,8 +68,9 @@ async def open_cli_db(
             ``False`` (기본) 이면 기존 ``Database(db_path)`` 호출을
             byte-for-byte 유지한다 (kwarg 미전달, 모든 write 소비자 무영향).
             read-only 모드는 기존 스키마를 부트스트랩 없이 읽는 offline read
-            명령(현재 ``backtest history``)에만 사용한다 — §4 예외 service 는
-            schema 분리 전까지 ``read_only=True`` 대상이 아니다.
+            명령(현재 ``backtest history``, ``data list`` 의 종목명 보강 —
+            #1984)에만 사용한다 — §4 예외 service 는 schema 분리 전까지
+            ``read_only=True`` 대상이 아니다.
         db_path_override: optional 명시 DB 경로. ``None`` 이면
             ``get_db_path(ctx)`` 로 해석한다. ``approval list/info/review/
             audit-types`` 등 ``--db-path`` Click option 을 지원하는 명령은

--- a/src/ante/instrument/service.py
+++ b/src/ante/instrument/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 from typing import TYPE_CHECKING
 
 from ante.instrument.models import Instrument
@@ -46,6 +47,36 @@ class InstrumentService:
         await self._db.execute_script(INSTRUMENT_SCHEMA)
         await self._warm_cache()
         logger.info("InstrumentService 초기화 완료 (캐시: %d건)", len(self._cache))
+
+    async def load_readonly(self) -> None:
+        """read-only DB 에서 schema DDL 없이 캐시만 워밍한다 (#1984).
+
+        ``initialize()`` 와 달리 ``CREATE TABLE IF NOT EXISTS instruments`` DDL
+        (writer 경로) 을 발화하지 않는다. read-only DB artifact (``data list
+        --db-path``) 에서 ``initialize()`` 를 호출하면 ``read_only=True``
+        ``Database`` 가 writer 연결을 열지 않아(또는 실제 read-only fs 에서 WAL
+        PRAGMA 가) 실패하므로, offline read 경로는 본 메서드로 캐시를 워밍한다
+        (``backtest history`` 의 ``BacktestRunStore.initialize()`` skip 와 동형
+        — offline-factory.md §2 옵션 A).
+
+        ``instruments`` 테이블이 부재한 (부트스트랩 안 된) DB 는 정의상 종목
+        마스터 부재와 동치이므로 빈 캐시로 graceful 정규화한다 — 이후
+        ``get_name(symbol)`` 은 symbol fallback 을 반환한다. malformed/locked DB
+        같은 다른 ``OperationalError`` 까지 삼키지 않도록 ``"no such table"``
+        메시지로만 좁혀 그 외는 호출 표면으로 재전파한다 (``backtest history``
+        의 ``list_by_strategy`` 가드 동형).
+        """
+        try:
+            await self._warm_cache()
+        except sqlite3.OperationalError as e:
+            if "no such table" in str(e).lower():
+                self._cache = {}
+                logger.info("instruments 테이블 부재 — 빈 캐시로 정규화 (read-only DB)")
+                return
+            raise
+        logger.info(
+            "InstrumentService read-only 로드 완료 (캐시: %d건)", len(self._cache)
+        )
 
     async def _warm_cache(self) -> None:
         """DB 전체 로드 → 메모리 캐시."""

--- a/tests/unit/contracts/factory_drift_allowlist.yaml
+++ b/tests/unit/contracts/factory_drift_allowlist.yaml
@@ -58,10 +58,10 @@ direct_database_construction:
     line: 254
     reason: "backtest run — long_running (progress-bar driven, deferred migration)"
 
-  # data domain — `data list` callsite. #1857 잔여로 본 사이클에서 보류.
-  - path: src/ante/cli/commands/data.py
-    line: 88
-    reason: "data list — offline (deferred migration, post-#1818 follow-up)"
+  # data domain — `data list` 는 `offline` 이며 #1984 에서 `open_cli_db`
+  # (read_only) + InstrumentService.load_readonly() 로 마이그레이션되어 직접
+  # Database 생성 callsite 가 사라졌다 — 엔트리 제거 (backtest history #1974
+  # 동형).
 
   # init — root-level `ante init` bootstrap command. CLI registry 의
   # 94 entries 외 follow-up set (`("init",)`). bootstrap 단계에서 DB 자체를

--- a/tests/unit/test_cli_data_list_readonly.py
+++ b/tests/unit/test_cli_data_list_readonly.py
@@ -1,0 +1,273 @@
+"""``ante data list`` read-only DB 조회 회귀 테스트 (#1984).
+
+``data list`` 는 ParquetStore (파일) 에서 datasets 를 읽는 offline read 명령이며,
+DB 는 종목명 보강 (``InstrumentService.get_name``) 에만 쓰인다. 따라서 read-only
+DB artifact 에서 schema DDL (``InstrumentService.initialize()`` → ``CREATE TABLE
+instruments``) 이나 writer 연결 (WAL PRAGMA) 을 발화하면 안 된다
+(offline-factory.md §2 옵션 A, ``backtest history`` #1974 동형). 핵심 회귀 락:
+
+(b)  read-only DB 에 ``instruments`` 테이블 존재 → 이름 보강 보존
+     (``load_readonly`` 캐시 워밍 — symbol fallback 퇴화 아님).
+(b2) ``instruments`` 부재 ("no such table") → symbol fallback graceful, traceback
+     없음.
+(c)  writable DB → 이름 enrichment 정상 (회귀).
+(d)  malformed DB → ``DATA_ERROR`` 재전파 (no-such-table 만 graceful — 메시지
+     의존 테스트 락).
+
+실제 read-only **파일시스템** (0444 DB + 0555 부모 dir) 의 WAL PRAGMA 실패
+경로 검증은 :mod:`tests.unit.test_cli_data_list_readonly_fs` 가 담당한다 (결정적
+프록시로 대체 금지 — #1976 교훈).
+
+CliRunner / auth 우회 fixture 는 ``test_cli_backtest_history_readonly.py`` 를
+미러한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import polars as pl
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.core.database import Database
+from ante.data.store import ParquetStore
+from ante.instrument.models import Instrument
+from ante.instrument.service import InstrumentService
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _make_ohlcv_df(symbol: str) -> pl.DataFrame:
+    """``data list`` 가 datasets 1 건을 반환하도록 최소 OHLCV DataFrame 생성."""
+    from datetime import datetime
+
+    timestamps = pl.datetime_range(
+        datetime.fromisoformat("2026-03-02T09:00:00"),
+        datetime.fromisoformat("2026-03-02T09:04:00"),
+        interval="1m",
+        eager=True,
+        time_zone="UTC",
+    )
+    n = len(timestamps)
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": [symbol] * n,
+            "open": [50000.0 + i * 100 for i in range(n)],
+            "high": [50100.0 + i * 100 for i in range(n)],
+            "low": [49900.0 + i * 100 for i in range(n)],
+            "close": [50050.0 + i * 100 for i in range(n)],
+            "volume": [1000 + i * 10 for i in range(n)],
+            "source": ["test"] * n,
+        }
+    )
+
+
+def _seed_dataset(data_path: Path, symbol: str = "005930") -> None:
+    """ParquetStore 에 OHLCV dataset 1 건을 기록한다 (``data list`` 비-DB 경로)."""
+    store = ParquetStore(base_path=data_path)
+    store.write(symbol, "1m", _make_ohlcv_df(symbol))
+
+
+def _seed_instruments_db(path: str, *, with_name: bool) -> None:
+    """``instruments`` 테이블을 가진 DB 를 생성한다.
+
+    ``with_name`` 이면 ``InstrumentService.bulk_upsert`` 로 종목명을 1 건 넣는다.
+    """
+
+    async def _create() -> None:
+        db = Database(path)
+        await db.connect()
+        try:
+            svc = InstrumentService(db)
+            await svc.initialize()
+            if with_name:
+                await svc.bulk_upsert(
+                    [Instrument(symbol="005930", exchange="KRX", name="삼성전자")]
+                )
+        finally:
+            await db.close()
+
+    asyncio.run(_create())
+
+
+def _make_empty_db(path: str) -> None:
+    """``instruments`` 테이블이 없는 빈 DB 파일을 생성한다.
+
+    파일이 존재하지 않으면 ``open_cli_db`` → ``Database.connect()`` 가 파일을
+    새로 생성하므로, connect→close 만 수행해 스키마 없는 빈 DB 파일을 미리 만든다.
+    """
+
+    async def _create() -> None:
+        db = Database(path)
+        await db.connect()
+        await db.close()
+
+    asyncio.run(_create())
+
+
+def _instruments_table_exists(path: str) -> bool:
+    conn = sqlite3.connect(path)
+    try:
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'instruments'"
+        )
+        return cur.fetchone() is not None
+    finally:
+        conn.close()
+
+
+def _run_data_list(runner, data_path: Path, db_file: Path):
+    return runner.invoke(
+        cli,
+        [
+            "--format",
+            "json",
+            "data",
+            "list",
+            "--data-path",
+            str(data_path),
+            "--db-path",
+            str(db_file),
+        ],
+    )
+
+
+class TestDataListReadOnlyDb:
+    def test_instruments_present_preserves_name_enrichment(
+        self, runner, tmp_path
+    ) -> None:
+        """(b) instruments 테이블 존재 → 이름 보강 보존 (load_readonly 캐시 로드).
+
+        symbol fallback 퇴화가 아니라 실제 종목명 ("삼성전자") 이 보존되어야
+        한다. 이는 단순 ``initialize()`` skip (캐시 비어 silent 퇴화) 와 본
+        ``load_readonly()`` (캐시 워밍) 의 차이를 lock 한다.
+        """
+        data_path = tmp_path / "data"
+        _seed_dataset(data_path)
+        db_file = tmp_path / "ante.db"
+        _seed_instruments_db(str(db_file), with_name=True)
+
+        result = _run_data_list(runner, data_path, db_file)
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 1, payload
+        assert payload["datasets"][0]["symbol"] == "005930"
+        assert payload["datasets"][0]["name"] == "삼성전자", payload
+
+    def test_instruments_absent_symbol_fallback_graceful(
+        self, runner, tmp_path
+    ) -> None:
+        """(b2) instruments 부재 → symbol fallback graceful, traceback 없음.
+
+        - exit 0 + datasets 1 건.
+        - ``name`` 이 symbol fallback ("005930") 으로 정규화.
+        - 실행 후에도 ``instruments`` 테이블이 생성되지 않음 (read-only DDL
+          부작용 부재).
+        - traceback / DATA_ERROR 미노출.
+        """
+        data_path = tmp_path / "data"
+        _seed_dataset(data_path)
+        db_file = tmp_path / "ante.db"
+        _make_empty_db(str(db_file))
+        assert not _instruments_table_exists(str(db_file))
+
+        result = _run_data_list(runner, data_path, db_file)
+
+        assert result.exit_code == 0, result.output
+        assert "Traceback" not in result.output, result.output
+        assert "DATA_ERROR" not in result.output, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 1, payload
+        assert payload["datasets"][0]["symbol"] == "005930"
+        # 캐시 미스 → symbol fallback.
+        assert payload["datasets"][0]["name"] == "005930", payload
+        # 핵심 회귀 락: read-only 조회가 instruments 테이블을 생성하지 않음.
+        assert not _instruments_table_exists(str(db_file))
+
+    def test_writable_db_name_enrichment_regression(self, runner, tmp_path) -> None:
+        """(c) writable DB → 이름 enrichment 정상 (회귀 보존).
+
+        read_only 마이그레이션 후에도 일반(쓰기 가능) DB 의 종목명 보강이
+        그대로 동작해야 한다.
+        """
+        data_path = tmp_path / "data"
+        _seed_dataset(data_path)
+        db_file = tmp_path / "ante.db"
+        _seed_instruments_db(str(db_file), with_name=True)
+
+        result = _run_data_list(runner, data_path, db_file)
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["datasets"][0]["name"] == "삼성전자", payload
+
+    def test_malformed_db_reraises_as_data_error(self, runner, tmp_path) -> None:
+        """(d) malformed DB → ``DATA_ERROR`` 재전파 (no-such-table 만 graceful).
+
+        ``instruments`` 테이블은 존재하지만 DB 파일이 손상된 경우, ``_warm_cache``
+        의 ``SELECT`` 가 ``no such table`` 이 아닌 OperationalError 로 실패한다.
+        traceback 대신 public error code (``DATA_ERROR``) + exit 1 로 변환되어야
+        한다 (메시지 의존 graceful 가드의 좁힘을 lock).
+        """
+        data_path = tmp_path / "data"
+        _seed_dataset(data_path)
+        db_file = tmp_path / "ante.db"
+        # 유효한 instruments DB 를 만든 뒤 메인 파일 본문을 손상시킨다 (헤더는
+        # 유지해 connect probe 는 통과하고 SELECT 시점에 malformed 로 실패).
+        _seed_instruments_db(str(db_file), with_name=True)
+        # WAL sidecar 를 제거해 손상이 메인 파일 read 로 surface 하도록 한다.
+        for sidecar in (
+            Path(str(db_file) + "-wal"),
+            Path(str(db_file) + "-shm"),
+        ):
+            if sidecar.exists():
+                sidecar.unlink()
+        raw = bytearray(db_file.read_bytes())
+        # SQLite 헤더 (첫 100 바이트) 는 보존하고 그 이후 페이지 본문을 깨뜨린다.
+        for i in range(100, len(raw)):
+            raw[i] = 0xFF
+        db_file.write_bytes(bytes(raw))
+
+        result = _run_data_list(runner, data_path, db_file)
+
+        assert result.exit_code == 1, result.output
+        assert "Traceback" not in result.output, result.output
+        payload = json.loads(result.output)
+        assert payload.get("code") == "DATA_ERROR", payload

--- a/tests/unit/test_cli_data_list_readonly_fs.py
+++ b/tests/unit/test_cli_data_list_readonly_fs.py
@@ -1,0 +1,254 @@
+"""``ante data list`` 실제 read-only 파일시스템 회귀 테스트 (#1984).
+
+``data list`` 의 종목명 보강 경로가 read-only DB artifact 를
+``Database(read_only=False)`` + ``InstrumentService.initialize()`` (DDL) 로 열어
+실제 read-only fs (DB 파일 0444 / 부모 디렉터리 0555) 에서 WAL PRAGMA / DDL 이
+``attempt to write a readonly database`` 로 실패하던 버그를 lock 한다 (backtest
+history #1974 동형).
+
+#1976 교훈에 따라 **결정적 no-DDL 프록시 테스트로 대체하지 않는다**: 쓰기 가능
+temp DB 의 "테이블 미생성" 프록시는 실제 read-only mount 의 WAL PRAGMA writer
+연결 실패 경로를 가리지 못한다 (그 누락이 #1974 리오픈을 유발했다). 본 테스트는
+실제 권한 조건을 재현한다 (offline-factory.md §2 옵션 A):
+
+- 데이터셋 (ParquetStore) 은 별도 writable 디렉터리에 둔다 — ``data list`` 의
+  비-DB 경로는 read-only 대상이 아니다.
+- read-only 대상은 ``--db-path`` 아티팩트 (종목명 보강용 instruments DB) 다.
+  ``instruments`` 테이블 + ``005930`` 종목명을 미리 생성 후 close.
+- WAL 잔여 처리 두 케이스:
+  - (case A) ``PRAGMA wal_checkpoint(TRUNCATE)`` 로 ``-wal``/``-shm`` 을 비운 artifact.
+  - (case B) ``-wal``/``-shm`` 이 존재하는 상태.
+- ``os.chmod(db, 0o444)`` + ``os.chmod(dir, 0o555)`` 후
+  ``ante --format json data list --data-path <writable> --db-path <ro>/ante.db``
+  실행 → exit 0 + datasets 1 건 + ``name`` == "삼성전자" (이름 보존).
+
+권한 복구는 ``try/finally`` 로 보장한다. root/권한무시 환경에서는 chmod 가
+의미 없으므로 skip 한다.
+
+수정 전에는 ``attempt to write a readonly database`` 로 FAIL (DATA_ERROR).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import polars as pl
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.core.database import Database
+from ante.data.store import ParquetStore
+from ante.instrument.models import Instrument
+from ante.instrument.service import InstrumentService
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+# root (또는 권한무시 환경) 에서는 0o444/0o555 chmod 가 효력이 없어
+# read-only fs 시나리오를 재현할 수 없으므로 skip 한다.
+_requires_unprivileged = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only fs 시나리오는 root/권한무시 환경에서 재현되지 않음",
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _make_ohlcv_df(symbol: str) -> pl.DataFrame:
+    timestamps = pl.datetime_range(
+        datetime.fromisoformat("2026-03-02T09:00:00"),
+        datetime.fromisoformat("2026-03-02T09:04:00"),
+        interval="1m",
+        eager=True,
+        time_zone="UTC",
+    )
+    n = len(timestamps)
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": [symbol] * n,
+            "open": [50000.0 + i * 100 for i in range(n)],
+            "high": [50100.0 + i * 100 for i in range(n)],
+            "low": [49900.0 + i * 100 for i in range(n)],
+            "close": [50050.0 + i * 100 for i in range(n)],
+            "volume": [1000 + i * 10 for i in range(n)],
+            "source": ["test"] * n,
+        }
+    )
+
+
+def _seed_dataset(data_path: Path, symbol: str = "005930") -> None:
+    """writable ParquetStore 에 OHLCV dataset 1 건을 기록한다."""
+    store = ParquetStore(base_path=data_path)
+    store.write(symbol, "1m", _make_ohlcv_df(symbol))
+
+
+def _seed_instruments_db(path: str) -> None:
+    """``instruments`` 테이블 + ``005930``("삼성전자") 1 건을 가진 DB 를 생성한다.
+
+    실제 ``Database`` write 경로 (WAL) 로 생성하므로, close 시점에 ``-wal``/
+    ``-shm`` artifact 가 남을 수 있다 (case B). case A 는 호출자가 이후
+    ``PRAGMA wal_checkpoint(TRUNCATE)`` 로 비운다.
+    """
+
+    async def _create() -> None:
+        db = Database(path)
+        await db.connect()
+        try:
+            svc = InstrumentService(db)
+            await svc.initialize()
+            await svc.bulk_upsert(
+                [Instrument(symbol="005930", exchange="KRX", name="삼성전자")]
+            )
+        finally:
+            await db.close()
+
+    asyncio.run(_create())
+
+
+def _checkpoint_truncate(path: str) -> None:
+    """``PRAGMA wal_checkpoint(TRUNCATE)`` 로 ``-wal``/``-shm`` 을 비운다 (case A)."""
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _run_list_under_readonly(runner, data_path: Path, db_dir: Path, db_file: Path):
+    """DB 디렉터리/파일을 read-only 로 만든 뒤 ``data list`` 를 실행한다.
+
+    ``--data-path`` (ParquetStore) 는 writable 로 둔다 — read-only 대상은
+    종목명 보강용 ``--db-path`` 아티팩트뿐이다. 권한 복구는 ``try/finally`` 로
+    보장한다.
+    """
+    sidecars = [
+        db_dir / f"{db_file.name}-wal",
+        db_dir / f"{db_file.name}-shm",
+    ]
+    # 파일 → 디렉터리 순으로 read-only. 디렉터리가 0o555 이면 그 안의 파일
+    # 권한 변경이 불가하므로 파일을 먼저 chmod 한다.
+    os.chmod(db_file, 0o444)
+    for s in sidecars:
+        if s.exists():
+            os.chmod(s, 0o444)
+    os.chmod(db_dir, 0o555)
+    try:
+        return runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "data",
+                "list",
+                "--data-path",
+                str(data_path),
+                "--db-path",
+                str(db_file),
+            ],
+        )
+    finally:
+        os.chmod(db_dir, 0o755)
+        os.chmod(db_file, 0o644)
+        for s in sidecars:
+            if s.exists():
+                os.chmod(s, 0o644)
+
+
+@_requires_unprivileged
+class TestDataListReadOnlyFilesystem:
+    def test_list_on_readonly_fs_checkpointed_wal(self, runner, tmp_path) -> None:
+        """case A: ``-wal``/``-shm`` 을 truncate 한 read-only instruments 조회.
+
+        실제 권한 (DB 파일 0o444 / 디렉터리 0o555) 에서 exit 0 + datasets 1 건
+        + ``name`` == "삼성전자" (이름 보존). 수정 전: ``attempt to write a
+        readonly database`` 로 FAIL (DATA_ERROR).
+        """
+        data_path = tmp_path / "data"
+        _seed_dataset(data_path)
+
+        db_dir = tmp_path / "ro_checkpointed"
+        db_dir.mkdir()
+        db_file = db_dir / "ante.db"
+        _seed_instruments_db(str(db_file))
+        _checkpoint_truncate(str(db_file))
+
+        result = _run_list_under_readonly(runner, data_path, db_dir, db_file)
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 1, payload
+        assert payload["datasets"][0]["symbol"] == "005930"
+        # WAL PRAGMA 실패 없이 read-only DB 에서 이름 보강 보존.
+        assert payload["datasets"][0]["name"] == "삼성전자", payload
+
+    def test_list_on_readonly_fs_with_wal_sidecars(self, runner, tmp_path) -> None:
+        """case B: ``-wal`` 잔여 + ``-shm`` 부재 → immutable fallback 경로.
+
+        instruments 데이터를 메인 DB 로 checkpoint(TRUNCATE) 한 뒤, crash 잔여를
+        모사한 ``-wal`` 헤더 파일을 만들고 ``-shm`` 은 두지 않는다. 실제 read-only
+        fs (DB 파일 0o444 / 디렉터리 0o555) 에서:
+          - ``mode=ro`` 는 ``-shm`` 을 생성할 수 없어 ``unable to open database
+            file`` 로 실패한다.
+          - ``immutable=1`` fallback 이 메인 DB (모든 커밋 데이터 보유) 를 일관
+            read 한다.
+        → exit 0 + datasets 1 건 + ``name`` == "삼성전자". 수정 전:
+        ``attempt to write a readonly database`` 로 FAIL.
+        """
+        data_path = tmp_path / "data"
+        _seed_dataset(data_path)
+
+        db_dir = tmp_path / "ro_with_wal"
+        db_dir.mkdir()
+        db_file = db_dir / "ante.db"
+        _seed_instruments_db(str(db_file))
+        # 데이터를 메인 DB 로 합치고 -wal/-shm 을 비운다.
+        _checkpoint_truncate(str(db_file))
+        # crash 잔여를 모사: -shm 없이 -wal 헤더만 존재 → mode=ro 가 실패하고
+        # immutable fallback 이 트리거된다.
+        wal = db_dir / "ante.db-wal"
+        shm = db_dir / "ante.db-shm"
+        if shm.exists():
+            shm.unlink()
+        wal.write_bytes(b"\x37\x7f\x06\x82" + b"\x00" * 28)
+
+        result = _run_list_under_readonly(runner, data_path, db_dir, db_file)
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 1, payload
+        assert payload["datasets"][0]["symbol"] == "005930"
+        assert payload["datasets"][0]["name"] == "삼성전자", payload

--- a/tests/unit/test_data_success_output_drift.py
+++ b/tests/unit/test_data_success_output_drift.py
@@ -236,10 +236,10 @@ def test_data_list_out_of_range_page_count_preserves_total(tmp_path) -> None:
 def test_data_list_non_empty_envelope_matches_raw_legacy(tmp_path) -> None:
     """``data list`` non-empty: ``{datasets: [...], count: N}`` 평면.
 
-    data.py:95: ``fmt.output({"datasets": datasets, "count": result["total"]})``
-    JSON 분기. ``_enrich`` 후 InstrumentService 가 name 을 추가하지만 본
-    fixture 는 InstrumentService 까지 mock 하기 어려우므로 ``get_name`` 만
-    patch 한다.
+    ``fmt.output({"datasets": datasets, "count": result["total"]})`` JSON 분기.
+    ``_enrich`` 후 InstrumentService 가 name 을 추가하지만 본 fixture 는
+    InstrumentService 까지 mock 하기 어려우므로 ``load_readonly`` (read-only
+    캐시 워밍 — #1984) 와 ``get_name`` 을 patch 한다.
     """
     items = [
         {
@@ -259,7 +259,7 @@ def test_data_list_non_empty_envelope_matches_raw_legacy(tmp_path) -> None:
             return_value={"items": items, "total": 1},
         ),
         patch(
-            "ante.instrument.service.InstrumentService.initialize",
+            "ante.instrument.service.InstrumentService.load_readonly",
             new=AsyncMock(),
         ),
         patch(


### PR DESCRIPTION
Closes #1984

## Summary
- `data list`가 read-only DB artifact(--db-path)를 받으면 종목명 보강(`_enrich`)에서 `Database(read_only=False)`+`svc.initialize()`(DDL)로 WAL/DDL 실패 + JSON traceback 노출하던 것을, **read-only 조회 경로로 확대**(backtest history #1974 미러).
- InstrumentService.`load_readonly()` 추가: `SELECT * FROM instruments` 캐시 워밍(DDL 없음), 'no such table'→빈 캐시 graceful(symbol fallback), 다른 OperationalError 재전파. data.py `_enrich`가 `open_cli_db(read_only=True)`+`load_readonly()`로 → **read-only DB에서도 이름 보존**.
- JSON DB-error → public DATA_ERROR envelope(traceback 미노출). db_context §4 + factory_drift allowlist(data.py 직접 Database 콜사이트 제거).

## Test Plan
- **실제 0444 DB + 0555 parent dir**(checkpointed WAL + immutable fallback): exit 0 + datasets + 이름 보존(삼성전자). instruments 부재→symbol fallback graceful, writable 회귀, malformed→DATA_ERROR(no-such-table만 graceful)
- 전체 `pytest tests/unit/`: 6900 passed, 2 skipped, 0 failed(factory_drift 포함). ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (6ee253c4)

## 비고
report list/view read_only=#2114(별개 module sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)