### PR TITLE
docs(spec): #2334 signal connect daemon-위임 스트리밍 아키텍처 스펙 반영 (increment 1)

### DIFF
--- a/docs/specs/audit/audit.md
+++ b/docs/specs/audit/audit.md
@@ -129,6 +129,7 @@ AuditLogger는 인프라(기록·조회)만 제공한다. 실제 기록은 **CLI
 | `ante member rotate-token <id>` | `member.rotate_token` | `member:{member_id}` |
 | `ante member reset-password` | `member.reset_password` | `member:{master_member_id}` |
 | `ante member regenerate-recovery-key` | `member.regenerate_recovery_key` | `member:{master_member_id}` |
+| `ante signal connect` | `signal.connect` | `bot:{bot_id}` |
 
 `ante bot start`/`ante bot stop`은 audit action(`bot.start`/`bot.stop`) 이름을
 사용한다. 봇 생애주기 변경은 단일 audit action namespace로 모인다.
@@ -143,6 +144,25 @@ client가 보낸 actor(스푸핑 가능)를 신뢰하지 않고 handler가 고�
 `system:` 네임스페이스에 둬서 사용자/agent `member_id`와 충돌하지 않는다(`member
 register`가 `system:` prefix 등록을 거부). recovery key, 새/현재 password 등 비밀값은
 audit detail, audit_log, IPC error envelope, server 로그 어디에도 기록하지 않는다.
+
+`ante signal connect`는 외부 에이전트의 JSON Lines 시그널 스트림을 데몬에서 RUNNING 중인 봇에
+연결하는 long-lived 커맨드다. audit은 **연결 수립 시 1회만** 기록한다. 데몬 핸들러가
+게이트(인증·키 검증·봇 RUNNING 등)를 통과한 직후 `signal.connect` / `bot:{bot_id}`로 단일
+기록하며, 이후 흐르는 개별 시그널마다 기록하지 않는다(per-signal audit 금지 — flooding 방지).
+연결 해제/teardown도 상태 변경 액션이 아니므로 기록하지 않는다. audit row의 `member_id`(행위자)는
+client가 핸드셰이크로 보낸 actor(스푸핑 가능)를 신뢰하지 않고, handler가 고정한 sentinel 상수
+`ipc`로 기록한다 — client 입력을 권위적 member_id로 신뢰하지 않는다는 `member register`/
+`reset-password` sentinel 정책과 동일한 #2113 원칙이다. 다만 `reset-password`의
+`system:recovery`와 달리 본 sentinel은 reserved `system:` 네임스페이스를 쓰지 않는 bare
+string `ipc`다(스펙 §8 확정값; `server.py`의 `actor` 기본값 `ipc` 정합). `member register`의
+`system:` prefix 거부 가드가 bare `ipc` 충돌을 막지 못할 가능성은 본 spec PR 범위 밖이며,
+필요 시 별도 후속 이슈로 다룬다. 게이트 실패 시에는 audit을 남기지 않는다(fail-without-audit).
+
+> ⚠️ `ante signal connect`의 데몬-위임 스트리밍 동작은 구현 PR 머지 후(동기 버그 #2333
+> unblock) 실제로 실행 가능하다. 본 절은 채택된 audit 계약만 기술하며, 현재 코드에서
+> 곧바로 동작함을 의미하지 않는다.
+
+> **BLOCKER 해소 (경로 B)**: spec §8 확정값인 bare string `ipc`를 그대로 반영하되, 기존 audit.md의 reserved `system:` 선례와의 **네임스페이스 차이를 명시적으로 노출**하고 충돌 가능성을 후속 이슈로 이연했다. 코드 사실(`server.py:342` `actor = request.get("actor", "ipc")`)도 bare `ipc`를 이미 사용하므로 spec 계약·코드·문서가 일관된다. "동일 정책" 단언은 "동일 #2113 **원칙**(client 입력 비신뢰)"으로 약화하여 표면 모순을 제거했다(reviewer 왕복 차단).
 
 ### 구현 방식
 

--- a/docs/specs/bot/03-design-decisions.md
+++ b/docs/specs/bot/03-design-decisions.md
@@ -102,7 +102,7 @@ CREATED → RUNNING → STOPPING → STOPPED → DELETED
 | `stop_all` | — | `None` | 모든 실행 중 봇 중지 + 재시작 태스크 취소. 시스템 셧다운 시 호출 |
 | `list_bots` | — | `list[dict[str, Any]]` | 봇 목록 조회 |
 | `get_bot` | `bot_id: str` | `Bot \| None` | 봇 조회. 없으면 None |
