### PR TITLE
fix(cli): #2144 strategy summary를 trades.strategy_id로 전략 전체 집계 (첫 봇만→모든 트레이드)

### DIFF
--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -108,7 +108,7 @@ allowlist 후보에서 제거한다.
 | `ante strategy info <name>` | `offline` | StrategyRegistry 조회 |
 | `ante strategy performance <name> --account-id <account_id>` | `offline` | 성과 DB 집계 (account-scoped, semantic-required) |
 | `ante strategy set-status <strategy_id> --status adopted\|archived` | `runtime IPC` | 전략 상태 변경 |
-| `ante strategy summary <strategy_id> --period daily\|weekly\|monthly` | `offline` | 성과 기간 집계 |
+| `ante strategy summary <strategy_id> --period daily\|weekly\|monthly` | `offline` | 전략 전체 거래의 기간별 절대 집계 (cross-account, `trades.strategy_id`) |
 | `ante treasury status --account <account_id>` | `offline` | persisted treasury 상태 조회 (`--account` 필수) |
 | `ante treasury allocate <bot_id> <amount> --account <account_id>` | `runtime IPC` | 서버 TreasuryManager 캐시 갱신 |
 | `ante treasury deallocate <bot_id> <amount> --account <account_id>` | `runtime IPC` | 서버 TreasuryManager 캐시 갱신 |
@@ -408,6 +408,16 @@ ante strategy summary <strategy_id> --period daily|weekly|monthly  # 전략 기�
 
 `strategy submit`은 전략 파일을 `StrategyRegistry`에 등록하고 `strategy_id`를 생성한다.
 이후 봇 생성은 이 `strategy_id`를 참조한다.
+
+`strategy summary`는 전략의 `trades.strategy_id`(거래 시점 전략 귀속 키)로
+해당 전략의 **모든 거래**를 집계한다. 같은 전략을 여러 봇·여러 계좌에서
+운용해도 전체가 합산되며, 삭제된 봇의 과거 거래도 포함되고, 봇이 이후 다른
+전략으로 바뀌어 발생시킨 거래는 오염되지 않는다. 지표는
+`realized_pnl`/`trade_count`/`win_rate`의 **기간별 절대(absolute) 집계**다.
+`strategy performance`(계좌별 portfolio-relative, `--account-id` semantic-required)와
+달리 account-scoped가 아니므로 여러 계좌·통화의 거래가 섞일 수 있고, 다중 통화
+운용 시 `realized_pnl`은 통화가 혼합될 수 있다. 응답에는 단일 `bot_id`가
+포함되지 않는다(전략 전체 집계라 첫 봇만 가리키는 필드는 의미가 없다).
 
 ### `ante treasury` — 자금 관리
 

