### PR TITLE
fix(strategy): #2323 IndicatorCalculator.compute None 결과 가드로 TypeError 차단

### DIFF
--- a/docs/specs/strategy/03-06-indicator-calculator.md
+++ b/docs/specs/strategy/03-06-indicator-calculator.md
@@ -36,6 +36,8 @@ pandas-ta를 래핑하여 15종의 기술 지표를 계산한다. pandas-ta는 *
 | `supported_indicators` | — | `list[str]` | 지원 지표 목록 |
 | `compute` | `name: str, ohlcv: dict[str, ndarray], **params` | `dict[str, ndarray]` | 지표 계산. 단일 출력: `{"sma": array}`, 다중: `{"macd": array, "signal": array, "hist": array}` |
 
+데이터 부족 등으로 지표를 계산할 수 없으면(pandas-ta가 `None` 반환) `compute`는 빈 dict `{}`를 반환한다 (`LiveDataProvider.get_indicator`의 빈 OHLCV 동작과 동일 sentinel). 이 계약은 단일·다중 출력 지표 모두에 적용되며, 세 소비자(`StrategyContext` / `LiveDataProvider` / `BacktestDataProvider`)가 동일하게 안정적인 빈 결과를 받는다.
+
 `ohlcv_to_numpy()` 유틸리티: polars DataFrame 또는 `list[dict]`를 numpy 배열 딕셔너리로 변환.
 
 **설계 근거**:

--- a/src/ante/strategy/indicators.py
+++ b/src/ante/strategy/indicators.py
@@ -97,6 +97,7 @@ class IndicatorCalculator:
             결과 키 → numpy 배열 딕셔너리.
             단일 출력: ``{"sma": array}``.
             다중 출력: ``{"macd": array, "signal": array, "hist": array}``.
+            데이터 부족 등으로 계산 불가 시(pandas-ta가 None 반환) 빈 dict ``{}``.
 
         Raises:
             ValueError: 미지원 지표 또는 필수 입력 누락.
@@ -133,6 +134,13 @@ class IndicatorCalculator:
             result = func(high, low, close, volume, **merged_params)
         else:
             raise ValueError(f"Unknown input type: {input_type}")
+
+        # 데이터 부족 등으로 pandas-ta가 None을 반환하면 계산 불가 → 빈 dict.
+        # 이 가드가 다중/단일 출력 두 None 경우를 한 곳에서 처리한다
+        # (LiveDataProvider.get_indicator의 빈 OHLCV 동작과 동일 sentinel).
+        if result is None:
+            logger.warning("지표 계산 불가(데이터 부족/None 결과): %s", name_lower)
+            return {}
 
         # 결과 포맷팅
         if name_lower in _MULTI_OUTPUT:

--- a/tests/unit/test_indicators.py
+++ b/tests/unit/test_indicators.py
@@ -83,6 +83,37 @@ def ohlcv_arrays() -> dict[str, np.ndarray]:
     }
 
 
+@pytest.fixture
+def short_ohlcv_arrays() -> dict[str, np.ndarray]:
+    """지표 계산에 부족한 짧은 OHLCV (n=5).
+
+    macd(slow=26 + signal=9), bbands(length=20), stoch(k=14) 등의 lookback
+    윈도우 미만이라 pandas-ta가 ``None``을 반환한다.
+    """
+    rng = np.random.default_rng(42)
+    n = 5
+    close = 50000.0 + np.cumsum(rng.normal(0, 100, n))
+    high = close + rng.uniform(50, 200, n)
+    low = close - rng.uniform(50, 200, n)
+    open_ = close + rng.normal(0, 50, n)
+    volume = rng.uniform(1000, 10000, n)
+    return {
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+    }
+
+
+@pytest.fixture
+def empty_ohlcv_arrays() -> dict[str, np.ndarray]:
+    """빈 OHLCV 배열 딕셔너리."""
+    return {
+        k: np.array([], dtype=float) for k in ("open", "high", "low", "close", "volume")
+    }
+
+
 # ── IndicatorCalculator ──
 
 
@@ -254,6 +285,78 @@ def test_compute_stoch(ohlcv_arrays: dict[str, np.ndarray]):
     assert set(result.keys()) == {"slowk", "slowd"}
 
 
