### PR TITLE
fix(broker): #2324 KIS 빈 msg1 시 get_error_message 폴백으로 비공백 에러메시지 보장

### DIFF
--- a/docs/specs/broker-adapter/07-kis-base-adapter.md
+++ b/docs/specs/broker-adapter/07-kis-base-adapter.md
@@ -50,5 +50,6 @@ KIS API는 broker-side business failure(예: 원주문번호 오류, 잘못된 �
    2. HTTP status가 non-retryable(401/403/404/422 등) → `False` (강제, msg_cd 무시).
    3. `msg_cd` ∈ `TRANSIENT_MSG_CODES` → `True`.
    4. 그 외 unknown msg_cd → HTTP status retryable 기준에 위임.
+5. **메시지 비공백 보장 (#2324)**: business error 승격 시 `msg1`이 빈 문자열/공백이면 `get_error_message(msg_cd)`로 폴백해 `APIError`의 error_message가 절대 비어 있으면 안 된다. 미등록 코드도 `알 수 없는 에러 ({msg_cd})`로 코드가 보존된 triage-able 메시지가 된다. (generic `HTTP <status>: <text>` fallback 경로는 해당 없음.)
 
 HTTP 200 + `rt_cd != "0"` 경로는 기존 동작을 유지하며 별도로 `error_code = msg_cd`만 설정한다 (status_code 미설정).

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -23,6 +23,7 @@ from ante.broker.circuit_breaker import CircuitBreaker
 from ante.broker.error_codes import (
     PERMANENT_MSG_CODES,
     TRANSIENT_MSG_CODES,
+    get_error_message,
     is_retryable_http_status,
     is_retryable_msg_code,
 )
@@ -390,6 +391,12 @@ class KISBaseAdapter(BrokerAdapter):
             except (ValueError, TypeError):
                 pass
             if msg_cd:
+                # msg1이 빈 문자열/공백이면 get_error_message(msg_cd)로 폴백해
+                # error_message가 비어 있지 않도록 보장한다 (#2324). 이 분기는
+                # msg_cd truthy일 때만 실행되므로 폴백은 항상 의미 있는 값이다.
+                msg1 = str(payload.get("msg1") or "").strip()
+                if not msg1:
+                    msg1 = get_error_message(msg_cd)
                 # retryable 우선순위 (#1338, Codex Plan Review v2):
                 # 1. PERMANENT_MSG_CODES → false 강제.
                 # 2. HTTP non-retryable (auth/client) → false 강제.
@@ -418,7 +425,11 @@ class KISBaseAdapter(BrokerAdapter):
         rt_cd = result.get("rt_cd", "")
         if rt_cd != "0":
             msg_cd = result.get("msg_cd", "")
-            msg1 = result.get("msg1", "Unknown")
+            # msg1이 빈 문자열/공백이면 get_error_message(msg_cd)로 폴백해
+            # error_message가 비어 있지 않도록 보장한다 (#2324).
+            msg1 = str(result.get("msg1") or "").strip()
+            if not msg1:
+                msg1 = get_error_message(msg_cd)
             retryable = is_retryable_msg_code(msg_cd)
             raise APIError(
                 f"KIS API Error [{msg_cd}]: {msg1}",

--- a/tests/unit/test_kis_handle_response_business_error.py
+++ b/tests/unit/test_kis_handle_response_business_error.py
@@ -309,3 +309,88 @@ def test_handle_response_http_200_success_returns_payload() -> None:
 
     result = _run(adapter._handle_response(resp))
     assert result == payload
+
+
+# ── 빈 msg1 폴백 (#2324) ──────────────────────────────────────────
+#
+# msg1이 빈 문자열/공백이면 get_error_message(msg_cd)로 폴백해
+# APIError의 error_message가 절대 비어 있지 않도록 보장한다. 그렇지
+# 않으면 ``KIS API Error [40910000]: `` (콜론 뒤 공백)가 gateway 로그
+# 및 OrderFailedEvent.error_message로 전파되어 triage가 불가능하다.
+
+
+def test_handle_response_http_200_empty_msg1_unregistered_falls_back_to_code() -> None:
+    """HTTP 200 + rt_cd≠0 + 미등록 msg_cd + msg1="" → 코드 보존 폴백.
+
+    미등록 코드(40910000)도 ``알 수 없는 에러 (40910000)``로 코드가
+    보존된 non-empty triage-able 메시지가 된다.
+    """
+    adapter = _make_adapter()
+    payload = {"rt_cd": "1", "msg_cd": "40910000", "msg1": ""}
+    resp = _FakeResponse(status=200, text_body="", json_body=payload)
+
+    with pytest.raises(APIError) as exc_info:
+        _run(adapter._handle_response(resp))
+
+    err = exc_info.value
+    assert err.error_code == "40910000"
+    assert "40910000" in str(err)
+    assert "알 수 없는 에러 (40910000)" in str(err)
+    # 콜론 뒤 본문이 비공백이어야 한다.
+    assert str(err).split("]:", 1)[1].strip() != ""
+
+
+def test_handle_response_http_200_empty_msg1_registered_falls_back_to_korean() -> None:
+    """HTTP 200 + rt_cd≠0 + 등록 msg_cd + msg1="" → 한글 설명 폴백.
+
+    등록 코드(APBK0013)는 ``잘못된 종목코드``로 폴백된다.
+    """
+    adapter = _make_adapter()
+    payload = {"rt_cd": "1", "msg_cd": "APBK0013", "msg1": ""}
+    resp = _FakeResponse(status=200, text_body="", json_body=payload)
+
+    with pytest.raises(APIError) as exc_info:
+        _run(adapter._handle_response(resp))
+
+    err = exc_info.value
+    assert err.error_code == "APBK0013"
+    assert "잘못된 종목코드" in str(err)
+
+
+def test_handle_response_http_200_whitespace_msg1_falls_back() -> None:
+    """HTTP 200 + rt_cd≠0 + msg1="   " (공백만) → strip() 후 폴백.
+
+    공백만 있는 msg1도 strip() 후 빈 값으로 판정되어 폴백되어야 한다.
+    """
+    adapter = _make_adapter()
+    payload = {"rt_cd": "1", "msg_cd": "40910000", "msg1": "   "}
+    resp = _FakeResponse(status=200, text_body="", json_body=payload)
+
+    with pytest.raises(APIError) as exc_info:
+        _run(adapter._handle_response(resp))
+
+    err = exc_info.value
+    assert err.error_code == "40910000"
+    assert "알 수 없는 에러 (40910000)" in str(err)
+    assert str(err).split("]:", 1)[1].strip() != ""
+
+
+def test_handle_response_http_500_empty_msg1_falls_back_to_code() -> None:
+    """HTTP 500 business payload + msg1="" → 등록 코드 한글 폴백.
+
+    IGW00022는 등록 코드이므로 ``원주문번호 오류 또는 처리 불가``로
+    폴백되며, msg_cd / status_code는 보존된다.
+    """
+    adapter = _make_adapter()
+    body = json.dumps({"rt_cd": "1", "msg_cd": "IGW00022", "msg1": ""})
+    resp = _FakeResponse(status=500, text_body=body)
+
+    with pytest.raises(APIError) as exc_info:
+        _run(adapter._handle_response(resp))
+
+    err = exc_info.value
+    assert err.error_code == "IGW00022"
+    assert err.status_code == 500
+    assert "IGW00022" in str(err)
+    assert "원주문번호 오류 또는 처리 불가" in str(err)
+    assert str(err).split("]:", 1)[1].strip() != ""


### PR DESCRIPTION
Closes #2324

## Summary
- KIS 주문 제출 실패 시 `KISBaseAdapter._handle_response`의 두 business error 경로에서 KIS `msg1`이 빈 문자열/공백이면 빈 메시지(`KIS API Error [40910000]: `)가 기록돼 사용자 triage가 불가능했다.
- `msg1`을 `str(...).strip()`로 정규화하고 빈 값이면 `get_error_message(msg_cd)`로 폴백해 `APIError.error_message`가 절대 비어 있지 않도록 보장한다. 미등록 코드(40910000)도 `알 수 없는 에러 (40910000)`로 코드가 보존된 triage-able 메시지가 된다. 등록 코드는 한글 설명으로 폴백.
- 단일 chokepoint(`_handle_response`) 수정으로 gateway 로그·`OrderFailedEvent.error_message` 소비자가 transitively 비공백 메시지를 받는다.

## Scope / Non-Goals
- `error_code`(msg_cd) 보존, terminal `OrderFailedEvent` 발행은 이미 동작 — 변경 없음.
- 40910000의 구체적 한글 메시지·retryability/permanent 분류는 KIS 공식문서 권위 확인 필요 → 별도 follow-up (등록 안 함).
- oracle 집계(`kis_errors.total`/`order_actions.total`), terminal-event 누락은 #2325/#2329 소관.
- generic `HTTP <status>: <text>` fallback 경로는 미변경.

## Test Plan
- 회귀 테스트(`tests/unit/test_kis_handle_response_business_error.py`): HTTP 200 미등록(40910000) empty→코드 보존 비공백, HTTP 200 등록(APBK0013) empty→한글 폴백, HTTP 200 whitespace-only→strip 폴백, HTTP 500 등록(IGW00022) empty→비공백.
- `uv run pytest tests/unit/test_kis_handle_response_business_error.py tests/unit/test_kis_error_codes_40240000.py -q` → 22 passed
- `uv run pytest tests/unit -k 'kis or broker or gateway' -q` → 532 passed (회귀 없음)
- `uv run mypy src/ante/broker/kis.py src/ante/broker/error_codes.py` PASS
- `uv run ruff check` / `ruff format --check` PASS

## Spec
- `docs/specs/broker-adapter/07-kis-base-adapter.md` 에러 분류 섹션에 규약 5(메시지 비공백 보장 #2324) 추가.

## Plan / Review
- plan-preflight:done, Codex Plan Review: approve-implement
- Codex 브랜치 리뷰: PASS (head 0a11b2d1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)