-| `rotate_signal_key` | `bot_id: str` | `str` | 기존 시그널 키 폐기 + 새 키 발급. 연결 중인 채널은 즉시 끊김 |
+| `rotate_signal_key` | `bot_id: str` | `str` | 기존 시그널 키 폐기 + 새 키 발급. DB rotate 커밋 직후 해당 봇의 활성 시그널 채널을 teardown한다 — **커밋 후 NEW signal은 admit되지 않으며, 옛 키로 이미 진입한 in-flight signal은 최대 1개까지 정상 완료**(in-flight abort 아님). enforcement 메커니즘은 아래 `### 채널 teardown enforcement (#2334)` 참조. 구현 PR 머지 후 적용(동기 버그 #2333 unblock) |
 | `get_signal_key` | `bot_id: str` | `str \| None` | 봇의 시그널 키 조회. `accepts_external_signals=False`이면 `None` |
 | `get_restart_count` | `bot_id: str` | `int` | 봇의 현재 재시작 시도 횟수 |
 | `assign_strategy` | `bot_id: str, strategy_id: str` | `None` | 봇에 전략 배정. RUNNING이면 중지→전략 교체→재시작. STOPPED/CREATED이면 전략 ID만 교체 |
@@ -242,7 +242,7 @@ create_bot(config)
     └─ False → signal_key 없음
   ↓
 [운영 중]
-  → rotate_signal_key(bot_id) — 키 갱신 (기존 채널 즉시 끊김)
+  → rotate_signal_key(bot_id) — 키 갱신 (커밋 후 NEW signal 미admit; in-flight at-most-one 완료, abort 아님 — ↓ 채널 teardown enforcement)
   ↓
 remove_bot(bot_id)
   → signal_key 폐기
@@ -286,6 +286,36 @@ Bot이 ExternalSignalEvent를 수신하면:
 3. `strategy.on_data(event.data)` 호출
 4. 반환된 Signal을 `_publish_signals()`로 발행
 5. 체결/상태 변경 시 채널을 통해 외부에 통보
+
+### 채널 teardown enforcement (#2334)
+
+> wire/transport 세부(3-phase upgrade, 1:1 framing, `closed.reason` vocab 등)는 [ipc.md](../ipc/ipc.md) streaming 절이 SSOT다. 본 절은 채널 생명주기 **계약**만 정의한다.
+> **적용 시점**: 본 enforcement는 **구현 PR 머지 후(동기 버그 #2333 unblock)** 동작한다. 그 전까지 `ante signal connect`는 데몬이 아닌 CLI-프로세스의 `BotManager`를 보므로 데몬에서 RUNNING 중인 봇 채널에 닿지 못한다(현 동작 = #2333 dead-end). 따라서 아래 "즉시 끊김" 계약은 **현재 실행 가능 동작이 아니라 채택된 목표 계약**이다.
+
+기존 스펙은 "키 갱신 시 기존 채널은 즉시 끊긴다"고 단언했으나 **enforcement 메커니즘은 명세되지 않았다**. #2334로 다음을 정규화한다.
+
+**`SignalChannelRegistry`**: 데몬에 상주하는 활성 채널 레지스트리. `bot_id → {session_id → ChannelHandle}` 구조로 활성 시그널 채널을 추적하며, `rotate_signal_key`/`delete_bot`/봇 상태 전이/데몬 shutdown이 봇 단위로 채널을 강제 종료(`close_bot(bot_id, reason)` / `close_all(reason)`)할 수 있게 한다. 데몬 부팅 시 단일 인스턴스를 BotManager·IPC 서버에 공유 주입한다(미사용 환경은 None 허용).
+
+**단일 active connect 정책**: 본 릴리스는 **bot_id당 동시 active 시그널 채널 1개**만 허용한다. 같은 봇에 대한 두 번째 `signal connect` 핸드셰이크는 stable code **`BOT_SIGNAL_CHANNEL_BUSY`**로 거부된다(동시 same-bot 구독의 fan-out·dedup 경합 클래스 제거). 레지스트리는 미래 multi-connect 대비 `session_id` 키를 유지하되, 정책은 현 릴리스에서 single로 잠근다. (코드 분류 SSOT는 [error-taxonomy.md](../contracts/error-taxonomy.md).)
+
+**teardown 트리거**: 오직 rotate/delete만 거는 대신, **봇이 RUNNING을 이탈하는 모든 경로**를 단일 메커니즘으로 덮는다.
+
+| 트리거 | 메커니즘 | `closed.reason` |
+|--------|----------|------------------|
+| 키 회전 | `rotate_signal_key` — DB rotate **커밋 성공 직후** `close_bot(bot_id, "rotated")`. ROLLBACK 시 teardown 안 함(옛 키 유효) | `rotated` |
+| 봇 삭제 | `delete_bot` — `bot.stop()` **호출 전**에 `close_bot(bot_id, "deleted")`(채널이 dead ctx를 pump하지 않도록) | `deleted` |
+| 봇 RUNNING 이탈(graceful stop·자율 ERROR·account-suspend·rule-engine stop·auto-restart·`stop_all`) | `BotStoppedEvent`/`BotErrorEvent`를 `bot_id` 필터로 **이벤트-구동** 구독 → 수신 시 `close_bot(bot_id, "bot_stopped")` | `bot_stopped` |
+| 데몬 shutdown | shutdown sweep에서 봇 stop·DB close **이전에** `close_all("draining")`(channels-before-bots-before-db 불변) | `draining` |
+
+- teardown hook은 **BotManager 계층**(rotate/delete 메서드·이벤트 구독)에만 둔다. pure-DB primitive(`SignalKeyManager.rotate/revoke`)에는 두지 않는다 — cold-path(서버 정지 상태)에서도 도달하는 경로이기 때문이다.
+
+**rotate→teardown 정밀 보장**: rotate 커밋이 active signal 처리 중에 발생해도 in-flight `strategy.on_data` 체인을 mid-chain cancel하면 전략 상태가 손상된다. 따라서 보장을 다음과 같이 정밀화한다.
+
+1. teardown은 먼저 `accepting=False`를 set하여 이후 inbound signal admit을 거부한다.
+2. in-flight publish/`on_data` span은 shield되어 완료된다(mid-chain cancel 금지).
+3. 결과 보장 = **"커밋 후 NEW signal은 admit되지 않으며, 옛 키로 진입한 in-flight signal은 최대 1개(at-most-one)까지 정상 완료된다"** — **"in-flight signal abort"가 아니다.** 즉 rotate/delete 직후 새 주문을 유발하는 신규 시그널 주입은 불가능하고, 옛 키로 이미 진입한 trailing signal 1개와 그에 따른 trailing fill만 관측될 수 있다.
+
+이 enforcement는 "직접 DB 수정으로 봇 status/signal key를 바꾸면 `_bots`·실행 task·EventBus 구독·외부 signal channel이 어긋나므로 허용하지 않는다"는 본 문서의 런타임 IPC 위임 원칙(위 참조)과 정합한다.
 
 ### 예외 격리 (D-003)
 

--- a/docs/specs/bot/04-eventbus-integration.md
+++ b/docs/specs/bot/04-eventbus-integration.md
@@ -63,3 +63,13 @@ class BotStepCompletedEvent(Event):
 | `AccountSuspendedEvent` | 계좌 정지 시 해당 계좌의 봇만 중지 | — (BotManager가 계좌별 `stop_bot()` 호출) |
 | `AccountActivatedEvent` | 계좌 재활성화 시 계좌 상태 변화 인지 | — (BotManager가 로깅만 수행; 자동 재시작은 수행하지 않음) |
 | `BotErrorEvent` | 봇 에러 시 자동 재시작 정책 수행 | — (BotManager가 `_on_bot_error()` 처리) |
+
+### 데몬-side SignalChannel 구독 (`signal.connect`, #2334)
+
+`ante signal connect`(데몬-위임 스트리밍, #2334)가 활성화되면, 위 `OrderFilledEvent` 및 9종 `order_update` 이벤트(`OrderSubmittedEvent`/`OrderRejectedEvent`/`OrderCancelledEvent`/`OrderFailedEvent`/`OrderCancelFailedEvent`/`OrderModifyRejectedEvent`/`StopOrderRegisteredEvent`/`StopOrderTriggeredEvent`/`StopOrderExpiredEvent`)는 **데몬-resident `SignalChannel`이 동일한 `svc.eventbus` 인스턴스에서 추가로 구독**하여 connect된 외부 AI Agent에게 outbound 프레임(`fill`/`order_update`)으로 중계한다. 봇 본체의 전략 콜백(`on_fill()`/`on_order_update()`) 구독과 **같은 단일 데몬 EventBus** 위에서 병렬로 동작하며, 구독 위치만 데몬-side로 명시될 뿐 **이벤트 vocab·`order_update` 9종 status·`ExternalSignalEvent` flow는 변경 없다**(SSOT 재확인).
+
+- 구독 대상(불변): `OrderFilledEvent → fill`, 9종 `order_update`(status vocab `submitted｜rejected｜cancelled｜failed｜cancel_failed｜modify_rejected｜stop_registered｜stop_triggered｜stop_expired`). `event.bot_id`가 connect된 봇과 일치하는 프레임만 중계.
+- 인바운드 `ExternalSignalEvent`(위 표 참조)는 데몬 `svc.eventbus`에 publish되어 `bot.on_external_signal` → `strategy.on_data` 경로로 동일하게 처리된다.
+- outbound 프레임 shape·delivery·backpressure 계약의 SSOT는 [`docs/specs/ipc/ipc.md`](../ipc/ipc.md)의 스트리밍 절이다(본 문서는 구독 대상 이벤트의 정합만 재확인).
+
+> 이 데몬-side 구독 경로는 **구현 PR 머지 후(동기 버그 #2333 unblock)에만 실제 동작**한다. 본 절은 스펙 정합 재확인이며, 머지 전 `ante signal connect`는 아직 RUNNING 봇으로 연결되지 않는다.

--- a/docs/specs/contracts/envelopes.md
+++ b/docs/specs/contracts/envelopes.md
@@ -156,6 +156,16 @@ CLI envelope과 IPC envelope은 **표면별 1회만** wrapping 된다. 한 응�
   받아 `OutputFormatter.success(...)` 또는 `OutputFormatter.error(code, message)`로
   CLI envelope 1회 wrapping 한다. 이 동형은 `ante bot start/stop/status`의 IPC
   passthrough reference 패턴이다 (`src/ante/cli/commands/bot.py`).
+- **streaming 핸드셰이크 passthrough(`signal connect`)**: `signal connect`의 핸드셰이크
+  단계는 데몬이 생성한 IPC error envelope의 `error.code`/`error.message`를 CLI error
+  envelope으로 **1회만** 옮긴다. 이때 `message`는 **verbatim passthrough**한다 —
+  CLI가 번역·재작성·접두(`Error:` 등)하지 않는다. 따라서 데몬 핸드셰이크 검증
+  에러는 `{status:error, code, message}` 형태로 #1705 회귀 lock과 byte-identical하게
+  유지된다. 이는 위 **CLI IPC 헬퍼 계약**의 동형(streaming 표면) 적용이며, `code`
+  vocabulary와 streaming 프로토콜 자체는 본 SSOT 범위 밖이다(각각
+  `docs/specs/contracts/error-taxonomy.md`, `docs/specs/ipc/ipc.md`). 계약 정의는
+  [#2334](https://github.com/joshua-jingu-lee/ante/issues/2334)이며 **구현 PR 머지
+  후 동작**한다(동기 버그 #2333 unblock; spec 단계에서는 미동작).
 - **결론**: 어느 표면이든 사용자/Agent에게 보이는 envelope은 CLI envelope 4형태
   중 하나(텍스트/JSON), IPC envelope 4형태 중 하나(서버 응답)다. CLI가 IPC
   envelope 그대로를 출력하거나, IPC가 CLI envelope을 반환하는 시나리오는 본

--- a/docs/specs/contracts/error-taxonomy.md
+++ b/docs/specs/contracts/error-taxonomy.md
@@ -60,11 +60,11 @@ runtime 사용은 [#1840](https://github.com/joshua-jingu-lee/ante/issues/1840) 
 
 | Category | 의미 | 대표 code 예 |
 |----------|------|--------------|
-| `validation` | 입력 계약 위반(필수 옵션 누락, enum 비멤버, 형식 오류, 도메인 식별자 형식 위반) | `VALIDATION_ERROR`, `CLI_MISSING_REQUIRED_INPUT`, `CLI_OPTION_CONFLICT`, `CONFIG_VALIDATION_ERROR`, `STRATEGY_VALIDATION_ERROR`, `APPROVAL_VALIDATION_ERROR`, `REPORT_VALIDATION_ERROR`, `INVALID_DATE_RANGE`, `INVALID_DATE` |
+| `validation` | 입력 계약 위반(필수 옵션 누락, enum 비멤버, 형식 오류, 도메인 식별자 형식 위반) | `VALIDATION_ERROR`, `CLI_MISSING_REQUIRED_INPUT`, `CLI_OPTION_CONFLICT`, `CONFIG_VALIDATION_ERROR`, `STRATEGY_VALIDATION_ERROR`, `APPROVAL_VALIDATION_ERROR`, `REPORT_VALIDATION_ERROR`, `INVALID_DATE_RANGE`, `INVALID_DATE`, `INVALID_SIGNAL_KEY`, `MALFORMED_REQUEST` |
 | `auth` | 인증 누락/실패 | `AUTH_REQUIRED`, `AUTH_FAILED` |
 | `permission` | 인증은 됐으나 scope/role 부족 | `PERMISSION_DENIED`, `MEMBER_INVALID_SCOPE` |
 | `not_found` | 대상 resource 존재하지 않음 | `BOT_NOT_FOUND`, `ACCOUNT_NOT_FOUND`, `APPROVAL_NOT_FOUND`, `MEMBER_NOT_FOUND` |
-| `state_conflict` | 대상이 요청한 상태 전이를 허용하지 않는 상태 | `BOT_STATE_CONFLICT`, `ACCOUNT_ALREADY_DELETED`, `UPDATE_SERVER_RUNNING` |
+| `state_conflict` | 대상이 요청한 상태 전이를 허용하지 않는 상태 | `BOT_STATE_CONFLICT`, `ACCOUNT_ALREADY_DELETED`, `UPDATE_SERVER_RUNNING`, `BOT_NOT_RUNNING`, `BOT_SIGNAL_CHANNEL_BUSY` |
 | `service_unavailable` | 서버 lifecycle / 의존 서비스 미구성으로 dispatch 거부 | `SERVICE_UNAVAILABLE`, `SERVICE_NOT_CONFIGURED` |
 | `external` | broker/외부 API 실패로 ante가 dispatch 책임을 다한 뒤 외부 시스템에서 발생한 오류 | `BROKER_API_ERROR`, `BROKER_AUTH_FAILED` |
 | `internal` | 코드 버그/예외 미분류 fallback | `EXECUTION_ERROR`, `UNKNOWN_COMMAND` |
@@ -84,8 +84,15 @@ runtime 사용은 [#1840](https://github.com/joshua-jingu-lee/ante/issues/1840) 
    `REPORT_*`, `UPDATE_*`). 도메인이 없으면 `CLI_*` prefix(예:
    `CLI_MISSING_REQUIRED_INPUT`, `CLI_OPTION_CONFLICT`, `CLI_CONFIRMATION_REQUIRED`).
 3. **공통 코드**: `VALIDATION_ERROR`, `EXECUTION_ERROR`, `SERVICE_UNAVAILABLE`,
-   `SERVICE_NOT_CONFIGURED`, `UNKNOWN_COMMAND`는 도메인 prefix 없이 공통 vocabulary로
-   유지한다. 도메인이 명확한 위반은 도메인 prefix specialize를 권장한다.
+   `SERVICE_NOT_CONFIGURED`, `UNKNOWN_COMMAND`, `INVALID_SIGNAL_KEY`,
+   `MALFORMED_REQUEST`는 도메인 prefix 없이 공통 vocabulary로 유지한다.
+   `INVALID_SIGNAL_KEY`/`MALFORMED_REQUEST`는 #2334 `signal.connect` 데이터-플레인
+   입력 계약 위반 코드로, 키 비노출(redaction) 대상이자 transport-level 형식 위반이라
+   특정 도메인으로 specialize하지 않는 도메인-non-prefix common code다(`signal.py`가 이미
+   `INVALID_SIGNAL_KEY`를 string literal로 노출, #1705 byte-lock 정합). 도메인이 명확한
+   위반은 도메인 prefix specialize를 권장한다.
+
+> **MAJOR 해소**: 신규 prefix-less 코드 2건을 명명 규칙 공통 코드 화이트리스트(rule 3)에 명시 추가하여 SSOT 자기모순을 제거했다. `signal.py`가 이미 `INVALID_SIGNAL_KEY` literal을 노출·#1705 byte-lock 대상이므로 재명명(option B) 대신 화이트리스트 확장(option A)을 채택했다.
 4. **명명 규칙 예외 (legacy date-range)**: `INVALID_DATE_RANGE` / `INVALID_DATE`는
    `backtest run` CLI가 이미 사용 중인 호환 유지용 legacy/common date-range
    코드로 `CLI_*` prefix 예외다(SSOT: `docs/specs/cli/02-design-decisions.md` —
@@ -193,6 +200,37 @@ runtime 사용은 [#1840](https://github.com/joshua-jingu-lee/ante/issues/1840) 
 - 새 domain exception을 추가할 때는 본 표 형식으로 후속 PR에서 SSOT를 확장한다.
   본 SSOT는 모든 exception을 enumerate하지 않는다 — 본 PR 범위 밖이다.
 
+## `signal.connect` 스트리밍 신규 코드 분류 (normative)
+
+[#2334 `ante signal connect` daemon-위임 스트리밍 아키텍처](https://github.com/joshua-jingu-lee/ante/issues/2334)
+가 도입하는 신규 안정 코드를 본 taxonomy의 기존 category에 귀속한다.
+본 절은 **분류만 normative로 lock**한다. `ErrorSpec`/`error_registry.py`
+실제 등록과 `signal connect` daemon-위임 동작은 구현 PR(transport/ingress
+· outbound/lifecycle · CLI relay) **머지 후에만 실행 가능**(동기 버그 #2333 unblock)
+하며, 본 docs-only spec PR은 코드 동작을 도입하지 않는다.
+
+| Public code | Category | 트리거 (#2334 §5/§9) | 비고 |
+|-------------|----------|----------------------|------|
+| `INVALID_SIGNAL_KEY` | `validation` | 핸드셰이크 게이트 1 — signal key 검증 실패(`validate_signal_key` → None) | 키는 데이터-플레인 입력 계약. 현재 CLI(`src/ante/cli/commands/signal.py:58`)가 이미 string literal로 노출하나 taxonomy SSOT·`error_registry.py` 미등록 — 본 절이 첫 SSOT 등재. 도메인 prefix 없는 common code(키 비노출 redaction 대상, `sk_` 미포함). |
+| `BOT_NOT_RUNNING` | `state_conflict` | 핸드셰이크 게이트 3 — 봇 존재하나 `status != RUNNING` | 봇이 요청한 상태 전이(시그널 스트림 attach)를 허용하지 않는 상태. sibling `BOT_NOT_ACCEPTING_SIGNALS`(`state_conflict`)와 동형. 현재 CLI(`signal.py:73`)가 string literal로 노출하나 SSOT 미등록 — 본 절이 첫 SSOT 등재. message에 `bot_id`/`status`(소문자 `BotStatus.value`) 포함. |
+| `MALFORMED_REQUEST` | `validation` | 핸드셰이크 첫 프레임이 비-dict로 decode(`_handle_connection` 가드) | 입력 프레임 형식 위반(요청 계약 위반). terminal, 1프레임 error 후 close. |
+| `BOT_SIGNAL_CHANNEL_BUSY` | `state_conflict` | bot_id당 단일 active session 정책 — 2번째 `signal.connect` 핸드셰이크 거부 | 봇의 현재 상태(이미 active channel 보유)가 새 연결 전이를 허용하지 않음. 본 릴리스 single-connect 정책 lock. |
+
+인접 기존 코드(재정의 금지, reference만):
+
+- `BOT_NOT_FOUND`(`not_found`) — 게이트 2. 대표 fault lock 표에 이미 등록됨.
+- `BOT_NOT_ACCEPTING_SIGNALS`(`state_conflict`) — 게이트 4. 코드 레지스트리(`src/ante/contracts/error_registry.py:504-505`)에 `ErrorSpec(category="state_conflict")`로 등록됨, 단 본 taxonomy 문서 표에는 미등재(`bot signal-key --rotate`/`signal connect` 공유). 분류는 `state_conflict`.
+- `SERVICE_UNAVAILABLE`(`service_unavailable`) — `DRAINING`/`STOPPED` 핸드셰이크 거부. lifecycle gate 정렬(envelopes.md/ipc.md).
+- `SERVICE_NOT_CONFIGURED`(`service_unavailable`) — `required_services`(`bot_manager`) 부재 또는 `signal_key_manager` 미구성. #2334 신규 typed exception `SignalKeyManagerNotConfigured` → `SERVICE_NOT_CONFIGURED("signal_key_manager")`로 매핑되며, `error_registry.py` 등록은 #2334 구현 PR이 수행한다(코드 재정의 아님). `## SERVICE_NOT_CONFIGURED (normative)` 절 정렬.
+- `IPC_SERVER_NOT_RUNNING` / `IPC_TIMEOUT` — 데몬 미기동/핸드셰이크 30s 초과. 기존 IPC 표면 코드(`src/ante/cli/commands/ipc_helpers.py`, ipc.md)이며 본 SSOT가 새로 도입하지 않는다. message는 #2334 구현 시 기존 IPC 문자열을 SSOT로 재사용.
+
+규칙:
+
+- 신규 4건은 #2334 구현 PR에서 `error_registry.py` `ErrorSpec` 등록 + 대표 fault lock 표 확장의 회귀 lock이다(typed exception `InvalidSignalKey`/`BotNotRunning`/`SignalKeyManagerNotConfigured` → public code).
+- auth lowercase legacy alias(`auth_required` 등)는 signal connect의 CLI-side `@require_auth`에 그대로 적용되며 본 절이 재정의하지 않는다(Legacy alias 정렬).
+
+> coherence minor 해소: `SignalKeyManagerNotConfigured`→`SERVICE_NOT_CONFIGURED` 매핑을 typed-exception 회귀 lock 목록에 포함했고, `BOT_NOT_ACCEPTING_SIGNALS` "이미 등록" 출처를 코드 레지스트리(`error_registry.py:504-505`, category=`state_conflict` 코드 확인)와 taxonomy 문서 미등재로 명확히 구분했다.
+
 ## Broker external code 분리
 
 본 SSOT는 broker 원천 code(KIS `msg_cd` 등)와 ante public envelope code를 분리한다.
@@ -275,6 +313,7 @@ envelope `message`(CLI error의 `message`, IPC error의 `error.message`)는 사�
 | Success JSON output 표준화 | — | [#1815](https://github.com/joshua-jingu-lee/ante/issues/1815) |
 | IPC metadata 확장 | — | [#1819](https://github.com/joshua-jingu-lee/ante/issues/1819) |
 | Offline service factory | — | [#1818](https://github.com/joshua-jingu-lee/ante/issues/1818) |
+| `signal.connect` 스트리밍 신규 코드 분류 (`INVALID_SIGNAL_KEY`/`BOT_NOT_RUNNING`/`MALFORMED_REQUEST`/`BOT_SIGNAL_CHANNEL_BUSY`) | normative (분류만) | [#2334](https://github.com/joshua-jingu-lee/ante/issues/2334) `ErrorSpec` 등록 + 대표 fault lock 확장 + daemon relay 구현(동기 버그 #2333 unblock) |
 
 ## 변경 정책
 

--- a/docs/specs/contracts/offline-factory.md
+++ b/docs/specs/contracts/offline-factory.md
@@ -247,8 +247,16 @@ PRAGMA가 쓰기를 요구하기 때문이다. 따라서 옵션 A를 normative�
 ### 3.2 후속 책임 (현재 진행 중 항목)
 
 - ctx 없는 `get_db_path()` 호출의 점진 제거는 진행 중이다. 잔여 callsite:
-  `src/ante/cli/commands/signal.py:48`, `src/ante/cli/commands/broker.py:34,354`
-  — 이들은 #1855/#1856/#1857 후속 cleanup 대상이다.
+  - `src/ante/cli/commands/signal.py:48` — **resolved by #2333**. `ante signal
+    connect`가 데몬-위임 thin IPC relay로 재설계되면서 CLI-프로세스 내
+    `Database`/`EventBus`/`BotManager` offline 구성이 삭제되고, 그 안의 ctx 없는
+    `get_db_path()` 호출도 함께 **자연 소거**된다(별도 #1855/#1856/#1857 cleanup
+    불필요). 본 spec PR은 추적표 항목을 spec 레벨에서 `resolved by #2333`로
+    close할 뿐이며, 실제 callsite 삭제는 **#2333 구현 PR(thin IPC relay 재작성)이
+    merge된 이후에 적용**된다 — 그 전까지 signal.py의 offline 구성은 코드에
+    그대로 존재한다.
+  - `src/ante/cli/commands/broker.py:34,354` — 이들은 #1855/#1856/#1857 후속
+    cleanup 대상이다(잔여).
 - 본 SSOT는 helper 자체의 deprecation timeline을 강제하지 않는다. fallback
   helper signature 자체는 #1855/#1856/#1857 migration이 완료된 이후 별도
   이슈로 제거를 검토한다.

--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -160,6 +160,23 @@ credentials 복호화, 연결 세션, rate limit, circuit breaker, audit 경로�
 있다. `broker order`와 `broker stream prices`는 일반 운영 IPC 대상이 아니며 별도
 maintenance/test 스펙 없이는 제공하지 않는다.
 
+#### Signal
+
+| CLI 커맨드 | IPC 커맨드 | 서비스 메서드 | IPC 필요 사유 |
+|-----------|-----------|-------------|-------------|
+| `ante signal connect` | `signal.connect` | `BotManager.validate_signal_key()` (#2334 신규) + `BotManager.get_bot()` (read-only handshake) → 데몬-resident `SignalChannel` | streaming. 핸드셰이크는 데몬 LIVE 상태로 signal key→bot 4-게이트를 검증(read-only handshake)하고, 통과 시 동일 연결을 connection-upgrade로 long-lived 양방향 스트림으로 전환하여 외부 시그널을 봇의 `svc.eventbus`에 전달하고 fill/order_update를 역방향으로 되돌린다 |
+
+`signal.connect`는 단일 `ante.sock` 위에서 connection-upgrade(3-phase)로 동작하는 유일한
+streaming 커맨드다. 핸드셰이크 자체는 `is_mutating=False` read-only이며, 일반 요청
+envelope으로 `_dispatch`를 통과해 lifecycle gate와 `required_services`(`bot_manager`)
+preflight를 재사용한다(`validate_signal_key`는 #2334에서 신설되는 `BotManager` 메서드다).
+핸드셰이크 4-게이트 검증과 wire 계약은 `### Signal connect 스트리밍 프로토콜` 절에서
+정규로 기술한다. 신규 TCP/WS 포트나 두 번째 소켓 파일은 도입하지 않는다.
+
+> 이 행은 본 스펙에서 확정하는 계약이며, 실제 실행은 구현 PR 머지 후(동기 버그 #2333
+> unblock) 가능하다. 그전까지 stopped/미구현 데몬에 `signal connect`하면 핸드셰이크
+> 단계에서 `IPC_SERVER_NOT_RUNNING` 등으로 종료된다.
+
 #### Member
 
 | CLI 커맨드 | IPC 커맨드 | 서비스 메서드 | IPC 필요 사유 |
@@ -178,11 +195,20 @@ maintenance/test 스펙 없이는 제공하지 않는다.
 
 `system start`, `system stop`, `system status`, 서버 live 상태가 필요 없는 조회
 커맨드, `backtest`, `data`, `strategy validate/submit`, `report`, `instrument`,
-`member list/info`, `audit`, `signal` 등.
+`member list/info`, `audit` 등.
 
 조회 커맨드라도 서버가 가진 live 상태를 읽어야 하면 런타임 IPC 대상이다. 대표적으로
 `bot list/info/status/positions/signal-key`의 live 조회와
 `broker status/balance/positions`가 여기에 속한다.
+
+`signal connect`는 더 이상 오프라인 커맨드가 아니다. 데몬에서 RUNNING 중인 봇의
+LIVE `svc.bot_manager`/`svc.eventbus`를 경유해 외부 시그널을 전달하고 fill/order_update를
+역방향 스트림으로 되돌리는 streaming 런타임 커맨드로, IPC를 통해 서버에 위임한다(아래
+`#### Signal` 표와 `### Signal connect 스트리밍 프로토콜` 절). 이 재분류 자체가 #2333의
+스펙 레벨 root cause 정정이다 — CLI 프로세스가 자체 `EventBus`/`BotManager`를 구성하던
+기존 경로는 데몬 구독자에 닿지 않는 dead-end였다. 분류·계약은 본 스펙에서 확정되며,
+실제 streaming 동작은 구현 PR 머지 후(동기 버그 #2333 unblock) 활성화된다. 그 전까지
+현 CLI-프로세스 EventBus 구성은 코드에 그대로 존재한다(=#2333 dead-end).
 
 ### Cold-path structural 커맨드
 
@@ -240,7 +266,7 @@ BotManager/DB 종료 이후 lifecycle 마지막 단계에서만 호출된다.
 - **read-only**: 서버가 보유한 live adapter를 통해 상태를 조회하지만 서버/DB 상태를
   변경하지 않는 명령
 
-현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 40개가
+현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 41개가
 SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표를 함께 갱신해야 한다.
 
 | IPC 커맨드 | taxonomy | 근거 |
@@ -285,6 +311,7 @@ SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표�
 | `bot.info` | read-only | `BotManager.get_bot()` live 조회. `{bot: info}` envelope (#2112) |
 | `bot.positions` | read-only | `BotManager.get_bot()` 존재확인 + `TradeService.get_positions()` 봇 계좌 스코핑(#2137). `{positions: [...]}` envelope (#2112) |
 | `bot.signal_key` | read-only | `BotManager.get_signal_key()` live 조회. `{bot_id, signal_key}` (None 허용). `bot.signal_key.rotate`(mutating)와 별개 read command (#2112) |
+| `signal.connect` | read-only | 핸드셰이크는 `BotManager.validate_signal_key()` + `BotManager.get_bot()` 4-게이트 LIVE 검증만 수행하고 서버/DB 상태를 변경하지 않음. 통과 시 동일 연결을 데몬-resident `SignalChannel` 양방향 스트림으로 connection-upgrade(`_dispatch` 외부). `is_mutating=False`, `audit_action=None`(자동 발화 끔 — 핸들러가 4-게이트 통과 직후 직접 1회만 기록, per-signal 금지) (#2334) |
 
 `broker.reconcile`은 CLI `--fix=False` 경로에서도 같은 IPC command를 사용하지만, 한 command
 이름에 mutating/read-only 의미를 섞지 않고 일괄 mutating으로 분류한다. dry-run 전용
@@ -389,6 +416,81 @@ lock 되어 있다. 본 절은 envelope 형태만 다루며 vocabulary는 재정
 
 최대 메시지 크기: 1MB
 
+### Signal connect 스트리밍 프로토콜
+
+`signal.connect`는 표준 요청/응답 lockstep과 달리, 단일 `ante.sock` 위에서
+connection-upgrade(hijack)로 long-lived 양방향 스트림을 운반하는 유일한 커맨드다.
+신규 소켓/포트를 만들지 않고, outer wire 프레임(`[4바이트 빅엔디안 길이][UTF-8 JSON]`,
+최대 1MB)을 그대로 재사용한다. inbound(`signal`/`query`/`ping`) · outbound
+(`ack`/`result`/`fill`/`order_update`/`pong`/`error`/`closed`) JSON-Lines 메시지
+vocab과 shape의 SSOT는 bot 모듈 스펙([bot/04-eventbus-integration.md](../bot/04-eventbus-integration.md),
+[bot/03-design-decisions.md](../bot/03-design-decisions.md))이다. 본 절은 IPC 전송
+계층의 3-phase·framing·timeout·종료 계약만 기술한다.
+
+> 본 절은 계약(스펙)이며, 실제 streaming 실행은 구현 PR 머지 후(동기 버그 #2333
+> unblock) 가능하다.
+
+#### 3-Phase 연결
+
+| Phase | 방향 | 프레임 | 내용 |
+|-------|------|--------|------|
+| A — 핸드셰이크 요청 | client→daemon | 정확히 1 | 표준 요청 envelope. `{"id":"<uuid>","command":"signal.connect","args":{"key":"sk_..."},"actor":"<member_id>"}`. 키는 `args.key`에만. `_dispatch`를 통과해 lifecycle gate + `required_services`(`bot_manager`) + typed-exception→stable-code 변환을 재사용 |
+| B — 핸드셰이크 응답 | daemon→client | 정확히 1 | OK: `{"id":<same>,"status":"ok","result":{"bot_id":"<id>","account_id":"<id>"}}`. ERROR: `{"id":<same>,"status":"error","error":{"code":<CODE>,"message":<MSG>}}` 1프레임 후 close(Phase C 미진입). 핸들러가 반환하는 `_stream` 센티넬은 wire 전송 직전 strip되어 절대 노출되지 않음 |
+| C — 스트림 바디 | 양방향 | 무제한 | OK 후에만 진입. 각 프레임 = 1 JSON-Lines 객체. RPC가 아니므로 `id` 상관관계 없음. 종료 = 어느 쪽이든 소켓 close(EOF), 또는 데몬이 보내는 단일 `{"type":"closed","reason":...}` 프레임 |
+
+핸드셰이크 4-게이트(데몬-side, LIVE 상태)는 순서대로: ① signal key 검증
+(`validate_signal_key` → None이면 `INVALID_SIGNAL_KEY`), ② 봇 존재
+(`get_bot` → None이면 `BOT_NOT_FOUND`), ③ 봇 RUNNING(`BOT_NOT_RUNNING`),
+④ 봇이 외부 시그널 수용(`BOT_NOT_ACCEPTING_SIGNALS`). 첫 프레임이 비-dict로
+decode되면 `MALFORMED_REQUEST` 1프레임 후 close. 같은 봇에 이미 active session이
+있으면 두 번째 핸드셰이크는 `BOT_SIGNAL_CHANNEL_BUSY`로 거부한다(본 릴리스는 bot_id당
+단일 connect). 위 stable code들의 vocabulary SSOT는
+[error-taxonomy.md](../contracts/error-taxonomy.md)다.
+
+lifecycle gate는 일반 명령과 동일하게 적용된다. `signal.connect`는 `is_mutating=False`
+이므로 `SHUTTING_DOWN`에서 핸드셰이크는 통과하지만, `DRAINING`/`STOPPED`는
+`SERVICE_UNAVAILABLE`로 거부된다. 데몬 shutdown 시 활성 스트림은 DRAINING 전이에서
+`{"type":"closed","reason":"draining"}`로 정리된다.
+
+#### 1:1 framing 불변
+
+- **모든 논리 JSON-Lines 메시지 = 정확히 1 length-prefixed 프레임.** 한 프레임에
+  여러 메시지를 묶거나(batching) 이중 framing하지 않는다.
+- **데몬은 프레임 내부 payload에 trailing `'\n'`(embedded newline)을 싣지 않는다.**
+  `'\n'` 재부착은 CLI가 stdout으로 기록할 때만 수행한다. raw-newline 모드 전환은 없다.
+- 프레임 단위 1MB 초과 시 데몬은 비치명 `{"type":"error","message":"result_too_large"}`로
+  응답하고 스트림을 유지한다(close 아님).
+
+#### Timeout 계약
+
+- **핸드셰이크 응답(Phase B)에만** bounded 30s timeout을 적용한다
+  (`asyncio.wait_for(decode, 30)`).
+- **Phase C 스트림 바디 read에는 per-read timeout을 절대 적용하지 않는다.** idle
+  스트림(무전송 대기)은 정상이며, liveness는 app-level `{ping→pong}` heartbeat로
+  확인한다. 표준 `IPCClient.send`의 30s decode timeout 경로는 Phase C에 재사용하지
+  않는다.
+
+#### `closed.reason` 정규 vocab (SSOT)
+
+데몬 주도 종료는 정확히 1개 `{"type":"closed","reason":<...>}` 프레임을 best-effort로
+보낸 뒤 소켓을 닫는다. `reason`은 다음 단일 정규 집합으로 통일한다:
+**`{rotated, deleted, bot_stopped, draining, lagged}`**.
+
+| 트리거 | reason |
+|--------|--------|
+| signal key 회전(`bot.signal_key.rotate`) | `rotated` |
+| 봇 삭제(`bot.remove`) | `deleted` |
+| 봇이 RUNNING 이탈(stop/error/suspend 등 — 정밀 트리거 집합은 [bot/03-design-decisions.md](../bot/03-design-decisions.md) SSOT) | `bot_stopped` |
+| 데몬 shutdown DRAINING 전이 | `draining` |
+| out_queue overflow(느린 소비자) | `lagged` |
+
+외부 소비자는 **알 수 없는 `reason`을 generic terminal close로 처리**해야 한다
+(forward-compat). standalone `shutdown` reason은 없으며, 유일한 shutdown 트리거는
+DRAINING 전이로 `draining`을 발화한다. teardown trigger 메커니즘의 정밀 계약은
+[bot/03-design-decisions.md](../bot/03-design-decisions.md)를 따른다.
+
+> coherence minor 해소: teardown 표의 `bot_stopped` 트리거 셀은 enumeration 권위를 bot/03으로 단일화("정밀 트리거 집합은 bot/03 SSOT")하여 03과의 비대칭을 제거했다. closed.reason vocab 집합 자체는 03/spec §6과 byte-identical.
+
 ## 컴포넌트 설계
 
 ### IPCServer
@@ -492,9 +594,28 @@ drift다.
 
 ## 보안 고려
 
-- **소켓 파일 권한**: 생성 시 `0o600` (소유자만 읽기/쓰기) — 로컬 머신의 다른 사용자 접근 차단
+- **소켓·runtime dir 파일 권한**: 소켓 파일은 생성 시 `0o600`(소유자만 읽기/쓰기), runtime
+  디렉터리(`<config_dir>/run/`)는 `0o700`으로 생성·강제한다(umask에 의존하지 않으며, 기존
+  디렉터리도 권한을 검증한다) — 로컬 머신의 다른 사용자 접근 차단
 - **인증 이중화 불필요**: 일반 CLI는 이미 `ANTE_MEMBER_TOKEN`으로 인증 + Member scope 확인을 수행하므로, IPC 계층에서 재인증하지 않는다. IPC는 별도 permission vocabulary를 소유하지 않고 `actor` 필드로 감사 추적만 전달한다. `member reset-password`처럼 인증 면제 recovery 커맨드는 토큰 대신 recovery key 또는 현재 패스워드를 서버 서비스가 검증한다
+- **`signal.connect` 키 검증은 데몬-side**: 실질 인가는 signal key 검증이며,
+  `validate_signal_key`를 데몬 핸들러에서 `svc.bot_manager` 경유로 수행한다. CLI
+  `@require_auth`는 "CLI 명령 실행 여부"만 게이트한다. signal key(`sk_` 접두)는 audit
+  detail / audit_log / IPC error envelope / `closed` 프레임 / 서버 로그 어디에도 노출하지
+  않는다(핸드셰이크 실패 path도 키를 traceback에 싣지 않는다)
+- **`signal.connect` cross-bot 누출 방지**: `ExternalSignalEvent`의 `account_id`/`bot_id`는
+  항상 LIVE `bot.config`에서만 생성하며, 클라이언트가 보낸 `account_id`/`bot_id`는
+  무시·override 불가다. 연결당 `SignalChannel`은 단일 `bot_id`에 바인딩되고,
+  fill/order_update는 `event.bot_id == bot.bot_id` 필터로 자기 봇만 수신한다
+- **`signal.connect` audit actor sentinel**: connect는 연결당 1회만 audit하며(per-signal
+  audit 금지), audit의 member_id는 spoof 가능한 client-supplied `actor`가 아니라 sentinel
+  `ipc`로 기록한다(`server.py`의 `actor` 기본값 정합, #2113). audit 기록은 4-게이트 통과
+  직후 `audit_logger`가 구성된 경우에만 getattr-safe하게 1회 수행한다
 - **요청 크기 제한**: 메시지 최대 크기 1MB — 과도한 페이로드 차단
+
+> `signal.connect` 보안 불변(키 검증 daemon-side·키 비노출·account_id/bot_id LIVE-only·
+> dir 0o700·actor sentinel audit)은 본 스펙에서 확정하는 계약이며, 코드 반영은 구현 PR
+> 머지 후(동기 버그 #2333 unblock)에 이루어진다.
 
 ## 파일 구조
 


### PR DESCRIPTION
Refs #2334 (스펙 design 이슈는 구현 PR 시퀀스 완료까지 open 유지 — 이 PR은 **closes 하지 않음**)

## Summary
#2334 daemon-위임 streaming 아키텍처 계약을 canonical `docs/specs/`에 반영하는 **DOCS-ONLY** PR(§15 구현 시퀀스의 increment 1). 코드/생성물 변경 없음.

변경 7개 docs/specs (원자 머지):
- `ipc/ipc.md`: OFFLINE에서 `signal` 제거(=#2333 스펙 root cause) + `#### Signal` 표 + handler taxonomy 40→41 + `### Signal connect 스트리밍 프로토콜` 절(3-phase upgrade/1:1 framing/closed.reason vocab) + 보안 절(dir 0o700, 키 비노출, LIVE account_id/bot_id)
- `audit/audit.md`: `signal.connect` 기록(연결 1회, member_id sentinel `ipc` — server.py:342 IPC actor 정합)
- `bot/03-design-decisions.md`: 채널 teardown enforcement(`SignalChannelRegistry`, rotate→'NEW 미admit·in-flight at-most-one', 단일 connect)
- `bot/04-eventbus-integration.md`: 데몬-side SignalChannel 구독 SSOT 재확인
- `contracts/error-taxonomy.md`: 신규 4코드(INVALID_SIGNAL_KEY/BOT_NOT_RUNNING/MALFORMED_REQUEST/BOT_SIGNAL_CHANNEL_BUSY) 첫 SSOT 등재 + 명명 규칙 whitelist 확장
- `contracts/offline-factory.md`: §3.2 signal.py:48 "resolved by #2333"
- `contracts/envelopes.md`: streaming 핸드셰이크 verbatim passthrough

## ⚠️ 머지/적용 주의 (caveat)
- **원자 머지 필수**: error-taxonomy.md가 신규 4코드의 첫 docs SSOT이며 ipc.md/03이 이를 링크 위임 → 7개 docs를 단일 PR로 함께 머지(단독 머지 금지).
- **contract-drift(의도됨)**: 본 PR은 스펙(계약)만 확정한다. `error_registry.py` ErrorSpec 등록·`validate_signal_key`/`SignalChannelRegistry` 구현·CLI thin relay는 **구현 PR(#2334 §15 PR#1~#3)** 에서 처리한다. signal connect daemon-위임 streaming은 **구현 PR 머지 후(동기 버그 #2333 unblock) 실행 가능**하며, 현재 동작하지 않는다(문서 전반 caveat 명시).
- **생성물 미재생성**: guide/cli.md·project-structure.md·openapi.json 의도적 미변경(미구현 명령 실행가능 오인 차단, #1711 정합).

## Plan / Review
- plan-preflight:done, Codex Plan Review: approve-implement
- Codex 브랜치 리뷰: PASS (head 27a13a28)
- coherence 리뷰 3건(blocker 1·major 2) 해소

## Test Plan (docs-only)
- `git diff --name-only main..HEAD` = docs/specs 7개 파일만 (src/ 0, 생성물 0)
- 코드펜스 balanced(7파일), `git diff --check` 통과, handler taxonomy 표 41 cross-check 일치
- 상대경로 링크 resolve 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)