### PR TITLE
fix(cli): #2001 backtest run CLI를 D-004 subprocess 격리 경로로 전환

### DIFF
--- a/docs/specs/backtest/02-design-decisions.md
+++ b/docs/specs/backtest/02-design-decisions.md
@@ -70,7 +70,12 @@
 
 가상 체결 시뮬레이션 엔진. 슬리피지, 수수료를 포함하여 현실적인 시뮬레이션을 제공한다.
 
-`run(progress_callback=None)` 메서드는 선택적 진행률 콜백을 받아 CLI 프로그레스 바와 연동한다.
+`run(progress_callback=None)` 메서드는 선택적 진행률 콜백을 받는다. 이 콜백은
+in-process `BacktestService.run()` 을 임베드 호출하는 경우(프로그래매틱/IPC
+임베드)에만 진행률을 스트리밍한다. `ante backtest run` CLI 는 D-004 격리 계약대로
+`run_subprocess()`(`python -m ante.backtest.runner`) 경로를 사용하며, 자식
+프로세스 stdout 은 단일 결과 라인이라 진행률 스트리밍을 지원하지 않는다(progress
+bar 없음 — 격리 우선, #2001).
 
 **시뮬레이션 루프**:
 ```
@@ -228,8 +233,8 @@ def to_dict(self) -> dict:
 
 | 메서드 | 설명 |
 |--------|------|
-| `run(config, progress_callback=None) → BacktestResult` | 백테스트를 in-process로 실행. 선택적 진행률 콜백 지원 |
-| `run_subprocess(config) → dict` | 백테스트를 subprocess로 격리 실행 (D-004), JSON 결과 반환 |
+| `run(config, progress_callback=None) → BacktestResult` | 백테스트를 in-process로 실행. 진행률 콜백은 in-process 임베드 호출 한정 (CLI subprocess 경로는 미지원) |
+| `run_subprocess(config) → dict` | 백테스트를 subprocess로 격리 실행 (D-004). `ante backtest run` CLI 의 격리 경로. `runner.run_backtest` 가 emit 하는 additive envelope(`to_dict()` superset + 런타임 `result_path`/`strategy_name`/`strategy_version`)를 반환해 `result_path` 를 `backtest_runs` 이력으로 전파한다 (#1998/#2001) |
 
 **설정 필수 키**: `strategy_path`, `start_date`, `end_date`
 **선택 키**: `symbols` (list[str]), `timeframe` (기본 `"1d"`), `initial_balance` (기본 10,000,000), `buy_commission_rate` (기본 0.00015), `sell_commission_rate` (기본 0.00195), `slippage_rate` (기본 0.001), `data_paths` (기본 Config resolver의 `data.path`), `data_path` (하위호환, 단수)
@@ -266,9 +271,9 @@ def _validate_config(self, config: dict[str, Any]) -> BacktestConfig:
 | 모듈 | 영향 | 조치 |
 |------|------|------|
 | **ReportDraftGenerator** | 자동 호환 — `detail = dict(result_data)` 로 전체 복사하므로 config/datasets 자동 포함 | 수정 불필요 |
-| **BacktestRunner** (subprocess) | 자동 호환 — service.py에서 주입 후 `result.to_dict()`에 포함 | 수정 불필요 |
+| **BacktestRunner** (subprocess) | `run_backtest()` 는 `result.to_dict()` superset envelope(+ 런타임 `result_path`/`strategy_name`/`strategy_version`)를 emit한다. config/datasets 는 to_dict 키로 그대로 포함. `output_path` 파일 아티팩트는 to_dict 그대로 유지 (#2001) | 수정 불필요 |
 | **BacktestRunStore** | params_json에 입력 config만 저장 중 | 선택: resolved config 저장으로 개선 가능 |
-| **CLI** (`backtest run`) | to_dict() 기존 키 유지, 신규 키 추가만 | 선택: 결과 출력에 config 요약 추가 |
+| **CLI** (`backtest run`) | `run_subprocess()` 의 envelope dict 를 소비 — to_dict 키 유지 + 런타임 `result_path`/`strategy_name`/`strategy_version` 직접 사용. `_save_backtest_run` 은 combined `strategy` 를 split 파싱하지 않는다 (#2001) | 선택: 결과 출력에 config 요약 추가 |
 | **to_dict() 소비자** | 기존 필드 불변, 추가 키만 — **backward compatible** | 기존 코드 수정 불필요 |
 
 ### BacktestStrategyContext

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -537,7 +537,7 @@ ante data delete <dataset_id> --type ohlcv|fundamental --yes [--data-path <경�
 `--data-path`를 생략하면 canonical data root(`data.path`)에서 Parquet 데이터를 읽는다.
 
 ```bash
-ante backtest run <strategy_path> --start <날짜> --end <날짜> [--symbols <종목,...>] [--balance <초기자금>] [--timeframe <주기>] [--exchange <거래소>] [--data-path <경로>] [--db-path <경로>]  # 진행률 바 표시 (text 모드, --exchange 기본 KRX)
+ante backtest run <strategy_path> --start <날짜> --end <날짜> [--symbols <종목,...>] [--balance <초기자금>] [--timeframe <주기>] [--exchange <거래소>] [--data-path <경로>] [--db-path <경로>]  # subprocess 격리 실행(D-004), 진행률 스트리밍 없음 (--exchange 기본 KRX)
 ante backtest history <strategy_name> [--limit N] [--db-path <경로>]  # 전략별 백테스트 실행 이력
 ```
 

--- a/docs/specs/cli/06-cross-module-notes.md
+++ b/docs/specs/cli/06-cross-module-notes.md
@@ -10,6 +10,6 @@
 - **Member 스펙**: `member list/info`는 오프라인 조회가 가능하다. 등록, 상태 변경, 토큰/패스워드/복구키 변경은 서버 실행 중 IPC로 처리하고, 서버 정지 상태에서는 recovery/maintenance fallback만 허용한다.
 - **Strategy 스펙**: `ante strategy validate`는 StrategyValidator를 호출하고, `ante strategy submit <path>`는 검증 + 로드 테스트 + StrategyRegistry 등록을 수행한다. 등록 결과인 `strategy_id`가 `ante bot create --strategy` 입력이다.
 - **Report Store 스펙**: `ante report submit/schema` → ReportStore, PerformanceFeedback 호출
-- **Backtest 스펙**: `ante backtest run` → BacktestService.run_backtest() (subprocess)
+- **Backtest 스펙**: `ante backtest run` → BacktestService.run_subprocess() (subprocess 격리, D-004)
 - **Data Pipeline 스펙**: `ante data list/schema/storage/validate` → ParquetStore 호출. `ante data retention` 커맨드는 미구현 (RetentionPolicy는 프로그래매틱 사용만)
 - **DataFeed 스펙**: `ante feed init/status/config/inject/run/start` → FeedConfig, FeedInjector, FeedOrchestrator 호출

--- a/src/ante/backtest/runner.py
+++ b/src/ante/backtest/runner.py
@@ -13,7 +13,24 @@ from ante.backtest.service import BACKTEST_RESULT_SENTINEL
 
 
 async def run_backtest(config: dict) -> dict:
-    """백테스트 실행 후 결과를 dict로 반환."""
+    """백테스트 실행 후 결과를 additive envelope dict로 반환 (#2001).
+
+    반환 dict 는 ``result.to_dict()`` 의 모든 키를 보존하는 superset 이며,
+    ``to_dict()`` 가 (artifact self-reference 회피 + draft 소비 shape 유지를
+    위해) 직렬화에서 제외하는 런타임 메타데이터 3키를 명시적으로 surface 한다:
+
+    - ``result_path``: ``service.run()`` 이 저장한 durable artifact 경로
+      (#1998). subprocess(stdout) → ``run_subprocess`` → CLI ``_save_backtest_run``
+      → ``backtest_runs.result_path`` 추적성 전파용. 저장 실패 시 ``""``.
+    - ``strategy_name`` / ``strategy_version``: ``to_dict`` 가 combined
+      ``strategy`` (``"{name}_v{version}"``) 만 제공하므로, CLI 가 split 파싱
+      없이 개별 키를 직접 쓰도록 surface 한다.
+
+    이는 ``run_backtest()`` 반환 계약의 **명시적 additive 확장**이다
+    (``to_dict()`` 직렬화 계약 자체는 무변경). ``output_path`` 로 기록하는
+    파일 아티팩트는 envelope 가 아닌 ``to_dict()`` 그대로 유지한다 —
+    ReportDraftGenerator 등 artifact 소비 shape 를 바꾸지 않기 위함이다.
+    """
     from ante.backtest.service import BacktestService
 
     service = BacktestService(
@@ -21,15 +38,22 @@ async def run_backtest(config: dict) -> dict:
     )
     result = await service.run(config)
 
+    payload = result.to_dict()
+
     output_path = config.get("output_path")
     if output_path:
         from pathlib import Path
 
-        Path(output_path).write_text(
-            json.dumps(result.to_dict(), indent=2, default=str)
-        )
+        # 파일 아티팩트는 to_dict() 그대로 유지(envelope 아님 — artifact 소비
+        # shape 무변경). stdout envelope 와 의도적으로 형식을 분리한다.
+        Path(output_path).write_text(json.dumps(payload, indent=2, default=str))
 
-    return result.to_dict()
+    return {
+        **payload,
+        "result_path": result.result_path,
+        "strategy_name": result.strategy_name,
+        "strategy_version": result.strategy_version,
+    }
 
 
 def main() -> None:

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -205,10 +205,21 @@ class BacktestService:
     async def run_subprocess(self, config: dict[str, Any]) -> dict:
         """백테스트를 subprocess로 격리 실행 (D-004).
 
-        #1998 비목표: 이 경로는 BacktestCompleteEvent 를 발행하지 않고 CLI 에서
-        사용되지 않으므로(critical path 밖), 결과 artifact 저장·자동 리포트 초안
-        생성을 지원하지 않는다. durable artifact + result_path 전파는 in-process
-        ``run()`` 한정이다.
+        ``ante backtest run`` CLI 의 격리 실행 경로다(#2001). ``python -m
+        ante.backtest.runner`` 자식 프로세스를 띄워 stdin 으로 JSON config 를
+        전달하고, stdout 의 ``BACKTEST_RESULT_SENTINEL`` 라인만 파싱한 dict 를
+        반환한다. returncode≠0 또는 sentinel 라인 부재는 ``BacktestError`` 다.
+
+        반환 dict 는 ``runner.run_backtest`` 가 emit 하는 additive envelope 로,
+        ``to_dict()`` 키 superset 에 더해 런타임 메타데이터 ``result_path`` /
+        ``strategy_name`` / ``strategy_version`` 를 포함한다. 자식 프로세스의
+        ``run()`` 이 durable artifact 를 저장하고 그 경로를 ``result_path`` 로
+        surface 하므로, CLI ``_save_backtest_run`` 이 이를
+        ``backtest_runs.result_path`` 로 영속해 추적성을 전파한다(#1998).
+
+        이 경로는 부모 프로세스에서 ``BacktestCompleteEvent`` 를 발행하지 않는다
+        (격리된 자식 프로세스에는 eventbus 가 없다). ``to_dict()`` 직렬화 계약은
+        무변경이며, 런타임 3키는 envelope 반환에서만 보강된다.
         """
         self._validate_config(config)
 

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import re
 import sqlite3
-from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -13,9 +12,6 @@ from ante.cli._data_path import resolve_data_path
 from ante.cli._validators import validate_positive_finite_amount
 from ante.cli.db_context import open_cli_db
 from ante.cli.main import get_formatter
-
-if TYPE_CHECKING:
-    from ante.backtest.result import BacktestResult
 from ante.cli.middleware import require_auth, require_scope
 
 # strict YYYY-MM-DD 가드 (feed/cli.py·backfill_runner.py 패턴 미러). Python
@@ -119,13 +115,15 @@ def run(
 
     # 타임프레임/심볼 검증 (CLI 경계 단일 지점, SSOT helper 위임).
     # precedence: date/exchange 검증 이후 → ① timeframe → ② 빈 segment →
-    # ③ KRX symbol shape. config build·BacktestService.run·_save_backtest_run
-    # 이전이어야 invalid 입력 시 backtest_runs history가 생성되지 않는다.
+    # ③ KRX symbol shape. config build·BacktestService.run_subprocess·
+    # _save_backtest_run 이전이어야 invalid 입력 시 backtest_runs history가
+    # 생성되지 않는다 (subprocess 생성 전 ingress 거부 — #2053/#2060/#1995).
     #
     # #2060: ``--timeframe`` 생략(None) 은 "전략 meta 사용" 신호이므로 CLI
-    # vocab 검증을 skip 하고 config 에 None 을 그대로 전달한다 —
-    # BacktestService.run() 이 load 후 StrategyMeta.timeframe 으로 fallback·
-    # 재검증한다. 명시값(비-None)은 기존대로 ingress 에서 거부한다.
+    # vocab 검증을 skip 하고 config 에 None 을 그대로 전달한다 — subprocess
+    # 자식 프로세스의 ``BacktestService.run()`` 이 load 후 StrategyMeta.
+    # timeframe 으로 fallback·재검증한다. 명시값(비-None)은 기존대로 ingress
+    # 에서 거부한다.
     if timeframe is not None and not is_valid_timeframe(timeframe):
         fmt.error(
             f"유효하지 않은 타임프레임: {timeframe!r}. "
@@ -161,8 +159,9 @@ def run(
         "end_date": end,
         "symbols": symbols.split(",") if symbols else [],
         "initial_balance": balance,
-        # #2060: ``--timeframe`` 생략 시 None 을 그대로 전달 — service.run()
-        # 이 StrategyMeta.timeframe 으로 fallback 한다(명시값은 그대로 전달).
+        # #2060: ``--timeframe`` 생략 시 None 을 그대로 전달 — subprocess
+        # 자식의 service.run() 이 StrategyMeta.timeframe 으로 fallback 한다
+        # (명시값은 그대로 전달).
         "timeframe": timeframe,
         "exchange": exchange,
         "data_path": data_path,
@@ -170,32 +169,14 @@ def run(
 
     try:
         service = BacktestService(data_path=data_path)
-        show_progress = not fmt.is_json
 
-        progress_bar: Any = None
-
-        def _progress_callback(current: int, total: int) -> None:
-            nonlocal progress_bar
-            if not show_progress:
-                return
-            if progress_bar is None and total > 0:
-                progress_bar = click.progressbar(
-                    length=total,
-                    label="백테스트 진행",
-                    show_percent=True,
-                    show_pos=True,
-                )
-                progress_bar.__enter__()
-            if progress_bar is not None:
-                progress_bar.update(1)
-
-        result = asyncio.run(service.run(config, progress_callback=_progress_callback))
-
-        if progress_bar is not None:
-            progress_bar.__exit__(None, None, None)
-            click.echo()
-
-        result_dict = result.to_dict()
+        # #2001: D-004 격리 계약대로 subprocess(`python -m ante.backtest.runner`)
+        # 로 실행한다. 자식 프로세스 stdout 은 단일 결과 라인이라 진행률
+        # 스트리밍이 불가하므로 in-process 전용 progress bar 는 제거한다
+        # (cli/03-commands.md·backtest/02-design-decisions.md 정합). 반환
+        # ``result_dict`` 는 ``to_dict()`` superset envelope 로 런타임 메타데이터
+        # (result_path/strategy_name/strategy_version)를 포함한다.
+        result_dict = asyncio.run(service.run_subprocess(config))
         metrics = result_dict.get("metrics", {})
 
         # #1995: 명시 종목 전체가 데이터 없음(row_count=0)이면 이력 저장 없이 실패
@@ -214,7 +195,7 @@ def run(
 
         # backtest_runs 이력 저장
         run_id = asyncio.run(
-            _save_backtest_run(resolved_db_path, result, config, metrics)
+            _save_backtest_run(resolved_db_path, result_dict, config, metrics)
         )
         result_dict["run_id"] = run_id
 
@@ -243,11 +224,18 @@ def run(
 
 async def _save_backtest_run(
     db_path: str,
-    result: BacktestResult,
+    result_dict: dict,
     config: dict,
     metrics: dict,
 ) -> str:
-    """backtest_runs 테이블에 이력 저장."""
+    """backtest_runs 테이블에 이력 저장 (#2001: envelope dict 기반).
+
+    ``result_dict`` 는 ``service.run_subprocess`` 가 반환한 additive envelope
+    (``to_dict()`` superset + 런타임 메타데이터)이다. ``strategy_name`` /
+    ``strategy_version`` 은 envelope 의 개별 키를 직접 사용하며 combined
+    ``strategy`` (``"{name}_v{version}"``) 를 split 파싱하지 않는다 — 버전
+    문자열에 ``_v`` 가 포함될 수 있어 split 이 안전하지 않기 때문이다.
+    """
     from ante.backtest.run_store import BacktestRunStore
     from ante.core.database import Database
 
@@ -257,18 +245,19 @@ async def _save_backtest_run(
         store = BacktestRunStore(db)
         await store.initialize()
         return await store.save(
-            strategy_name=result.strategy_name,
-            strategy_version=result.strategy_version,
+            # combined "strategy" 파싱 금지 — envelope 개별 키 직접 사용.
+            strategy_name=result_dict["strategy_name"],
+            strategy_version=result_dict["strategy_version"],
             params=config,
-            total_return_pct=round(result.total_return, 2),
+            total_return_pct=result_dict["total_return_pct"],
             sharpe_ratio=metrics.get("sharpe_ratio"),
             max_drawdown_pct=metrics.get("max_drawdown"),
-            total_trades=len(result.trades),
+            total_trades=result_dict["total_trades"],
             win_rate=metrics.get("win_rate"),
-            # #1998: service.run() 이 저장한 durable artifact 경로를 이력에 기록한다
-            # (저장 실패 시 ""). backtest_runs.result_path 와 BacktestCompleteEvent.
-            # result_path 가 동일 artifact 를 가리켜 추적성을 보장한다.
-            result_path=result.result_path,
+            # #1998: subprocess 의 run() 이 저장한 durable artifact 경로를 이력에
+            # 기록한다(저장 실패 시 ""). run_subprocess envelope 의 result_path 가
+            # backtest_runs.result_path 로 전파되어 추적성을 보장한다.
+            result_path=result_dict["result_path"],
         )
     finally:
         await db.close()

--- a/tests/unit/contracts/factory_drift_allowlist.yaml
+++ b/tests/unit/contracts/factory_drift_allowlist.yaml
@@ -46,13 +46,16 @@ direct_database_construction:
     line: 131
     reason: "report submit — offline write (INSERT), read-only 비대상; deferred migration"
 
-  # backtest domain — `backtest run` 은 spec 상 `long_running` 분류 (progress
-  # bar 와 함께 장시간 작업) 이라 직접 Database 생성을 유지한다.
+  # backtest domain — `backtest run` 은 spec 상 `long_running` 분류 (subprocess
+  # 격리 실행, D-004) 이라 직접 Database 생성을 유지한다. #2001 에서 in-process
+  # 실행이 subprocess 격리로 전환되며 `_save_backtest_run` 의 직접 Database 생성
+  # callsite 줄번호가 이동했다 (import 정리 + docstring 추가). write(INSERT)
+  # 명령이라 read-only 마이그레이션 대상이 아니다.
   # `backtest history` 는 `offline` 이며 #1974 에서 `open_cli_db` (read_only)
   # 로 마이그레이션되어 직접 Database 생성 callsite 가 사라졌다 — 엔트리 제거.
   - path: src/ante/cli/commands/backtest.py
-    line: 254
-    reason: "backtest run — long_running (progress-bar driven, deferred migration)"
+    line: 242
+    reason: "backtest run — long_running (subprocess 격리 D-004), write INSERT; deferred migration"
 
   # data domain — `data list` 는 `offline` 이며 #1984 에서 `open_cli_db`
   # (read_only) + InstrumentService.load_readonly() 로 마이그레이션되어 직접

--- a/tests/unit/test_backtest_exchange_plumbing.py
+++ b/tests/unit/test_backtest_exchange_plumbing.py
@@ -450,11 +450,12 @@ class TestResultToDictSerializesExchange:
 
 
 class TestRunnerForwardsToDictUnmodified:
-    """runner.run_backtest()는 service 결과의 to_dict()를 무가공 반환.
+    """runner.run_backtest()는 service 결과의 to_dict() superset envelope 반환 (#2001).
 
-    subprocess 실제 기동은 무거우므로, runner가 result.to_dict()를
-    그대로 전달함을 가벼운 단위로 갈음한다 (to_dict 출력 단언은 in-process
-    TestResultToDictSerializesExchange가 필수로 커버).
+    subprocess 실제 기동은 무거우므로, runner가 result.to_dict()의 모든 키를
+    보존하면서 런타임 메타데이터(result_path/strategy_name/strategy_version)를
+    additive 로 surface 함을 가벼운 단위로 갈음한다 (to_dict 출력 단언은
+    in-process TestResultToDictSerializesExchange가 필수로 커버).
     """
 
     @pytest.mark.asyncio
@@ -504,7 +505,16 @@ class TestRunnerForwardsToDictUnmodified:
                 }
             )
 
-        assert out == result.to_dict()
+        # #2001: envelope 은 to_dict() 의 superset — to_dict 의 모든 키/값을
+        # 보존하면서 런타임 메타데이터 3키를 additive 로 추가한다.
+        to_dict = result.to_dict()
+        assert set(out) >= set(to_dict), "to_dict() 키가 모두 보존되어야 한다"
+        for key, value in to_dict.items():
+            assert out[key] == value, f"{key} 값이 to_dict 와 동일해야 한다"
+        # 런타임 메타데이터 3키 surface.
+        assert out["result_path"] == result.result_path
+        assert out["strategy_name"] == "S"
+        assert out["strategy_version"] == "1"
         assert out["trades"][0]["exchange"] == "NYSE"
 
 

--- a/tests/unit/test_backtest_success_output_drift.py
+++ b/tests/unit/test_backtest_success_output_drift.py
@@ -20,7 +20,7 @@ callsite shape 와 일치함을 단순 lock 만 한다. callsite shape 가 drift
 history non-empty +1):
 
 0. registry sanity — backtest 2 entries 의 envelope 분류기 범위 내.
-1. ``run`` success (mock service.run) → ``raw_legacy`` (BacktestResult dict).
+1. ``run`` success (mock service.run_subprocess) → ``raw_legacy`` (envelope dict).
 2. ``history`` empty → ``raw_legacy`` (``{message, runs: []}``).
 3. ``history`` non-empty → ``raw_legacy`` (``{strategy_name, runs: [...]}``).
 """
@@ -143,24 +143,18 @@ def _load_json_payload(output: str) -> Any:
 def test_backtest_run_success_envelope_matches_raw_legacy(tmp_path: Path) -> None:
     """``backtest run`` success: ``fmt.output(result_dict, template)`` 평면 dict.
 
-    backtest.py:173-181: ``fmt.output(result_dict, ...)`` 평면 dict. ``result_dict``
-    는 ``BacktestResult.to_dict()`` 의 결과로 ``{strategy, period,
-    total_return_pct, total_trades, final_balance, trades, metrics,
-    equity_curve, config, datasets, run_id}`` 평면 shape. ``BacktestService.run``
-    을 mock 해 성공 경로를 강제한다.
+    backtest.py: ``fmt.output(result_dict, ...)`` 평면 dict. ``result_dict`` 는
+    ``run_subprocess`` 가 반환하는 envelope(``to_dict()`` superset + 런타임
+    result_path/strategy_name/strategy_version)이며 ``run_id`` 추가 후 평면 shape.
+    ``BacktestService.run_subprocess`` 를 mock 해 성공 경로를 강제한다 (#2001).
     """
     # strategy file (Path(exists=True) callback 통과용)
     strat_path = tmp_path / "strat.py"
     strat_path.write_text("# dummy strategy file\n", encoding="utf-8")
     db_path = tmp_path / "ante.db"
 
-    # BacktestResult mock — to_dict() 가 평면 dict 반환.
-    result_obj = MagicMock()
-    result_obj.strategy_name = "test_strategy"
-    result_obj.strategy_version = "1.0.0"
-    result_obj.total_return = 12.5
-    result_obj.trades = []
-    result_obj.to_dict.return_value = {
+    # run_subprocess 가 반환하는 envelope dict — 평면 shape.
+    result_envelope = {
         "strategy": "test_strategy_v1.0.0",
         "period": "2025-01-01 ~ 2025-12-31",
         "initial_balance": 10_000_000.0,
@@ -176,12 +170,16 @@ def test_backtest_run_success_envelope_matches_raw_legacy(tmp_path: Path) -> Non
         "trades": [],
         "config": {},
         "datasets": [],
+        # #2001: 런타임 메타데이터 3키.
+        "result_path": "",
+        "strategy_name": "test_strategy",
+        "strategy_version": "1.0.0",
     }
 
     with (
         patch(
-            "ante.backtest.service.BacktestService.run",
-            new=AsyncMock(return_value=result_obj),
+            "ante.backtest.service.BacktestService.run_subprocess",
+            new=AsyncMock(return_value=result_envelope),
         ),
         patch(
             "ante.backtest.run_store.BacktestRunStore.initialize",

--- a/tests/unit/test_cli_backtest_exchange_validation.py
+++ b/tests/unit/test_cli_backtest_exchange_validation.py
@@ -178,10 +178,11 @@ class TestBacktestExchangeValidation:
 
 
 def _capture_config():
-    """BacktestService.run에 넘어온 config dict를 캡처하는 스파이.
+    """BacktestService.run_subprocess 에 넘어온 config dict를 캡처하는 스파이 (#2001).
 
     CLI가 검증만 통과시키고 config에 exchange를 누락해도 잡아낸다
-    (validation/plumbing 테스트만으로는 못 잡는 hop — q2).
+    (validation/plumbing 테스트만으로는 못 잡는 hop — q2). CLI 가 subprocess
+    격리 경로(run_subprocess)로 전환되었으므로 그 hop 을 spy 한다.
     """
     captured: dict = {}
 
@@ -189,7 +190,7 @@ def _capture_config():
         def __init__(self, *args, **kwargs):
             pass
 
-        async def run(self, config, progress_callback=None):
+        async def run_subprocess(self, config):
             captured["config"] = dict(config)
             raise RuntimeError("stop after config handoff")
 

--- a/tests/unit/test_cli_backtest_result_path.py
+++ b/tests/unit/test_cli_backtest_result_path.py
@@ -1,4 +1,11 @@
-"""#1998: CLI ``_save_backtest_run`` 이 result.result_path 를 이력에 기록한다."""
+"""#1998/#2001: CLI ``_save_backtest_run`` 이 envelope result_path 를 이력에 기록한다.
+
+#2001 으로 ``_save_backtest_run`` 시그니처가 ``BacktestResult`` 객체에서
+``run_subprocess`` 가 반환하는 additive envelope dict 기반으로 바뀌었다. 본
+테스트는 envelope dict 의 ``result_path`` / ``strategy_name`` /
+``strategy_version`` / ``total_return_pct`` / ``total_trades`` 가
+``backtest_runs`` 행으로 그대로 전파됨을 검증한다 (#1998 추적성 보존).
+"""
 
 from __future__ import annotations
 
@@ -10,27 +17,43 @@ from ante.cli.commands.backtest import _save_backtest_run
 from ante.core.database import Database
 
 
-@pytest.mark.asyncio
-async def test_save_backtest_run_records_result_path(tmp_path):
-    """_save_backtest_run 이 result.result_path 를 backtest_runs.result_path 로 저장."""
-    db_path = str(tmp_path / "test.db")
-    artifact_path = str(tmp_path / ".backtest" / "results" / "momentum_v1.0.0_abc.json")
-
+def _envelope(
+    *,
+    strategy_name: str = "momentum",
+    strategy_version: str = "1.0.0",
+    total_return: float = 10.0,
+    result_path: str = "",
+) -> dict:
+    """run_subprocess 가 반환하는 envelope(to_dict superset + 런타임 3키)."""
     result = BacktestResult(
-        strategy_name="momentum",
-        strategy_version="1.0.0",
+        strategy_name=strategy_name,
+        strategy_version=strategy_version,
         start_date="2025-01-01",
         end_date="2025-12-31",
         initial_balance=10_000_000.0,
         final_balance=11_000_000.0,
-        total_return=10.0,
+        total_return=total_return,
     )
-    result.result_path = artifact_path
+    result.result_path = result_path
+    return {
+        **result.to_dict(),
+        "result_path": result.result_path,
+        "strategy_name": result.strategy_name,
+        "strategy_version": result.strategy_version,
+    }
 
+
+@pytest.mark.asyncio
+async def test_save_backtest_run_records_result_path(tmp_path):
+    """_save_backtest_run 이 envelope result_path 를 이력 result_path 로 저장."""
+    db_path = str(tmp_path / "test.db")
+    artifact_path = str(tmp_path / ".backtest" / "results" / "momentum_v1.0.0_abc.json")
+
+    result_dict = _envelope(result_path=artifact_path)
     config = {"start_date": "2025-01-01", "end_date": "2025-12-31"}
     metrics = {"sharpe_ratio": 1.1, "max_drawdown": -5.0, "win_rate": 0.6}
 
-    run_id = await _save_backtest_run(db_path, result, config, metrics)
+    run_id = await _save_backtest_run(db_path, result_dict, config, metrics)
     assert run_id
 
     db = Database(db_path)
@@ -43,6 +66,10 @@ async def test_save_backtest_run_records_result_path(tmp_path):
 
     assert run is not None
     assert run.result_path == artifact_path
+    # envelope 스칼라 키가 그대로 전파된다.
+    assert run.strategy_name == "momentum"
+    assert run.strategy_version == "1.0.0"
+    assert run.total_return_pct == 10.0
 
 
 @pytest.mark.asyncio
@@ -50,19 +77,11 @@ async def test_save_backtest_run_empty_path_on_save_failure(tmp_path):
     """저장 실패 fallback(result_path="") 도 이력에 그대로 기록(무회귀)."""
     db_path = str(tmp_path / "test.db")
 
-    result = BacktestResult(
-        strategy_name="momentum",
-        strategy_version="1.0.0",
-        start_date="2025-01-01",
-        end_date="2025-12-31",
-        initial_balance=10_000_000.0,
-        final_balance=11_000_000.0,
-        total_return=10.0,
-    )
-    # service.run() 저장 실패 시 result_path 는 "" fallback 으로 남는다
-    assert result.result_path == ""
+    # subprocess run() 저장 실패 시 envelope result_path 는 "" fallback.
+    result_dict = _envelope(result_path="")
+    assert result_dict["result_path"] == ""
 
-    run_id = await _save_backtest_run(db_path, result, {}, {})
+    run_id = await _save_backtest_run(db_path, result_dict, {}, {})
 
     db = Database(db_path)
     await db.connect()
@@ -74,3 +93,38 @@ async def test_save_backtest_run_empty_path_on_save_failure(tmp_path):
 
     assert run is not None
     assert run.result_path == ""
+
+
+@pytest.mark.asyncio
+async def test_save_backtest_run_does_not_split_combined_strategy(tmp_path):
+    """#2001: combined ``strategy`` 를 split 파싱하지 않고 개별 키를 직접 사용한다.
+
+    version 문자열에 ``_v`` 가 포함된 경우 combined ``strategy``
+    (``"{name}_v{version}"``) split 파싱은 잘못된 name/version 을 만든다.
+    envelope 의 strategy_name/strategy_version 개별 키를 직접 써야 안전하다.
+    """
+    db_path = str(tmp_path / "test.db")
+
+    # 일부러 strategy_name 에 ``_v`` 를 포함 → combined split 이면 깨진다.
+    result_dict = _envelope(
+        strategy_name="alpha_v2_breakout",
+        strategy_version="1.0.0",
+        result_path="",
+    )
+    # combined 표현은 "alpha_v2_breakout_v1.0.0" — split("_v") 면 잘못 분해된다.
+    assert result_dict["strategy"] == "alpha_v2_breakout_v1.0.0"
+
+    run_id = await _save_backtest_run(db_path, result_dict, {}, {})
+
+    db = Database(db_path)
+    await db.connect()
+    try:
+        store = BacktestRunStore(db)
+        run = await store.get(run_id)
+    finally:
+        await db.close()
+
+    assert run is not None
+    # 개별 키가 그대로 — split 파싱이면 name/version 이 깨진다.
+    assert run.strategy_name == "alpha_v2_breakout"
+    assert run.strategy_version == "1.0.0"

--- a/tests/unit/test_cli_backtest_run_json_single_document.py
+++ b/tests/unit/test_cli_backtest_run_json_single_document.py
@@ -54,12 +54,12 @@ def _make_runner() -> CliRunner:
     return r
 
 
-def _make_result_with_metrics() -> BacktestResult:
-    """metrics가 비어있지 않은 BacktestResult를 만든다.
+def _make_result_envelope() -> dict:
+    """run_subprocess 가 반환하는 envelope(to_dict superset + 런타임 3키).
 
     `if metrics and not fmt.is_json:` 분기를 타려면 metrics가 truthy해야 한다.
     """
-    return BacktestResult(
+    result = BacktestResult(
         strategy_name="momentum",
         strategy_version="1.0.0",
         start_date="2026-01-01",
@@ -77,16 +77,22 @@ def _make_result_with_metrics() -> BacktestResult:
             "total_trades": 5,
         },
     )
+    return {
+        **result.to_dict(),
+        "result_path": result.result_path,
+        "strategy_name": result.strategy_name,
+        "strategy_version": result.strategy_version,
+    }
 
 
 class _SpyService:
-    """BacktestService를 흉내내고 미리 만들어진 BacktestResult를 돌려주는 spy."""
+    """BacktestService를 흉내내고 envelope dict 를 돌려주는 subprocess spy (#2001)."""
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         pass
 
-    async def run(self, config: dict, progress_callback=None) -> BacktestResult:  # noqa: ARG002
-        return _make_result_with_metrics()
+    async def run_subprocess(self, config: dict) -> dict:  # noqa: ARG002
+        return _make_result_envelope()
 
 
 def _invoke_run(runner: CliRunner, tmp_path, *extra_args: str):
@@ -118,7 +124,7 @@ def _invoke_run(runner: CliRunner, tmp_path, *extra_args: str):
 
 async def _fake_save_backtest_run(
     db_path: str,  # noqa: ARG001
-    result,  # noqa: ARG001
+    result_dict: dict,  # noqa: ARG001
     config: dict,  # noqa: ARG001
     metrics: dict,  # noqa: ARG001
 ) -> str:

--- a/tests/unit/test_cli_backtest_subprocess_isolation.py
+++ b/tests/unit/test_cli_backtest_subprocess_isolation.py
@@ -1,0 +1,236 @@
+"""#2001: ``ante backtest run`` CLI 가 D-004 subprocess 격리 경로를 사용한다.
+
+회귀 검증 축:
+- (a) CLI run 이 ``service.run_subprocess`` 를 호출하고 ``service.run`` 을
+  직접 호출하지 않는다 (in-process 회귀 차단).
+- (b) ``run_subprocess`` envelope 의 ``result_path`` 가 ``_save_backtest_run`` →
+  ``BacktestRunStore.save`` → ``backtest_runs.result_path`` 로 전파된다 (#1998).
+- (c) subprocess 실패(returncode≠0)는 ``BACKTEST_ERROR`` exit 1.
+- (d) sentinel 라인 부재도 ``BACKTEST_ERROR`` exit 1.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+def _make_runner() -> CliRunner:
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _envelope(*, result_path: str = "") -> dict:
+    """run_subprocess 가 emit 하는 envelope(to_dict superset + 런타임 3키)."""
+    return {
+        "strategy": "momentum_v1.0.0",
+        "period": "2026-01-01 ~ 2026-01-31",
+        "initial_balance": 10_000_000.0,
+        "final_balance": 11_000_000.0,
+        "total_return_pct": 10.0,
+        "total_trades": 3,
+        "metrics": {"sharpe_ratio": 1.5, "max_drawdown": -3.0, "win_rate": 0.6},
+        "equity_curve": [],
+        "trades": [],
+        "config": {},
+        "datasets": [],
+        "result_path": result_path,
+        "strategy_name": "momentum",
+        "strategy_version": "1.0.0",
+    }
+
+
+def _run_args(strategy_path, *extra):
+    return [
+        "backtest",
+        "run",
+        str(strategy_path),
+        "--start",
+        "2026-01-01",
+        "--end",
+        "2026-01-31",
+        *extra,
+    ]
+
+
+# ── (a) CLI run → run_subprocess 호출, run 직접호출 안 함 ──────────────────
+
+
+class TestCliUsesSubprocessIsolation:
+    """CLI run 이 D-004 격리 경로(run_subprocess)를 사용한다."""
+
+    def test_run_invokes_run_subprocess_not_run(self, tmp_path):
+        """run 이 service.run_subprocess 를 호출하고 service.run 은 호출 안 함."""
+        strategy = tmp_path / "strat.py"
+        strategy.write_text("# dummy")
+        db_path = tmp_path / "ante.db"
+        runner = _make_runner()
+
+        run_subprocess_mock = AsyncMock(return_value=_envelope())
+        run_mock = AsyncMock()
+
+        with (
+            patch(
+                "ante.backtest.service.BacktestService.run_subprocess",
+                new=run_subprocess_mock,
+            ),
+            patch("ante.backtest.service.BacktestService.run", new=run_mock),
+            patch(
+                "ante.cli.commands.backtest._save_backtest_run",
+                new=AsyncMock(return_value="run-iso-1"),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", *_run_args(strategy, "--db-path", str(db_path))],
+            )
+
+        assert result.exit_code == 0, result.output
+        # 격리 경로 호출 + in-process 경로 미호출.
+        run_subprocess_mock.assert_awaited_once()
+        run_mock.assert_not_called()
+        payload = json.loads(result.stdout)
+        assert payload["run_id"] == "run-iso-1"
+        assert payload["strategy"] == "momentum_v1.0.0"
+
+
+# ── (b) envelope result_path → _save_backtest_run → store.save 전파 ───────
+
+
+class TestResultPathPropagation:
+    """#1998: envelope result_path 가 backtest_runs.result_path 로 전파."""
+
+    def test_result_path_flows_to_run_store_save(self, tmp_path):
+        """run_subprocess result_path → store.save(result_path=...) 전파."""
+        strategy = tmp_path / "strat.py"
+        strategy.write_text("# dummy")
+        db_path = tmp_path / "ante.db"
+        runner = _make_runner()
+
+        artifact = str(tmp_path / ".backtest" / "results" / "momentum_v1.0.0_x.json")
+        save_mock = AsyncMock(return_value="run-1998")
+
+        with (
+            patch(
+                "ante.backtest.service.BacktestService.run_subprocess",
+                new=AsyncMock(return_value=_envelope(result_path=artifact)),
+            ),
+            patch(
+                "ante.backtest.run_store.BacktestRunStore.initialize",
+                new=AsyncMock(),
+            ),
+            patch("ante.backtest.run_store.BacktestRunStore.save", new=save_mock),
+            patch("ante.core.database.Database.connect", new=AsyncMock()),
+            patch("ante.core.database.Database.close", new=AsyncMock()),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", *_run_args(strategy, "--db-path", str(db_path))],
+            )
+
+        assert result.exit_code == 0, result.output
+        save_mock.assert_awaited_once()
+        kwargs = save_mock.await_args.kwargs
+        assert kwargs["result_path"] == artifact
+        # envelope 개별 키가 그대로 전파 (combined strategy split 아님).
+        assert kwargs["strategy_name"] == "momentum"
+        assert kwargs["strategy_version"] == "1.0.0"
+        assert kwargs["total_return_pct"] == 10.0
+        assert kwargs["total_trades"] == 3
+
+
+# ── (c)/(d) subprocess 실패 → BACKTEST_ERROR ──────────────────────────────
+
+
+class TestSubprocessFailureSurfacesError:
+    """run_subprocess 가 BacktestError 를 raise 하면 BACKTEST_ERROR exit 1."""
+
+    def test_nonzero_returncode_surfaces_backtest_error(self, tmp_path):
+        """(c) returncode≠0 → run_subprocess BacktestError → BACKTEST_ERROR."""
+        from ante.backtest.exceptions import BacktestError
+
+        strategy = tmp_path / "strat.py"
+        strategy.write_text("# dummy")
+        db_path = tmp_path / "ante.db"
+        runner = _make_runner()
+
+        with patch(
+            "ante.backtest.service.BacktestService.run_subprocess",
+            new=AsyncMock(
+                side_effect=BacktestError("Backtest subprocess failed: boom")
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", *_run_args(strategy, "--db-path", str(db_path))],
+            )
+
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BACKTEST_ERROR"
+
+    def test_missing_sentinel_surfaces_backtest_error(self, tmp_path):
+        """(d) sentinel 부재 → run_subprocess BacktestError → BACKTEST_ERROR.
+
+        실제 ``create_subprocess_exec`` 를 mock 해 returncode=0 이지만 sentinel
+        라인이 없는 stdout 을 주면 run_subprocess 가 "did not emit a result
+        line" BacktestError 를 raise → CLI 가 BACKTEST_ERROR 로 변환한다.
+        """
+        strategy = tmp_path / "strat.py"
+        strategy.write_text("# dummy")
+        db_path = tmp_path / "ante.db"
+        runner = _make_runner()
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+
+        async def _fake_communicate(input=None):  # noqa: A002, ARG001
+            return (b"noise only\n{}\n", b"")
+
+        mock_proc.communicate = _fake_communicate
+
+        async def _fake_spawn(*args, **kwargs):  # noqa: ARG001
+            return mock_proc
+
+        with patch(
+            "ante.backtest.service.asyncio.create_subprocess_exec",
+            side_effect=_fake_spawn,
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", *_run_args(strategy, "--db-path", str(db_path))],
+            )
+
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BACKTEST_ERROR"


### PR DESCRIPTION
Closes #2001

## Summary
- `ante backtest run`이 in-process `BacktestService.run()` 대신 `run_subprocess`(`python -m ante.backtest.runner`)로 격리 실행 — D-004 ADR + backtest/02 + cli/06 계약 정합.
- `runner.run_backtest()` 반환을 to_dict() **additive envelope**(+result_path/strategy_name/strategy_version)로 확장 — #1998 result_path 추적성 전파. to_dict() 직렬화 계약·output_path 파일 아티팩트는 무변경.
- CLI `_save_backtest_run`을 dict/스칼라 기반으로 리팩터(combined `"strategy"` 파싱 금지, envelope 키 직접 사용). #1995 datasets row_count=0 검사·invalid 입력 ingress 거부(#2053/#2060)·subprocess 실패→BACKTEST_ERROR 보존.
- progress bar 제거(subprocess 진행률 스트리밍 불가, D-004 격리 우선) + 스펙 정합(cli/03 progress 문구, cli/06 명칭, backtest/02 caveat+result_path). D-004 무변경.

## Test Plan
- `PYTHONPATH=src .venv/bin/python -m pytest tests/unit/ -q` — 6979 passed, 2 skipped
- `ruff check` / `ruff format --check` / `mypy src/` — clean
- 신규: CLI→run_subprocess 호출 회귀, result_path→backtest_runs 전파(#1998), #1995 data-not-found, subprocess 실패→BACKTEST_ERROR, ingress 거부 보존, run_backtest envelope superset 단위
- Codex 브랜치 리뷰: PASS (attempt 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
