### PR TITLE
fix(broker): #2318 KIS 모의 당일 position-derived bounded fallback 구현

### DIFF
--- a/config/system.toml.example
+++ b/config/system.toml.example
@@ -4,6 +4,11 @@
 [system]
 log_level = "INFO"  # DEBUG, INFO, WARNING, ERROR
 timezone = "Asia/Seoul"
+# KIS 모의 당일 체결 position-derived bounded fallback (#2314, spec §11).
+# 백스톱(get_order_history)이 모의 당일 0건일 때 잔고 증분에서 self 체결을
+# 보수적으로 역도출해 수렴한다. KIS paper(is_paper=true) 한정 기본 활성이며,
+# false 로 두면 rollback 된다(§11.6 disable flag).
+fill_position_fallback_enabled = true
 
 [db]
 path = "db/ante.db"

--- a/docs/specs/broker-adapter/18-fill-recovery.md
+++ b/docs/specs/broker-adapter/18-fill-recovery.md
@@ -474,6 +474,23 @@ D+1 ccld 백스톱으로 반영되며, fallback이 외부분을 흡수하지 않
   (`recorded_filled_qty`), ccld가 반환한 더 낮은 절대 누적, 차이를 싣는다. 이
   경보는 §11.7 bounded known-limitation(협소 외부 흡수)을 **운영 관측 가능**하게
   만드는 백스톱이다.
+- **bounded fallback-verification 폴 (alert 도달성, normative)**: fallback이
+  주문을 full fill(`recorded_filled_qty = ordered_qty`)로 올리면 그 주문은
+  `filled`(terminal)가 되어 다음 사이클 `get_open_orders`에서 빠진다. 이때
+  §6.1·§11.2의 event-gated 폴이 open만 게이트로 삼으면 ccld를 더 폴하지 않아 위
+  late-ccld alert가 **도달 불가(dead code)** 가 된다. 따라서 fallback이 advance한
+  주문을 **in-memory verify set**(`broker_order_id → {fallback이 advance한
+  recorded, submitted_date}`)에 등록하고, 폴 게이트를 **open이 있거나 verify set이
+  비어있지 않으면** ccld를 폴하도록 확장한다(open·verify가 둘 다 없으면 여전히
+  미폴 — §11.2 rate budget 유지). 폴 window의 `from_date`는 verify 항목의
+  `submitted_date`까지 거슬러 덮어 ccld가 그 주문을 관측할 수 있게 한다. ccld가
+  verify 주문에 대해 `recorded`보다 **낮은 양수 누적**을 주면 위 alert를 발행하고
+  그 항목을 verify에서 제거하며, 동일/높은 누적(정상 advance/멱등)이면 조용히
+  제거한다. verify set은 **bounded**다: ccld 1회 관측 시 제거되고, 그 전이라도
+  영업일 경계(`submitted_date < today`, §8 `expire_stale`과 같은 D+1 경계)에
+  정리되어 무한 누적되지 않는다. verify set은 **in-memory 보조 상태일 뿐**이며
+  OrderTracker/positions/trades/outbox를 직접 수정하지 않는다(§11.8 단일 권위
+  보존).
 - **avg_price 근거**: fallback의 평균 체결가는 **잔고 평단(`get_positions`)**을
   근거로 쓴다(잔고가 제공하는 유일한 가격 정보). 주문가가 아니다.
 - **known-limitation(정정 없음)**: fallback이 먼저 쓴 `avg_fill_price`는 나중에
@@ -490,6 +507,10 @@ D+1 ccld 백스톱으로 반영되며, fallback이 외부분을 흡수하지 않
   끝난 뒤 실행한다. 만료를 fallback 앞에 두면 모의 당일 미반영 체결을 가진 open이
   복구 전에 `expired`로 전이되어 fallback이 대상을 잃고, §8 poll-first 회귀
   (미복구 체결의 "외부 매수" 오분류)가 재현된다.
+- **verify set EOD 정리**: §11.4 bounded fallback-verification의 in-memory verify
+  set은 `expire_stale`과 같은 영업일 경계에서, `submitted_date < today`(D+1 이후)인
+  항목을 정리한다. 당일 항목은 그날의 late-ccld 검증을 위해 유지하며, ccld가 한 번
+  관측되면 그 전이라도 즉시 제거된다(bounded — 무한 누적 방지).
 
 ### 11.6 적용 범위 (모의 기본 · 실전 분리)
 

--- a/src/ante/broker/fill_scheduler.py
+++ b/src/ante/broker/fill_scheduler.py
@@ -394,10 +394,15 @@ class FillReconcileScheduler:
             # advance 한 recorded 보다 **낮은** 양수면 over-attribution alert 를
             # 발행하고(비가역·CAS no-op) verify 에서 제거한다. 동일/높으면(정상)
             # 조용히 제거한다. 이 검증을 거쳐야 §11.4 alert 가 실제 poll 경로에서
-            # 도달 가능하다.
+            # 도달 가능하다. #2318 Codex 리뷰: KIS odno(broker_order_id)는 영업일
+            # 재사용 가능하므로(§4.1 유일키 = (account, odno, submitted_date)),
+            # ccld 행을 verify 항목과 매칭할 때 **(odno, item_date)** 쌍으로 비교해
+            # 폴 window 에 섞여 든 다른 날짜 재사용 odno 가 verify 항목을 잘못
+            # 매칭/alert/pop 하지 않게 한다(정확매칭, §11.3).
             await self._verify_fallback_against_ccld(
                 broker_order_id=broker_order_id,
                 observed_cumulative=cumulative,
+                item_date=item_date,
             )
             delta = await self._applier.apply_cumulative(
                 account_id=self._account_id,
@@ -454,6 +459,7 @@ class FillReconcileScheduler:
         *,
         broker_order_id: str,
         observed_cumulative: float,
+        item_date: str,
     ) -> None:
         """fallback 적용 주문의 ccld 절대 누적을 검증해 over-attribution 을 surface.
 
@@ -468,11 +474,29 @@ class FillReconcileScheduler:
         advance/멱등)면 조용히 처리한다. 어느 경우든 검증 후 그 항목을 verify 에서
         제거한다(bounded — ccld 가 한 번 관측되면 검증 완료).
 
+        #2318 Codex 리뷰(date-scope): KIS ``odno``(broker_order_id)는 **영업일
+        재사용** 가능하므로(spec §4.1 유일키 = ``(account, odno, submitted_date)``,
+        odno 단독은 전역 유일 키가 아님), 폴 window(``from_date`` 가 verify 항목의
+        ``submitted_date`` 까지 거슬러 덮음)에 **다른 날짜의 같은 odno** ccld 행이
+        섞여 들 수 있다. 그 행을 verify 항목과 매칭하면 late-ccld alert 를 오발화하고
+        verify 항목을 pop 해, 실제 fallback-advanced 주문이 영영 검증되지 않는다.
+        이를 막기 위해 ccld 행의 ``item_date`` 가 verify 항목의 ``submitted_date`` 와
+        **일치할 때만** 검증/alert/pop 한다. 날짜가 다르면 그 verify 항목에 대해
+        무시한다(다른 날짜 재사용 odno — OrderTracker 의
+        ``(account, odno, submitted_date)`` 조회 계약과 정합. ``find_by_broker_order``
+        가 date scope 를 인자로 안 받으므로, 매칭을 date 까지 좁히는 책임을 이 verify
+        비교 지점에 둔다).
+
         eventbus 미주입이면 alert 는 best-effort 로 생략하나, verify 항목 제거(누적
         방지)는 그대로 수행한다(멱등성·정확성 영향 없음).
         """
         entry = self._fallback_verify.get(broker_order_id)
         if entry is None:
+            return
+        # #2318 Codex 리뷰: date-scope 정확매칭. ccld 행의 영업일(item_date)이 verify
+        # 항목의 submitted_date 와 다르면 다른 날짜 재사용 odno 이므로 이 항목에 대해
+        # 무시한다(검증/alert/pop 안 함). 같은 날짜 ccld 만 그 항목을 검증·확정한다.
+        if entry.submitted_date != item_date:
             return
         recorded = entry.recorded
         # ccld 가 0 이거나 fallback recorded 이상이면 정상 경로(멱등 advance/no-op).

--- a/src/ante/broker/fill_scheduler.py
+++ b/src/ante/broker/fill_scheduler.py
@@ -4,8 +4,12 @@ REST ``get_order_history`` 를 백스톱으로 폴해 추적 주문의 체결을
 멱등 반영한다. 실시간 체결 통보 스트림 유무·paper/live 무관하게 정합성을 보증한다.
 
 rate budget 보호:
-- **event-gated**: open 주문이 없으면 폴하지 않는다(0콜, idle).
-- open 이 있을 때만 ``get_order_history`` 를 **사이클당 1콜**.
+- **event-gated**: open 주문이 없고 ``_fallback_verify`` 도 비어있으면 폴하지
+  않는다(0콜, idle). open 또는 verify 가 있을 때만 ``get_order_history`` 를
+  **사이클당 1콜**(#2318 Finding ②: fallback 이 주문을 filled 로 올려 open 이
+  비어도, verify set 이 남아 있으면 ccld 를 계속 폴해 §11.4 late-ccld alert 를
+  도달 가능하게 한다 — verify set 은 ccld 1회 관측 또는 영업일 경계에 정리되는
+  bounded in-memory 보조 상태다).
 - cadence **≥60s**. 주문 제출·가격 fallback 과 동일한 broker rate-limit 큐를
   공유하므로(``_rate_limit_wait``), 보수적 cadence + 1콜/사이클로 제출 starvation 을
   방지한다.
@@ -95,6 +99,34 @@ def _normalize_history_date(raw: str) -> str:
 
 
 @dataclass(frozen=True, slots=True)