--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -73,21 +73,6 @@ async def _create_registry(
         yield registry, db
 
 
-async def _find_bot_id_for_strategy(db, strategy_id: str) -> str | None:  # noqa: ANN001
-    """전략에 연결된 첫 번째 봇 ID를 반환한다."""
-    try:
-        row = await db.fetch_one(
-            "SELECT bot_id FROM bots WHERE strategy_id = ? AND status != 'deleted' "
-            "ORDER BY bot_id LIMIT 1",
-            (strategy_id,),
-        )
-    except sqlite3.OperationalError as e:
-        if "no such table" in str(e).lower():
-            return None
-        raise
-    return row["bot_id"] if row else None
-
-
 @strategy.command()
 @click.argument("path", type=click.Path(exists=True))
 @click.pass_context
@@ -627,7 +612,18 @@ def _load_strategy_params(filepath: str) -> dict | None:
 @require_auth
 @require_scope("strategy:read")
 def strategy_summary(ctx: click.Context, strategy_id: str, period: str) -> None:
-    """전략 기간별 성과 집계."""
+    """전략 기간별 성과 집계 (전략 전체 거래, absolute 지표).
+
+    전략의 ``trades.strategy_id`` (거래 시점 전략 귀속 durable key)로
+    해당 전략의 **모든 거래**를 집계한다. 같은 전략을 여러 봇/여러 계좌에서
+    운용해도 전체가 합산되며, 삭제된 봇의 과거 거래도 포함되고 봇의 이후
+    전략 변경으로 다른 전략에 귀속된 거래는 오염되지 않는다 (#2144).
+
+    지표는 ``realized_pnl``/``trade_count``/``win_rate`` 의 **기간별 절대
+    집계**다. ``strategy performance`` (계좌별 portfolio-relative) 와 달리
+    account-scoped 가 아니므로 여러 계좌·통화의 거래가 섞일 수 있다
+    (다중 통화 운용 시 ``realized_pnl`` 은 통화가 혼합될 수 있다).
+    """
     fmt = get_formatter(ctx)
 
     async def _summary() -> dict | None:
@@ -641,23 +637,27 @@ def strategy_summary(ctx: click.Context, strategy_id: str, period: str) -> None:
                 return None
 
             tracker = PerformanceTracker(db)
-            bot_id = await _find_bot_id_for_strategy(db, strategy_id)
             if period == "daily":
-                daily_summaries = await tracker.get_daily_summary(bot_id=bot_id)
+                daily_summaries = await tracker.get_daily_summary(
+                    strategy_id=strategy_id
+                )
                 items = [asdict(s) for s in daily_summaries]
             elif period == "weekly":
-                weekly_summaries = await tracker.get_weekly_summary(bot_id=bot_id)
+                weekly_summaries = await tracker.get_weekly_summary(
+                    strategy_id=strategy_id
+                )
                 items = [
                     {**asdict(s), "week_label": s.week_label} for s in weekly_summaries
                 ]
             else:
-                monthly_summaries = await tracker.get_monthly_summary(bot_id=bot_id)
+                monthly_summaries = await tracker.get_monthly_summary(
+                    strategy_id=strategy_id
+                )
                 items = [asdict(s) for s in monthly_summaries]
 
             return {
                 "strategy_id": strategy_id,
                 "period": period,
-                "bot_id": bot_id,
                 "items": items,
             }
 

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 _COND_STATUS_FILLED = "t.status = ?"
 _COND_SIDE_SELL = "t.side = 'sell'"
 _COND_BOT_ID = "t.bot_id = ?"
+_COND_STRATEGY_ID = "t.strategy_id = ?"
 _JOIN_POSITION_HISTORY = """LEFT JOIN position_history ph
                 ON ph.trade_id = CAST(t.trade_id AS TEXT)
                 AND ph.action = 'sell'"""
@@ -107,6 +108,7 @@ class PerformanceTracker:
         end_date: str | None = None,
         *,
         account_id: str | None = None,
+        strategy_id: str | None = None,
     ) -> list[DailySummary]:
         """일별 성과 집계.
 
@@ -118,6 +120,12 @@ class PerformanceTracker:
                 집계한다 (read query 정책 — #1218 영역). 단일 계좌에
                 바인딩된 호출자(DailyReportScheduler 등)는 자기 계좌만
                 집계되도록 명시적으로 전달해야 한다 (#1240).
+            strategy_id: 전략 ID 필터. ``None`` 이면 전략 무관 전체를
+                집계한다. 지정 시 ``trades.strategy_id`` 컬럼(거래 시점
+                전략 귀속 durable key)으로 전략 전체 거래를 집계하며,
+                봇 멤버십/상태(삭제 여부)나 봇의 이후 전략 변경과
+                무관하다 (#2144). ``bot_id``/``account_id`` 와 함께
+                전달되면 AND 로 결합된다.
         """
         conditions: list[str] = [
             _COND_STATUS_FILLED,
@@ -131,6 +139,9 @@ class PerformanceTracker:
         if account_id:
             conditions.append("t.account_id = ?")
             params.append(account_id)
+        if strategy_id:
+            conditions.append(_COND_STRATEGY_ID)
+            params.append(strategy_id)
         if start_date:
             conditions.append("date(t.timestamp) >= ?")
             params.append(start_date)
@@ -173,6 +184,8 @@ class PerformanceTracker:
     async def get_weekly_summary(
         self,
         bot_id: str | None = None,
+        *,
+        strategy_id: str | None = None,
     ) -> list[WeeklySummary]:
         """주별 성과 집계.
 
@@ -180,6 +193,10 @@ class PerformanceTracker:
 
         Args:
             bot_id: 봇 ID 필터 (None이면 전체)
+            strategy_id: 전략 ID 필터. ``None`` 이면 전략 무관 전체.
+                지정 시 ``trades.strategy_id`` 로 전략 전체 거래를
+                집계하며 봇 멤버십/상태와 무관하다 (#2144). ``bot_id`` 와
+                함께 전달되면 AND 로 결합된다.
         """
         conditions: list[str] = [
             _COND_STATUS_FILLED,
@@ -190,6 +207,9 @@ class PerformanceTracker:
         if bot_id:
             conditions.append(_COND_BOT_ID)
             params.append(bot_id)
+        if strategy_id:
+            conditions.append(_COND_STRATEGY_ID)
+            params.append(strategy_id)
 
         where = " AND ".join(conditions)
         query = f"""
@@ -229,12 +249,18 @@ class PerformanceTracker:
         self,
         bot_id: str | None = None,
         year: int | None = None,
+        *,
+        strategy_id: str | None = None,
     ) -> list[MonthlySummary]:
         """월별 성과 집계.
 
         Args:
             bot_id: 봇 ID 필터 (None이면 전체)
             year: 연도 필터 (None이면 전체)
+            strategy_id: 전략 ID 필터. ``None`` 이면 전략 무관 전체.
+                지정 시 ``trades.strategy_id`` 로 전략 전체 거래를
+                집계하며 봇 멤버십/상태와 무관하다 (#2144). ``bot_id``/
+                ``year`` 와 함께 전달되면 AND 로 결합된다.
         """
         conditions: list[str] = [
             _COND_STATUS_FILLED,
@@ -245,6 +271,9 @@ class PerformanceTracker:
         if bot_id:
             conditions.append(_COND_BOT_ID)
             params.append(bot_id)
+        if strategy_id:
+            conditions.append(_COND_STRATEGY_ID)
+            params.append(strategy_id)
         if year:
             conditions.append("strftime('%Y', t.timestamp) = ?")
             params.append(str(year))

--- a/tests/unit/test_performance_summary.py
+++ b/tests/unit/test_performance_summary.py
@@ -349,3 +349,94 @@ class TestReportPerformanceCLI:
                 ],
             )
             assert result.exit_code == 0
+
+
+class TestSummaryStrategyIdFilter:
+    """get_*_summary 의 strategy_id 필터 (#2144).
+
+    ``trades.strategy_id`` (거래 시점 전략 귀속 durable key) 로 전략 전체
+    거래를 집계한다. 봇 멤버십/상태와 무관하며, bot_id/account_id 와 함께
+    전달되면 AND 로 결합된다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_with_strategy_filter(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_daily_summary(strategy_id="strat-1")
+
+        assert result == []
+        query, params = db.fetch_all.call_args[0]
+        assert "t.strategy_id = ?" in query
+        assert "strat-1" in params
+
+    @pytest.mark.asyncio
+    async def test_weekly_summary_with_strategy_filter(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_weekly_summary(strategy_id="strat-1")
+
+        assert result == []
+        query, params = db.fetch_all.call_args[0]
+        assert "t.strategy_id = ?" in query
+        assert "strat-1" in params
+
+    @pytest.mark.asyncio
+    async def test_monthly_summary_with_strategy_filter(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_monthly_summary(strategy_id="strat-1")
+
+        assert result == []
+        query, params = db.fetch_all.call_args[0]
+        assert "t.strategy_id = ?" in query
+        assert "strat-1" in params
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_bot_and_strategy_are_anded(self):
+        """bot_id + strategy_id 동시 전달 시 둘 다 AND 로 적용."""
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        await tracker.get_daily_summary(bot_id="bot-1", strategy_id="strat-1")
+
+        query, params = db.fetch_all.call_args[0]
+        assert "t.bot_id = ?" in query
+        assert "t.strategy_id = ?" in query
+        assert "bot-1" in params
+        assert "strat-1" in params
+
+    @pytest.mark.asyncio
+    async def test_monthly_summary_year_and_strategy_are_anded(self):
+        """year + strategy_id 동시 전달 시 둘 다 AND 로 적용."""
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        await tracker.get_monthly_summary(year=2026, strategy_id="strat-1")
+
+        query, params = db.fetch_all.call_args[0]
+        assert "strftime('%Y', t.timestamp) = ?" in query
+        assert "t.strategy_id = ?" in query
+        assert "2026" in params
+        assert "strat-1" in params
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_no_strategy_filter_omits_condition(self):
+        """strategy_id 미전달(기존 호출자) 시 strategy_id 조건 미포함 (무회귀)."""
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        await tracker.get_daily_summary(bot_id="bot-1")
+
+        query, params = db.fetch_all.call_args[0]
+        assert "t.strategy_id = ?" not in query
+        assert "strat-1" not in params

--- a/tests/unit/test_strategy_success_output_drift.py
+++ b/tests/unit/test_strategy_success_output_drift.py
@@ -30,9 +30,9 @@ empty JSON 분기 +1):
 5. ``info`` (found) → ``raw_legacy`` (``fmt.output(result)`` 평면 metadata
    + params dict)
 6. ``summary`` (with items) → ``raw_legacy`` (``fmt.output(result)`` 평면
-   ``{strategy_id, period, bot_id, items}``)
+   ``{strategy_id, period, items}`` — #2144 로 단일 ``bot_id`` 제거)
 7. ``summary`` empty JSON 분기 → ``raw_legacy`` (``fmt.output(result)``
-   동일 평면 ``{strategy_id, period, bot_id, items: []}``)
+   동일 평면 ``{strategy_id, period, items: []}``)
 8. ``performance`` (found) → ``raw_legacy`` (``fmt.output(result)`` 평면
    ``{strategy_name, strategy_id, metrics}``)
 9. ``set-status`` (IPC 분기) → ``raw_legacy`` (``fmt.output(result)`` 평면
@@ -410,19 +410,16 @@ def test_strategy_summary_with_items_envelope_matches_raw_legacy(
 ) -> None:
     """``strategy summary`` with items: ``fmt.output(result)`` 평면 dict.
 
-    strategy.py:662-663: ``if fmt.is_json: fmt.output(result)`` → ``{strategy_id,
-    period, bot_id, items: [...]}``. text 모드는 fmt.table 분기.
+    strategy.py: ``if fmt.is_json: fmt.output(result)`` → ``{strategy_id,
+    period, items: [...]}``. #2144 로 단일 ``bot_id`` 필드는 제거되었다
+    (전략 전체 집계라 첫 봇만 가리키는 필드는 의미가 없다). text 모드는
+    fmt.table 분기.
     """
     from ante.trade.models import DailySummary
 
     registry, _db = mock_create_registry
     record = _make_record()
     registry.get = AsyncMock(return_value=record)
-
-    # _find_bot_id_for_strategy 는 db.fetch_one 을 호출한다.
-    # mock_create_registry fixture 의 db 가 default 로 ``None`` 을 반환하지만,
-    # 본 케이스에서 bot_id 가 있는 결과를 보고 싶다면 fetch_one 을 customize.
-    _db.fetch_one = AsyncMock(return_value={"bot_id": "bot-1"})
 
     daily = DailySummary(
         date="2026-01-01",
@@ -447,7 +444,8 @@ def test_strategy_summary_with_items_envelope_matches_raw_legacy(
     )
     assert payload["strategy_id"] == "strat-1"
     assert payload["period"] == "daily"
-    assert payload["bot_id"] == "bot-1"
+    # #2144: 단일 bot_id 필드 제거 (전략 전체 집계, 첫-봇 artifact 아님).
+    assert "bot_id" not in payload
     assert isinstance(payload["items"], list)
     assert len(payload["items"]) == 1
     assert payload["items"][0]["date"] == "2026-01-01"
@@ -469,7 +467,6 @@ def test_strategy_summary_empty_json_envelope_matches_raw_legacy(
     registry, _db = mock_create_registry
     record = _make_record()
     registry.get = AsyncMock(return_value=record)
-    _db.fetch_one = AsyncMock(return_value=None)  # bot_id 부재 → None.
 
     # PerformanceTracker.get_daily_summary 가 빈 list 반환.
     with patch(
@@ -486,7 +483,8 @@ def test_strategy_summary_empty_json_envelope_matches_raw_legacy(
         f"strategy summary empty json: standard envelope 아님. payload={payload!r}"
     )
     assert payload["strategy_id"] == "strat-1"
-    assert payload["bot_id"] is None
+    # #2144: 단일 bot_id 필드 제거.
+    assert "bot_id" not in payload
     assert payload["items"] == []
 
 

--- a/tests/unit/test_strategy_summary_all_bots.py
+++ b/tests/unit/test_strategy_summary_all_bots.py
@@ -1,0 +1,253 @@
+"""strategy summary 가 전략 전체 거래를 ``trades.strategy_id`` 로 집계 (#2144).
+
+기존 동작은 ``_find_bot_id_for_strategy`` 로 전략의 **첫 번째 봇만** 골라
+집계했다 (다중 봇/다중 계좌 전략의 성과 누락). 본 모듈은 실제 SQLite DB 에
+거래/포지션 이력을 적재하고 ``PerformanceTracker.get_*_summary(strategy_id=...)``
+가 전략 전체를 정확히 집계하는지 검증한다:
+
+- 같은 전략 2봇 → 양쪽 거래 합산 (첫 봇만 아님)
+- strategy 변경 봇 (그 봇이 다른 전략으로 낸 거래) → 다른-전략 거래 미포함 (오염 없음)
+- 삭제된 봇의 과거 거래 → 포함 (strategy_id 필터라 봇 status 무관)
+- 0 거래 → 빈 graceful
+- cross-account 절대지표 합산
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.core.database import Database
+from ante.trade.performance import PerformanceTracker
+from ante.trade.position import POSITION_SCHEMA
+from ante.trade.recorder import TRADE_SCHEMA
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db = Database(str(tmp_path / "summary.db"))
+    await db.connect()
+    await db.execute_script(TRADE_SCHEMA)
+    await db.execute_script(POSITION_SCHEMA)
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+async def _insert_sell(
+    db: Database,
+    *,
+    trade_id: str,
+    bot_id: str,
+    strategy_id: str,
+    account_id: str,
+    pnl: float,
+    timestamp: str,
+    symbol: str = "005930",
+) -> None:
+    """체결된 매도 거래 1건 + 대응 position_history(pnl) 적재.
+
+    get_*_summary 는 ``t.status='filled' AND t.side='sell'`` 거래를
+    ``position_history.pnl`` 과 trade_id 로 JOIN 해 realized_pnl/승패를
+    산출한다. 본 helper 는 그 JOIN 이 성립하도록 양쪽을 함께 넣는다.
+    """
+    await db.execute(
+        """INSERT INTO trades
+           (trade_id, bot_id, strategy_id, symbol, side, quantity, price,
+            status, timestamp, account_id)
+           VALUES (?, ?, ?, ?, 'sell', 10, 70000, 'filled', ?, ?)""",
+        (trade_id, bot_id, strategy_id, symbol, timestamp, account_id),
+    )
+    await db.execute(
+        """INSERT INTO position_history
+           (bot_id, symbol, action, quantity, price, pnl, timestamp,
+            account_id, trade_id)
+           VALUES (?, ?, 'sell', 10, 70000, ?, ?, ?, ?)""",
+        (bot_id, symbol, pnl, timestamp, account_id, trade_id),
+    )
+
+
+class TestStrategySummaryAllBots:
+    async def test_two_bots_same_strategy_are_summed(self, db):
+        """같은 전략을 쓰는 2봇 → 양쪽 거래가 합산된다 (첫 봇만 아님)."""
+        await _insert_sell(
+            db,
+            trade_id="t-a",
+            bot_id="bot-a",
+            strategy_id="strat-1",
+            account_id="acc-a",
+            pnl=10_000.0,
+            timestamp="2026-03-10 10:00:00",
+        )
+        await _insert_sell(
+            db,
+            trade_id="t-b",
+            bot_id="bot-b",
+            strategy_id="strat-1",
+            account_id="acc-a",
+            pnl=5_000.0,
+            timestamp="2026-03-10 11:00:00",
+        )
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_daily_summary(strategy_id="strat-1")
+
+        assert len(result) == 1
+        day = result[0]
+        assert day.date == "2026-03-10"
+        # 두 봇 거래 모두 포함 (첫 봇만이면 1건/10_000 만 보였을 것).
+        assert day.trade_count == 2
+        assert day.realized_pnl == pytest.approx(15_000.0)
+        assert day.win_rate == pytest.approx(1.0)
+
+    async def test_first_bot_only_would_miss_second_bot(self, db):
+        """대조군: bot_id 단일 필터는 그 봇 거래만 본다 (회귀 가드)."""
+        await _insert_sell(
+            db,
+            trade_id="t-a",
+            bot_id="bot-a",
+            strategy_id="strat-1",
+            account_id="acc-a",
+            pnl=10_000.0,
+            timestamp="2026-03-10 10:00:00",
+        )
+        await _insert_sell(
+            db,
+            trade_id="t-b",
+            bot_id="bot-b",
+            strategy_id="strat-1",
+            account_id="acc-a",
+            pnl=5_000.0,
+            timestamp="2026-03-10 11:00:00",
+        )
+
+        tracker = PerformanceTracker(db)
+        first_bot_only = await tracker.get_daily_summary(bot_id="bot-a")
+        assert first_bot_only[0].trade_count == 1
+        assert first_bot_only[0].realized_pnl == pytest.approx(10_000.0)
+
+    async def test_strategy_changed_bot_does_not_contaminate(self, db):
+        """봇이 다른 전략으로 낸 거래는 strategy_id 필터에 안 잡힌다 (오염 없음).
+
+        같은 봇(bot-a)이 strat-1 과 strat-2 로 각각 거래를 냈을 때,
+        strat-1 집계에는 strat-2 거래가 섞이지 않는다.
+        """
+        await _insert_sell(
+            db,
+            trade_id="t-1",
+            bot_id="bot-a",
+            strategy_id="strat-1",
+            account_id="acc-a",
+            pnl=10_000.0,
+            timestamp="2026-03-10 10:00:00",
+        )
+        await _insert_sell(
+            db,
+            trade_id="t-2",
+            bot_id="bot-a",
+            strategy_id="strat-2",
+            account_id="acc-a",
+            pnl=99_000.0,
+            timestamp="2026-03-10 12:00:00",
+        )
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_daily_summary(strategy_id="strat-1")
+
+        assert len(result) == 1
+        assert result[0].trade_count == 1
+        # strat-2 의 99_000 은 포함되지 않는다.
+        assert result[0].realized_pnl == pytest.approx(10_000.0)
+
+    async def test_deleted_bot_past_trades_included(self, db):
+        """삭제된 봇의 과거 거래도 포함된다 (strategy_id 필터라 봇 status 무관).
+
+        trades.strategy_id 로 집계하므로 봇이 bots 테이블에 존재하는지/
+        status 가 deleted 인지와 무관하게 거래 시점 전략 귀속으로 잡힌다.
+        (bots 테이블 자체를 만들지 않아도 집계가 성립함을 함께 확인.)
+        """
+        await _insert_sell(
+            db,
+            trade_id="t-old",
+            bot_id="bot-deleted",
+            strategy_id="strat-1",
+            account_id="acc-a",
+            pnl=7_000.0,
+            timestamp="2026-03-10 09:00:00",
+        )
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_daily_summary(strategy_id="strat-1")
+
+        assert len(result) == 1
+        assert result[0].trade_count == 1
+        assert result[0].realized_pnl == pytest.approx(7_000.0)
+
+    async def test_zero_trades_returns_empty_gracefully(self, db):
+        """전략에 거래가 없으면 빈 리스트 (graceful)."""
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_daily_summary(strategy_id="strat-empty")
+        assert result == []
+
+    async def test_cross_account_absolute_metrics_summed(self, db):
+        """여러 계좌의 거래도 절대지표(realized_pnl/trade_count)로 합산된다."""
+        await _insert_sell(
+            db,
+            trade_id="t-acc-a",
+            bot_id="bot-a",
+            strategy_id="strat-1",
+            account_id="acc-a",
+            pnl=10_000.0,
+            timestamp="2026-03-10 10:00:00",
+        )
+        await _insert_sell(
+            db,
+            trade_id="t-acc-b",
+            bot_id="bot-b",
+            strategy_id="strat-1",
+            account_id="acc-b",
+            pnl=20_000.0,
+            timestamp="2026-03-10 11:00:00",
+        )
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_daily_summary(strategy_id="strat-1")
+
+        assert len(result) == 1
+        assert result[0].trade_count == 2
+        assert result[0].realized_pnl == pytest.approx(30_000.0)
+
+    async def test_weekly_and_monthly_summary_strategy_scoped(self, db):
+        """weekly/monthly 도 strategy_id 로 전략 전체를 집계한다."""
+        await _insert_sell(
+            db,
+            trade_id="t-w-a",
+            bot_id="bot-a",
+            strategy_id="strat-1",
+            account_id="acc-a",
+            pnl=10_000.0,
+            timestamp="2026-03-10 10:00:00",
+        )
+        await _insert_sell(
+            db,
+            trade_id="t-w-b",
+            bot_id="bot-b",
+            strategy_id="strat-1",
+            account_id="acc-a",
+            pnl=5_000.0,
+            timestamp="2026-03-11 10:00:00",
+        )
+
+        tracker = PerformanceTracker(db)
+        weekly = await tracker.get_weekly_summary(strategy_id="strat-1")
+        monthly = await tracker.get_monthly_summary(strategy_id="strat-1")
+
+        assert len(weekly) == 1
+        assert weekly[0].trade_count == 2
+        assert weekly[0].realized_pnl == pytest.approx(15_000.0)
+
+        assert len(monthly) == 1
+        assert monthly[0].year == 2026
+        assert monthly[0].month == 3
+        assert monthly[0].trade_count == 2
+        assert monthly[0].realized_pnl == pytest.approx(15_000.0)


### PR DESCRIPTION
Closes #2144

## Summary
- `strategy summary <strategy_id>`가 같은 전략의 여러 봇 중 **첫 봇만**(_find_bot_id_for_strategy LIMIT 1) 집계하던 것을, **`trades.strategy_id`로 전략 전체 트레이드 집계**로 수정.
- get_daily/weekly/monthly_summary에 `strategy_id` 필터(`t.strategy_id = ?`, optional, 기존 bot_id/account_id/year와 AND). strategy_summary가 직접 호출(_find_bot_id_for_strategy 제거). **삭제봇 과거트레이드 포함**(status 무관), **strategy-변경봇 다른전략 트레이드 미포함**(거래시점 전략귀속 durable key).
- 반환에서 오해 소지 단일 `bot_id` 제거(첫-봇 artifact, JSON drift 문서화). cross-account **absolute 기간별 집계**(realized_pnl/trade_count/win_rate, 다중통화 caveat) — strategy performance(account-relative)와 구분 03-commands.md 명시.

## Test Plan
- 2봇 합산/strategy-변경봇 오염없음/삭제봇 포함/0트레이드 graceful/cross-account 합산/bot_id+strategy_id·year+strategy_id AND/기존 호출자 무회귀/bot_id 제거 output drift
- 전체 `pytest tests/unit/`: 6936 passed, 2 skipped, 0 failed. ruff/mypy pass, generated 무변경
- Codex 브랜치 리뷰 PASS (154091e7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)