### PR TITLE
fix(feed): #1993 rows_written을 net-new 저장 delta로 — checkpoint·DART store-merge 가드 분리

### DIFF
--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -274,6 +274,26 @@ class ParquetStore:
         self._pending_warnings.clear()
         return drained
 
+    def pending_merge_failure_count(self) -> int:
+        """현재 버퍼에 쌓인 ``store_merge`` 경고 수를 **비파괴적으로** 센다.
+
+        ``drain_warnings()`` 와 달리 버퍼를 비우지 않는다(read-only count).
+        DART collector처럼 checkpoint.save를 자체적으로 수행하는 호출자가
+        ``store.write`` 직전/직후 이 값을 비교해 이번 단계에서 발생한
+        store-merge 실패(파티션 merge 실패 → 기존 파일 보존, 데이터 미반영)를
+        감지하는 데 쓴다(#1993). 누적 카운트이므로 **직전/직후 증가분**으로
+        이번 단계의 실패를 판정해야 한다(이전 단계 경고가 아직 runner에 의해
+        drain되지 않았을 수 있음).
+
+        파괴적 drain은 backfill_runner가 collect 종료 후 단일 소유로 수행하므로,
+        DART가 여기서 drain하면 runner가 보고할 경고를 소실시킨다. 따라서 이
+        메서드는 절대 버퍼를 비우지 않는다(drain 소유권 보존, #1993 R2).
+
+        Returns:
+            ``type == "store_merge"`` 인 pending 경고의 수.
+        """
+        return sum(1 for w in self._pending_warnings if w.get("type") == "store_merge")
+
     def _resolve_path(
         self,
         symbol: str,

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -459,8 +459,18 @@ class ParquetStore:
         data: pl.DataFrame,
         data_type: str = "ohlcv",
         exchange: str = "KRX",
-    ) -> None:
+    ) -> int:
         """데이터를 Parquet에 기록. 파티셔닝, 중복 제거(merge).
+
+        Returns:
+            이번 write로 **실제 새로 저장된 net-new 행 수**(rows_written, #1993).
+            파티션별 net delta = ``max(0, len(merged) - len(existing))``의 합이다
+            (legacy 중복 정리로 merged < existing이면 0으로 clamp). 빈 입력/
+            exchange는 0. 기존엔 입력 ``len(data)`` 를 누적해 dedup·재수집을
+            과대계상했다. 신규 파티션 write는 dedup 후 결과 행 수다. merge 실패
+            (기존 파일 보존 + store_merge 경고)는 0(저장 반영 없음). 반환은 정보용
+            이며 silent overwrite/transaction 동작은 변경하지 않는다(하위호환:
+            기존 None 반환을 사용하던 호출자 0건).
 
         파티셔닝 해상도(04-schema.md 파일 규격, #2115):
         - OHLCV 중 subminute(`_SUBMINUTE_TIMEFRAMES` = 10s/30s)는 **일별**
@@ -487,7 +497,7 @@ class ParquetStore:
             )
 
         if data.is_empty():
-            return
+            return 0
 
         time_col = _TIME_COLUMN.get(data_type, "timestamp")
         if time_col in data.columns and bool(data[time_col].is_null().any()):
@@ -518,11 +528,19 @@ class ParquetStore:
         else:
             partitioned = self._partition_by_month(data, time_col)
 
+        net_delta = 0
         for part_val, group in partitioned:
             filepath = path / f"{part_val}.parquet"
-            self._persist_partition(filepath, group, key)
+            net_delta += self._persist_partition(filepath, group, key)
 
-        logger.debug("Wrote %d rows for %s/%s", len(data), symbol, timeframe)
+        logger.debug(
+            "Wrote %s/%s: input=%d net_new=%d",
+            symbol,
+            timeframe,
+            len(data),
+            net_delta,
+        )
+        return net_delta
 
     def _partition_by_month(
         self, data: pl.DataFrame, time_col: str
@@ -573,7 +591,7 @@ class ParquetStore:
 
     def _persist_partition(
         self, filepath: Path, group: pl.DataFrame, key: list[str]
-    ) -> None:
+    ) -> int:
         """단일 파티션을 Parquet 파일에 기록. 기존 파일이 있으면 merge.
 
         merge 전략(#1964):
@@ -589,10 +607,18 @@ class ParquetStore:
             filepath: 대상 파티션 파일 경로.
             group: 이번 write로 들어온 (단일 월) DataFrame.
             key: natural key 컬럼 목록. 비어 있으면 dedup/sort 생략.
+
+        Returns:
+            이 파티션에 **새로 저장된 net-new 행 수**(#1993):
+            ``max(0, len(merged) - len(existing))``. 기존 파일이 없으면 dedup
+            결과 행 수(신규 전량). 재write/dedup으로 merged 행 수가 늘지 않으면 0.
+            legacy 중복 정리로 merged < existing이면(행이 줄어들면) 0으로 clamp
+            한다. merge 실패(기존 파일 보존)는 저장 반영이 없으므로 0.
         """
         if filepath.exists():
             try:
                 existing = pl.read_parquet(filepath)
+                existing_len = len(existing)
                 merged = pl.concat([existing, group], how="diagonal_relaxed")
                 if key:
                     present = [c for c in key if c in merged.columns]
@@ -601,10 +627,13 @@ class ParquetStore:
                             present
                         )
                 merged.write_parquet(str(filepath), compression=self._compression)
-                return
+                # net-new = merged 행 수 - 기존 행 수. dedup으로 그대로면 0,
+                # legacy 중복 정리로 줄면 음수 → 0으로 clamp(과대/음수 방지).
+                return max(0, len(merged) - existing_len)
             except Exception as exc:
                 # 방어: diagonal_relaxed로도 결합 불가한 케이스. 기존 파일을
-                # 절대 덮어쓰지 않고(데이터 손실 방지) 이상만 기록한다.
+                # 절대 덮어쓰지 않고(데이터 손실 방지) 이상만 기록한다. 저장
+                # 반영이 없으므로 net-new는 0이다.
                 logger.warning(
                     "Parquet 파티션 merge 실패: %s — 기존 파일 보존, write 건너뜀 (%s)",
                     filepath,
@@ -620,13 +649,15 @@ class ParquetStore:
                         ),
                     }
                 )
-                return
+                return 0
 
         if key:
             present = [c for c in key if c in group.columns]
             if present:
                 group = group.unique(subset=present, keep="last").sort(present)
         group.write_parquet(str(filepath), compression=self._compression)
+        # 신규 파티션: dedup 후 결과 행 수가 곧 net-new 저장 행 수.
+        return len(group)
 
     def append(
         self,

--- a/src/ante/feed/models/result.py
+++ b/src/ante/feed/models/result.py
@@ -73,7 +73,11 @@ class CollectionResult:
     """수집 실패 종목 수."""
 
     rows_written: int = 0
-    """저장된 총 행 수."""
+    """**net-new 저장 행 수** (#1993).
+
+    store에 실제로 새로 저장된 행 수의 합이다. 입력 len 누적이 아니라 파티션별
+    ``max(0, len(merged) - len(existing))`` delta의 합이므로, 재수집/dedup/
+    지표 in-place overwrite는 0으로 집계된다(과대계상 제거)."""
 
     data_types: list[str] = field(default_factory=list)
     """수집된 데이터 유형 목록 (예: ['ohlcv', 'fundamental'])."""

--- a/src/ante/feed/pipeline/backfill_runner.py
+++ b/src/ante/feed/pipeline/backfill_runner.py
@@ -394,6 +394,21 @@ class BackfillRunner:
             건너뛴다(실패 직전 날짜에 checkpoint 고정). 수집 자체는 best-effort로
             계속하므로 ``continue``(루프 진행)는 유지한다 — DataGoKr 결과는
             ParquetStore natural-key dedup으로 재-fetch overwrite 멱등.
+
+        checkpoint 가드 = stored_ok 3-state (#1993, #2015 무회귀):
+            checkpoint 전진은 더 이상 ``written > 0``(net-delta)가 아니라
+            collector가 보고하는 ``stored_ok``(유효 데이터 store 성공 반영) 신호로
+            구동한다. rows_written을 net-new delta로 바꾸면 재수집 날짜는
+            net_delta=0이 되는데, ``written > 0`` 가드라면 그 날짜가 미전진해
+            checkpoint stall이 생긴다. 3-state로 분리:
+              - 빈 응답(stored_ok=False) → 미전진(#2015 보존)
+              - 유효 재수집(stored_ok=True, net_delta=0) → 전진(stall 해소)
+              - store-merge 실패 → 미전진. ``_persist_partition`` 은 merge 실패
+                시 raise하지 않고(R1) 기존 파일 보존 + ``store_merge`` 경고만
+                적재하므로, runner가 checkpoint save **직전** 이번 날짜 write 직후
+                store 경고를 drain해 ``store_merge`` 존재를 확인하는 가드로 미전진
+                시킨다. drain은 반드시 collect/write 직후·checkpoint save 직전에
+                수행한다(지연 drain이면 실패 날짜가 이미 전진).
         """
         if self._data_go_kr is None:
             return
@@ -419,24 +434,33 @@ class BackfillRunner:
                 break
 
             try:
-                written, syms, warns = await self._data_go_kr.collect(
+                net_delta, stored_ok, syms, warns = await self._data_go_kr.collect(
                     target_date,
                     store,
                 )
-                ctx.add_success(written, syms, warns)
-                if written > 0:
+                ctx.add_success(net_delta, syms, warns)
+                if stored_ok:
                     ctx.data_types.update(["ohlcv", "fundamental"])
-                # checkpoint는 데이터가 실제 저장된 날짜(written > 0)에만
-                # 전진시킨다(#2015). 빈 응답(written == 0: 미공개/지연공개/
-                # 캘린더 미인식 공휴일)에 전진하면 그 날짜가 다음 run에서
-                # last_checkpoint 이전으로 간주되어 영구 skip된다(데이터 손실).
-                # dates는 오름차순이므로 checkpoint = 마지막 written>0 날짜이며,
+
+                # R1: store 경고를 checkpoint save 직전·이번 날짜 write 직후
+                # drain한다. store-merge 실패(기존 파일 보존)는 raise하지 않고
+                # 경고만 남기므로, 이번 날짜에 발생한 store_merge가 있으면
+                # checkpoint를 전진시키지 않는다(데이터 미반영 날짜 영구 skip 방지).
+                store_merge_failed = self._drain_store_warnings(store, ctx)
+
+                # checkpoint는 유효 데이터가 store에 반영된 날짜(stored_ok)에만
+                # 전진시킨다(#1993/#2015). 빈 응답/전 drop/validation 차단
+                # (stored_ok=False: 미공개/지연공개/캘린더 미인식 공휴일)에
+                # 전진하면 그 날짜가 다음 run에서 last_checkpoint 이전으로 간주되어
+                # 영구 skip된다(데이터 손실). 유효 재수집(net_delta=0)은 stored_ok로
+                # 정상 전진해 stall을 만들지 않는다.
+                # dates는 오름차순이므로 checkpoint = 마지막 stored_ok 날짜이며,
                 # 내부 빈 날짜는 다음 데이터 날짜에서 jump해 자연 커버(stall 없음),
                 # trailing 빈 날짜는 미전진 → 다음 실행에서 재시도(손실 없음).
                 #
-                # halt 이후에는 written 여부와 무관하게 전진시키지 않는다(#2078).
-                # 앞선 실패 날짜 너머로 last_date가 진행되면 그 날짜가 영구 skip된다.
-                if not halt and written > 0:
+                # halt(#2078) 이후 또는 store-merge 실패 시에는 stored_ok여도
+                # 전진시키지 않는다(실패 날짜 너머 전진 → 영구 skip 방지).
+                if not halt and stored_ok and not store_merge_failed:
                     checkpoint.save(target_date)
 
             except (DataGoKrDailyLimitError, DataGoKrCriticalError) as exc:
@@ -465,6 +489,25 @@ class BackfillRunner:
                 # 못하도록 halt한다(#2078). break는 도입하지 않고(best-effort
                 # 수집 계속) checkpoint.save만 위 success 경로에서 가드한다.
                 halt = True
+
+    @staticmethod
+    def _drain_store_warnings(store: ParquetStore, ctx: _RunContext) -> bool:
+        """store의 pending 경고를 즉시 drain해 ctx.warnings로 옮기고,
+
+        이번 drain에 ``store_merge`` (파티션 merge 실패 → 기존 파일 보존, 데이터
+        미반영) 경고가 있었는지 반환한다(#1993 R1).
+
+        checkpoint save 직전에 호출해야 한다 — collect/write 직후 drain해야 이번
+        날짜에서 발생한 store-merge 실패를 정확히 귀속할 수 있다(지연 drain이면
+        실패 날짜가 이미 checkpoint를 전진시킨 뒤가 된다).
+
+        Returns:
+            이번 drain에 ``type == "store_merge"`` 경고가 하나라도 있었으면 True.
+        """
+        drained = store.drain_warnings()
+        if drained:
+            ctx.warnings.extend(drained)
+        return any(w.get("type") == "store_merge" for w in drained)
 
     async def _wait_out_trading_pause(
         self,
@@ -572,15 +615,17 @@ class BackfillRunner:
             return
 
         try:
-            written, syms, warns = await self._dart.collect(
+            net_delta, stored_ok, syms, warns = await self._dart.collect(
                 data_path,
                 feed_dir,
                 checkpoint,
                 config,
                 store,
             )
-            ctx.add_success(written, syms, warns)
-            if written > 0:
+            ctx.add_success(net_delta, syms, warns)
+            # data_types는 유효 분기 저장 여부(stored_ok)로 표시한다 — 재수집
+            # (net_delta=0)이어도 fundamental 데이터가 store에 있으므로 True(#1993).
+            if stored_ok:
                 ctx.data_types.add("fundamental")
         except (DARTDailyLimitError, DARTCriticalError) as exc:
             logger.critical("DART 수집 중단: %s", exc)
@@ -640,12 +685,17 @@ class _RunContext:
 
     def add_success(
         self,
-        written: int,
+        net_delta: int,
         syms: set[str],
         warns: list[dict],
     ) -> None:
-        """성공 결과를 집계한다."""
-        self.rows_written += written
+        """성공 결과를 집계한다.
+
+        ``net_delta`` 는 collector가 보고한 **실제 net-new 저장 행 수**
+        (rows_written, #1993)다. 입력 len 누적이 아니라 store가 실제 새로 저장한
+        delta를 누적하므로 재수집/dedup이 rows_written을 과대계상하지 않는다.
+        """
+        self.rows_written += net_delta
         self.total_symbols.update(syms)
         self.success_symbols.update(syms)
         if warns:

--- a/src/ante/feed/pipeline/daily_runner.py
+++ b/src/ante/feed/pipeline/daily_runner.py
@@ -116,12 +116,14 @@ class DailyRunner:
             return
 
         try:
-            written, syms, warns = await self._data_go_kr.collect(
+            net_delta, stored_ok, syms, warns = await self._data_go_kr.collect(
                 target_date,
                 store,
             )
-            ctx.add_success(written, syms, warns)
-            if written > 0:
+            ctx.add_success(net_delta, syms, warns)
+            # data_types는 유효 데이터 store 반영 여부(stored_ok)로 표시한다 —
+            # 재수집(net_delta=0)이어도 데이터가 store에 있으므로 True(#1993).
+            if stored_ok:
                 ctx.data_types.update(["ohlcv", "fundamental"])
         except (DataGoKrDailyLimitError, DataGoKrCriticalError) as exc:
             ctx.config_errors.append(
@@ -163,7 +165,7 @@ class DailyRunner:
             # collectable 분기 1개"만 수집한다(#2101). backfill_since 전 분기를
             # 순회하지 않는다. 과거 미충전 분기 보정은 backfill 모드 책임이며,
             # daily는 최신 분기 증분만 담당한다.
-            written, syms, warns = await self._dart.collect(
+            net_delta, stored_ok, syms, warns = await self._dart.collect(
                 data_path,
                 feed_dir,
                 checkpoint,
@@ -171,8 +173,9 @@ class DailyRunner:
                 store,
                 daily=True,
             )
-            ctx.add_success(written, syms, warns)
-            if written > 0:
+            ctx.add_success(net_delta, syms, warns)
+            # data_types는 유효 분기 저장 여부(stored_ok)로 표시한다(#1993).
+            if stored_ok:
                 ctx.data_types.add("fundamental")
         except (DARTDailyLimitError, DARTCriticalError) as exc:
             ctx.config_errors.append(

--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -108,7 +108,7 @@ class DARTCollector:
         config: dict[str, Any],
         store: ParquetStore,
         daily: bool = False,
-    ) -> tuple[int, set[str], list[dict]]:
+    ) -> tuple[int, bool, set[str], list[dict]]:
         """DART 재무제표를 분기별로 수집한다.
 
         Args:
@@ -126,7 +126,17 @@ class DARTCollector:
                 최신 분기 증분만 담당한다.
 
         Returns:
-            (기록 행 수, 수집된 심볼 집합, 경고 목록).
+            ``(net_delta, stored_ok, 수집된 심볼 집합, 경고 목록)`` (#1993):
+
+            - ``net_delta``: store에 **실제 새로 저장된 net-new 행 수**(rows_written).
+              재수집(dedup)이면 0이다.
+            - ``stored_ok``: **유효 분기 데이터가 store에 성공 반영되었는지**
+              (한 분기라도 ``QuarterStatus.OK``, 즉 storable_rows>0). net_delta와
+              무관하다 — 재수집으로 net_delta=0이어도 OK 분기가 있으면 True다.
+              빈 매핑/전 분기 SKIP_EMPTY/no-storable HALT 등 저장 반영이 전무하면
+              False다. DART checkpoint 전진은 내부 ``QuarterStatus`` 로직이 분기별로
+              자체 관리하므로(#2028/#2054), 이 stored_ok는 runner의
+              ``data_types`` 반영용이다(checkpoint 가드 아님).
         """
         corp_code_map = await self._load_corp_codes(feed_dir)
         if not corp_code_map:
@@ -140,7 +150,7 @@ class DARTCollector:
                     ),
                 }
             ]
-            return 0, set(), warns
+            return 0, False, set(), warns
 
         last_checkpoint = checkpoint.get_last_date()
         last_checkpoint = self._migrate_checkpoint_key(last_checkpoint)
@@ -212,12 +222,19 @@ class DARTCollector:
         start_year: int,
         end_year: int,
         last_checkpoint: str | None,
-    ) -> tuple[int, set[str], list[dict]]:
-        """연도/분기를 순회하며 재무제표를 수집한다."""
+    ) -> tuple[int, bool, set[str], list[dict]]:
+        """연도/분기를 순회하며 재무제표를 수집한다.
+
+        Returns:
+            ``(net_delta, stored_ok, symbols, warns)`` (#1993). net_delta는
+            ``_fetch_quarter`` 가 반환한 rows_written(net-new 저장 행 수)의 합이며,
+            stored_ok는 한 분기라도 ``QuarterStatus.OK`` (storable 저장)였는지다.
+        """
         corp_codes_list = list(corp_code_map.keys())
         rows_written = 0
         symbols: set[str] = set()
         warns: list[dict] = []
+        stored_ok = False
 
         # collectable 상한: period-end가 today(KST)를 지난 분기만 fetch/save.
         # 미래 분기(예: 실행일 2026-05-29 기준 2026-Q2/Q3/Q4)는 데이터가
@@ -265,16 +282,21 @@ class DARTCollector:
                 symbols.update(syms)
                 if status is QuarterStatus.HALT:
                     halt = True
-                elif status is QuarterStatus.OK and not halt:
-                    checkpoint.save(quarter_key)
+                elif status is QuarterStatus.OK:
+                    # storable 저장이 일어난 분기 — stored_ok 신호 set(net_delta
+                    # 무관). checkpoint 전진은 halt 미설정일 때만(#2054 보존).
+                    stored_ok = True
+                    if not halt:
+                        checkpoint.save(quarter_key)
                 # QuarterStatus.SKIP_EMPTY: checkpoint 미전진 + halt 미설정(no-op).
 
         logger.info(
-            "DART 수집 완료: symbols=%d rows=%d",
+            "DART 수집 완료: symbols=%d rows=%d stored_ok=%s",
             len(symbols),
             rows_written,
+            stored_ok,
         )
-        return rows_written, symbols, warns
+        return rows_written, stored_ok, symbols, warns
 
     @staticmethod
     def _latest_collectable_quarter(
@@ -318,7 +340,7 @@ class DARTCollector:
         store: ParquetStore,
         checkpoint: Checkpoint,
         last_checkpoint: str | None,
-    ) -> tuple[int, set[str], list[dict]]:
+    ) -> tuple[int, bool, set[str], list[dict]]:
         """daily 모드: 최신 collectable 분기 1개만 수집한다(#2101).
 
         ``backfill_since`` 범위를 순회하지 않고, today(KST) 기준 가장 최근에
@@ -328,6 +350,10 @@ class DARTCollector:
 
         운영 전제: 이 경로는 최신 분기만 본다. 과거 미충전 분기는 backfill
         모드로 채워야 하며, daily가 과거 누락을 보정하지 않는다.
+
+        Returns:
+            ``(net_delta, stored_ok, symbols, warns)`` (#1993). stored_ok는
+            최신 분기가 ``QuarterStatus.OK`` (storable 저장)인지다.
         """
         corp_codes_list = list(corp_code_map.keys())
         warns: list[dict] = []
@@ -337,7 +363,7 @@ class DARTCollector:
         if latest is None:
             # collectable 분기 부재(매핑 이상 등): no-op.
             logger.info("DART daily: collectable 분기 없음")
-            return 0, set(), warns
+            return 0, False, set(), warns
 
         year, reprt_code = latest
         quarter_key = f"{year}-{REPRT_TO_QUARTER[reprt_code]}"
@@ -349,7 +375,7 @@ class DARTCollector:
                 quarter_key,
                 last_checkpoint,
             )
-            return 0, set(), warns
+            return 0, False, set(), warns
 
         written, syms, status = await self._fetch_quarter(
             corp_codes_list,
@@ -361,7 +387,8 @@ class DARTCollector:
         )
         # SKIP_EMPTY(미공시 가능)/HALT(transient·no-storable)는 backfill과 동일하게
         # checkpoint를 전진시키지 않는다. OK일 때만 save한다(#2028/#2054 보존).
-        if status is QuarterStatus.OK:
+        stored_ok = status is QuarterStatus.OK
+        if stored_ok:
             checkpoint.save(quarter_key)
 
         logger.info(
@@ -371,7 +398,7 @@ class DARTCollector:
             written,
             status.value,
         )
-        return written, syms, warns
+        return written, stored_ok, syms, warns
 
     async def _fetch_quarter(
         self,
@@ -433,15 +460,21 @@ class DARTCollector:
             # checkpoint.save가 jump 커버, trailing 빈 분기는 다음 run 재시도).
             return 0, set(), QuarterStatus.SKIP_EMPTY
 
-        written, syms = self._normalize_and_store(
+        # storable_rows/net_delta를 분리 수신(#1993). QuarterStatus 판정은
+        # storable_rows(정규화/저장 가능 행 수) 기준으로 유지하고(#2028 무변경),
+        # 반환하는 written(rows_written)은 net_delta(실제 net-new 저장 행 수)다.
+        storable_rows, net_delta, syms = self._normalize_and_store(
             raw_items,
             corp_code_map,
             store,
         )
-        if written == 0:
+        if storable_rows == 0:
             # raw_items는 있으나 정규화/저장에서 0 rows(normalized empty,
-            # symbol 컬럼 부재 등 no-storable). 데이터 손실을 surface하고
-            # checkpoint를 전진시키지 않아 다음 run에서 재시도되게 한다.
+            # symbol 컬럼 부재 등 no-storable). net-delta가 아니라 storable
+            # 기준으로 판정한다 — 재수집(dedup, net_delta=0)은 storable>0이라
+            # 여기 걸리지 않고 OK로 처리되어 checkpoint stall을 만들지 않는다.
+            # no-storable은 데이터 손실을 surface하고 checkpoint를 전진시키지
+            # 않아 다음 run에서 재시도되게 한다.
             logger.warning(
                 "DART 정규화/저장 결과 0건: year=%s reprt=%s raw=%d",
                 year,
@@ -461,27 +494,45 @@ class DARTCollector:
             )
             return 0, syms, QuarterStatus.HALT
 
-        return written, syms, QuarterStatus.OK
+        # storable_rows>0 → checkpoint 전진 자격(OK). 재수집이면 net_delta=0이라
+        # rows_written은 0이지만 status는 OK로 checkpoint가 정상 전진한다.
+        return net_delta, syms, QuarterStatus.OK
 
     def _normalize_and_store(
         self,
         raw_items: list[dict],
         corp_code_map: dict[str, str],
         store: ParquetStore,
-    ) -> tuple[int, set[str]]:
-        """raw 데이터를 정규화하고 심볼별로 저장한다."""
+    ) -> tuple[int, int, set[str]]:
+        """raw 데이터를 정규화하고 심볼별로 저장한다.
+
+        Returns:
+            ``(storable_rows, net_delta, symbols)`` — 두 신호를 **분리** 반환한다
+            (#1993, #2028 보존):
+
+            - ``storable_rows``: 정규화/저장 가능한 행 수(정규화 결과 심볼별 행
+              수의 합). normalized가 비거나 symbol 컬럼이 없으면 0. 이 값이
+              ``_fetch_quarter`` 의 ``written == 0`` no-storable HALT 판정을
+              구동한다(QuarterStatus 동작 무변경 — net-delta가 아니라 storable
+              기준). 재수집(dedup으로 net_delta=0)이어도 storable_rows>0이라
+              빈응답/no-storable과 구분된다.
+            - ``net_delta``: ``store.write`` 가 반환한 **실제 net-new 저장 행 수**
+              의 합(rows_written, #1993). 재수집/dedup이면 0.
+            - ``symbols``: 저장 대상 심볼 집합.
+        """
         df = pl.DataFrame(raw_items)
         normalized = self._normalizer.normalize(df, corp_code_map)
 
         if normalized.is_empty() or "symbol" not in normalized.columns:
-            return 0, set()
+            return 0, 0, set()
 
-        rows = 0
+        storable_rows = 0
+        net_delta = 0
         symbols: set[str] = set()
         for sym in normalized["symbol"].unique().to_list():
             sym_df = normalized.filter(pl.col("symbol") == sym)
-            store.write(sym, "krx", sym_df, data_type="fundamental")
-            rows += len(sym_df)
+            net_delta += store.write(sym, "krx", sym_df, data_type="fundamental")
+            storable_rows += len(sym_df)
             symbols.add(sym)
 
-        return rows, symbols
+        return storable_rows, net_delta, symbols

--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -257,6 +257,12 @@ class DARTCollector:
         # 분기의 checkpoint.save가 jump하여 커버하고, trailing 빈 분기는 미전진
         # 상태로 남아 다음 run에서 재시도된다(분기종료 직후 빈 응답을 "완료"로
         # 오인해 이후 공시를 누락하던 버그 해소).
+        #
+        # store-merge 실패(#1993 R2)는 분기별로 독립 판정한다. halt와 달리 이후
+        # 분기로 전파되지 않으며(halt를 세우지 않음), 해당 분기만 checkpoint를
+        # 미전진시켜 다음 run에 재시도되게 한다. data.go.kr는 runner R1이 store
+        # 경고 drain으로 가드하지만 DART는 checkpoint.save가 collector 내부라
+        # _fetch_quarter의 비파괴적 peek 결과(store_merge_failed)로 게이트한다.
         halt = False
 
         for year in range(start_year, end_year + 1):
@@ -270,7 +276,7 @@ class DARTCollector:
                     # 미래 분기: fetch/save 모두 건너뛴다.
                     continue
 
-                written, syms, status = await self._fetch_quarter(
+                written, syms, status, store_merge_failed = await self._fetch_quarter(
                     corp_codes_list,
                     corp_code_map,
                     store,
@@ -284,9 +290,14 @@ class DARTCollector:
                     halt = True
                 elif status is QuarterStatus.OK:
                     # storable 저장이 일어난 분기 — stored_ok 신호 set(net_delta
-                    # 무관). checkpoint 전진은 halt 미설정일 때만(#2054 보존).
+                    # 무관). checkpoint 전진은 halt 미설정 + store-merge 성공일
+                    # 때만(#2054 보존, #1993 R2). store-merge 실패(net_delta=0 +
+                    # store_merge 경고)면 QuarterStatus는 OK여도 checkpoint를
+                    # 전진시키지 않아 다음 run에 재시도된다(데이터 미반영 분기
+                    # 영구 skip 방지). store_merge 경고는 runner가 collect 종료 후
+                    # drain해 보고한다(DART는 비파괴적 peek만 함).
                     stored_ok = True
-                    if not halt:
+                    if not halt and not store_merge_failed:
                         checkpoint.save(quarter_key)
                 # QuarterStatus.SKIP_EMPTY: checkpoint 미전진 + halt 미설정(no-op).
 
@@ -377,7 +388,7 @@ class DARTCollector:
             )
             return 0, False, set(), warns
 
-        written, syms, status = await self._fetch_quarter(
+        written, syms, status, store_merge_failed = await self._fetch_quarter(
             corp_codes_list,
             corp_code_map,
             store,
@@ -386,9 +397,12 @@ class DARTCollector:
             warns,
         )
         # SKIP_EMPTY(미공시 가능)/HALT(transient·no-storable)는 backfill과 동일하게
-        # checkpoint를 전진시키지 않는다. OK일 때만 save한다(#2028/#2054 보존).
+        # checkpoint를 전진시키지 않는다. OK일 때만 save하되, store-merge 실패
+        # (net_delta=0 + store_merge 경고)면 QuarterStatus가 OK여도 checkpoint를
+        # 전진시키지 않는다(#1993 R2, 다음 run 재시도). store_merge 경고는 runner가
+        # collect 종료 후 drain해 보고한다(DART는 비파괴적 peek만 함).
         stored_ok = status is QuarterStatus.OK
-        if stored_ok:
+        if stored_ok and not store_merge_failed:
             checkpoint.save(quarter_key)
 
         logger.info(
@@ -408,12 +422,15 @@ class DARTCollector:
         year: int,
         reprt_code: str,
         warns: list[dict],
-    ) -> tuple[int, set[str], QuarterStatus]:
+    ) -> tuple[int, set[str], QuarterStatus, bool]:
         """단일 분기 재무제표를 수집/정규화/저장한다.
 
         Returns:
-            (기록 행 수, 수집된 심볼 집합, status). ``status``는 이 분기에 대한
-            checkpoint 전진/halt 결정을 구동하는 3-상태다(#2028, #2054):
+            (기록 행 수, 수집된 심볼 집합, status, store_merge_failed).
+
+            ``status``는 이 분기에 대한 checkpoint 전진/halt 결정을 구동하는
+            3-상태다(#2028, #2054). **storable_rows 기준으로만 판정**하며
+            store-merge 실패를 절대 섞지 않는다(#2028 의미 보존):
 
             - transient 예외(warn 추가) → ``QuarterStatus.HALT``
               (미전진 + 이후 분기 동결, 다음 run 재시도)
@@ -424,6 +441,21 @@ class DARTCollector:
             - ``raw_items``는 있는데 정규화/저장 결과 0 rows(no-storable) →
               warn 추가 + ``QuarterStatus.HALT``(데이터 손실 surface, 미전진)
             - 정상 저장(written>0) → ``QuarterStatus.OK``(checkpoint 전진 자격)
+
+            ``store_merge_failed``는 이번 분기 ``store.write`` 가 파티션 merge
+            실패(기존 파일 보존 + ``store_merge`` 경고 적재, net_delta=0)를
+            일으켰는지다(#1993). data.go.kr는 runner R1이 store 경고 drain으로
+            checkpoint를 가드하지만 DART는 checkpoint.save를 collector 내부에서
+            하므로(``_collect_quarters``/``_collect_latest_quarter``) 호출자가 이
+            bool로 checkpoint 전진을 게이트한다. QuarterStatus는 storable 기준
+            그대로(OK)이되 store_merge_failed면 checkpoint만 미전진시켜 다음 run에
+            재시도되게 한다.
+
+            store_merge 감지는 ``store.pending_merge_failure_count()`` 의
+            **비파괴적 peek**로 한다. runner가 DART collect 전체 종료 후 단일
+            소유로 drain하므로(backfill_runner) DART가 drain하면 경고가 소실된다.
+            누적 카운트라 ``_normalize_and_store`` **직전/직후 증가분**으로 이번
+            분기 실패를 판정한다(이전 분기 경고가 아직 drain 안 됐을 수 있음).
 
             ``DARTDailyLimitError``/``DARTCriticalError``는 기존대로 re-raise.
         """
@@ -450,7 +482,7 @@ class DARTCollector:
                     "message": str(exc),
                 }
             )
-            return 0, set(), QuarterStatus.HALT
+            return 0, set(), QuarterStatus.HALT, False
 
         if not raw_items:
             # 빈 응답: 분기종료 직후 아직 공시되지 않았을 수 있다(미공시 가능).
@@ -458,7 +490,13 @@ class DARTCollector:
             # 오인, #2028) 미전진한다. 단 halt는 세우지 않아 후속 분기 처리는
             # 계속한다(오름차순 순회에서 내부 빈 분기는 후속 데이터 분기의
             # checkpoint.save가 jump 커버, trailing 빈 분기는 다음 run 재시도).
-            return 0, set(), QuarterStatus.SKIP_EMPTY
+            return 0, set(), QuarterStatus.SKIP_EMPTY, False
+
+        # store-merge 실패 감지(#1993): 비파괴적 peek로 _normalize_and_store
+        # 직전/직후 store_merge 경고 누적 카운트를 캡처하고 증가분으로 이번 분기
+        # 실패를 판정한다. drain은 runner가 collect 종료 후 단일 소유로 하므로
+        # 여기서는 count만 읽는다(drain 소유권 보존).
+        merge_failures_before = store.pending_merge_failure_count()
 
         # storable_rows/net_delta를 분리 수신(#1993). QuarterStatus 판정은
         # storable_rows(정규화/저장 가능 행 수) 기준으로 유지하고(#2028 무변경),
@@ -468,6 +506,10 @@ class DARTCollector:
             corp_code_map,
             store,
         )
