### PR TITLE
feat(ipc): #2336 signal.connect transport+ingress 골격 (daemon-위임 PR#1)

### DIFF
--- a/src/ante/bot/exceptions.py
+++ b/src/ante/bot/exceptions.py
@@ -15,6 +15,11 @@ BOT_NOT_ACCEPTING_SIGNALS_CODE = "BOT_NOT_ACCEPTING_SIGNALS"
 BOT_ALREADY_EXISTS_CODE = "BOT_ALREADY_EXISTS"
 BOT_STRATEGY_ALREADY_RUNNING_CODE = "BOT_STRATEGY_ALREADY_RUNNING"
 BOT_IMMUTABLE_FIELD_CODE = "BOT_IMMUTABLE_FIELD"
+# Refs #2334 / #2336 (PR#1): signal.connect 핸드셰이크 4-게이트 stable code.
+# ``SignalKeyManagerNotConfigured`` 는 전용 코드를 발명하지 않고 taxonomy
+# SSOT(error-taxonomy.md) 의 공통 ``SERVICE_NOT_CONFIGURED`` 를 재사용한다.
+INVALID_SIGNAL_KEY_CODE = "INVALID_SIGNAL_KEY"
+BOT_NOT_RUNNING_CODE = "BOT_NOT_RUNNING"
 
 
 class BotError(Exception):
