### PR TITLE
fix(backtest): #2071 zero-OHLC 무거래 행 backtest-load flat-bar 정규화

### DIFF
--- a/docs/specs/backtest/02-design-decisions.md
+++ b/docs/specs/backtest/02-design-decisions.md
@@ -64,6 +64,16 @@
   - `get_current_price()` → empty OHLCV에서 `BacktestDataError` (현재가 unavailable)
 - **implicit warm-up 없음**: 시스템은 row 0을 건너뛰지 않으며 별도의 warm-up 구간을 두지 않는다. row 0에서 lookback이 필요한 전략은 그 시점에 history가 1개 봉뿐이므로, 충분한 history 확보는 전략의 책임이다(정책상 의도된 노출).
 
+**무거래 zero-OHLC 행의 backtest-load 정규화 (#2071)**:
+
+> 소스: [`src/ante/backtest/data_provider.py`](../../../src/ante/backtest/data_provider.py) `_normalize_no_trade_bars`
+
+data.go.kr 원본 OHLCV는 거래정지/무거래일을 `open==high==low==0 & close>0 & volume==0`(amount 컬럼이 있으면 `amount==0`까지) 시그니처로 표현한다(V2 장기 데이터에서 다수 관찰). 이 행을 그대로 두면 전략이 high/low/open을 직접 쓸 때 intraday range가 `0..close`처럼 비현실적으로 벌어져 변동성·가격범위 지표를 왜곡한다. `BacktestDataProvider.load()`는 `store.read()` 직후(캐시 저장 전) 이 행을 **flat bar(`O=H=L=C=close`)로 정규화**한다.
+
+- **(a) backtest view 한정 — 저장 raw 불변**: 정규화는 `load()`가 캐시에 담기 직전의 DataFrame에만 적용된다. 저장 raw(parquet)는 변형하지 않는다. 이는 데이터 무손실 우선 원칙([data-feed/02 L31](../data-feed/02-design-decisions.md), [data-feed/09](../data-feed/09-failure-recovery.md)의 "비즈니스 위반(`low<=open/close<=high` 등)은 경고 로그 후 저장" 계약)을 유지하기 위함이다. 따라서 storage/normalizer/report/품질 경고 pipeline은 본 정책에서 **제외**된다. `get_ohlcv()` 등 on-demand 적재 경로도 `load()`를 거치므로 동일하게 정규화가 적용된다.
+- **(b) flat-bar 의미 — intraday range만 0**: `O=H=L=C=close`는 무거래일의 **intraday range를 0으로 본다**는 뜻이며 close(carrying price)는 보존된다. 이는 "모든 변동성이 0"이라는 의미가 **아니다** — **전일 종가 대비 변화(ATR true-range의 `|close - prev_close|`, 갭 등 일간 변화 지표)는 그대로 보존**된다.
+- **(c) 정확 시그니처 한정 — 마스킹 방지**: 정규화는 위 정확 시그니처에만 적용한다. partial-zero(예: `open>0 & low==0`), `volume>0`, `amount>0`인 행은 실제 데이터 오류일 수 있으므로 **마스킹하지 않고 그대로 둔다**. 무거래 bar를 missing/제외 처리하지 않는다(flat-bar가 carrying price 보존에 더 안전). live/실거래 데이터 경로는 정규화 대상이 아니다(백테스트 한정).
+
 ### BacktestExecutor — 시뮬레이션 실행
 
 > 소스: [`src/ante/backtest/executor.py`](../../../src/ante/backtest/executor.py)

--- a/src/ante/backtest/data_provider.py
+++ b/src/ante/backtest/data_provider.py
@@ -105,6 +105,9 @@ class BacktestDataProvider(DataProvider):
             raise BacktestDataError(
                 f"백테스트 데이터 로드 실패(손상 파티션): {symbol}: {e}"
             ) from e
+        # 무거래 zero-OHLC 행을 backtest view 한정으로 flat bar 정규화한다(#2071).
+        # 저장 raw(parquet)는 불변이며, 캐시 view에만 적용된다(데이터 무손실 우선).
+        df = self._normalize_no_trade_bars(df)
         self._cache[key] = df
         # 새 데이터가 캐시에 들어오면 통합 timeline을 무효화한다(#2098). 다음
         # advance()/get_total_steps()/get_current_timestamp() 접근 시 lazy-build.
@@ -124,6 +127,62 @@ class BacktestDataProvider(DataProvider):
         self._loaded_datasets.append(info)
 
         return len(df)
+
+    def _normalize_no_trade_bars(self, df: pl.DataFrame) -> pl.DataFrame:
+        """data.go.kr 무거래 zero-OHLC 행을 flat bar(O=H=L=C)로 정규화한다(#2071).
+
+        data.go.kr 원본은 거래정지/무거래일을 ``open==high==low==0 & close>0 &
+        volume==0`` (amount 컬럼 존재 시 ``amount==0`` 까지) 시그니처로 표현한다.
+        이 행을 그대로 두면 전략이 high/low/open을 직접 쓸 때 intraday range가
+        ``0..close`` 처럼 비현실적으로 벌어져 변동성·가격범위 지표를 왜곡한다.
+
+        **정규화 범위는 backtest view 한정이다.** 저장 raw(parquet)는 변형하지
+        않으며(데이터 무손실 우선 — data-feed/02 L31, data-feed/09 비즈니스
+        위반 경고-후-저장 계약), 이 메서드는 ``load()`` 가 캐시에 담기 직전의
+        DataFrame에만 적용된다. 따라서 리포트/품질 경고/저장 경로는 무영향이다.
+
+        정규화는 **정확 시그니처에만** 적용한다. partial-zero(예: ``open>0 &
+        low==0``), ``volume>0``, ``amount>0`` 인 행은 실제 데이터 오류일 수
+        있으므로 마스킹하지 않고 그대로 둔다. 무거래 행은 ``O=H=L=C=close`` 가
+        되어 intraday range가 0이 되지만, **전일 종가 대비 변화(ATR true-range의
+        ``|close - prev_close|``, 갭 등)는 그대로 보존된다** — "모든 변동성이
+        0"이 되는 것이 아니라 무거래일의 intraday range만 0으로 본다는 뜻이다.
+
+        OHLCV 컬럼이 없는(존재하지 않는 심볼의) 빈 df는 그대로 반환한다.
+        """
+        required = {"open", "high", "low", "close", "volume"}
+        if not required.issubset(df.columns):
+            return df
+        no_trade = (
+            (pl.col("open") == 0)
+            & (pl.col("high") == 0)
+            & (pl.col("low") == 0)
+            & (pl.col("close") > 0)
+            & (pl.col("volume") == 0)
+        )
+        if "amount" in df.columns:
+            no_trade = no_trade & (pl.col("amount") == 0)
+        normalized = df.with_columns(
+            pl.when(no_trade)
+            .then(pl.col("close"))
+            .otherwise(pl.col("open"))
+            .alias("open"),
+            pl.when(no_trade)
+            .then(pl.col("close"))
+            .otherwise(pl.col("high"))
+            .alias("high"),
+            pl.when(no_trade)
+            .then(pl.col("close"))
+            .otherwise(pl.col("low"))
+            .alias("low"),
+        )
+        if logger.isEnabledFor(logging.DEBUG):
+            count = int(df.filter(no_trade).height)
+            if count:
+                logger.debug(
+                    "무거래 zero-OHLC bar %d개를 flat bar로 정규화(#2071)", count
+                )
+        return normalized
 
     def _build_timeline(self) -> list[datetime]:
         """전 캐시 DataFrame의 timestamp를 union·오름차순 정렬·dedupe한 통합 시간축.

--- a/tests/unit/test_backtest_no_trade_normalize.py
+++ b/tests/unit/test_backtest_no_trade_normalize.py
@@ -1,0 +1,256 @@
+"""무거래 zero-OHLC 행의 backtest-load flat-bar 정규화 테스트(#2071).
+
+data.go.kr 무거래/거래정지 행(``open==high==low==0 & close>0 & volume==0``,
+amount 컬럼 존재 시 ``amount==0``)을 ``BacktestDataProvider.load`` 가 backtest
+view 한정으로 flat bar(``O=H=L=C=close``)로 정규화하는지 검증한다. 저장 raw는
+불변이어야 하고(데이터 무손실 우선), 정확 시그니처 밖의 행은 마스킹하지 않는다.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import polars as pl
+
+from ante.backtest.data_provider import BacktestDataProvider
+
+
+def _ts(n: int) -> list[datetime]:
+    start = datetime(2026, 1, 2, 0, 0, tzinfo=UTC)
+    return [start + timedelta(days=i) for i in range(n)]
+
+
+def _df(rows: list[dict], *, with_amount: bool = True) -> pl.DataFrame:
+    """행 dict 목록으로 OHLCV DataFrame 구성. timestamp는 일별로 자동 부여."""
+    n = len(rows)
+    ts = _ts(n)
+    data: dict[str, list] = {
+        "timestamp": ts,
+        "symbol": ["005930"] * n,
+        "open": [float(r["open"]) for r in rows],
+        "high": [float(r["high"]) for r in rows],
+        "low": [float(r["low"]) for r in rows],
+        "close": [float(r["close"]) for r in rows],
+        "volume": [int(r["volume"]) for r in rows],
+    }
+    if with_amount:
+        data["amount"] = [int(r.get("amount", 0)) for r in rows]
+    data["source"] = ["data.go.kr"] * n
+    return pl.DataFrame(data)
+
+
+def _provider_with(raw_df: pl.DataFrame) -> tuple[BacktestDataProvider, MagicMock]:
+    """store.read가 ``raw_df`` 를 반환하도록 mock한 provider."""
+    store = MagicMock()
+    store.read.return_value = raw_df
+    store.resolve_path.return_value = MagicMock(exists=MagicMock(return_value=False))
+    provider = BacktestDataProvider(
+        store=store, start_date="2026-01-01", end_date="2026-12-31"
+    )
+    return provider, store
+
+
+def _cached(provider: BacktestDataProvider, symbol: str = "005930") -> pl.DataFrame:
+    """load 후 캐시에 들어간 (정규화된) view를 꺼낸다."""
+    return provider._cache[f"{symbol}:1d"]
+
+
+# (a) 정확 시그니처(O=H=L=0, C>0, V=0, amount=0) → O=H=L=C 정규화 ─────────
+
+
+async def test_no_trade_signature_normalized_to_flat_bar():
+    raw = _df(
+        [
+            {
+                "open": 50000,
+                "high": 50500,
+                "low": 49500,
+                "close": 50250,
+                "volume": 1000,
+            },
+            {"open": 0, "high": 0, "low": 0, "close": 465, "volume": 0, "amount": 0},
+        ]
+    )
+    provider, _ = _provider_with(raw)
+    provider.load("005930", "1d")
+    view = _cached(provider)
+
+    # 무거래 행이 flat bar로 정규화됨: O=H=L=C=close(465).
+    assert view["open"][1] == 465.0
+    assert view["high"][1] == 465.0
+    assert view["low"][1] == 465.0
+    assert view["close"][1] == 465.0
+    # 정상 행은 무변경.
+    assert view["open"][0] == 50000.0
+    assert view["high"][0] == 50500.0
+    assert view["low"][0] == 49500.0
+
+
+async def test_no_trade_signature_without_amount_column_normalized():
+    """amount 컬럼이 없는 df도 (O=H=L=0,C>0,V=0)만으로 정규화된다."""
+    raw = _df(
+        [{"open": 0, "high": 0, "low": 0, "close": 51600, "volume": 0}],
+        with_amount=False,
+    )
+    provider, _ = _provider_with(raw)
+    provider.load("005930", "1d")
+    view = _cached(provider)
+    assert view["open"][0] == 51600.0
+    assert view["high"][0] == 51600.0
+    assert view["low"][0] == 51600.0
+
+
+# (b) partial-zero(open>0, low=0) → 무변경 (실제 데이터 오류 마스킹 금지) ─────
+
+
+async def test_partial_zero_not_normalized():
+    raw = _df(
+        [{"open": 100, "high": 200, "low": 0, "close": 150, "volume": 0, "amount": 0}]
+    )
+    provider, _ = _provider_with(raw)
+    provider.load("005930", "1d")
+    view = _cached(provider)
+    # partial-zero(low=0이지만 open>0)는 정확 시그니처가 아니므로 무변경.
+    assert view["open"][0] == 100.0
+    assert view["high"][0] == 200.0
+    assert view["low"][0] == 0.0
+    assert view["close"][0] == 150.0
+
+
+# (c) volume>0 또는 amount>0(거래 발생) → 무변경 ───────────────────────────
+
+
+async def test_volume_positive_not_normalized():
+    raw = _df(
+        [{"open": 0, "high": 0, "low": 0, "close": 465, "volume": 5, "amount": 0}]
+    )
+    provider, _ = _provider_with(raw)
+    provider.load("005930", "1d")
+    view = _cached(provider)
+    # volume>0이면 거래가 발생한 것이므로 zero OHL을 보정하지 않는다.
+    assert view["open"][0] == 0.0
+    assert view["high"][0] == 0.0
+    assert view["low"][0] == 0.0
+
+
+async def test_amount_positive_not_normalized():
+    raw = _df(
+        [{"open": 0, "high": 0, "low": 0, "close": 465, "volume": 0, "amount": 123}]
+    )
+    provider, _ = _provider_with(raw)
+    provider.load("005930", "1d")
+    view = _cached(provider)
+    # amount>0이면 거래가 발생한 것이므로 보정하지 않는다.
+    assert view["open"][0] == 0.0
+    assert view["high"][0] == 0.0
+    assert view["low"][0] == 0.0
+
+
+# (d) 정상 bar(O,H,L,C>0) → 무변경 ──────────────────────────────────────────
+
+
+async def test_normal_bar_unchanged():
+    raw = _df(
+        [
+            {
+                "open": 50000,
+                "high": 50500,
+                "low": 49500,
+                "close": 50250,
+                "volume": 1000,
+            },
+            {
+                "open": 51000,
+                "high": 51500,
+                "low": 50500,
+                "close": 51250,
+                "volume": 2000,
+            },
+        ]
+    )
+    provider, _ = _provider_with(raw)
+    provider.load("005930", "1d")
+    view = _cached(provider)
+    assert view["open"].to_list() == [50000.0, 51000.0]
+    assert view["high"].to_list() == [50500.0, 51500.0]
+    assert view["low"].to_list() == [49500.0, 50500.0]
+
+
+# (e) 저장 raw 무영향 — load만 정규화, store가 돌려준 raw 객체는 불변 ─────────
+
+
+async def test_storage_raw_unaffected():
+    """store.read mock으로 raw 반환 후, raw 객체 자체는 정규화로 변형되지 않는다.
+
+    저장 raw(parquet)는 데이터 무손실 우선 원칙으로 불변이어야 한다. 정규화는
+    캐시 view에만 적용되며, store가 돌려준 DataFrame은 그대로 남아야 한다.
+    """
+    raw = _df(
+        [{"open": 0, "high": 0, "low": 0, "close": 465, "volume": 0, "amount": 0}]
+    )
+    provider, store = _provider_with(raw)
+    provider.load("005930", "1d")
+
+    # store가 돌려준 raw 객체는 여전히 zero-OHL(불변).
+    returned_raw = store.read.return_value
+    assert returned_raw["open"][0] == 0.0
+    assert returned_raw["high"][0] == 0.0
+    assert returned_raw["low"][0] == 0.0
+    # 캐시 view만 정규화됨.
+    assert _cached(provider)["open"][0] == 465.0
+
+
+# (f) 무거래일 intraday range가 0 ──────────────────────────────────────────
+
+
+async def test_no_trade_intraday_range_zero():
+    raw = _df(
+        [{"open": 0, "high": 0, "low": 0, "close": 104600, "volume": 0, "amount": 0}]
+    )
+    provider, _ = _provider_with(raw)
+    provider.load("005930", "1d")
+    view = _cached(provider)
+    intraday_range = view["high"][0] - view["low"][0]
+    assert intraday_range == 0.0
+    # carrying price(close)는 보존.
+    assert view["close"][0] == 104600.0
+
+
+# (g) get_ohlcv on-demand 경로도 load 경유라 정규화 적용 ──────────────────────
+
+
+async def test_get_ohlcv_on_demand_normalized():
+    """캐시 미스 → get_ohlcv가 load()를 거치므로 정규화가 적용된다."""
+    raw = _df(
+        [
+            {
+                "open": 50000,
+                "high": 50500,
+                "low": 49500,
+                "close": 50250,
+                "volume": 1000,
+            },
+            {"open": 0, "high": 0, "low": 0, "close": 465, "volume": 0, "amount": 0},
+        ]
+    )
+    provider, _ = _provider_with(raw)
+    # load를 직접 호출하지 않고 get_ohlcv로 lazy-load 유도.
+    provider.advance()  # idx 0
+    provider.advance()  # idx 1 (마지막 행까지 노출)
+    df = await provider.get_ohlcv("005930", "1d", limit=100)
+    # on-demand 경로에서도 무거래 행이 flat bar로 정규화됨.
+    last = df.tail(1)
+    assert last["open"][0] == 465.0
+    assert last["high"][0] == 465.0
+    assert last["low"][0] == 465.0
+
+
+# 빈 df(존재하지 않는 심볼) → 가드 ──────────────────────────────────────────
+
+
+async def test_empty_df_passthrough():
+    provider, _ = _provider_with(pl.DataFrame())
+    # OHLCV 컬럼이 없는 빈 df는 그대로 통과(에러 없음).
+    provider.load("999999", "1d")
+    assert _cached(provider, "999999").is_empty()


### PR DESCRIPTION
Closes #2071

## Summary
- data.go.kr 무거래 zero-OHLC 행(open=high=low=0, close>0, volume=0)이 백테스트 지표(intraday range/변동성)를 왜곡하던 문제를 **backtest-load 계층 정규화**로 해소. 저장 raw는 불변(data-feed/02 L31 데이터 무손실 우선 준수).
- `BacktestDataProvider.load`에서 `store.read()` 직후·캐시 전 `_normalize_no_trade_bars` 적용 — 정확 시그니처(+amount==0 if present)만 `O=H=L=C=close` flat-bar로. partial-zero/volume>0/amount>0/정상 bar 무변경.
- backtest/02-design-decisions.md에 정책 명시: backtest view 한정·저장 raw 불변·flat-bar는 intraday range만 0(ATR/갭 전일종가 변화 보존)·storage/normalizer/report/warning 제외.

## Test Plan
- 신규 `test_backtest_no_trade_normalize.py` 10개(시그니처 정규화/partial-zero·volume>0·amount>0 무변경/정상·빈 df/저장 raw 무영향/range 0/on-demand)
- 전체 `pytest tests/unit/ -q` — 6989 passed, 2 skipped
- ruff/mypy clean
- Codex 브랜치 리뷰: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