+
+        merge_failures_after = store.pending_merge_failure_count()
+        store_merge_failed = merge_failures_after > merge_failures_before
+
         if storable_rows == 0:
             # raw_items는 있으나 정규화/저장에서 0 rows(normalized empty,
             # symbol 컬럼 부재 등 no-storable). net-delta가 아니라 storable
@@ -492,11 +534,13 @@ class DARTCollector:
                     ),
                 }
             )
-            return 0, syms, QuarterStatus.HALT
+            return 0, syms, QuarterStatus.HALT, store_merge_failed
 
         # storable_rows>0 → checkpoint 전진 자격(OK). 재수집이면 net_delta=0이라
-        # rows_written은 0이지만 status는 OK로 checkpoint가 정상 전진한다.
-        return net_delta, syms, QuarterStatus.OK
+        # rows_written은 0이지만 status는 OK로 checkpoint가 정상 전진한다. 단
+        # store-merge 실패(net_delta=0 + store_merge 경고)면 호출자가
+        # store_merge_failed로 checkpoint를 게이트해 미전진시킨다(다음 run 재시도).
+        return net_delta, syms, QuarterStatus.OK, store_merge_failed
 
     def _normalize_and_store(
         self,

--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -46,13 +46,17 @@ class DataGoKrCollector:
               (= ``store.write`` 반환 합, rows_written). 재수집(dedup)이면 0이며,
               이는 정상이다(과대계상 제거).
             - ``stored_ok``: **유효 데이터가 store에 성공적으로 반영되었는지**.
-              net_delta와 무관하다 — 재수집으로 net_delta=0이어도 유효 데이터를
-              검증 통과시켜 ``store.write`` 를 호출 완료했으면 ``True`` 다(checkpoint
-              전진 자격). 빈 응답/전 row drop/validation 차단처럼 저장 자체를
-              하지 못한 경우만 ``False`` 다. store-merge 실패(기존 파일 보존)는
-              ``store.write`` 호출은 완료했으므로 여기서는 ``True`` 이며,
-              checkpoint 미전진은 runner가 store_merge 경고 존재로 별도 가드한다
-              (R1: ``_persist_partition`` 은 merge 실패 시 raise하지 않는다).
+              net_delta와 무관하며 ``bool(symbols)`` (실제 ``store.write`` 가
+              호출된 심볼 존재)에서 유도한다 — 재수집으로 net_delta=0이어도 유효
+              데이터를 정규화·저장 완료했으면 symbols가 비어있지 않아 ``True`` 다
+              (checkpoint 전진 자격). 빈 응답/전 row drop/validation 차단처럼 저장
+              자체를 못한 경우는 조기 ``False`` 반환하고, survivor가 validation을
+              통과했어도 정규화 단계에서 추가 drop돼 ohlcv/fundamental 둘 다
+              no-symbol이면 symbols가 비어 ``False`` 다(저장 0건 → 미전진).
+              store-merge 실패(기존 파일 보존)는 ``store.write`` 호출은 완료했으므로
+              해당 심볼이 symbols에 남아 여기서는 ``True`` 이며, checkpoint 미전진은
+              runner가 store_merge 경고 존재로 별도 가드한다(R1:
+              ``_persist_partition`` 은 merge 실패 시 raise하지 않는다).
         """
         raw_items = await self._source.fetch(target_date)
         if not raw_items:
@@ -94,10 +98,17 @@ class DataGoKrCollector:
             target_date,
         )
 
-        # 유효 survivor batch가 validation을 통과해 store.write를 호출 완료했다
-        # → stored_ok=True(net_delta=0 재수집이어도 checkpoint 전진 자격). 빈
-        # 응답/전 drop/validation 차단은 위에서 stored_ok=False로 조기 반환했다.
-        return net_delta, True, symbols, warns
+        # stored_ok는 하드코딩 True가 아니라 **실제 저장 심볼 존재(bool(symbols))**
+        # 에서 유도한다. `symbols`는 `_store_ohlcv`/`_store_fundamental`에서
+        # 실제 `store.write`가 호출된 심볼만 add되므로:
+        #   - 빈 응답/전 drop/validation 차단 → 위에서 stored_ok=False 조기 반환.
+        #   - survivor가 validation을 통과했더라도 정규화 단계에서 추가 drop돼
+        #     normalize_ohlcv·normalize_fundamental이 **둘 다** empty/no-symbol이면
+        #     symbols가 빈 set → stored_ok=False(미전진). 저장 0건인데 checkpoint를
+        #     전진시켜 데이터를 영구 skip하는 회귀를 막는다.
+        #   - 재수집(net_delta=0이지만 정규화 정상)은 symbols가 비어있지 않아
+        #     stored_ok=True(전진 유지). net_delta와 무관하게 저장 반영 여부만 본다.
+        return net_delta, bool(symbols), symbols, warns
 
     @staticmethod
     def _filter_invalid_symbols(

--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -36,16 +36,28 @@ class DataGoKrCollector:
         self,
         target_date: str,
         store: ParquetStore,
-    ) -> tuple[int, set[str], list[dict]]:
+    ) -> tuple[int, bool, set[str], list[dict]]:
         """특정 날짜의 전종목 데이터를 수집한다.
 
         Returns:
-            (기록 행 수, 수집된 심볼 집합, 경고 목록).
+            ``(net_delta, stored_ok, 수집된 심볼 집합, 경고 목록)`` (#1993):
+
+            - ``net_delta``: store에 **실제 새로 저장된 net-new 행 수**
+              (= ``store.write`` 반환 합, rows_written). 재수집(dedup)이면 0이며,
+              이는 정상이다(과대계상 제거).
+            - ``stored_ok``: **유효 데이터가 store에 성공적으로 반영되었는지**.
+              net_delta와 무관하다 — 재수집으로 net_delta=0이어도 유효 데이터를
+              검증 통과시켜 ``store.write`` 를 호출 완료했으면 ``True`` 다(checkpoint
+              전진 자격). 빈 응답/전 row drop/validation 차단처럼 저장 자체를
+              하지 못한 경우만 ``False`` 다. store-merge 실패(기존 파일 보존)는
+              ``store.write`` 호출은 완료했으므로 여기서는 ``True`` 이며,
+              checkpoint 미전진은 runner가 store_merge 경고 존재로 별도 가드한다
+              (R1: ``_persist_partition`` 은 merge 실패 시 raise하지 않는다).
         """
         raw_items = await self._source.fetch(target_date)
         if not raw_items:
             logger.debug("data.go.kr: date=%s 데이터 없음", target_date)
-            return 0, set(), []
+            return 0, False, set(), []
 
         raw_items, symbol_warns = self._filter_invalid_symbols(raw_items, target_date)
 
@@ -59,7 +71,7 @@ class DataGoKrCollector:
             logger.warning(
                 "data.go.kr: date=%s 유효 레코드 없음(전 row drop)", target_date
             )
-            return 0, set(), warns
+            return 0, False, set(), warns
 
         # (c) 검증 게이트: survivor batch가 validate_all에서 passed=False면
         # (transport status≠200, syntax, 또는 향후 schema 검사) 저장하지 않는다.
@@ -71,18 +83,21 @@ class DataGoKrCollector:
                 target_date,
                 len(survivors),
             )
-            return 0, set(), warns
+            return 0, False, set(), warns
 
         df = pl.DataFrame(survivors)
         df = self._deduplicate(df)
 
-        rows_written, symbols = self._normalize_and_store(
+        net_delta, symbols = self._normalize_and_store(
             df,
             store,
             target_date,
         )
 
-        return rows_written, symbols, warns
+        # 유효 survivor batch가 validation을 통과해 store.write를 호출 완료했다
+        # → stored_ok=True(net_delta=0 재수집이어도 checkpoint 전진 자격). 빈
+        # 응답/전 drop/validation 차단은 위에서 stored_ok=False로 조기 반환했다.
+        return net_delta, True, symbols, warns
 
     @staticmethod
     def _filter_invalid_symbols(
@@ -219,7 +234,12 @@ class DataGoKrCollector:
         store: ParquetStore,
         target_date: str,
     ) -> tuple[int, set[str]]:
-        """OHLCV와 fundamental을 정규화하고 저장한다."""
+        """OHLCV와 fundamental을 정규화하고 저장한다.
+
+        Returns:
+            ``(net_delta, symbols)``. net_delta는 ohlcv/fundamental ``store.write``
+            반환(실제 net-new 저장 행 수)의 합이다(#1993). 재수집/dedup이면 0.
+        """
         rows_written = 0
         symbols: set[str] = set()
 
@@ -248,7 +268,12 @@ class DataGoKrCollector:
         store: ParquetStore,
         symbols: set[str],
     ) -> int:
-        """OHLCV 데이터를 정규화하여 심볼별로 저장한다."""
+        """OHLCV 데이터를 정규화하여 심볼별로 저장한다.
+
+        Returns:
+            ``store.write`` 반환(net-new 저장 행 수)의 합(#1993). 입력 len이
+            아니라 실제 저장 delta다(재수집/dedup이면 0).
+        """
         ohlcv_df = self._normalizer.normalize_ohlcv(df)
         if ohlcv_df.is_empty() or "symbol" not in ohlcv_df.columns:
             return 0
@@ -256,8 +281,7 @@ class DataGoKrCollector:
         rows = 0
         for sym in ohlcv_df["symbol"].unique().to_list():
             sym_df = ohlcv_df.filter(pl.col("symbol") == sym)
-            store.write(sym, "1d", sym_df, data_type="ohlcv")
-            rows += len(sym_df)
+            rows += store.write(sym, "1d", sym_df, data_type="ohlcv")
             symbols.add(sym)
         return rows
 
@@ -267,7 +291,12 @@ class DataGoKrCollector:
         store: ParquetStore,
         symbols: set[str],
     ) -> int:
-        """fundamental 데이터를 정규화하여 심볼별로 저장한다."""
+        """fundamental 데이터를 정규화하여 심볼별로 저장한다.
+
+        Returns:
+            ``store.write`` 반환(net-new 저장 행 수)의 합(#1993). 입력 len이
+            아니라 실제 저장 delta다(재수집/dedup이면 0).
+        """
         fund_df = self._normalizer.normalize_fundamental(df)
         if fund_df.is_empty() or "symbol" not in fund_df.columns:
             return 0
@@ -275,8 +304,7 @@ class DataGoKrCollector:
         rows = 0
         for sym in fund_df["symbol"].unique().to_list():
             sym_df = fund_df.filter(pl.col("symbol") == sym)
-            store.write(sym, "krx", sym_df, data_type="fundamental")
-            rows += len(sym_df)
+            rows += store.write(sym, "krx", sym_df, data_type="fundamental")
             symbols.add(sym)
         return rows
 

--- a/src/ante/feed/pipeline/indicator_calculator.py
+++ b/src/ante/feed/pipeline/indicator_calculator.py
@@ -133,7 +133,10 @@ class IndicatorCalculator:
         """심볼 목록에 대해 파생 지표를 계산하여 저장한다.
 
         Returns:
-            갱신된 행 수.
+            **net-new 저장 행 수**(rows_written, #1993). 지표 계산은 기존 일별
+            fundamental 행을 비율 컬럼만 채워 같은 natural key로 in-place
+            overwrite하므로(행 수 불변), 보통 net-delta=0이다. 이는 정상이며
+            rows_written 과대계상을 방지한다.
         """
         rows_updated = 0
 
@@ -159,6 +162,11 @@ class IndicatorCalculator:
         ``join_asof(strategy="backward")``로 결합한 뒤 비율을 계산하여
         일별 행을 write-back한다. 두 소스 중 하나라도 비어 있거나
         source/date 컬럼이 없으면 0을 반환한다(graceful).
+
+        Returns:
+            ``store.write`` 가 반환한 **net-new 저장 행 수**(#1993). 비율 컬럼만
+            채운 in-place overwrite(같은 natural key)라 행 수가 늘지 않으므로
+            보통 0이다(과대계상 방지). 계산 불가(graceful 0) 시에도 0.
         """
         try:
             fundamental = store.read(sym, "krx", data_type="fundamental")
@@ -189,8 +197,8 @@ class IndicatorCalculator:
         # write-back 전 FUNDAMENTAL 스키마 밖 컬럼(total_assets 등) 제거.
         keep = [c for c in updated.columns if c in _FUNDAMENTAL_COLUMN_SET]
         updated = updated.select(keep)
-        store.write(sym, "krx", updated, data_type="fundamental")
-        return len(updated)
+        # net-new 저장 행 수(#1993). in-place overwrite라 보통 0이다.
+        return store.write(sym, "krx", updated, data_type="fundamental")
 
     @staticmethod
     def _join_asof(

--- a/tests/unit/feed/test_backfill_data_go_kr_checkpoint.py
+++ b/tests/unit/feed/test_backfill_data_go_kr_checkpoint.py
@@ -30,12 +30,13 @@ class _ScriptedDataGoKrCollector:
     """target_date별 raise/성공 응답을 스크립트로 지정하는 collector 스텁.
 
     ``BackfillRunner._collect_data_go_kr`` 가 호출하는
-    ``collect(target_date, store) -> (written, syms, warns)`` 시그니처를
-    그대로 구현한다.
+    ``collect(target_date, store) -> (net_delta, stored_ok, syms, warns)``
+    4-tuple 시그니처(#1993)를 그대로 구현한다. 성공(미실패)은 유효 데이터가
+    store에 반영된 것으로 보아 ``stored_ok=True`` 를 보고한다.
 
     Args:
         fail_dates: 이 집합에 든 날짜는 ``collect`` 가 transient 예외를 raise.
-        written_per_date: 성공 시 보고할 기록 행 수(>0이면 success로 집계).
+        written_per_date: 성공 시 보고할 net-new 저장 행 수(rows_written 집계용).
 
     Attributes:
         calls: ``collect`` 가 실제로 호출된 ``target_date`` 의 순서 리스트.
@@ -56,11 +57,23 @@ class _ScriptedDataGoKrCollector:
         self,
         target_date: str,
         store: object,
-    ) -> tuple[int, set[str], list[dict]]:
+    ) -> tuple[int, bool, set[str], list[dict]]:
         self.calls.append(target_date)
         if target_date in self._fail_dates:
             raise RuntimeError(f"transient failure on {target_date}")
-        return self._written, {f"SYM-{target_date[-2:]}"}, []
+        return self._written, True, {f"SYM-{target_date[-2:]}"}, []
+
+
+class _NoWarnStore:
+    """drain_warnings()만 제공하는 최소 store 스텁(#1993).
+
+    collect 스텁은 store를 쓰지 않지만, runner는 checkpoint save 직전 store
+    경고를 drain하므로(R1: store-merge 실패 가드) ``drain_warnings() -> []``
+    가 필요하다. 항상 빈 목록(=store-merge 실패 없음)을 반환한다.
+    """
+
+    def drain_warnings(self) -> list[dict]:
+        return []
 
 
 async def _run_collect(
@@ -71,7 +84,8 @@ async def _run_collect(
     """``_collect_data_go_kr`` 를 직접 호출해 checkpoint/ctx/collector를 반환한다.
 
     이슈 #2078 재현 스크립트와 동일한 진입점(메서드 직접 호출 + 가드 no-op)을
-    사용한다. store는 collect 스텁이 사용하지 않으므로 sentinel object로 둔다.
+    사용한다. collect 스텁은 store를 안 쓰지만 runner가 store 경고를 drain하므로
+    ``_NoWarnStore`` (drain_warnings → [])를 주입한다.
     """
     collector = _ScriptedDataGoKrCollector(fail_dates=fail_dates)
     checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
@@ -81,7 +95,7 @@ async def _run_collect(
     await runner._collect_data_go_kr(
         dates,
         {},
-        object(),  # store: 스텁 collect가 사용하지 않음
+        _NoWarnStore(),  # store: collect 스텁 미사용, runner drain_warnings용
         checkpoint,
         ctx,
         lambda _config, _date: False,  # is_blocked_day: 항상 거래일

--- a/tests/unit/feed/test_backfill_empty_response_checkpoint.py
+++ b/tests/unit/feed/test_backfill_empty_response_checkpoint.py
@@ -22,16 +22,35 @@ from ante.feed.pipeline.backfill_runner import BackfillRunner, _RunContext
 from ante.feed.pipeline.checkpoint import Checkpoint
 
 
+class _NoWarnStore:
+    """drain_warnings()만 제공하는 최소 store 스텁(#1993).
+
+    collect 스텁은 store를 쓰지 않지만, runner는 checkpoint save 직전 store
+    경고를 drain하므로(R1: store-merge 실패 가드) ``drain_warnings() -> []`` 가
+    필요하다. 항상 빈 목록(=store-merge 실패 없음)을 반환한다.
+    """
+
+    def drain_warnings(self) -> list[dict]:
+        return []
+
+
 class _WrittenScriptedCollector:
     """target_date별 written 행 수를 스크립트로 지정하는 collector 스텁.
 
     ``BackfillRunner._collect_data_go_kr`` 가 호출하는
-    ``collect(target_date, store) -> (written, syms, warns)`` 시그니처를
-    그대로 구현한다.
+    ``collect(target_date, store) -> (net_delta, stored_ok, syms, warns)``
+    4-tuple 시그니처(#1993)를 그대로 구현한다.
+
+    이 스텁은 ``written>0`` 을 "유효 데이터 store 반영"(stored_ok=True), ``written==0``
+    을 "빈 응답"(stored_ok=False)으로 매핑한다. 따라서 #2015 빈 응답 미전진
+    회귀를 그대로 잠근다(빈 응답=stored_ok False → checkpoint 미전진). 재수집
+    (유효 데이터 stored_ok=True, net_delta=0)으로 인한 전진은 별도 테스트에서
+    검증한다.
 
     Args:
-        written_by_date: 날짜→written 행 수 맵. 맵에 없는 날짜는 ``default``.
-        default: 맵에 없는 날짜의 written(기본 0 = 빈 응답).
+        written_by_date: 날짜→net_delta(net-new 저장 행 수) 맵. 맵에 없는 날짜는
+            ``default``. 0은 빈 응답(stored_ok=False)으로 본다.
+        default: 맵에 없는 날짜의 net_delta(기본 0 = 빈 응답).
 
     Attributes:
         calls: ``collect`` 가 실제로 호출된 ``target_date`` 의 순서 리스트.
@@ -50,12 +69,13 @@ class _WrittenScriptedCollector:
         self,
         target_date: str,
         store: object,
-    ) -> tuple[int, set[str], list[dict]]:
+    ) -> tuple[int, bool, set[str], list[dict]]:
         self.calls.append(target_date)
-        written = self._written_by_date.get(target_date, self._default)
-        # written > 0 인 날짜만 symbol을 보고한다(빈 응답은 symbol 없음).
-        syms = {f"SYM-{target_date[-2:]}"} if written > 0 else set()
-        return written, syms, []
+        net_delta = self._written_by_date.get(target_date, self._default)
+        # net_delta>0 = 유효 데이터 store 반영(stored_ok), 0 = 빈 응답(미전진).
+        stored_ok = net_delta > 0
+        syms = {f"SYM-{target_date[-2:]}"} if stored_ok else set()
+        return net_delta, stored_ok, syms, []
 
 
 async def _run_collect(
@@ -66,7 +86,8 @@ async def _run_collect(
     """``_collect_data_go_kr`` 를 직접 호출해 checkpoint/ctx/collector를 반환한다.
 
     가드(is_blocked_day/is_trading_paused)는 no-op으로 두고, stop_event는
-    None(one-shot)으로 둔다. store는 스텁이 사용하지 않으므로 sentinel.
+    None(one-shot)으로 둔다. collect 스텁은 store를 안 쓰지만 runner가 store
+    경고를 drain하므로 ``_NoWarnStore`` (drain_warnings → [])를 주입한다(#1993).
     """
     collector = _WrittenScriptedCollector(written_by_date=written_by_date)
     checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
@@ -76,7 +97,7 @@ async def _run_collect(
     await runner._collect_data_go_kr(
         dates,
         {},
-        object(),  # store: 스텁 collect가 사용하지 않음
+        _NoWarnStore(),  # store: collect 스텁 미사용, runner drain_warnings용
         checkpoint,
         ctx,
         lambda _config, _date: False,  # is_blocked_day: 항상 거래일
@@ -213,11 +234,12 @@ async def test_halt_blocks_advance_even_when_written_positive(
             self,
             target_date: str,
             store: object,
-        ) -> tuple[int, set[str], list[dict]]:
+        ) -> tuple[int, bool, set[str], list[dict]]:
             self.calls.append(target_date)
             if target_date == "2026-01-02":
                 raise RuntimeError("transient")
-            return 1, {f"SYM-{target_date[-2:]}"}, []  # written>0
+            # net_delta>0 + stored_ok=True(유효 저장).
+            return 1, True, {f"SYM-{target_date[-2:]}"}, []
 
     feed_dir = tmp_path / ".feed"
     collector = _FailThenWrittenCollector()
@@ -228,7 +250,7 @@ async def test_halt_blocks_advance_even_when_written_positive(
     await runner._collect_data_go_kr(
         ["2026-01-01", "2026-01-02", "2026-01-03"],
         {},
-        object(),
+        _NoWarnStore(),
         checkpoint,
         ctx,
         lambda _config, _date: False,

--- a/tests/unit/feed/test_backfill_stored_ok_checkpoint.py
+++ b/tests/unit/feed/test_backfill_stored_ok_checkpoint.py
@@ -1,0 +1,220 @@
+"""rows_written net-delta 전환 시 checkpoint 가드 무회귀 검증(#1993, #2015 무회귀).
+
+rows_written을 net-new 저장 delta로 바꾸면 재수집 날짜는 net_delta=0이 된다.
+checkpoint 전진을 ``written > 0`` (net-delta)로 가드하면 재수집 날짜가 미전진해
+stall이 생긴다. 그래서 가드를 collector의 ``stored_ok`` (유효 데이터 store 성공
+반영) 신호로 전환했다. 3-state:
+  - 빈 응답(stored_ok=False) → 미전진(#2015 보존)
+  - 유효 재수집(stored_ok=True, net_delta=0) → 전진(stall 해소)
+  - store-merge 실패(R1: raise 안 함, store 경고만) → 미전진
+
+이 파일은:
+  (f) 재수집(stored_ok, net_delta=0) → checkpoint 전진(#2015 무회귀)
+  (g) store-merge 실패 → checkpoint 미전진(R1 가드)
+  (k) partial multi-write(일부 성공/일부 merge 실패) → rows_written 반영 +
+      checkpoint 미전진
+을 잠근다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ante.feed.pipeline.backfill_runner import BackfillRunner, _RunContext
+from ante.feed.pipeline.checkpoint import Checkpoint
+
+
+class _ScriptedStore:
+    """날짜별로 net_delta / store_merge 경고를 스크립트로 지정하는 store 스텁.
+
+    runner는 collect 직후 ``store.drain_warnings()`` 를 호출해 store-merge 실패를
+    가드한다. 이 스텁은 ``merge_fail_dates`` 에 든 날짜에서 다음 drain이
+    ``store_merge`` 경고를 반환하도록 한다(ParquetStore._pending_warnings 동형).
+    """
+
+    def __init__(self, merge_fail_dates: set[str]) -> None:
+        self._merge_fail_dates = merge_fail_dates
+        self._pending: list[dict] = []
+        self.current_date: str | None = None
+
+    def arm(self, target_date: str) -> None:
+        """이 날짜의 collect가 store-merge 실패를 유발하면 경고를 적재한다."""
+        if target_date in self._merge_fail_dates:
+            self._pending.append(
+                {
+                    "type": "store_merge",
+                    "path": f"/fake/{target_date}.parquet",
+                    "message": "파티션 merge 실패로 기존 데이터 보존",
+                }
+            )
+
+    def drain_warnings(self) -> list[dict]:
+        drained = list(self._pending)
+        self._pending.clear()
+        return drained
+
+
+class _ScriptedCollector:
+    """날짜별 (net_delta, stored_ok)를 스크립트로 지정하는 collector 스텁.
+
+    collect 시 store.arm(target_date)를 호출해 해당 날짜의 store-merge 경고를
+    무장시킨다(실제 ParquetStore가 _pending_warnings를 적재하는 시점을 모사).
+    """
+
+    def __init__(
+        self,
+        net_delta_by_date: dict[str, int],
+        stored_ok_by_date: dict[str, bool],
+        default_stored_ok: bool = True,
+    ) -> None:
+        self._net = net_delta_by_date
+        self._stored_ok = stored_ok_by_date
+        self._default_stored_ok = default_stored_ok
+        self.calls: list[str] = []
+
+    async def collect(
+        self,
+        target_date: str,
+        store: _ScriptedStore,
+    ) -> tuple[int, bool, set[str], list[dict]]:
+        self.calls.append(target_date)
+        store.arm(target_date)
+        net = self._net.get(target_date, 0)
+        stored_ok = self._stored_ok.get(target_date, self._default_stored_ok)
+        syms = {f"SYM-{target_date[-2:]}"} if stored_ok else set()
+        return net, stored_ok, syms, []
+
+
+async def _run(
+    feed_dir: Path,
+    collector: _ScriptedCollector,
+    store: _ScriptedStore,
+    dates: list[str],
+) -> tuple[Checkpoint, _RunContext]:
+    checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+    runner = BackfillRunner(data_go_kr_collector=collector)
+    ctx = _RunContext()
+    await runner._collect_data_go_kr(
+        dates,
+        {},
+        store,
+        checkpoint,
+        ctx,
+        lambda _config, _date: False,
+        lambda _config: False,
+        None,
+    )
+    return checkpoint, ctx
+
+
+# ── (f) 재수집(stored_ok, net_delta=0) → checkpoint 전진(#2015 무회귀) ─────────
+
+
+@pytest.mark.asyncio
+async def test_recollect_delta_zero_advances_checkpoint(tmp_path: Path) -> None:
+    """유효 재수집(net_delta=0, stored_ok=True)이어도 checkpoint가 전진한다.
+
+    rows_written을 net-delta로 바꾸면 재수집 날짜는 net_delta=0이 된다. 만약
+    checkpoint 가드가 ``written > 0`` 였다면 이 날짜가 미전진해 stall이 생긴다.
+    stored_ok 가드로 전환했으므로, 유효 데이터가 store에 반영된 재수집 날짜는
+    net_delta=0이어도 정상 전진한다(#1993, #2015 무회귀).
+    """
+    feed_dir = tmp_path / ".feed"
+    dates = ["2026-01-02", "2026-01-03"]
+    collector = _ScriptedCollector(
+        net_delta_by_date={"2026-01-02": 0, "2026-01-03": 0},  # 전부 재수집(delta 0)
+        stored_ok_by_date={"2026-01-02": True, "2026-01-03": True},
+    )
+    store = _ScriptedStore(merge_fail_dates=set())
+
+    checkpoint, ctx = await _run(feed_dir, collector, store, dates)
+
+    # 재수집(delta=0)이어도 stored_ok로 마지막 날짜까지 전진(stall 없음).
+    assert checkpoint.get_last_date() == "2026-01-03"
+    # rows_written은 net-delta 합 = 0(재수집 과대계상 제거).
+    assert ctx.rows_written == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_response_still_blocks_advance(tmp_path: Path) -> None:
+    """빈 응답(stored_ok=False)은 여전히 checkpoint 미전진(#2015 보존).
+
+    net_delta=0이 모두 전진을 유발하지 않도록, stored_ok=False(빈 응답)는
+    재수집(stored_ok=True, delta=0)과 구분되어 미전진해야 한다.
+    """
+    feed_dir = tmp_path / ".feed"
+    dates = ["2026-05-28", "2026-05-29"]
+    collector = _ScriptedCollector(
+        net_delta_by_date={"2026-05-28": 3, "2026-05-29": 0},
+        stored_ok_by_date={"2026-05-28": True, "2026-05-29": False},  # 29 빈 응답
+    )
+    store = _ScriptedStore(merge_fail_dates=set())
+
+    checkpoint, _ctx = await _run(feed_dir, collector, store, dates)
+
+    # 28(stored_ok)까지 전진, 29(빈 응답)는 미전진.
+    assert checkpoint.get_last_date() == "2026-05-28"
+
+
+# ── (g) store-merge 실패 → checkpoint 미전진(R1 가드) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_store_merge_failure_blocks_advance(tmp_path: Path) -> None:
+    """store-merge 실패 날짜는 stored_ok=True여도 checkpoint를 전진시키지 않는다.
+
+    R1: ``_persist_partition`` 은 merge 실패 시 raise하지 않고 store_merge 경고만
+    적재한다(기존 파일 보존). 따라서 collector는 stored_ok=True를 보고할 수 있다.
+    runner는 checkpoint save 직전 store 경고를 drain해 이번 날짜에 store_merge가
+    있으면 미전진시킨다(데이터 미반영 날짜 영구 skip 방지).
+    """
+    feed_dir = tmp_path / ".feed"
+    dates = ["2026-01-02", "2026-01-03"]
+    collector = _ScriptedCollector(
+        net_delta_by_date={"2026-01-02": 0, "2026-01-03": 5},
+        stored_ok_by_date={"2026-01-02": True, "2026-01-03": True},
+    )
+    # 2026-01-03에서 store-merge 실패.
+    store = _ScriptedStore(merge_fail_dates={"2026-01-03"})
+
+    checkpoint, ctx = await _run(feed_dir, collector, store, dates)
+
+    # 02는 전진, 03은 store_merge 실패라 미전진 → checkpoint=02.
+    assert checkpoint.get_last_date() == "2026-01-02"
+    # store_merge 경고가 ctx.warnings로 표면화된다.
+    assert any(w.get("type") == "store_merge" for w in ctx.warnings)
+
+
+# ── (k) partial multi-write → rows_written 반영 + checkpoint 미전진 ───────────
+
+
+@pytest.mark.asyncio
+async def test_partial_multi_write_reflects_rows_but_blocks_checkpoint(
+    tmp_path: Path,
+) -> None:
+    """일부 파티션 성공/일부 merge 실패 → rows_written엔 성공분 반영, checkpoint 미전진.
+
+    한 날짜의 collect가 여러 파티션에 걸쳐 일부는 net-new 저장(net_delta>0), 일부는
+    merge 실패(store_merge 경고)를 동시에 낼 수 있다. 이때:
+      - rows_written: 성공 파티션의 net-new는 반영된다(데이터 반영 사실 보존).
+      - checkpoint: 같은 날짜에 store_merge 실패가 있으면 미전진(부분 손실 날짜를
+        완료 처리하지 않음).
+    """
+    feed_dir = tmp_path / ".feed"
+    dates = ["2026-01-02"]
+    # 성공 파티션 net-new 4행 보고 + 같은 날짜 store_merge 실패 동시 발생.
+    collector = _ScriptedCollector(
+        net_delta_by_date={"2026-01-02": 4},
+        stored_ok_by_date={"2026-01-02": True},
+    )
+    store = _ScriptedStore(merge_fail_dates={"2026-01-02"})
+
+    checkpoint, ctx = await _run(feed_dir, collector, store, dates)
+
+    # 성공 파티션의 net-new는 rows_written에 반영.
+    assert ctx.rows_written == 4
+    # store_merge 실패가 같은 날짜에 있으므로 checkpoint 미전진(None).
+    assert checkpoint.get_last_date() is None
+    assert any(w.get("type") == "store_merge" for w in ctx.warnings)

--- a/tests/unit/feed/test_daily_runner_dart_daily_flag.py
+++ b/tests/unit/feed/test_daily_runner_dart_daily_flag.py
@@ -33,9 +33,10 @@ class _RecordingDARTCollector:
         config: dict[str, Any],
         store: ParquetStore,
         daily: bool = False,
-    ) -> tuple[int, set[str], list[dict]]:
+    ) -> tuple[int, bool, set[str], list[dict]]:
+        # (net_delta, stored_ok, syms, warns) 4-tuple (#1993). 저장 반영 없음.
         self.daily_calls.append(daily)
-        return 0, set(), []
+        return 0, False, set(), []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/feed/test_daily_runner_store_merge_drain.py
+++ b/tests/unit/feed/test_daily_runner_store_merge_drain.py
@@ -36,7 +36,7 @@ class _AnomalyDataGoKrCollector:
         self,
         target_date: str,
         store: ParquetStore,
-    ) -> tuple[int, set[str], list[dict]]:
+    ) -> tuple[int, bool, set[str], list[dict]]:
         df = pl.DataFrame(
             {
                 "date": [date(2025, 9, 30)],
@@ -45,8 +45,11 @@ class _AnomalyDataGoKrCollector:
                 "source": ["data_go_kr"],
             }
         )
-        store.write("005930", "krx", df, data_type="fundamental")
-        return 1, {"005930"}, []
+        # merge 실패 시 store.write는 net_delta=0 반환(기존 파일 보존).
+        net_delta = store.write("005930", "krx", df, data_type="fundamental")
+        # (net_delta, stored_ok, syms, warns) 4-tuple (#1993). 유효 데이터 write
+        # 호출 완료 → stored_ok=True. store-merge 실패는 store 경고로 표면화된다.
+        return net_delta, True, {"005930"}, []
 
 
 @pytest.mark.asyncio
@@ -111,7 +114,7 @@ async def test_daily_run_no_store_warnings_when_clean(tmp_path: Path) -> None:
             self,
             target_date: str,
             store: ParquetStore,
-        ) -> tuple[int, set[str], list[dict]]:
+        ) -> tuple[int, bool, set[str], list[dict]]:
             df = pl.DataFrame(
                 {
                     "date": [date(2025, 9, 30)],
@@ -120,8 +123,9 @@ async def test_daily_run_no_store_warnings_when_clean(tmp_path: Path) -> None:
                     "source": ["data_go_kr"],
                 }
             )
-            store.write("005930", "krx", df, data_type="fundamental")
-            return 1, {"005930"}, []
+            net_delta = store.write("005930", "krx", df, data_type="fundamental")
+            # (net_delta, stored_ok, syms, warns) 4-tuple (#1993).
+            return net_delta, True, {"005930"}, []
 
     store = ParquetStore(base_path=data_path)
     runner = DailyRunner(

--- a/tests/unit/feed/test_dart_collector.py
+++ b/tests/unit/feed/test_dart_collector.py
@@ -586,7 +586,7 @@ class TestRecollectQuarterDeltaZero:
 
         # 단일 분기 재수집(_fetch_quarter 직접): 이미 저장됨 → net_delta=0 + OK.
         warns2: list[dict] = []
-        net_delta, syms2, status = await collector._fetch_quarter(
+        net_delta, syms2, status, store_merge_failed = await collector._fetch_quarter(
             ["00126380"],
             {"00126380": "005930"},
             store,
@@ -595,10 +595,12 @@ class TestRecollectQuarterDeltaZero:
             warns2,
         )
         # storable>0이라 OK(no-storable HALT 아님), net_delta=0(재수집 dedup).
+        # store-merge 정상이므로 store_merge_failed=False(checkpoint 전진 자격).
         assert status is QuarterStatus.OK
         assert net_delta == 0
         assert syms2 == {"005930"}
         assert warns2 == []
+        assert store_merge_failed is False
 
         # 2차 전체 재수집(fresh checkpoint): 전부 재수집(net_delta=0)이어도 OK로
         # checkpoint가 Q4까지 정상 전진(stall 없음). #2028 무회귀.
@@ -637,7 +639,7 @@ class TestEmptyQuarterSkip:
             tmp_path, behaviors={}
         )
         warns: list[dict] = []
-        written, syms, status = await collector._fetch_quarter(
+        written, syms, status, store_merge_failed = await collector._fetch_quarter(
             ["00126380"],
             {"00126380": "005930"},
             store,
@@ -649,6 +651,7 @@ class TestEmptyQuarterSkip:
         assert written == 0
         assert syms == set()
         assert warns == []
+        assert store_merge_failed is False
 
     async def test_empty_quarter_skips_without_halt(self, tmp_path: Path) -> None:
         """(a) 빈 분기 → checkpoint 미전진 AND halt 미설정(후속 처리 계속).
@@ -1181,3 +1184,307 @@ class TestAvailableDateEndToEnd:
         result = store.read("005930", "krx", data_type="fundamental")
         assert "available_date" in result.columns
         assert result["available_date"][0] is None
+
+
+# ── store_merge 게이트(#1993 Finding 2): DART checkpoint 미전진 ───────────────
+
+
+def _corrupt_partition(store: ParquetStore, symbol: str, month: str) -> Path:
+    """해당 fundamental 파티션 월에 손상(읽기 불가) 파일을 사전 배치한다.
+
+    다음 ``store.write`` 가 이 파일과 merge를 시도하면 ParquetStore는 기존
+    파일을 덮어쓰지 않고 ``store_merge`` 경고만 ``_pending_warnings`` 에 적재한다
+    (net_delta=0, 기존 파일 보존). 실제 ParquetStore의 merge-실패 경로를
+    결정적으로 재현한다(test_daily_runner_store_merge_drain 동형).
+
+    Returns:
+        배치한 손상 파일 경로.
+    """
+    part_dir = store.base_path / "fundamental" / "KRX" / symbol
+    part_dir.mkdir(parents=True, exist_ok=True)
+    filepath = part_dir / f"{month}.parquet"
+    filepath.write_bytes(b"corrupt-not-parquet")
+    return filepath
+
+
+class TestStorePendingMergeFailureCountPeek:
+    """ParquetStore.pending_merge_failure_count는 비파괴적 peek다(#1993 Finding 2)."""
+
+    def test_counts_only_store_merge_and_does_not_drain(self, tmp_path: Path) -> None:
+        """store_merge 경고만 세고, 호출 후에도 drain_warnings가 동일 경고 반환."""
+        store = ParquetStore(base_path=tmp_path / "data")
+
+        # 손상 파티션 위로 write → store_merge 경고 1건 적재(net_delta=0).
+        _corrupt_partition(store, "005930", "2015-12")
+        df = _stored_df_quarter("2015", 12)
+        net_delta = store.write("005930", "krx", df, data_type="fundamental")
+        assert net_delta == 0
+
+        # peek: store_merge 1건. 비-store_merge 경고는 세지 않는다.
+        assert store.pending_merge_failure_count() == 1
+        # 반복 호출해도 동일(비파괴적).
+        assert store.pending_merge_failure_count() == 1
+
+        # drain은 여전히 경고를 반환한다 = peek가 버퍼를 비우지 않았다.
+        drained = store.drain_warnings()
+        assert len(drained) == 1
+        assert drained[0]["type"] == "store_merge"
+        # drain 후에는 count 0.
+        assert store.pending_merge_failure_count() == 0
+
+    def test_zero_when_no_merge_failure(self, tmp_path: Path) -> None:
+        """정상 write(merge 실패 없음)는 count 0."""
+        store = ParquetStore(base_path=tmp_path / "data")
+        df = _stored_df_quarter("2015", 12)
+        net_delta = store.write("005930", "krx", df, data_type="fundamental")
+        assert net_delta == 1
+        assert store.pending_merge_failure_count() == 0
+
+
+class TestDartStoreMergeFailureBlocksCheckpoint:
+    """#1993 Finding 2: DART store-merge 실패 분기는 checkpoint를 전진시키지 않는다.
+
+    DART는 checkpoint.save를 collector 내부에서 한다(data.go.kr처럼 runner R1
+    drain 가드를 거치지 않음). store.write가 merge 실패(net_delta=0 + store_merge
+    경고)를 내면 QuarterStatus는 storable_rows>0이라 OK지만, checkpoint는
+    store_merge_failed로 게이트되어 미전진해야 한다(다음 run 재시도). 비파괴적
+    peek로 분기 전후 증가분을 보므로 runner의 drain 소유권은 보존된다.
+    """
+
+    async def test_backfill_merge_failure_trailing_quarter_blocks_advance(
+        self, tmp_path: Path
+    ) -> None:
+        """backfill 경로: trailing 분기 merge 실패 → checkpoint 그 분기 미전진.
+
+        2015 단일 연도 4분기를 distinct 월에 저장하되, 마지막 분기 Q4(2015-12)
+        파티션을 손상시켜 merge 실패를 유발한다. Q1~Q3는 정상 저장되어 Q3까지
+        전진하지만, trailing Q4는 store-merge 실패로 미전진한다(checkpoint=Q3,
+        다음 run에 Q4부터 재시도). store-merge는 halt가 아니므로 Q1~Q3 전진은
+        기존대로 유지되고 손상된 trailing 분기만 막힌다.
+
+        주의: store-merge는 halt를 세우지 않으므로(지침), 내부(non-trailing)
+        분기가 막히면 후속 데이터 분기의 save가 checkpoint를 jump 전진시킨다.
+        따라서 단일 분기 미전진을 결정적으로 검증하려면 trailing 분기를
+        손상시킨다(daily 경로의 단일 분기 케이스와 동형).
+        """
+        behaviors: dict[tuple[str, str], object] = {
+            ("2015", "11013"): [_raw_item("2015", "11013")],
+            ("2015", "11012"): [_raw_item("2015", "11012")],
+            ("2015", "11014"): [_raw_item("2015", "11014")],
+            ("2015", "11011"): [_raw_item("2015", "11011")],
+        }
+        norm_results = {
+            ("2015", "11013"): _stored_df_quarter("2015", 3),
+            ("2015", "11012"): _stored_df_quarter("2015", 6),
+            ("2015", "11014"): _stored_df_quarter("2015", 9),
+            ("2015", "11011"): _stored_df_quarter("2015", 12),
+        }
+        collector, checkpoint, store, _source, _config = _make_collector_env(
+            tmp_path, behaviors, norm_results
+        )
+
+        # trailing Q4(2015-12) 파티션 손상 → 이 분기 write가 merge 실패(net_delta=0).
+        _corrupt_partition(store, "005930", "2015-12")
+
+        net_delta, stored_ok, syms, warns = await collector._collect_quarters(
+            {"00126380": "005930"},
+            store,
+            checkpoint,
+            2015,
+            2015,
+            None,
+        )
+
+        # Q1~Q3는 정상 전진, trailing Q4는 store-merge 실패라 미전진 → checkpoint=Q3.
+        assert checkpoint.get_last_date() == "2015-Q3"
+
+        # storable_rows>0 분기가 존재 → stored_ok=True(QuarterStatus 의미 무변경).
+        assert stored_ok is True
+        assert syms == {"005930"}
+        # store_merge 경고는 store 버퍼에 남아(비파괴적 peek) runner가 drain한다.
+        # collector는 warns에 store_merge를 넣지 않는다(드레인 소유권은 runner).
+        assert all(w.get("type") != "store_merge" for w in warns)
+        assert store.pending_merge_failure_count() >= 1
+
+    async def test_backfill_merge_failure_single_quarter_blocks_advance(
+        self, tmp_path: Path
+    ) -> None:
+        """backfill 경로(단일 collectable 분기): merge 실패 → checkpoint 미전진.
+
+        end_year=start_year에 last_checkpoint를 Q3로 두어 Q4 한 분기만
+        collectable하게 만든다. 그 단일 분기를 손상시키면 QuarterStatus는 OK여도
+        checkpoint가 Q3에서 전진하지 못한다(store_merge_failed 게이트).
+        """
+        behaviors: dict[tuple[str, str], object] = {
+            ("2015", "11011"): [_raw_item("2015", "11011")],  # Q4만 데이터
+        }
+        norm_results = {("2015", "11011"): _stored_df_quarter("2015", 12)}
+        collector, checkpoint, store, _source, _config = _make_collector_env(
+            tmp_path, behaviors, norm_results
+        )
+
+        # Q4(2015-12) 손상 → merge 실패.
+        _corrupt_partition(store, "005930", "2015-12")
+
+        # 사전 checkpoint=Q3(Q1~Q3 완료 상태). last_checkpoint=Q3 → Q4만 순회.
+        checkpoint.save("2015-Q3")
+
+        net_delta, stored_ok, syms, warns = await collector._collect_quarters(
+            {"00126380": "005930"},
+            store,
+            checkpoint,
+            2015,
+            2015,
+            "2015-Q3",
+        )
+
+        # 단일 분기 Q4가 merge 실패 → checkpoint는 Q3에서 미전진(다음 run 재시도).
+        assert checkpoint.get_last_date() == "2015-Q3"
+        assert stored_ok is True  # storable_rows>0 → QuarterStatus OK
+        assert syms == {"005930"}
+        assert all(w.get("type") != "store_merge" for w in warns)
+        assert store.pending_merge_failure_count() >= 1
+
+    async def test_backfill_clean_recollect_quarter_still_advances(
+        self, tmp_path: Path
+    ) -> None:
+        """회귀 가드: store_merge 없는 재수집 분기(net_delta=0)는 전진(#1993 무회귀).
+
+        손상 파티션 없이 2회 collect한다. 2차는 dedup으로 net_delta=0이지만
+        store_merge 경고가 없으므로 checkpoint가 정상 전진해야 한다(Finding 2
+        게이트가 정상 재수집을 막지 않음을 확인).
+        """
+        behaviors: dict[tuple[str, str], object] = {
+            ("2015", "11013"): [_raw_item("2015", "11013")],
+            ("2015", "11012"): [_raw_item("2015", "11012")],
+            ("2015", "11014"): [_raw_item("2015", "11014")],
+            ("2015", "11011"): [_raw_item("2015", "11011")],
+        }
+        norm_results = {
+            ("2015", "11013"): _stored_df_quarter("2015", 3),
+            ("2015", "11012"): _stored_df_quarter("2015", 6),
+            ("2015", "11014"): _stored_df_quarter("2015", 9),
+            ("2015", "11011"): _stored_df_quarter("2015", 12),
+        }
+        collector, checkpoint, store, _source, _config = _make_collector_env(
+            tmp_path, behaviors, norm_results
+        )
+
+        # 1차: 정상 저장 → Q4까지 전진.
+        await collector._collect_quarters(
+            {"00126380": "005930"}, store, checkpoint, 2015, 2015, None
+        )
+        assert checkpoint.get_last_date() == "2015-Q4"
+
+        # 2차(fresh checkpoint): 전부 재수집(net_delta=0), store_merge 없음 → 전진.
+        checkpoint2 = Checkpoint(tmp_path / ".feed", "dart", "fundamental")
+        net_delta2, _stored_ok2, _syms2, warns2 = await collector._collect_quarters(
+            {"00126380": "005930"}, store, checkpoint2, 2015, 2015, None
+        )
+        assert net_delta2 == 0  # 재수집 → net-new 0
+        assert checkpoint2.get_last_date() == "2015-Q4"  # store_merge 없음 → 전진
+        assert all(w.get("type") != "store_merge" for w in warns2)
+        assert store.pending_merge_failure_count() == 0
+
+    async def test_daily_merge_failure_quarter_no_checkpoint_advance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """daily 경로: 최신 분기 merge 실패 → checkpoint 미전진(QuarterStatus OK).
+
+        ``_collect_latest_quarter`` 도 backfill과 동일하게 store_merge_failed를
+        게이트한다. today=2026-05-29 → 최신 2026-Q1(period_end 3/31, 파티션
+        2026-03). 그 파티션을 손상시켜 merge 실패를 유발하면 checkpoint 미전진.
+        """
+        import ante.feed.pipeline.dart_collector as dc
+
+        monkeypatch.setattr(dc, "_today_kst", lambda: date(2026, 5, 29))
+
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        store = ParquetStore(base_path=tmp_path / "data")
+        checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+
+        # 최신 분기(2026-Q1, period_end 3/31 → 파티션 2026-03)를 손상시킨다.
+        _corrupt_partition(store, "005930", "2026-03")
+
+        behaviors: dict[tuple[str, str], object] = {
+            ("2026", "11013"): [_raw_item("2026", "11013")],
+        }
+        source = _ScriptedDARTSource({"00126380": "005930"}, behaviors)
+        normalizer = _ScriptedNormalizer(
+            {("2026", "11013"): _stored_df_quarter("2026", 3)}
+        )
+        collector = DARTCollector(source=source, normalizer=normalizer)
+
+        config = {"schedule": {"backfill_since": "2015-01-01"}}
+        rows, stored_ok, syms, warns = await collector.collect(
+            data_path=tmp_path / "data",
+            feed_dir=feed_dir,
+            checkpoint=checkpoint,
+            config=config,
+            store=store,
+            daily=True,
+        )
+
+        # 최신 분기만 fetch했고 merge 실패 → net_delta=0, checkpoint 미전진.
+        assert source.fetched == [("2026", "11013")]
+        assert rows == 0
+        # storable_rows>0이라 QuarterStatus는 OK → stored_ok=True(의미 무변경).
+        assert stored_ok is True
+        assert syms == {"005930"}
+        # store_merge 게이트로 checkpoint는 전진하지 않는다(다음 daily run 재시도).
+        assert checkpoint.get_last_date() is None
+        # collector는 store_merge를 warns에 넣지 않고 store 버퍼에 남긴다.
+        assert all(w.get("type") != "store_merge" for w in warns)
+        assert store.pending_merge_failure_count() >= 1
+
+    async def test_daily_clean_recollect_quarter_still_advances(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """회귀 가드: daily 재수집(net_delta=0, store_merge 없음)은 전진.
+
+        #1993 무회귀.
+        """
+        import ante.feed.pipeline.dart_collector as dc
+
+        monkeypatch.setattr(dc, "_today_kst", lambda: date(2026, 5, 29))
+
+        feed_dir = tmp_path / ".feed"
+        feed_dir.mkdir()
+        store = ParquetStore(base_path=tmp_path / "data")
+        behaviors: dict[tuple[str, str], object] = {
+            ("2026", "11013"): [_raw_item("2026", "11013")],
+        }
+        source = _ScriptedDARTSource({"00126380": "005930"}, behaviors)
+        normalizer = _ScriptedNormalizer(
+            {("2026", "11013"): _stored_df_quarter("2026", 3)}
+        )
+        collector = DARTCollector(source=source, normalizer=normalizer)
+        config = {"schedule": {"backfill_since": "2015-01-01"}}
+
+        # 1차: 정상 저장 → 2026-Q1 전진.
+        checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+        await collector.collect(
+            data_path=tmp_path / "data",
+            feed_dir=feed_dir,
+            checkpoint=checkpoint,
+            config=config,
+            store=store,
+            daily=True,
+        )
+        assert checkpoint.get_last_date() == "2026-Q1"
+
+        # 2차(fresh checkpoint): 재수집 net_delta=0, store_merge 없음 → 전진.
+        checkpoint2 = Checkpoint(feed_dir, "dart", "fundamental")
+        rows2, _stored_ok2, _syms2, warns2 = await collector.collect(
+            data_path=tmp_path / "data",
+            feed_dir=feed_dir,
+            checkpoint=checkpoint2,
+            config=config,
+            store=store,
+            daily=True,
+        )
+        assert rows2 == 0  # 재수집 → net-new 0
+        assert checkpoint2.get_last_date() == "2026-Q1"  # store_merge 없음 → 전진
+        assert all(w.get("type") != "store_merge" for w in warns2)
+        assert store.pending_merge_failure_count() == 0

--- a/tests/unit/feed/test_dart_collector.py
+++ b/tests/unit/feed/test_dart_collector.py
@@ -188,7 +188,7 @@ class TestEmptyCorpCodeMapWarning:
         collector = DARTCollector(source=source)
 
         config = {"schedule": {"backfill_since": "2026-01-01"}}
-        rows, symbols, warns = await collector.collect(
+        rows, _stored_ok, symbols, warns = await collector.collect(
             data_path=tmp_path / "data",
             feed_dir=feed_dir,
             checkpoint=checkpoint,
@@ -219,7 +219,7 @@ class TestEmptyCorpCodeMapWarning:
         collector = DARTCollector(source=source)
 
         config = {"schedule": {"backfill_since": "2026-01-01"}}
-        _rows, _symbols, warns = await collector.collect(
+        _rows, _stored_ok, _symbols, warns = await collector.collect(
             data_path=tmp_path / "data",
             feed_dir=feed_dir,
             checkpoint=checkpoint,
@@ -350,9 +350,14 @@ async def _run_collect(
     config: dict,
     end_year: int = 2015,
 ) -> tuple[int, set[str], list[dict]]:
-    """단일 연도만 순회하도록 _resolve_year_range를 고정해 collect 실행."""
+    """단일 연도만 순회하도록 _resolve_year_range를 고정해 collect 실행.
+
+    ``_collect_quarters`` 는 #1993 이후 ``(net_delta, stored_ok, syms, warns)``
+    4-tuple을 반환한다. 기존 호출부 호환을 위해 stored_ok를 떼고
+    ``(net_delta, syms, warns)`` 3-tuple로 어댑트해 반환한다(net_delta=rows_written).
+    """
     # end_year를 고정(_today_kst 기반 현재 연도 대신)하여 단일 연도만 순회.
-    return await collector._collect_quarters(  # type: ignore[attr-defined]
+    net_delta, _stored_ok, syms, warns = await collector._collect_quarters(  # type: ignore[attr-defined]
         {"00126380": "005930"},
         store,
         checkpoint,
@@ -360,6 +365,7 @@ async def _run_collect(
         end_year,
         None,
     )
+    return net_delta, syms, warns
 
 
 # 2015-Q1 period-end(3/31)는 today(2026+)보다 과거이므로 모든 분기 collectable.
@@ -521,6 +527,96 @@ class TestCheckpointHaltOnFailure:
         assert len(warns) == 4
 
 
+def _stored_df_quarter(year: str, month: int) -> pl.DataFrame:
+    """분기별로 distinct한 period_end(date)를 가진 정규화 결과(재수집 delta 검증용)."""
+    from calendar import monthrange
+
+    day = monthrange(int(year), month)[1]
+    return pl.DataFrame(
+        {
+            "date": [date(int(year), month, day)],
+            "symbol": ["005930"],
+            "revenue": [100],
+            "source": ["dart"],
+        }
+    )
+
+
+class TestRecollectQuarterDeltaZero:
+    """#1993/#2028: 재수집 분기는 net_delta=0이어도 QuarterStatus.OK로 전진한다.
+
+    rows_written을 net-new 저장 delta로 바꾸면 이미 저장된 분기를 다시 수집할 때
+    net_delta=0이 된다. QuarterStatus 판정을 net-delta가 아니라 **storable_rows**
+    (정규화/저장 가능 행 수) 기준으로 유지하므로, 재수집 분기는 storable>0이라
+    OK로 checkpoint가 정상 전진한다(net-delta로 판정하면 no-storable HALT로
+    오판해 stall). #2028 QuarterStatus(SKIP_EMPTY/HALT/OK) 동작은 무변경이다.
+    """
+
+    async def test_recollect_quarter_storable_positive_net_delta_zero_ok(
+        self, tmp_path: Path
+    ) -> None:
+        """이미 저장된 분기 재수집: storable>0, net_delta=0, status=OK, 전진."""
+        from ante.feed.pipeline.dart_collector import QuarterStatus
+
+        # 분기별 distinct date(3/31, 6/30, 9/30, 12/31)로 실제 신규 저장 보장.
+        behaviors: dict[tuple[str, str], object] = {
+            ("2015", "11013"): [_raw_item("2015", "11013")],
+            ("2015", "11012"): [_raw_item("2015", "11012")],
+            ("2015", "11014"): [_raw_item("2015", "11014")],
+            ("2015", "11011"): [_raw_item("2015", "11011")],
+        }
+        norm_results = {
+            ("2015", "11013"): _stored_df_quarter("2015", 3),
+            ("2015", "11012"): _stored_df_quarter("2015", 6),
+            ("2015", "11014"): _stored_df_quarter("2015", 9),
+            ("2015", "11011"): _stored_df_quarter("2015", 12),
+        }
+        collector, checkpoint, store, _source, config = _make_collector_env(
+            tmp_path, behaviors, norm_results
+        )
+
+        # 1차 수집: 4개 분기 신규 저장 → net_delta>0.
+        rows1, syms1, warns1 = await _run_collect(
+            tmp_path, collector, checkpoint, store, config
+        )
+        assert checkpoint.get_last_date() == "2015-Q4"
+        assert rows1 > 0
+        assert warns1 == []
+        assert syms1 == {"005930"}
+
+        # 단일 분기 재수집(_fetch_quarter 직접): 이미 저장됨 → net_delta=0 + OK.
+        warns2: list[dict] = []
+        net_delta, syms2, status = await collector._fetch_quarter(
+            ["00126380"],
+            {"00126380": "005930"},
+            store,
+            2015,
+            "11013",
+            warns2,
+        )
+        # storable>0이라 OK(no-storable HALT 아님), net_delta=0(재수집 dedup).
+        assert status is QuarterStatus.OK
+        assert net_delta == 0
+        assert syms2 == {"005930"}
+        assert warns2 == []
+
+        # 2차 전체 재수집(fresh checkpoint): 전부 재수집(net_delta=0)이어도 OK로
+        # checkpoint가 Q4까지 정상 전진(stall 없음). #2028 무회귀.
+        checkpoint2 = Checkpoint(tmp_path / ".feed", "dart", "fundamental")
+        net_delta2, stored_ok2, _syms3, warns3 = await collector._collect_quarters(
+            {"00126380": "005930"},
+            store,
+            checkpoint2,
+            2015,
+            2015,
+            None,
+        )
+        assert checkpoint2.get_last_date() == "2015-Q4"
+        assert net_delta2 == 0  # 전부 재수집 → net-new 0(과대계상 제거)
+        assert stored_ok2 is True  # storable 저장 분기 존재 → stored_ok True
+        assert warns3 == []
+
+
 class TestEmptyQuarterSkip:
     """#2028: 빈 분기(not raw_items)를 SKIP_EMPTY로 처리해 checkpoint를 전진/
 
@@ -647,7 +743,7 @@ class TestEmptyQuarterSkip:
         store = ParquetStore(base_path=tmp_path / "data")
         checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
 
-        rows, _syms, warns = await collector._collect_quarters(
+        rows, stored_ok, _syms, warns = await collector._collect_quarters(
             {"00126380": "005930"},
             store,
             checkpoint,
@@ -658,6 +754,8 @@ class TestEmptyQuarterSkip:
 
         assert checkpoint.get_last_date() is None
         assert rows == 0
+        # 전 분기 빈 응답(SKIP_EMPTY) → 저장 반영 전무 → stored_ok=False.
+        assert stored_ok is False
         assert warns == []
 
 
@@ -700,7 +798,7 @@ class TestDailyLatestQuarter:
         collector = DARTCollector(source=source, normalizer=normalizer)
 
         config = {"schedule": {"backfill_since": "2015-01-01"}}
-        rows, syms, warns = await collector.collect(
+        rows, _stored_ok, syms, warns = await collector.collect(
             data_path=tmp_path / "data",
             feed_dir=feed_dir,
             checkpoint=checkpoint,
@@ -741,7 +839,7 @@ class TestDailyLatestQuarter:
         collector = DARTCollector(source=source)
 
         config = {"schedule": {"backfill_since": "2015-01-01"}}
-        rows, syms, warns = await collector.collect(
+        rows, _stored_ok, syms, warns = await collector.collect(
             data_path=tmp_path / "data",
             feed_dir=feed_dir,
             checkpoint=checkpoint,
@@ -781,7 +879,7 @@ class TestDailyLatestQuarter:
         collector = DARTCollector(source=source)
 
         config = {"schedule": {"backfill_since": "2015-01-01"}}
-        rows, _syms, warns = await collector.collect(
+        rows, _stored_ok, _syms, warns = await collector.collect(
             data_path=tmp_path / "data",
             feed_dir=feed_dir,
             checkpoint=checkpoint,
@@ -822,7 +920,7 @@ class TestDailyLatestQuarter:
         collector = DARTCollector(source=source)
 
         config = {"schedule": {"backfill_since": "2015-01-01"}}
-        rows, _syms, warns = await collector.collect(
+        rows, _stored_ok, _syms, warns = await collector.collect(
             data_path=tmp_path / "data",
             feed_dir=feed_dir,
             checkpoint=checkpoint,
@@ -1038,13 +1136,15 @@ class TestAvailableDateEndToEnd:
             },
         ]
 
-        written, syms = collector._normalize_and_store(
+        storable_rows, net_delta, syms = collector._normalize_and_store(
             raw_items,
             {"00126380": "005930"},
             store,
         )
 
-        assert written == 1
+        # 신규 write: storable_rows == net_delta == 1 (#1993).
+        assert storable_rows == 1
+        assert net_delta == 1
         assert syms == {"005930"}
 
         result = store.read("005930", "krx", data_type="fundamental")
@@ -1069,13 +1169,15 @@ class TestAvailableDateEndToEnd:
             },
         ]
 
-        written, syms = collector._normalize_and_store(
+        storable_rows, net_delta, syms = collector._normalize_and_store(
             raw_items,
             {"00126380": "005930"},
             store,
         )
 
-        assert written == 1
+        # 신규 write: storable_rows == net_delta == 1 (#1993).
+        assert storable_rows == 1
+        assert net_delta == 1
         result = store.read("005930", "krx", data_type="fundamental")
         assert "available_date" in result.columns
         assert result["available_date"][0] is None

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -1686,3 +1686,154 @@ class TestValidateCredentials:
             valid, detail = await source.validate_credentials()
         assert valid is None
         assert detail is not None
+
+
+# ── DataGoKrCollector: stored_ok = bool(symbols) 유도 (#1993 Finding 1) ─────
+
+
+class _EmptyNormalizer:
+    """normalize_ohlcv·normalize_fundamental이 둘 다 **빈** DataFrame을 반환한다.
+
+    survivor가 validation을 통과해도(정상 raw) 정규화 단계에서 추가 drop돼
+    저장 0건이 되는 케이스를 모사한다(no-symbol). DataGoKrNormalizer와 동형
+    시그니처를 제공한다(collector가 normalize_ohlcv/normalize_fundamental만
+    호출하므로 그 둘만 정의).
+    """
+
+    def normalize_ohlcv(self, df):  # type: ignore[no-untyped-def]
+        import polars as pl
+
+        return pl.DataFrame()
+
+    def normalize_fundamental(self, df):  # type: ignore[no-untyped-def]
+        import polars as pl
+
+        return pl.DataFrame()
+
+
+class TestCollectorStoredOkFromSymbols:
+    """stored_ok가 하드코딩 True가 아니라 bool(symbols)에서 유도된다 (#1993 Finding 1).
+
+    survivor가 validation을 통과해도 정규화 단계에서 ohlcv·fundamental이 둘 다
+    no-symbol이면 실제 저장 0건이다. 이때 stored_ok=True로 하드코딩하면 저장이
+    없는데 checkpoint가 전진해 데이터가 영구 skip된다(회귀). bool(symbols)로
+    유도하면 둘 다 빈 정규화 결과는 stored_ok=False(미전진)로 가드된다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_normalize_all_drop_yields_stored_ok_false(self, tmp_path) -> None:
+        """정규화 단계 전drop(둘 다 no-symbol) → stored_ok=False, symbols 빈 set."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(
+            source=_FakeSource([_raw("005930")]),
+            normalizer=_EmptyNormalizer(),  # type: ignore[arg-type]
+        )
+
+        net_delta, stored_ok, symbols, _warns = await collector.collect(
+            "20260102", store
+        )
+
+        # 정규화 결과 0심볼 → 저장 0건 → bool(symbols)=False.
+        assert net_delta == 0
+        assert symbols == set()
+        assert stored_ok is False
+        # 실제로 어떤 데이터도 저장되지 않았다.
+        assert store.list_symbols("1d") == []
+        assert store.list_symbols(data_type="fundamental") == []
+
+    @pytest.mark.asyncio
+    async def test_normal_data_yields_stored_ok_true(self, tmp_path) -> None:
+        """정상 데이터(기본 normalizer) → stored_ok=True(회귀 가드)."""
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
+
+        net_delta, stored_ok, symbols, _warns = await collector.collect(
+            "20260102", store
+        )
+
+        assert net_delta > 0
+        assert symbols == {"005930"}
+        assert stored_ok is True
+
+    @pytest.mark.asyncio
+    async def test_recollect_delta_zero_yields_stored_ok_true(self, tmp_path) -> None:
+        """재수집(net_delta=0, 정규화 정상) → stored_ok=True(전진 유지, 회귀 가드).
+
+        같은 날짜를 두 번 collect한다. 2차는 dedup으로 net_delta=0이지만 정규화는
+        정상이라 symbols가 비어있지 않아 stored_ok=True여야 한다(stall 방지).
+        """
+        store = ParquetStore(base_path=tmp_path)
+        collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
+
+        await collector.collect("20260102", store)
+        net_delta2, stored_ok2, symbols2, _warns2 = await collector.collect(
+            "20260102", store
+        )
+
+        # 재수집 → net-new 0이지만 정규화/저장 호출은 정상 → stored_ok True.
+        assert net_delta2 == 0
+        assert symbols2 == {"005930"}
+        assert stored_ok2 is True
+
+
+class _StoredOkScriptedCollector:
+    """runner 통합용: collect가 collector 단위 결과를 그대로 전달하는 thin wrapper.
+
+    실 DataGoKrCollector를 감싸 _collect_data_go_kr가 collector의 stored_ok를
+    그대로 받아 checkpoint를 게이트하는지 잠근다(#1993 Finding 1 end-to-end).
+    """
+
+    def __init__(self, inner: DataGoKrCollector) -> None:
+        self._inner = inner
+        self.calls: list[str] = []
+
+    async def collect(
+        self,
+        target_date: str,
+        store: ParquetStore,
+    ) -> tuple[int, bool, set[str], list[dict]]:
+        self.calls.append(target_date)
+        return await self._inner.collect(target_date, store)
+
+
+class TestCollectorStoredOkRunnerGate:
+    """runner가 collector stored_ok=False(정규화 전drop) 날짜를 미전진시킨다."""
+
+    @pytest.mark.asyncio
+    async def test_runner_blocks_checkpoint_on_normalize_all_drop(
+        self, tmp_path
+    ) -> None:
+        """정규화 전drop 날짜(stored_ok=False) → 해당 날짜 checkpoint 미전진.
+
+        Finding 1 회귀: collector가 저장 0건인데 stored_ok=True를 하드코딩하면
+        runner가 checkpoint를 전진시켜 데이터 영구 skip. bool(symbols) 유도로
+        stored_ok=False가 되어 runner의 기존 stored_ok 가드가 미전진시킨다.
+        """
+        from ante.feed.pipeline.backfill_runner import BackfillRunner, _RunContext
+        from ante.feed.pipeline.checkpoint import Checkpoint
+
+        feed_dir = tmp_path / ".feed"
+        store = ParquetStore(base_path=tmp_path / "data")
+        inner = DataGoKrCollector(
+            source=_FakeSource([_raw("005930")]),
+            normalizer=_EmptyNormalizer(),  # type: ignore[arg-type]
+        )
+        collector = _StoredOkScriptedCollector(inner)
+        checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        runner = BackfillRunner(data_go_kr_collector=collector)
+        ctx = _RunContext()
+
+        await runner._collect_data_go_kr(
+            ["2026-01-02"],
+            {},
+            store,
+            checkpoint,
+            ctx,
+            lambda _config, _date: False,
+            lambda _config: False,
+            None,
+        )
+
+        # 정규화 전drop으로 stored_ok=False → checkpoint 미전진(영구 skip 방지).
+        assert checkpoint.get_last_date() is None
+        assert collector.calls == ["2026-01-02"]

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -1030,7 +1030,7 @@ class TestCollectorSymbolValidation:
         store = ParquetStore(base_path=tmp_path)
         collector = DataGoKrCollector(source=_FakeSource([_raw("ABCDEF")]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows == 0
         assert symbols == set()
@@ -1046,7 +1046,7 @@ class TestCollectorSymbolValidation:
         store = ParquetStore(base_path=tmp_path)
         collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows > 0
         assert symbols == {"005930"}
@@ -1062,7 +1062,7 @@ class TestCollectorSymbolValidation:
             source=_FakeSource([_raw("005930"), _raw("ABCDEF")])
         )
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows > 0
         assert symbols == {"005930"}
@@ -1078,7 +1078,7 @@ class TestCollectorSymbolValidation:
         store = ParquetStore(base_path=tmp_path)
         collector = DataGoKrCollector(source=_FakeSource([_raw(None), _raw(123456)]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows == 0
         assert symbols == set()
@@ -1092,7 +1092,7 @@ class TestCollectorSymbolValidation:
         store = ParquetStore(base_path=tmp_path)
         collector = DataGoKrCollector(source=_FakeSource([_raw("１２３４５６")]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows == 0
         assert symbols == set()
@@ -1118,7 +1118,7 @@ class TestCollectorSchemaValidation:
         store = ParquetStore(base_path=tmp_path)
         collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows > 0
         assert symbols == {"005930"}
@@ -1133,7 +1133,7 @@ class TestCollectorSchemaValidation:
         del item["mkp"]
         collector = DataGoKrCollector(source=_FakeSource([item]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows == 0
         assert symbols == set()
@@ -1150,7 +1150,7 @@ class TestCollectorSchemaValidation:
         item["clpr"] = None
         collector = DataGoKrCollector(source=_FakeSource([item]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows == 0
         assert symbols == set()
@@ -1170,7 +1170,7 @@ class TestCollectorSchemaValidation:
         bad_null["trqu"] = None
         collector = DataGoKrCollector(source=_FakeSource([good, bad_missing, bad_null]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows > 0
         assert symbols == {"005930"}
@@ -1192,7 +1192,7 @@ class TestCollectorSchemaValidation:
         item["lopr"] = "200"
         collector = DataGoKrCollector(source=_FakeSource([item]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows > 0
         assert symbols == {"005930"}
@@ -1239,13 +1239,19 @@ class TestCollectorSchemaValidation:
 
 
 class _RecordingStore:
-    """write() 호출을 기록하는 가짜 store (저장 차단 검증용)."""
+    """write() 호출을 기록하는 가짜 store (저장 차단 검증용).
+
+    write()는 ParquetStore와 동형으로 **net-new 저장 행 수**(int)를 반환한다
+    (#1993 fake store sweep). 신규 write로 가정해 ``len(df)`` 를 반환하므로,
+    collector의 ``rows += store.write(...)`` 누적이 None으로 깨지지 않는다.
+    """
 
     def __init__(self) -> None:
         self.writes: list[tuple] = []
 
-    def write(self, symbol, timeframe, df, data_type) -> None:
+    def write(self, symbol, timeframe, df, data_type) -> int:
         self.writes.append((symbol, timeframe, data_type, len(df)))
+        return len(df)
 
 
 class TestCollectorValidationGate:
@@ -1285,7 +1291,9 @@ class TestCollectorValidationGate:
         )
 
         with caplog.at_level(logging.ERROR):
-            rows, symbols, warns = await collector.collect("20260102", store)
+            rows, _stored_ok, symbols, warns = await collector.collect(
+                "20260102", store
+            )
 
         # 저장 차단: write 미호출, rows_written=0, symbols 추가 0.
         assert rows == 0
@@ -1300,10 +1308,11 @@ class TestCollectorValidationGate:
 
     @pytest.mark.asyncio
     async def test_validate_all_failure_does_not_raise(self, monkeypatch) -> None:
-        """passed=False여도 예외 없이 (0, set(), warns)로 정상 반환한다.
+        """passed=False여도 예외 없이 (0, False, set(), warns)로 정상 반환한다.
 
         다른 날짜/소스 수집을 막지 않도록 부분 결과를 정상 반환해야 한다.
-        collect() (written, syms, warns) 시그니처는 불변이다.
+        collect() (net_delta, stored_ok, syms, warns) 4-tuple 시그니처(#1993).
+        validation 차단은 stored_ok=False다.
         """
         from ante.feed.models.result import ValidationResult
 
@@ -1320,9 +1329,10 @@ class TestCollectorValidationGate:
         result = await collector.collect("20260102", store)
 
         assert isinstance(result, tuple)
-        assert len(result) == 3
-        written, syms, warns = result
-        assert written == 0
+        assert len(result) == 4
+        net_delta, stored_ok, syms, warns = result
+        assert net_delta == 0
+        assert stored_ok is False
         assert syms == set()
         assert isinstance(warns, list)
 
@@ -1341,7 +1351,7 @@ class TestCollectorValidationGate:
         del bad2["clpr"]
         collector = DataGoKrCollector(source=_FakeSource([bad1, bad2]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows == 0
         assert symbols == set()
@@ -1505,7 +1515,7 @@ class TestCollectorInstrumentsStore:
             source=_FakeSource([_raw_inst("005930", "삼성전자", "KOSPI")])
         )
 
-        rows, symbols, _ = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, _ = await collector.collect("20260102", store)
 
         assert rows > 0
         assert symbols == {"005930"}
@@ -1529,7 +1539,7 @@ class TestCollectorInstrumentsStore:
         # itmsNm/mrktCtg 키가 전혀 없는 raw(=_raw 기본).
         collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
 
-        rows, symbols, _ = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, _ = await collector.collect("20260102", store)
 
         assert rows > 0
         assert symbols == {"005930"}
@@ -1577,7 +1587,7 @@ class TestCollectorInstrumentsStore:
         store = ParquetStore(base_path=tmp_path)
         collector = DataGoKrCollector(source=_FakeSource([]))
 
-        rows, symbols, warns = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, warns = await collector.collect("20260102", store)
 
         assert rows == 0
         assert symbols == set()
@@ -1593,7 +1603,7 @@ class TestCollectorInstrumentsStore:
         del bad["mkp"]  # 필수 필드 누락 → 선필터 drop.
         collector = DataGoKrCollector(source=_FakeSource([bad]))
 
-        rows, symbols, _ = await collector.collect("20260102", store)
+        rows, _stored_ok, symbols, _ = await collector.collect("20260102", store)
 
         assert rows == 0
         assert symbols == set()

--- a/tests/unit/feed/test_indicator_calculator.py
+++ b/tests/unit/feed/test_indicator_calculator.py
@@ -109,8 +109,11 @@ def test_indicator_asof_join_non_null(store: ParquetStore) -> None:
         ],
     )
 
+    # 지표 계산은 기존 일별 행을 비율 컬럼만 채워 같은 natural key로 in-place
+    # overwrite한다(행 수 불변) → net-new 저장 행 수 = 0(#1993). 데이터 정확성은
+    # 아래 비율 assert로 검증한다(rows_written 과대계상 제거).
     rows = IndicatorCalculator().compute(store, [SYMBOL])
-    assert rows == 2
+    assert rows == 0
 
     daily = _daily_rows(store)
     assert len(daily) == 2
@@ -427,8 +430,10 @@ def test_indicator_nonstandard_period_end_month_removed(store: ParquetStore) -> 
         ],
     )
 
+    # in-place overwrite(같은 natural key) → net-new 저장 0(#1993). 정확성은
+    # 아래 비율 assert로 검증.
     rows = IndicatorCalculator().compute(store, [SYMBOL])
-    assert rows == 1
+    assert rows == 0
 
     row = _daily_rows(store).row(0, named=True)
     # 비표준 행이 제거되고 표준 Q1만 적용 → Q1 값으로 산출(999 값이 아님).

--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -639,7 +639,9 @@ async def test_compute_derived_indicators(tmp_data_path: Path) -> None:
     calculator = IndicatorCalculator()
     rows = calculator.compute(store, ["005930"])
 
-    assert rows > 0
+    # 지표 write-back은 기존 일별 행을 같은 natural key로 in-place overwrite하므로
+    # net-new 저장 행 수 = 0(#1993). 데이터 정확성은 아래 비율 assert로 검증한다.
+    assert rows == 0
 
     # 결과 읽기 — 지표는 일별(data_go_kr) 행에 부여된다.
     result = store.read("005930", "krx", data_type="fundamental")

--- a/tests/unit/feed/test_report.py
+++ b/tests/unit/feed/test_report.py
@@ -569,7 +569,7 @@ class _AnomalyDataGoKrCollector:
         self,
         target_date: str,
         store: ParquetStore,
-    ) -> tuple[int, set[str], list[dict]]:
+    ) -> tuple[int, bool, set[str], list[dict]]:
         df = pl.DataFrame(
             {
                 "date": [date(2025, 9, 30)],
@@ -578,8 +578,12 @@ class _AnomalyDataGoKrCollector:
                 "source": ["data_go_kr"],
             }
         )
-        store.write("005930", "krx", df, data_type="fundamental")
-        return 1, {"005930"}, []
+        # merge 실패 시 store.write는 net_delta=0을 반환한다(기존 파일 보존).
+        net_delta = store.write("005930", "krx", df, data_type="fundamental")
+        # (net_delta, stored_ok, syms, warns) 4-tuple (#1993). 유효 데이터를
+        # validation 통과시켜 write 호출 완료 → stored_ok=True. store-merge 실패는
+        # store 경고로 별도 표면화되며 runner의 checkpoint 가드가 미전진 처리한다.
+        return net_delta, True, {"005930"}, []
 
 
 class TestBackfillReportSurfacesStoreMergeWarning:

--- a/tests/unit/feed/test_rows_written_delta.py
+++ b/tests/unit/feed/test_rows_written_delta.py
@@ -1,0 +1,238 @@
+"""rows_written을 net-new 저장 delta로 산출하는 store/collector 계약 테스트(#1993).
+
+기존 ``ParquetStore.write`` 는 None을 반환했고 collector는 입력 ``len`` 을
+누적했다. 이는 dedup/재수집/지표 in-place overwrite를 모두 과대계상해
+report ``rows_written`` 이 실제 저장량을 크게 초과했다(관측: 4.7M vs 6.8M).
+
+수정(#1993):
+  - ``_persist_partition`` / ``write`` 가 **net-new 저장 행 수**(int)를 반환한다:
+    ``max(0, len(merged) - len(existing))`` (legacy 중복 정리 시 음수 → 0 clamp,
+    merge 실패 시 0, 빈 입력 0, 신규 write는 dedup 결과 행 수).
+  - collector는 입력 len이 아니라 ``store.write`` 반환을 누적한다.
+
+이 파일은 store 계층(a~e)과 collector 누적(j)을 잠근다. checkpoint/DART
+QuarterStatus 무회귀(f~h)는 각 runner/collector 테스트에서 검증한다.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from ante.data.store import ParquetStore
+from ante.feed.pipeline.data_go_kr_collector import DataGoKrCollector
+
+
+def _ohlcv_df(symbol: str, days: list[int], month: int = 3) -> pl.DataFrame:
+    """주어진 일(day)들로 1d OHLCV DataFrame을 만든다(파티션은 월별)."""
+    from datetime import datetime
+
+    ts = [datetime(2026, month, d) for d in days]
+    n = len(ts)
+    return pl.DataFrame(
+        {
+            "timestamp": pl.Series(
+                ts, dtype=pl.Datetime(time_unit="us")
+            ).dt.replace_time_zone("UTC"),
+            "symbol": [symbol] * n,
+            "open": [50000.0] * n,
+            "high": [50100.0] * n,
+            "low": [49900.0] * n,
+            "close": [50050.0] * n,
+            "volume": [1000] * n,
+            "source": ["test"] * n,
+        }
+    )
+
+
+# ── (a) 신규 write → delta == 입력 행 수 ──────────────────────────────────────
+
+
+def test_new_write_returns_input_len(tmp_path) -> None:
+    """기존 파일이 없는 신규 write는 dedup 결과 행 수(=입력 행 수)를 반환한다."""
+    store = ParquetStore(base_path=tmp_path)
+    df = _ohlcv_df("005930", [2, 3, 4])
+
+    net = store.write("005930", "1d", df, data_type="ohlcv")
+
+    assert net == 3
+    assert store.get_row_count("005930", "1d") == 3
+
+
+# ── (b) 재write(동일 데이터) → delta == 0 (dedup) ─────────────────────────────
+
+
+def test_rewrite_same_data_returns_zero(tmp_path) -> None:
+    """같은 데이터를 다시 write하면 natural-key dedup으로 net-new=0이다."""
+    store = ParquetStore(base_path=tmp_path)
+    df = _ohlcv_df("005930", [2, 3, 4])
+
+    first = store.write("005930", "1d", df, data_type="ohlcv")
+    second = store.write("005930", "1d", df, data_type="ohlcv")
+
+    assert first == 3
+    assert second == 0  # 재수집 dedup → net-new 없음
+    assert store.get_row_count("005930", "1d") == 3  # 행 수 불변
+
+
+def test_partial_overlap_returns_only_new_rows(tmp_path) -> None:
+    """일부만 신규(겹치는 날짜 + 새 날짜)면 net-new는 새 날짜 수만큼이다."""
+    store = ParquetStore(base_path=tmp_path)
+    store.write("005930", "1d", _ohlcv_df("005930", [2, 3]), data_type="ohlcv")
+
+    # 3(중복) + 4,5(신규) → net-new 2.
+    net = store.write("005930", "1d", _ohlcv_df("005930", [3, 4, 5]), data_type="ohlcv")
+
+    assert net == 2
+    assert store.get_row_count("005930", "1d") == 4  # 2,3,4,5
+
+
+# ── (c) legacy 중복 정리(merged < existing) → max(0) = 0 ──────────────────────
+
+
+def test_legacy_duplicate_cleanup_clamps_to_zero(tmp_path) -> None:
+    """기존 파일에 natural-key 중복이 있어 merge가 행을 줄여도 delta는 0으로 clamp.
+
+    fundamental natural key는 (date, source). 기존 파일에 같은 (date, source)
+    중복 2행을 심어두면 merge dedup이 1행으로 줄여 merged < existing이 된다.
+    이때 net-new = max(0, len(merged) - len(existing)) = 0(음수 금지).
+    """
+    store = ParquetStore(base_path=tmp_path)
+    # 같은 (date, source) 중복 2행을 가진 fundamental 파티션을 직접 배치.
+    dup = pl.DataFrame(
+        {
+            "date": [date(2026, 3, 31), date(2026, 3, 31)],
+            "symbol": ["005930", "005930"],
+            "market_cap": [100, 100],
+            "source": ["data_go_kr", "data_go_kr"],
+        }
+    )
+    part_dir = tmp_path / "fundamental" / "KRX" / "005930"
+    part_dir.mkdir(parents=True)
+    dup.write_parquet(str(part_dir / "2026-03.parquet"))
+
+    # 같은 (date, source) 1행을 write → merge dedup이 (2+1)→1로 줄어든다.
+    new = pl.DataFrame(
+        {
+            "date": [date(2026, 3, 31)],
+            "symbol": ["005930"],
+            "market_cap": [200],
+            "source": ["data_go_kr"],
+        }
+    )
+    net = store.write("005930", "krx", new, data_type="fundamental")
+
+    # merged(1) < existing(2) → max(0, 1-2) = 0.
+    assert net == 0
+
+
+# ── (d) 다파티션 write → 파티션별 delta 합 ────────────────────────────────────
+
+
+def test_multi_partition_sums_deltas(tmp_path) -> None:
+    """여러 월 파티션에 걸친 write는 파티션별 net-new의 합을 반환한다."""
+    store = ParquetStore(base_path=tmp_path)
+    # 3월 2일 + 4월 2일 → 두 월 파티션, 각 1행 신규.
+    df = pl.concat(
+        [_ohlcv_df("005930", [2], month=3), _ohlcv_df("005930", [2], month=4)]
+    )
+
+    net = store.write("005930", "1d", df, data_type="ohlcv")
+
+    assert net == 2  # 2026-03(1) + 2026-04(1)
+
+
+# ── (e) merge 실패(손상 파티션 보존) → delta == 0 + store_merge 경고 ──────────
+
+
+def test_merge_failure_returns_zero_and_warns(tmp_path) -> None:
+    """기존 파티션이 손상이면 merge 실패 → 기존 보존 + net-new 0 + store_merge 경고."""
+    store = ParquetStore(base_path=tmp_path)
+    part_dir = tmp_path / "fundamental" / "KRX" / "005930"
+    part_dir.mkdir(parents=True)
+    (part_dir / "2026-03.parquet").write_bytes(b"corrupt-not-parquet")
+
+    new = pl.DataFrame(
+        {
+            "date": [date(2026, 3, 31)],
+            "symbol": ["005930"],
+            "market_cap": [200],
+            "source": ["data_go_kr"],
+        }
+    )
+    net = store.write("005930", "krx", new, data_type="fundamental")
+
+    assert net == 0  # 저장 반영 없음(기존 파일 보존)
+    warnings = store.drain_warnings()
+    assert any(w.get("type") == "store_merge" for w in warnings)
+    # 손상 파일은 보존(데이터 손실 방지).
+    assert (part_dir / "2026-03.parquet").read_bytes() == b"corrupt-not-parquet"
+
+
+# ── (j) collector rows_written == store 실제 저장 합(재수집 0) ────────────────
+
+
+class _FakeSource:
+    """data.go.kr source 스텁: fetch가 고정 raw_items를 반환한다."""
+
+    def __init__(self, items: list[dict]) -> None:
+        self._items = items
+
+    async def fetch(self, target_date: str) -> list[dict]:
+        return list(self._items)
+
+
+def _raw(symbol: str) -> dict:
+    """정규화 가능한 최소 data.go.kr raw row."""
+    return {
+        "srtnCd": symbol,
+        "basDt": "20260102",
+        "mrktCtg": "KOSPI",
+        "clpr": "50000",
+        "mkp": "49900",
+        "hipr": "50500",
+        "lopr": "49500",
+        "trqu": "1000",
+        "itmsNm": "삼성전자",
+        "lstgStCnt": "5969782550",
+        "mrktTotAmt": "300000000000000",
+    }
+
+
+@pytest.mark.asyncio
+async def test_collector_rows_written_is_store_net_delta(tmp_path) -> None:
+    """collector net_delta = store 실제 저장 합. 재수집 시 net_delta=0, stored_ok=True.
+
+    (a) 첫 수집: 유효 데이터 저장 → net_delta>0, stored_ok=True.
+    (b) 같은 날짜 재수집: dedup으로 net_delta=0, **stored_ok=True**(유효 데이터가
+        store에 반영됨 — checkpoint stall 방지). 입력 len 누적이 아니라 store
+        실제 저장 delta를 보고하므로 재수집이 rows_written을 과대계상하지 않는다.
+    """
+    store = ParquetStore(base_path=tmp_path)
+    collector = DataGoKrCollector(source=_FakeSource([_raw("005930")]))
+
+    net1, stored_ok1, syms1, _w1 = await collector.collect("20260102", store)
+    assert net1 > 0
+    assert stored_ok1 is True
+    assert syms1 == {"005930"}
+
+    # 같은 날짜 재수집 → net_delta=0(dedup), stored_ok=True(유효 데이터 반영).
+    net2, stored_ok2, syms2, _w2 = await collector.collect("20260102", store)
+    assert net2 == 0
+    assert stored_ok2 is True
+    assert syms2 == {"005930"}
+
+
+@pytest.mark.asyncio
+async def test_collector_empty_response_stored_ok_false(tmp_path) -> None:
+    """빈 응답(raw 없음) → net_delta=0 AND stored_ok=False(저장 반영 전무)."""
+    store = ParquetStore(base_path=tmp_path)
+    collector = DataGoKrCollector(source=_FakeSource([]))
+
+    net, stored_ok, syms, _w = await collector.collect("20260102", store)
+
+    assert net == 0
+    assert stored_ok is False
+    assert syms == set()


### PR DESCRIPTION
Closes #1993

## Summary
- `rows_written`이 입력 row len을 누적해 중복/재수집을 과대집계하던 문제를 **net-new 저장 delta**로 정정.
- `ParquetStore.write`/`_persist_partition`가 `max(0, len(merged)-len(existing))`(net-new 행 수) 반환. merge 실패는 raise 없이 기존 보존 + `store_merge` 경고만 적재(delta=0).
- collector `collect()`가 4-tuple `(net_delta, stored_ok, syms, warns)` — rows_written(net_delta)과 checkpoint 전진 자격(stored_ok)을 분리. 재수집(net_delta=0)도 유효 데이터면 전진(#2015 stall 무회귀).
- **checkpoint 3-state 가드**: 빈응답→미전진 / 유효 재수집(stored_ok, delta=0)→전진 / store-merge 실패→미전진(R1, runner store_merge drain 가드).
- DART는 `storable_rows`/`net_delta` 분리 — QuarterStatus(OK/SKIP_EMPTY/HALT)는 storable 기준 무변경(#2028 보존), rows_written만 net_delta.
- `stored_ok`는 실제 저장 심볼 기반(`bool(symbols)`) — 정규화 단계 전drop 시 미전진.
- DART checkpoint는 collector 내부 save라 runner R1 미적용이던 gap을, `ParquetStore.pending_merge_failure_count()` 비파괴적 peek(before/after diff)로 store-merge 실패만 checkpoint.save 게이트(backfill+daily 양 경로). drain 소유권은 runner 단독 보존.

## Test Plan
- `PYTHONPATH=src .venv/bin/python -m pytest tests/unit/ -q` — 6974 passed, 2 skipped
- `ruff check` / `ruff format --check` / `mypy src/` — clean
- 신규: 신규 write→delta=len, 재write→0(dedup), legacy 음수→max(0)=0, 다파티션 delta 합, merge실패→0, 재수집 checkpoint 전진(stored_ok), store-merge 실패→미전진(R1), DART QuarterStatus 무회귀+재수집 quarter delta=0 OK, stored_ok=bool(symbols) 전drop 미전진, DART store-merge 실패 checkpoint 미전진(backfill+daily), pending_merge_failure_count 비파괴 peek
- Codex 브랜치 리뷰: PASS (attempt 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
