### PR TITLE
fix(rule): #2315 미복구 self-order 반복 매수 가드 추가

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-06-02 (KST)
+> 마지막 생성 시점: 2026-06-04 (KST)
 
 ## 최상위 구조
 
@@ -399,7 +399,18 @@ tests/
 │   │   ├── test_orchestrator_run_daily_target_date.py
 │   │   ├── test_backfill_guard_wait.py
 │   │   ├── test_indicator_calculator.py
-│   │   └── test_backfill_data_go_kr_checkpoint.py
+│   │   ├── test_backfill_data_go_kr_checkpoint.py
+│   │   ├── test_backfill_empty_response_checkpoint.py
+│   │   ├── test_backfill_last_published_cap.py
+│   │   ├── test_backfill_stored_ok_checkpoint.py
+│   │   ├── test_cli_config_check.py
+│   │   ├── test_cli_feed_config_validation.py
+│   │   ├── test_cli_feed_nice_value.py
+│   │   ├── test_cli_output.py
+│   │   ├── test_daily_runner_dart_daily_flag.py
+│   │   ├── test_daily_runner_store_merge_drain.py
+│   │   ├── test_rows_written_delta.py
+│   │   └── test_scheduler_time_validation.py
 │   ├── cli/
 │   │   ├── __init__.py
 │   │   ├── test_version.py
@@ -427,7 +438,9 @@ tests/
 │   │   ├── test_dispatch_wrapper_preflight.py
 │   │   ├── test_dispatch_wrapper_audit.py
 │   │   ├── test_cli_registry_ipc_cross_ref.py
-│   │   └── test_docs_taxonomy_drift.py
+│   │   ├── test_docs_taxonomy_drift.py
+│   │   ├── test_member_admin_ipc_wiring.py
+│   │   └── test_treasury_account_scoping.py
 │   ├── specs/
 │   │   ├── __init__.py
 │   │   ├── test_cold_path_terminology.py
@@ -672,7 +685,30 @@ tests/
 │   ├── test_feedback_account_scope.py
 │   ├── test_member_security_events.py
 │   ├── test_rule_engine_unrealized_account_scope.py
-│   └── test_strategy_file_access.py
+│   ├── test_strategy_file_access.py
+│   ├── _async_test_utils.py
+│   ├── test_account_killswitch_notification.py
+│   ├── test_backtest_meta_fallback.py
+│   ├── test_backtest_no_trade_normalize.py
+│   ├── test_backtest_subprocess_sentinel.py
+│   ├── test_bot_strategy_consistency.py
+│   ├── test_cli_backtest_result_path.py
+│   ├── test_cli_backtest_subprocess_isolation.py
+│   ├── test_cli_bot_read_ipc.py
+│   ├── test_cli_bot_signal_key_rotate_ipc.py
+│   ├── test_cli_data_list_readonly.py
+│   ├── test_cli_data_list_readonly_fs.py
+│   ├── test_cli_data_validate_fix_scope.py
+│   ├── test_cli_member_ipc_routing.py
+│   ├── test_cli_report_readonly_fs.py
+│   ├── test_cli_report_readonly_graceful.py
+│   ├── test_cli_report_view_db_error.py
+│   ├── test_kis_pagination.py
+│   ├── test_report_backtest_run_id.py
+│   ├── test_report_validation_detail_json.py
+│   ├── test_rule_engine_unrecovered_buy_guard.py
+│   ├── test_rule_modify_enrich.py
+│   └── test_strategy_summary_all_bots.py
 └── __init__.py
 ```
 

--- a/docs/specs/rule-engine/07-rule-engine-core.md
+++ b/docs/specs/rule-engine/07-rule-engine-core.md
@@ -20,6 +20,9 @@ RuleEngine(
     treasury: Treasury | None = None,
     trade_service: TradeService | None = None,
     account: Account | None = None,
+    order_tracker: OrderTracker | None = None,
+    unrecovered_buy_guard_min_age: float = 60.0,
+    allow_unrecovered_buy_overlap: bool = False,
 )
 ```
 