+# ── None 결과 가드 (#2323) ──
+#
+# pandas-ta는 데이터 부족 시 None을 반환할 수 있다. compute()가 이를 방어하지
+# 않으면 다중 출력 지표는 `dict(zip(keys, [np.asarray(r) for r in result]))`
+# 에서 `TypeError: 'NoneType' object is not iterable`로 하드 크래시하고
+# (보고된 버그), 단일 출력 지표는 `np.asarray(None)` → `array(None, dtype=object)`
+# 로 조용히 오염된다. 두 경우 모두 빈 dict `{}`를 반환해야 한다.
+
+
+def test_compute_macd_short_returns_empty(
+    short_ohlcv_arrays: dict[str, np.ndarray],
+):
+    """짧은 OHLCV에서 macd는 빈 dict를 반환한다 (보고된 TypeError 미발생)."""
+    result = IndicatorCalculator.compute("macd", short_ohlcv_arrays)
+    assert result == {}
+
+
+def test_compute_bbands_short_returns_empty(
+    short_ohlcv_arrays: dict[str, np.ndarray],
+):
+    """짧은 OHLCV에서 bbands는 빈 dict를 반환한다 (보고된 TypeError 미발생)."""
+    result = IndicatorCalculator.compute("bbands", short_ohlcv_arrays)
+    assert result == {}
+
+
+def test_compute_stoch_short_returns_empty(
+    short_ohlcv_arrays: dict[str, np.ndarray],
+):
+    """짧은 OHLCV에서 stoch는 빈 dict를 반환한다 (_MULTI_OUTPUT 대표성)."""
+    result = IndicatorCalculator.compute("stoch", short_ohlcv_arrays)
+    assert result == {}
+
+
+def test_compute_macd_empty_returns_empty(
+    empty_ohlcv_arrays: dict[str, np.ndarray],
+):
+    """빈 OHLCV에서 macd는 빈 dict를 반환한다."""
+    result = IndicatorCalculator.compute("macd", empty_ohlcv_arrays)
+    assert result == {}
+
+
+def test_compute_bbands_empty_returns_empty(
+    empty_ohlcv_arrays: dict[str, np.ndarray],
+):
+    """빈 OHLCV에서 bbands는 빈 dict를 반환한다."""
+    result = IndicatorCalculator.compute("bbands", empty_ohlcv_arrays)
+    assert result == {}
+
+
+def test_compute_sma_empty_returns_empty(
+    empty_ohlcv_arrays: dict[str, np.ndarray],
+):
+    """빈 OHLCV에서 단일 출력 sma는 빈 dict를 반환한다.
+
+    가드 이전에는 `np.asarray(None)` → `{"sma": array(None, dtype=object)}`
+    로 조용히 오염된 0-d object array를 반환했다. 이제 빈 dict여야 한다.
+    """
+    result = IndicatorCalculator.compute("sma", empty_ohlcv_arrays)
+    assert result == {}
+
+
+def test_compute_none_guard_logs_warning(
+    short_ohlcv_arrays: dict[str, np.ndarray],
+    caplog: pytest.LogCaptureFixture,
+):
+    """계산 불가 시 경고 로그를 남긴다."""
+    with caplog.at_level(logging.WARNING, logger="ante.strategy.indicators"):
+        result = IndicatorCalculator.compute("macd", short_ohlcv_arrays)
+    assert result == {}
+    assert any("지표 계산 불가" in rec.message for rec in caplog.records)
+
+
 # ── ohlcv_to_dataframe / ohlcv_to_numpy ──
 
 
@@ -375,6 +478,71 @@ async def test_context_get_indicator_computes_directly():
     result = await ctx.get_indicator("005930", "sma", {"length": 10})
     assert "sma" in result
     assert isinstance(result["sma"], np.ndarray)
