### PR TITLE
fix(cli): #2114 report list/view를 read-only DB artifact 조회로 확대 (offline-factory read_only sweep)

### DIFF
--- a/docs/specs/contracts/README.md
+++ b/docs/specs/contracts/README.md
@@ -139,7 +139,8 @@ error-taxonomy.md 자체를 갱신한다.
   실패 시 `immutable=1` fallback)을 열어 실제 read-only 파일시스템에서도 schema
   /WAL 쓰기 없이 read한다. `read_only=False` 경로는 기존 baseline과 byte-for-byte
   동일(모든 write 소비자 무영향). 옵션 A의 `read_only=True`는 기존 스키마를
-  부트스트랩 없이 읽는 명령(현재 `backtest history`)에만 적용한다.
+  부트스트랩 없이 읽는 명령(현재 `backtest history`(#1974), `data list`의
+  종목명 보강(#1984), `report list`/`report view`(#2114))에만 적용한다.
 - ctx 정책: 신규 factory 내부에서 `get_db_path(ctx)` 명시 전달이 권장. ctx 없는
   암시 fallback은 deprecated.
 - read-only 예외: `AccountService`/`MemberService`/`ApprovalService`/

--- a/docs/specs/contracts/offline-factory.md
+++ b/docs/specs/contracts/offline-factory.md
@@ -158,7 +158,8 @@ amend는 §2.3의 보류를 해제하고 옵션 A를 normative로 채택해 이 
 #### 적용 범위
 
 옵션 A의 `read_only=True`는 **기존 스키마를 부트스트랩 없이 읽을 수 있는
-명령(현재 `backtest history`)에만** 적용한다. §4 예외 service는 본 모드의
+명령(현재 `backtest history`(#1974), `data list`의 종목명 보강(#1984),
+`report list`/`report view`(#2114))에만** 적용한다. §4 예외 service는 본 모드의
 대상이 아니다(§4.1 명확화 참조).
 
 **CLI 인증 경로와의 경계 (중요, #1974 R2 [P2] 명확화)**: 옵션 A의
@@ -273,10 +274,11 @@ service는 read-only 명령에서도 `initialize()`를 호출한다 (즉 옵션 
 가능하므로 — fresh/non-bootstrapped DB에서 schema를 쓰기로 생성해야 하므로 —
 **schema 분리(§4.3) 전까지 `read_only=True`의 대상이 아니다.** 옵션 A의
 `read_only=True`(Database read-only 연결 모드)는 **기존 스키마를 부트스트랩 없이
-읽을 수 있는 명령(현재 `backtest history`)에만** 적용한다. §4 예외 service를
-read-only 연결 모드로 강제하면 `initialize()`의 schema DDL이 read-only 연결에서
-실패하므로, 이들은 본 amend의 적용 대상에서 명시적으로 제외한다. 이들의 read-only
-지원은 §4.3 schema 분리 결정을 선행 조건으로 하는 별도 follow-up이다.
+읽을 수 있는 명령(현재 `backtest history`(#1974), `data list`의 종목명
+보강(#1984), `report list`/`report view`(#2114))에만** 적용한다. §4 예외
+service를 read-only 연결 모드로 강제하면 `initialize()`의 schema DDL이 read-only
+연결에서 실패하므로, 이들은 본 amend의 적용 대상에서 명시적으로 제외한다. 이들의
+read-only 지원은 §4.3 schema 분리 결정을 선행 조건으로 하는 별도 follow-up이다.
 
 ### 4.2 예외 목록 (baseline 2026-05-27 KST)
 
@@ -399,9 +401,12 @@ account/member/approval을 같은 1차 PR(#1856)에 함께 다뤘다" — 가
 - CLI command migration enumeration — 동일.
 - DI framework 도입.
 - IPC routing / IPC fallback 통합.
-- 옵션 A `read_only=True`를 `backtest history` 외 명령(report/data/§4 예외
-  service 등)으로 확대 — 별도 follow-up. §4 예외 service는 schema 분리(§4.3)를
-  선행 조건으로 한다.
+- 옵션 A `read_only=True`를 §4 예외 service
+  (`AccountService`/`MemberService`/`ApprovalService`/`AuditLogger`/
+  `DynamicConfigService`)로 확대 — 별도 follow-up. §4 예외 service는 schema
+  분리(§4.3)를 선행 조건으로 한다. (`backtest history`(#1974) /
+  `data list`(#1984) / `report list`·`report view`(#2114)는 이미 적용 — §적용
+  범위 참조.)
 - live 동시쓰기 DB의 read-only 일관성 — `immutable=1`은 read-only artifact
   전용이며, checkpoint되지 않은 live WAL frame은 대상이 아니다(§2.1 (b)).
 - WAL→다른 journal 마이그레이션, DB immutable 정책 전면 재설계.

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import sqlite3
 
 import click
 from pydantic import ValidationError
@@ -221,22 +222,38 @@ def report_list(ctx: click.Context, status: str | None, db_path: str | None) -> 
         raise SystemExit(1)
 
     async def _list() -> list[dict]:
-        from ante.core.database import Database
-
-        # ``db.connect()`` 이후의 모든 라이프사이클(``ReportStore.initialize``,
-        # ``list_reports`` 호출 포함)을 ``except BaseException`` 블록으로 감싸
-        # 실패 시 ``db.close()``를 보장한다. ``initialize``/``list_reports`` 가
-        # raise되면 aiosqlite 연결이 leak되어 asyncio 종료 시 worker thread가
-        # 정리되며 stderr에 traceback이 노출되는 회귀를 차단한다
-        # (``_create_account_service`` cleanup 패턴 1:1 미러).
-        db = Database(resolved_db_path)
-        try:
-            await db.connect()
+        # ``report list`` 는 offline read 명령이므로 read-only DB 아티팩트
+        # (0444 파일 / 0555 부모 디렉터리 — 실제 read-only mount) 도 열 수 있어야
+        # 한다. 기존 ``Database(resolved_db_path)`` (writer + WAL PRAGMA) +
+        # ``ReportStore.initialize()`` (CREATE TABLE reports DDL) 는 read-only fs
+        # 에서 ``attempt to write a readonly database`` 로 실패했다. backtest
+        # history (#1974) / data list (#1984) 동형으로 ``open_cli_db(
+        # read_only=True)`` (mode=ro + immutable fallback, WAL/DDL 미발화) 를
+        # 사용하고 ``initialize()`` 를 호출하지 않는다.
+        #
+        # ``ReportStore.list_reports`` 는 캐시 없이 rows 를 직접 SELECT 하므로
+        # initialize 의 schema 부트스트랩이 read 에 필요하지 않다(#1984
+        # InstrumentService 캐시 워밍과 달리 캐시 워밍도 불요). 단, ``reports``
+        # 테이블이 부재한(아직 한 번도 부트스트랩되지 않은) DB 에서는 SELECT 가
+        # ``sqlite3.OperationalError: no such table: reports`` 로 실패하므로,
+        # 그 메시지에 한해 빈 목록으로 graceful 처리한다. 다른
+        # ``OperationalError`` (locked / disk I/O / malformed 등) 는 삼키지 않고
+        # 재전파해 호출 경계에서 ``REPORT_ERROR`` 로 변환되도록 한다.
+        async with open_cli_db(
+            ctx, read_only=True, db_path_override=resolved_db_path
+        ) as db:
             store = ReportStore(db=db)
-            await store.initialize()
             report_status = ReportStatus(status) if status else None
-            reports = await store.list_reports(status=report_status)
-            rows = [
+            try:
+                reports = await store.list_reports(status=report_status)
+            except sqlite3.OperationalError as exc:
+                if "no such table" not in str(exc).lower():
+                    raise
+                logger.debug(
+                    "reports 테이블 부재 — 빈 목록으로 graceful 처리", exc_info=True
+                )
+                return []
+            return [
                 {
                     "report_id": r.report_id,
                     "strategy": r.strategy_name,
@@ -245,18 +262,6 @@ def report_list(ctx: click.Context, status: str | None, db_path: str | None) -> 
                 }
                 for r in reports
             ]
-        except BaseException:
-            try:
-                await db.close()
-            except Exception:
-                # close 실패는 원본 예외를 가리지 않고 무시한다 — 호출자가
-                # 안정적인 ``code`` 로 종료할 수 있어야 한다.
-                logger.debug(
-                    "db.close() after list failure raised — ignored", exc_info=True
-                )
-            raise
-        await db.close()
-        return rows
 
     try:
         rows = asyncio.run(_list())
@@ -403,14 +408,32 @@ def report_view(ctx: click.Context, report_id: str, db_path: str | None) -> None
     resolved_db_path = db_path or get_db_path(ctx)
 
     async def _view() -> dict | None:
-        from ante.core.database import Database
-
-        db = Database(resolved_db_path)
-        await db.connect()
-        try:
+        # ``report view`` 도 offline read 명령이므로 read-only DB 아티팩트를
+        # 열 수 있어야 한다. ``report list`` 와 동형으로 ``open_cli_db(
+        # read_only=True)`` (mode=ro + immutable fallback, WAL/DDL 미발화) +
+        # ``initialize()`` 미호출. ``ReportStore.get`` 도 캐시 없이 단일 row 를
+        # SELECT 하므로 schema 부트스트랩이 read 에 필요하지 않다(backtest
+        # history #1974 / data list #1984 동형).
+        #
+        # ``reports`` 테이블이 부재한 DB 에서는 ``get`` 의 SELECT 가
+        # ``sqlite3.OperationalError: no such table: reports`` 로 실패하므로 그
+        # 메시지에 한해 ``None`` (미발견) 으로 graceful 처리한다 → 호출 경계에서
+        # ``REPORT_NOT_FOUND`` envelope 로 종료된다. 다른 ``OperationalError`` 는
+        # 재전파해 ``REPORT_ERROR`` 로 변환되도록 한다(삼키지 않음).
+        async with open_cli_db(
+            ctx, read_only=True, db_path_override=resolved_db_path
+        ) as db:
             store = ReportStore(db)
-            await store.initialize()
-            r = await store.get(report_id)
+            try:
+                r = await store.get(report_id)
+            except sqlite3.OperationalError as exc:
+                if "no such table" not in str(exc).lower():
+                    raise
+                logger.debug(
+                    "reports 테이블 부재 — 미발견(None)으로 graceful 처리",
+                    exc_info=True,
+                )
+                return None
             if not r:
                 return None
             return {
@@ -431,8 +454,6 @@ def report_view(ctx: click.Context, report_id: str, db_path: str | None) -> None
                 "risks": r.risks,
                 "recommendations": r.recommendations,
             }
-        finally:
-            await db.close()
 
     # DB 연결/조회 실패 시 traceback 노출 대신 구조화된 에러 envelope 로
     # 변환한다 (``report_list`` L255-260 와 동형). ``_view()`` 내부 try/finally

--- a/src/ante/cli/db_context.py
+++ b/src/ante/cli/db_context.py
@@ -21,8 +21,8 @@ Codex Plan Review v2 lock:
    ``read_only=False``이면 기존 ``Database(db_path)`` 호출을 byte-for-byte
    유지한다(kwarg 미전달 — #1856/#1857 patch 호환 및 모든 write 소비자 무영향
    invariant). read-only 모드는 기존 스키마를 부트스트랩 없이 읽는 offline read
-   명령(현재 ``backtest history``, ``data list`` 의 종목명 보강 — #1984)에만
-   적용된다 — §4 예외 service
+   명령(현재 ``backtest history`` — #1974, ``data list`` 의 종목명 보강 — #1984,
+   ``report list``/``report view`` — #2114)에만 적용된다 — §4 예외 service
    (`AccountService`/`MemberService`/`ApprovalService`/`AuditLogger`/
    `DynamicConfigService`)는 ``initialize()``가 schema DDL을 발화해야 read가
    가능하므로 schema 분리 전까지 ``read_only=True`` 대상이 아니다.
@@ -68,9 +68,9 @@ async def open_cli_db(
             ``False`` (기본) 이면 기존 ``Database(db_path)`` 호출을
             byte-for-byte 유지한다 (kwarg 미전달, 모든 write 소비자 무영향).
             read-only 모드는 기존 스키마를 부트스트랩 없이 읽는 offline read
-            명령(현재 ``backtest history``, ``data list`` 의 종목명 보강 —
-            #1984)에만 사용한다 — §4 예외 service 는 schema 분리 전까지
-            ``read_only=True`` 대상이 아니다.
+            명령(현재 ``backtest history`` — #1974, ``data list`` 의 종목명 보강
+            — #1984, ``report list``/``report view`` — #2114)에만 사용한다 — §4
+            예외 service 는 schema 분리 전까지 ``read_only=True`` 대상이 아니다.
         db_path_override: optional 명시 DB 경로. ``None`` 이면
             ``get_db_path(ctx)`` 로 해석한다. ``approval list/info/review/
             audit-types`` 등 ``--db-path`` Click option 을 지원하는 명령은

--- a/src/ante/core/database.py
+++ b/src/ante/core/database.py
@@ -53,7 +53,9 @@ class Database:
     설정한다(기존 baseline). ``read_only=True``는 reader 단일 연결만 SQLite
     ``file:...?mode=ro`` URI 로 열어 schema/WAL 쓰기 없이 기존 DB 를 읽는다
     (offline-factory.md §2 옵션 A). read-only 모드는 기존 스키마를 부트스트랩
-    없이 읽는 offline read 명령(현재 ``backtest history``)에만 적용된다.
+    없이 읽는 offline read 명령(현재 ``backtest history`` — #1974, ``data list``
+    의 종목명 보강 — #1984, ``report list``/``report view`` — #2114)에만
+    적용된다.
     """
 
     def __init__(self, db_path: str, *, read_only: bool = False) -> None:

--- a/tests/unit/contracts/factory_drift_allowlist.yaml
+++ b/tests/unit/contracts/factory_drift_allowlist.yaml
@@ -37,18 +37,14 @@ direct_database_construction:
     line: 48
     reason: "signal connect — long_running stream channel (external process lifecycle)"
 
-  # report domain — offline execution 이지만 #1857 epic 의 broker/signal
-  # 제외 scope 결정에 따라 본 factory migration 사이클에서 별도 spec 정렬 PR
-  # 로 이연된 잔여. 후속 이슈에서 `open_cli_db` 로 마이그레이션할 후보.
+  # report domain — `report list` / `report view` 는 `offline` read 명령이며
+  # #2114 에서 `open_cli_db` (read_only) 로 마이그레이션되어 직접 Database 생성
+  # callsite 가 사라졌다 — 두 엔트리 제거 (backtest history #1974 / data list
+  # #1984 동형). `report submit` 은 write 명령(INSERT)이라 read-only 대상이
+  # 아니며 직접 Database 생성을 유지한다 — 단일 엔트리 잔존.
   - path: src/ante/cli/commands/report.py
-    line: 130
-    reason: "report submit — offline (deferred migration, post-#1818 follow-up)"
-  - path: src/ante/cli/commands/report.py
-    line: 232
-    reason: "report list — offline (deferred migration, post-#1818 follow-up)"
-  - path: src/ante/cli/commands/report.py
-    line: 408
-    reason: "report view — offline (deferred migration, post-#1818 follow-up)"
+    line: 131
+    reason: "report submit — offline write (INSERT), read-only 비대상; deferred migration"
 
   # backtest domain — `backtest run` 은 spec 상 `long_running` 분류 (progress
   # bar 와 함께 장시간 작업) 이라 직접 Database 생성을 유지한다.

--- a/tests/unit/test_cli_report_list_filters.py
+++ b/tests/unit/test_cli_report_list_filters.py
@@ -112,7 +112,13 @@ class TestReportListValidStatus:
     """`report list` valid `--status`는 회귀 없이 정상 동작 (#1462)."""
 
     def test_report_list_valid_status_still_works(self, runner, tmp_path) -> None:
-        """valid `--status`는 preflight 통과 후 ReportStore.list_reports 호출."""
+        """valid `--status`는 preflight 통과 후 ReportStore.list_reports 호출.
+
+        #2114: `report list` 는 read-only DB artifact 조회 경로로 확대되어
+        `open_cli_db(read_only=True)` 를 거친다 → `Database(db_path,
+        read_only=True)` 로 생성되고 `ReportStore.initialize()` (DDL) 는
+        호출되지 않는다 (backtest history #1974 / data list #1984 동형).
+        """
         db_cls, store_cls, store = _mock_store_layer([])
         db_path = str(tmp_path / "report.db")
         with (
@@ -132,7 +138,9 @@ class TestReportListValidStatus:
                 ],
             )
         assert result.exit_code == 0, result.output
-        db_cls.assert_called_once_with(db_path)
+        db_cls.assert_called_once_with(db_path, read_only=True)
+        # read-only 조회는 schema DDL 부트스트랩(initialize)을 발화하지 않는다.
+        store.initialize.assert_not_called()
         store.list_reports.assert_awaited_once_with(
             status=ReportStatus.SUBMITTED,
         )

--- a/tests/unit/test_cli_report_readonly_fs.py
+++ b/tests/unit/test_cli_report_readonly_fs.py
@@ -1,0 +1,278 @@
+"""``ante report list`` / ``report view`` 실제 read-only 파일시스템 회귀 (#2114).
+
+``report list`` / ``report view`` 가 read-only DB artifact 를
+``Database(read_only=False)`` + ``ReportStore.initialize()`` (CREATE TABLE
+reports DDL) 로 열어, 실제 read-only fs (DB 파일 0444 / 부모 디렉터리 0555) 에서
+WAL PRAGMA / DDL 이 ``attempt to write a readonly database`` 로 실패하던 버그를
+lock 한다 (backtest history #1974 / data list #1984 동형).
+
+#1976 교훈에 따라 **결정적 no-DDL 프록시 테스트로 대체하지 않는다**: 쓰기 가능
+temp DB 의 "테이블 미생성" 프록시는 실제 read-only mount 의 WAL PRAGMA writer
+연결 실패 경로를 가리지 못한다 (그 누락이 #1974 리오픈을 유발했다). 본 테스트는
+실제 권한 조건을 재현한다 (offline-factory.md §적용 범위, 옵션 A):
+
+- ``reports`` 테이블 + report 1 건을 ``ReportStore`` 의 실제 write 경로 (WAL)
+  로 미리 생성 후 close. (case A) ``PRAGMA wal_checkpoint(TRUNCATE)`` 로 ``-wal``/
+  ``-shm`` 을 비운 artifact. (case B) ``-wal`` 잔여 + ``-shm`` 부재 → immutable
+  fallback 경로.
+- auth 멤버 DB 는 ``--db-path`` 아티팩트와 다른 트리이며, 본 테스트는 auth 를
+  mock 으로 우회하므로 read-only 대상은 ``--db-path`` 아티팩트뿐이다.
+- ``os.chmod(db, 0o444)`` + ``os.chmod(dir, 0o555)`` 후
+  ``ante --format json report list --db-path <ro>/ante.db`` /
+  ``report view <id> --db-path <ro>/ante.db`` 실행 → exit 0 + 결과 보존.
+
+권한 복구는 ``try/finally`` 로 보장한다. root/권한무시 환경에서는 chmod 가
+의미 없으므로 skip 한다.
+
+수정 전에는 ``attempt to write a readonly database`` 로 FAIL (REPORT_ERROR).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.core.database import Database
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.report import ReportStore
+from ante.report.models import ReportStatus, StrategyReport
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+# root (또는 권한무시 환경) 에서는 0o444/0o555 chmod 가 효력이 없어
+# read-only fs 시나리오를 재현할 수 없으므로 skip 한다.
+_requires_unprivileged = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only fs 시나리오는 root/권한무시 환경에서 재현되지 않음",
+)
+
+_REPORT_ID = "rpt-ro-1"
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _make_report() -> StrategyReport:
+    return StrategyReport(
+        report_id=_REPORT_ID,
+        strategy_name="momentum_breakout",
+        strategy_version="1.0.0",
+        strategy_path="strategies/momentum_breakout.py",
+        status=ReportStatus.SUBMITTED,
+        submitted_at=datetime(2026, 3, 2, tzinfo=UTC),
+        submitted_by="agent",
+        backtest_period="2024-01 ~ 2026-03",
+        total_return_pct=15.3,
+        total_trades=42,
+        sharpe_ratio=1.2,
+        max_drawdown_pct=-8.5,
+        win_rate=58.0,
+        summary="20일 이동평균 돌파",
+        rationale="모멘텀",
+        risks="횡보장 손절",
+    )
+
+
+def _seed_reports_db(path: str) -> None:
+    """``reports`` 테이블 + report 1 건을 가진 DB 를 실제 write 경로로 생성한다.
+
+    ``Database`` write 경로 (WAL) 로 생성하므로 close 시점에 ``-wal``/``-shm``
+    artifact 가 남을 수 있다 (case B). case A 는 호출자가 이후
+    ``PRAGMA wal_checkpoint(TRUNCATE)`` 로 비운다.
+    """
+
+    async def _create() -> None:
+        db = Database(path)
+        await db.connect()
+        try:
+            store = ReportStore(db)
+            await store.initialize()
+            await store.submit(_make_report())
+        finally:
+            await db.close()
+
+    asyncio.run(_create())
+
+
+def _checkpoint_truncate(path: str) -> None:
+    """``PRAGMA wal_checkpoint(TRUNCATE)`` 로 ``-wal``/``-shm`` 을 비운다 (case A)."""
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _run_under_readonly(runner, db_dir: Path, db_file: Path, args: list[str]):
+    """DB 디렉터리/파일을 read-only 로 만든 뒤 ``ante report ...`` 를 실행한다.
+
+    권한 복구는 ``try/finally`` 로 보장한다.
+    """
+    sidecars = [
+        db_dir / f"{db_file.name}-wal",
+        db_dir / f"{db_file.name}-shm",
+    ]
+    # 파일 → 디렉터리 순으로 read-only. 디렉터리가 0o555 이면 그 안의 파일
+    # 권한 변경이 불가하므로 파일을 먼저 chmod 한다.
+    os.chmod(db_file, 0o444)
+    for s in sidecars:
+        if s.exists():
+            os.chmod(s, 0o444)
+    os.chmod(db_dir, 0o555)
+    try:
+        return runner.invoke(cli, args)
+    finally:
+        os.chmod(db_dir, 0o755)
+        os.chmod(db_file, 0o644)
+        for s in sidecars:
+            if s.exists():
+                os.chmod(s, 0o644)
+
+
+@_requires_unprivileged
+class TestReportListReadOnlyFilesystem:
+    """``report list`` 실제 read-only fs 조회 (case A / case B)."""
+
+    def test_list_on_readonly_fs_checkpointed_wal(self, runner, tmp_path) -> None:
+        """case A: ``-wal``/``-shm`` truncate 후 read-only report 목록 조회."""
+        db_dir = tmp_path / "ro_checkpointed"
+        db_dir.mkdir()
+        db_file = db_dir / "ante.db"
+        _seed_reports_db(str(db_file))
+        _checkpoint_truncate(str(db_file))
+
+        result = _run_under_readonly(
+            runner,
+            db_dir,
+            db_file,
+            ["--format", "json", "report", "list", "--db-path", str(db_file)],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        rows = payload["data"] if isinstance(payload, dict) else payload
+        assert any(r["report_id"] == _REPORT_ID for r in rows), payload
+
+    def test_list_on_readonly_fs_with_wal_sidecars(self, runner, tmp_path) -> None:
+        """case B: ``-wal`` 잔여 + ``-shm`` 부재 → immutable fallback 경로."""
+        db_dir = tmp_path / "ro_with_wal"
+        db_dir.mkdir()
+        db_file = db_dir / "ante.db"
+        _seed_reports_db(str(db_file))
+        _checkpoint_truncate(str(db_file))
+        wal = db_dir / "ante.db-wal"
+        shm = db_dir / "ante.db-shm"
+        if shm.exists():
+            shm.unlink()
+        wal.write_bytes(b"\x37\x7f\x06\x82" + b"\x00" * 28)
+
+        result = _run_under_readonly(
+            runner,
+            db_dir,
+            db_file,
+            ["--format", "json", "report", "list", "--db-path", str(db_file)],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        rows = payload["data"] if isinstance(payload, dict) else payload
+        assert any(r["report_id"] == _REPORT_ID for r in rows), payload
+
+
+@_requires_unprivileged
+class TestReportViewReadOnlyFilesystem:
+    """``report view`` 실제 read-only fs 조회 (case A / case B)."""
+
+    def test_view_on_readonly_fs_checkpointed_wal(self, runner, tmp_path) -> None:
+        """case A: ``-wal``/``-shm`` truncate 후 read-only report 상세 조회."""
+        db_dir = tmp_path / "ro_checkpointed"
+        db_dir.mkdir()
+        db_file = db_dir / "ante.db"
+        _seed_reports_db(str(db_file))
+        _checkpoint_truncate(str(db_file))
+
+        result = _run_under_readonly(
+            runner,
+            db_dir,
+            db_file,
+            [
+                "--format",
+                "json",
+                "report",
+                "view",
+                _REPORT_ID,
+                "--db-path",
+                str(db_file),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["report_id"] == _REPORT_ID, payload
+        assert payload["total_trades"] == 42, payload
+
+    def test_view_on_readonly_fs_with_wal_sidecars(self, runner, tmp_path) -> None:
+        """case B: ``-wal`` 잔여 + ``-shm`` 부재 → immutable fallback 경로."""
+        db_dir = tmp_path / "ro_with_wal"
+        db_dir.mkdir()
+        db_file = db_dir / "ante.db"
+        _seed_reports_db(str(db_file))
+        _checkpoint_truncate(str(db_file))
+        wal = db_dir / "ante.db-wal"
+        shm = db_dir / "ante.db-shm"
+        if shm.exists():
+            shm.unlink()
+        wal.write_bytes(b"\x37\x7f\x06\x82" + b"\x00" * 28)
+
+        result = _run_under_readonly(
+            runner,
+            db_dir,
+            db_file,
+            [
+                "--format",
+                "json",
+                "report",
+                "view",
+                _REPORT_ID,
+                "--db-path",
+                str(db_file),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["report_id"] == _REPORT_ID, payload

--- a/tests/unit/test_cli_report_readonly_graceful.py
+++ b/tests/unit/test_cli_report_readonly_graceful.py
@@ -1,0 +1,241 @@
+"""``report list`` / ``report view`` table-absence graceful + 재전파 (#2114).
+
+#2114 에서 ``report list`` / ``report view`` 를 read-only DB artifact 조회
+경로(``open_cli_db(read_only=True)`` + ``initialize()`` 미호출)로 확대하면서,
+``reports`` 테이블이 아직 부트스트랩되지 않은 DB 에서는 SELECT 가
+``sqlite3.OperationalError: no such table: reports`` 로 실패한다. 본 모듈은:
+
+- G1: ``reports`` 테이블 부재 → ``report list`` 는 빈 목록, ``report view`` 는
+  ``REPORT_NOT_FOUND`` 으로 graceful 처리되고 traceback 이 노출되지 않는다.
+- G2: ``no such table`` 이외의 ``OperationalError`` (locked / disk I/O /
+  malformed 등) 는 **삼키지 않고 재전파**되어 호출 경계에서 ``REPORT_ERROR``
+  envelope (exit 1) 로 변환된다. 메시지 한정 분기(``no such table`` 만 graceful)
+  를 lock 한다.
+- G3: writable DB 회귀 — 정상 reports 테이블이 있는 쓰기 가능 DB 에서 ``list`` /
+  ``view`` 가 그대로 동작한다 (read_only 전환이 정상 경로를 깨지 않음).
+
+실제 read-only 파일시스템 (0444/0555) 회귀는 ``test_cli_report_readonly_fs.py``
+가 별도로 lock 한다 (#1976 교훈: 결정적 프록시는 실제 WAL PRAGMA 실패 경로를
+대체하지 못함). 본 모듈은 table-absence / 재전파 분기를 deterministic 하게
+보강한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.core.database import Database
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.report import ReportStore
+from ante.report.models import ReportStatus, StrategyReport
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status=MemberStatus.ACTIVE,
+    scopes=[],
+)
+
+_REPORT_ID = "rpt-graceful-1"
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": _MOCK_MASTER}),
+    ):
+        yield
+
+
+def _invoke(args: list[str]):
+    runner = CliRunner()
+    return runner.invoke(cli, args, env={"ANTE_MEMBER_TOKEN": ""})
+
+
+def _load_json(output: str):
+    text = output.lstrip()
+    decoder = json.JSONDecoder()
+    obj, _ = decoder.raw_decode(text)
+    return obj
+
+
+def _make_report() -> StrategyReport:
+    return StrategyReport(
+        report_id=_REPORT_ID,
+        strategy_name="strat-G",
+        strategy_version="1.0.0",
+        strategy_path="strategies/strat_g.py",
+        status=ReportStatus.SUBMITTED,
+        submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        submitted_by="agent",
+        backtest_period="2024-01 ~ 2026-03",
+        total_return_pct=5.0,
+        total_trades=7,
+        summary="s",
+        rationale="r",
+    )
+
+
+def _empty_writable_db(path: Path) -> str:
+    """``reports`` 테이블이 부재한 빈(writable) DB 파일을 만든다.
+
+    다른 무관한 테이블(``misc``)만 생성해 파일이 valid SQLite DB 이되 ``reports``
+    테이블은 없도록 한다 → ``SELECT ... FROM reports`` 가
+    ``no such table: reports`` 로 실패하는 조건.
+    """
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE misc (x INTEGER)")
+        conn.commit()
+    finally:
+        conn.close()
+    return str(path)
+
+
+def _writable_seeded_db(path: Path) -> str:
+    """``reports`` 테이블 + report 1 건을 가진 writable DB 를 만든다."""
+
+    async def _create() -> None:
+        db = Database(str(path))
+        await db.connect()
+        try:
+            store = ReportStore(db)
+            await store.initialize()
+            await store.submit(_make_report())
+        finally:
+            await db.close()
+
+    asyncio.run(_create())
+    return str(path)
+
+
+# ── G1: 테이블 부재 graceful ──────────────────────────────────────────────
+
+
+class TestReportTableAbsenceGraceful:
+    def test_list_table_absent_returns_empty(self, tmp_path) -> None:
+        """``reports`` 부재 → ``report list`` 빈 목록 + exit 0 + no traceback."""
+        db_path = _empty_writable_db(tmp_path / "no_reports.db")
+        result = _invoke(["--format", "json", "report", "list", "--db-path", db_path])
+        assert result.exit_code == 0, result.output
+        assert "Traceback" not in result.output, result.output
+        payload = _load_json(result.output)
+        rows = payload["data"] if isinstance(payload, dict) else payload
+        assert rows == [], payload
+
+    def test_view_table_absent_returns_not_found(self, tmp_path) -> None:
+        """``reports`` 부재 → ``report view`` ``REPORT_NOT_FOUND`` + no traceback."""
+        db_path = _empty_writable_db(tmp_path / "no_reports.db")
+        result = _invoke(
+            ["--format", "json", "report", "view", "any-id", "--db-path", db_path]
+        )
+        assert result.exit_code == 1, result.output
+        assert "Traceback" not in result.output, result.output
+        payload = _load_json(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "REPORT_NOT_FOUND", payload
+
+
+# ── G2: no-such-table 이외 OperationalError 재전파 → REPORT_ERROR ──────────
+
+
+class TestReportOperationalErrorReRaised:
+    """``no such table`` 만 graceful; 다른 ``OperationalError`` 는 재전파."""
+
+    def test_list_locked_error_surfaces_report_error(self, tmp_path) -> None:
+        """``list_reports`` 가 ``database is locked`` → ``REPORT_ERROR`` (재전파)."""
+        with (
+            patch("ante.core.database.Database.connect", new=AsyncMock()),
+            patch("ante.core.database.Database.close", new=AsyncMock()),
+            patch(
+                "ante.report.ReportStore.list_reports",
+                new=AsyncMock(
+                    side_effect=sqlite3.OperationalError("database is locked")
+                ),
+            ),
+        ):
+            result = _invoke(
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "list",
+                    "--db-path",
+                    str(tmp_path / "ante.db"),
+                ]
+            )
+        assert result.exit_code == 1, result.output
+        assert "Traceback" not in result.output, result.output
+        payload = _load_json(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "REPORT_ERROR", payload
+
+    def test_view_malformed_error_surfaces_report_error(self, tmp_path) -> None:
+        """``get`` 이 ``malformed`` → ``REPORT_ERROR`` (NOT_FOUND 아님, 재전파)."""
+        with (
+            patch("ante.core.database.Database.connect", new=AsyncMock()),
+            patch("ante.core.database.Database.close", new=AsyncMock()),
+            patch(
+                "ante.report.ReportStore.get",
+                new=AsyncMock(
+                    side_effect=sqlite3.OperationalError(
+                        "database disk image is malformed"
+                    )
+                ),
+            ),
+        ):
+            result = _invoke(
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "view",
+                    "rpt-x",
+                    "--db-path",
+                    str(tmp_path / "ante.db"),
+                ]
+            )
+        assert result.exit_code == 1, result.output
+        assert "Traceback" not in result.output, result.output
+        payload = _load_json(result.output)
+        assert payload["status"] == "error"
+        # malformed 는 graceful(NOT_FOUND) 가 아니라 REPORT_ERROR 로 재전파.
+        assert payload["code"] == "REPORT_ERROR", payload
+
+
+# ── G3: writable DB 회귀 ──────────────────────────────────────────────────
+
+
+class TestReportWritableRegression:
+    """정상 reports 테이블을 가진 writable DB 에서 list/view 회귀 보존."""
+
+    def test_list_writable_db_returns_report(self, tmp_path) -> None:
+        db_path = _writable_seeded_db(tmp_path / "seeded.db")
+        result = _invoke(["--format", "json", "report", "list", "--db-path", db_path])
+        assert result.exit_code == 0, result.output
+        payload = _load_json(result.output)
+        rows = payload["data"] if isinstance(payload, dict) else payload
+        assert any(r["report_id"] == _REPORT_ID for r in rows), payload
+
+    def test_view_writable_db_returns_report(self, tmp_path) -> None:
+        db_path = _writable_seeded_db(tmp_path / "seeded.db")
+        result = _invoke(
+            ["--format", "json", "report", "view", _REPORT_ID, "--db-path", db_path]
+        )
+        assert result.exit_code == 0, result.output
+        payload = _load_json(result.output)
+        assert payload["report_id"] == _REPORT_ID, payload
+        assert payload["total_trades"] == 7, payload


### PR DESCRIPTION
Closes #2114

## Summary
- `report list/view`가 read-only DB artifact에서 `Database(read_only=False)`+`store.initialize()`(DDL)로 실패하던 것을, **read-only 조회 경로로 확대**(#1984 data list / #1974 backtest history sibling).
- report_list/view → `open_cli_db(read_only=True)` + initialize skip. reports 테이블 부재('no such table' 메시지 한정)→빈/NOT_FOUND graceful, 다른 OperationalError→REPORT_ERROR(삼키지 않음). submit(write)/performance(이미 open_cli_db) 무변경.
- **read_only 적용범위 SSOT 전수 sweep**: offline-factory.md(적용범위 2곳+Non-Goals), contracts/README.md, db_context.py §4, **core/database.py docstring** → 모두 backtest history(#1974)+data list(#1984)+report list/view(#2114). #1984가 누락한 spec sweep도 함께 정렬.

## Test Plan
- **실제 0444 DB + 0555 parent dir**(WAL truncate + immutable fallback) list/view; table-absence graceful; other-OperationalError→REPORT_ERROR; writable 회귀
- 전체 `pytest tests/unit/`: 6933 passed, 2 skipped, 0 failed(factory_drift 포함). ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (1028422, attempt 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)