@@ -110,3 +115,58 @@ class BotImmutableFieldError(BotError):
     """
 
     code: str = BOT_IMMUTABLE_FIELD_CODE
+
+
+class InvalidSignalKey(BotError):  # noqa: N818
+    """``signal.connect`` 핸드셰이크 게이트① — signal key 검증 실패 (#2334/#2336).
+
+    ``validate_signal_key`` 가 ``None`` 을 반환한 경우(미발급/회전/오타 키)
+    핸들러가 raise 한다. IPC ``server.py`` 의 ``getattr(e, "code", ...)`` 가
+    안정 코드 ``INVALID_SIGNAL_KEY`` 로 변환한다.
+
+    **redaction 불변**: 메시지에 키/bot_id 를 절대 interpolate 하지 않는다.
+    ``__init__`` 인자를 0개로 강제해 호출처 실수로 키가 새는 경로를 차단한다
+    (error-taxonomy.md ``validation`` 카테고리).
+    """
+
+    code: str = INVALID_SIGNAL_KEY_CODE
+
+    def __init__(self) -> None:
+        super().__init__("Invalid signal key")
+
+
+class BotNotRunning(BotError):  # noqa: N818
+    """``signal.connect`` 핸드셰이크 게이트③ — 봇이 RUNNING 아님 (#2334/#2336).
+
+    handshake 시점에 ``bot.status != BotStatus.RUNNING`` 이면 핸들러가 raise
+    한다. IPC ``server.py`` 의 ``getattr(e, "code", ...)`` 가 안정 코드
+    ``BOT_NOT_RUNNING`` 으로 변환한다 (error-taxonomy.md ``state_conflict``).
+
+    ``status`` 는 caller(핸들러 게이트③)가 ``bot.status.value`` 로 넘긴
+    **소문자** ``BotStatus.value`` 다. 본 클래스는 받은 문자열을 그대로
+    포맷하며 ``BotStatus.name``(대문자)/``repr`` 을 사용하지 않는다.
+    """
+
+    code: str = BOT_NOT_RUNNING_CODE
+
+    def __init__(self, bot_id: str, status: str) -> None:
+        self.bot_id = bot_id
+        self.status = status
+        super().__init__(f"Bot is not running: {bot_id} (status: {status})")
+
+
+class SignalKeyManagerNotConfigured(BotError):  # noqa: N818
+    """``signal.connect`` 키 검증에 필요한 ``SignalKeyManager`` 가 부재 (#2334/#2336).
+
+    ``BotManager.validate_signal_key`` 가 ``_signal_key_manager is None`` 일 때
+    raise 한다. ``rotate_signal_key`` 의 generic ``BotError``(EXECUTION_ERROR
+    로 fold) 를 미러하지 않고, taxonomy SSOT 의 공통 안정 코드
+    ``SERVICE_NOT_CONFIGURED``(``service_unavailable``) 를 재사용한다 —
+    전용 코드를 발명하지 않는다. 메시지는 키-free 이며 관찰 가능한
+    ``signal_key_manager`` 토큰만 포함한다.
+    """
+
+    code: str = "SERVICE_NOT_CONFIGURED"
+
+    def __init__(self) -> None:
+        super().__init__("SignalKeyManager not configured: signal_key_manager")

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -25,6 +25,7 @@ from ante.bot.exceptions import (
     BotNotFoundError,
     BotStateConflict,
     BotStrategyAlreadyRunningError,
+    SignalKeyManagerNotConfigured,
 )
 
 if TYPE_CHECKING:
@@ -1325,6 +1326,23 @@ class BotManager:
         if not self._signal_key_manager:
             return None
         return await self._signal_key_manager.get_key(bot_id)
+
+    async def validate_signal_key(self, key: str) -> str | None:
+        """``signal.connect`` 핸드셰이크 게이트① — signal key → bot_id 검증.
+
+        Refs #2334/#2336 (PR#1): IPC ``_handle_signal_connect`` 가 호출하는
+        passthrough. 세 결과를 분리한다.
+
+        * manager 구성 + key hit → ``bot_id``.
+        * manager 구성 + key miss → ``None`` (핸들러가 ``InvalidSignalKey``
+          로 변환; 본 메서드는 raise 하지 않음).
+        * manager 미구성(``_signal_key_manager is None``) →
+          ``SignalKeyManagerNotConfigured`` (generic ``BotError`` /
+          EXECUTION_ERROR fold 회피). 키는 로깅/메시지에 노출하지 않는다.
+        """
+        if self._signal_key_manager is None:
+            raise SignalKeyManagerNotConfigured()
+        return await self._signal_key_manager.validate_key(key)
 
     async def rotate_signal_key(self, bot_id: str) -> str:
         """시그널 키 재발급.

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -204,11 +204,26 @@ baseline 으로 그대로 유지된다 (#1842 ``AccountError`` 와 동일 패턴
   정상 경로에서는 발생하지 않으며, 발생 시 호출 코드 버그를 의미하므로
   taxonomy ``internal`` 로 명시 매핑 — 암묵적 fallback drift 가 아님을 lock).
 
-추가로 ``SERVICE_NOT_CONFIGURED`` 는 #1819 dispatch wrapper 가 도입할 예정인
-``ServiceNotConfiguredError`` 의 ErrorSpec value 를 module-level constant
-(``_SERVICE_NOT_CONFIGURED_SPEC``) 로 reserved 보존한다. 해당 exception class
-는 본 PR 에서 import 하지 않으며 (#1819 가 도입할 책임), 후속 PR 이 class 를
-추가하면 한 줄 entry 추가로 mapping 을 연결할 수 있다.
+추가로 ``SERVICE_NOT_CONFIGURED`` 는 module-level constant
+(``_SERVICE_NOT_CONFIGURED_SPEC``) 로 보존한다 — taxonomy SSOT 가
+``service_unavailable`` 카테고리로 lock 한 공통 안정 코드다. #2336 (PR#1) 이
+``SignalKeyManagerNotConfigured`` (``.code="SERVICE_NOT_CONFIGURED"``) 를 도입해
+이 상수를 ``EXCEPTION_TO_SPEC`` 한 줄 entry 로 wiring 한다(전용 코드 미발명).
+
+#2336 (PR#1) signal.connect 핸드셰이크 신규 4코드:
+
+- ``INVALID_SIGNAL_KEY`` (validation) — ``InvalidSignalKey`` typed entry.
+- ``BOT_NOT_RUNNING`` (state_conflict) — ``BotNotRunning`` typed entry.
+- ``MALFORMED_REQUEST`` (validation) — server.py 가 비-dict 첫 프레임에 inline
+  envelope 으로 발화. typed exception 없음 → 상수-only(entry 미등록).
+- ``BOT_SIGNAL_CHANNEL_BUSY`` (state_conflict) — bot_id 당 단일 connect 거부.
+  raiser 는 PR#2(#2337) ``SignalChannelRegistry`` 이며, 본 PR 은 ErrorSpec
+  상수만 등록해 #2335 contract-drift 를 종료한다(상수-only, PR#1 raiser 없음).
+
+즉 typed-2(``INVALID_SIGNAL_KEY``/``BOT_NOT_RUNNING``) + inline-2
+(``MALFORMED_REQUEST``/``BOT_SIGNAL_CHANNEL_BUSY``) split. typed-2 의
+``EXCEPTION_TO_SPEC`` entry 는 helper 의 bare-``.code``→``internal`` wrap 을
+회피해 category 정확성을 lock 하는 load-bearing 이다.
 
 본 모듈은 helper-internal 로 취급한다 — ``ante.contracts.__init__`` 에서
 re-export 하지 않으며, 외부 소비자는 ``error_spec_for_exception(exc)`` 를
@@ -242,8 +257,11 @@ from ante.bot.exceptions import (
     BotImmutableFieldError,
     BotNotAcceptingSignals,
     BotNotFoundError,
+    BotNotRunning,
     BotStateConflict,
     BotStrategyAlreadyRunningError,
+    InvalidSignalKey,
+    SignalKeyManagerNotConfigured,
 )
 from ante.broker.exceptions import (
     APIError,
@@ -527,6 +545,52 @@ _BOT_STRATEGY_ALREADY_RUNNING_SPEC: Final[ErrorSpec] = ErrorSpec(
 _BOT_IMMUTABLE_FIELD_SPEC: Final[ErrorSpec] = ErrorSpec(
     code="BOT_IMMUTABLE_FIELD",
     category="validation",
+)
+
+
+# ── signal.connect 핸드셰이크 신규 코드(#2336/#2334 PR#1) ────────────────────
+#
+# error-taxonomy.md 가 신규 4코드를 분류한다: ``INVALID_SIGNAL_KEY``=validation,
+# ``BOT_NOT_RUNNING``=state_conflict, ``MALFORMED_REQUEST``=validation,
+# ``BOT_SIGNAL_CHANNEL_BUSY``=state_conflict. 이 중 typed exception 이 존재하는
+# 2코드(``INVALID_SIGNAL_KEY``/``BOT_NOT_RUNNING``)만 ``EXCEPTION_TO_SPEC`` 에
+# entry 를 갖고, 나머지 2코드는 상수-only(``MALFORMED_REQUEST`` 는 server.py 가
+# 비-dict 첫 프레임에 대해 inline envelope 으로 발화, ``BOT_SIGNAL_CHANNEL_BUSY``
+# 의 raiser 는 단일-connect 정책으로 PR#2(#2337)). ``_MALFORMED_REQUEST_SPEC``
+# 와 동형으로 ``_SERVICE_NOT_CONFIGURED_SPEC`` reserved 선례를 따른다.
+
+# ``signal.connect`` 게이트① — signal key 검증 실패. 입력 계약 위반이므로
+# ``validation`` 카테고리. server.py:446 ``getattr(e, "code", ...)`` 가
+# ``InvalidSignalKey.code`` → ``INVALID_SIGNAL_KEY`` envelope 으로 변환하고,
+# ``EXCEPTION_TO_SPEC`` entry 가 category 정확성(``internal`` wrap 회피)을 lock.
+_INVALID_SIGNAL_KEY_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="INVALID_SIGNAL_KEY",
+    category="validation",
+)
+
+# ``signal.connect`` 게이트③ — 봇이 RUNNING 아님. 운영 상태가 핸드셰이크
+# 전이를 허용하지 않으므로 ``state_conflict`` (``_BOT_NOT_ACCEPTING_SIGNALS_SPEC``
+# 1:1 미러).
+_BOT_NOT_RUNNING_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BOT_NOT_RUNNING",
+    category="state_conflict",
+)
+
+# ``signal.connect`` 첫 프레임이 비-dict 로 decode 되면 server.py 가 inline
+# envelope 으로 발화. JSON object 가 아닌 입력 계약 위반이므로 ``validation``.
+# typed exception 없음 → ``EXCEPTION_TO_SPEC`` entry 없음(상수-only).
+_MALFORMED_REQUEST_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="MALFORMED_REQUEST",
+    category="validation",
+)
+
+# 같은 봇에 이미 active session 이 있을 때 두 번째 핸드셰이크 거부 (bot_id 당
+# 단일 connect). 운영 상태 충돌이므로 ``state_conflict``. raiser 는 PR#2
+# (#2337) 의 ``SignalChannelRegistry`` 이며, 본 PR 은 ErrorSpec 상수만 등록해
+# #2335 contract-drift 를 종료한다(상수-only, PR#1 에 raiser 없음 — 의도적).
+_BOT_SIGNAL_CHANNEL_BUSY_SPEC: Final[ErrorSpec] = ErrorSpec(
+    code="BOT_SIGNAL_CHANNEL_BUSY",
+    category="state_conflict",
 )
 
 
@@ -816,6 +880,14 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     BotStrategyAlreadyRunningError: _BOT_STRATEGY_ALREADY_RUNNING_SPEC,
     # ── #2282 bot account_id 불변 lock (Account 선례 미러) ────────────────
     BotImmutableFieldError: _BOT_IMMUTABLE_FIELD_SPEC,
+    # ── #2336/#2334 PR#1 signal.connect 핸드셰이크 (typed 2 + 재사용 1) ────
+    # ``MALFORMED_REQUEST``/``BOT_SIGNAL_CHANNEL_BUSY`` 는 typed exception 이
+    # 없어 entry 를 두지 않는다(추가 시 NameError — ``_SERVICE_NOT_CONFIGURED_SPEC``
+    # 상수-only 선례). ``SignalKeyManagerNotConfigured`` 는 기존
+    # ``_SERVICE_NOT_CONFIGURED_SPEC`` 를 재사용해 category 정확성을 wiring.
+    InvalidSignalKey: _INVALID_SIGNAL_KEY_SPEC,
+    BotNotRunning: _BOT_NOT_RUNNING_SPEC,
+    SignalKeyManagerNotConfigured: _SERVICE_NOT_CONFIGURED_SPEC,
     # ── #1843 sub-PR 4 treasury 7 sub-class (실측 .code mirror) ───────────
     TreasuryInvalidAmountError: _TREASURY_INVALID_AMOUNT_SPEC,
     TreasuryInsufficientUnallocatedError: _TREASURY_INSUFFICIENT_BALANCE_SPEC,

--- a/src/ante/eventbus/bus.py
+++ b/src/ante/eventbus/bus.py
@@ -79,7 +79,11 @@ class EventBus:
                     type(event).__name__,
                 )
 
-        handlers = self._handlers.get(type(event), [])
+        # Refs #2334 §6 stale-ref guard: 핸들러 순회 전에 list 를 snapshot 한다.
+        # publish 중 한 핸들러가 같은 event_type 에 subscribe(in-place
+        # append+sort) / 다른 핸들러가 unsubscribe(rebind) 해도 in-flight 순회는
+        # 결정적이다(skip/double-fire/RuntimeError 없음). 기존 동작 보존.
+        handlers = list(self._handlers.get(type(event), []))
         if not handlers:
             logger.debug("구독자 없는 이벤트: %s", type(event).__name__)
             return

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -665,6 +665,75 @@ async def _handle_bot_signal_key(
     return {"bot_id": bot_id, "signal_key": key}
 
 
+async def _handle_signal_connect(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    """``signal.connect`` 핸드셰이크 IPC handler (read-only, #2334/#2336 PR#1).
+
+    데몬-side·LIVE 상태 4-게이트를 순서대로 검증한 뒤, 통과 시
+    ``_stream`` 센티넬이 포함된 dict 를 반환한다. ``IPCServer._handle_connection``
+    이 ``response["result"]["_stream"] == "signal.connect"`` 를 감지해 동일 연결을
+    long-lived 스트림으로 connection-upgrade 하며, wire 전송 직전 센티넬을 strip
+    한다(절대 노출 안 됨 — ipc.md §"1:1 framing 불변").
+
+    4-게이트(ipc.md §"3-Phase 연결"):
+
+    * ① signal key 검증: ``validate_signal_key(key)`` → ``None`` 이면
+      ``InvalidSignalKey``. key 부재(``args`` 에 ``key`` 없음)도 ``args.get`` 으로
+      ``None`` → 동일 거부(``KeyError`` 아님).
+    * ② 봇 존재: ``get_bot(bot_id)`` → ``None`` 이면 ``BotNotFoundError``
+      (기존 코드 재사용, 재정의 금지).
+    * ③ 봇 RUNNING: ``bot.status != BotStatus.RUNNING`` 이면
+      ``BotNotRunning(bot_id, bot.status.value)`` (소문자 ``.value``).
+    * ④ 외부 시그널 수용: 전략 부재 또는 ``accepts_external_signals=False`` 면
+      ``BotNotAcceptingSignals``.
+
+    ``account_id`` 는 LIVE ``bot.config`` 에서만 취하고 ``args`` 의 spoof 값은
+    무시한다. ``audit_action=None`` (자동 audit OFF) — 단일 manual connect-audit
+    는 PR#2(#2337) lifecycle 소관이다. 키는 로깅/반환에 노출하지 않는다.
+
+    PR#2(#2337) 경계: routing/``SignalChannel``/out_queue/teardown/단일-connect
+    ``BOT_SIGNAL_CHANNEL_BUSY`` raise 는 본 PR 범위 밖이다.
+    """
+    from ante.bot.config import BotStatus
+    from ante.bot.exceptions import (
+        BotNotAcceptingSignals,
+        BotNotFoundError,
+        BotNotRunning,
+        InvalidSignalKey,
+    )
+
+    # 게이트① — signal key 검증. key 부재/비-str(``args={}`` 포함) 은
+    # ``args.get`` 으로 ``None`` → miss 와 동일하게 ``InvalidSignalKey``
+    # (``KeyError`` 아님). manager 미구성 시는 ``validate_signal_key`` 가
+    # ``SignalKeyManagerNotConfigured`` 를 raise 한다.
+    key = args.get("key")
+    if not isinstance(key, str):
+        raise InvalidSignalKey()
+    bot_id = await svc.bot_manager.validate_signal_key(key)
+    if bot_id is None:
+        raise InvalidSignalKey()
+
+    # 게이트② — 봇 존재.
+    bot = svc.bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise BotNotFoundError(bot_id)
+
+    # 게이트③ — 봇 RUNNING.
+    if bot.status != BotStatus.RUNNING:
+        raise BotNotRunning(bot_id, bot.status.value)
+
+    # 게이트④ — 외부 시그널 수용.
+    if not bot.strategy or not bot.strategy.meta.accepts_external_signals:
+        raise BotNotAcceptingSignals(f"Bot {bot_id} does not accept external signals")
+
+    return {
+        "bot_id": bot_id,
+        "account_id": bot.config.account_id,
+        "_stream": "signal.connect",
+    }
+
+
 async def _handle_bot_update(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
@@ -1492,9 +1561,9 @@ async def _handle_broker_reconcile(
 
 
 def register_all_handlers(registry: CommandRegistry) -> None:
-    """40개 런타임 커맨드 핸들러를 일괄 등록.
+    """41개 런타임 커맨드 핸들러를 일괄 등록.
 
-    Refs #1184: 각 핸들러는 mutating(32개) 또는 read-only(8개)로 분류된다.
+    Refs #1184: 각 핸들러는 mutating(32개) 또는 read-only(9개)로 분류된다.
     분류는 ``docs/specs/ipc/ipc.md``의 "Handler taxonomy" 섹션과 동기화되어야
     한다. mutating 명령은 ``IPCServer``가 ``SHUTTING_DOWN`` 상태일 때
     ``SERVICE_UNAVAILABLE``로 거부된다.
@@ -1555,6 +1624,12 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     ``regenerate_recovery_key`` 는 auth-exempt 라 master-lookup 을 handler
     (서버 chokepoint)에서 수행하고 audit member_id 를 고정 sentinel 상수로
     기록한다. mutating 24→32, audit 18→26, 총 32→40.
+
+    Refs #2334 (#2336 PR#1): ``signal.connect`` (read-only) 추가 — daemon-위임
+    signal.connect 핸드셰이크의 4-게이트 LIVE 검증 경로. 통과 시 동일 연결을
+    connection-upgrade(``result_kind="stream"``). audit 없음(``audit_action=None``;
+    connect-audit 1회는 PR#2 #2337). read-only 8→9, 총 40→41. mutating 32 /
+    audit 26 불변(signal.connect 는 비-mutating·비-audit).
     """
     # ── mutating (32개): 서버 상태/DB를 변경 ──────────
     # system.* — account_service의 suspend_all/activate_all (collective ops).
@@ -1958,4 +2033,17 @@ def register_all_handlers(registry: CommandRegistry) -> None:
         result_kind="entity",
         result_key="signal_key",
         required_services=frozenset({"bot_manager"}),
+    )
+    # Refs #2334 (#2336 PR#1): signal.connect 핸드셰이크. read-only(4-게이트
+    # LIVE 검증만 수행, 상태 미변경) · ``result_kind="stream"`` (통과 시
+    # 동일 연결을 connection-upgrade) · ``audit_action`` 생략(=None, 자동 audit
+    # OFF — connect-audit 1회는 PR#2 #2337). ``account_id_policy="none"``:
+    # account_id 는 LIVE ``bot.config`` 에서만 취하고 args 는 무시한다.
+    registry.register(
+        "signal.connect",
+        _handle_signal_connect,
+        is_mutating=False,
+        result_kind="stream",
+        required_services=frozenset({"bot_manager"}),
+        account_id_policy="none",
     )

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -230,7 +230,38 @@ class IPCServer:
                     await writer.drain()
                     break
 
+                # Refs #2334 (#2336 PR#1): 첫 프레임이 JSON object 가 아니면
+                # (list/scalar 등) MALFORMED_REQUEST 1프레임 후 close. 비-dict 는
+                # usable id 가 없어 id=None (MESSAGE_TOO_LARGE 블록 미러).
+                if not isinstance(request, dict):
+                    response = self._malformed_request("요청은 JSON object여야 합니다")
+                    data = await protocol.encode(response)
+                    writer.write(data)
+                    await writer.drain()
+                    break
+
                 response = await self._dispatch(request)
+
+                # Refs #2334 (#2336 PR#1): signal.connect 핸드셰이크 OK 응답이면
+                # 동일 연결을 long-lived 스트림으로 connection-upgrade 한다.
+                # 센티넬은 ``response["result"]["_stream"]`` (중첩) — 최상위로
+                # 읽으면 silent fall-through 로 센티넬이 누출된다.
+                result = response.get("result")
+                if (
+                    response.get("status") == "ok"
+                    and isinstance(result, dict)
+                    and result.get("_stream") == "signal.connect"
+                ):
+                    # wire 전송 직전 센티넬 strip (절대 노출 안 됨).
+                    result.pop("_stream", None)
+                    ack = await protocol.encode(response)
+                    writer.write(ack)
+                    await writer.drain()
+                    await self._run_signal_stream(reader, writer, result["bot_id"])
+                    # break 아님 — hijack 연결은 lockstep 재진입 금지. finally 가
+                    # teardown(writer close) 를 단일 소유한다.
+                    return
+
                 data = await protocol.encode(response)
                 writer.write(data)
                 await writer.drain()
@@ -257,6 +288,26 @@ class IPCServer:
             "status": "error",
             "error": {
                 "code": "SERVICE_UNAVAILABLE",
+                "message": message,
+            },
+        }
+
+    @staticmethod
+    def _malformed_request(message: str) -> dict:
+        """``MALFORMED_REQUEST`` error 응답 dict 생성.
+
+        Refs #2334 (#2336 PR#1): 첫 프레임이 JSON object 가 아닐 때 사용한다.
+        비-dict 입력은 usable ``id`` 가 없어 ``id=None`` 으로 고정한다
+        (``MESSAGE_TOO_LARGE`` 블록 동형). taxonomy SSOT
+        (``docs/specs/contracts/error-taxonomy.md``) 의 ``validation`` 카테고리
+        안정 코드. ``_service_unavailable`` 와 동일 envelope shape 으로 다른 IPC
+        consumer(CLI/MCP)가 기존 generic error path 로 흘러가게 한다.
+        """
+        return {
+            "id": None,
+            "status": "error",
+            "error": {
+                "code": "MALFORMED_REQUEST",
                 "message": message,
             },
         }
@@ -452,3 +503,44 @@ class IPCServer:
                     "message": str(e),
                 },
             }
+
+    async def _run_signal_stream(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        bot_id: str,
+    ) -> None:
+        """signal.connect Phase-C 스트림 바디 루프 (#2334 / #2336 PR#1 스켈레톤).
+
+        핸드셰이크 OK 후 동일 연결을 hijack 해 long-lived 양방향 스트림으로
+        운반한다. PR#1 은 call seam + per-read timeout 없는 read-until-EOF 루프만
+        제공한다. 시그니처 ``(reader, writer, bot_id)`` 는 PR#2(#2337) relay 가
+        그대로 쓰도록 고정한다.
+
+        Phase-C read 에는 per-read timeout 을 **절대** 적용하지 않는다 — idle
+        스트림(무전송 대기)은 정상이며 liveness 는 app-level ``{ping→pong}``
+        heartbeat 로 확인한다(ipc.md §"Timeout 계약"). EOF(client close)에는
+        ``IncompleteReadError`` 로 graceful 종료한다.
+
+        PR#2(#2337) 이연(known-limitation):
+
+        * inbound 프레임 routing/ack/pong → 현재는 read+discard.
+        * >1MB 프레임 비치명 ``{"type":"error","message":"result_too_large"}``
+          후 스트림 유지 → 현재는 ``MessageTooLargeError`` 로 close. PR#1 은
+          Phase-C 의존 client 가 없어 close 허용.
+        * ``SignalChannel``/bounded ``out_queue``/writer_task/eventbus
+          subscribe·relay/``SignalChannelRegistry``/teardown = 전부 PR#2.
+
+        ``writer`` 를 직접 close 하지 않는다 — ``_handle_connection`` finally 가
+        teardown 을 단일 소유한다.
+        """
+        try:
+            while True:
+                # PR#1: routing 없음 — 프레임을 읽어 discard.
+                await protocol.decode(reader)
+        except asyncio.IncompleteReadError:
+            # EOF (어느 쪽이든 소켓 close) — graceful 종료.
+            return
+        except MessageTooLargeError:
+            # PR#1: close. PR#2 에서 비치명 result_too_large 로 스트림 유지.
+            return

--- a/tests/unit/contracts/test_signal_connect_codes.py
+++ b/tests/unit/contracts/test_signal_connect_codes.py
@@ -1,0 +1,74 @@
+"""signal.connect 신규 4코드 category-resolution lock (#2334/#2336 PR#1).
+
+이 테스트의 회귀 가드는 ``error_drift`` 스캐너가 아니라 **category 정확성**이다:
+``helpers.error_spec_for_exception`` 은 ``EXCEPTION_TO_SPEC`` registry miss 시
+bare ``.code`` 를 ``category="internal"`` 로 보수적 wrap 한다(helpers.py:74-76).
+따라서 typed exception(``InvalidSignalKey``/``BotNotRunning``) 은 class-level
+``.code`` (server.py getattr 경로) **그리고** ``EXCEPTION_TO_SPEC`` entry
+(category) 둘 다 필요하다 — entry 가 빠지면 코드는 맞지만 category 가
+``internal`` 로 drift 한다. 이 테스트가 그 trap 을 lock 한다.
+
+또한 신규 4코드(typed 2 + inline 2)가 모두 ErrorSpec 상수로 present 함을
+확인한다 — ``BOT_SIGNAL_CHANNEL_BUSY`` 는 PR#1 에 raiser 가 없지만(PR#2 #2337)
+#2335 contract-drift 종료를 위해 상수로 등록된다.
+"""
+
+from __future__ import annotations
+
+from ante.bot.exceptions import (
+    BotNotRunning,
+    InvalidSignalKey,
+    SignalKeyManagerNotConfigured,
+)
+from ante.contracts import error_spec_for_exception
+from ante.contracts.error_registry import (
+    _BOT_NOT_RUNNING_SPEC,
+    _BOT_SIGNAL_CHANNEL_BUSY_SPEC,
+    _INVALID_SIGNAL_KEY_SPEC,
+    _MALFORMED_REQUEST_SPEC,
+)
+
+
+class TestCategoryResolutionLock:
+    """typed exception 의 category 가 ``internal`` 로 wrap 되지 않음을 lock."""
+
+    def test_invalid_signal_key_resolves_validation(self) -> None:
+        spec = error_spec_for_exception(InvalidSignalKey())
+        assert spec.code == "INVALID_SIGNAL_KEY"
+        # entry 누락 시 helpers 가 bare .code 를 internal 로 wrap → 회귀 검출.
+        assert spec.category == "validation"
+
+    def test_bot_not_running_resolves_state_conflict(self) -> None:
+        spec = error_spec_for_exception(BotNotRunning("b1", "stopped"))
+        assert spec.code == "BOT_NOT_RUNNING"
+        assert spec.category == "state_conflict"
+
+    def test_signal_key_manager_not_configured_reuses_service_not_configured(
+        self,
+    ) -> None:
+        """``SignalKeyManagerNotConfigured`` 는 기존 ``SERVICE_NOT_CONFIGURED``
+        spec 재사용 — category ``service_unavailable`` (internal 아님)."""
+        spec = error_spec_for_exception(SignalKeyManagerNotConfigured())
+        assert spec.code == "SERVICE_NOT_CONFIGURED"
+        assert spec.category == "service_unavailable"
+
+
+class TestAllFourCodesRegistered:
+    """신규 4코드(typed 2 + inline 2) 가 모두 ErrorSpec 상수로 present."""
+
+    def test_invalid_signal_key_spec(self) -> None:
+        assert _INVALID_SIGNAL_KEY_SPEC.code == "INVALID_SIGNAL_KEY"
+        assert _INVALID_SIGNAL_KEY_SPEC.category == "validation"
+
+    def test_bot_not_running_spec(self) -> None:
+        assert _BOT_NOT_RUNNING_SPEC.code == "BOT_NOT_RUNNING"
+        assert _BOT_NOT_RUNNING_SPEC.category == "state_conflict"
+
+    def test_malformed_request_spec(self) -> None:
+        assert _MALFORMED_REQUEST_SPEC.code == "MALFORMED_REQUEST"
+        assert _MALFORMED_REQUEST_SPEC.category == "validation"
+
+    def test_bot_signal_channel_busy_spec(self) -> None:
+        """PR#1 에 raiser 없음(PR#2 #2337) — 상수만 등록(#2335 drift 종료)."""
+        assert _BOT_SIGNAL_CHANNEL_BUSY_SPEC.code == "BOT_SIGNAL_CHANNEL_BUSY"
+        assert _BOT_SIGNAL_CHANNEL_BUSY_SPEC.category == "state_conflict"

--- a/tests/unit/ipc/test_docs_taxonomy_drift.py
+++ b/tests/unit/ipc/test_docs_taxonomy_drift.py
@@ -46,6 +46,9 @@ _IPC_COMMAND_PREFIXES = (
     "config.",
     "approval.",
     "broker.",
+    # Refs #2334 (#2336 PR#1): signal.connect drift lock 활성화. prefix 추가
+    # 전에는 docs 의 signal.* row 가 silent skip(dead lock) 됐다.
+    "signal.",
 )
 
 # docs 표에는 등장하지만 IPC ``CommandRegistry`` 등록 대상이 아닌 토큰.

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -65,7 +65,7 @@ def test_commands_property(registry: CommandRegistry) -> None:
 
 
 def test_register_all_handlers() -> None:
-    """register_all_handlers가 40개 핸들러를 등록 (account.delete 제외).
+    """register_all_handlers가 41개 핸들러를 등록 (account.delete 제외).
 
     `account.delete`는 1.0 IPC 계약에서 제거되어 cold-path CLI에서 직접
     AccountService를 호출한다.
@@ -95,7 +95,7 @@ def test_register_all_handlers() -> None:
     """
     registry = CommandRegistry()
     register_all_handlers(registry)
-    assert len(registry.commands) == 40
+    assert len(registry.commands) == 41
 
     expected = {
         "system.halt",
@@ -113,6 +113,7 @@ def test_register_all_handlers() -> None:
         "bot.info",
         "bot.positions",
         "bot.signal_key",
+        "signal.connect",
         "treasury.allocate",
         "treasury.deallocate",
         "treasury.set_balance",
@@ -147,7 +148,7 @@ def test_register_all_handlers() -> None:
 
 
 def test_register_all_handlers_taxonomy() -> None:
-    """등록된 40개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다.
+    """등록된 41개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다.
 
     Refs #1712: ``bot.start`` / ``bot.stop`` mutating, ``bot.status``
     read-only — ``docs/specs/ipc/ipc.md`` Handler taxonomy SSOT 와 동기화.
@@ -158,6 +159,8 @@ def test_register_all_handlers_taxonomy() -> None:
     ``bot.signal_key`` read-only 추가 (read-only 4→8).
 
     Refs #2113: member admin mutation 8건 추가 (mutating 24→32).
+
+    Refs #2334 (#2336 PR#1): ``signal.connect`` read-only 추가 (read-only 8→9).
     """
     registry = CommandRegistry()
     register_all_handlers(registry)
@@ -205,10 +208,11 @@ def test_register_all_handlers_taxonomy() -> None:
         "bot.info",
         "bot.positions",
         "bot.signal_key",
+        "signal.connect",
     }
 
     assert len(mutating) == 32
-    assert len(read_only) == 8
+    assert len(read_only) == 9
     assert mutating | read_only == set(registry.commands)
 
     for command in mutating:
@@ -1274,12 +1278,12 @@ class TestRegisteredCommandsMetadataCompleteness:
         for spec in loaded.iter_specs():
             assert spec.cross_validators == (), spec.name
 
-    def test_iter_specs_returns_all_40_specs(self, loaded: CommandRegistry) -> None:
-        """``iter_specs``가 40 commands 모두를 ``CommandSpec`` 인스턴스로
+    def test_iter_specs_returns_all_41_specs(self, loaded: CommandRegistry) -> None:
+        """``iter_specs``가 41 commands 모두를 ``CommandSpec`` 인스턴스로
         반환한다 (#2112: 28→32, bot.* read 4건; #2113: 32→40, member admin
-        mutation 8건 추가)."""
+        mutation 8건 추가; #2334/#2336 PR#1: 40→41, ``signal.connect``)."""
         specs = loaded.iter_specs()
-        assert len(specs) == 40
+        assert len(specs) == 41
         assert all(isinstance(s, CommandSpec) for s in specs)
         # 등록 순서 보존(dict insertion order).
         assert [s.name for s in specs] == loaded.commands

--- a/tests/unit/ipc/test_server_signal_connect.py
+++ b/tests/unit/ipc/test_server_signal_connect.py
@@ -1,0 +1,377 @@
+"""signal.connect 핸드셰이크 transport+ingress 테스트 (#2334/#2336 PR#1).
+
+T1 — daemon handshake (server 경유 + 핸들러 단위): 4-게이트 성공/거부 →
+stable code, ``_stream`` 센티넬 비노출, account_id 는 ``bot.config`` 유래.
+T3 — framing/upgrade: ack 1프레임 round-trip(trailing ``'\n'`` 없음), idle
+스트림이 timeout/close 하지 않음, MALFORMED 비-dict 첫 프레임 거부.
+
+``test_server_client.py`` 의 unix-socket round-trip 패턴을 미러하되, MALFORMED
+wire 직조와 Phase-C EOF 제어를 위해 raw ``asyncio.open_unix_connection`` 으로
+프레임을 직접 다룬다. ``_run_signal_stream`` 은 PR#1 스켈레톤이며 routing 없음.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.bot.config import BotStatus
+from ante.bot.exceptions import (
+    BotNotAcceptingSignals,
+    BotNotFoundError,
+    BotNotRunning,
+    InvalidSignalKey,
+    SignalKeyManagerNotConfigured,
+)
+from ante.core.registry import ServiceRegistry
+from ante.ipc.registry import (
+    CommandRegistry,
+    _handle_signal_connect,
+    register_all_handlers,
+)
+from ante.ipc.server import IPCServer
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── wire helpers (length-prefixed framing 직접 제어) ──────────────────
+
+
+async def _read_frame(reader: asyncio.StreamReader) -> bytes:
+    """1 length-prefixed 프레임의 raw payload bytes 를 읽는다."""
+    raw_len = await reader.readexactly(4)
+    (length,) = struct.unpack("!I", raw_len)
+    return await reader.readexactly(length)
+
+
+async def _write_json_frame(writer: asyncio.StreamWriter, obj: object) -> None:
+    payload = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+    writer.write(struct.pack("!I", len(payload)) + payload)
+    await writer.drain()
+
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def socket_path() -> str:
+    td = tempfile.mkdtemp(prefix="ipc-sig", dir="/tmp")
+    return str(Path(td) / "t.sock")
+
+
+def _make_bot(
+    *,
+    account_id: str = "acc-live",
+    status: BotStatus = BotStatus.RUNNING,
+    accepts: bool = True,
+) -> MagicMock:
+    bot = MagicMock()
+    bot.config.account_id = account_id
+    bot.status = status
+    bot.strategy.meta.accepts_external_signals = accepts
+    return bot
+
+
+def _make_service_registry(bot_manager: MagicMock) -> ServiceRegistry:
+    return ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=bot_manager,
+        treasury_manager=MagicMock(),
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=MagicMock(),
+    )
+
+
+def _signal_only_registry() -> CommandRegistry:
+    """``signal.connect`` 만 등록한 registry (전체 required_services 회피)."""
+    reg = CommandRegistry()
+    reg.register(
+        "signal.connect",
+        _handle_signal_connect,
+        is_mutating=False,
+        result_kind="stream",
+        required_services=frozenset({"bot_manager"}),
+        account_id_policy="none",
+    )
+    return reg
+
+
+async def _start_server(socket_path: str, bot_manager: MagicMock) -> IPCServer:
+    svc = _make_service_registry(bot_manager)
+    server = IPCServer(socket_path, svc, _signal_only_registry())
+    await server.start()
+    return server
+
+
+# ── T1: handshake 성공 (server 경유) ─────────────────────────────────
+
+
+async def test_handshake_ok_returns_envelope_without_stream_sentinel(
+    socket_path: str,
+) -> None:
+    """4-게이트 성공 → ``{bot_id, account_id}`` ok envelope, ``_stream`` 비노출."""
+    bm = MagicMock()
+    bm.validate_signal_key = AsyncMock(return_value="bot-1")
+    bm.get_bot = MagicMock(return_value=_make_bot(account_id="acc-live"))
+    server = await _start_server(socket_path, bm)
+
+    try:
+        reader, writer = await asyncio.open_unix_connection(socket_path)
+        await _write_json_frame(
+            writer,
+            {"id": "h1", "command": "signal.connect", "args": {"key": "sk_x"}},
+        )
+        resp = json.loads((await _read_frame(reader)).decode("utf-8"))
+
+        assert resp["id"] == "h1"
+        assert resp["status"] == "ok"
+        assert resp["result"]["bot_id"] == "bot-1"
+        assert resp["result"]["account_id"] == "acc-live"
+        # 센티넬 strip 불변 — wire 에 절대 노출 안 됨.
+        assert "_stream" not in resp["result"]
+
+        # client close → _run_signal_stream 이 EOF 로 return, 연결 task 무에러.
+        writer.close()
+        await writer.wait_closed()
+        await asyncio.sleep(0.05)
+    finally:
+        await server.stop()
+
+
+async def test_handshake_invalid_key_one_error_frame_no_upgrade(
+    socket_path: str,
+) -> None:
+    """게이트① 거부 → 정확히 1 error 프레임(INVALID_SIGNAL_KEY) 후 EOF."""
+    bm = MagicMock()
+    bm.validate_signal_key = AsyncMock(return_value=None)  # miss
+    bm.get_bot = MagicMock()
+    server = await _start_server(socket_path, bm)
+
+    try:
+        reader, writer = await asyncio.open_unix_connection(socket_path)
+        await _write_json_frame(
+            writer,
+            {"id": "h2", "command": "signal.connect", "args": {"key": "sk_bad"}},
+        )
+        resp = json.loads((await _read_frame(reader)).decode("utf-8"))
+
+        assert resp["id"] == "h2"
+        assert resp["status"] == "error"
+        assert resp["error"]["code"] == "INVALID_SIGNAL_KEY"
+        # 보안: 프레임/메시지에 키 prefix 미포함.
+        assert "sk_" not in json.dumps(resp)
+        # upgrade 미진입 — get_bot 미호출.
+        bm.get_bot.assert_not_called()
+
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        await server.stop()
+
+
+async def test_handshake_malformed_non_dict_first_frame(socket_path: str) -> None:
+    """첫 프레임이 비-dict(JSON list) → MALFORMED_REQUEST, id=None 후 close."""
+    bm = MagicMock()
+    bm.validate_signal_key = AsyncMock()
+    server = await _start_server(socket_path, bm)
+
+    try:
+        reader, writer = await asyncio.open_unix_connection(socket_path)
+        # 4바이트 길이 + json.dumps([1, 2]) 직조.
+        await _write_json_frame(writer, [1, 2])
+        resp = json.loads((await _read_frame(reader)).decode("utf-8"))
+
+        assert resp["id"] is None
+        assert resp["status"] == "error"
+        assert resp["error"]["code"] == "MALFORMED_REQUEST"
+        # 핸들러 미도달 — key 검증 호출 안 됨.
+        bm.validate_signal_key.assert_not_called()
+
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        await server.stop()
+
+
+# ── T3: framing / upgrade ────────────────────────────────────────────
+
+
+async def test_ack_frame_has_no_trailing_newline(socket_path: str) -> None:
+    """ack 가 1 length-prefixed 프레임이고 JSON payload 에 trailing '\\n' 없음."""
+    bm = MagicMock()
+    bm.validate_signal_key = AsyncMock(return_value="bot-1")
+    bm.get_bot = MagicMock(return_value=_make_bot())
+    server = await _start_server(socket_path, bm)
+
+    try:
+        reader, writer = await asyncio.open_unix_connection(socket_path)
+        await _write_json_frame(
+            writer,
+            {"id": "h3", "command": "signal.connect", "args": {"key": "sk_x"}},
+        )
+        raw = await _read_frame(reader)
+        # 프레임 payload 자체에 embedded newline 이 없어야 한다(데몬 미부착).
+        assert not raw.endswith(b"\n")
+        assert b"\n" not in raw
+        # 정상 decode 가능.
+        json.loads(raw.decode("utf-8"))
+
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        await server.stop()
+
+
+async def test_idle_stream_does_not_timeout_or_close(socket_path: str) -> None:
+    """upgrade 후 idle 스트림(프레임 0개)에서 _run_signal_stream 이 close 안 함.
+
+    daemon-side per-read timeout 부재 lock — idle 은 정상. client 가 닫기
+    전까지 연결이 살아 있다.
+    """
+    bm = MagicMock()
+    bm.validate_signal_key = AsyncMock(return_value="bot-1")
+    bm.get_bot = MagicMock(return_value=_make_bot())
+    server = await _start_server(socket_path, bm)
+
+    try:
+        reader, writer = await asyncio.open_unix_connection(socket_path)
+        await _write_json_frame(
+            writer,
+            {"id": "h4", "command": "signal.connect", "args": {"key": "sk_x"}},
+        )
+        await _read_frame(reader)  # ack
+
+        # 아무것도 보내지 않고 대기 — daemon 이 close/EOF 하지 않아야 한다.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(reader.read(1), timeout=0.3)
+        # 연결이 여전히 살아 있음(EOF 아님).
+        assert not reader.at_eof()
+
+        writer.close()
+        await writer.wait_closed()
+        await asyncio.sleep(0.05)
+    finally:
+        await server.stop()
+
+
+# ── 핸들러 단위 (4-게이트 + account_id 출처) ─────────────────────────
+
+
+class TestHandleSignalConnectUnit:
+    async def _svc(self, bm: MagicMock) -> ServiceRegistry:
+        return _make_service_registry(bm)
+
+    async def test_ok_returns_stream_sentinel_and_config_account_id(self) -> None:
+        bm = MagicMock()
+        bm.validate_signal_key = AsyncMock(return_value="bot-1")
+        bm.get_bot = MagicMock(return_value=_make_bot(account_id="acc-live"))
+        svc = await self._svc(bm)
+
+        result = await _handle_signal_connect(
+            svc, {"key": "sk_x", "account_id": "SPOOF"}, "ipc"
+        )
+
+        assert result["bot_id"] == "bot-1"
+        # account_id 는 bot.config 유래 — args spoof 값 무시.
+        assert result["account_id"] == "acc-live"
+        assert result["_stream"] == "signal.connect"
+
+    async def test_missing_key_raises_invalid_signal_key_not_keyerror(self) -> None:
+        """``args={}`` (key 없음) → InvalidSignalKey (KeyError 아님)."""
+        bm = MagicMock()
+        bm.validate_signal_key = AsyncMock(return_value="bot-1")
+        bm.get_bot = MagicMock(return_value=_make_bot())
+        svc = await self._svc(bm)
+
+        with pytest.raises(InvalidSignalKey):
+            await _handle_signal_connect(svc, {}, "ipc")
+
+    async def test_gate1_key_miss_raises_invalid_signal_key(self) -> None:
+        bm = MagicMock()
+        bm.validate_signal_key = AsyncMock(return_value=None)
+        bm.get_bot = MagicMock()
+        svc = await self._svc(bm)
+
+        with pytest.raises(InvalidSignalKey) as ei:
+            await _handle_signal_connect(svc, {"key": "sk_bad"}, "ipc")
+        assert ei.value.code == "INVALID_SIGNAL_KEY"
+
+    async def test_manager_not_configured_propagates(self) -> None:
+        """manager None → SignalKeyManagerNotConfigured (게이트① 위임)."""
+        bm = MagicMock()
+        bm.validate_signal_key = AsyncMock(side_effect=SignalKeyManagerNotConfigured())
+        svc = await self._svc(bm)
+
+        with pytest.raises(SignalKeyManagerNotConfigured) as ei:
+            await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+        assert ei.value.code == "SERVICE_NOT_CONFIGURED"
+
+    async def test_gate2_bot_not_found(self) -> None:
+        bm = MagicMock()
+        bm.validate_signal_key = AsyncMock(return_value="bot-x")
+        bm.get_bot = MagicMock(return_value=None)
+        svc = await self._svc(bm)
+
+        with pytest.raises(BotNotFoundError) as ei:
+            await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+        assert ei.value.code == "BOT_NOT_FOUND"
+
+    async def test_gate3_bot_not_running_uses_lowercase_status_value(self) -> None:
+        bm = MagicMock()
+        bm.validate_signal_key = AsyncMock(return_value="bot-1")
+        bm.get_bot = MagicMock(return_value=_make_bot(status=BotStatus.STOPPED))
+        svc = await self._svc(bm)
+
+        with pytest.raises(BotNotRunning) as ei:
+            await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+        assert ei.value.code == "BOT_NOT_RUNNING"
+        # caller 가 bot.status.value(소문자)를 전달하는 계약 lock.
+        assert str(ei.value) == "Bot is not running: bot-1 (status: stopped)"
+
+    async def test_gate4_not_accepting_external_signals_english_literal(self) -> None:
+        bm = MagicMock()
+        bm.validate_signal_key = AsyncMock(return_value="bot-1")
+        bm.get_bot = MagicMock(return_value=_make_bot(accepts=False))
+        svc = await self._svc(bm)
+
+        with pytest.raises(BotNotAcceptingSignals) as ei:
+            await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+        assert ei.value.code == "BOT_NOT_ACCEPTING_SIGNALS"
+        # raise-site 영어 리터럴(한국어 rotate 메시지 재사용 금지).
+        assert str(ei.value) == "Bot bot-1 does not accept external signals"
+
+    async def test_gate4_no_strategy_rejected(self) -> None:
+        bm = MagicMock()
+        bm.validate_signal_key = AsyncMock(return_value="bot-1")
+        bot = _make_bot()
+        bot.strategy = None
+        bm.get_bot = MagicMock(return_value=bot)
+        svc = await self._svc(bm)
+
+        with pytest.raises(BotNotAcceptingSignals):
+            await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+
+
+# ── registry 등록 메타데이터 lock ────────────────────────────────────
+
+
+async def test_signal_connect_registered_metadata() -> None:
+    """signal.connect 가 read-only/stream/account_id_policy=none/audit None."""
+    reg = CommandRegistry()
+    register_all_handlers(reg)
+    spec = reg.get("signal.connect")
+    assert spec is not None
+    assert spec.is_mutating is False
+    assert spec.result_kind == "stream"
+    assert spec.required_services == frozenset({"bot_manager"})
+    assert spec.account_id_policy == "none"
+    assert spec.audit_action is None
+    assert spec.result_key is None

--- a/tests/unit/test_bot_signal_connect_exceptions.py
+++ b/tests/unit/test_bot_signal_connect_exceptions.py
@@ -1,0 +1,95 @@
+"""signal.connect 핸드셰이크 typed exception byte-lock 테스트 (#2334/#2336 PR#1).
+
+CLI 소스(``cli/commands/signal.py``)·error-taxonomy.md 와 byte-identical 한
+``str(e)`` / ``.code`` / category 계약을 lock 한다. DB 불필요(순수 단위).
+
+T6: ``InvalidSignalKey`` / ``BotNotRunning`` / ``SignalKeyManagerNotConfigured``
+의 메시지·코드·redaction 불변.
+"""
+
+from __future__ import annotations
+
+from ante.bot.config import BotStatus
+from ante.bot.exceptions import (
+    BotError,
+    BotNotRunning,
+    InvalidSignalKey,
+    SignalKeyManagerNotConfigured,
+)
+
+
+class TestInvalidSignalKey:
+    def test_str_byte_lock(self) -> None:
+        """``str(InvalidSignalKey())`` 가 정확히 ``Invalid signal key``."""
+        assert str(InvalidSignalKey()) == "Invalid signal key"
+
+    def test_code(self) -> None:
+        assert InvalidSignalKey.code == "INVALID_SIGNAL_KEY"
+        assert InvalidSignalKey().code == "INVALID_SIGNAL_KEY"
+
+    def test_no_args(self) -> None:
+        """``__init__`` 인자 0개 — 키/bot_id 를 interpolate 할 경로 없음."""
+        exc = InvalidSignalKey()
+        assert isinstance(exc, BotError)
+
+    def test_redaction(self) -> None:
+        """메시지에 키 prefix(``sk_``)/bot_id 가 절대 새지 않는다."""
+        msg = str(InvalidSignalKey())
+        assert "sk_" not in msg
+        assert "bot" not in msg.lower() or msg == "Invalid signal key"
+
+
+class TestBotNotRunning:
+    def test_str_byte_lock(self) -> None:
+        """``str(BotNotRunning(bot_id, status))`` byte-exact 포맷."""
+        exc = BotNotRunning("b1", "stopped")
+        assert str(exc) == "Bot is not running: b1 (status: stopped)"
+
+    def test_code(self) -> None:
+        assert BotNotRunning.code == "BOT_NOT_RUNNING"
+        assert BotNotRunning("b1", "stopped").code == "BOT_NOT_RUNNING"
+
+    def test_fields_preserved(self) -> None:
+        exc = BotNotRunning("b1", "stopped")
+        assert exc.bot_id == "b1"
+        assert exc.status == "stopped"
+
+    def test_status_is_lowercase_botstatus_value(self) -> None:
+        """caller 가 ``bot.status.value`` (소문자 StrEnum value) 를 넘기는
+        계약을 lock — ``BotStatus.STOPPED.value`` 로 구성해 소문자 검증."""
+        status = BotStatus.STOPPED.value
+        assert status == "stopped"  # StrEnum value 소문자 sanity
+        exc = BotNotRunning("b1", status)
+        assert str(exc) == "Bot is not running: b1 (status: stopped)"
+        # 대문자 name 을 쓰면 lock 이 깨진다(회귀 가드).
+        assert BotStatus.STOPPED.name == "STOPPED"
+        assert "STOPPED" not in str(exc)
+
+    def test_is_bot_error(self) -> None:
+        assert isinstance(BotNotRunning("b1", "stopped"), BotError)
+
+
+class TestSignalKeyManagerNotConfigured:
+    def test_str_byte_lock(self) -> None:
+        """메시지에 관찰 가능한 ``signal_key_manager`` 토큰 포함, 키-free."""
+        exc = SignalKeyManagerNotConfigured()
+        assert str(exc) == "SignalKeyManager not configured: signal_key_manager"
+        assert "signal_key_manager" in str(exc)
+
+    def test_code_reuses_service_not_configured(self) -> None:
+        """전용 코드 발명 금지 — 공통 ``SERVICE_NOT_CONFIGURED`` 재사용."""
+        assert SignalKeyManagerNotConfigured.code == "SERVICE_NOT_CONFIGURED"
+        assert SignalKeyManagerNotConfigured().code == "SERVICE_NOT_CONFIGURED"
+
+    def test_redaction(self) -> None:
+        assert "sk_" not in str(SignalKeyManagerNotConfigured())
+
+    def test_is_bot_error(self) -> None:
+        assert isinstance(SignalKeyManagerNotConfigured(), BotError)
+
+
+def test_all_three_are_bot_error_subclasses_with_class_code() -> None:
+    """3 클래스 모두 ``BotError`` 서브클래스 + class-level ``.code`` 존재."""
+    for cls in (InvalidSignalKey, BotNotRunning, SignalKeyManagerNotConfigured):
+        assert issubclass(cls, BotError)
+        assert isinstance(cls.code, str) and cls.code

--- a/tests/unit/test_eventbus.py
+++ b/tests/unit/test_eventbus.py
@@ -223,3 +223,75 @@ async def test_event_immutability():
     event = OrderRequestEvent(symbol="005930", account_id="acc-test")
     with pytest.raises(AttributeError):
         event.symbol = "other"  # type: ignore[misc]
+
+
+# ── publish 핸들러 리스트 snapshot stale-ref 가드 (#2334 §6) ────────
+
+
+async def test_publish_handler_subscribe_during_publish_is_deterministic(bus):
+    """publish 중 한 핸들러가 같은 event_type 에 subscribe 해도 in-flight
+    순회가 결정적이다 (#2334 §6 stale-ref guard).
+
+    snapshot(``handlers = list(...)``) 없이 in-place append+sort 되는
+    리스트를 직접 순회하면 새로 추가된 핸들러가 같은 publish 안에서
+    double-fire 되거나 ``RuntimeError: list changed size during iteration``
+    위험이 있다. snapshot 이 in-flight 순회를 결정화한다.
+    """
+    fired: list[str] = []
+
+    async def late_handler(event):
+        fired.append("late")
+
+    async def subscriber(event):
+        fired.append("subscriber")
+        # publish 진행 중 같은 event_type 에 새 핸들러 등록(append+sort).
+        bus.subscribe(OrderRequestEvent, late_handler)
+
+    bus.subscribe(OrderRequestEvent, subscriber)
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
+
+    # 첫 publish 의 snapshot 에는 late_handler 가 없으므로 호출되지 않는다.
+    assert fired == ["subscriber"]
+
+    # 두 번째 publish 부터는 late_handler 가 정상 포함된다.
+    fired.clear()
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
+    assert fired.count("subscriber") == 1
+    assert fired.count("late") == 1
+
+
+async def test_publish_handler_unsubscribe_during_publish_no_skip(bus):
+    """publish 중 한 핸들러가 다른 핸들러를 unsubscribe(rebind) 해도 남은
+    핸들러가 skip 되지 않는다 (#2334 §6 stale-ref guard).
+
+    snapshot 이 없으면 ``unsubscribe`` 가 ``self._handlers[type]`` 를
+    새 리스트로 rebind 하면서 진행 중인 순회가 stale list 를 참조하거나
+    index drift 로 핸들러를 누락할 수 있다. snapshot 이 양쪽을 결정화한다.
+    """
+    fired: list[str] = []
+
+    async def victim(event):
+        fired.append("victim")
+
+    async def unsubscriber(event):
+        fired.append("unsubscriber")
+        # 진행 중 victim 을 등록 해제(같은 event_type list rebind).
+        bus.unsubscribe(OrderRequestEvent, victim)
+
+    async def tail(event):
+        fired.append("tail")
+
+    # priority 로 unsubscriber → victim → tail 순서 강제.
+    bus.subscribe(OrderRequestEvent, unsubscriber, priority=30)
+    bus.subscribe(OrderRequestEvent, victim, priority=20)
+    bus.subscribe(OrderRequestEvent, tail, priority=10)
+
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
+
+    # snapshot 덕분에 이번 publish 의 모든 핸들러(victim 포함)가 호출된다.
+    assert fired == ["unsubscriber", "victim", "tail"]
+
+    # 다음 publish 부터는 victim 이 제거되어 호출되지 않는다.
+    fired.clear()
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
+    assert fired == ["unsubscriber", "tail"]

--- a/tests/unit/test_ipc_bot_lifecycle.py
+++ b/tests/unit/test_ipc_bot_lifecycle.py
@@ -652,11 +652,12 @@ class TestRegistryRegistration:
         assert spec.is_mutating is False
         assert spec.handler is _handle_bot_status
 
-    def test_total_command_count_is_40(self) -> None:
+    def test_total_command_count_is_41(self) -> None:
         """#1712 이후 CLI/IPC parity mutation 5개 + #2111
         ``bot.signal_key.rotate`` + #2112 ``bot.list`` / ``bot.info`` /
         ``bot.positions`` / ``bot.signal_key`` (read-only) 4건 (28→32) +
-        #2113 member admin mutation 8건 (32→40)을 포함한다."""
+        #2113 member admin mutation 8건 (32→40) + #2334 (#2336 PR#1)
+        ``signal.connect`` (read-only) 1건 (40→41)을 포함한다."""
         registry = CommandRegistry()
         register_all_handlers(registry)
-        assert len(registry.commands) == 40
+        assert len(registry.commands) == 41

--- a/tests/unit/test_signal_key.py
+++ b/tests/unit/test_signal_key.py
@@ -320,3 +320,60 @@ class TestBotManagerSignalKey:
 
         key = await manager.get_signal_key("bot-005")
         assert key == "sk_test"
+
+    async def test_validate_signal_key_hit(self) -> None:
+        """manager 구성 + key hit → bot_id 반환 (#2334/#2336 게이트①)."""
+        from ante.bot.manager import BotManager
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.subscribe = MagicMock()
+
+        skm = MagicMock()
+        skm.validate_key = AsyncMock(return_value="bot-hit")
+
+        manager = BotManager(eventbus=eventbus, db=db, signal_key_manager=skm)
+
+        bot_id = await manager.validate_signal_key("sk_x")
+        assert bot_id == "bot-hit"
+        skm.validate_key.assert_awaited_once_with("sk_x")
+
+    async def test_validate_signal_key_miss_returns_none(self) -> None:
+        """manager 구성 + key miss → None (raise 하지 않음)."""
+        from ante.bot.manager import BotManager
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.subscribe = MagicMock()
+
+        skm = MagicMock()
+        skm.validate_key = AsyncMock(return_value=None)
+
+        manager = BotManager(eventbus=eventbus, db=db, signal_key_manager=skm)
+
+        assert await manager.validate_signal_key("sk_bad") is None
+
+    async def test_validate_signal_key_manager_none_raises_typed(self) -> None:
+        """signal_key_manager=None → SignalKeyManagerNotConfigured.
+
+        generic BotError(EXECUTION_ERROR fold) 가 아니라 typed exception 으로
+        SERVICE_NOT_CONFIGURED 코드를 가진다.
+        """
+        from ante.bot.exceptions import SignalKeyManagerNotConfigured
+        from ante.bot.manager import BotManager
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.subscribe = MagicMock()
+
+        manager = BotManager(eventbus=eventbus, db=db, signal_key_manager=None)
+
+        with pytest.raises(SignalKeyManagerNotConfigured) as ei:
+            await manager.validate_signal_key("sk_x")
+        assert ei.value.code == "SERVICE_NOT_CONFIGURED"


### PR DESCRIPTION
Closes #2336 (스펙 #2334 §15 구현 PR#1)

## Summary
daemon-위임 `signal.connect`의 **transport + ingress 골격**(PR#1). 머지된 스펙(#2334, docs/specs)의 connection-upgrade 계약을 구현한다.

- `ipc/server.py`: `_handle_connection`에 ① `isinstance(request,dict)` MALFORMED_REQUEST 가드 ② `_stream` 센티넬(중첩 `result._stream`) 감지→strip→ack→`_run_signal_stream`→return(lockstep 재진입 없음, finally가 teardown 단일 소유). `_run_signal_stream`은 PR#1 스켈레톤(per-read timeout 없는 read-until-EOF). **daemon-side 30s handshake timeout 미추가**(client/PR#3 관심사 — 전 lockstep 명령 회귀 차단).
- `ipc/registry.py`: `_handle_signal_connect` 4-게이트(validate_signal_key→get_bot→RUNNING→accepts; account_id=LIVE bot.config) + `signal.connect` CommandSpec(is_mutating=False/result_kind=stream/required_services={bot_manager}/account_id_policy=none, 비-audit). handler taxonomy 40→41, read-only 8→9.
- `bot/exceptions.py`: `InvalidSignalKey`/`BotNotRunning`/`SignalKeyManagerNotConfigured` typed exception(class .code, noqa N818, str(e) #1705 byte-lock — status는 소문자 BotStatus.value). `bot/manager.py`: `validate_signal_key` passthrough.
- `contracts/error_registry.py`: 신규 4 ErrorSpec(#2335 docs SSOT의 error_registry 등재 — contract-drift 해소) + EXCEPTION_TO_SPEC(category-correctness). `BOT_SIGNAL_CHANNEL_BUSY`는 const-only(raiser는 PR#2).
- `eventbus/bus.py`: `publish` 핸들러 리스트 snapshot(stale-ref 가드, 1줄).

## Scope / Non-Goals
- PR#2(#2337): SignalChannel/out_queue/registry/teardown/single-connect raise/manual-audit/DRAINING sweep — `_run_signal_stream`은 스켈레톤만.
- PR#3(#2338): CLI `signal.py` thin relay(미변경) → #2333 unblock.

## Test Plan
- 신규: `test_server_signal_connect.py`(T1 handshake+T3 framing), `test_bot_signal_connect_exceptions.py`(T6 byte-lock), `test_signal_connect_codes.py`(category lock)
- 수정(회귀 lock): `test_registry.py`(count 40→41·read-only 8→9·set), `test_ipc_bot_lifecycle.py`(40→41), `test_docs_taxonomy_drift.py`(signal. prefix), `test_eventbus.py`(snapshot), `test_signal_key.py`(validate_signal_key)
- `uv run ruff check`/`ruff format --check`/`mypy`(6 src) PASS
- `pytest` 타겟 145 passed, 광역 `-k 'ipc or registry or eventbus or signal or error'` 1376 passed

## Plan / Review
- plan-preflight:done, Codex Plan Review: approve-implement(1R revise 해소: manager.py import F401)
- Codex 브랜치 리뷰: PASS (head 29c1ae03)
- 15-에이전트 plan-preflight 워크플로가 발견한 4건(daemon timeout 오배치/count 하드코딩/drift prefix/exception category) 사전 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)