### PR TITLE
docs(eventbus): #2186 MemberRegistered/Reactivated 구독자 Notification→Audit (member/07·runtime 정합)

### DIFF
--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -196,9 +196,9 @@ D-005에서 정의한 EventBus 대상 이벤트. 모든 이벤트는 `Event`를 
 
 | 이벤트 타입 | 발행자 | 구독자 | 핵심 필드 |
 |------------|--------|--------|----------|
-| `MemberRegisteredEvent` | MemberService | Notification | `member_id`, `member_type`, `role`, `registered_by` |
+| `MemberRegisteredEvent` | MemberService | Audit | `member_id`, `member_type`, `role`, `registered_by` |
 | `MemberSuspendedEvent` | MemberService | SessionService, Notification | `member_id`, `suspended_by` |
-| `MemberReactivatedEvent` | MemberService | Notification | `member_id`, `reactivated_by` |
+| `MemberReactivatedEvent` | MemberService | Audit | `member_id`, `reactivated_by` |
 | `MemberRevokedEvent` | MemberService | SessionService, Notification | `member_id`, `revoked_by` |
 | `MemberTokenRotatedEvent` | MemberService | Audit | `member_id`, `rotated_by` |
 | `MemberPasswordChangedEvent` | MemberService | SessionService, Notification | `member_id`, `changed_by`, `reason` |


### PR DESCRIPTION
Closes #2186

## Summary
- `docs/specs/eventbus/eventbus.md` 멤버 이벤트 표에서 `MemberRegisteredEvent`/`MemberReactivatedEvent` 구독자를 `Notification`→`Audit`로 정정해 SSOT drift 해소.
- 근거 3축 일치: (1) `member/07-eventbus-integration.md`(register/reactivate=감사 로그 only), (2) runtime `service.py`(register/reactivate는 NotificationEvent 미발행; suspend/revoke/password/recovery/auth-failed만 발행), (3) eventbus.md 자체 컨벤션(`MemberTokenRotatedEvent`=`Audit`). eventbus.md L199/201만 outlier였음.
- suspend/revoke/password 등 Notification 보유 행 무변경. register/reactivate Notification wiring 추가 안 함(member/07이 audit-only 의도). docs-only.

## Test Plan
- 전체 `pytest tests/unit/ -q` — 7006 passed, 2 skipped(docs 무영향)
- grep: eventbus.md register/reactivate 구독자 Notification 없음, member/07 일치
- Codex 브랜치 리뷰: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
