### PR TITLE
test(cli): #2309 bot_remove flaky 해소 — is_active_runtime mock + per-test gc.collect 제거

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,29 +48,33 @@ def _set_encryption_key():
 
 @pytest.fixture(autouse=True)
 def _sync_boundary_cleanup():
-    """모든 테스트(sync + async) 경계에서 결정적 GC + patch.stopall 보장.
+    """모든 테스트(sync + async) 경계에서 ``patch.stopall`` 보장.
 
     Refs #2304: 기존 ``_cleanup_tasks`` 는 ``async def`` autouse fixture 라
-    async 테스트 경계에서만 ``gc.collect()`` / ``mock.patch.stopall()`` 을
-    수행한다. 반면 sync 테스트(예: ``CliRunner.invoke`` 가 내부적으로
-    ``asyncio.run(coro)`` 을 호출하는 ``ante bot remove`` 표면)는 같은 보장
-    밖에 있어, 직전 async IPC 테스트가 누수한 ``_SelectorTransport`` /
-    ``aiosqlite.Connection`` 이 sync 테스트의 ``asyncio.run`` cleanup 또는
-    GC 단계에서 ``RuntimeError: Event loop is closed`` 로 표출되며 원래
-    ClickException(예: ``BOT_NOT_FOUND``) 을 마스킹해 ``EXECUTION_ERROR`` 로
-    오분류되는 cross-test contamination 이 발생한다(full-suite ``-n auto``
-    flaky).
+    async 테스트 경계에서만 ``mock.patch.stopall()`` 을 수행한다. 반면 sync
+    테스트(예: ``CliRunner.invoke`` 가 내부적으로 ``asyncio.run(coro)`` 을
+    호출하는 ``ante bot remove`` 표면)는 같은 보장 밖에 있어, ``patch.start()``
+    후 ``stop()`` 누락(예: ``try`` 진입 전 예외)으로 module attribute 가 mock
+    으로 영구 leak 되는 cross-test contamination 이 발생할 수 있다. 본 sync
+    autouse fixture 는 sync + async 두 경계 **모두** 에서 매 테스트 종료 직후
+    ``mock.patch.stopall()`` 을 한 번 더 수행해 그 leak 을 차단한다(idempotent —
+    ``_cleanup_tasks`` async 와 중복 호출되어도 회귀 없음).
 
-    본 sync autouse fixture 는 sync + async 두 경계 **모두** 에서 매 테스트
-    종료 직후 ``gc.collect()`` 와 ``mock.patch.stopall()`` 을 한 번 더 수행해,
-    leak source 정리(IPC fixture 명시 close)의 보강 안전망으로 작동한다.
-    비용은 테스트당 ms 급(빈 GC + idempotent stopall)으로 suite 시간에
-    유의미한 영향이 없다. ``_cleanup_tasks`` (async) 와 중복으로 호출되어도
-    둘 다 멱등하므로 회귀가 없다.
+    Refs #2309: 본 fixture 에서 매-테스트 ``gc.collect()`` 는 제거했다.
+    - ``#2304`` 의 실제 flaky(``test_cli_direct_not_found_via_remove`` 의
+      ``EXECUTION_ERROR`` 오분류)는 GC 가능한 누수가 아니라 ``bot remove`` 의
+      ``is_active_runtime()`` runtime-state 분기가 비결정적이었던 것이며, 해당
+      테스트에 ``is_active_runtime`` mock 을 추가해 결정화했다. broad
+      ``gc.collect()`` 는 이 flaky 에 무효였다.
+    - ``#2304`` transport 누수는 ``test_server_client.py`` 의 server-side
+      transport 명시 ``close()`` (source-close, ``_settle_server_side_transports``)
+      로 이미 결정적으로 해소돼 broad GC 안전망이 불필요하다.
+    - 매-테스트 ``gc.collect()`` 는 full-suite 시간을 ~2x 로 회귀시키는 고비용
+      연산이라 제거해 성능을 회복한다.
+    - async 경계의 ``gc.collect()`` 는 ``_cleanup_tasks`` (Refs #1897) 에 그대로
+      유지된다.
     """
     yield
-    # Refs #2304: 남은 transport / DB Connection 객체를 결정적으로 정리.
-    gc.collect()
     # Refs #1904 / #2304: stop-orphaned patch leak 방어 (idempotent).
     mock.patch.stopall()
 

--- a/tests/unit/test_bot_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_bot_cli_ipc_error_equivalence.py
@@ -153,7 +153,19 @@ class TestBotNotFoundEquivalence:
         async def _raise(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
             raise click_exc
 
-        with patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise):
+        # #2309: ``bot remove`` 는 ``if is_active_runtime(): ipc_send(...) else:
+        # cold-path`` 분기(bot.py:492)를 가진다. ``is_active_runtime`` 은
+        # ``get_config_dir()`` 의 PID/socket 파일 존재로 판정하므로, mock 하지
+        # 않으면 xdist 워커에서 선행 테스트가 남긴 runtime-state 에 따라 분기가
+        # 비결정적이 된다(False → cold-path → 미설정 DB → code 없는 예외 →
+        # ``EXECUTION_ERROR`` 오분류). IPC-path equivalence 를 검증하는 본
+        # 테스트는 ``is_active_runtime`` 을 ``True`` 로 고정해 결정적으로
+        # ipc_send 경로를 타게 한다(``test_bot_success_output_drift.py`` /
+        # ``test_cli_bot_treasury_ipc.py`` 의 bot_remove IPC 테스트 미러).
+        with (
+            patch("ante.cli.commands.bot.is_active_runtime", return_value=True),
+            patch("ante.cli.commands.ipc_helpers.ipc_send", new=_raise),
+        ):
             result = runner.invoke(
                 cli,
                 ["--format", "json", "bot", "remove", "missing", "--yes"],


### PR DESCRIPTION
Closes #2309

## Summary
- **진짜 root cause**: `bot_remove`(bot.py:492)만 `if is_active_runtime()`로 IPC/cold-path 분기. `is_active_runtime`(cold_path.py)은 config_dir PID/socket 파일 의존. 실패 테스트 `test_cli_direct_not_found_via_remove`가 `ipc_send`만 mock하고 `is_active_runtime`을 mock 안 해, xdist 선행 테스트 PID 오염 시 cold-path→EXECUTION_ERROR. (#2304가 transport 경고는 고쳤으나 이건 별개 runtime-state 분기.)
- **fix(test-only)**: 해당 테스트에 `patch("ante.cli.commands.bot.is_active_runtime", return_value=True)` 추가(기존 `test_bot_success_output_drift`/`test_cli_bot_treasury_ipc`의 bot_remove IPC 패턴 미러). census상 누락된 유일한 테스트. cold-path 의도 테스트(`test_bot_remove_cold_path*`, return_value=False) 보존.
- **perf 회복**: #2304가 추가한 `_sync_boundary_cleanup` 매-테스트 `gc.collect()` 제거(CI 2x 지연 원인, 실제 flaky는 runtime-state라 무효). patch.stopall·async #1897 gc는 유지. transport stress green 확인.

## Test Plan
- 회귀 입증: mock 없이 PID 부재 강제 → EXECUTION_ERROR 재현 / mock 추가 → BOT_NOT_FOUND(cold_path 미호출 assert)
- 재현순서 `-p no:randomly` 5회 + transport stress `-W error::PytestUnraisableExceptionWarning` 3회 green
- 전체 `tests/unit/ -n auto` — 6989 passed, flaky 0, suite 시간 ~22% 단축(로컬 200s→155s)
- ruff/mypy clean
- Codex 브랜치 리뷰: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