@@ -61,6 +64,7 @@ RuleEngine(
 | `load_strategy_rules_from_config` | `(self, strategy_id: str, rule_configs: list[dict[str, Any]]) -> None` | 설정 리스트에서 전략별 룰 인스턴스 생성 |
 | `evaluate` | `(self, context: RuleContext) -> EvaluationResult` | 주문에 대한 룰 평가. 계좌 룰 → 전략별 순서 |
 | `set_bot_strategy_resolver` | `(self, resolver: Callable[[str], str \| None]) -> None` | 봇 ID → 전략 ID 변환 콜백 설정. 초기화 후 BotManager 연결 시 호출 |
+| `set_unrecovered_buy_overlap` | `(self, bot_id: str, allow: bool) -> None` | 봇 단위 `allow_unrecovered_buy_overlap` opt-out 등록 (#2315). 미등록 봇은 계좌 기본값 사용 |
 | `update_rules` | `(self, bot_id: str, rules: list[dict]) -> None` | 봇의 거래 규칙 갱신. bot_strategy_resolver로 전략 ID 조회 후 룰 교체 |
 | `remove_strategy_rules` | `(self, strategy_id: str) -> None` | 특정 전략의 룰 제거 |
 
@@ -89,3 +93,29 @@ Reject payload 정규화 (`_build_safe_rejected_event`):
 - non-finite/non-number `quantity`는 `0.0`으로 정규화 (sqlite `trades.quantity REAL NOT NULL` 호환).
 - non-finite/non-number `price`는 `None`으로 정규화 (sqlite `trades.price REAL nullable` 호환).
 - reason 문자열은 `_safe_repr`로 안전 조립하며 `0` / `0.0` / `-0.0` 부호와 값을 그대로 보존한다.
+
+### 미복구 매수 가드 (#2315)
+
+> 소스: `RuleEngine._check_unrecovered_buy_guard` (`src/ante/rule/engine.py`)
+> 배경: #2314 캐스케이드 방어 (defense-in-depth). 부모 #2314의 fill-recovery 근본수정과 **독립**이다.
+
+OrderRequestEvent preflight 도메인 검증(`side`/`order_type`/`symbol`/`price`/`stop_price`/`quantity`)을 모두 통과한 뒤, RuleContext 생성과 룰 평가 **이전에** 미복구 self-order 반복 매수 가드를 평가한다.
+
+매수 주문이 제출됐으나 내부 체결 복구가 지연/실패해 `positions`가 0으로 고정되면(#2314), 전략 컨텍스트가 계속 `quantity=0`을 관측해 동일 매수를 반복 제출할 수 있다. 이는 #1945 인시던트의 핵심 캐스케이드(반복매수 → 예산 소진 → 외부매수 오분류 → 재매도)의 진입 경로다. 본 가드는 미복구 self-order가 잔존하는 동안 동일 매수의 중복 제출을 차단한다.
+
+**차단룰 (normative)**: 새 `buy` `OrderRequestEvent`를 다음 **4개 조건 모두(AND)** 성립 시 `OrderRejectedEvent`로 거부한다.
+
+1. 같은 `(account_id, bot_id, symbol, side="buy")`에 대해 `OrderTracker`의 **non-terminal**(`open` / `partially_filled`) buy 주문 중 `remaining = ordered_qty - recorded_filled_qty > 0`인 주문이 존재한다. (`OrderTracker.get_open_orders_for(...)` — reconciler self-submitted 판정(#1950)과 동형 기준.)
+2. 그 미복구 주문의 `submitted_at` age ≥ `unrecovered_buy_guard_min_age`(기본 `60.0`초 = `max(fill_poll_interval 60s, 60s)` — fill-recovery 폴이 최소 1회 미복구 잔량을 복구할 기회를 보장). `submitted_at`이 `None`/비문자열/파싱 불가/naive(tz 미인지)면 **age 산정 불가**로 보아 조건②를 미충족 처리한다(과대차단 회피 — 음수 age는 0으로 클램프).
+3. RuleEngine이 `self._trade_service.get_positions(bot_id, account_id=self._account_id)`로 조회한 **해당 symbol 내부 position 수량 합 == 0** (전략이 보유를 인지하지 못한 #2314 증상).
+4. opt-out `allow_unrecovered_buy_overlap`(봇/전략 단위 override → 계좌 기본값) 가 `false`(기본).
+
+4조건이 모두 성립할 때에만 차단하며, 그 외에는 통과시킨다. 즉 **합법적 분할매수/피라미딩은 비차단**이다: 내부 position > 0(이미 보유 인지)이거나, 미복구 outstanding의 age < threshold(빠른 연속 주문)이거나, opt-out = true이거나, 다른 키(account/bot/symbol 또는 `side="sell"`)면 통과한다.
+
+복구가 완료되거나(`recorded_filled_qty == ordered_qty` → `remaining = 0`) 주문이 terminal(`cancelled`/`rejected`/`failed`/`expired`/`filled`)로 전이되면 조건①이 깨져 차단이 자동 해제된다.
+
+**활성 조건 / opt-out 배선**:
+- `self._order_tracker is None`(또는 `self._trade_service is None`)이면 가드는 **비활성**(허용)이다. reconciler #1950 패턴과 동형으로, tracker 미주입 시 self-check를 생략한다.
+- `unrecovered_buy_guard_min_age`(기본 `60.0`)와 `allow_unrecovered_buy_overlap`(계좌 기본, 기본 `false`)은 `RuleEngine` 생성자 인자이며 `RuleEngineManager`를 통해 전파된다. 봇/전략 단위 opt-out은 `RuleEngine.set_unrecovered_buy_overlap(bot_id, allow)`로 등록하며, 미등록 봇은 계좌 기본값을 따른다.
+
+**fail-closed (audit trail 보존, #1302 invariant)**: 가드 활성 중 `OrderTracker.get_open_orders_for` 또는 `get_positions` 조회가 **예외**를 던지면, 가드 게이트는 이를 try/except로 삼켜 허용(silent-pass)하지 **않는다**. 예외는 `_on_order_request`의 catch-all로 전파되어 fail-closed generic `OrderRejectedEvent`로 audit trail이 잠긴다. 정상 DB의 일시적 조회 예외에서도 정상 주문이 보수적으로 reject될 수 있으나(과도 거부 trade-off), #2314 캐스케이드 회피를 외부 검출/통과 완전성보다 우선하는 의도적 안전 선택이다.

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -268,6 +268,8 @@ class RuleEngine:
         trade_service: TradeService | None = None,
         account: Account | None = None,
         order_tracker: OrderTracker | None = None,
+        unrecovered_buy_guard_min_age: float = 60.0,
+        allow_unrecovered_buy_overlap: bool = False,
     ) -> None:
         from ante.account.scoping import require_account_id
 
@@ -289,6 +291,17 @@ class RuleEngine:
         # 기존 호출자(테스트 fixture 등) 호환을 위해 ``None`` 허용 — None일 때
         # reload 경로는 helper를 우회하여 stored 그대로 적용한다 (#1296).
         self._account = account
+
+        # #2315: 미복구 self-order 반복 매수 가드 설정.
+        # ``unrecovered_buy_guard_min_age``는 미복구 outstanding buy 주문이 차단
+        # 대상이 되기까지 경과해야 하는 최소 age(초)다. 기본 60.0 =
+        # max(fill_poll_interval 60s, 60s) — fill-recovery 폴이 최소 1회 미복구
+        # 잔량을 복구할 기회를 보장한 뒤에만 차단한다(빠른 연속 분할매수 비차단).
+        # ``allow_unrecovered_buy_overlap``은 계좌 기본 opt-out이며, 봇/전략 단위
+        # override는 ``set_unrecovered_buy_overlap``로 등록한다.
+        self._unrecovered_buy_guard_min_age = unrecovered_buy_guard_min_age
+        self._allow_unrecovered_buy_overlap_default = allow_unrecovered_buy_overlap
+        self._allow_unrecovered_buy_overlap_by_bot: dict[str, bool] = {}
 
         self._account_rules: list[Rule] = []
         self._strategy_rules: dict[str, list[Rule]] = {}
@@ -334,6 +347,16 @@ class RuleEngine:
     def set_bot_strategy_resolver(self, resolver: Callable[[str], str | None]) -> None:
         """봇 ID → 전략 ID 변환 콜백 설정 (초기화 후 BotManager 연결 시 호출)."""
         self._bot_strategy_resolver = resolver
+
+    def set_unrecovered_buy_overlap(self, bot_id: str, allow: bool) -> None:
+        """봇 단위 ``allow_unrecovered_buy_overlap`` opt-out 등록 (#2315).
+
+        의도적으로 미복구 outstanding self-buy와 중첩되는 다중 주문을 내는 전략은
+        ``allow=True``로 등록하여 미복구 매수 가드를 면제받는다. 미등록 봇은 계좌
+        기본값(``allow_unrecovered_buy_overlap`` 생성자 인자, 기본 ``False``)을
+        따른다.
+        """
+        self._allow_unrecovered_buy_overlap_by_bot[bot_id] = allow
 
     def update_rules(self, bot_id: str, rules: list[dict[str, Any]]) -> None:
         """봇의 거래 규칙을 갱신.
@@ -593,6 +616,125 @@ class RuleEngine:
         except Exception:
             logger.warning("미실현 손익 계산 실패: bot=%s", bot_id)
             return 0.0
+
+    @staticmethod
+    def _unrecovered_buy_age_seconds(submitted_at: str | None) -> float | None:
+        """``submitted_at`` ISO 문자열의 age(초)를 계산. 산정 불가면 ``None`` (#2315).
+
+        ``submitted_at``은 ``OrderSubmittedEvent.timestamp.isoformat()`` (tz-aware
+        UTC)로 seed되지만 nullable이고 형식이 깨질 수 있다. ``None``/비문자열/파싱
+        불가/naive(미인지) datetime은 모두 **age 산정 불가**로 보아 ``None``을
+        반환한다. 호출부는 ``None``일 때 차단룰 조건②(age ≥ threshold)를 **미충족**
+        으로 처리해 차단하지 않는다(과대차단 회피). 음수 age(미래 timestamp)는
+        0.0으로 클램프하여 절대 threshold를 넘지 않게 한다.
+        """
+        from datetime import UTC, datetime
+
+        if not isinstance(submitted_at, str) or not submitted_at:
+            return None
+        try:
+            parsed = datetime.fromisoformat(submitted_at)
+        except (ValueError, TypeError):
+            return None
+        if parsed.tzinfo is None:
+            # naive datetime은 UTC↔KST 등 오프셋 모호성으로 age를 신뢰할 수 없으므로
+            # 산정 불가로 처리한다(차단하지 않음).
+            return None
+        age = (datetime.now(UTC) - parsed).total_seconds()
+        return max(age, 0.0)
+
+    async def _check_unrecovered_buy_guard(self, event: object) -> str | None:
+        """미복구 self-order 반복 매수 가드 (#2315 — #2314 캐스케이드 방어).
+
+        새 ``buy`` ``OrderRequestEvent``를 다음 **4조건 AND** 성립 시에만 차단하고,
+        차단 시 reject reason 문자열을 반환한다. 미충족이면 ``None``(허용).
+
+        1. 같은 ``(account_id, bot_id, symbol, side="buy")``에 ``OrderTracker``의
+           non-terminal(open/partially_filled) buy 주문 중
+           ``remaining = ordered_qty - recorded_filled_qty > 0``인 주문 존재.
+        2. 그 주문의 ``submitted_at`` age ≥ ``unrecovered_buy_guard_min_age``
+           (기본 60s = max(fill_poll_interval 60s, 60s) — 최소 1회 fill-recovery
+           폴 기회 경과). age 산정 불가(None/파싱불가/naive)면 미충족(허용).
+        3. ``get_positions``로 조회한 해당 symbol 내부 position 수량 == 0
+           (전략이 보유를 인지 못한 #2314 증상).
+        4. opt-out ``allow_unrecovered_buy_overlap``(봇 override → 계좌 기본)이
+           false.
+
+        합법적 분할매수/피라미딩은 비차단: position>0(보유 인지)·age<threshold
+        (빠른 연속 주문)·opt-out=true·다른 키(account/bot/symbol/side)는 통과한다.
+
+        fail-open 방지(#1302 invariant 보존): ``self._order_tracker is None``이면
+        가드 **비활성**(reconciler #1950 패턴 동형 — tracker 미주입 시 self-check
+        생략 = 허용). 가드 활성 중 ``get_open_orders_for``/``get_positions`` 조회가
+        **예외**면 여기서 try/except로 삼켜 허용(silent-pass)하지 **않는다** —
+        예외를 그대로 ``_on_order_request`` catch-all까지 전파시켜 fail-closed
+        generic reject로 audit trail을 잠근다. 정상 DB의 일시적 조회 예외도 보수적
+        으로 reject되지만(과도 거부 trade-off), #2314 캐스케이드(반복매수→예산
+        소진→외부매수 오분류→재매도) 회피를 우선한다.
+        """
+        # 조건①의 선결: side="buy"만 대상. tracker 미주입이면 가드 비활성(허용).
+        if self._order_tracker is None or self._trade_service is None:
+            return None
+        if getattr(event, "side", None) != "buy":
+            return None
+
+        bot_id = getattr(event, "bot_id", "")
+        symbol = getattr(event, "symbol", "")
+
+        # opt-out(조건④): 봇 override → 계좌 기본. true면 가드 면제(허용).
+        allow_overlap = self._allow_unrecovered_buy_overlap_by_bot.get(
+            bot_id, self._allow_unrecovered_buy_overlap_default
+        )
+        if allow_overlap:
+            return None
+
+        # 조건①: non-terminal self-buy 중 remaining > 0인 주문 존재.
+        # NOTE(#2315 fail-closed): get_open_orders_for 예외는 여기서 잡지 않고
+        # _on_order_request catch-all로 전파시켜 fail-closed reject한다.
+        open_orders = await self._order_tracker.get_open_orders_for(
+            account_id=self._account_id,
+            bot_id=bot_id,
+            symbol=symbol,
+            side="buy",
+        )
+        unrecovered = [
+            o for o in open_orders if (o.ordered_qty - o.recorded_filled_qty) > 0
+        ]
+        if not unrecovered:
+            return None
+
+        # 조건②: 미복구 주문 중 age ≥ threshold인 주문이 하나라도 존재.
+        # age 산정 불가(None)는 미충족으로 보아 해당 주문을 무시한다(과대차단 회피).
+        threshold = self._unrecovered_buy_guard_min_age
+        aged = [
+            o
+            for o in unrecovered
+            if (age := self._unrecovered_buy_age_seconds(o.submitted_at)) is not None
+            and age >= threshold
+        ]
+        if not aged:
+            return None
+
+        # 조건③: 해당 symbol 내부 position 수량 == 0.
+        # NOTE(#2315 fail-closed): get_positions 예외도 catch-all로 전파한다.
+        positions = await self._trade_service.get_positions(
+            bot_id, account_id=self._account_id
+        )
+        held_qty = sum(p.quantity for p in positions if p.symbol == symbol)
+        if held_qty != 0:
+            return None
+
+        # 4조건 AND 성립 → 차단. audit trail용 reason 조립(_safe_str로 안전화).
+        oldest = aged[0]
+        remaining = oldest.ordered_qty - oldest.recorded_filled_qty
+        return (
+            f"Unrecovered buy guard: outstanding self-buy order "
+            f"{_safe_str(oldest.order_id)} on {_safe_str(symbol)} "
+            f"(remaining={remaining}, status={_safe_str(oldest.status)}) "
+            f"is unrecovered (age ≥ {threshold}s) while internal position is 0 "
+            f"— blocking duplicate buy to prevent #2314 cascade "
+            f"(set allow_unrecovered_buy_overlap to opt out)"
+        )
 
     # ── EventBus 핸들러 ──────────────────────────────
 
@@ -956,6 +1098,24 @@ class RuleEngine:
                         account_id=self._account_id,
                         event=event,
                         reason=reason,
+                    )
+                )
+                return
+
+            # 미복구 self-order 반복 매수 가드 (#2315 — #2314 캐스케이드 방어).
+            # side/order_type/symbol/quantity 계약 검증 이후, RuleContext 생성/룰
+            # evaluate 이전에 둔다. 4조건 AND(미복구 outstanding self-buy + age≥
+            # threshold + 내부 position==0 + opt-out=false) 성립 시에만 차단한다.
+            # tracker/trade_service 미주입이면 비활성(허용). 가드 내부의 OrderTracker/
+            # get_positions 조회 예외는 silent-pass하지 않고 본 try의 catch-all로
+            # 전파되어 fail-closed generic reject로 audit trail을 잠근다(#1302 보존).
+            guard_reason = await self._check_unrecovered_buy_guard(event)
+            if guard_reason is not None:
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason=guard_reason,
                     )
                 )
                 return

--- a/src/ante/rule/manager.py
+++ b/src/ante/rule/manager.py
@@ -29,6 +29,8 @@ class RuleEngineManager:
         treasury_manager: TreasuryManagerType | None = None,
         trade_service: TradeService | None = None,
         order_tracker: OrderTracker | None = None,
+        unrecovered_buy_guard_min_age: float = 60.0,
+        allow_unrecovered_buy_overlap: bool = False,
     ) -> None:
         self._eventbus = eventbus
         self._account_service = account_service
@@ -38,6 +40,11 @@ class RuleEngineManager:
         # default None — 기존 호출자/테스트 무회귀. None이면 RuleEngine은 modify
         # event의 symbol/side를 보강하지 않고 "" graceful degrade한다.
         self._order_tracker = order_tracker
+        # #2315: 미복구 self-order 반복 매수 가드 설정을 생성하는 모든 RuleEngine에
+        # 전파한다. 봇/전략 단위 opt-out은 RuleEngine.set_unrecovered_buy_overlap
+        # 로 별도 등록한다.
+        self._unrecovered_buy_guard_min_age = unrecovered_buy_guard_min_age
+        self._allow_unrecovered_buy_overlap = allow_unrecovered_buy_overlap
         self._engines: dict[str, RuleEngine] = {}
 
     def create_engine(
@@ -77,6 +84,8 @@ class RuleEngineManager:
             trade_service=self._trade_service,
             account=account,
             order_tracker=self._order_tracker,
+            unrecovered_buy_guard_min_age=self._unrecovered_buy_guard_min_age,
+            allow_unrecovered_buy_overlap=self._allow_unrecovered_buy_overlap,
         )
 
         if rule_configs:

--- a/tests/unit/test_rule_engine_unrecovered_buy_guard.py
+++ b/tests/unit/test_rule_engine_unrecovered_buy_guard.py
@@ -1,0 +1,505 @@
+"""RuleEngine 미복구 self-order 반복 매수 가드 회귀 테스트. Refs #2315.
+
+#2314 캐스케이드 방어(defense-in-depth): 매수 주문이 제출됐으나 내부 체결 복구가
+지연/실패해 `positions`가 0으로 고정되면, 전략이 동일 매수를 반복 제출해
+#1945 캐스케이드(반복매수 → 예산 소진 → 외부매수 오분류 → 재매도)로 진입할 수
+있다. RuleEngine은 미복구 outstanding self-buy가 잔존하는 동안 동일 매수의 중복
+제출을 차단한다.
+
+차단룰(4조건 AND, `docs/specs/rule-engine/07-rule-engine-core.md` "미복구 매수 가드"):
+1. `(account_id, bot_id, symbol, side="buy")` non-terminal buy 중 remaining > 0 존재.
+2. 그 주문의 `submitted_at` age ≥ `unrecovered_buy_guard_min_age`(기본 60s).
+3. 해당 symbol 내부 position 수량 합 == 0.
+4. opt-out `allow_unrecovered_buy_overlap` == false.
+
+테스트 매트릭스(9): ① 차단 / ② terminal 후 허용 / ③ recorded==ordered 허용 /
+④ position>0 허용 / ⑤ age<60s 허용 / ⑥ opt-out=true 허용 /
+⑦ 다른 account/bot/symbol/side=sell 비차단 / ⑧ order_tracker 미주입 비활성 /
+⑨ 조회 예외 fail-closed reject.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ante.eventbus import EventBus
+from ante.eventbus.events import (
+    OrderRejectedEvent,
+    OrderRequestEvent,
+    OrderValidatedEvent,
+)
+from ante.rule import RuleEngine
+
+ACCOUNT = "domestic"
+BOT = "bot1"
+SYMBOL = "005930"
+
+
+@dataclass
+class FakePosition:
+    """position 수량 조회에 필요한 최소 PositionSnapshot 형태."""
+
+    bot_id: str
+    symbol: str
+    quantity: float
+    avg_entry_price: float = 60000.0
+    realized_pnl: float = 0.0
+
+
+@dataclass
+class FakeOrderRecord:
+    """OrderTrackerRecord 의 가드 평가 관련 최소 필드."""
+
+    order_id: str
+    ordered_qty: float
+    recorded_filled_qty: float
+    status: str
+    submitted_at: str | None
+    symbol: str = SYMBOL
+    side: str = "buy"
+
+
+class FakeOrderTracker:
+    """`(account, bot, symbol, side)` 별 non-terminal 주문을 반환하는 가짜 tracker.
+
+    `get_open_orders_for`는 실제 OrderTracker 와 동일하게 keyword 인자를 받으며,
+    non-terminal(open/partially_filled) 주문만 보유하도록 시드된다(terminal 주문은
+    리스트에서 제외). `raise_on_query=True`면 조회 시 예외를 던져 fail-closed
+    경로를 검증한다.
+    """
+
+    def __init__(
+        self,
+        records: dict[tuple[str, str, str, str], list[FakeOrderRecord]] | None = None,
+        *,
+        raise_on_query: bool = False,
+    ) -> None:
+        self._records = records or {}
+        self._raise = raise_on_query
+        self.calls: list[dict[str, str]] = []
+
+    async def get_open_orders_for(
+        self, account_id: str, bot_id: str, symbol: str, side: str
+    ) -> list[FakeOrderRecord]:
+        self.calls.append(
+            {
+                "account_id": account_id,
+                "bot_id": bot_id,
+                "symbol": symbol,
+                "side": side,
+            }
+        )
+        if self._raise:
+            raise RuntimeError("simulated OrderTracker query failure")
+        return list(self._records.get((account_id, bot_id, symbol, side), []))
+
+    # _on_order_modify 가 호출하는 인터페이스 — 본 테스트에서는 미사용.
+    async def get(self, order_id: str) -> None:  # pragma: no cover - 미사용
+        return None
+
+
+class FakeTradeService:
+    """symbol 별 position 을 반환하는 가짜 TradeService.
+
+    `get_positions`는 실제 `TradeService.get_positions`와 동일하게 `bot_id`
+    positional + keyword-only `account_id`(기본 None)를 받는다.
+    `raise_on_query=True`면 예외를 던져 fail-closed 경로를 검증한다.
+    """
+
+    def __init__(
+        self,
+        positions: dict[str, list[FakePosition]] | None = None,
+        *,
+        raise_on_query: bool = False,
+    ) -> None:
+        self._positions = positions or {}
+        self._raise = raise_on_query
+        self.calls: list[dict[str, object]] = []
+
+    async def get_positions(
+        self,
+        bot_id: str,
+        include_closed: bool = False,
+        *,
+        account_id: str | None = None,
+    ) -> list[FakePosition]:
+        self.calls.append({"bot_id": bot_id, "account_id": account_id})
+        if self._raise:
+            raise RuntimeError("simulated get_positions failure")
+        scoped = self._positions.get(account_id or "", [])
+        return [p for p in scoped if p.bot_id == bot_id]
+
+
+def _iso_age(seconds: float) -> str:
+    """현재로부터 ``seconds`` 초 전의 tz-aware ISO 문자열."""
+    return (datetime.now(UTC) - timedelta(seconds=seconds)).isoformat()
+
+
+@dataclass
+class _Captured:
+    rejected: list[OrderRejectedEvent] = field(default_factory=list)
+    validated: list[OrderValidatedEvent] = field(default_factory=list)
+
+
+def _build_engine(
+    eventbus: EventBus,
+    *,
+    order_tracker: FakeOrderTracker | None,
+    trade_service: FakeTradeService | None,
+    allow_overlap: bool = False,
+    min_age: float = 60.0,
+) -> RuleEngine:
+    return RuleEngine(
+        eventbus=eventbus,
+        account_id=ACCOUNT,
+        trade_service=trade_service,
+        order_tracker=order_tracker,
+        unrecovered_buy_guard_min_age=min_age,
+        allow_unrecovered_buy_overlap=allow_overlap,
+    )
+
+
+def _capture(eventbus: EventBus) -> _Captured:
+    cap = _Captured()
+    eventbus.subscribe(OrderRejectedEvent, lambda e: cap.rejected.append(e))
+    eventbus.subscribe(OrderValidatedEvent, lambda e: cap.validated.append(e))
+    return cap
+
+
+def _buy_order(
+    *,
+    account_id: str = ACCOUNT,
+    bot_id: str = BOT,
+    symbol: str = SYMBOL,
+    side: str = "buy",
+) -> OrderRequestEvent:
+    return OrderRequestEvent(
+        account_id=account_id,
+        bot_id=bot_id,
+        strategy_id="s1",
+        symbol=symbol,
+        side=side,
+        quantity=10.0,
+        order_type="market",
+        price=50000.0,
+    )
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+class TestUnrecoveredBuyGuard:
+    @pytest.mark.asyncio
+    async def test_case1_block_unrecovered_open_self_buy(
+        self, eventbus: EventBus
+    ) -> None:
+        """① 미복구 open self-buy(age≥60s) + position==0 + opt-out=false → 차단."""
+        tracker = FakeOrderTracker(
+            {
+                (ACCOUNT, BOT, SYMBOL, "buy"): [
+                    FakeOrderRecord(
+                        order_id="o1",
+                        ordered_qty=1.0,
+                        recorded_filled_qty=0.0,
+                        status="open",
+                        submitted_at=_iso_age(120.0),
+                    )
+                ]
+            }
+        )
+        trade = FakeTradeService({ACCOUNT: []})  # position 없음 → 수량 0
+        engine = _build_engine(eventbus, order_tracker=tracker, trade_service=trade)
+        engine.start()
+        cap = _capture(eventbus)
+
+        await eventbus.publish(_buy_order())
+
+        assert len(cap.rejected) == 1
+        assert len(cap.validated) == 0
+        assert "Unrecovered buy guard" in cap.rejected[0].reason
+        # position 조회가 자기 계좌로 스코핑되어 호출됐는지 확인.
+        assert trade.calls[-1]["account_id"] == ACCOUNT
+
+    @pytest.mark.asyncio
+    async def test_case2_terminal_order_allows(self, eventbus: EventBus) -> None:
+        """② 주문 terminal(취소/만료) 후 → 허용.
+
+        terminal 주문은 `get_open_orders_for`(non-terminal only)에서 제외되므로
+        tracker 가 빈 리스트를 반환한다 → 조건① 미충족 → 통과.
+        """
+        tracker = FakeOrderTracker({(ACCOUNT, BOT, SYMBOL, "buy"): []})
+        trade = FakeTradeService({ACCOUNT: []})
+        engine = _build_engine(eventbus, order_tracker=tracker, trade_service=trade)
+        engine.start()
+        cap = _capture(eventbus)
+
+        await eventbus.publish(_buy_order())
+
+        assert len(cap.rejected) == 0
+        assert len(cap.validated) == 1
+
+    @pytest.mark.asyncio
+    async def test_case3_recorded_equals_ordered_allows(
+        self, eventbus: EventBus
+    ) -> None:
+        """③ recorded==ordered(복구 완료) → 허용 (remaining=0 → 조건① 미충족)."""
+        tracker = FakeOrderTracker(
+            {
+                (ACCOUNT, BOT, SYMBOL, "buy"): [
+                    FakeOrderRecord(
+                        order_id="o1",
+                        ordered_qty=1.0,
+                        recorded_filled_qty=1.0,
+                        status="partially_filled",
+                        submitted_at=_iso_age(120.0),
+                    )
+                ]
+            }
+        )
+        trade = FakeTradeService({ACCOUNT: []})
+        engine = _build_engine(eventbus, order_tracker=tracker, trade_service=trade)
+        engine.start()
+        cap = _capture(eventbus)
+
+        await eventbus.publish(_buy_order())
+
+        assert len(cap.rejected) == 0
+        assert len(cap.validated) == 1
+
+    @pytest.mark.asyncio
+    async def test_case4_position_held_allows_scaling_in(
+        self, eventbus: EventBus
+    ) -> None:
+        """④ position>0(합법적 분할매수/피라미딩) → 허용 (조건③ 미충족)."""
+        tracker = FakeOrderTracker(
+            {
+                (ACCOUNT, BOT, SYMBOL, "buy"): [
+                    FakeOrderRecord(
+                        order_id="o1",
+                        ordered_qty=1.0,
+                        recorded_filled_qty=0.0,
+                        status="open",
+                        submitted_at=_iso_age(120.0),
+                    )
+                ]
+            }
+        )
+        trade = FakeTradeService(
+            {ACCOUNT: [FakePosition(bot_id=BOT, symbol=SYMBOL, quantity=5.0)]}
+        )
+        engine = _build_engine(eventbus, order_tracker=tracker, trade_service=trade)
+        engine.start()
+        cap = _capture(eventbus)
+
+        await eventbus.publish(_buy_order())
+
+        assert len(cap.rejected) == 0
+        assert len(cap.validated) == 1
+
+    @pytest.mark.asyncio
+    async def test_case5_age_below_threshold_allows(self, eventbus: EventBus) -> None:
+        """⑤ outstanding age < 60s(빠른 연속 주문) → 허용 (조건② 미충족)."""
+        tracker = FakeOrderTracker(
+            {
+                (ACCOUNT, BOT, SYMBOL, "buy"): [
+                    FakeOrderRecord(
+                        order_id="o1",
+                        ordered_qty=1.0,
+                        recorded_filled_qty=0.0,
+                        status="open",
+                        submitted_at=_iso_age(5.0),  # 5초 전 → threshold 미만
+                    )
+                ]
+            }
+        )
+        trade = FakeTradeService({ACCOUNT: []})
+        engine = _build_engine(eventbus, order_tracker=tracker, trade_service=trade)
+        engine.start()
+        cap = _capture(eventbus)
+
+        await eventbus.publish(_buy_order())
+
+        assert len(cap.rejected) == 0
+        assert len(cap.validated) == 1
+
+    @pytest.mark.asyncio
+    async def test_case6_opt_out_allows(self, eventbus: EventBus) -> None:
+        """⑥ opt-out(allow_unrecovered_buy_overlap=true) → 허용 (조건④ 미충족).
+
+        계좌 기본 opt-out 과 봇 단위 override 둘 다 검증한다.
+        """
+        tracker = FakeOrderTracker(
+            {
+                (ACCOUNT, BOT, SYMBOL, "buy"): [
+                    FakeOrderRecord(
+                        order_id="o1",
+                        ordered_qty=1.0,
+                        recorded_filled_qty=0.0,
+                        status="open",
+                        submitted_at=_iso_age(120.0),
+                    )
+                ]
+            }
+        )
+        trade = FakeTradeService({ACCOUNT: []})
+
+        # (a) 계좌 기본 opt-out=true.
+        engine = _build_engine(
+            eventbus, order_tracker=tracker, trade_service=trade, allow_overlap=True
+        )
+        engine.start()
+        cap = _capture(eventbus)
+        await eventbus.publish(_buy_order())
+        assert len(cap.rejected) == 0
+        assert len(cap.validated) == 1
+
+        # (b) 계좌 기본은 false 이나 봇 단위 override=true.
+        eventbus2 = EventBus()
+        engine2 = _build_engine(
+            eventbus2, order_tracker=tracker, trade_service=trade, allow_overlap=False
+        )
+        engine2.set_unrecovered_buy_overlap(BOT, True)
+        engine2.start()
+        cap2 = _capture(eventbus2)
+        await eventbus2.publish(_buy_order())
+        assert len(cap2.rejected) == 0
+        assert len(cap2.validated) == 1
+
+    @pytest.mark.asyncio
+    async def test_case7_other_keys_not_blocked(self, eventbus: EventBus) -> None:
+        """⑦ 다른 account/bot/symbol/side=sell → 비차단.
+
+        tracker 는 `(ACCOUNT, BOT, SYMBOL, "buy")` 에만 미복구 주문을 시드한다.
+        다른 키로 들어오는 주문은 조건①을 충족하지 못해 통과한다.
+        """
+        tracker = FakeOrderTracker(
+            {
+                (ACCOUNT, BOT, SYMBOL, "buy"): [
+                    FakeOrderRecord(
+                        order_id="o1",
+                        ordered_qty=1.0,
+                        recorded_filled_qty=0.0,
+                        status="open",
+                        submitted_at=_iso_age(120.0),
+                    )
+                ]
+            }
+        )
+        trade = FakeTradeService({ACCOUNT: []})
+        engine = _build_engine(eventbus, order_tracker=tracker, trade_service=trade)
+        engine.start()
+        cap = _capture(eventbus)
+
+        # 다른 bot.
+        await eventbus.publish(_buy_order(bot_id="bot2"))
+        # 다른 symbol.
+        await eventbus.publish(_buy_order(symbol="069500"))
+        # side=sell (가드는 buy 전용; sell 은 inventory 검증 룰 대상 아님).
+        await eventbus.publish(_buy_order(side="sell"))
+
+        # 셋 모두 차단되지 않아야 한다.
+        assert len(cap.rejected) == 0
+        assert len(cap.validated) == 3
+
+    @pytest.mark.asyncio
+    async def test_case8_no_order_tracker_disables_guard(
+        self, eventbus: EventBus
+    ) -> None:
+        """⑧ order_tracker 미주입 → 가드 비활성(허용).
+
+        reconciler #1950 패턴 동형: tracker 미주입 시 self-check 생략 = allow.
+        """
+        trade = FakeTradeService({ACCOUNT: []})
+        engine = _build_engine(eventbus, order_tracker=None, trade_service=trade)
+        engine.start()
+        cap = _capture(eventbus)
+
+        await eventbus.publish(_buy_order())
+
+        # tracker 미주입 → 가드는 일찍 None 반환(비활성)하고 통과시킨다.
+        # (이후 evaluate 경로의 unrealized-PnL 계산이 get_positions 를 부르는 것은
+        #  가드와 무관한 정상 흐름이므로 calls 자체로는 가드 활성 여부를 단정하지
+        #  않는다 — reject 부재 + validated 발행으로 비활성을 확인한다.)
+        assert len(cap.rejected) == 0
+        assert len(cap.validated) == 1
+
+    @pytest.mark.asyncio
+    async def test_case9_query_exception_fail_closed_reject(
+        self, eventbus: EventBus
+    ) -> None:
+        """⑨ OrderTracker/get_positions 조회 예외 → fail-closed reject (audit trail).
+
+        가드 게이트는 조회 예외를 silent-pass 하지 않고 catch-all 로 전파시켜
+        generic reject 를 강제 발행한다(#1302 fail-open 방지 invariant 보존).
+        """
+        # (a) OrderTracker 조회 예외.
+        tracker = FakeOrderTracker(raise_on_query=True)
+        trade = FakeTradeService({ACCOUNT: []})
+        engine = _build_engine(eventbus, order_tracker=tracker, trade_service=trade)
+        engine.start()
+        cap = _capture(eventbus)
+
+        await eventbus.publish(_buy_order())
+
+        assert len(cap.rejected) == 1
+        assert len(cap.validated) == 0
+        assert "preflight error" in cap.rejected[0].reason
+
+        # (b) get_positions 조회 예외 (OrderTracker 는 미복구 주문을 정상 반환).
+        tracker2 = FakeOrderTracker(
+            {
+                (ACCOUNT, BOT, SYMBOL, "buy"): [
+                    FakeOrderRecord(
+                        order_id="o1",
+                        ordered_qty=1.0,
+                        recorded_filled_qty=0.0,
+                        status="open",
+                        submitted_at=_iso_age(120.0),
+                    )
+                ]
+            }
+        )
+        trade2 = FakeTradeService(raise_on_query=True)
+        eventbus2 = EventBus()
+        engine2 = _build_engine(eventbus2, order_tracker=tracker2, trade_service=trade2)
+        engine2.start()
+        cap2 = _capture(eventbus2)
+
+        await eventbus2.publish(_buy_order())
+
+        assert len(cap2.rejected) == 1
+        assert len(cap2.validated) == 0
+        assert "preflight error" in cap2.rejected[0].reason
+
+
+class TestUnrecoveredBuyAgeHelper:
+    """`_unrecovered_buy_age_seconds` 의 age 산정 불가 케이스 회귀."""
+
+    def test_none_submitted_at_returns_none(self) -> None:
+        assert RuleEngine._unrecovered_buy_age_seconds(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert RuleEngine._unrecovered_buy_age_seconds("") is None
+
+    def test_unparseable_returns_none(self) -> None:
+        assert RuleEngine._unrecovered_buy_age_seconds("not-a-timestamp") is None
+
+    def test_naive_datetime_returns_none(self) -> None:
+        """naive(tz 미인지) datetime 은 오프셋 모호성으로 산정 불가."""
+        naive = datetime.now().replace(tzinfo=None).isoformat()  # noqa: DTZ005
+        assert RuleEngine._unrecovered_buy_age_seconds(naive) is None
+
+    def test_aware_past_returns_positive_age(self) -> None:
+        age = RuleEngine._unrecovered_buy_age_seconds(_iso_age(100.0))
+        assert age is not None
+        assert age >= 100.0
+
+    def test_future_timestamp_clamped_to_zero(self) -> None:
+        """미래 timestamp(음수 age)는 0.0 으로 클램프되어 threshold 를 넘지 않는다."""
+        future = (datetime.now(UTC) + timedelta(seconds=300)).isoformat()
+        assert RuleEngine._unrecovered_buy_age_seconds(future) == 0.0


### PR DESCRIPTION
Closes #2315

## Summary
- #2314/#1945 캐스케이드 방어(defense-in-depth): KIS 모의 체결복구 지연으로 `positions`가 0에 고정되면 전략이 동일 매수를 반복 제출하는 경로를 RuleEngine에서 차단.
- **4조건 AND 차단룰**(Codex Plan Review 제안): ① `(account,bot,symbol,side=buy)` non-terminal self-buy 중 remaining>0 ② 그 주문 `submitted_at` age ≥ `unrecovered_buy_guard_min_age`(기본 60s) ③ 해당 symbol 내부 position==0 ④ opt-out `allow_unrecovered_buy_overlap`=false. → 4조건 충족 시에만 `OrderRejectedEvent`.
- **합법적 분할매수/피라미딩 비차단**: position>0·age<threshold·opt-out=true·다른 키는 통과.
- **fail-closed**: tracker/trade_service 미주입 시 가드 비활성(허용); 활성 중 조회 예외는 `_on_order_request` catch-all로 전파해 fail-closed reject(#1302 audit-trail invariant 보존). 게이트는 side/symbol 검증 후·Treasury/evaluate 전.
- spec: `docs/specs/rule-engine/07-rule-engine-core.md` '미복구 매수 가드' normative 절.
- config: RuleEngine 생성자 + RuleEngineManager 전파, 봇 단위 opt-out `set_unrecovered_buy_overlap`. OrderRequestEvent 스키마 무변경.

## Test Plan
- `tests/unit/test_rule_engine_unrecovered_buy_guard.py` 신규(9 케이스 + age helper). 오케스트레이터 메인 repo 독립검증: `pytest` 265 passed, `mypy src/ante/rule/` clean, `ruff check/format` clean, `project-structure --check` up to date.
- branch-review `/codex:review --base main` PASS.

## 비고
- `project-structure.md`는 신규 테스트 반영 재생성. 누적된 pre-existing mechanical drift(2026-06-02 스냅샷 누락 테스트들) 포함 — correct-by-generation, 재생성이 소유.
- 부모 epic #2314. 관련 #2316(spec)·#2318(impl)·#2317(live).