### PR TITLE
fix(bot): #2282 account_id를 update_bot 불변 필드로 제약

### DIFF
--- a/docs/specs/bot/03-design-decisions.md
+++ b/docs/specs/bot/03-design-decisions.md
@@ -27,7 +27,7 @@ CREATED → RUNNING → STOPPING → STOPPED → DELETED
 |------|------|--------|------|
 | `bot_id` | `str` | (필수) | 고유 ID |
 | `strategy_id` | `str` | (필수) | 등록된 전략 ID (또는 파일 경로) |
-| `account_id` | `str` | (필수) | 소속 계좌 ID |
+| `account_id` | `str` | (필수) | 소속 계좌 ID. **생성 후 불변** — `update_bot`으로 변경할 수 없다(아래 `update_bot` 항목 참조) |
 | `name` | `str` | `""` | 봇 표시 이름 |
 | `interval_seconds` | `int` | `60` | `on_step()` 호출 주기 (초) |
 | `auto_restart` | `bool` | `True` | 에러 시 자동 재시작 여부 |
@@ -95,7 +95,9 @@ CREATED → RUNNING → STOPPING → STOPPED → DELETED
 | `create_bot` | `config: BotConfig, strategy_cls: type[Strategy], ctx: StrategyContext \| None = None` | `Bot` | 봇 생성. ctx가 주입되면 그대로 사용하고, None이면 context_factory로 자동 생성. 이벤트 구독 등록 + DB 저장. `accepts_external_signals=True`이면 시그널 키 자동 발급 |
 | `start_bot` | `bot_id: str` | `None` | 봇 시작. `bot.start()` 호출 |
 | `stop_bot` | `bot_id: str` | `None` | 봇 중지 |