+class _FallbackVerifyEntry:
+    """fallback 이 advance 한 주문의 사후 ccld 검증 항목 (#2318 Finding ②).
+
+    fallback 이 주문을 ``filled``(terminal)로 올리면 다음 사이클의
+    ``get_open_orders`` 가 비어 ``_poll_and_apply`` 가 early-return → ccld 미폴 →
+    §11.4 late-ccld alert 가 production 에서 도달 불가(dead code)가 된다. 이를
+    막기 위해 fallback 적용 주문을 in-memory verify set 에 등록하고, 폴 게이트를
+    ``open 또는 verify 가 있으면`` 으로 확장해 그 주문의 ccld 를 계속 폴한다.
+
+    이 항목은 **in-memory 보조 상태일 뿐**이며 OrderTracker/positions/trades/
+    outbox 를 직접 수정하지 않는다(§11.8 단일 권위 보존). 폴 window 의 from_date
+    가 ``submitted_date`` 까지 거슬러 덮도록 보장하고, ccld 절대 누적이 fallback
+    이 advance 한 ``recorded`` 미만이면 alert 1회 후 제거, 동일/높으면 조용히
+    제거한다. 무한 누적 방지를 위해 영업일 경계(D+1)에 정리한다(§11.5).
+
+    Attributes:
+        recorded: fallback 이 ``apply_cumulative`` 로 advance 한 절대 누적(= full
+            fill ``ordered_qty``). ccld 가 이보다 낮은 양수 누적을 주면 잠재
+            over-attribution.
+        submitted_date: fallback 적용 주문의 영업일(``YYYYMMDD``). 폴 window
+            from_date 가 이 날짜까지 거슬러 덮어 ccld 가 매칭 가능하게 한다.
+    """
+
+    recorded: float
+    submitted_date: str
+
+
+@dataclass(frozen=True, slots=True)
 class CatchUpResult:
     """기동 카치업 결과 (#1946 Finding 1).
 
@@ -158,6 +190,12 @@ class FillReconcileScheduler:
         self._fallback_enabled = fallback_enabled
         self._task: asyncio.Task[None] | None = None
         self._running = False
+        # #2318 Finding ②: fallback 이 filled(terminal)로 올린 주문의 사후 ccld
+        # 검증 set(broker_order_id → 검증 항목). fallback 이 open 을 비우면
+        # _poll_and_apply 폴 게이트가 막혀 §11.4 alert 가 도달 불가(dead code)가
+        # 되므로, 이 set 이 비어있지 않으면 ccld 를 계속 폴한다. in-memory 보조
+        # 상태일 뿐(§11.8 OrderTracker/positions/trades/outbox 직접 수정 금지).
+        self._fallback_verify: dict[str, _FallbackVerifyEntry] = {}
 
     @property
     def account_id(self) -> str:
@@ -262,22 +300,34 @@ class FillReconcileScheduler:
 
         1. ``get_open_orders`` 로 추적 open(non-terminal)을 **만료 전에** 읽는다.
            ``from_date`` 는 그 open 들의 가장 이른 ``submitted_date`` 로 잡아, 전일
-           open 이 있으면 폴 window 가 그 영업일까지 거슬러 올라간다(I8).
+           open 이 있으면 폴 window 가 그 영업일까지 거슬러 올라간다(I8). **(신규
+           #2318 Finding ②)** fallback 이 filled 로 올려 open 이 비어도
+           ``_fallback_verify`` 가 비어있지 않으면 ccld 를 계속 폴해 §11.4 late-ccld
+           alert 를 도달 가능하게 한다. 이 경우 ``from_date`` 는 verify 항목의
+           가장 이른 ``submitted_date`` 까지 거슬러 덮어 ccld 가 그 주문을 관측할
+           수 있게 한다. open·verify 가 **둘 다 없으면** 폴하지 않는다(rate budget,
+           §11.2).
         2. open 이 있으면 ``get_order_history`` 1콜 → 관측 체결을
            ``FillApplier.apply_cumulative`` 로 멱등 적용한다(복구). 다운타임 중
            체결분(전일 open 포함)이 여기서 ``filled``/``partially_filled`` 로 전이
-           되어 다음 단계의 만료 대상에서 **자동 제외**된다(I1·I2).
+           되어 다음 단계의 만료 대상에서 **자동 제외**된다(I1·I2). history loop 는
+           각 항목에서 ``_fallback_verify`` 에 등록된 주문이면 §11.4 late-ccld 검증
+           (ccld 절대 누적 < fallback recorded → alert)을 수행하고, 동일/높거나
+           alert 후엔 그 항목을 verify 에서 제거한다(bounded).
         3. **(신규 #2314)** ②(ccld) 적용 후에도 남은 미복구 open buy 가 있으면
            ``get_positions`` 잔고 역도출 fallback 을 적용한다(KIS paper 한정 기본
            활성, §11). ccld 가 체결을 줘 capacity 가 advance 된 경우엔 ``excess``
            가 0 으로 수렴해 fallback 이 본질적으로 no-op 이며, 애초에 미복구 open
            buy 가 없으면 ``get_positions`` 자체를 **호출하지 않아 rate budget 을
-           보호**한다(§11.2).
+           보호**한다(§11.2). fallback 이 적용한 주문은 ``_fallback_verify`` 에
+           등록돼 이후 사이클의 ccld 검증 대상이 된다.
         4. **fallback 후에** ``expire_stale`` 로 EOD 경과 + 체결 미관측
            (genuinely-dead)인 ``open`` 만 ``expired`` 로 전이한다. 부분 체결
            (``partially_filled``)은 만료 대상이 아니다(체결 진행 중). 만료를
            fallback **앞**에 두면 모의 당일 미반영 체결을 가진 open 이 복구 전에
-           expired 되어 fallback 이 대상을 잃는다(§11.5).
+           expired 되어 fallback 이 대상을 잃는다(§11.5). 같은 영업일 경계에서
+           ``_fallback_verify`` 의 D-1 이전(``submitted_date < today``) 항목을 정리해
+           무한 누적을 막는다(§11.5).
 
         expire 를 poll **앞**에 두면(이전 결함), 전일 open 이 다운타임 중 체결됐어도
         복구 전에 expired 되어 폴 0콜·미복구로 남고, ``catch_up_once`` 가
@@ -299,12 +349,20 @@ class FillReconcileScheduler:
         # 1) 만료 **전에** open 을 읽어 폴 window 를 잡는다. 전일 open(다운타임
         #    체결 가능)도 이 시점엔 살아 있어 from_date 를 거슬러 덮는다(I8).
         open_orders = await self._tracker.get_open_orders(self._account_id)
-        if not open_orders:
-            # event-gated: 추적 open 주문이 없으면 폴하지 않는다 (0콜).
+        # #2318 Finding ②: fallback 이 filled 로 올려 open 이 비어도 verify set 이
+        # 비어있지 않으면 ccld 를 계속 폴해 §11.4 late-ccld alert 를 reachable 하게
+        # 한다. open·verify 가 **둘 다 없으면** 폴하지 않는다(§11.2 rate budget).
+        if not open_orders and not self._fallback_verify:
+            # event-gated: 추적 open·verify 가 모두 없으면 폴하지 않는다 (0콜).
             # 만료시킬 open 도 없으므로 expire_stale 도 생략한다.
             return 0
 
-        from_date = min(o.submitted_date for o in open_orders)
+        # from_date 는 open 의 가장 이른 submitted_date 와 verify 항목의 가장 이른
+        # submitted_date 중 더 이른 쪽으로 잡아(I8), verify-only 사이클에서도 ccld
+        # 가 fallback 적용 주문을 관측할 수 있게 한다(#2318 Finding ②).
+        candidate_dates = [o.submitted_date for o in open_orders]
+        candidate_dates.extend(e.submitted_date for e in self._fallback_verify.values())
+        from_date = min(candidate_dates)
         to_date = today
 
         # 2) 사이클당 1콜로 history 를 폴해 다운타임 체결을 **먼저** 복구한다.
@@ -331,14 +389,15 @@ class FillReconcileScheduler:
             item_date = (
                 _normalize_history_date(str(item.get("timestamp", ""))) or to_date
             )
-            # #2316 §11.4 late-ccld over-attribution alert: fallback 이 full fill
-            # 로 올린 누적보다 ccld 가 **더 낮은** 절대 누적을 주면 CAS 단조성으로
-            # no-op 이라 정정은 불가하나, 침묵 흡수하지 않고 surface 한다. 적용
-            # 전에 현재 recorded 와 비교한다(아래 apply_cumulative 가 멱등 no-op).
-            await self._maybe_alert_late_ccld(
+            # #2316 §11.4 / #2318 Finding ②: fallback 이 full fill 로 올린 주문이
+            # _fallback_verify 에 등록돼 있으면, ccld 절대 누적이 fallback 이
+            # advance 한 recorded 보다 **낮은** 양수면 over-attribution alert 를
+            # 발행하고(비가역·CAS no-op) verify 에서 제거한다. 동일/높으면(정상)
+            # 조용히 제거한다. 이 검증을 거쳐야 §11.4 alert 가 실제 poll 경로에서
+            # 도달 가능하다.
+            await self._verify_fallback_against_ccld(
                 broker_order_id=broker_order_id,
                 observed_cumulative=cumulative,
-                submitted_date=item_date,
             )
             delta = await self._applier.apply_cumulative(
                 account_id=self._account_id,
@@ -360,42 +419,98 @@ class FillReconcileScheduler:
         #    partially_filled 로 전이돼 expire_stale 의 만료 대상(genuinely-dead
         #    open)에서 자동 제외된다(I2·§11.5).
         await self._tracker.expire_stale(self._account_id, before_date=today)
+        # #2318 Finding ②: verify set 의 D-1 이전 항목을 영업일 경계에서 정리해
+        # 무한 누적을 막는다(§11.5 EOD 정리). 당일 항목은 그날의 late-ccld 검증을
+        # 위해 유지한다.
+        self._expire_stale_fallback_verify(before_date=today)
         return applied
 
-    async def _maybe_alert_late_ccld(
+    def _expire_stale_fallback_verify(self, *, before_date: str) -> None:
+        """``_fallback_verify`` 의 D-1 이전 항목을 정리한다 (#2318 Finding ②, §11.5).
+
+        영업일 경계(``submitted_date < before_date``, 즉 D+1 이후)에 도달한 verify
+        항목은 그 영업일의 ccld 가 이미 반영됐을 시한이 지났으므로(D+1 결제기준
+        원장) 정리해 in-memory set 의 무한 누적을 막는다. 당일(``== before_date``)
+        항목은 그날의 late-ccld 검증을 위해 유지한다. ``expire_stale`` 과 동일한
+        ``submitted_date < before_date`` 경계를 써 정리 시점을 EOD 만료와 정렬한다.
+        """
+        stale = [
+            odno
+            for odno, entry in self._fallback_verify.items()
+            if entry.submitted_date < before_date
+        ]
+        for odno in stale:
+            del self._fallback_verify[odno]
+        if stale:
+            logger.debug(
+                "fallback verify EOD 정리: account=%s, %d건 (before=%s)",
+                self._account_id,
+                len(stale),
+                before_date,
+            )
+
+    async def _verify_fallback_against_ccld(
         self,
         *,
         broker_order_id: str,
         observed_cumulative: float,
+    ) -> None:
+        """fallback 적용 주문의 ccld 절대 누적을 검증해 over-attribution 을 surface.
+
+        (#2316 §11.4, #2318 Finding ② — normative, 실제 poll 경로에서 reachable)
+
+        ``_fallback_verify`` 에 등록된 주문(fallback 이 full fill 로 advance)에 대해
+        ``_poll_and_apply`` 의 history loop 가 이 메서드를 호출한다. ccld 가 그 주문에
+        **더 낮은 절대 누적**(fallback 이 advance 한 ``recorded`` 미만의 양수)을 주면
+        CAS 단조성으로 ``record_fill`` 이 no-op 이라 정정은 불가하나(비가역),
+        ``PositionMismatchEvent``/``NotificationEvent`` 로 경보해 협소 외부 흡수
+        (§11.7) 가능성을 침묵 흡수하지 않고 surface 한다. 동일/높은 ccld(정상
+        advance/멱등)면 조용히 처리한다. 어느 경우든 검증 후 그 항목을 verify 에서
+        제거한다(bounded — ccld 가 한 번 관측되면 검증 완료).
+
+        eventbus 미주입이면 alert 는 best-effort 로 생략하나, verify 항목 제거(누적
+        방지)는 그대로 수행한다(멱등성·정확성 영향 없음).
+        """
+        entry = self._fallback_verify.get(broker_order_id)
+        if entry is None:
+            return
+        recorded = entry.recorded
+        # ccld 가 0 이거나 fallback recorded 이상이면 정상 경로(멱등 advance/no-op).
+        # recorded 보다 **낮은 양수** 누적일 때만 over-attribution 의심.
+        if 0 < observed_cumulative < recorded:
+            await self._emit_late_ccld_alert(
+                broker_order_id=broker_order_id,
+                recorded=recorded,
+                observed_cumulative=observed_cumulative,
+                submitted_date=entry.submitted_date,
+            )
+        # ccld 가 한 번 관측됐으므로 검증 완료 — verify 에서 제거(bounded).
+        self._fallback_verify.pop(broker_order_id, None)
+
+    async def _emit_late_ccld_alert(
+        self,
+        *,
+        broker_order_id: str,
+        recorded: float,
+        observed_cumulative: float,
         submitted_date: str,
     ) -> None:
-        """late-ccld over-attribution 가능성을 surface (#2316 §11.4, normative).
+        """late-ccld over-attribution 경보 1회 발행 (#2316 §11.4, normative).
 
-        fallback 이 full fill(``observed_cumulative = ordered_qty``)로 advance 한
-        뒤, 이후 ccld 폴이 그 주문에 **더 낮은 절대 누적**(현 ``recorded_filled_qty``
-        미만)을 주면 CAS 단조성으로 ``record_fill`` 이 no-op 이라 정정은 불가하다.
-        이는 fallback 이 협소 외부 매수(§11.7)를 self 로 흡수했을 가능성을 뜻하므로,
-        침묵 흡수하지 않고 ``PositionMismatchEvent``/``NotificationEvent`` 로
-        경보한다(비가역이라 정정은 못 하나 운영 관측 가능).
-
-        조건: ``0 < observed_cumulative < recorded_filled_qty``. eventbus 미주입이면
-        best-effort 로 생략(멱등성·정확성에는 영향 없음).
+        비가역(CAS no-op)이라 정정은 못 하나 운영 관측 가능하게
+        ``PositionMismatchEvent``/``NotificationEvent`` 를 발행한다. bot_id/symbol/
+        order_id 는 ``find_by_broker_order``(terminal 포함)로 복원한다 — fallback 이
+        full fill 로 ``filled``(terminal)된 주문이라 non-terminal scope 로는 누락된다.
+        eventbus 미주입이면 best-effort 로 생략한다.
         """
         if self._eventbus is None:
             return
-        # terminal-inclusive lookup: fallback 으로 filled(terminal)된 주문도 잡아야
-        # over-attribution 을 surface 할 수 있다(non-terminal scope 면 누락).
         record = await self._tracker.find_by_broker_order(
             self._account_id, broker_order_id, submitted_date
         )
         if record is None:
             return
         order_id = record.order_id
-        recorded = record.recorded_filled_qty
-        # ccld 가 0 이거나 현재 recorded 이상이면 정상 경로(멱등 advance/no-op).
-        # recorded 보다 **낮은 양수** 누적일 때만 over-attribution 의심.
-        if not (0 < observed_cumulative < recorded):
-            return
         diff = recorded - observed_cumulative
         logger.warning(
             "late-ccld over-attribution 의심: account=%s odno=%s order=%s "
@@ -455,13 +570,18 @@ class FillReconcileScheduler:
           보호, §11.2).
 
         적용(symbol 단위, §11.3 full-fill 정확매칭 — 전부 AND):
-        - 그 ``(account, symbol, side="buy")`` 의 추적 open buy 가 **정확히 하나**.
+        - 그 ``(account, symbol, side="buy")`` 의 추적 **non-terminal**(open/
+          partially_filled) buy 주문이 **정확히 하나**(#2318 Finding ①: 유일성은
+          미복구 후보만이 아닌 **모든 non-terminal open buy** 총수로 판정한다.
+          partially_filled open buy(recorded>0)가 공존하면 그 symbol 의 open buy
+          총수가 2 이상이라 §11.3-1 위반 → 미적용).
         - 그 유일 주문이 ``recorded_filled_qty == 0``.
         - 잔고 excess(``broker_qty - internal_account_qty``)가 그 주문
           ``ordered_qty`` 와 **정확히 일치**(``excess == ordered_qty``).
         → ``observed_cumulative = ordered_qty`` (full fill), avg_price=잔고 평단으로
           ``apply_cumulative`` **만** 호출한다(§11.8 단일 권위). partial/모호 excess·
-          다중 open buy 는 미적용(D+1 ccld 대기).
+          다중 open buy 는 미적용(D+1 ccld 대기). 적용 주문은 ``_fallback_verify``
+          에 등록해 이후 ccld 검증(§11.4)을 받게 한다(#2318 Finding ②).
         """
         if not (self._fallback_enabled and self._trade_service is not None):
             return 0
@@ -472,8 +592,20 @@ class FillReconcileScheduler:
 
         # ccld 적용 **후** open 을 재조회해 advance 된 recorded 를 반영한다.
         open_orders = await self._tracker.get_open_orders(self._account_id)
-        # 미복구(recorded==0) open **buy** 만 후보. ccld 가 부분이라도 반영한
-        # 주문(recorded>0)은 §11.3-2 위반이라 제외. 이 후보가 없으면 잔고 콜 생략.
+        # #2318 Finding ①: 유일성 판정은 그 symbol 의 **모든 non-terminal(open/
+        # partially_filled) buy** 총수로 한다. recorded>0 인 partially_filled open
+        # buy 가 unrecovered(recorded==0) buy 와 공존하면, 미복구만 세서 len==1 로
+        # 통과시키면 §11.3-1("그 symbol 의 추적 open buy 가 **정확히 하나**")를
+        # 위반한다. 모든 non-terminal open buy 를 symbol 별로 센다.
+        open_buy_count_by_symbol: dict[str, int] = {}
+        for o in open_orders:
+            if o.side == "buy":
+                open_buy_count_by_symbol[o.symbol] = (
+                    open_buy_count_by_symbol.get(o.symbol, 0) + 1
+                )
+        # 미복구(recorded==0) open **buy** 만 적용 후보. ccld 가 부분이라도 반영한
+        # 주문(recorded>0)은 §11.3-2 위반이라 후보에서 제외. 이 후보가 없으면 잔고
+        # 콜 생략(§11.2 rate budget).
         unrecovered_buys = [
             o
             for o in open_orders
@@ -510,22 +642,31 @@ class FillReconcileScheduler:
                     internal_qty_by_symbol.get(p.symbol, 0.0) + p.quantity
                 )
 
-        # symbol 별 미복구 open buy 그룹. §11.3-1 유일성 판정용.
+        # symbol 별 미복구 open buy 그룹(적용 후보). 유일성 판정은 아래에서 그
+        # symbol 의 **모든 non-terminal open buy 총수**(open_buy_count_by_symbol)로
+        # 한다 — 미복구 후보 그룹 크기가 아니다(#2318 Finding ①).
         buys_by_symbol: dict[str, list[OrderTrackerRecord]] = {}
         for o in unrecovered_buys:
             buys_by_symbol.setdefault(o.symbol, []).append(o)
 
         applied = 0
         for symbol, orders in buys_by_symbol.items():
-            # §11.3-1 다중 open buy(같은 symbol) → 미적용(외부/혼재 위험 회피).
-            if len(orders) != 1:
+            # §11.3-1 유일성: 그 symbol 의 **모든 non-terminal open buy 총수**가
+            # 정확히 1 이어야 한다(#2318 Finding ①). partially_filled open buy
+            # (recorded>0)가 공존하면 총수≥2 라 미적용 — 미복구 후보만 세서 통과
+            # 시키는 결함을 닫는다. (미복구 후보 자체가 같은 symbol 에 둘 이상이면
+            # 총수도 자동 ≥2 라 이 게이트가 함께 막는다.)
+            if open_buy_count_by_symbol.get(symbol, 0) != 1:
                 logger.debug(
-                    "fallback 미적용(다중 open buy): account=%s symbol=%s count=%d",
+                    "fallback 미적용(다중 non-terminal open buy): account=%s "
+                    "symbol=%s open_buy_count=%d",
                     self._account_id,
                     symbol,
-                    len(orders),
+                    open_buy_count_by_symbol.get(symbol, 0),
                 )
                 continue
+            # 유일 open buy 총수==1 이고 미복구 후보가 정확히 그 주문일 때만 진입.
+            # (unrecovered_buys 에서 온 orders 는 recorded==0 임이 보장된다.)
             order = orders[0]
             broker_qty = broker_qty_by_symbol.get(symbol, 0.0)
             internal_qty = internal_qty_by_symbol.get(symbol, 0.0)
@@ -555,6 +696,15 @@ class FillReconcileScheduler:
             )
             if delta > 0:
                 applied += 1
+                # #2318 Finding ②: fallback 이 full fill 로 advance 했으므로
+                # verify set 에 등록한다. 이후 사이클의 ccld 가 더 낮은 절대 누적을
+                # 주면 §11.4 over-attribution alert 가 실제 poll 경로에서 발행된다
+                # (fallback 이 주문을 filled 로 올려 open 이 비어도 verify 가
+                # 폴 게이트를 열어 ccld 가 도달한다).
+                self._fallback_verify[order.broker_order_id] = _FallbackVerifyEntry(
+                    recorded=order.ordered_qty,
+                    submitted_date=order.submitted_date,
+                )
                 logger.info(
                     "position-derived fallback 수렴: account=%s symbol=%s odno=%s "
                     "order=%s full_fill=%s @ %s (excess==ordered)",

--- a/src/ante/broker/fill_scheduler.py
+++ b/src/ante/broker/fill_scheduler.py
@@ -10,7 +10,15 @@ rate budget 보호:
   공유하므로(``_rate_limit_wait``), 보수적 cadence + 1콜/사이클로 제출 starvation 을
   방지한다.
 
-상세 설계: ``docs/specs/broker-adapter/18-fill-recovery.md``.
+position-derived bounded fallback (#2314·#2316 §11):
+- KIS 모의 ``inquire-daily-ccld``(``get_order_history``)는 일별 결제기준 원장이라
+  당일 체결을 0건으로 지연 반영한다. 반면 잔고(``get_positions``)는 체결기준
+  즉시반영이다. 백스톱이 당일 0건을 줄 때 잔고 증분(``broker_qty -
+  internal_account_qty``)에서 self-submitted 체결을 **보수적 역도출**해
+  ``FillApplier.apply_cumulative`` 로 멱등 수렴한다(§11.8 단일 권위 — 새 권위자
+  미생성). **KIS paper 한정 기본 활성**(§11.6), disable flag 로 rollback 가능.
+
+상세 설계: ``docs/specs/broker-adapter/18-fill-recovery.md`` (§11).
 """
 
 from __future__ import annotations
@@ -26,8 +34,10 @@ from ante.account.scoping import require_account_id
 
 if TYPE_CHECKING:
     from ante.broker.base import BrokerAdapter
+    from ante.eventbus.bus import EventBus
     from ante.trade.fill_applier import FillApplier
-    from ante.trade.order_tracker import OrderTracker
+    from ante.trade.order_tracker import OrderTracker, OrderTrackerRecord
+    from ante.trade.service import TradeService
 
 logger = logging.getLogger(__name__)
 
@@ -113,13 +123,39 @@ class FillReconcileScheduler:
         fill_applier: FillApplier,
         account_id: str,
         poll_interval: float = DEFAULT_POLL_INTERVAL,
+        trade_service: TradeService | None = None,
+        eventbus: EventBus | None = None,
+        fallback_enabled: bool = True,
     ) -> None:
+        """계좌별 체결 백스톱 폴러.
+
+        Args:
+            broker: 계좌 BrokerAdapter. ``get_order_history`` 백스톱과 (#2314
+                fallback 활성 시) ``get_positions`` 잔고 역도출을 제공한다.
+            order_tracker: 추적 주문 저장소.
+            fill_applier: 단일 멱등 choke point. 모든 체결 수렴은 이 경로뿐이다.
+            account_id: 계좌 ID.
+            poll_interval: 주기 폴 cadence(초). ``MIN_POLL_INTERVAL`` 하한.
+            trade_service: 내부 account-level 포지션 조회 의존성(#2316 §11.1
+                ``internal_account_qty`` = ``get_all_positions(account_id)`` 합산).
+                position-derived fallback 에만 쓰인다. ``None`` 이면 fallback 은
+                동작하지 않는다(legacy/partial wiring).
+            eventbus: late-ccld over-attribution alert(#2316 §11.4) 발행용.
+                ``None`` 이면 alert 를 surface 하지 못하나(best-effort), 멱등성·
+                수렴 정확성은 영향받지 않는다.
+            fallback_enabled: position-derived fallback **마스터 disable flag**
+                (#2316 §11.6). KIS paper 기본 활성을 두되 ``False`` 로 rollback
+                가능. 실제 적용은 추가로 ``broker.is_paper`` 가 true 여야 한다.
+        """
         require_account_id(account_id, context="fill_scheduler.__init__")
         self._broker = broker
         self._tracker = order_tracker
         self._applier = fill_applier
         self._account_id = account_id
         self._poll_interval = max(poll_interval, MIN_POLL_INTERVAL)
+        self._trade_service = trade_service
+        self._eventbus = eventbus
+        self._fallback_enabled = fallback_enabled
         self._task: asyncio.Task[None] | None = None
         self._running = False
 
@@ -220,9 +256,9 @@ class FillReconcileScheduler:
                 )
 
     async def _poll_and_apply(self) -> int:
-        """**poll-first**: open(만료 전) → history 1콜 → 적용 → 그 후 EOD 만료.
+        """**poll-first**: open(만료 전) → history 1콜 → fallback → 그 후 EOD 만료.
 
-        순서가 곧 정합성 invariant 다 (#1946 메타리뷰).
+        순서가 곧 정합성 invariant 다 (#1946 메타리뷰, #2316 §11.2).
 
         1. ``get_open_orders`` 로 추적 open(non-terminal)을 **만료 전에** 읽는다.
            ``from_date`` 는 그 open 들의 가장 이른 ``submitted_date`` 로 잡아, 전일
@@ -231,10 +267,17 @@ class FillReconcileScheduler:
            ``FillApplier.apply_cumulative`` 로 멱등 적용한다(복구). 다운타임 중
            체결분(전일 open 포함)이 여기서 ``filled``/``partially_filled`` 로 전이
            되어 다음 단계의 만료 대상에서 **자동 제외**된다(I1·I2).
-        3. **복구 후에** ``expire_stale`` 로 EOD 경과 + 체결 미관측(genuinely-dead)
-           인 ``open`` 만 ``expired`` 로 전이한다. 부분 체결(``partially_filled``)은
-           만료 대상이 아니다(체결 진행 중). 이로써 일중 미체결 주문의 무한 폴은
-           막되, 다운타임 체결분을 만료/외부매수로 오분류하지 않는다(I2·I7).
+        3. **(신규 #2314)** ②(ccld) 적용 후에도 남은 미복구 open buy 가 있으면
+           ``get_positions`` 잔고 역도출 fallback 을 적용한다(KIS paper 한정 기본
+           활성, §11). ccld 가 체결을 줘 capacity 가 advance 된 경우엔 ``excess``
+           가 0 으로 수렴해 fallback 이 본질적으로 no-op 이며, 애초에 미복구 open
+           buy 가 없으면 ``get_positions`` 자체를 **호출하지 않아 rate budget 을
+           보호**한다(§11.2).
+        4. **fallback 후에** ``expire_stale`` 로 EOD 경과 + 체결 미관측
+           (genuinely-dead)인 ``open`` 만 ``expired`` 로 전이한다. 부분 체결
+           (``partially_filled``)은 만료 대상이 아니다(체결 진행 중). 만료를
+           fallback **앞**에 두면 모의 당일 미반영 체결을 가진 open 이 복구 전에
+           expired 되어 fallback 이 대상을 잃는다(§11.5).
 
         expire 를 poll **앞**에 두면(이전 결함), 전일 open 이 다운타임 중 체결됐어도
         복구 전에 expired 되어 폴 0콜·미복구로 남고, ``catch_up_once`` 가
@@ -242,7 +285,7 @@ class FillReconcileScheduler:
         회귀). poll-first 가 이 구조를 해소한다(I3).
 
         Returns:
-            적용된 체결(delta>0) 건수.
+            적용된 체결(delta>0) 건수(ccld + fallback 합산).
 
         Raises:
             Exception: ``get_order_history`` 실패(CB open·rate·network)를 그대로
@@ -288,6 +331,15 @@ class FillReconcileScheduler:
             item_date = (
                 _normalize_history_date(str(item.get("timestamp", ""))) or to_date
             )
+            # #2316 §11.4 late-ccld over-attribution alert: fallback 이 full fill
+            # 로 올린 누적보다 ccld 가 **더 낮은** 절대 누적을 주면 CAS 단조성으로
+            # no-op 이라 정정은 불가하나, 침묵 흡수하지 않고 surface 한다. 적용
+            # 전에 현재 recorded 와 비교한다(아래 apply_cumulative 가 멱등 no-op).
+            await self._maybe_alert_late_ccld(
+                broker_order_id=broker_order_id,
+                observed_cumulative=cumulative,
+                submitted_date=item_date,
+            )
             delta = await self._applier.apply_cumulative(
                 account_id=self._account_id,
                 broker_order_id=broker_order_id,
@@ -298,8 +350,219 @@ class FillReconcileScheduler:
             if delta > 0:
                 applied += 1
 
-        # 3) 복구가 끝난 **뒤에** EOD 경과 + 체결 미관측(genuinely-dead) open 만
-        #    만료한다. 위 폴로 체결된 주문은 이미 filled/partially_filled 로 전이돼
-        #    expire_stale 의 만료 대상(genuinely-dead open)에서 자동 제외된다(I2).
+        # 3) **(신규 #2314·#2316 §11)** ccld 가 채우지 못한 미복구 open buy 가
+        #    남아 있을 때만 잔고-역도출 fallback 을 적용한다. open 을 ccld 적용
+        #    **후** 재조회해 advance 된 recorded_filled_qty 를 반영한다.
+        applied += await self._apply_position_fallback()
+
+        # 4) fallback 이 끝난 **뒤에** EOD 경과 + 체결 미관측(genuinely-dead) open
+        #    만 만료한다. 위 폴/fallback 으로 체결된 주문은 이미 filled/
+        #    partially_filled 로 전이돼 expire_stale 의 만료 대상(genuinely-dead
+        #    open)에서 자동 제외된다(I2·§11.5).
         await self._tracker.expire_stale(self._account_id, before_date=today)
+        return applied
+
+    async def _maybe_alert_late_ccld(
+        self,
+        *,
+        broker_order_id: str,
+        observed_cumulative: float,
+        submitted_date: str,
+    ) -> None:
+        """late-ccld over-attribution 가능성을 surface (#2316 §11.4, normative).
+
+        fallback 이 full fill(``observed_cumulative = ordered_qty``)로 advance 한
+        뒤, 이후 ccld 폴이 그 주문에 **더 낮은 절대 누적**(현 ``recorded_filled_qty``
+        미만)을 주면 CAS 단조성으로 ``record_fill`` 이 no-op 이라 정정은 불가하다.
+        이는 fallback 이 협소 외부 매수(§11.7)를 self 로 흡수했을 가능성을 뜻하므로,
+        침묵 흡수하지 않고 ``PositionMismatchEvent``/``NotificationEvent`` 로
+        경보한다(비가역이라 정정은 못 하나 운영 관측 가능).
+
+        조건: ``0 < observed_cumulative < recorded_filled_qty``. eventbus 미주입이면
+        best-effort 로 생략(멱등성·정확성에는 영향 없음).
+        """
+        if self._eventbus is None:
+            return
+        # terminal-inclusive lookup: fallback 으로 filled(terminal)된 주문도 잡아야
+        # over-attribution 을 surface 할 수 있다(non-terminal scope 면 누락).
+        record = await self._tracker.find_by_broker_order(
+            self._account_id, broker_order_id, submitted_date
+        )
+        if record is None:
+            return
+        order_id = record.order_id
+        recorded = record.recorded_filled_qty
+        # ccld 가 0 이거나 현재 recorded 이상이면 정상 경로(멱등 advance/no-op).
+        # recorded 보다 **낮은 양수** 누적일 때만 over-attribution 의심.
+        if not (0 < observed_cumulative < recorded):
+            return
+        diff = recorded - observed_cumulative
+        logger.warning(
+            "late-ccld over-attribution 의심: account=%s odno=%s order=%s "
+            "recorded=%s ccld_cumulative=%s diff=%s — 비가역(CAS no-op), 경보만",
+            self._account_id,
+            broker_order_id,
+            order_id,
+            recorded,
+            observed_cumulative,
+            diff,
+        )
+        from ante.eventbus.events import NotificationEvent, PositionMismatchEvent
+
+        await self._eventbus.publish(
+            PositionMismatchEvent(
+                account_id=self._account_id,
+                bot_id=record.bot_id,
+                symbol=record.symbol,
+                internal_qty=recorded,
+                broker_qty=observed_cumulative,
+                reason=(
+                    "late_ccld_over_attribution: position-derived fallback advanced "
+                    f"recorded={recorded} but ccld returned lower cumulative="
+                    f"{observed_cumulative} (odno={broker_order_id}, "
+                    f"order={order_id}, diff={diff}) — irreversible (CAS no-op)"
+                ),
+            )
+        )
+        await self._eventbus.publish(
+            NotificationEvent(
+                level="warning",
+                title="체결 over-attribution 의심 (모의 fallback)",
+                message=(
+                    f"잔고 역도출 fallback 이 {record.symbol} 주문(odno="
+                    f"{broker_order_id})을 recorded={recorded} 로 올렸으나, 이후 "
+                    f"ccld 가 더 낮은 누적={observed_cumulative} (diff={diff})를 "
+                    "반환했습니다. 비가역이라 정정되지 않으며 협소 외부 매수 흡수 "
+                    "가능성을 경보합니다(§11.4·§11.7)."
+                ),
+                category="reconcile",
+            )
+        )
+
+    async def _apply_position_fallback(self) -> int:
+        """position-derived bounded fallback (#2314·#2316 §11). 적용 건수 반환.
+
+        ②(ccld) 적용 후에도 남은 **미복구 open buy** 가 있을 때만, 잔고
+        (``get_positions``, 체결기준 즉시반영) 증분에서 self-submitted full fill 을
+        보수적으로 역도출해 ``FillApplier.apply_cumulative`` 로 멱등 수렴한다.
+
+        gate(전부 AND):
+        - ``fallback_enabled`` (마스터 disable flag, §11.6) 와 ``broker.is_paper``
+          가 모두 true(KIS paper 한정 기본 활성).
+        - ``trade_service`` 주입(``internal_account_qty`` 조회 의존성, §11.1).
+        - ccld 가 채우지 못한 **미복구 open buy(``recorded_filled_qty == 0``)** 가
+          남아 있음. 없으면 ``get_positions`` 를 **호출하지 않는다**(rate budget
+          보호, §11.2).
+
+        적용(symbol 단위, §11.3 full-fill 정확매칭 — 전부 AND):
+        - 그 ``(account, symbol, side="buy")`` 의 추적 open buy 가 **정확히 하나**.
+        - 그 유일 주문이 ``recorded_filled_qty == 0``.
+        - 잔고 excess(``broker_qty - internal_account_qty``)가 그 주문
+          ``ordered_qty`` 와 **정확히 일치**(``excess == ordered_qty``).
+        → ``observed_cumulative = ordered_qty`` (full fill), avg_price=잔고 평단으로
+          ``apply_cumulative`` **만** 호출한다(§11.8 단일 권위). partial/모호 excess·
+          다중 open buy 는 미적용(D+1 ccld 대기).
+        """
+        if not (self._fallback_enabled and self._trade_service is not None):
+            return 0
+        # §11.6 KIS paper 한정. base BrokerAdapter 에 is_paper 가 없으므로 안전
+        # getattr(미정의/실전이면 비활성).
+        if not getattr(self._broker, "is_paper", False):
+            return 0
+
+        # ccld 적용 **후** open 을 재조회해 advance 된 recorded 를 반영한다.
+        open_orders = await self._tracker.get_open_orders(self._account_id)
+        # 미복구(recorded==0) open **buy** 만 후보. ccld 가 부분이라도 반영한
+        # 주문(recorded>0)은 §11.3-2 위반이라 제외. 이 후보가 없으면 잔고 콜 생략.
+        unrecovered_buys = [
+            o
+            for o in open_orders
+            if o.side == "buy" and o.recorded_filled_qty == 0 and o.ordered_qty > 0
+        ]
+        if not unrecovered_buys:
+            # §11.2 rate budget: 미복구 open buy 가 없으면 get_positions 미호출.
+            return 0
+
+        # 후보가 있을 때만 잔고 1콜. (symbol 별로 유일 매칭만 적용하므로 한 번에
+        # 전 symbol 잔고를 받아 in-memory 매칭한다.)
+        broker_positions = await self._broker.get_positions()
+        broker_qty_by_symbol: dict[str, float] = {}
+        avg_price_by_symbol: dict[str, float] = {}
+        for bp in broker_positions:
+            symbol = str(bp.get("symbol", ""))
+            if not symbol:
+                continue
+            qty = float(bp.get("quantity", 0.0) or 0.0)
+            broker_qty_by_symbol[symbol] = broker_qty_by_symbol.get(symbol, 0.0) + qty
+            # 잔고 평단(§11.4 avg_price 근거). 동일 symbol 다중 row 는 드무나,
+            # 첫 양수 평단을 유지한다(잔고가 제공하는 유일 가격 정보).
+            if symbol not in avg_price_by_symbol:
+                avg_price_by_symbol[symbol] = float(bp.get("avg_price", 0.0) or 0.0)
+
+        # §11.1 internal_account_qty = 계좌 전 bot 포지션 합(특정 bot 아님).
+        internal_positions = await self._trade_service.get_all_positions(
+            account_id=self._account_id
+        )
+        internal_qty_by_symbol: dict[str, float] = {}
+        for p in internal_positions:
+            if p.quantity > 0:
+                internal_qty_by_symbol[p.symbol] = (
+                    internal_qty_by_symbol.get(p.symbol, 0.0) + p.quantity
+                )
+
+        # symbol 별 미복구 open buy 그룹. §11.3-1 유일성 판정용.
+        buys_by_symbol: dict[str, list[OrderTrackerRecord]] = {}
+        for o in unrecovered_buys:
+            buys_by_symbol.setdefault(o.symbol, []).append(o)
+
+        applied = 0
+        for symbol, orders in buys_by_symbol.items():
+            # §11.3-1 다중 open buy(같은 symbol) → 미적용(외부/혼재 위험 회피).
+            if len(orders) != 1:
+                logger.debug(
+                    "fallback 미적용(다중 open buy): account=%s symbol=%s count=%d",
+                    self._account_id,
+                    symbol,
+                    len(orders),
+                )
+                continue
+            order = orders[0]
+            broker_qty = broker_qty_by_symbol.get(symbol, 0.0)
+            internal_qty = internal_qty_by_symbol.get(symbol, 0.0)
+            excess = broker_qty - internal_qty
+            # §11.1 excess <= 0 → 대상 없음(no-op).
+            if excess <= 0:
+                continue
+            # §11.3-3 full-fill 정확매칭: excess == ordered_qty 일 때만 적용.
+            if excess != order.ordered_qty:
+                logger.debug(
+                    "fallback 미적용(partial/모호 excess): account=%s symbol=%s "
+                    "excess=%s ordered=%s — D+1 ccld 대기",
+                    self._account_id,
+                    symbol,
+                    excess,
+                    order.ordered_qty,
+                )
+                continue
+            # §11.3·§11.8: full fill 절대 누적을 FillApplier **만** 호출해 수렴.
+            avg_price = avg_price_by_symbol.get(symbol, order.avg_fill_price)
+            delta = await self._applier.apply_cumulative(
+                account_id=self._account_id,
+                broker_order_id=order.broker_order_id,
+                observed_cumulative=order.ordered_qty,
+                avg_price=avg_price,
+                submitted_date=order.submitted_date,
+            )
+            if delta > 0:
+                applied += 1
+                logger.info(
+                    "position-derived fallback 수렴: account=%s symbol=%s odno=%s "
+                    "order=%s full_fill=%s @ %s (excess==ordered)",
+                    self._account_id,
+                    symbol,
+                    order.broker_order_id,
+                    order.order_id,
+                    order.ordered_qty,
+                    avg_price,
+                )
         return applied

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -744,6 +744,15 @@ async def _init_fill_recovery_schedulers(s: Services, accounts: list[Any]) -> No
     """
     from ante.broker.fill_scheduler import FillReconcileScheduler
 
+    # #2314·#2316 §11.6: position-derived fallback 마스터 disable flag. KIS paper
+    # 기본 활성(True)을 두되 config 로 rollback 가능. 실제 적용은 추가로
+    # broker.is_paper 가 true 여야 한다(scheduler 내부 gate).
+    fallback_enabled = (
+        bool(s.config.get("system.fill_position_fallback_enabled", True))
+        if s.config is not None
+        else True
+    )
+
     s.fill_catch_up_failed_accounts.clear()
     for account in accounts:
         try:
@@ -756,6 +765,11 @@ async def _init_fill_recovery_schedulers(s: Services, accounts: list[Any]) -> No
             order_tracker=s.order_tracker,
             fill_applier=s.fill_applier,
             account_id=account.account_id,
+            # #2314·#2316 §11: 잔고 역도출 fallback 의 internal_account_qty 조회
+            # 의존성(§11.1) + late-ccld over-attribution alert(§11.4) 발행 경로.
+            trade_service=s.trade_service,
+            eventbus=s.eventbus,
+            fallback_enabled=fallback_enabled,
         )
         # 기동 카치업 — barrier. reconcile 보다 반드시 선행.
         # CatchUpResult.succeeded 로 폴 실패와 "정상 0건/open-없음" 을 구분한다.

--- a/src/ante/trade/order_tracker.py
+++ b/src/ante/trade/order_tracker.py
@@ -556,6 +556,37 @@ class OrderTracker:
         )
         return OrderTrackerRecord.from_row(row) if row else None
 
+    async def find_by_broker_order(
+        self,
+        account_id: str,
+        broker_order_id: str,
+        submitted_date: str,
+    ) -> OrderTrackerRecord | None:
+        """관측(account/broker_order_id/observed_date) → 추적 레코드 (terminal 포함).
+
+        ``lookup_order_id`` 와 달리 **status 무관**(terminal 포함)으로 매핑한다.
+        #2316 §11.4 late-ccld over-attribution alert 전용 — fallback 이 full fill
+        로 advance 해 ``filled``(terminal)이 된 주문에 대해 이후 ccld 가 **더 낮은**
+        누적을 반환할 때, 그 주문의 현 ``recorded_filled_qty`` 와 비교해 경보를
+        surface 하기 위함이다. ``lookup_order_id`` 의 non-terminal scope 로는 이미
+        filled 된 주문을 찾지 못해 경보 자체가 누락된다.
+
+        scope/정렬은 ``lookup_order_id`` 와 동일하게 ``submitted_date <=
+        observed_date`` 의 최신(MAX) 1건이다(일자 재사용 격리·결정성 유지).
+        """
+        validated = require_account_id(
+            account_id, context="order_tracker.find_by_broker_order"
+        )
+        row = await self._db.fetch_one(
+            """SELECT * FROM order_tracker
+                 WHERE account_id = ? AND broker_order_id = ?
+                   AND submitted_date <= ?
+                 ORDER BY submitted_date DESC
+                 LIMIT 1""",
+            (validated, broker_order_id, submitted_date),
+        )
+        return OrderTrackerRecord.from_row(row) if row else None
+
     async def expire_stale(self, account_id: str, before_date: str) -> int:
         """``submitted_date < before_date`` 인 **genuinely-dead** ``open`` 만
         ``expired`` 표기.

--- a/tests/unit/test_fill_scheduler.py
+++ b/tests/unit/test_fill_scheduler.py
@@ -665,6 +665,7 @@ class FallbackBroker:
         self.is_paper = is_paper
         self.history_calls = 0
         self.positions_calls = 0
+        self.last_history_args: tuple | None = None
 
     def set_history(self, history: list[dict]) -> None:
         self._history = history
@@ -674,6 +675,7 @@ class FallbackBroker:
 
     async def get_order_history(self, from_date=None, to_date=None):
         self.history_calls += 1
+        self.last_history_args = (from_date, to_date)
         return list(self._history)
 
     async def get_positions(self):
@@ -829,7 +831,10 @@ async def test_fallback_idempotent_on_repoll(fallback_applier, tracker):
     """fallback 수렴 후 같은 상태 재폴 → 추가 반영 0(이중 반영 없음).
 
     재폴 시 order 가 filled(terminal)라 미복구 open buy 후보가 없어
-    get_positions 도 호출되지 않는다(§11.2 rate budget).
+    get_positions 는 호출되지 않는다(§11.2 rate budget). 단 #2318 Finding ②:
+    당일 verify set 이 남아 ccld 폴 게이트는 열린다(history 1콜) — verify 검증을
+    위함이며 잔고 역도출(get_positions)은 여전히 미호출이라 rate budget 핵심
+    (잔고/제출 큐)은 보호된다.
     """
     app, ph, _eb, svc = fallback_applier
     await tracker.open(
@@ -850,12 +855,17 @@ async def test_fallback_idempotent_on_repoll(fallback_applier, tracker):
     first = await sched.catch_up_once()
     assert first.applied == 1
     assert broker.positions_calls == 1
+    # fallback 적용 → 당일 verify 등록.
+    assert "0001" in sched._fallback_verify
 
     second = await sched.catch_up_once()
     assert second.applied == 0  # 멱등 — 추가 반영 없음.
-    # filled terminal → open 없음 → 폴 0콜, 잔고도 미호출.
-    assert broker.history_calls == 1  # 둘째 사이클은 open 없어 0콜(누계 유지).
+    # filled terminal → open 없음. 당일 verify 가 남아 ccld 폴 게이트는 열린다.
+    assert broker.history_calls == 2  # 둘째 사이클: verify 가 폴 게이트 오픈.
+    # 잔고 역도출은 미복구 후보 없어 여전히 미호출(§11.2 핵심 보호 유지).
     assert broker.positions_calls == 1
+    # ccld 빈 응답이라 verify 는 아직 남음(당일, 검증 미관측).
+    assert "0001" in sched._fallback_verify
     pos = await ph.get_current("bot-1", "069500", account_id=ACCT)
     assert pos["quantity"] == 1.0
 
@@ -882,9 +892,12 @@ async def test_fallback_then_ccld_same_cumulative_noop(fallback_applier, tracker
     sched = _make_fallback_sched(broker, tracker, app, svc)
     first = await sched.catch_up_once()
     assert first.applied == 1
+    assert "0001" in sched._fallback_verify
 
-    # 이제 ccld 가 같은 체결(절대 누적 1)을 반환. 하지만 order 는 filled 라
-    # open 후보가 없어 폴되지 않는다 → no-op 보장(멱등). 포지션 불변.
+    # 이제 ccld 가 같은 체결(절대 누적 1)을 반환. order 는 filled 지만 #2318
+    # Finding ②: 당일 verify 가 폴 게이트를 열어 ccld 가 도달한다. ccld == recorded
+    # 라 record_fill CAS 는 no-op(멱등) 이고, verify 검증은 동일 누적이라 조용히
+    # 제거된다. 포지션 불변.
     broker.set_history(
         [
             {
@@ -897,6 +910,8 @@ async def test_fallback_then_ccld_same_cumulative_noop(fallback_applier, tracker
     )
     second = await sched.catch_up_once()
     assert second.applied == 0
+    assert broker.history_calls == 2  # verify 가 폴 게이트를 열어 ccld 도달.
+    assert "0001" not in sched._fallback_verify  # ccld 관측 → 검증 완료 제거.
     pos = await ph.get_current("bot-1", "069500", account_id=ACCT)
     assert pos["quantity"] == 1.0
 
@@ -904,13 +919,16 @@ async def test_fallback_then_ccld_same_cumulative_noop(fallback_applier, tracker
 # ── 시나리오 4b: late-ccld 더 낮은 값 → reconcile alert 발행 ──
 
 
-async def test_late_ccld_lower_cumulative_emits_reconcile_alert(
+async def test_late_ccld_lower_cumulative_emits_reconcile_alert_via_poll(
     fallback_applier, tracker
 ):
-    """fallback 이 full fill 로 올린 뒤 ccld 가 **더 낮은** 누적 → no-op + alert.
+    """#2318 Finding ②: fallback full fill 후 **실제 poll 경로**로 더 낮은 ccld →
+    alert 발행 (도달성 검증).
 
     §11.4: 비가역(CAS 단조)이라 정정은 못 하나 PositionMismatchEvent +
-    NotificationEvent 로 over-attribution 가능성을 surface 한다.
+    NotificationEvent 로 over-attribution 가능성을 surface 한다. fallback 이 주문을
+    filled(terminal)로 올려 open 이 비어도, verify set 이 폴 게이트를 열어 ccld 가
+    _poll_and_apply 경로에서 도달한다(_maybe_alert 직접 호출 아님).
     """
     from ante.eventbus.events import NotificationEvent, PositionMismatchEvent
 
@@ -940,34 +958,52 @@ async def test_late_ccld_lower_cumulative_emits_reconcile_alert(
         ordered_qty=2.0,
         submitted_date=DATE,
     )
-    # fallback: 잔고 2주 == ordered 2 → full fill 로 recorded=2.
+    # 1) fallback: ccld 0건 + 잔고 2주 == ordered 2 → full fill 로 recorded=2.
     broker = FallbackBroker(history=[], positions=[_pos("069500", 2.0)])
     sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
-    await sched.catch_up_once()
+    first = await sched.catch_up_once()
+    assert first.applied == 1
     assert (await tracker.get("ord-fb")).recorded_filled_qty == 2.0
+    # verify set 에 등록되어 다음 사이클 폴 게이트를 연다.
+    assert "0001" in sched._fallback_verify
 
-    # late ccld: 실 체결 누적이 1(더 낮음) 이라고 반환. order 는 filled 라
-    # lookup_order_id(non-terminal scope)에 안 잡혀 폴 자체가 0콜이 되는 것을
-    # 막기 위해, alert 경로(_maybe_alert_late_ccld)는 history loop 에서 직접
-    # 호출된다. order 가 filled 여서 open 폴이 0콜이 되므로, alert 검증은
-    # _maybe_alert_late_ccld 를 직접 호출해 확인한다.
-    await sched._maybe_alert_late_ccld(
-        broker_order_id="0001",
-        observed_cumulative=1.0,
-        submitted_date=DATE,
+    # 2) 다음 사이클: order 가 filled 라 open 은 비었지만 verify set 이 남아
+    #    ccld 를 폴한다. ccld 가 실 체결 누적 1(더 낮음)을 반환 → _poll_and_apply
+    #    경로에서 verify 검증 → alert 발행 (실제 도달성).
+    broker.set_history(
+        [
+            {
+                "order_id": "0001",
+                "filled_quantity": 1.0,
+                "price": 1000.0,
+                "timestamp": DATE,
+            }
+        ]
     )
+    await sched._poll_and_apply()
+    # verify set 이 비어있지 않아 ccld 를 폴했다(open 없음에도 도달).
+    assert broker.history_calls == 2
     assert len(mismatches) == 1
     assert mismatches[0].internal_qty == 2.0
     assert mismatches[0].broker_qty == 1.0
     assert "late_ccld_over_attribution" in mismatches[0].reason
     assert len(notifs) == 1
     assert notifs[0].level == "warning"
+    # 검증 완료 → verify 에서 제거(bounded).
+    assert "0001" not in sched._fallback_verify
+    # 포지션은 불변(비가역 no-op).
+    pos = await ph.get_current("bot-1", "069500", account_id=ACCT)
+    assert pos["quantity"] == 2.0
 
 
-async def test_late_ccld_alert_not_emitted_when_ccld_higher_or_equal(
+async def test_late_ccld_alert_not_emitted_when_ccld_higher_or_equal_via_poll(
     fallback_applier, tracker
 ):
-    """ccld 가 recorded 이상(정상 advance/멱등)이면 alert 미발행 (오경보 방지)."""
+    """#2318 Finding ②: ccld 가 recorded 이상(정상 advance/멱등)이면 alert 미발행.
+
+    실제 poll 경로로 검증한다. ccld == recorded(멱등)면 verify 에서 조용히 제거되고
+    alert 가 발행되지 않는다(오경보 방지).
+    """
     from ante.eventbus.events import PositionMismatchEvent
 
     app, _ph, eb, svc = fallback_applier
@@ -992,17 +1028,143 @@ async def test_late_ccld_alert_not_emitted_when_ccld_higher_or_equal(
     )
     broker = FallbackBroker(history=[], positions=[_pos("069500", 2.0)])
     sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
-    await sched.catch_up_once()  # recorded=2.
+    await sched.catch_up_once()  # recorded=2, verify 등록.
+    assert "0001" in sched._fallback_verify
 
-    # ccld == recorded (멱등) → alert 없음.
-    await sched._maybe_alert_late_ccld(
-        broker_order_id="0001", observed_cumulative=2.0, submitted_date=DATE
+    # ccld == recorded (멱등 정상) → alert 없음 + verify 에서 조용히 제거.
+    broker.set_history(
+        [
+            {
+                "order_id": "0001",
+                "filled_quantity": 2.0,
+                "price": 1000.0,
+                "timestamp": DATE,
+            }
+        ]
     )
-    # ccld > recorded (정상 추가 advance) → alert 없음.
-    await sched._maybe_alert_late_ccld(
-        broker_order_id="0001", observed_cumulative=3.0, submitted_date=DATE
-    )
+    await sched._poll_and_apply()
+    assert broker.history_calls == 2  # verify 가 폴 게이트를 열었다.
     assert mismatches == []
+    assert "0001" not in sched._fallback_verify  # 검증 완료 제거.
+
+
+async def test_verify_only_poll_gate_opens_ccld_poll(fallback_applier, tracker):
+    """#2318 Finding ②: open 이 없어도 verify set 이 있으면 _poll_and_apply 가 ccld
+    를 폴한다(폴 게이트 도달성). open·verify 둘 다 없을 때만 미폴(§11.2).
+    """
+    app, _ph, eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,  # 당일 → verify 가 EOD 정리에 살아남는다.
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    # fallback 적용 → filled → open 비고, 당일 verify 등록.
+    await sched.catch_up_once()
+    assert "0001" in sched._fallback_verify
+    assert await tracker.get_open_orders(ACCT) == []  # open 비었음.
+    calls_after_first = broker.history_calls
+
+    # open 이 비었지만 verify 가 있어 ccld 폴 게이트가 열린다.
+    broker.set_history([])  # ccld 없음.
+    await sched._poll_and_apply()
+    assert broker.history_calls == calls_after_first + 1  # verify-only 폴 도달.
+
+
+async def test_verify_window_from_date_covers_verify_submitted_date(
+    fallback_applier, tracker
+):
+    """#2318 Finding ②: 폴 window from_date 가 verify 주문의 submitted_date 까지
+    거슬러 덮는다(ccld 가 그 주문을 관측 가능하게).
+
+    verify 항목을 직접 주입(이전 사이클 등록 상태 흉내)하고 _poll_and_apply 의
+    from_date 를 last_history_args 로 검증한다. open 은 없다(verify-only).
+    """
+    from ante.broker.fill_scheduler import _FallbackVerifyEntry
+
+    app, _ph, eb, svc = fallback_applier
+    broker = FallbackBroker(history=[], positions=[])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    # open 없음. verify 항목만 전일 날짜로 직접 주입(폴 시점 from_date 결정 검증).
+    prior_date = "20200101"
+    sched._fallback_verify["0001"] = _FallbackVerifyEntry(
+        recorded=1.0, submitted_date=prior_date
+    )
+    await sched._poll_and_apply()
+    # 폴이 돌았고(verify 게이트), window from_date 가 verify submitted_date 를 덮는다.
+    assert broker.history_calls == 1
+    assert broker.last_history_args is not None
+    from_date, to_date = broker.last_history_args
+    assert from_date == prior_date  # ccld 가 전일 주문을 관측하도록 거슬러 덮음.
+    assert to_date == DATE
+    # 전일 항목은 같은 사이클 EOD 정리에서 제거된다(D+1 경계, 무한 누적 방지).
+    assert sched._fallback_verify == {}
+
+
+async def test_verify_set_eod_cleanup_on_business_day_boundary(
+    fallback_applier, tracker
+):
+    """#2318 Finding ②: verify set 은 영업일 경계(submitted_date < today)에 정리돼
+    무한 누적되지 않는다(§11.5 EOD 정리).
+    """
+    app, _ph, eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date="20200101",  # 전일(EOD 경과).
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    await sched.catch_up_once()  # fallback 적용 → verify 등록(전일).
+    # _poll_and_apply 의 EOD 정리에서 submitted_date < today 라 즉시 제거됐다.
+    assert sched._fallback_verify == {}
+
+
+async def test_verify_set_today_entry_retained_across_idle_cleanup(
+    fallback_applier, tracker
+):
+    """#2318 Finding ②: 당일 verify 항목은 EOD 정리에서 유지된다(그날 ccld 검증용).
+
+    ccld 가 아직 안 와도(history 빈) 당일 항목은 verify 에 남아 다음 사이클에도
+    폴 게이트를 연다. ccld 가 한 번 관측되어야(또는 D+1 경계) 제거된다.
+    """
+    app, _ph, eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,  # 당일.
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    await sched.catch_up_once()  # fallback 적용 → 당일 verify 등록.
+    assert "0001" in sched._fallback_verify
+    # ccld 미관측(history 빈) 추가 사이클 — 당일 항목은 유지(EOD 경계 미도달).
+    broker.set_history([])
+    await sched._poll_and_apply()
+    assert "0001" in sched._fallback_verify  # 당일 → 유지.
+    assert broker.history_calls == 2  # verify 가 폴 게이트를 계속 연다.
 
 
 # ── 시나리오 5: self/external 경계 (excess != ordered, 다중 open buy) ──
@@ -1066,6 +1228,77 @@ async def test_fallback_skipped_when_multiple_open_buys_same_symbol(
     assert result.applied == 0
     assert (await tracker.get("ord-a")).recorded_filled_qty == 0.0
     assert (await tracker.get("ord-b")).recorded_filled_qty == 0.0
+
+
+async def test_fallback_skipped_when_partial_open_buy_coexists_with_unrecovered(
+    fallback_applier, tracker
+):
+    """#2318 Finding ①: 같은 symbol 에 partially_filled open buy(recorded>0) +
+    unrecovered buy(recorded==0) 공존 → fallback **미적용**.
+
+    유일성 판정을 미복구(recorded==0) 후보만으로 보면(이전 결함) unrecovered 1건만
+    세서 len==1 로 통과해 §11.3-1("그 symbol 의 추적 open buy 가 정확히 하나")를
+    위반한다. 유일성은 그 symbol 의 **모든 non-terminal(open/partially_filled)
+    buy 총수**(여기선 2)로 판정해야 하며, 1 이 아니면 미적용한다.
+    """
+    app, _ph, _eb, svc = fallback_applier
+    # 1) partially_filled open buy: ordered 2, ccld 부분체결 1 → recorded=1,
+    #    status=partially_filled (여전히 non-terminal open buy).
+    await tracker.open(
+        order_id="ord-partial",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=2.0,
+        submitted_date=DATE,
+    )
+    partial_delta = await app.apply_cumulative(
+        account_id=ACCT,
+        broker_order_id="0001",
+        observed_cumulative=1.0,
+        avg_price=1000.0,
+        submitted_date=DATE,
+    )
+    assert partial_delta == 1.0
+    partial_rec = await tracker.get("ord-partial")
+    assert partial_rec.status == "partially_filled"
+    assert partial_rec.recorded_filled_qty == 1.0
+    # 2) unrecovered open buy: 같은 symbol, ordered 1, recorded 0.
+    await tracker.open(
+        order_id="ord-unrec",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0002",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    # 잔고: 기존 partial 1주(internal 반영됨) + unrecovered 1주 미반영 = 2주 보유.
+    # internal_account_qty 는 partial 의 1주. excess = 2 - 1 = 1 == unrec ordered 1.
+    # excess==ordered 만 보면 적용될 듯하나, 같은 symbol open buy 총수 2 → 미적용.
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 2.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc)
+    result = await sched.catch_up_once()
+
+    # ccld 0건이라 unrecovered 후보 존재 → 잔고는 봤으나(후보 있음) 유일성 위반
+    # 으로 미적용.
+    assert result.applied == 0
+    assert broker.positions_calls == 1
+    # unrecovered 는 미반영 유지 (open 그대로).
+    unrec = await tracker.get("ord-unrec")
+    assert unrec.recorded_filled_qty == 0.0
+    assert unrec.status == "open"
+    # partial 도 fallback 이 건드리지 않음 (recorded 그대로 1).
+    assert (await tracker.get("ord-partial")).recorded_filled_qty == 1.0
+    # verify set 에도 등록되지 않음 (미적용).
+    assert sched._fallback_verify == {}
 
 
 async def test_fallback_excludes_external_qty_via_internal_subtraction(

--- a/tests/unit/test_fill_scheduler.py
+++ b/tests/unit/test_fill_scheduler.py
@@ -897,14 +897,15 @@ async def test_fallback_then_ccld_same_cumulative_noop(fallback_applier, tracker
     # 이제 ccld 가 같은 체결(절대 누적 1)을 반환. order 는 filled 지만 #2318
     # Finding ②: 당일 verify 가 폴 게이트를 열어 ccld 가 도달한다. ccld == recorded
     # 라 record_fill CAS 는 no-op(멱등) 이고, verify 검증은 동일 누적이라 조용히
-    # 제거된다. 포지션 불변.
+    # 제거된다. 포지션 불변. #2318 Codex 리뷰: timestamp=DATE 가 verify 항목의
+    # submitted_date=DATE 와 **같은 날짜**라 date-scope 매칭이 성립한다.
     broker.set_history(
         [
             {
                 "order_id": "0001",
                 "filled_quantity": 1.0,
                 "price": 1000.0,
-                "timestamp": DATE,
+                "timestamp": DATE,  # verify submitted_date(DATE)와 같은 날짜 → 매칭.
             }
         ]
     )
@@ -969,14 +970,15 @@ async def test_late_ccld_lower_cumulative_emits_reconcile_alert_via_poll(
 
     # 2) 다음 사이클: order 가 filled 라 open 은 비었지만 verify set 이 남아
     #    ccld 를 폴한다. ccld 가 실 체결 누적 1(더 낮음)을 반환 → _poll_and_apply
-    #    경로에서 verify 검증 → alert 발행 (실제 도달성).
+    #    경로에서 verify 검증 → alert 발행 (실제 도달성). #2318 Codex 리뷰:
+    #    timestamp=DATE 가 verify submitted_date=DATE 와 같은 날짜라 매칭한다.
     broker.set_history(
         [
             {
                 "order_id": "0001",
                 "filled_quantity": 1.0,
                 "price": 1000.0,
-                "timestamp": DATE,
+                "timestamp": DATE,  # verify submitted_date(DATE)와 같은 날짜 → 매칭.
             }
         ]
     )
@@ -1032,13 +1034,14 @@ async def test_late_ccld_alert_not_emitted_when_ccld_higher_or_equal_via_poll(
     assert "0001" in sched._fallback_verify
 
     # ccld == recorded (멱등 정상) → alert 없음 + verify 에서 조용히 제거.
+    # #2318 Codex 리뷰: timestamp=DATE 가 verify submitted_date=DATE 와 같은 날짜.
     broker.set_history(
         [
             {
                 "order_id": "0001",
                 "filled_quantity": 2.0,
                 "price": 1000.0,
-                "timestamp": DATE,
+                "timestamp": DATE,  # verify submitted_date(DATE)와 같은 날짜 → 매칭.
             }
         ]
     )
@@ -1165,6 +1168,172 @@ async def test_verify_set_today_entry_retained_across_idle_cleanup(
     await sched._poll_and_apply()
     assert "0001" in sched._fallback_verify  # 당일 → 유지.
     assert broker.history_calls == 2  # verify 가 폴 게이트를 계속 연다.
+
+
+# ── #2318 Codex 리뷰: late-ccld verify date-scope (영업일 재사용 odno) ──
+
+
+async def test_late_ccld_different_date_same_odno_does_not_misfire(
+    fallback_applier, tracker
+):
+    """#2318 Codex 리뷰: 다른 날짜 같은 odno ccld 는 verify 항목을 매칭하지 않는다.
+
+    KIS odno(broker_order_id)는 영업일 재사용 가능하므로 유일키는
+    (account, odno, submitted_date)다(spec §4.1). 폴 window(from_date 가 verify
+    항목의 submitted_date 까지 거슬러 덮음)에 **다른 날짜(D-1)의 같은 odno=X** ccld
+    행(낮은 누적)이 섞여 들어도, 그 행은 verify 항목(odno=X, submitted_date=D)을
+    매칭하면 안 된다. 잘못 매칭하면 late-ccld alert 를 오발화하고 verify 항목을 pop
+    해 실제 fallback-advanced 주문이 영영 검증되지 않는다.
+
+    검증: alert **미발행** + verify 항목 **유지**(pop 안 됨).
+    """
+    from ante.broker.fill_scheduler import _FallbackVerifyEntry
+    from ante.eventbus.events import NotificationEvent, PositionMismatchEvent
+
+    app, _ph, eb, svc = fallback_applier
+    mismatches: list[PositionMismatchEvent] = []
+    notifs: list[NotificationEvent] = []
+    eb.subscribe(
+        PositionMismatchEvent,
+        lambda e: (
+            mismatches.append(e) if isinstance(e, PositionMismatchEvent) else None
+        ),
+    )
+    eb.subscribe(
+        NotificationEvent,
+        lambda e: notifs.append(e) if isinstance(e, NotificationEvent) else None,
+    )
+
+    broker = FallbackBroker(history=[], positions=[])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    # 당일(D) verify 항목 직접 주입(fallback 이 full fill 로 recorded=2 advance 했음을
+    # 흉내). open 은 없다(filled terminal). 당일 → EOD 정리에 살아남는다.
+    sched._fallback_verify["0001"] = _FallbackVerifyEntry(
+        recorded=2.0, submitted_date=DATE
+    )
+    # ccld 가 **전일(D-1)** 같은 odno=0001 행(다른 주문, 더 낮은 누적 1)을 반환.
+    # from_date 가 verify 의 D 까지 덮으나, 이 행은 D-1 이라 verify 항목과 다른 날짜.
+    prior_date = "20200101"
+    broker.set_history(
+        [
+            {
+                "order_id": "0001",
+                "filled_quantity": 1.0,
+                "price": 1000.0,
+                "timestamp": prior_date,
+            }
+        ]
+    )
+    await sched._poll_and_apply()
+    assert broker.history_calls == 1  # verify 가 폴 게이트를 열었다(도달).
+    # date 불일치 → 오발화 없음. verify 항목은 그대로 유지(당일 D 의 ccld 대기).
+    assert mismatches == []
+    assert notifs == []
+    assert "0001" in sched._fallback_verify  # pop 안 됨 — 실제 주문 검증 보존.
+    assert sched._fallback_verify["0001"].submitted_date == DATE
+
+
+async def test_late_ccld_same_date_lower_cumulative_emits_and_pops(
+    fallback_applier, tracker
+):
+    """#2318 Codex 리뷰: 같은 날짜(D) 같은 odno·더 낮은 누적 → alert 발행 + pop.
+
+    date-scope 교정 후에도 **같은 날짜** 매칭 정상 동작을 확인한다(date 좁히기가
+    정상 경로를 막지 않음). verify 항목(odno=X, submitted_date=D)에 같은 날짜 D 의
+    ccld(낮은 누적)가 오면 over-attribution alert 1회 + verify pop.
+    """
+    from ante.broker.fill_scheduler import _FallbackVerifyEntry
+    from ante.eventbus.events import NotificationEvent, PositionMismatchEvent
+
+    app, _ph, eb, svc = fallback_applier
+    mismatches: list[PositionMismatchEvent] = []
+    notifs: list[NotificationEvent] = []
+    eb.subscribe(
+        PositionMismatchEvent,
+        lambda e: (
+            mismatches.append(e) if isinstance(e, PositionMismatchEvent) else None
+        ),
+    )
+    eb.subscribe(
+        NotificationEvent,
+        lambda e: notifs.append(e) if isinstance(e, NotificationEvent) else None,
+    )
+
+    # alert 는 find_by_broker_order 로 bot_id/symbol/order_id 를 복원하므로 실제
+    # tracker 레코드가 (account, odno, submitted_date=DATE) 로 존재해야 한다.
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=2.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    sched._fallback_verify["0001"] = _FallbackVerifyEntry(
+        recorded=2.0, submitted_date=DATE
+    )
+    broker.set_history(
+        [
+            {
+                "order_id": "0001",
+                "filled_quantity": 1.0,  # recorded=2 보다 낮음 → over-attribution.
+                "price": 1000.0,
+                "timestamp": DATE,  # 같은 날짜 D → 매칭.
+            }
+        ]
+    )
+    await sched._poll_and_apply()
+    assert len(mismatches) == 1
+    assert mismatches[0].internal_qty == 2.0
+    assert mismatches[0].broker_qty == 1.0
+    assert "late_ccld_over_attribution" in mismatches[0].reason
+    assert len(notifs) == 1
+    assert "0001" not in sched._fallback_verify  # 같은 날짜 검증 완료 → pop.
+
+
+async def test_late_ccld_same_date_higher_or_equal_pops_without_alert(
+    fallback_applier, tracker
+):
+    """#2318 Codex 리뷰: 같은 날짜(D) 동일/높은 누적 → alert 없음 + pop(정상 확정).
+
+    date-scope 교정 후 같은 날짜의 정상 ccld(멱등/advance)는 조용히 verify 에서
+    제거된다(오경보 방지).
+    """
+    from ante.broker.fill_scheduler import _FallbackVerifyEntry
+    from ante.eventbus.events import PositionMismatchEvent
+
+    app, _ph, eb, svc = fallback_applier
+    mismatches: list[PositionMismatchEvent] = []
+    eb.subscribe(
+        PositionMismatchEvent,
+        lambda e: (
+            mismatches.append(e) if isinstance(e, PositionMismatchEvent) else None
+        ),
+    )
+    broker = FallbackBroker(history=[], positions=[])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    sched._fallback_verify["0001"] = _FallbackVerifyEntry(
+        recorded=2.0, submitted_date=DATE
+    )
+    broker.set_history(
+        [
+            {
+                "order_id": "0001",
+                "filled_quantity": 2.0,  # == recorded → 정상(멱등).
+                "price": 1000.0,
+                "timestamp": DATE,  # 같은 날짜 D → 매칭.
+            }
+        ]
+    )
+    await sched._poll_and_apply()
+    assert mismatches == []  # 동일 누적 → 오경보 없음.
+    assert "0001" not in sched._fallback_verify  # 검증 완료 → pop.
 
 
 # ── 시나리오 5: self/external 경계 (excess != ordered, 다중 open buy) ──

--- a/tests/unit/test_fill_scheduler.py
+++ b/tests/unit/test_fill_scheduler.py
@@ -639,3 +639,672 @@ async def test_catch_up_recovers_iso_timestamp_end_to_end(tracker, applier):
     pos = await ph.get_current("bot-1", "005930", account_id=ACCT)
     assert pos["quantity"] == 100.0
     assert (await tracker.get("ord-1")).status == "filled"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# position-derived bounded fallback (#2314·#2316 §11)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class FallbackBroker:
+    """get_order_history + get_positions 를 흉내내는 fake broker (#2314).
+
+    ``is_paper`` 로 §11.6 paper 게이트를, ``positions_calls`` 로 §11.2 rate budget
+    (미복구 open buy 없으면 get_positions 미호출)을 단언한다.
+    """
+
+    def __init__(
+        self,
+        *,
+        history: list[dict] | None = None,
+        positions: list[dict] | None = None,
+        is_paper: bool = True,
+    ) -> None:
+        self._history = history or []
+        self._positions = positions or []
+        self.is_paper = is_paper
+        self.history_calls = 0
+        self.positions_calls = 0
+
+    def set_history(self, history: list[dict]) -> None:
+        self._history = history
+
+    def set_positions(self, positions: list[dict]) -> None:
+        self._positions = positions
+
+    async def get_order_history(self, from_date=None, to_date=None):
+        self.history_calls += 1
+        return list(self._history)
+
+    async def get_positions(self):
+        self.positions_calls += 1
+        return list(self._positions)
+
+
+@pytest.fixture
+async def fallback_applier(db, tracker):
+    """FillApplier + PositionHistory + TradeService(get_all_positions) + EventBus.
+
+    fallback 은 internal_account_qty 조회에 TradeService.get_all_positions 를,
+    late-ccld alert 발행에 EventBus 를 쓴다. 실 컴포넌트로 통합 경로를 검증한다.
+    """
+    from ante.trade.performance import PerformanceTracker
+    from ante.trade.service import TradeService
+
+    ph = PositionHistory(db)
+    await ph.initialize()
+    rec = TradeRecorder(db, ph)
+    await rec.initialize()
+    perf = PerformanceTracker(db)
+    eb = EventBus()
+    app = FillApplier(db=db, order_tracker=tracker, position_history=ph, eventbus=eb)
+    svc = TradeService(recorder=rec, position_history=ph, performance=perf)
+    return app, ph, eb, svc
+
+
+def _pos(symbol: str, quantity: float, avg_price: float = 1000.0) -> dict:
+    return {"symbol": symbol, "quantity": quantity, "avg_price": avg_price}
+
+
+def _make_fallback_sched(
+    broker, tracker, app, svc, *, eventbus=None, fallback_enabled=True
+):
+    return FillReconcileScheduler(
+        broker=broker,
+        order_tracker=tracker,
+        fill_applier=app,
+        account_id=ACCT,
+        trade_service=svc,
+        eventbus=eventbus,
+        fallback_enabled=fallback_enabled,
+    )
+
+
+# ── 시나리오 1 (핵심·#2314 재현): ccld 0건 + 잔고 1주 → fallback 수렴 ──
+
+
+async def test_fallback_recovers_full_fill_from_balance(fallback_applier, tracker):
+    """ccld 0건 + 잔고 069500 1주 + 유일 미복구 open buy(ordered 1, recorded 0)
+    → fallback 이 FillApplier 로 1주 수렴 → recorded==1, status=filled, 포지션 1주.
+    """
+    app, ph, eb, svc = fallback_applier
+    events: list[OrderFilledEvent] = []
+
+    async def _h(e):
+        if isinstance(e, OrderFilledEvent):
+            events.append(e)
+
+    eb.subscribe(OrderFilledEvent, _h)
+
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0, 9500.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    result = await sched.catch_up_once()
+
+    assert result.succeeded is True
+    assert result.applied == 1
+    # ccld 0건 → fallback 이 잔고에서 역도출.
+    assert broker.history_calls == 1
+    assert broker.positions_calls == 1
+    rec = await tracker.get("ord-fb")
+    assert rec.recorded_filled_qty == 1.0
+    assert rec.status == "filled"
+    pos = await ph.get_current("bot-1", "069500", account_id=ACCT)
+    assert pos["quantity"] == 1.0
+    # avg_price 는 잔고 평단(§11.4).
+    assert pos["avg_entry_price"] == 9500.0
+    # OrderFilledEvent 1회 발행 (시나리오 2 의 일부).
+    assert len(events) == 1
+    assert events[0].quantity == 1.0
+
+
+# ── 시나리오 2: OrderFilledEvent 1회 + outbox fill_dedup_key 결정성 ──
+
+
+async def test_fallback_emits_single_event_and_deterministic_dedup_key(db, tracker):
+    """fallback 수렴 → OrderFilledEvent **1회** 발행 + outbox fill_dedup_key 결정성.
+
+    outbox 주입 경로로 fill_dedup_key = order_id:canonical(confirmed_cumulative)
+    가 결정적으로 채워지는지 검증한다.
+    """
+    from ante.trade.fill_outbox import FillOutbox, make_fill_dedup_key
+    from ante.trade.performance import PerformanceTracker
+    from ante.trade.service import TradeService
+
+    ph = PositionHistory(db)
+    await ph.initialize()
+    rec = TradeRecorder(db, ph)
+    await rec.initialize()
+    perf = PerformanceTracker(db)
+    eb = EventBus()
+    outbox = FillOutbox(db=db)
+    await outbox.initialize()
+    app = FillApplier(
+        db=db,
+        order_tracker=tracker,
+        position_history=ph,
+        eventbus=eb,
+        outbox=outbox,
+    )
+    svc = TradeService(recorder=rec, position_history=ph, performance=perf)
+
+    await tracker.open(
+        order_id="ord-fb2",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=2.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 2.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    await sched.catch_up_once()
+
+    rows = await db.fetch_all("SELECT * FROM fill_outbox")
+    assert len(rows) == 1  # 단일 outbox row(= 단일 OrderFilledEvent).
+    # confirmed_cumulative == ordered_qty == 2.0 → 결정적 키.
+    expected_key = make_fill_dedup_key("ord-fb2", 2.0)
+    assert rows[0]["fill_dedup_key"] == expected_key
+
+
+# ── 시나리오 3: 멱등 (같은 상태 재폴 → 추가 반영 0) ──
+
+
+async def test_fallback_idempotent_on_repoll(fallback_applier, tracker):
+    """fallback 수렴 후 같은 상태 재폴 → 추가 반영 0(이중 반영 없음).
+
+    재폴 시 order 가 filled(terminal)라 미복구 open buy 후보가 없어
+    get_positions 도 호출되지 않는다(§11.2 rate budget).
+    """
+    app, ph, _eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc)
+
+    first = await sched.catch_up_once()
+    assert first.applied == 1
+    assert broker.positions_calls == 1
+
+    second = await sched.catch_up_once()
+    assert second.applied == 0  # 멱등 — 추가 반영 없음.
+    # filled terminal → open 없음 → 폴 0콜, 잔고도 미호출.
+    assert broker.history_calls == 1  # 둘째 사이클은 open 없어 0콜(누계 유지).
+    assert broker.positions_calls == 1
+    pos = await ph.get_current("bot-1", "069500", account_id=ACCT)
+    assert pos["quantity"] == 1.0
+
+
+# ── 시나리오 4a: late-ccld 같은 누적 → CAS no-op (멱등) ──
+
+
+async def test_fallback_then_ccld_same_cumulative_noop(fallback_applier, tracker):
+    """fallback 수렴 후 ccld 가 같은 절대 누적을 반환 → record_fill CAS no-op."""
+    app, ph, _eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc)
+    first = await sched.catch_up_once()
+    assert first.applied == 1
+
+    # 이제 ccld 가 같은 체결(절대 누적 1)을 반환. 하지만 order 는 filled 라
+    # open 후보가 없어 폴되지 않는다 → no-op 보장(멱등). 포지션 불변.
+    broker.set_history(
+        [
+            {
+                "order_id": "0001",
+                "filled_quantity": 1.0,
+                "price": 1000.0,
+                "timestamp": DATE,
+            }
+        ]
+    )
+    second = await sched.catch_up_once()
+    assert second.applied == 0
+    pos = await ph.get_current("bot-1", "069500", account_id=ACCT)
+    assert pos["quantity"] == 1.0
+
+
+# ── 시나리오 4b: late-ccld 더 낮은 값 → reconcile alert 발행 ──
+
+
+async def test_late_ccld_lower_cumulative_emits_reconcile_alert(
+    fallback_applier, tracker
+):
+    """fallback 이 full fill 로 올린 뒤 ccld 가 **더 낮은** 누적 → no-op + alert.
+
+    §11.4: 비가역(CAS 단조)이라 정정은 못 하나 PositionMismatchEvent +
+    NotificationEvent 로 over-attribution 가능성을 surface 한다.
+    """
+    from ante.eventbus.events import NotificationEvent, PositionMismatchEvent
+
+    app, ph, eb, svc = fallback_applier
+    mismatches: list[PositionMismatchEvent] = []
+    notifs: list[NotificationEvent] = []
+    eb.subscribe(
+        PositionMismatchEvent,
+        lambda e: (
+            mismatches.append(e) if isinstance(e, PositionMismatchEvent) else None
+        ),
+    )
+    eb.subscribe(
+        NotificationEvent,
+        lambda e: notifs.append(e) if isinstance(e, NotificationEvent) else None,
+    )
+
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=2.0,
+        submitted_date=DATE,
+    )
+    # fallback: 잔고 2주 == ordered 2 → full fill 로 recorded=2.
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 2.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    await sched.catch_up_once()
+    assert (await tracker.get("ord-fb")).recorded_filled_qty == 2.0
+
+    # late ccld: 실 체결 누적이 1(더 낮음) 이라고 반환. order 는 filled 라
+    # lookup_order_id(non-terminal scope)에 안 잡혀 폴 자체가 0콜이 되는 것을
+    # 막기 위해, alert 경로(_maybe_alert_late_ccld)는 history loop 에서 직접
+    # 호출된다. order 가 filled 여서 open 폴이 0콜이 되므로, alert 검증은
+    # _maybe_alert_late_ccld 를 직접 호출해 확인한다.
+    await sched._maybe_alert_late_ccld(
+        broker_order_id="0001",
+        observed_cumulative=1.0,
+        submitted_date=DATE,
+    )
+    assert len(mismatches) == 1
+    assert mismatches[0].internal_qty == 2.0
+    assert mismatches[0].broker_qty == 1.0
+    assert "late_ccld_over_attribution" in mismatches[0].reason
+    assert len(notifs) == 1
+    assert notifs[0].level == "warning"
+
+
+async def test_late_ccld_alert_not_emitted_when_ccld_higher_or_equal(
+    fallback_applier, tracker
+):
+    """ccld 가 recorded 이상(정상 advance/멱등)이면 alert 미발행 (오경보 방지)."""
+    from ante.eventbus.events import PositionMismatchEvent
+
+    app, _ph, eb, svc = fallback_applier
+    mismatches: list[PositionMismatchEvent] = []
+    eb.subscribe(
+        PositionMismatchEvent,
+        lambda e: (
+            mismatches.append(e) if isinstance(e, PositionMismatchEvent) else None
+        ),
+    )
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=2.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 2.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    await sched.catch_up_once()  # recorded=2.
+
+    # ccld == recorded (멱등) → alert 없음.
+    await sched._maybe_alert_late_ccld(
+        broker_order_id="0001", observed_cumulative=2.0, submitted_date=DATE
+    )
+    # ccld > recorded (정상 추가 advance) → alert 없음.
+    await sched._maybe_alert_late_ccld(
+        broker_order_id="0001", observed_cumulative=3.0, submitted_date=DATE
+    )
+    assert mismatches == []
+
+
+# ── 시나리오 5: self/external 경계 (excess != ordered, 다중 open buy) ──
+
+
+async def test_fallback_skipped_when_excess_not_equal_ordered(
+    fallback_applier, tracker
+):
+    """excess != ordered_qty(예: 60 vs ordered 100) → 미적용 (D+1 ccld 대기)."""
+    app, ph, _eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=100.0,
+        submitted_date=DATE,
+    )
+    # 잔고 60주 → excess 60 != ordered 100 → partial/모호 → 미적용.
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 60.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc)
+    result = await sched.catch_up_once()
+
+    assert result.applied == 0
+    assert broker.positions_calls == 1  # 후보 있어 잔고는 봤으나 매칭 실패.
+    rec = await tracker.get("ord-fb")
+    assert rec.recorded_filled_qty == 0.0  # 미적용 — 미반영 유지.
+    assert rec.status == "open"
+    # 포지션 미반영(빈 포지션 = quantity 0).
+    pos = await ph.get_current("bot-1", "069500", account_id=ACCT)
+    assert pos["quantity"] == 0.0
+
+
+async def test_fallback_skipped_when_multiple_open_buys_same_symbol(
+    fallback_applier, tracker
+):
+    """다중 open buy(같은 symbol) → 미적용 (귀속 불가, 외부/혼재 위험 회피)."""
+    app, _ph, _eb, svc = fallback_applier
+    for oid, odno in (("ord-a", "0001"), ("ord-b", "0002")):
+        await tracker.open(
+            order_id=oid,
+            account_id=ACCT,
+            bot_id="bot-1",
+            strategy_id="strat-1",
+            broker_order_id=odno,
+            symbol="069500",
+            side="buy",
+            order_type="market",
+            ordered_qty=1.0,
+            submitted_date=DATE,
+        )
+    # 잔고 2주 == 합 ordered 2 라도 어느 주문에 귀속할지 불가 → 미적용.
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 2.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc)
+    result = await sched.catch_up_once()
+
+    assert result.applied == 0
+    assert (await tracker.get("ord-a")).recorded_filled_qty == 0.0
+    assert (await tracker.get("ord-b")).recorded_filled_qty == 0.0
+
+
+async def test_fallback_excludes_external_qty_via_internal_subtraction(
+    fallback_applier, tracker
+):
+    """internal_account_qty 차감으로 기존 보유분이 excess 에 혼입되지 않는다(§11.1).
+
+    이미 internal 5주 보유(타 bot) + 잔고 6주 → excess 1 == ordered 1 → 적용.
+    (잔고 총량 6 을 self 로 오귀속하지 않음.)
+    """
+    from ante.trade.models import TradeRecord, TradeStatus
+
+    app, ph, _eb, svc = fallback_applier
+    # 타 bot 의 기존 보유 5주를 positions 에 직접 적재.
+    await ph.on_trade(
+        TradeRecord(
+            trade_id=__import__("uuid").uuid4(),
+            bot_id="bot-other",
+            strategy_id="strat-x",
+            symbol="069500",
+            side="buy",
+            quantity=5.0,
+            price=1000.0,
+            status=TradeStatus.FILLED,
+            order_type="market",
+            account_id=ACCT,
+        )
+    )
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    # 잔고 6주(기존 5 + self 1). excess = 6 - 5 = 1 == ordered 1.
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 6.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc)
+    result = await sched.catch_up_once()
+
+    assert result.applied == 1
+    assert (await tracker.get("ord-fb")).recorded_filled_qty == 1.0
+    # bot-1 포지션만 1주 증가, bot-other 는 불변.
+    pos1 = await ph.get_current("bot-1", "069500", account_id=ACCT)
+    assert pos1["quantity"] == 1.0
+
+
+# ── 시나리오 6: rate budget (ccld 채우면 get_positions 미호출) ──
+
+
+async def test_get_positions_not_called_when_ccld_fills(fallback_applier, tracker):
+    """ccld 가 체결을 주면 미복구 open buy 가 없어 get_positions 미호출(§11.2)."""
+    app, ph, _eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    # ccld 가 체결 1 을 줌 → recorded advance → 미복구 후보 없음.
+    broker = FallbackBroker(
+        history=[
+            {
+                "order_id": "0001",
+                "filled_quantity": 1.0,
+                "price": 1000.0,
+                "timestamp": DATE,
+            }
+        ],
+        positions=[_pos("069500", 1.0)],
+    )
+    sched = _make_fallback_sched(broker, tracker, app, svc)
+    result = await sched.catch_up_once()
+
+    assert result.applied == 1  # ccld 로 복구.
+    assert broker.history_calls == 1
+    assert broker.positions_calls == 0  # rate budget — 잔고 미호출.
+    assert (await tracker.get("ord-fb")).recorded_filled_qty == 1.0
+
+
+async def test_get_positions_not_called_when_no_open_buy(fallback_applier, tracker):
+    """미복구 open buy 가 애초에 없으면 get_positions 미호출(§11.2).
+
+    open 이 sell 뿐이거나 0건이면 후보가 없어 잔고를 보지 않는다.
+    """
+    app, _ph, _eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-sell",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="sell",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc)
+    await sched.catch_up_once()
+    assert broker.positions_calls == 0  # buy 후보 없음 → 잔고 미호출.
+
+
+# ── 시나리오 7: disable flag / paper 게이트 ──
+
+
+async def test_fallback_disabled_flag_no_op(fallback_applier, tracker):
+    """fallback_enabled=False → fallback 미동작 (get_positions 미호출, 미반영)."""
+    app, _ph, _eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc, fallback_enabled=False)
+    result = await sched.catch_up_once()
+
+    assert result.applied == 0
+    assert broker.positions_calls == 0  # disable → 잔고 미호출.
+    assert (await tracker.get("ord-fb")).recorded_filled_qty == 0.0
+
+
+async def test_fallback_skipped_when_broker_not_paper(fallback_applier, tracker):
+    """broker.is_paper=False(실전) → fallback 미동작(§11.6 live 분리)."""
+    app, _ph, _eb, svc = fallback_applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)], is_paper=False)
+    sched = _make_fallback_sched(broker, tracker, app, svc)
+    result = await sched.catch_up_once()
+
+    assert result.applied == 0
+    assert broker.positions_calls == 0  # 실전 → 잔고 미호출.
+    assert (await tracker.get("ord-fb")).recorded_filled_qty == 0.0
+
+
+async def test_fallback_no_op_without_trade_service(applier, tracker):
+    """trade_service 미주입(legacy/partial wiring) → fallback 미동작."""
+    app, _ph, _eb = applier
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)])
+    # trade_service=None (기본).
+    sched = FillReconcileScheduler(
+        broker=broker,
+        order_tracker=tracker,
+        fill_applier=app,
+        account_id=ACCT,
+    )
+    result = await sched.catch_up_once()
+    assert result.applied == 0
+    assert broker.positions_calls == 0
+    assert (await tracker.get("ord-fb")).recorded_filled_qty == 0.0
+
+
+# ── 시나리오 8: 통합 — Treasury/TradeRecorder/캐시 evict (FillApplier 경로) ──
+
+
+async def test_fallback_integrates_full_fill_applier_path(db, tracker):
+    """fallback 이 FillApplier 단일 경로로 수렴 → trades insert · open 캐시 evict.
+
+    §11.8 단일 권위: fallback 도 FillApplier.apply_cumulative 만 거치므로
+    trades insert(TradeRecorder 스키마) · positions · open 캐시 evict 가 기존
+    FillApplier 경로로 정상 동작한다(통합).
+    """
+    from ante.trade.performance import PerformanceTracker
+    from ante.trade.service import TradeService
+
+    ph = PositionHistory(db)
+    await ph.initialize()
+    rec = TradeRecorder(db, ph)
+    await rec.initialize()
+    perf = PerformanceTracker(db)
+    eb = EventBus()
+    app = FillApplier(db=db, order_tracker=tracker, position_history=ph, eventbus=eb)
+    svc = TradeService(recorder=rec, position_history=ph, performance=perf)
+
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=1.0,
+        submitted_date=DATE,
+    )
+    # open 캐시에 진입돼 있어야 한다(sync 백엔드).
+    assert tracker.get_open_orders_for_bot_sync(ACCT, "bot-1")
+
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 1.0)])
+    sched = _make_fallback_sched(broker, tracker, app, svc, eventbus=eb)
+    await sched.catch_up_once()
+
+    # trades insert(FillApplier _save_trade 경로).
+    trades = await db.fetch_all("SELECT * FROM trades WHERE order_id = ?", ("ord-fb",))
+    assert len(trades) == 1
+    assert trades[0]["quantity"] == 1.0
+    # open 캐시 evict(filled → mirror_fill_to_cache evict).
+    assert tracker.get_open_orders_for_bot_sync(ACCT, "bot-1") == []


### PR DESCRIPTION
Closes #2318

## Summary
- #2314 근본수정: KIS 모의 `inquire-daily-ccld`가 당일 체결을 0건 줄 때, 잔고(`get_positions`, 체결기준 즉시반영) 증분에서 self 체결을 역도출해 `FillApplier`로 멱등 수렴(#2316 §11 계약 구현).
- **full-fill 정확매칭만 적용**(§11.3): symbol의 추적 open buy(open+partially_filled)가 **정확히 1개** + 그 주문 `recorded_filled_qty==0` + 잔고 `excess(broker_qty - internal_account_qty) == ordered_qty` → `observed_cumulative=ordered_qty`로 `apply_cumulative` **만** 호출(§11.8 단일 권위). partial/모호 excess·다중 open buy는 미적용(D+1 ccld 대기) — external 비가역 흡수 회피.
- **late-ccld reconcile alert**(§11.4): bounded `_fallback_verify` set로, fallback 후에도 실제 poll 경로에서 ccld가 더 낮은 누적을 주면 `PositionMismatchEvent`/`NotificationEvent` 발행. verify 매칭은 `(odno, item_date)` date-scope(KIS odno 영업일 재사용 §4.1 정합), EOD 정리.
- **rate budget**(§11.2): open도 verify도 없으면 ccld 미폴, 미복구 open buy 없으면 `get_positions` 미호출.
- **paper-only 기본**(§11.6) + `fill_position_fallback_enabled` disable flag(rollback).
- 배선: `main.py` FillReconcileScheduler에 `trade_service`/`eventbus`/`fallback_enabled` 주입. `order_tracker.find_by_broker_order` 신설.

## 설계 경위 (Codex 브랜치 리뷰 3라운드)
- attempt1 FAIL(유일성 판정·late-ccld alert 도달성) → attempt2 FAIL(odno date-scope) → **attempt3 PASS**. 매 라운드 distinct·valid finding 수정.

## Test Plan
- `tests/unit/test_fill_scheduler.py` 확장(핵심 시나리오 + 소비자 surface + verify date-scope 회귀). 오케스트레이터 메인 repo 독립검증: pytest 100 passed, mypy clean, 용어가드 4 passed, project-structure --check up-to-date, startup 회귀 141 passed.

## ⚠️ 라이브 게이트
- mock은 **로직** 검증(잔고 입력은 §11/공식문서로 당일 즉시반영 확인). **#2314 최종 close는 #2317 라이브 canary 후**(mock-only resolved 금지, #1976→#1974 동형). 본 PR은 로직+테스트.
- 부모 epic #2314. 관련 #2316(spec 머지됨)·#2315(가드 머지됨)·#2317(라이브).