### PR TITLE
refactor(member): #2294 register 무조건 master 게이트 + #2295 recovery sentinel 비충돌 reserved guard

### DIFF
--- a/docs/specs/audit/audit.md
+++ b/docs/specs/audit/audit.md
@@ -139,8 +139,10 @@ AuditLogger는 인프라(기록·조회)만 제공한다. 실제 기록은 **CLI
 (auth-exempt) 커맨드다. 대상은 항상 master 멤버이며 그 `member_id`는 서버 handler가
 master-lookup으로 해석해 `resource`에 기록한다. 다만 audit row의 `member_id`(행위자)는
 client가 보낸 actor(스푸핑 가능)를 신뢰하지 않고 handler가 고정한 sentinel 상수
-(`recovery`)로 기록한다. recovery key, 새/현재 password 등 비밀값은 audit detail,
-audit_log, IPC error envelope, server 로그 어디에도 기록하지 않는다.
+(`system:recovery`)로 기록한다. 이 sentinel은 `system:kill_switch`와 동일한 reserved
+`system:` 네임스페이스에 둬서 사용자/agent `member_id`와 충돌하지 않는다(`member
+register`가 `system:` prefix 등록을 거부). recovery key, 새/현재 password 등 비밀값은
+audit detail, audit_log, IPC error envelope, server 로그 어디에도 기록하지 않는다.
 
 ### 구현 방식
 

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -51,6 +51,10 @@ Non-Goals).
   ``state_conflict`` (#1825)
 - ``MemberAlreadyExistsError`` → ``MEMBER_ALREADY_EXISTS`` /
   ``state_conflict`` (#1826)
+- ``ReservedMemberIdError`` → ``MEMBER_ID_RESERVED`` / ``validation``
+  (#2295; ``register`` 의 ``system:`` reserved-prefix guard — duplicate
+  와 별개 fault, existing-member 조회 이전 거부. ``ValueError`` 다중상속
+  으로 기존 generic fallback 회귀 없음.)
 - ``MemberInvalidRecoveryCredentialError`` →
   ``MEMBER_INVALID_RECOVERY_CREDENTIAL`` / ``auth`` (#1826)
 
@@ -253,6 +257,7 @@ from ante.member.errors import (
     MemberNotFoundError,
     MemberStateConflictError,
     PermissionDeniedError,
+    ReservedMemberIdError,
 )
 from ante.member.scopes import InvalidScopeError
 from ante.rule.exceptions import RuleConfigError
@@ -397,6 +402,16 @@ _MEMBER_STATE_CONFLICT_SPEC: Final[ErrorSpec] = ErrorSpec(
 _MEMBER_ALREADY_EXISTS_SPEC: Final[ErrorSpec] = ErrorSpec(
     code="MEMBER_ALREADY_EXISTS",
     category="state_conflict",
+)
+
+# reserved ``system:`` prefix member_id 등록 거부 (#2295) 는 입력 네임스페이스
+# 계약 위반이므로 taxonomy ``validation`` 카테고리. duplicate
+# (``MEMBER_ALREADY_EXISTS`` / state_conflict) 와 별개 fault 로 분리한다 — register
+# 의 reserved-prefix guard 가 existing-member 조회 이전에 배치되어 legacy
+# ``system:*`` 행이 있어도 본 코드가 surface 된다.
+_MEMBER_ID_RESERVED_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="MEMBER_ID_RESERVED",
+    category="validation",
 )
 
 # recovery credential validation 거부는 의미상 인증(auth) 카테고리.
@@ -767,6 +782,8 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     MemberNotFoundError: _MEMBER_NOT_FOUND_SPEC,
     MemberStateConflictError: _MEMBER_STATE_CONFLICT_SPEC,
     MemberAlreadyExistsError: _MEMBER_ALREADY_EXISTS_SPEC,
+    # ── #2295 member reserved-prefix guard (실측 .code mirror) ────────────
+    ReservedMemberIdError: _MEMBER_ID_RESERVED_SPEC,
     MemberInvalidRecoveryCredentialError: _MEMBER_INVALID_RECOVERY_CREDENTIAL_SPEC,
     # ── #1915 member 2 sub-class (emoji 형식 / master 보호) ───────────────
     MemberInvalidEmojiError: _MEMBER_INVALID_EMOJI_SPEC,

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -1090,7 +1090,12 @@ async def _handle_member_rotate_token(
 # 의 audit member_id 는 client-supplied actor(스푸핑 가능) 를 절대 쓰지 않고
 # handler 가 고정한 sentinel 상수를 ``_audit_detail["member_id"]`` 로 전달한다.
 # ``_dispatch`` wrapper 는 이 override 가 있으면 actor 대신 사용한다.
-_RECOVERY_AUDIT_MEMBER_ID = "recovery"
+#
+# Refs #2295: sentinel 값을 ``"recovery"`` → ``"system:recovery"`` 로 변경한다.
+# 기존 ``system:kill_switch`` audit 네임스페이스 관례와 정합하며, 사용자/agent
+# member_id 와 충돌하지 않는 reserved ``system:`` prefix 네임스페이스에 둔다
+# (member register 가 ``system:`` prefix 등록을 거부 — defense-in-depth).
+_RECOVERY_AUDIT_MEMBER_ID = "system:recovery"
 
 
 async def _resolve_master_member_id(member: Any) -> str:

--- a/src/ante/member/errors.py
+++ b/src/ante/member/errors.py
@@ -151,6 +151,39 @@ class MemberAlreadyExistsError(MemberError, ValueError):
         super().__init__(f"이미 존재하는 member_id: {member_id}")
 
 
+class ReservedMemberIdError(MemberError, ValueError):
+    """reserved ``system:`` prefix member_id 등록 거부 (#2295).
+
+    ``register`` 가 ``member_id.startswith("system:")`` 등록 요청을 받았을 때
+    raise 한다. ``system:`` 는 system audit sentinel 네임스페이스
+    (``system:kill_switch`` / ``system:recovery``) 전용 reserved prefix 이며,
+    사용자/agent member_id 가 이를 점유하면 audit 행위자 식별이 오염된다.
+
+    ``MemberError`` 와 ``ValueError`` 다중상속으로 둔다 — #1807
+    ``MemberAlreadyExistsError`` 패턴 1:1 미러. 기존 caller (CLI ``register``
+    의 ``except (ValueError, PermissionError)`` generic fallback) 가 회귀
+    없이 동일하게 잡히도록 한다. ``except ReservedMemberIdError`` 를 먼저 둔
+    caller 는 typed 분기를 우선 매칭해 안정 코드 envelope 을 surface 한다
+    (Python MRO 보장).
+
+    duplicate (``MemberAlreadyExistsError`` / MEMBER_ALREADY_EXISTS) 와는
+    별개 fault 로 분리한다 (Codex v2) — register 의 reserved-prefix guard 는
+    existing-member 조회 *이전* 에 배치되어, legacy ``system:*`` 행이 있어도
+    MEMBER_ALREADY_EXISTS 가 아닌 ``MEMBER_ID_RESERVED`` 코드가 surface 된다.
+    permission fault (``PermissionDeniedError`` / PERMISSION_DENIED) 와도
+    별개다 — reserved-prefix 는 권한 부족이 아니라 입력 네임스페이스 위반이다.
+
+    클래스 레벨 ``code`` 속성은 CLI/IPC envelope 이 안정 코드
+    ``"MEMBER_ID_RESERVED"`` 로 surface 하도록 한다.
+    """
+
+    code: str = "MEMBER_ID_RESERVED"
+
+    def __init__(self, member_id: str) -> None:
+        self.member_id = member_id
+        super().__init__(f"예약된 member_id prefix 는 사용할 수 없습니다: {member_id}")
+
+
 class MemberInvalidRecoveryCredentialError(MemberError, ValueError, PermissionError):
     """recovery credential validation 거부 (#1806 Group R sweep).
 

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -57,6 +57,13 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_ORG = "default"
 
+# Refs #2295: ``system:`` 는 system audit sentinel 네임스페이스
+# (``system:kill_switch`` / ``system:recovery``) 전용 reserved prefix 다. 사용자/
+# agent 등록 member_id 가 이 prefix 를 점유하면 audit 행위자(member_id) 식별이
+# 오염되므로 ``register`` 가 거부한다. 정확히 ``startswith(_RESERVED_MEMBER_ID_PREFIX)``
+# 만 거부하며 ``system`` 단독·``systemic`` 등은 오거부하지 않는다.
+_RESERVED_MEMBER_ID_PREFIX = "system:"
+
 MEMBER_SCHEMA = """
 CREATE TABLE IF NOT EXISTS members (
     member_id          TEXT PRIMARY KEY,
@@ -392,9 +399,26 @@ class MemberService:
         재검증한다. 검증은 ``_assert_master``
         직후, ``_assert_type_role`` 직전에 둬서 enum membership 위반이
         type-role 분기보다 먼저 거부되도록 한다.
+
+        master 검증은 **무조건** 수행한다 (#2294 — #2113 메타리뷰 후속). 이전
+        에는 ``if registered_by:`` 가드로 빈 actor 를 우회 허용했으나, 형제
+        mutation (suspend/reactivate/revoke/rotate_token/update_scopes) 가 모두
+        무조건 ``_assert_master`` 를 호출하는 것·#1351 이 ``update_scopes`` 에서
+        동일 가드를 제거한 선례와 동형으로 무조건 호출한다. ``registered_by=""``
+        (빈 actor) 는 ``_assert_master("")`` → ``get("")`` 가 ``None`` 을 반환해
+        ``PermissionDeniedError`` 로 거부된다 (의도된 defense-in-depth). 정상
+        IPC actor (``'ipc'``) / CLI actor (``'unknown'``) 는 truthy 이므로
+        master 조회 경로를 거쳐 무영향이다.
+
+        ``member_id`` 가 ``system:`` reserved prefix 로 시작하면 등록을 거부
+        한다 (#2295 — audit sentinel 네임스페이스 보호). existing-member 조회
+        이전에 ``ReservedMemberIdError`` (.code=MEMBER_ID_RESERVED) 로 거부해,
+        legacy ``system:*`` 행이 있어도 MEMBER_ALREADY_EXISTS 가 아닌 reserved
+        코드가 surface 되도록 한다. 정확히 ``startswith("system:")`` 만 거부하며
+        ``system`` 단독·``systemic`` 등은 오거부하지 않는다.
         """
-        if registered_by:
-            await self._assert_master(registered_by, "register")
+        await self._assert_master(registered_by, "register")
+        self._assert_reserved_member_id(member_id)
         self._assert_role_enum(role)
         self._assert_type_enum(member_type)
         self._assert_type_role(member_type, role)
@@ -886,6 +910,27 @@ class MemberService:
         for scope in scopes:
             if not is_valid_scope(scope):
                 raise InvalidScopeError(scope)
+
+    @staticmethod
+    def _assert_reserved_member_id(member_id: str) -> None:
+        """reserved ``system:`` prefix 점유 여부를 검증한다 (#2295).
+
+        ``system:`` 는 system audit sentinel 네임스페이스 (``system:kill_switch``
+        / ``system:recovery``) 전용이다. 사용자/agent 등록 member_id 가 이 prefix
+        를 점유하면 audit row 의 행위자(member_id) 식별이 오염되므로 ``register``
+        가 거부한다.
+
+        existing-member 조회 이전에 호출해, legacy ``system:*`` 행이 DB 에 있어도
+        ``MemberAlreadyExistsError`` (MEMBER_ALREADY_EXISTS) 가 아니라
+        ``ReservedMemberIdError`` (MEMBER_ID_RESERVED) 가 surface 되도록 한다.
+
+        정확히 ``startswith("system:")`` 만 거부한다 — ``system`` 단독,
+        ``systemic`` 등 콜론 없는 일반 member_id 는 오거부하지 않는다.
+        """
+        from ante.member.errors import ReservedMemberIdError
+
+        if member_id.startswith(_RESERVED_MEMBER_ID_PREFIX):
+            raise ReservedMemberIdError(member_id)
 
     @staticmethod
     def _assert_role_enum(role: str) -> None:

--- a/tests/unit/ipc/test_member_admin_ipc_wiring.py
+++ b/tests/unit/ipc/test_member_admin_ipc_wiring.py
@@ -402,6 +402,18 @@ async def test_regenerate_recovery_key_handler_sentinel_and_result_only(
     _assert_no_secret(_audit_call_strings(audit_logger))
 
 
+def test_recovery_audit_sentinel_is_reserved_namespace() -> None:
+    """#2295: recovery audit sentinel 은 reserved ``system:`` 네임스페이스 값.
+
+    이전 (#2295 이전): ``"recovery"`` — 사용자/agent member_id 와 충돌 가능.
+    #2295 가 ``"system:recovery"`` 로 변경해 ``system:kill_switch`` 와 동일한
+    reserved ``system:`` 네임스페이스에 두고 충돌을 제거한다 (member register
+    가 ``system:`` prefix 등록을 거부 — defense-in-depth).
+    """
+    assert _RECOVERY_AUDIT_MEMBER_ID == "system:recovery"
+    assert _RECOVERY_AUDIT_MEMBER_ID.startswith("system:")
+
+
 # ── (e) comprehensive secret 비노출: 실패 경로 envelope + server log ────────
 
 

--- a/tests/unit/test_cli_group_q_state_conflict_sweep.py
+++ b/tests/unit/test_cli_group_q_state_conflict_sweep.py
@@ -512,7 +512,9 @@ class TestServiceLayerTypedRaise:
 
             # master + ACTIVE agent 생성 → suspend 1회 후 재정지 시 typed.
             await service.bootstrap_master("owner", "pass1234")
-            await service.register("agent-grp-q", MemberType.AGENT)
+            await service.register(
+                "agent-grp-q", MemberType.AGENT, registered_by="owner"
+            )
             await service.suspend("agent-grp-q", suspended_by="owner")
 
             with pytest.raises(MemberStateConflictError) as excinfo:

--- a/tests/unit/test_cli_group_r_member_duplicate_validation_sweep.py
+++ b/tests/unit/test_cli_group_r_member_duplicate_validation_sweep.py
@@ -272,10 +272,16 @@ class TestServiceLayerTypedRaise:
             service = MemberService(db, eventbus=eventbus)
             await service.initialize()
 
-            await service.register("agent-grp-r", MemberType.AGENT)
+            # #2294: register 는 무조건 master actor 를 요구한다.
+            await service.bootstrap_master("owner", "pass1234")
+            await service.register(
+                "agent-grp-r", MemberType.AGENT, registered_by="owner"
+            )
 
             with pytest.raises(MemberAlreadyExistsError) as excinfo:
-                await service.register("agent-grp-r", MemberType.AGENT)
+                await service.register(
+                    "agent-grp-r", MemberType.AGENT, registered_by="owner"
+                )
             assert getattr(excinfo.value, "code", None) == "MEMBER_ALREADY_EXISTS"
             assert excinfo.value.member_id == "agent-grp-r"
             # ``ValueError`` 다중상속 회귀 보호 — 기존 ``except ValueError``

--- a/tests/unit/test_member.py
+++ b/tests/unit/test_member.py
@@ -203,24 +203,38 @@ class TestRegister:
         assert member.scopes == ["strategy:write", "data:read"]
 
     async def test_register_duplicate_fails(self, service):
-        await service.register("agent-01", MemberType.AGENT)
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         with pytest.raises(ValueError, match="이미 존재하는"):
-            await service.register("agent-01", MemberType.AGENT)
+            await service.register("agent-01", MemberType.AGENT, registered_by="owner")
 
     async def test_register_agent_as_master_fails(self, service):
+        await service.bootstrap_master("owner", "pass123")
         with pytest.raises(PermissionError, match="agent 타입은 master"):
             await service.register(
-                "bad-agent", MemberType.AGENT, role=MemberRole.MASTER
+                "bad-agent",
+                MemberType.AGENT,
+                role=MemberRole.MASTER,
+                registered_by="owner",
             )
 
     async def test_register_agent_as_admin_fails(self, service):
+        await service.bootstrap_master("owner", "pass123")
         with pytest.raises(PermissionError, match="agent 타입은 master 또는 admin"):
-            await service.register("bad-agent", MemberType.AGENT, role=MemberRole.ADMIN)
+            await service.register(
+                "bad-agent",
+                MemberType.AGENT,
+                role=MemberRole.ADMIN,
+                registered_by="owner",
+            )
 
 
 class TestAuthenticate:
     async def test_authenticate_token(self, service):
-        _, token = await service.register("agent-01", MemberType.AGENT)
+        await service.bootstrap_master("owner", "pass123")
+        _, token = await service.register(
+            "agent-01", MemberType.AGENT, registered_by="owner"
+        )
         member = await service.authenticate(token)
         assert member.member_id == "agent-01"
 
@@ -229,13 +243,16 @@ class TestAuthenticate:
             await service.authenticate("invalid_token_xyz")
 
     async def test_authenticate_wrong_token(self, service):
-        await service.register("agent-01", MemberType.AGENT)
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         with pytest.raises(PermissionError, match="인증 실패"):
             await service.authenticate("ante_ak_nonexistent_token")
 
     async def test_authenticate_suspended_member(self, service):
         await service.bootstrap_master("owner", "pass123")
-        _, token = await service.register("agent-01", MemberType.AGENT)
+        _, token = await service.register(
+            "agent-01", MemberType.AGENT, registered_by="owner"
+        )
         await service.suspend("agent-01", suspended_by="owner")
         with pytest.raises(PermissionError, match="비활성 멤버"):
             await service.authenticate(token)
@@ -267,7 +284,8 @@ class TestAuthenticatePassword:
             await service.authenticate_password("owner", "wrong")
 
     async def test_agent_cannot_password_auth(self, service):
-        await service.register("agent-01", MemberType.AGENT)
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         with pytest.raises(PermissionError, match="human 멤버만"):
             await service.authenticate_password("agent-01", "anything")
 
@@ -279,7 +297,7 @@ class TestAuthenticatePassword:
 class TestSuspendReactivateRevoke:
     async def test_suspend_and_reactivate(self, service):
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         m = await service.suspend("agent-01", suspended_by="owner")
         assert m.status == MemberStatus.SUSPENDED
 
@@ -293,14 +311,14 @@ class TestSuspendReactivateRevoke:
 
     async def test_revoke(self, service):
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         m = await service.revoke("agent-01", revoked_by="owner")
         assert m.status == MemberStatus.REVOKED
         assert m.token_hash == ""
 
     async def test_revoke_suspended_member(self, service):
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         await service.suspend("agent-01", suspended_by="owner")
         m = await service.revoke("agent-01", revoked_by="owner")
         assert m.status == MemberStatus.REVOKED
@@ -308,7 +326,7 @@ class TestSuspendReactivateRevoke:
 
     async def test_revoke_already_revoked_fails(self, service):
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         await service.revoke("agent-01", revoked_by="owner")
         with pytest.raises(PermissionError, match="active, suspended 상태에서만"):
             await service.revoke("agent-01", revoked_by="owner")
@@ -328,7 +346,7 @@ class TestSuspendReactivateRevoke:
         from ante.member.errors import MemberStateConflictError
 
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         with pytest.raises(MemberStateConflictError) as excinfo:
             await service.reactivate("agent-01", reactivated_by="owner")
         assert excinfo.value.code == "MEMBER_STATE_CONFLICT"
@@ -345,7 +363,7 @@ class TestSuspendReactivateRevoke:
         eventbus.subscribe(MemberSuspendedEvent, domain_events.append)
         eventbus.subscribe(NotificationEvent, notifications.append)
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         await service.suspend("agent-01", suspended_by="owner")
         assert len(domain_events) == 1
         assert domain_events[0].member_id == "agent-01"
@@ -362,7 +380,7 @@ class TestSuspendReactivateRevoke:
         notifications: list = []
         eventbus.subscribe(NotificationEvent, notifications.append)
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         await service.suspend("agent-01", suspended_by="owner")
 
         suspend_notifs = [n for n in notifications if n.title == "멤버 정지"]
@@ -384,7 +402,7 @@ class TestSuspendReactivateRevoke:
         from ante.member.errors import MemberStateConflictError
 
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         await service.suspend("agent-01", suspended_by="owner")
 
         # 첫 suspend 의 발행물을 배제하기 위해 두 번째 suspend 직전부터 수집.
@@ -404,7 +422,7 @@ class TestSuspendReactivateRevoke:
         events: list = []
         eventbus.subscribe(MemberReactivatedEvent, events.append)
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         await service.suspend("agent-01", suspended_by="owner")
         await service.reactivate("agent-01", reactivated_by="owner")
         assert len(events) == 1
@@ -418,7 +436,7 @@ class TestSuspendReactivateRevoke:
         eventbus.subscribe(MemberRevokedEvent, domain_events.append)
         eventbus.subscribe(NotificationEvent, notifications.append)
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         await service.revoke("agent-01", revoked_by="owner")
         assert len(domain_events) == 1
         revoke_notifs = [n for n in notifications if n.title == "멤버 폐기"]
@@ -432,7 +450,7 @@ class TestSuspendReactivateRevoke:
         notifications: list = []
         eventbus.subscribe(NotificationEvent, notifications.append)
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         await service.revoke("agent-01", revoked_by="owner")
 
         revoke_notifs = [n for n in notifications if n.title == "멤버 폐기"]
@@ -448,7 +466,9 @@ class TestSuspendReactivateRevoke:
 class TestRotateToken:
     async def test_rotate_token(self, service):
         await service.bootstrap_master("owner", "pass123")
-        _, old_token = await service.register("agent-01", MemberType.AGENT)
+        _, old_token = await service.register(
+            "agent-01", MemberType.AGENT, registered_by="owner"
+        )
         _, new_token = await service.rotate_token("agent-01", rotated_by="owner")
         assert old_token != new_token
         # 새 토큰으로 인증 성공
@@ -499,7 +519,7 @@ class TestPasswordManagement:
 class TestScopes:
     async def test_update_scopes(self, service):
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         m = await service.update_scopes(
             "agent-01", ["strategy:write", "data:read"], updated_by="owner"
         )
@@ -516,7 +536,8 @@ class TestMasterPermissionCheck:
         """agent 역할의 멤버가 register 호출 시 PermissionDeniedError."""
         from ante.member.errors import PermissionDeniedError
 
-        await service.register("agent-caller", MemberType.AGENT)
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-caller", MemberType.AGENT, registered_by="owner")
         with pytest.raises(PermissionDeniedError, match="master만"):
             await service.register(
                 "new-agent", MemberType.AGENT, registered_by="agent-caller"
@@ -553,17 +574,26 @@ class TestMasterPermissionCheck:
         with pytest.raises(PermissionDeniedError, match="master만"):
             await service.register("new-agent", MemberType.AGENT, registered_by="ghost")
 
-    async def test_register_without_caller_succeeds(self, service):
-        """registered_by가 빈 문자열(내부 호출)이면 검증 스킵."""
-        member, token = await service.register("agent-01", MemberType.AGENT)
-        assert member.member_id == "agent-01"
+    async def test_register_without_caller_fails(self, service):
+        """``registered_by``가 빈 문자열이면 PermissionDeniedError (#2294 회귀 잠금).
+
+        과거에는 빈 caller가 master 검증을 우회했으나(``if registered_by:``
+        가드), #2294 (#2113 메타리뷰 후속)가 이 분기를 제거하고 형제 mutation
+        과 동일하게 무조건 master 검증을 강제한다. ``_assert_master("")`` →
+        ``get("")`` 가 ``None`` 을 반환해 거부된다 (의도된 defense-in-depth).
+        """
+        from ante.member.errors import PermissionDeniedError
+
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await service.register("agent-01", MemberType.AGENT, registered_by="owner")
 
     async def test_update_scopes_by_agent_fails(self, service):
         """agent 역할의 멤버가 update_scopes 호출 시 PermissionDeniedError."""
         from ante.member.errors import PermissionDeniedError
 
-        await service.register("agent-01", MemberType.AGENT)
-        await service.register("agent-caller", MemberType.AGENT)
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
+        await service.register("agent-caller", MemberType.AGENT, registered_by="owner")
         with pytest.raises(PermissionDeniedError, match="master만"):
             await service.update_scopes(
                 "agent-01", ["strategy:write"], updated_by="agent-caller"
@@ -572,7 +602,7 @@ class TestMasterPermissionCheck:
     async def test_update_scopes_by_master_succeeds(self, service):
         """master 역할이면 update_scopes 정상 수행."""
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         m = await service.update_scopes(
             "agent-01", ["strategy:write"], updated_by="owner"
         )
@@ -587,28 +617,42 @@ class TestMasterPermissionCheck:
         """
         from ante.member.errors import PermissionDeniedError
 
-        await service.register("agent-01", MemberType.AGENT)
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         with pytest.raises(PermissionDeniedError, match="master만"):
             await service.update_scopes("agent-01", ["data:read"])
 
 
 class TestList:
     async def test_list_all(self, service):
-        await service.register("agent-01", MemberType.AGENT)
-        await service.register("agent-02", MemberType.AGENT, org="risk")
+        # #2294: register 는 무조건 master actor 를 요구한다. master(human) +
+        # agent 2 명 → 전체 3 명.
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
+        await service.register(
+            "agent-02", MemberType.AGENT, org="risk", registered_by="owner"
+        )
         members = await service.list_members()
-        assert len(members) == 2
+        assert len(members) == 3
+        agents = [m for m in members if m.type == MemberType.AGENT]
+        assert len(agents) == 2
 
     async def test_list_by_type(self, service):
         await service.bootstrap_master("owner", "pass123")
-        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-01", MemberType.AGENT, registered_by="owner")
         humans = await service.list_members(member_type=MemberType.HUMAN)
         assert len(humans) == 1
         assert humans[0].type == MemberType.HUMAN
 
     async def test_list_by_org(self, service):
-        await service.register("a1", MemberType.AGENT, org="strategy-lab")
-        await service.register("a2", MemberType.AGENT, org="risk")
+        # #2294: master(org=default) + agent a1(strategy-lab)/a2(risk).
+        await service.bootstrap_master("owner", "pass123")
+        await service.register(
+            "a1", MemberType.AGENT, org="strategy-lab", registered_by="owner"
+        )
+        await service.register(
+            "a2", MemberType.AGENT, org="risk", registered_by="owner"
+        )
         result = await service.list_members(org="risk")
         assert len(result) == 1
         assert result[0].member_id == "a2"
@@ -633,12 +677,20 @@ class TestEmojiField:
         assert m.emoji == ""
 
     async def test_register_auto_assigns_emoji(self, service):
-        member, _ = await service.register("a1", MemberType.AGENT)
+        # #2294: register 는 무조건 master actor 를 요구한다. master 는 non-pool
+        # emoji(👑) 로 부트스트랩해 pool 자동 배정/유일성 검증에 간섭하지 않는다.
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        member, _ = await service.register(
+            "a1", MemberType.AGENT, registered_by="owner"
+        )
         assert member.emoji != ""
         assert member.emoji in ANIMAL_EMOJI_POOL
 
     async def test_register_with_explicit_emoji(self, service):
-        member, _ = await service.register("a1", MemberType.AGENT, emoji="🎸")
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        member, _ = await service.register(
+            "a1", MemberType.AGENT, emoji="🎸", registered_by="owner"
+        )
         assert member.emoji == "🎸"
 
     async def test_bootstrap_auto_assigns_emoji(self, service):
@@ -651,21 +703,30 @@ class TestEmojiField:
         assert member.emoji == "👑"
 
     async def test_emoji_persisted_in_db(self, service):
-        await service.register("a1", MemberType.AGENT, emoji="🐶")
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        await service.register(
+            "a1", MemberType.AGENT, emoji="🐶", registered_by="owner"
+        )
         fetched = await service.get("a1")
         assert fetched.emoji == "🐶"
 
 
 class TestUpdateEmoji:
     async def test_update_emoji(self, service):
-        await service.register("a1", MemberType.AGENT, emoji="🐶")
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        await service.register(
+            "a1", MemberType.AGENT, emoji="🐶", registered_by="owner"
+        )
         m = await service.update_emoji("a1", "🐱", updated_by="owner")
         assert m.emoji == "🐱"
         fetched = await service.get("a1")
         assert fetched.emoji == "🐱"
 
     async def test_update_emoji_to_empty(self, service):
-        await service.register("a1", MemberType.AGENT, emoji="🐶")
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        await service.register(
+            "a1", MemberType.AGENT, emoji="🐶", registered_by="owner"
+        )
         m = await service.update_emoji("a1", "", updated_by="owner")
         assert m.emoji == ""
 
@@ -676,59 +737,100 @@ class TestUpdateEmoji:
 
 class TestEmojiValidation:
     async def test_invalid_emoji_text(self, service):
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
         with pytest.raises(ValueError, match="단일 이모지만"):
-            await service.register("a1", MemberType.AGENT, emoji="abc")
+            await service.register(
+                "a1", MemberType.AGENT, emoji="abc", registered_by="owner"
+            )
 
     async def test_invalid_emoji_multiple(self, service):
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
         with pytest.raises(ValueError, match="단일 이모지만"):
-            await service.register("a1", MemberType.AGENT, emoji="🐶🐱")
+            await service.register(
+                "a1", MemberType.AGENT, emoji="🐶🐱", registered_by="owner"
+            )
 
     async def test_duplicate_emoji_fails(self, service):
-        await service.register("a1", MemberType.AGENT, emoji="🐶")
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        await service.register(
+            "a1", MemberType.AGENT, emoji="🐶", registered_by="owner"
+        )
         with pytest.raises(ValueError, match="이미.*사용 중"):
-            await service.register("a2", MemberType.AGENT, emoji="🐶")
+            await service.register(
+                "a2", MemberType.AGENT, emoji="🐶", registered_by="owner"
+            )
 
     async def test_duplicate_emoji_message_includes_owner(self, service):
-        await service.register("a1", MemberType.AGENT, emoji="🐶")
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        await service.register(
+            "a1", MemberType.AGENT, emoji="🐶", registered_by="owner"
+        )
         with pytest.raises(ValueError, match="a1"):
-            await service.register("a2", MemberType.AGENT, emoji="🐶")
+            await service.register(
+                "a2", MemberType.AGENT, emoji="🐶", registered_by="owner"
+            )
 
     async def test_empty_emoji_allows_duplicates(self, service):
         # emoji=""는 빈 문자열 명시 (자동 배정 안 함)
-        m1, _ = await service.register("a1", MemberType.AGENT, emoji="")
-        m2, _ = await service.register("a2", MemberType.AGENT, emoji="")
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        m1, _ = await service.register(
+            "a1", MemberType.AGENT, emoji="", registered_by="owner"
+        )
+        m2, _ = await service.register(
+            "a2", MemberType.AGENT, emoji="", registered_by="owner"
+        )
         assert m1.emoji == ""
         assert m2.emoji == ""
 
     async def test_update_emoji_duplicate_fails(self, service):
-        await service.register("a1", MemberType.AGENT, emoji="🐶")
-        await service.register("a2", MemberType.AGENT, emoji="🐱")
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        await service.register(
+            "a1", MemberType.AGENT, emoji="🐶", registered_by="owner"
+        )
+        await service.register(
+            "a2", MemberType.AGENT, emoji="🐱", registered_by="owner"
+        )
         with pytest.raises(ValueError, match="이미.*사용 중"):
             await service.update_emoji("a2", "🐶")
 
     async def test_update_emoji_same_value_ok(self, service):
-        await service.register("a1", MemberType.AGENT, emoji="🐶")
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        await service.register(
+            "a1", MemberType.AGENT, emoji="🐶", registered_by="owner"
+        )
         m = await service.update_emoji("a1", "🐶")
         assert m.emoji == "🐶"
 
 
 class TestAutoAssignEmoji:
     async def test_auto_assign_unique(self, service):
-        m1, _ = await service.register("a1", MemberType.AGENT)
-        m2, _ = await service.register("a2", MemberType.AGENT)
+        # #2294: master 는 non-pool emoji(👑) 로 부트스트랩해 pool 자동 배정에
+        # 간섭하지 않는다.
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        m1, _ = await service.register("a1", MemberType.AGENT, registered_by="owner")
+        m2, _ = await service.register("a2", MemberType.AGENT, registered_by="owner")
         assert m1.emoji != m2.emoji
 
     async def test_auto_assign_exhausted_pool(self, service):
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
         for i in range(len(ANIMAL_EMOJI_POOL)):
             await service.register(
-                f"a{i}", MemberType.AGENT, emoji=ANIMAL_EMOJI_POOL[i]
+                f"a{i}",
+                MemberType.AGENT,
+                emoji=ANIMAL_EMOJI_POOL[i],
+                registered_by="owner",
             )
         # 풀 소진 후 등록 — 에러 없이 빈 문자열
-        member, _ = await service.register("overflow", MemberType.AGENT)
+        member, _ = await service.register(
+            "overflow", MemberType.AGENT, registered_by="owner"
+        )
         assert member.emoji == ""
 
     async def test_auto_assigned_can_be_changed(self, service):
-        member, _ = await service.register("a1", MemberType.AGENT)
+        await service.bootstrap_master("owner", "pass123", emoji="👑")
+        member, _ = await service.register(
+            "a1", MemberType.AGENT, registered_by="owner"
+        )
         original = member.emoji
         m = await service.update_emoji("a1", "🎸")
         assert m.emoji == "🎸"

--- a/tests/unit/test_member.py
+++ b/tests/unit/test_member.py
@@ -575,12 +575,37 @@ class TestMasterPermissionCheck:
             await service.register("new-agent", MemberType.AGENT, registered_by="ghost")
 
     async def test_register_without_caller_fails(self, service):
-        """``registered_by``가 빈 문자열이면 PermissionDeniedError (#2294 회귀 잠금).
+        """``registered_by``가 빈 문자열(빈 actor)이면 PermissionDeniedError (#2294).
 
         과거에는 빈 caller가 master 검증을 우회했으나(``if registered_by:``
         가드), #2294 (#2113 메타리뷰 후속)가 이 분기를 제거하고 형제 mutation
-        과 동일하게 무조건 master 검증을 강제한다. ``_assert_master("")`` →
-        ``get("")`` 가 ``None`` 을 반환해 거부된다 (의도된 defense-in-depth).
+        과 동일하게 무조건 master 검증을 강제한다. ``registered_by=""`` (빈
+        actor) 는 ``_assert_master("")`` → ``get("")`` 가 ``None`` 을 반환해
+        거부된다 (의도된 defense-in-depth).
+
+        빈-actor 경로를 정확히 검증한다: master(``owner``) 가 *존재하는*
+        상태에서 호출해 — caller 부재가 master 존재 여부와 무관하게 빈 actor
+        자체로 거부됨을 잠근다 (unknown-caller 케이스는 별도
+        ``test_register_with_unknown_caller_fails`` 가 검증).
+        """
+        from ante.member.errors import PermissionDeniedError
+
+        await service.bootstrap_master("owner", "pass123")
+        # 빈 문자열 명시.
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await service.register("agent-01", MemberType.AGENT, registered_by="")
+        # ``registered_by`` 생략(기본값 "") 도 동일하게 거부된다.
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await service.register("agent-02", MemberType.AGENT)
+
+    async def test_register_with_unknown_caller_fails(self, service):
+        """존재하지 않는 caller("owner" 부트스트랩 전) 도 거부된다.
+
+        빈-actor 케이스(``test_register_without_caller_fails``) 와 별개로
+        unknown-caller(존재하지 않는 member_id) 경로를 잠근다. master 미존재
+        상태에서 ``_assert_master("owner")`` → ``get("owner")`` 가 ``None`` 을
+        반환해 동일하게 거부된다 (``test_register_by_nonexistent_caller_fails``
+        의 "ghost" 와 동형).
         """
         from ante.member.errors import PermissionDeniedError
 

--- a/tests/unit/test_member_service.py
+++ b/tests/unit/test_member_service.py
@@ -48,7 +48,9 @@ async def _seed_invalid_role_row(
     invalid_role: str = "oracle_invalid_role",
 ) -> None:
     """write path 를 우회해 legacy invalid-role agent row 를 심는다."""
-    await service.register(member_id, MemberType.AGENT)
+    # #2294: register 는 무조건 master actor 를 요구한다. 본 helper 의 caller 는
+    # 모두 사전에 ``bootstrap_master("owner", ...)`` 를 수행한다.
+    await service.register(member_id, MemberType.AGENT, registered_by="owner")
     await db.execute(
         "UPDATE members SET role = ? WHERE member_id = ?",
         (invalid_role, member_id),

--- a/tests/unit/test_member_service_master_guard.py
+++ b/tests/unit/test_member_service_master_guard.py
@@ -16,9 +16,11 @@ import pytest
 from ante.core.database import Database
 from ante.eventbus import EventBus
 from ante.member.errors import (
+    MemberAlreadyExistsError,
     MemberInvalidEmojiError,
     MemberMasterProtectedError,
     PermissionDeniedError,
+    ReservedMemberIdError,
 )
 from ante.member.models import MemberStatus, MemberType
 from ante.member.service import MemberService
@@ -196,6 +198,156 @@ class TestUpdateScopesMasterGuard:
             "agent-active", ["data:read"], updated_by="owner"
         )
         assert member.scopes == ["data:read"]
+
+
+# ── register (#2294 — 무조건 master 게이트) ────────────────────────────────
+
+
+class TestRegisterMasterGuard:
+    """#2294: ``register`` 의 master 검증이 **무조건** 수행되어야 한다.
+
+    이전에는 ``if registered_by:`` 가드로 빈 actor 가 master 검증을
+    우회했다. #2294 (#2113 메타리뷰 후속) 가 이 분기를 제거하고, 형제
+    mutation (suspend/reactivate/revoke/rotate_token/update_scopes) 과 동일
+    하게 caller 가 항상 master 여야 한다는 invariant 를 강제한다.
+    """
+
+    async def test_register_with_empty_caller_raises(
+        self, populated_service: MemberService
+    ) -> None:
+        """빈 actor("") 가 더 이상 master 검증을 우회하면 안 된다 (회귀 잠금).
+
+        ``_assert_master("")`` → ``get("")`` 가 ``None`` 을 반환해
+        ``PermissionDeniedError`` 로 거부된다 (의도된 defense-in-depth).
+        """
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await populated_service.register(
+                "agent-new", MemberType.AGENT, registered_by=""
+            )
+
+    async def test_register_with_non_master_caller_raises(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await populated_service.register(
+                "agent-new", MemberType.AGENT, registered_by="agent-caller"
+            )
+
+    async def test_register_with_unknown_caller_raises(
+        self, populated_service: MemberService
+    ) -> None:
+        """CLI 미인증 actor("unknown") 도 존재하지 않으므로 거부된다."""
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await populated_service.register(
+                "agent-new", MemberType.AGENT, registered_by="unknown"
+            )
+
+    async def test_register_with_master_caller_succeeds(
+        self, populated_service: MemberService
+    ) -> None:
+        member, token = await populated_service.register(
+            "agent-new", MemberType.AGENT, registered_by="owner"
+        )
+        assert member.member_id == "agent-new"
+        assert token.startswith("ante_ak_")
+
+
+# ── register reserved-prefix guard (#2295) ─────────────────────────────────
+
+
+class TestRegisterReservedMemberIdGuard:
+    """#2295: ``register`` 가 reserved ``system:`` prefix member_id 를 거부.
+
+    ``system:`` 는 system audit sentinel 네임스페이스
+    (``system:kill_switch`` / ``system:recovery``) 전용 reserved prefix 다.
+    사용자/agent member_id 가 이를 점유하면 audit 행위자 식별이 오염되므로
+    ``ReservedMemberIdError`` (.code=MEMBER_ID_RESERVED) 로 거부한다.
+    """
+
+    async def test_register_system_recovery_rejected(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(ReservedMemberIdError):
+            await populated_service.register(
+                "system:recovery", MemberType.AGENT, registered_by="owner"
+            )
+
+    async def test_register_system_colon_arbitrary_rejected(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(ReservedMemberIdError):
+            await populated_service.register(
+                "system:abc", MemberType.AGENT, registered_by="owner"
+            )
+
+    async def test_reserved_error_has_stable_code(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(ReservedMemberIdError) as excinfo:
+            await populated_service.register(
+                "system:kill_switch", MemberType.AGENT, registered_by="owner"
+            )
+        assert excinfo.value.code == "MEMBER_ID_RESERVED"
+
+    async def test_reserved_error_is_valueerror(
+        self, populated_service: MemberService
+    ) -> None:
+        """``ValueError`` 다중상속으로 기존 generic fallback 회귀 없음."""
+        with pytest.raises(ValueError):
+            await populated_service.register(
+                "system:x", MemberType.AGENT, registered_by="owner"
+            )
+
+    async def test_register_plain_system_allowed(
+        self, populated_service: MemberService
+    ) -> None:
+        """콜론 없는 ``system`` 단독 member_id 는 오거부하지 않는다."""
+        member, _ = await populated_service.register(
+            "system", MemberType.AGENT, registered_by="owner"
+        )
+        assert member.member_id == "system"
+
+    async def test_register_systemic_allowed(
+        self, populated_service: MemberService
+    ) -> None:
+        """``systemic`` 등 ``system:`` 으로 시작하지 않는 member_id 는 허용."""
+        member, _ = await populated_service.register(
+            "systemic", MemberType.AGENT, registered_by="owner"
+        )
+        assert member.member_id == "systemic"
+
+    async def test_register_normal_id_allowed(
+        self, populated_service: MemberService
+    ) -> None:
+        member, _ = await populated_service.register(
+            "agent-normal", MemberType.AGENT, registered_by="owner"
+        )
+        assert member.member_id == "agent-normal"
+
+    async def test_reserved_guard_precedes_existing_member_lookup(
+        self, populated_service: MemberService
+    ) -> None:
+        """reserved guard 는 existing-member 조회 *이전* 에 배치되어야 한다.
+
+        legacy ``system:*`` 행이 DB 에 있어도 ``MEMBER_ALREADY_EXISTS`` 가
+        아니라 ``MEMBER_ID_RESERVED`` 가 surface 되어야 한다 (Codex v2).
+        guard 가 정상이면 DB 에 row 가 없으므로 INSERT 우회 자체로
+        reserved 코드만 raise 된다 — 별도 row 주입 없이 reserved 가 항상
+        먼저 매칭됨을 단언한다.
+        """
+        with pytest.raises(ReservedMemberIdError):
+            await populated_service.register(
+                "system:recovery", MemberType.AGENT, registered_by="owner"
+            )
+        # reserved guard 통과 후에도 일반 member_id duplicate 는 여전히
+        # MemberAlreadyExistsError 로 별개 surface 됨 (분리된 fault 확인).
+        await populated_service.register(
+            "agent-dup", MemberType.AGENT, registered_by="owner"
+        )
+        with pytest.raises(MemberAlreadyExistsError):
+            await populated_service.register(
+                "agent-dup", MemberType.AGENT, registered_by="owner"
+            )
 
 
 # ── master 우선순위 회귀 ───────────────────────────────────────────────────

--- a/tests/unit/test_member_service_master_guard.py
+++ b/tests/unit/test_member_service_master_guard.py
@@ -325,20 +325,59 @@ class TestRegisterReservedMemberIdGuard:
         assert member.member_id == "agent-normal"
 
     async def test_reserved_guard_precedes_existing_member_lookup(
-        self, populated_service: MemberService
+        self, populated_service: MemberService, db: Database
     ) -> None:
         """reserved guard 는 existing-member 조회 *이전* 에 배치되어야 한다.
 
-        legacy ``system:*`` 행이 DB 에 있어도 ``MEMBER_ALREADY_EXISTS`` 가
-        아니라 ``MEMBER_ID_RESERVED`` 가 surface 되어야 한다 (Codex v2).
-        guard 가 정상이면 DB 에 row 가 없으므로 INSERT 우회 자체로
-        reserved 코드만 raise 된다 — 별도 row 주입 없이 reserved 가 항상
-        먼저 매칭됨을 단언한다.
+        순서 불변(reserved guard → existing-member 조회)을 결정적으로 잠근다:
+        legacy ``system:*`` member 행을 DB 에 직접 seed(register 우회 INSERT)한
+        뒤 *같은* ``system:*`` member_id 로 ``register`` 를 호출하면, guard 가
+        존재 조회보다 앞서므로 ``MemberAlreadyExistsError``
+        (MEMBER_ALREADY_EXISTS) 가 아니라 ``ReservedMemberIdError``
+        (MEMBER_ID_RESERVED) 가 surface 되어야 한다 (Codex v2).
+
+        회귀 검출력: guard 를 제거하거나 위치를 existing 조회 *뒤* 로 옮기면
+        seed 된 row 때문에 ``MemberAlreadyExistsError`` 가 raise 되어 이 단언이
+        FAIL 한다.
         """
-        with pytest.raises(ReservedMemberIdError):
+        # legacy system:* member 행을 reserved guard 를 우회해 직접 seed.
+        # (register 의 INSERT INTO members 와 동일 컬럼 셋.)
+        await db.execute(
+            """INSERT INTO members
+               (member_id, type, role, org, name, emoji, status, scopes,
+                token_hash, password_hash, recovery_key_hash,
+                created_at, created_by, token_expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "system:recovery",
+                MemberType.AGENT,
+                "default",
+                "default",
+                "system:recovery",
+                "",
+                MemberStatus.ACTIVE,
+                "[]",
+                "legacy_hash",
+                "",
+                "",
+                "2020-01-01T00:00:00+00:00",
+                "owner",
+                None,
+            ),
+        )
+        # seed 된 row 가 실제로 존재함을 확인 — guard 부재 시 이 row 가
+        # MemberAlreadyExistsError 경로로 빠진다는 전제를 명시.
+        seeded = await populated_service.get("system:recovery")
+        assert seeded is not None
+        assert seeded.member_id == "system:recovery"
+
+        # guard 가 정상이면 row 존재에도 불구하고 reserved 코드가 surface 된다.
+        with pytest.raises(ReservedMemberIdError) as excinfo:
             await populated_service.register(
                 "system:recovery", MemberType.AGENT, registered_by="owner"
             )
+        assert excinfo.value.code == "MEMBER_ID_RESERVED"
+
         # reserved guard 통과 후에도 일반 member_id duplicate 는 여전히
         # MemberAlreadyExistsError 로 별개 surface 됨 (분리된 fault 확인).
         await populated_service.register(


### PR DESCRIPTION
Closes #2294
Closes #2295

## Summary
- **#2294**: `MemberService.register`의 조건부 master 게이트(`if registered_by:`)를 무조건화 — 형제 메서드·#1351(update_scopes) 선례와 동형. 빈 actor 직접 호출 → PermissionDeniedError(defense-in-depth). 현재 IPC('ipc')/CLI('unknown') actor는 truthy라 무회귀.
- **#2295**: recovery audit sentinel `"recovery"` → `"system:recovery"`(기존 `system:kill_switch` audit 네임스페이스 정합) + register에 reserved-prefix guard(`member_id.startswith("system:")` → 신규 `ReservedMemberIdError`/`MEMBER_ID_RESERVED`, existing-member 조회 **이전** 배치)로 caller-provided 충돌 collision-proof화. error_registry 등록, audit.md 갱신.
- 무조건 게이트로 깨진 기존 fixture ~50곳을 master 부트스트랩 + actor 명시로 정렬(승인된 동작 변경의 직접 귀결, 단언 약화 없음).

## Test Plan
- 전체 `pytest tests/unit/ -q` — 7003 passed, 2 skipped
- 신규 `test_member_service_master_guard.py`: 빈 actor 거부/master ok/비-master 거부/system:* reserved 거부/일반 id 유지/**reserved guard가 existing 조회 이전**(legacy system:* seed 후 ReservedMemberIdError 우선); mutation 회귀 검출력 입증
- recovery audit actor == system:recovery(reset_password·regenerate), audit.md 갱신
- ruff/mypy clean
- Codex 브랜치 리뷰: PASS (attempt 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
