### PR TITLE
test: #1980 asyncio.run mock이 coroutine을 close하지 않아 발생하는 never-awaited 경고 제거

### DIFF
--- a/tests/unit/_async_test_utils.py
+++ b/tests/unit/_async_test_utils.py
@@ -1,0 +1,34 @@
+"""``asyncio.run`` mock 용 공유 테스트 helper (#1980).
+
+일부 CLI 테스트는 ``rows = asyncio.run(_coro())`` 형태의 인라인 coroutine
+생성부를 ``patch("asyncio.run")`` 으로 가로채 반환값만 단언한다. 이때
+``mock_run.return_value = X`` 만 두면 mock 이 넘어온 coroutine 을
+await/close 하지 않아 GC 시점에 ``RuntimeWarning: coroutine ... was never
+awaited`` + ``PytestUnraisableExceptionWarning`` 이 발생한다(#1897 zero-warning
+기준 위반).
+
+:func:`asyncio_run_returning` 은 ``side_effect`` 팩토리로, 넘어온 coroutine 을
+명시적으로 close 해 해당 경고를 막고 지정한 값을 반환한다.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+
+def asyncio_run_returning(value: Any) -> Callable[..., Any]:
+    """``patch("asyncio.run")`` 용 ``side_effect`` 팩토리(#1980).
+
+    반환된 함수는 첫 인자로 받은 coroutine 을 ``close()`` 하여
+    'coroutine was never awaited' 경고를 막고 ``value`` 를 반환한다.
+    ``-W error::RuntimeWarning`` 하에서도 동작하도록 coroutine 을 확실히 닫는다.
+    """
+
+    def _run(coro: Any = None, *args: Any, **kwargs: Any) -> Any:
+        if inspect.iscoroutine(coro):
+            coro.close()
+        return value
+
+    return _run

--- a/tests/unit/_async_test_utils.py
+++ b/tests/unit/_async_test_utils.py
@@ -21,14 +21,18 @@ from typing import Any
 def asyncio_run_returning(value: Any) -> Callable[..., Any]:
     """``patch("asyncio.run")`` 용 ``side_effect`` 팩토리(#1980).
 
-    반환된 함수는 첫 인자로 받은 coroutine 을 ``close()`` 하여
-    'coroutine was never awaited' 경고를 막고 ``value`` 를 반환한다.
-    ``-W error::RuntimeWarning`` 하에서도 동작하도록 coroutine 을 확실히 닫는다.
+    반환된 함수는 positional·keyword 로 전달된 **모든** coroutine 을
+    ``close()`` 하여 'coroutine was never awaited' 경고를 막고 ``value`` 를
+    반환한다. ``asyncio.run(main=coro)`` 처럼 keyword 로 넘어오거나 래퍼가
+    추가 인자를 함께 전달하는 경우에도 누락 없이 닫도록 args+kwargs 를 전수
+    스캔한다. ``-W error::RuntimeWarning`` 하에서도 동작하도록 coroutine 을
+    확실히 닫는다.
     """
 
-    def _run(coro: Any = None, *args: Any, **kwargs: Any) -> Any:
-        if inspect.iscoroutine(coro):
-            coro.close()
+    def _run(*args: Any, **kwargs: Any) -> Any:
+        for candidate in (*args, *kwargs.values()):
+            if inspect.iscoroutine(candidate):
+                candidate.close()
         return value
 
     return _run

--- a/tests/unit/test_cli_backtest_report.py
+++ b/tests/unit/test_cli_backtest_report.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit._async_test_utils import asyncio_run_returning
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -44,7 +45,7 @@ def runner():
 class TestBacktestHistory:
     def test_history_empty(self, runner):
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = []
+            mock_run.side_effect = asyncio_run_returning([])
             result = runner.invoke(cli, ["backtest", "history", "test_stg"])
             assert result.exit_code == 0
             assert "이력이 없습니다" in result.output
@@ -66,7 +67,7 @@ class TestBacktestHistory:
             },
         ]
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = rows
+            mock_run.side_effect = asyncio_run_returning(rows)
             result = runner.invoke(cli, ["backtest", "history", "momentum"])
             assert result.exit_code == 0
             assert "run-1" in result.output
@@ -88,7 +89,7 @@ class TestBacktestHistory:
             },
         ]
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = rows
+            mock_run.side_effect = asyncio_run_returning(rows)
             result = runner.invoke(
                 cli, ["--format", "json", "backtest", "history", "momentum"]
             )
@@ -117,12 +118,14 @@ class TestReportSubmitWithRun:
         )
 
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = {
-                "report_id": "rpt-123",
-                "strategy": "momentum",
-                "status": "submitted",
-                "backtest_run_id": "run-1",
-            }
+            mock_run.side_effect = asyncio_run_returning(
+                {
+                    "report_id": "rpt-123",
+                    "strategy": "momentum",
+                    "status": "submitted",
+                    "backtest_run_id": "run-1",
+                }
+            )
             result = runner.invoke(
                 cli,
                 [

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -26,6 +26,7 @@ from ante.cli.commands.report import schema as report_schema
 from ante.cli.formatter import OutputFormatter
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit._async_test_utils import asyncio_run_returning
 
 
 def _acm_factory(value):  # noqa: ANN001, ANN202
@@ -516,7 +517,7 @@ class TestTradeInfoFormatOption:
 
         with patch(
             "ante.cli.commands.trade.asyncio.run",
-            return_value=None,
+            side_effect=asyncio_run_returning(None),
         ):
             result = runner.invoke(
                 cli, ["trade", "info", "trade-123", "--format", "json"]

--- a/tests/unit/test_cli_instrument_import_exit.py
+++ b/tests/unit/test_cli_instrument_import_exit.py
@@ -37,6 +37,7 @@ from click.testing import CliRunner
 
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit._async_test_utils import asyncio_run_returning
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -494,7 +495,7 @@ class TestValidKrxSymbolRegression:
         )
 
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = 1
+            mock_run.side_effect = asyncio_run_returning(1)
             result = runner.invoke(
                 cli,
                 ["instrument", "import", str(json_file)],

--- a/tests/unit/test_cli_inverted_date_range.py
+++ b/tests/unit/test_cli_inverted_date_range.py
@@ -37,6 +37,7 @@ from click.testing import CliRunner
 
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit._async_test_utils import asyncio_run_returning
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -310,7 +311,7 @@ class TestValidRangeRegression:
     )
     def test_valid_passes_to_service(self, runner, cmd, args):
         with patch(_ASYNC_ENTRYPOINTS[cmd]) as mock_async:
-            mock_async.return_value = []
+            mock_async.side_effect = asyncio_run_returning([])
             result = runner.invoke(cli, args)
         assert result.exit_code == 0, _stdout(result)
         mock_async.assert_called_once()
@@ -351,14 +352,16 @@ class TestValidRangeRegression:
     )
     def test_treasury_valid_passes_to_service(self, runner, args):
         with patch("ante.cli.commands.treasury._run") as mock_run:
-            mock_run.return_value = {
-                "account_id": "oracle-paper",
-                "snapshot_date": "2026-01-15",
-                "total_asset": 1.0,
-                "ante_eval_amount": 1.0,
-                "ante_purchase_amount": 1.0,
-                "unallocated": 0.0,
-            }
+            mock_run.side_effect = asyncio_run_returning(
+                {
+                    "account_id": "oracle-paper",
+                    "snapshot_date": "2026-01-15",
+                    "total_asset": 1.0,
+                    "ante_eval_amount": 1.0,
+                    "ante_purchase_amount": 1.0,
+                    "unallocated": 0.0,
+                }
+            )
             result = runner.invoke(cli, ["--format", "json", *args])
         assert result.exit_code == 0, _stdout(result)
         mock_run.assert_called_once()

--- a/tests/unit/test_cli_report_performance_period_options.py
+++ b/tests/unit/test_cli_report_performance_period_options.py
@@ -17,6 +17,7 @@ from click.testing import CliRunner
 
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit._async_test_utils import asyncio_run_returning
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -323,14 +324,16 @@ class TestValidPeriodOptionCombosRegression:
 
     def test_daily_with_start_and_end(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "date": "2026-01-15",
-                    "realized_pnl": 12000.0,
-                    "trade_count": 2,
-                    "win_rate": 0.5,
-                }
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "date": "2026-01-15",
+                        "realized_pnl": 12000.0,
+                        "trade_count": 2,
+                        "win_rate": 0.5,
+                    }
+                ]
+            )
             result = runner.invoke(
                 cli,
                 [
@@ -350,15 +353,17 @@ class TestValidPeriodOptionCombosRegression:
 
     def test_monthly_with_year(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "year": 2026,
-                    "month": 1,
-                    "realized_pnl": 50000.0,
-                    "trade_count": 10,
-                    "win_rate": 0.7,
-                }
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "year": 2026,
+                        "month": 1,
+                        "realized_pnl": 50000.0,
+                        "trade_count": 10,
+                        "win_rate": 0.7,
+                    }
+                ]
+            )
             result = runner.invoke(
                 cli,
                 [
@@ -380,14 +385,16 @@ class TestValidPeriodOptionCombosRegression:
 
     def test_daily_with_bot_id_and_dates(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "date": "2026-01-10",
-                    "realized_pnl": 3000.0,
-                    "trade_count": 1,
-                    "win_rate": 1.0,
-                }
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "date": "2026-01-10",
+                        "realized_pnl": 3000.0,
+                        "trade_count": 1,
+                        "win_rate": 1.0,
+                    }
+                ]
+            )
             result = runner.invoke(
                 cli,
                 [
@@ -408,14 +415,14 @@ class TestValidPeriodOptionCombosRegression:
 
     def test_daily_default_no_options(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = []
+            mock_run.side_effect = asyncio_run_returning([])
             result = runner.invoke(cli, ["report", "performance"])
         assert result.exit_code == 0
         mock_run.assert_called_once()
 
     def test_monthly_default_no_options(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = []
+            mock_run.side_effect = asyncio_run_returning([])
             result = runner.invoke(
                 cli,
                 ["report", "performance", "--period", "monthly"],

--- a/tests/unit/test_cli_strategy.py
+++ b/tests/unit/test_cli_strategy.py
@@ -14,6 +14,7 @@ from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 from ante.strategy.registry import StrategyRecord, StrategyStatus
 from ante.trade.models import PerformanceMetrics
+from tests.unit._async_test_utils import asyncio_run_returning
 
 
 def _acm_factory(value):  # noqa: ANN001, ANN202
@@ -335,7 +336,7 @@ class TestStrategyPerformance:
         with (
             patch("ante.cli.commands.strategy.asyncio.run") as mock_run,
         ):
-            mock_run.return_value = None
+            mock_run.side_effect = asyncio_run_returning(None)
             result = runner.invoke(cli, ["strategy", "performance", "nonexistent"])
             assert result.exit_code == 1
 
@@ -347,7 +348,10 @@ class TestStrategyPerformance:
             "metrics": asdict(_SAMPLE_METRICS),
         }
 
-        with patch("ante.cli.commands.strategy.asyncio.run", return_value=expected):
+        with patch(
+            "ante.cli.commands.strategy.asyncio.run",
+            side_effect=asyncio_run_returning(expected),
+        ):
             result = runner.invoke(
                 cli,
                 ["strategy", "performance", "momentum", "--account-id", "acc-test"],
@@ -364,7 +368,10 @@ class TestStrategyPerformance:
             "metrics": asdict(_SAMPLE_METRICS),
         }
 
-        with patch("ante.cli.commands.strategy.asyncio.run", return_value=expected):
+        with patch(
+            "ante.cli.commands.strategy.asyncio.run",
+            side_effect=asyncio_run_returning(expected),
+        ):
             result = runner.invoke(
                 cli,
                 [
@@ -392,7 +399,10 @@ class TestStrategyPerformance:
             "metrics": asdict(empty),
         }
 
-        with patch("ante.cli.commands.strategy.asyncio.run", return_value=expected):
+        with patch(
+            "ante.cli.commands.strategy.asyncio.run",
+            side_effect=asyncio_run_returning(expected),
+        ):
             result = runner.invoke(
                 cli,
                 [
@@ -448,7 +458,10 @@ class TestStrategyPerformance:
         # 실제 _perf 코루틴 실행을 차단하기 위해 asyncio.run 결과만 mock한다.
         # 실패 분기(account-id 누락)는 별도 테스트가 책임지며, 본 테스트는
         # account-id 옵션이 있으면 SystemExit 없이 정상 흐름을 탄다는 것을 보장한다.
-        with patch("ante.cli.commands.strategy.asyncio.run", return_value=expected):
+        with patch(
+            "ante.cli.commands.strategy.asyncio.run",
+            side_effect=asyncio_run_returning(expected),
+        ):
             result = runner.invoke(
                 cli,
                 [

--- a/tests/unit/test_instrument_import.py
+++ b/tests/unit/test_instrument_import.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit._async_test_utils import asyncio_run_returning
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -51,7 +52,7 @@ class TestInstrumentImportCSV:
         )
 
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = 2
+            mock_run.side_effect = asyncio_run_returning(2)
             result = runner.invoke(
                 cli,
                 ["instrument", "import", str(csv_file)],
@@ -82,7 +83,7 @@ class TestInstrumentImportJSON:
         json_file.write_text(json.dumps(data))
 
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = 2
+            mock_run.side_effect = asyncio_run_returning(2)
             result = runner.invoke(
                 cli,
                 ["instrument", "import", str(json_file)],

--- a/tests/unit/test_listed_only.py
+++ b/tests/unit/test_listed_only.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 from ante.cli.main import cli
 from ante.instrument.service import InstrumentService
 from ante.member.models import Member, MemberRole, MemberType
+from tests.unit._async_test_utils import asyncio_run_returning
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -120,22 +121,24 @@ class TestListCLIListedOnly:
     def test_list_without_listed_only(self, runner):
         """기본 list는 모든 종목 표시."""
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "name": "삼성전자",
-                    "name_en": "Samsung",
-                    "type": "stock",
-                    "listed": "Y",
-                },
-                {
-                    "symbol": "000000",
-                    "name": "폐지종목",
-                    "name_en": "Delisted",
-                    "type": "stock",
-                    "listed": "N",
-                },
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "symbol": "005930",
+                        "name": "삼성전자",
+                        "name_en": "Samsung",
+                        "type": "stock",
+                        "listed": "Y",
+                    },
+                    {
+                        "symbol": "000000",
+                        "name": "폐지종목",
+                        "name_en": "Delisted",
+                        "type": "stock",
+                        "listed": "N",
+                    },
+                ]
+            )
             result = runner.invoke(cli, ["instrument", "list"])
             assert result.exit_code == 0
             assert "005930" in result.output
@@ -144,15 +147,17 @@ class TestListCLIListedOnly:
     def test_list_with_listed_only(self, runner):
         """--listed-only 시 상장 종목만 표시."""
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "name": "삼성전자",
-                    "name_en": "Samsung",
-                    "type": "stock",
-                    "listed": "Y",
-                },
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "symbol": "005930",
+                        "name": "삼성전자",
+                        "name_en": "Samsung",
+                        "type": "stock",
+                        "listed": "Y",
+                    },
+                ]
+            )
             result = runner.invoke(cli, ["instrument", "list", "--listed-only"])
             assert result.exit_code == 0
             assert "005930" in result.output
@@ -162,15 +167,17 @@ class TestSearchCLIListedOnly:
     def test_search_without_listed_only(self, runner):
         """기본 search는 모든 종목 검색."""
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "exchange": "KRX",
-                    "name": "삼성전자",
-                    "name_en": "Samsung",
-                    "type": "stock",
-                },
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "symbol": "005930",
+                        "exchange": "KRX",
+                        "name": "삼성전자",
+                        "name_en": "Samsung",
+                        "type": "stock",
+                    },
+                ]
+            )
             result = runner.invoke(cli, ["instrument", "search", "삼성"])
             assert result.exit_code == 0
             assert "005930" in result.output
@@ -178,15 +185,17 @@ class TestSearchCLIListedOnly:
     def test_search_with_listed_only(self, runner):
         """--listed-only 시 상장 종목만 검색."""
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "exchange": "KRX",
-                    "name": "삼성전자",
-                    "name_en": "Samsung",
-                    "type": "stock",
-                },
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "symbol": "005930",
+                        "exchange": "KRX",
+                        "name": "삼성전자",
+                        "name_en": "Samsung",
+                        "type": "stock",
+                    },
+                ]
+            )
             result = runner.invoke(
                 cli, ["instrument", "search", "--listed-only", "삼성"]
             )

--- a/tests/unit/test_performance_summary.py
+++ b/tests/unit/test_performance_summary.py
@@ -12,6 +12,7 @@ from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 from ante.trade.models import DailySummary, MonthlySummary
 from ante.trade.performance import PerformanceTracker
+from tests.unit._async_test_utils import asyncio_run_returning
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -270,29 +271,33 @@ class TestGetMonthlySummary:
 class TestReportPerformanceCLI:
     def test_daily_performance_text(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "date": "2026-03-10",
-                    "realized_pnl": 15000.0,
-                    "trade_count": 3,
-                    "win_rate": 0.67,
-                }
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "date": "2026-03-10",
+                        "realized_pnl": 15000.0,
+                        "trade_count": 3,
+                        "win_rate": 0.67,
+                    }
+                ]
+            )
             result = runner.invoke(cli, ["report", "performance", "--period", "daily"])
             assert result.exit_code == 0
             assert "2026-03-10" in result.output
 
     def test_monthly_performance_json(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "year": 2026,
-                    "month": 3,
-                    "realized_pnl": 50000.0,
-                    "trade_count": 10,
-                    "win_rate": 0.7,
-                }
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "year": 2026,
+                        "month": 3,
+                        "realized_pnl": 50000.0,
+                        "trade_count": 10,
+                        "win_rate": 0.7,
+                    }
+                ]
+            )
             result = runner.invoke(
                 cli,
                 ["--format", "json", "report", "performance", "--period", "monthly"],
@@ -305,21 +310,23 @@ class TestReportPerformanceCLI:
 
     def test_performance_empty(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = []
+            mock_run.side_effect = asyncio_run_returning([])
             result = runner.invoke(cli, ["report", "performance"])
             assert result.exit_code == 0
             assert "없습니다" in result.output
 
     def test_daily_with_bot_filter(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "date": "2026-03-10",
-                    "realized_pnl": 5000.0,
-                    "trade_count": 1,
-                    "win_rate": 1.0,
-                }
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "date": "2026-03-10",
+                        "realized_pnl": 5000.0,
+                        "trade_count": 1,
+                        "win_rate": 1.0,
+                    }
+                ]
+            )
             result = runner.invoke(
                 cli,
                 ["report", "performance", "--bot-id", "bot-1"],
@@ -328,15 +335,17 @@ class TestReportPerformanceCLI:
 
     def test_monthly_with_year_filter(self, runner):
         with patch("ante.cli.commands.report.asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "year": 2025,
-                    "month": 12,
-                    "realized_pnl": 100000.0,
-                    "trade_count": 20,
-                    "win_rate": 0.6,
-                }
-            ]
+            mock_run.side_effect = asyncio_run_returning(
+                [
+                    {
+                        "year": 2025,
+                        "month": 12,
+                        "realized_pnl": 100000.0,
+                        "trade_count": 20,
+                        "win_rate": 0.6,
+                    }
+                ]
+            )
             result = runner.invoke(
                 cli,
                 [

--- a/tests/unit/test_report_draft.py
+++ b/tests/unit/test_report_draft.py
@@ -13,6 +13,7 @@ from ante.eventbus.events import BacktestCompleteEvent, NotificationEvent
 from ante.member.models import Member, MemberRole, MemberType
 from ante.report.draft import ReportDraftGenerator
 from ante.report.models import ReportStatus
+from tests.unit._async_test_utils import asyncio_run_returning
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -193,23 +194,25 @@ class TestOnBacktestComplete:
 class TestReportViewCLI:
     def test_view_existing_report(self, runner):
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = {
-                "report_id": "rpt-1",
-                "strategy": "momentum v1.0.0",
-                "status": "draft",
-                "submitted_at": "2026-03-13",
-                "submitted_by": "system",
-                "backtest_period": "2025-01 ~ 2025-12",
-                "total_return_pct": 15.0,
-                "total_trades": 42,
-                "sharpe_ratio": 1.2,
-                "max_drawdown_pct": -8.5,
-                "win_rate": 0.58,
-                "summary": "백테스트 자동 생성 초안",
-                "rationale": "",
-                "risks": "",
-                "recommendations": "",
-            }
+            mock_run.side_effect = asyncio_run_returning(
+                {
+                    "report_id": "rpt-1",
+                    "strategy": "momentum v1.0.0",
+                    "status": "draft",
+                    "submitted_at": "2026-03-13",
+                    "submitted_by": "system",
+                    "backtest_period": "2025-01 ~ 2025-12",
+                    "total_return_pct": 15.0,
+                    "total_trades": 42,
+                    "sharpe_ratio": 1.2,
+                    "max_drawdown_pct": -8.5,
+                    "win_rate": 0.58,
+                    "summary": "백테스트 자동 생성 초안",
+                    "rationale": "",
+                    "risks": "",
+                    "recommendations": "",
+                }
+            )
             result = runner.invoke(cli, ["report", "view", "rpt-1"])
             assert result.exit_code == 0
             assert "rpt-1" in result.output
@@ -217,14 +220,14 @@ class TestReportViewCLI:
 
     def test_view_not_found(self, runner):
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = None
+            mock_run.side_effect = asyncio_run_returning(None)
             result = runner.invoke(cli, ["report", "view", "nonexistent"])
             assert result.exit_code == 1
             assert "찾을 수 없습니다" in result.output
 
     def test_view_not_found_json(self, runner):
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = None
+            mock_run.side_effect = asyncio_run_returning(None)
             result = runner.invoke(
                 cli, ["--format", "json", "report", "view", "nonexistent"]
             )
@@ -236,23 +239,25 @@ class TestReportViewCLI:
 
     def test_view_json_format(self, runner):
         with patch("asyncio.run") as mock_run:
-            mock_run.return_value = {
-                "report_id": "rpt-1",
-                "strategy": "momentum v1.0.0",
-                "status": "draft",
-                "submitted_at": "2026-03-13",
-                "submitted_by": "system",
-                "backtest_period": "2025-01 ~ 2025-12",
-                "total_return_pct": 15.0,
-                "total_trades": 42,
-                "sharpe_ratio": 1.2,
-                "max_drawdown_pct": -8.5,
-                "win_rate": 0.58,
-                "summary": "초안",
-                "rationale": "",
-                "risks": "",
-                "recommendations": "",
-            }
+            mock_run.side_effect = asyncio_run_returning(
+                {
+                    "report_id": "rpt-1",
+                    "strategy": "momentum v1.0.0",
+                    "status": "draft",
+                    "submitted_at": "2026-03-13",
+                    "submitted_by": "system",
+                    "backtest_period": "2025-01 ~ 2025-12",
+                    "total_return_pct": 15.0,
+                    "total_trades": 42,
+                    "sharpe_ratio": 1.2,
+                    "max_drawdown_pct": -8.5,
+                    "win_rate": 0.58,
+                    "summary": "초안",
+                    "rationale": "",
+                    "risks": "",
+                    "recommendations": "",
+                }
+            )
             result = runner.invoke(cli, ["--format", "json", "report", "view", "rpt-1"])
             assert result.exit_code == 0
             data = json.loads(result.output)


### PR DESCRIPTION
Closes #1980

## Summary
- `patch("asyncio.run")`/`_run` 래퍼 mock이 CLI 코드가 넘긴 inline coroutine을 close/await하지 않아 `RuntimeWarning: coroutine ... was never awaited` + `PytestUnraisableExceptionWarning`이 재노출되던 문제(#1897 zero-warning 회귀)를 해소.
- 공유 helper `tests/unit/_async_test_utils.py::asyncio_run_returning(value)` 신설 — args+kwargs 전수 스캔으로 positional·keyword 모든 coroutine을 close 후 value 반환.
- dangling `mock_run.return_value =` 호출부를 `side_effect=asyncio_run_returning(...)`로 치환(11개 파일, loop-until-dry full-suite warning-0로 census 외 `test_cli_format_option` `_run_info`까지 포착). `assert_not_called()`/검증 실패 경로는 무변경.
- **테스트 전용**(production 무변경).

## Test Plan
- 전체 `PYTHONPATH=src .venv/bin/python -m pytest tests/unit/ -q` — 6979 passed, 2 skipped; `was never awaited`/mock-leak `PytestUnraisableExceptionWarning` 0건
- 변경 파일 `-W error::RuntimeWarning` — 205 passed, 경고 0
- `ruff check` / `ruff format --check` / `mypy src/` — clean
- Codex 브랜치 리뷰: PASS (attempt 2)

## 후속
- 잔여 IPC transport teardown `_SelectorTransport.__del__` unraisable(2건)은 production async lifecycle(테스트 mock 아님)로 본 이슈 범위 밖 — 별도 follow-up 이슈 발행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