-| `update_bot` | `bot_id: str, updates: dict` | `Bot` | 봇 설정 수정. **중지 상태에서만 가능** — RUNNING이면 `BotError` 발생. BotConfig는 frozen dataclass이므로 재생성 패턴 적용: 기존 config를 dict로 풀고 → updates 병합 → 새 BotConfig 생성 → Bot.config 교체 → DB 갱신. `budget` 키가 포함되면 `Treasury.deallocate()` + `Treasury.allocate()`로 예산 재조정. `strategy_id` 변경 시 StrategyRegistry 존재 확인 + exchange 호환성 검증 |
+| `update_bot` | `bot_id: str, updates: dict` | `Bot` | 봇 설정 수정. **중지 상태에서만 가능** — RUNNING이면 `BotError` 발생. BotConfig는 frozen dataclass이므로 재생성 패턴 적용: 기존 config를 dict로 풀고 → updates 병합 → 새 BotConfig 생성 → Bot.config 교체 → DB 갱신. `budget` 키가 포함되면 `Treasury.deallocate()` + `Treasury.allocate()`로 예산 재조정. `strategy_id` 변경 시 StrategyRegistry 존재 확인 + exchange 호환성 검증. **`account_id`는 불변 필드** — updates에 현재 값과 다른 `account_id`가 포함되면 `BotImmutableFieldError`(안정 코드 `BOT_IMMUTABLE_FIELD`, validation 카테고리) 발생. 같은 값(no-op)·미포함은 통과 |
+
+**`account_id` 불변 정책 (#2282)**: 봇의 `account_id`는 생성 후 변경할 수 없다. treasury 예산은 옛 account 아래에 할당되고, broker credential도 옛 account에 바인딩되며, 포지션 격리도 account-bound이므로, `account_id`를 변경하면 이 자원들이 새 account로 재배치되지 않아 불일치가 발생한다. 단일 사용자 홈서버에서 복잡한 re-isolation(예산 이전·credential 재바인딩·포지션 마이그레이션)을 구현하는 대신, `account_id`를 `update_bot`의 불변 필드로 제약한다(YAGNI 안전 기본). 변경이 필요하면 **봇을 삭제 후 재생성**한다. 이는 Account의 불변 필드(`exchange`/`currency`/`trading_mode`/`broker_type`, `AccountImmutableFieldError`) 정책과 정합한다([account/04-account-service.md](../account/04-account-service.md) 참조). `_save_bot_config`의 UPSERT가 `account_id` 컬럼을 갱신하는 것(#2274, create/load 경로 persistence 일관성)은 그대로 유지되며, 제약은 `update_bot` ingress에서만 적용된다.
 | `delete_bot` | `bot_id: str, handle_positions: str = "keep"` | `None` | 봇 삭제. 실행 중이면 먼저 중지. `handle_positions="liquidate"` 시 TradeService를 통해 보유 종목 시장가 매도 주문 발행 후 삭제 진행. `"keep"`(기본)은 포지션 유지한 채 봇만 삭제. 이벤트 구독 해제 + VIRTUAL 계좌 봇의 VirtualExecutor 해제 + 시그널 키 폐기 + DB 레코드 삭제. `remove_bot`은 동일 기능의 별칭(alias) |
 | `stop_all` | — | `None` | 모든 실행 중 봇 중지 + 재시작 태스크 취소. 시스템 셧다운 시 호출 |
 | `list_bots` | — | `list[dict[str, Any]]` | 봇 목록 조회 |

--- a/src/ante/bot/__init__.py
+++ b/src/ante/bot/__init__.py
@@ -11,10 +11,12 @@ from ante.bot.config import (
 from ante.bot.context_factory import StrategyContextFactory
 from ante.bot.exceptions import (
     BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE,
+    BOT_IMMUTABLE_FIELD_CODE,
     BOT_NOT_FOUND_CODE,
     BOT_STATE_CONFLICT_CODE,
     BotAccountCredentialsNotConfigured,
     BotError,
+    BotImmutableFieldError,
     BotNotFoundError,
     BotStateConflict,
 )
@@ -26,11 +28,13 @@ __all__ = [
     "BotAccountCredentialsNotConfigured",
     "BotConfig",
     "BotError",
+    "BotImmutableFieldError",
     "BotNotFoundError",
     "BotStateConflict",
     "BotManager",
     "BotStatus",
     "BOT_ACCOUNT_CREDENTIALS_NOT_CONFIGURED_CODE",
+    "BOT_IMMUTABLE_FIELD_CODE",
     "BOT_NOT_FOUND_CODE",
     "BOT_STATE_CONFLICT_CODE",
     "MAX_INTERVAL_SECONDS",

--- a/src/ante/bot/exceptions.py
+++ b/src/ante/bot/exceptions.py
@@ -14,6 +14,7 @@ BOT_STATE_CONFLICT_CODE = "BOT_STATE_CONFLICT"
 BOT_NOT_ACCEPTING_SIGNALS_CODE = "BOT_NOT_ACCEPTING_SIGNALS"
 BOT_ALREADY_EXISTS_CODE = "BOT_ALREADY_EXISTS"
 BOT_STRATEGY_ALREADY_RUNNING_CODE = "BOT_STRATEGY_ALREADY_RUNNING"
+BOT_IMMUTABLE_FIELD_CODE = "BOT_IMMUTABLE_FIELD"
 
 
 class BotError(Exception):
@@ -89,3 +90,23 @@ class BotStrategyAlreadyRunningError(BotError):
     """
 
     code: str = BOT_STRATEGY_ALREADY_RUNNING_CODE
+
+
+class BotImmutableFieldError(BotError):
+    """봇 생성 후 변경할 수 없는 불변 필드 수정 시도 (#2282).
+
+    ``account_id`` 는 봇이 참조하는 treasury 예산·broker credential·포지션
+    격리가 모두 **account-bound** 라, ``update_bot`` 으로 변경하면 옛 account
+    아래의 예산/credential/포지션이 새 account 로 재배치되지 않아 불일치가
+    발생한다. 복잡한 re-isolation 대신 ``account_id`` 를 ``update_bot`` 의
+    불변 필드로 제약하고, 변경이 필요하면 봇을 삭제 후 재생성하도록 안내한다
+    (Account.update 의 ``AccountImmutableFieldError`` 선례 미러).
+
+    클래스 레벨 ``code`` 속성은 IPC ``server.py`` 의
+    ``getattr(e, "code", ...)`` 가 안정 코드 ``BOT_IMMUTABLE_FIELD`` 로
+    변환하도록 한다. ``bot.update`` handler 의 ``except BotError: raise`` 가
+    ``BotError`` 서브클래스인 본 예외를 그대로 surface 하므로 IPC/CLI 표면이
+    동일 코드를 노출한다.
+    """
+
+    code: str = BOT_IMMUTABLE_FIELD_CODE

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -20,6 +20,7 @@ from ante.bot.config import (
 from ante.bot.exceptions import (
     BotAlreadyExistsError,
     BotError,
+    BotImmutableFieldError,
     BotNotAcceptingSignals,
     BotNotFoundError,
     BotStateConflict,
@@ -494,6 +495,27 @@ class BotManager:
 
             if not updates and new_budget is None:
                 return bot
+
+            # account_id 불변 가드 (#2282).
+            # ``account_id`` 는 treasury 예산(옛 account 할당)·broker
+            # credential(옛 account 바인딩)·포지션 격리가 모두 **account-bound**
+            # 라, ``update_bot`` 으로 바꾸면 옛 account 아래 예산/credential/
+            # 포지션이 새 account 로 재배치되지 않아 불일치가 발생한다 (#2274 가
+            # account_id 컬럼 drift 를 고치며 변경이 실제 persist 되도록 만들면서
+            # 표면화). 복잡한 re-isolation 대신 ``account_id`` 를 불변 필드로
+            # 제약하고 변경 시 typed error 로 거부한다 (Account.update 의
+            # ``AccountImmutableFieldError`` 선례 미러). 같은 값(no-op)·미포함은
+            # 통과한다. 가드는 status 검증 직후, effective_account_id 로 strategy
+            # 검증/BotConfig 재생성 이전에 둔다 — 다른 필드(name/budget/
+            # strategy_id 등) 변경은 영향받지 않는다.
+            new_account_id = updates.get("account_id")
+            if new_account_id is not None and new_account_id != bot.config.account_id:
+                raise BotImmutableFieldError(
+                    "account_id 는 생성 후 변경할 수 없습니다 (treasury 예산·"
+                    "broker credential·포지션이 account-bound). 변경하려면 봇을 "
+                    f"삭제 후 재생성하세요: {bot_id} "
+                    f"(현재: {bot.config.account_id}, 요청: {new_account_id})"
+                )
 
             # strategy_id 변경 검증 (#2129).
             # ``bot.config`` 교체 + DB 저장(``_save_bot_config``) 전에

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -109,6 +109,14 @@ mirror, ``BotNotFoundError`` 는 #1840 lock 그대로 보존):
 - ``BotStrategyAlreadyRunningError`` → ``BOT_STRATEGY_ALREADY_RUNNING`` /
   ``state_conflict`` (#1800; "1전략 1봇" 정책 거부)
 
+#2282 가 추가한 bot 불변 필드 lock (Account ``AccountImmutableFieldError`` 선례
+미러):
+
+- ``BotImmutableFieldError`` → ``BOT_IMMUTABLE_FIELD`` / ``validation``
+  (#2282; ``update_bot`` 의 ``account_id`` 변경 거부 — treasury 예산·broker
+  credential·포지션이 account-bound 라 생성 후 불변. ``ACCOUNT_IMMUTABLE_FIELD``
+  / ``validation`` 동형 분류)
+
 ``BotError`` base 는 의도적으로 등록하지 않는다 — 사용 사례가 없으며
 ``pending_migration`` allowlist 에 baseline 으로 그대로 유지된다 (#1842
 ``AccountError`` 와 동일 패턴, #1843 sub-PR 3 Non-Goals).
@@ -231,6 +239,7 @@ from ante.approval.models import ApprovalValidationError
 from ante.bot.exceptions import (
     BotAccountCredentialsNotConfigured,
     BotAlreadyExistsError,
+    BotImmutableFieldError,
     BotNotAcceptingSignals,
     BotNotFoundError,
     BotStateConflict,
@@ -510,6 +519,14 @@ _BOT_ALREADY_EXISTS_SPEC: Final[ErrorSpec] = ErrorSpec(
 _BOT_STRATEGY_ALREADY_RUNNING_SPEC: Final[ErrorSpec] = ErrorSpec(
     code="BOT_STRATEGY_ALREADY_RUNNING",
     category="state_conflict",
+)
+
+# ``update_bot`` 의 ``account_id`` 변경 거부 (#2282). treasury 예산·broker
+# credential·포지션이 account-bound 라 생성 후 불변 — 입력 계약 위반이므로
+# Account ``ACCOUNT_IMMUTABLE_FIELD`` 와 동형으로 ``validation`` 카테고리.
+_BOT_IMMUTABLE_FIELD_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BOT_IMMUTABLE_FIELD",
+    category="validation",
 )
 
 
@@ -797,6 +814,8 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     BotNotAcceptingSignals: _BOT_NOT_ACCEPTING_SIGNALS_SPEC,
     BotAlreadyExistsError: _BOT_ALREADY_EXISTS_SPEC,
     BotStrategyAlreadyRunningError: _BOT_STRATEGY_ALREADY_RUNNING_SPEC,
+    # ── #2282 bot account_id 불변 lock (Account 선례 미러) ────────────────
+    BotImmutableFieldError: _BOT_IMMUTABLE_FIELD_SPEC,
     # ── #1843 sub-PR 4 treasury 7 sub-class (실측 .code mirror) ───────────
     TreasuryInvalidAmountError: _TREASURY_INVALID_AMOUNT_SPEC,
     TreasuryInsufficientUnallocatedError: _TREASURY_INSUFFICIENT_BALANCE_SPEC,

--- a/tests/unit/test_bot_cli_ipc_error_equivalence.py
+++ b/tests/unit/test_bot_cli_ipc_error_equivalence.py
@@ -19,6 +19,10 @@
   ``bot create`` 표면 중복 등록 거부, 실제 ``bot.create`` IPC handler 회귀)
 - ``BotStrategyAlreadyRunningError`` → ``BOT_STRATEGY_ALREADY_RUNNING``
   (state_conflict; ``bot create`` 표면 "1전략 1봇" 정책 거부)
+- ``BotImmutableFieldError`` → ``BOT_IMMUTABLE_FIELD`` (validation; #2282
+  ``bot.update`` 표면 ``account_id`` 변경 거부 — treasury 예산·broker
+  credential·포지션이 account-bound 라 생성 후 불변. 실제 ``bot.update`` IPC
+  handler 회귀로 envelope code surface 확인)
 
 bot CLI 의 mutating 표면 (``create``/``remove``/``start``/``stop``/``status``)
 은 모두 ``ipc_send`` 경유이므로 CLI direct path equivalence 는 ``ipc_send``
@@ -49,6 +53,7 @@ from click.testing import CliRunner
 from ante.bot.exceptions import (
     BotAccountCredentialsNotConfigured,
     BotAlreadyExistsError,
+    BotImmutableFieldError,
     BotNotAcceptingSignals,
     BotNotFoundError,
     BotStateConflict,
@@ -471,3 +476,82 @@ class TestBotStrategyAlreadyRunningEquivalence:
             "전략 s1 은 이미 실행 중인 다른 봇이 사용 중입니다"
         )
         assert _ipc_envelope_code(exc) == "BOT_STRATEGY_ALREADY_RUNNING"
+
+
+# ── (7) BotImmutableFieldError ↔ BOT_IMMUTABLE_FIELD (update) ───────────────
+
+
+class TestBotImmutableFieldEquivalence:
+    """``BotImmutableFieldError`` 는 양쪽에서 ``BOT_IMMUTABLE_FIELD`` (#2282).
+
+    CLI direct path: ``bot update`` 표면 — ``ipc_send`` 가 server error
+    envelope (code=``BOT_IMMUTABLE_FIELD``) 을 ClickException 으로 변환하고
+    CLI middleware 분기가 동일 코드를 surface 한다. registry MRO lookup 으로
+    ``BotImmutableFieldError`` → ``BOT_IMMUTABLE_FIELD`` resolve.
+
+    IPC path: 실제 ``bot.update`` IPC handler 를 ``IPCServer`` 위에서 실행해
+    ``account_id`` 변경 요청이 envelope code 로 거부됨을 확인한다 (#1842
+    ``account.suspend`` / ``bot.create`` 1:1 동형 회귀 lock).
+    """
+
+    def test_ipc_envelope_immutable_field(self) -> None:
+        exc = BotImmutableFieldError("account_id 는 생성 후 변경할 수 없습니다")
+        assert _ipc_envelope_code(exc) == "BOT_IMMUTABLE_FIELD"
+
+    @pytest.mark.asyncio
+    async def test_ipc_envelope_immutable_field_via_real_handler(self) -> None:
+        """실제 ``bot.update`` IPC handler 가 ``account_id`` 변경 거부 코드를
+        envelope 으로 surface 한다 (#2282; ``bot.create`` 1:1 동형 회귀 lock).
+
+        handler 는 ``svc.bot_manager.get_bot`` 으로 봇 존재를 먼저 확인한 뒤
+        ``update_bot`` 을 호출하므로, ``get_bot`` 은 봇을 돌려주고 ``update_bot``
+        이 ``BotImmutableFieldError`` 를 raise 하도록 mock 한다. handler 의
+        ``except BotError: raise`` 가 typed 예외를 그대로 propagate 하고 IPC
+        server 가 ``getattr(e, "code", ...)`` 로 ``BOT_IMMUTABLE_FIELD`` envelope
+        을 생성한다.
+        """
+
+        td = tempfile.mkdtemp(prefix="ipc_bot_immutable", dir="/tmp")
+        socket_path = str(Path(td) / "t.sock")
+
+        bot_manager = MagicMock()
+        bot_manager.get_bot = MagicMock(return_value=MagicMock())
+        bot_manager.update_bot = AsyncMock(
+            side_effect=BotImmutableFieldError(
+                "account_id 는 생성 후 변경할 수 없습니다: bot-1"
+            )
+        )
+
+        audit_logger = MagicMock()
+        audit_logger.log = AsyncMock(return_value=None)
+        svc_registry = ServiceRegistry(
+            account=MagicMock(),
+            bot_manager=bot_manager,
+            treasury_manager=MagicMock(),
+            dynamic_config=MagicMock(),
+            approval=MagicMock(),
+            reconciler=MagicMock(),
+            eventbus=MagicMock(),
+            member_service=MagicMock(),
+            strategy_registry=MagicMock(),
+            audit_logger=audit_logger,
+        )
+        cmd_registry = CommandRegistry()
+        register_all_handlers(cmd_registry)
+
+        server = IPCServer(socket_path, svc_registry, cmd_registry)
+        await server.start()
+        try:
+            client = IPCClient(socket_path, timeout=5.0)
+            response = await client.send(
+                "bot.update",
+                {
+                    "bot_id": "bot-1",
+                    "updates": {"account_id": "acc-new"},
+                },
+                actor="tester",
+            )
+            assert response["status"] == "error"
+            assert response["error"]["code"] == "BOT_IMMUTABLE_FIELD"
+        finally:
+            await server.stop()

--- a/tests/unit/test_bot_manager_update_bot_atomicity.py
+++ b/tests/unit/test_bot_manager_update_bot_atomicity.py
@@ -15,8 +15,9 @@ import logging
 
 import pytest
 
-from ante.bot import BotConfig, BotManager
+from ante.bot import BotConfig, BotImmutableFieldError, BotManager
 from ante.bot.config import BotStatus
+from ante.bot.exceptions import BOT_IMMUTABLE_FIELD_CODE
 from ante.core import Database
 from ante.eventbus import EventBus
 from ante.strategy import (
@@ -297,26 +298,25 @@ class TestUpdateBotBudgetRollback:
         assert bot.config.interval_seconds == 60
         assert await _read_db_interval(db, bot_id) == 60
 
-    async def test_update_bot_account_id_change_rolls_back_to_old_on_failure(
+    async def test_update_bot_account_id_change_rejected_before_budget(
         self, eventbus, db, ctx
     ) -> None:
-        """#2274: account_id 를 함께 바꾼 update 가 budget 실패로 rollback 되면
-        ``bots.account_id`` 컬럼·config_json 둘 다 옛 account_id 로 복원된다.
+        """#2282: account_id 를 다른 값으로 바꾸려는 update 는 budget 처리/
+        rollback 경로에 도달하기 전에 ``BotImmutableFieldError`` 로 거부된다.
 
-        #2274 가 UPSERT 에 ``account_id = excluded.account_id`` 를 추가한 뒤,
-        rollback 의 ``_save_bot_config(old_config)`` 가 컬럼·config_json 을 모두
-        옛 ``old_config.account_id`` 로 되돌리는지(stale 신 account_id 가 남지
-        않는지) 확인하는 회귀 가드.
-
-        treasury 는 새(effective) account_id 로 조회되므로 새 account 에 raising
-        treasury 를 등록해 ``update_budget`` 까지 진입 후 raise 시킨다.
+        #2274 가 account_id 변경을 실제 persist 되게 만들면서 treasury 예산·
+        broker credential·포지션이 account-bound 라 재배치 안 되는 불일치가
+        표면화됐고, #2282 가 ``account_id`` 를 ``update_bot`` 의 불변 필드로
+        제약했다. 가드는 budget(treasury) 처리보다 먼저 평가되므로,
+        ``update_budget`` 은 호출되지 않고 컬럼·config_json·memory 모두
+        미변경이어야 한다.
         """
 
         class _BoomError(RuntimeError):
             pass
 
         raising_treasury = _RaisingTreasury(_BoomError("boom"))
-        # budget 처리는 new_config.account_id(='acc-new') 로 treasury 를 조회한다.
+        # account_id 가 거부되므로 treasury 는 어느 account 로도 진입하지 않는다.
         tm = _RaisingTreasuryManager("acc-new", raising_treasury)
 
         manager = BotManager(eventbus=eventbus, db=db, treasury_manager=tm)
@@ -329,18 +329,17 @@ class TestUpdateBotBudgetRollback:
         acc_col, acc_cfg = await _read_db_account_ids(db, bot_id)
         assert acc_col == "acc-old" == acc_cfg
 
-        with pytest.raises(_BoomError):
+        with pytest.raises(BotImmutableFieldError) as exc_info:
             await manager.update_bot(bot_id, account_id="acc-new", budget=100_000.0)
+        assert exc_info.value.code == BOT_IMMUTABLE_FIELD_CODE
 
-        # update_budget 은 새 account_id 의 treasury 로 진입했어야 한다.
-        assert raising_treasury.update_budget_calls == [(bot_id, 100_000.0)]
+        # account_id 가 budget 처리 이전에 거부되므로 update_budget 미호출.
+        assert raising_treasury.update_budget_calls == []
 
         bot = manager.get_bot(bot_id)
         assert bot is not None
-        # memory rollback: 옛 account_id 로 복원.
+        # memory·DB(컬럼·config_json) 모두 옛 account_id 로 미변경.
         assert bot.config.account_id == "acc-old"
-        # DB rollback: 컬럼·config_json 둘 다 옛 account_id 로 복원되고
-        # 신 account_id("acc-new") 가 stale 로 남지 않는다.
         acc_col, acc_cfg = await _read_db_account_ids(db, bot_id)
         assert acc_col == "acc-old"
         assert acc_cfg == "acc-old"

--- a/tests/unit/test_bot_strategy_consistency.py
+++ b/tests/unit/test_bot_strategy_consistency.py
@@ -15,7 +15,8 @@ import json
 import pytest
 
 from ante.account.models import Account, AccountStatus
-from ante.bot import BotConfig, BotManager, BotStatus
+from ante.bot import BotConfig, BotImmutableFieldError, BotManager, BotStatus
+from ante.bot.exceptions import BOT_IMMUTABLE_FIELD_CODE
 from ante.core import Database
 from ante.eventbus import EventBus
 from ante.strategy import (
@@ -345,23 +346,28 @@ class TestUpdateBotStrategyConsistency:
 # ── account_id + strategy_id 동시 변경 → effective(새) 계좌로 검증 (브랜치 리뷰) ──
 
 
-class TestUpdateBotEffectiveAccountValidation:
-    """#2129 브랜치 리뷰: account_id 와 strategy_id 동시 변경 시 새 전략의
-    exchange 호환을 **옛 계좌가 아닌 새(effective) 계좌**로 검증한다.
+class TestUpdateBotAccountIdImmutableVsStrategy:
+    """#2282: ``account_id`` 는 ``update_bot`` 의 불변 필드다. 가드는 strategy
+    검증/BotConfig 재생성보다 **먼저** 평가되므로, account_id 변경을 동반한
+    요청은 strategy 호환성 검증에 도달하기 전에 ``BotImmutableFieldError`` 로
+    거부된다.
 
-    수정 전에는 ``_validate_strategy_change(old_config.account_id, ...)`` 로
-    옛 계좌를 사용해, 새 계좌에 비호환 전략이 commit 될 수 있었다.
+    #2129 가 도입했던 "account_id+strategy_id 동시 변경 시 effective(새) 계좌로
+    strategy 검증" 시나리오는 account_id 가 불변이 되면서 더 이상 발생할 수
+    없다(account_id 변경 자체가 먼저 거부). 따라서 strategy 검증은 항상
+    ``old_config.account_id`` 로 수행된다. 본 클래스는 (1) account_id 동반
+    변경이 strategy 검증 이전에 거부되는지, (2) account_id 를 바꾸지 않는
+    strategy 변경은 무회귀로 동작하는지 검증한다.
     """
 
-    async def test_simultaneous_change_compatible_with_new_account_persists_both(
+    async def test_simultaneous_account_and_strategy_change_rejected_before_validation(
         self, manager_with_account, account_service, ctx, db, tmp_path
     ):
-        """(a) 새 strategy 가 **새 계좌(NASDAQ)** exchange 와 호환 → 통과·둘 다 저장.
+        """(a) account_id + strategy_id 동시 변경 → strategy 검증 이전에 거부.
 
-        봇은 KRX 계좌(acc-test)에서 시작하지만, 한 요청으로 account_id 를
-        NASDAQ 계좌(acc-nasdaq)로, strategy 를 NASDAQ 전략으로 동시에 바꾼다.
-        새 전략은 옛 계좌(KRX)와는 비호환이지만 effective(새, NASDAQ) 계좌와는
-        호환이므로 통과해야 한다.
+        새 전략(NASDAQ)이 옛 계좌(KRX)와는 비호환이지만, account_id 불변 가드가
+        strategy 검증보다 먼저 평가되므로 ``IncompatibleExchangeError`` 가 아니라
+        ``BotImmutableFieldError`` 로 거부된다. 옛·새 store 모두 미변경이어야 한다.
         """
         await _make_krx_account(account_service)
         await _make_nasdaq_account(account_service)
@@ -371,80 +377,91 @@ class TestUpdateBotEffectiveAccountValidation:
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager_with_account.create_bot(config, SimpleStrategy, ctx)
 
-        bot = await manager_with_account.update_bot(
-            "bot1", account_id="acc-nasdaq", strategy_id=nasdaq_sid
-        )
+        with pytest.raises(BotImmutableFieldError) as exc_info:
+            await manager_with_account.update_bot(
+                "bot1", account_id="acc-nasdaq", strategy_id=nasdaq_sid
+            )
+        assert exc_info.value.code == BOT_IMMUTABLE_FIELD_CODE
 
-        # effective(새, NASDAQ) 계좌로 검증을 통과해 둘 다 새 값으로 commit.
-        # account_id 는 memory config 와 config_json 에 새 값으로 직렬화된다.
-        # #2274 수정 이후 ``bots.account_id`` 컬럼도 UPSERT 가 함께 갱신하므로
-        # 컬럼·config_json 둘 다 새 값으로 일관된다.
-        assert bot.config.account_id == "acc-nasdaq"
-        assert bot.config.strategy_id == nasdaq_sid
+        # 거부 후 memory config·DB(컬럼·config_json) 모두 옛 값 유지.
+        bot = manager_with_account.get_bot("bot1")
+        assert bot.config.strategy_id == "s1"
+        assert bot.config.account_id == "acc-test"
         col, cfg = await _row_strategy_ids(db, "bot1")
-        assert col == nasdaq_sid == cfg
+        assert col == "s1" == cfg
         acc_col, acc_cfg = await _row_account_ids(db, "bot1")
-        assert acc_col == "acc-nasdaq" == acc_cfg
+        assert acc_col == "acc-test" == acc_cfg
 
-    async def test_simultaneous_change_incompatible_with_new_account_raises(
+    async def test_strategy_change_same_account_still_validated_and_persisted(
         self, manager_with_account, account_service, ctx, db, tmp_path
     ):
-        """(b) 새 strategy 가 **새 계좌(NASDAQ)** exchange 와 비호환 → raise·미변경.
+        """(b) account_id 미변경 strategy 변경 → effective(=옛) 계좌로 검증·persist.
 
-        봇은 KRX 계좌에서 시작. 한 요청으로 account_id 를 NASDAQ 계좌로,
-        strategy 를 KRX 전략으로 동시에 바꾼다. KRX 전략은 옛 계좌(KRX)와는
-        호환이지만 effective(새, NASDAQ) 계좌와는 비호환이므로, effective
-        계좌로 검증하면 raise 되어야 한다 (옛 계좌로 검증하면 잘못 통과).
-
-        검증은 swap/DB 저장 전이므로 옛·새 store 모두 미변경이어야 한다.
+        account_id 를 바꾸지 않으므로 불변 가드를 통과하고, strategy 호환성
+        검증(옛 계좌=KRX)이 정상 수행되어 KRX 호환 전략으로 교체된다. account_id
+        는 무회귀로 옛 값을 유지한다.
         """
         await _make_krx_account(account_service)
-        await _make_nasdaq_account(account_service)
         krx_sid = await _register_strategy(
             db, _KRX_STRATEGY_SOURCE, "krx_compat", "1.0.0", tmp_path
         )
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager_with_account.create_bot(config, SimpleStrategy, ctx)
 
-        with pytest.raises(IncompatibleExchangeError):
-            await manager_with_account.update_bot(
-                "bot1", account_id="acc-nasdaq", strategy_id=krx_sid
-            )
+        bot = await manager_with_account.update_bot("bot1", strategy_id=krx_sid)
 
-        # swap/저장 전 raise: memory config 와 DB(컬럼·config_json·account_id)
-        # 모두 옛 값 유지.
-        bot = manager_with_account.get_bot("bot1")
-        assert bot.config.strategy_id == "s1"
+        assert bot.config.strategy_id == krx_sid
         assert bot.config.account_id == "acc-test"
         col, cfg = await _row_strategy_ids(db, "bot1")
-        assert col == "s1" == cfg
-        row = await db.fetch_one(
-            "SELECT account_id FROM bots WHERE bot_id = ?", ("bot1",)
-        )
-        assert row["account_id"] == "acc-test"
+        assert col == krx_sid == cfg
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        assert acc_col == "acc-test" == acc_cfg
 
-    async def test_account_only_change_does_not_trigger_validation(
+    async def test_account_id_noop_same_value_passes(
         self, manager_with_account, account_service, ctx, db
     ):
-        """(c) account_id 만 바꾸고 strategy 동일 → 전략 검증 미트리거.
+        """(c) account_id 를 같은 값으로 포함 → no-op 통과(거부 아님).
 
-        ``s1`` 은 registry 에 등록되지 않았지만, strategy_id 가 그대로이므로
-        검증이 트리거되지 않아 account_id-only update 가 성공해야 한다.
+        updates 에 ``account_id`` 가 현재와 동일하게 포함되어도 변경이 아니므로
+        불변 가드를 통과한다. ``s1`` 은 미등록이지만 strategy_id 가 그대로라
+        검증이 트리거되지 않아 raise 없이 성공한다.
+        """
+        await _make_krx_account(account_service)
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", name="old", account_id="acc-test"
+        )
+        await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager_with_account.update_bot(
+            "bot1", account_id="acc-test", name="new"
+        )
+
+        assert bot.config.account_id == "acc-test"
+        assert bot.config.name == "new"
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        assert acc_col == "acc-test" == acc_cfg
+
+    async def test_account_only_change_to_different_value_rejected(
+        self, manager_with_account, account_service, ctx, db
+    ):
+        """(d) account_id 만 다른 값으로 변경 → ``BotImmutableFieldError`` 거부.
+
+        strategy_id 가 그대로라 strategy 검증은 트리거되지 않지만, account_id
+        불변 가드가 다른 값으로의 변경을 거부한다. memory·DB 모두 미변경.
         """
         await _make_krx_account(account_service)
         await _make_krx_account(account_service, account_id="acc-test2")
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager_with_account.create_bot(config, SimpleStrategy, ctx)
 
-        bot = await manager_with_account.update_bot("bot1", account_id="acc-test2")
+        with pytest.raises(BotImmutableFieldError) as exc_info:
+            await manager_with_account.update_bot("bot1", account_id="acc-test2")
+        assert exc_info.value.code == BOT_IMMUTABLE_FIELD_CODE
 
-        # strategy 검증 미트리거 → 미등록 ``s1`` 에도 raise 없이 성공.
-        # account_id 는 memory config + config_json + 컬럼에 새 값으로 반영된다
-        # (#2274: UPSERT 가 account_id 컬럼도 갱신).
-        assert bot.config.account_id == "acc-test2"
-        assert bot.config.strategy_id == "s1"
+        bot = manager_with_account.get_bot("bot1")
+        assert bot.config.account_id == "acc-test"
         acc_col, acc_cfg = await _row_account_ids(db, "bot1")
-        assert acc_col == "acc-test2" == acc_cfg
+        assert acc_col == "acc-test" == acc_cfg
 
 
 # ── (d)(e) assign_strategy / change_strategy 일관성 ──────────────
@@ -672,23 +689,27 @@ class TestReloadConsistency:
 
 
 class TestUpdateBotAccountConsistency:
-    """#2274 (#2129/#2130 동형): ``update_bot(account_id=...)`` 가
-    ``bots.account_id`` 컬럼과 ``config_json.account_id`` 를 항상 동일하게
-    갱신하는지, 재시작(``load_from_db``) 시 새 account_id 로 복원되는지 검증한다.
+    """#2282 (#2274 후속): ``account_id`` 는 ``update_bot`` 의 불변 필드다.
+    다른 값으로의 변경은 ``BotImmutableFieldError`` 로 거부된다.
 
-    수정 전에는 ``_save_bot_config`` 의 ``ON CONFLICT DO UPDATE SET`` 에
-    ``account_id`` 컬럼이 빠져 있어, ``update_bot`` 으로 account_id 를 바꿔도
-    컬럼이 stale 하게 옛 값으로 남고, ``load_from_db`` 가 컬럼을 읽어 재시작 시
-    옛 account_id 로 복원되는 drift 가 있었다.
+    #2274 가 ``_save_bot_config`` 의 ``ON CONFLICT DO UPDATE SET`` 에
+    ``account_id = excluded.account_id`` 를 추가해 컬럼 drift 를 고쳤고, 그
+    결과 ``update_bot`` 으로 account_id 를 바꾸면 재시작 시 실제로 복원되며
+    treasury 예산·broker credential·포지션이 재배치되지 않는 불일치가 표면화됐다
+    (#2282). 정책 결정: ``account_id`` 를 불변 필드로 제약(Account.update 선례
+    미러). 단, ``_save_bot_config`` 의 ``account_id = excluded`` UPSERT 자체는
+    create/load·내부 persistence(change_strategy 등) 경로의 컬럼↔config_json
+    일관성을 위해 그대로 유지된다 — 제약은 ``update_bot`` ingress 에서만 적용.
     """
 
-    async def test_update_account_id_updates_column_not_stale(
+    async def test_update_account_id_to_different_value_rejected(
         self, manager_with_account, account_service, ctx, db
     ):
-        """(a) update_bot(account_id=new) → 컬럼·config_json 둘 다 new(stale 아님).
+        """(a) update_bot(account_id=other) → ``BotImmutableFieldError`` 거부.
 
-        strategy_id 는 그대로(미등록 ``s1``)라 전략 검증을 트리거하지 않으므로
-        account_id-only 변경만 검증한다.
+        strategy_id 는 그대로(미등록 ``s1``)라 전략 검증을 트리거하지 않지만,
+        account_id 불변 가드가 다른 값으로의 변경을 거부한다. 컬럼·config_json
+        모두 옛 값으로 미변경이어야 한다.
         """
         await _make_krx_account(account_service)
         await _make_krx_account(account_service, account_id="acc-new")
@@ -699,30 +720,40 @@ class TestUpdateBotAccountConsistency:
         acc_col, acc_cfg = await _row_account_ids(db, "bot1")
         assert acc_col == "acc-test" == acc_cfg
 
-        bot = await manager_with_account.update_bot("bot1", account_id="acc-new")
+        with pytest.raises(BotImmutableFieldError) as exc_info:
+            await manager_with_account.update_bot("bot1", account_id="acc-new")
+        assert exc_info.value.code == BOT_IMMUTABLE_FIELD_CODE
 
-        assert bot.config.account_id == "acc-new"
+        # 거부 후 memory·컬럼·config_json 모두 옛 값 미변경.
+        bot = manager_with_account.get_bot("bot1")
+        assert bot.config.account_id == "acc-test"
         acc_col, acc_cfg = await _row_account_ids(db, "bot1")
-        # 컬럼이 stale("acc-test") 로 남지 않고 새 값으로 갱신되어야 한다.
-        assert acc_col == "acc-new"
-        assert acc_cfg == "acc-new"
+        assert acc_col == "acc-test" == acc_cfg
 
-    async def test_update_account_id_then_reload_restores_new(
+    async def test_save_bot_config_upsert_preserves_account_id_on_internal_persist(
         self, manager_with_account, account_service, eventbus, ctx, db
     ):
-        """(b) account_id 변경 후 새 매니저로 load_from_db → 새 account_id 복원.
+        """(b) #2274 무회귀: ``_save_bot_config`` UPSERT(account_id=excluded) 가
+        내부 persistence 경로(change_strategy)에서 account_id 컬럼↔config_json
+        일관성을 유지하고, 재시작(load_from_db) 시 그대로 복원된다.
 
-        ``load_from_db`` 는 ``bots.account_id`` 컬럼에서 account_id 를 읽으므로,
-        UPSERT 가 컬럼을 갱신하지 않으면 재시작 시 옛 값으로 복원되는 drift 가
-        발생한다. 컬럼이 갱신되면 재로드된 config 가 새 account_id 여야 한다.
+        account_id 변경은 ``update_bot`` 에서 거부되지만, ``account_id =
+        excluded.account_id`` UPSERT 자체는 create/내부 persistence 경로에서
+        유지되어야 한다(#2282 stop condition). change_strategy 는 account_id 를
+        바꾸지 않은 채 ``_save_bot_config`` 를 다시 호출하므로, UPSERT 가
+        account_id 컬럼을 같은 값으로 일관되게 보존하는지 검증한다.
         """
         await _make_krx_account(account_service)
-        await _make_krx_account(account_service, account_id="acc-new")
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager_with_account.create_bot(config, SimpleStrategy, ctx)
-        await manager_with_account.update_bot("bot1", account_id="acc-new")
 
-        # 재시작 시뮬레이션: 새 매니저로 DB 에서 재로드.
+        # 내부 persistence 경로(account_id 미변경)로 _save_bot_config 재호출.
+        await manager_with_account.change_strategy("bot1", "s2")
+
+        acc_col, acc_cfg = await _row_account_ids(db, "bot1")
+        assert acc_col == "acc-test" == acc_cfg
+
+        # 재시작 시뮬레이션: 새 매니저로 DB 에서 재로드 → account_id 복원.
         manager2 = BotManager(eventbus=eventbus, db=db)
         await manager2.initialize()
         count = await manager2.load_from_db()
@@ -730,17 +761,16 @@ class TestUpdateBotAccountConsistency:
 
         reloaded = manager2.get_bot("bot1")
         acc_col, acc_cfg = await _row_account_ids(db, "bot1")
-        # 옛 account_id("acc-test") 로 복원되지 않고 새 값이어야 한다.
-        assert reloaded.config.account_id == acc_col == acc_cfg == "acc-new"
+        assert reloaded.config.account_id == acc_col == acc_cfg == "acc-test"
 
-    async def test_simultaneous_strategy_and_account_change_persists_both(
+    async def test_simultaneous_strategy_and_account_change_rejected(
         self, manager_with_account, account_service, ctx, db, tmp_path
     ):
-        """(c) strategy_id + account_id 동시 변경 → 둘 다 컬럼·config_json persist.
+        """(c) strategy_id + account_id 동시 변경 → account_id 불변 가드가 먼저 거부.
 
-        #2129/#2130 회귀 보존: 새 전략은 새(effective, NASDAQ) 계좌와 호환이므로
-        검증을 통과하고, strategy_id·account_id 컬럼과 config_json 이 모두 새
-        값으로 일관되게 commit 되어야 한다.
+        account_id 불변 가드가 strategy 검증보다 먼저 평가되므로, 새 전략의
+        호환성과 무관하게 ``BotImmutableFieldError`` 로 거부된다. strategy_id·
+        account_id 컬럼·config_json 모두 옛 값으로 미변경이어야 한다.
         """
         await _make_krx_account(account_service)
         await _make_nasdaq_account(account_service)
@@ -750,16 +780,19 @@ class TestUpdateBotAccountConsistency:
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager_with_account.create_bot(config, SimpleStrategy, ctx)
 
-        bot = await manager_with_account.update_bot(
-            "bot1", account_id="acc-nasdaq", strategy_id=nasdaq_sid
-        )
+        with pytest.raises(BotImmutableFieldError) as exc_info:
+            await manager_with_account.update_bot(
+                "bot1", account_id="acc-nasdaq", strategy_id=nasdaq_sid
+            )
+        assert exc_info.value.code == BOT_IMMUTABLE_FIELD_CODE
 
-        assert bot.config.strategy_id == nasdaq_sid
-        assert bot.config.account_id == "acc-nasdaq"
+        bot = manager_with_account.get_bot("bot1")
+        assert bot.config.strategy_id == "s1"
+        assert bot.config.account_id == "acc-test"
         sid_col, sid_cfg = await _row_strategy_ids(db, "bot1")
-        assert sid_col == nasdaq_sid == sid_cfg
+        assert sid_col == "s1" == sid_cfg
         acc_col, acc_cfg = await _row_account_ids(db, "bot1")
-        assert acc_col == "acc-nasdaq" == acc_cfg
+        assert acc_col == "acc-test" == acc_cfg
 
     async def test_update_without_account_change_is_noop_on_account_column(
         self, manager_with_account, account_service, ctx, db


### PR DESCRIPTION
Closes #2282

## Summary
- #2274가 bot account_id 변경을 실제 persist되게 하면서, update_bot(account_id 변경) 시 treasury 예산·broker credential·포지션 격리가 재배치 안 되는 불일치가 표면화. **정책: account_id를 update_bot 불변 필드로 제약**(복잡한 re-isolation 대신 YAGNI 안전기본; Account.update 불변필드(`AccountImmutableFieldError`) 선례 미러).
- `update_bot`이 status(중지) 검증 직후·BotConfig 재생성 이전에 account_id 변경(다른 값)을 `BotImmutableFieldError`(code `BOT_IMMUTABLE_FIELD`, BotError 서브) 거부. 같은 값(no-op)·미포함은 통과. delete+recreate 안내.
- error_registry 등록(안정 코드 surface), bot/03-design-decisions.md에 account_id 생성 후 불변 정책 명시. #2274의 account_id-change-persist 기대 테스트를 '변경 거부' 회귀로 전환, `_save_bot_config` UPSERT(create/load persistence)는 유지.

## Test Plan
- account_id 다른값 → BotImmutableFieldError(IPC envelope 코드까지 락); 같은값/미포함 → 통과; name/budget/strategy_id 무회귀; budget TreasuryManager 경로 무회귀; #2274 UPSERT 무회귀
- 전체 `pytest tests/unit/ -q` — 7006 passed, 2 skipped
- ruff/mypy clean
- Codex 브랜치 리뷰: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