+
+
+async def test_context_get_indicator_short_ohlcv_returns_empty():
+    """짧은 OHLCV에서 get_indicator(macd)가 빈 dict를 반환한다 (#2323).
+
+    보고된 end-to-end 경로: ctx.get_indicator -> IndicatorCalculator.compute가
+    데이터 부족 시 None을 받아 `TypeError: 'NoneType' object is not iterable`
+    로 봇 루프를 크래시시켰다. 이제 빈 dict로 안정적으로 반환되어야 한다.
+
+    get_indicator는 `get_ohlcv(symbol, limit=500)`을 호출하지만, 아래 Fake는
+    limit을 무시하고 macd lookback(slow=26+signal=9) 미만인 n=5짜리 짧은
+    DataFrame을 반환해 계산 불가를 유도한다.
+    """
+
+    class FakeDataProvider:
+        async def get_ohlcv(
+            self, symbol: str, timeframe: str = "1d", limit: int = 100
+        ) -> pl.DataFrame:
+            # limit 무시: 항상 n=5짜리 짧은 데이터만 반환.
+            rng = np.random.default_rng(42)
+            n = 5
+            close = 50000.0 + np.cumsum(rng.normal(0, 100, n))
+            high = close + rng.uniform(50, 200, n)
+            low = close - rng.uniform(50, 200, n)
+            open_ = close + rng.normal(0, 50, n)
+            volume = rng.uniform(1000, 10000, n)
+            return pl.DataFrame(
+                {
+                    "open": open_.tolist(),
+                    "high": high.tolist(),
+                    "low": low.tolist(),
+                    "close": close.tolist(),
+                    "volume": volume.tolist(),
+                }
+            )
+
+        async def get_current_price(self, symbol: str) -> float:
+            return 50000.0
+
+        async def get_indicator(
+            self, symbol: str, indicator: str, params: dict | None = None
+        ) -> dict:
+            return {"fallback": True}
+
+    class FakePortfolio:
+        def get_positions(self, bot_id: str) -> dict:
+            return {}
+
+        def get_balance(self, bot_id: str) -> dict:
+            return {}
+
+    class FakeOrderView:
+        def get_open_orders(self, bot_id: str) -> list:
+            return []
+
+    from ante.strategy.context import StrategyContext
+
+    ctx = StrategyContext(
+        bot_id="test-bot",
+        data_provider=FakeDataProvider(),  # type: ignore[arg-type]
+        portfolio=FakePortfolio(),  # type: ignore[arg-type]
+        order_view=FakeOrderView(),  # type: ignore[arg-type]
+    )
+    result = await ctx.get_indicator("069500", "macd", {})
+    assert result == {}
 
 
 # ── LiveDataProvider 지표 계산 통합 테스트 ──


### PR DESCRIPTION
Closes #2323

## Summary
- `IndicatorCalculator.compute()`가 pandas-ta의 `None` 반환(데이터 부족/빈 OHLCV)을 방어하지 않아, 다중 출력 지표(macd/bbands/stoch)는 `TypeError: 'NoneType' object is not iterable`로 하드 크래시(보고된 버그), 단일 출력 지표(sma 등)는 `np.asarray(None)` → `array(None, dtype=object)`로 silent corruption이 발생했다.
- 입력 디스패치 직후·결과 포맷팅 직전에 `if result is None: logger.warning(...); return {}` 가드를 추가했다. 단일 chokepoint 수정으로 세 소비자(`StrategyContext`/`LiveDataProvider`/`BacktestDataProvider`)가 모두 안정적인 빈 결과 `{}`를 받는다.
- `{}` sentinel은 기존 `LiveDataProvider.get_indicator` 빈 OHLCV 동작과 동일 (회귀: `test_live_data_provider_get_indicator_empty_ohlcv`).
- 스펙 `03-06-indicator-calculator.md`에 uncomputable→`{}` 계약을 명문화.

## Non-Goals
- 전략 측 `{}` 핸들링, `LiveDataProvider` 빈-OHLCV 가드 리팩터, `feed.pipeline`의 별개 `IndicatorCalculator`는 변경하지 않음.

## Test Plan
- 신규 회귀 테스트(`tests/unit/test_indicators.py`): macd/bbands/stoch short·empty → `{}`, sma empty → `{}`(silent corruption 제거), warning 로그, `StrategyContext.get_indicator` end-to-end short OHLCV → `{}`.
- `uv run ruff check` / `ruff format --check` PASS
- `uv run mypy src/ante/strategy/indicators.py` PASS
- `uv run pytest tests/unit/test_indicators.py -q` → 42 passed
- `uv run pytest tests/unit -k indicator -q` → 64 passed

## Plan / Review
- plan-preflight:done, Codex Plan Review: approve-implement
- Codex 브랜치 리뷰: PASS (head fab81bb8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)