### PR TITLE
feat(ipc): #2337 signal.connect outbound+registry+lifecycle (daemon-위임 PR#2)

### DIFF
--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -36,6 +36,7 @@ class Bot:
         exchange: str = "",
         trading_mode: str = "",
         currency: str = "",
+        signal_lock: asyncio.Lock | None = None,
     ) -> None:
         self.config = config
         self.bot_id = config.bot_id
@@ -45,6 +46,13 @@ class Bot:
         self._strategy_cls = strategy_cls
         self._ctx = ctx
         self._eventbus = eventbus
+        # #2337 F3: on_step()+drain span 과 on_external_signal span 을 직렬화하는
+        # per-bot lock. ``BotManager.create_bot`` 이 stable bot_id 키로 주입하고,
+        # 직접 생성 테스트(~10곳)는 ``None`` → 자체 ``asyncio.Lock`` 으로 폴백한다
+        # (백워드 호환). non-reentrant 이므로 lock 보유 중 cross-publish 가 동일
+        # bot ``ExternalSignalEvent`` 를 재발행하면 deadlock — 아래 두 span 의
+        # 감사 주석으로 불변을 명시 lock 한다.
+        self._signal_lock = signal_lock or asyncio.Lock()
 
         self.status = BotStatus.CREATED
         self.strategy: Strategy | None = None
@@ -111,137 +119,165 @@ class Bot:
 
         # 이전 반복의 stale step_start 가 후속 error emit 에 새지 않도록
         # 매 while 반복 시작에서 None 으로 재설정한다.
+        #
+        # #2337 F3 직렬화: on_step 호출부터 drain/publish_actions/BotStepCompleted
+        # 까지 전 span 을 ``self._signal_lock`` 으로 감싼다. 같은 lock 이
+        # ``on_external_signal`` span 도 감싸 ``_ctx._pending_actions`` 인터리브를
+        # 차단한다. **interval sleep 은 lock 밖**(starvation 회피) — timeout/
+        # overflow 분기의 continue 도 ``should_sleep`` 플래그를 set 하고 ``async
+        # with`` 를 탈출한 뒤 sleep+continue 한다(lock 보유 중 sleep 금지).
+        #
+        # **non-reentrancy 감사(asyncio.Lock non-reentrant)**: lock 보유 중
+        # publish 되는 ``OrderRequestEvent``/``OrderCancelEvent``/
+        # ``OrderModifyEvent``/``BotStepCompletedEvent``/``BotErrorEvent`` 의
+        # 핸들러가 동일 bot ``ExternalSignalEvent`` 를 재발행하지 않는다(재발행
+        # 시 deadlock). ``ExternalSignalEvent`` 는 오직 IPC ``_handle_signal``
+        # 에서만 publish(grep invariant). ``_on_fill``/``_on_order_update`` 는
+        # ``_signal_lock`` 미취득(put_nowait 만).
         step_start: float | None = None
         try:
             while self.status == BotStatus.RUNNING:
                 step_start = None
+                # continue/return 제어를 lock 밖으로 hoist 하기 위한 플래그.
+                should_sleep = False
+                should_return = False
                 step_context = {
                     "timestamp": datetime.now(UTC),
                     "portfolio": self._ctx.get_positions(),
                     "balance": self._ctx.get_balance(),
                 }
 
-                # on_step 타임아웃 적용
-                try:
-                    step_start = monotonic()
-                    signals = await asyncio.wait_for(
-                        self.strategy.on_step(step_context),  # type: ignore[union-attr]
-                        timeout=self.config.step_timeout_seconds,
-                    )
-                    # wait_for 정상 반환 직후 1 회 계산 — 시그널/action 발행
-                    # 시간을 제외한 on_step 순수 실행 시간. success 와
-                    # signal_overflow 발행에 공통 사용한다.
-                    step_duration_ms = int((monotonic() - step_start) * 1000)
-                except TimeoutError:
-                    # step_start 는 wait_for 직전에 set 되므로 timeout 진입
-                    # 시점엔 항상 float (assert 로 narrow — mypy guard).
-                    assert step_start is not None
-                    timeout_duration_ms = int((monotonic() - step_start) * 1000)
-                    self._consecutive_failures += 1
-                    timeout_msg = (
-                        f"on_step timeout "
-                        f"({self._consecutive_failures}/{self._max_consecutive_failures})"
-                    )
-                    logger.warning(
-                        "on_step 타임아웃: %s (%d/%d)",
-                        self.bot_id,
-                        self._consecutive_failures,
-                        self._max_consecutive_failures,
-                    )
-                    await self._eventbus.publish(
-                        BotStepCompletedEvent(
-                            bot_id=self.bot_id,
-                            account_id=self.config.account_id,
-                            result="timeout",
-                            message=timeout_msg,
-                            signal_count=0,
-                            duration_ms=timeout_duration_ms,
+                async with self._signal_lock:
+                    # on_step 타임아웃 적용
+                    try:
+                        step_start = monotonic()
+                        signals = await asyncio.wait_for(
+                            self.strategy.on_step(step_context),  # type: ignore[union-attr]
+                            timeout=self.config.step_timeout_seconds,
                         )
-                    )
-                    if self._consecutive_failures >= self._max_consecutive_failures:
-                        msg = (
-                            f"연속 타임아웃 한도 초과 "
+                        # wait_for 정상 반환 직후 1 회 계산 — 시그널/action 발행
+                        # 시간을 제외한 on_step 순수 실행 시간. success 와
+                        # signal_overflow 발행에 공통 사용한다.
+                        step_duration_ms = int((monotonic() - step_start) * 1000)
+                    except TimeoutError:
+                        # step_start 는 wait_for 직전에 set 되므로 timeout 진입
+                        # 시점엔 항상 float (assert 로 narrow — mypy guard).
+                        assert step_start is not None
+                        timeout_duration_ms = int((monotonic() - step_start) * 1000)
+                        self._consecutive_failures += 1
+                        timeout_msg = (
+                            f"on_step timeout "
                             f"({self._consecutive_failures}/{self._max_consecutive_failures})"
                         )
-                        logger.error(
-                            "연속 타임아웃 한도 초과 — 봇 ERROR 전이: %s",
+                        logger.warning(
+                            "on_step 타임아웃: %s (%d/%d)",
                             self.bot_id,
+                            self._consecutive_failures,
+                            self._max_consecutive_failures,
                         )
-                        self.status = BotStatus.ERROR
-                        self.error_message = msg
                         await self._eventbus.publish(
-                            BotErrorEvent(
+                            BotStepCompletedEvent(
                                 bot_id=self.bot_id,
                                 account_id=self.config.account_id,
-                                error_message=msg,
+                                result="timeout",
+                                message=timeout_msg,
+                                signal_count=0,
+                                duration_ms=timeout_duration_ms,
                             )
                         )
-                        return
+                        if self._consecutive_failures >= self._max_consecutive_failures:
+                            msg = (
+                                f"연속 타임아웃 한도 초과 "
+                                f"({self._consecutive_failures}/{self._max_consecutive_failures})"
+                            )
+                            logger.error(
+                                "연속 타임아웃 한도 초과 — 봇 ERROR 전이: %s",
+                                self.bot_id,
+                            )
+                            self.status = BotStatus.ERROR
+                            self.error_message = msg
+                            await self._eventbus.publish(
+                                BotErrorEvent(
+                                    bot_id=self.bot_id,
+                                    account_id=self.config.account_id,
+                                    error_message=msg,
+                                )
+                            )
+                            should_return = True
+                        else:
+                            should_sleep = True
+                    else:
+                        # Signal 수 상한 검증
+                        max_signals = self.config.max_signals_per_step
+                        if len(signals) > max_signals:
+                            self._consecutive_failures += 1
+                            overflow_msg = (
+                                f"Signal count exceeded: {len(signals)} > {max_signals}"
+                            )
+                            logger.warning(
+                                "Signal 수 초과: %s (%d > %d, 연속 %d/%d)",
+                                self.bot_id,
+                                len(signals),
+                                max_signals,
+                                self._consecutive_failures,
+                                self._max_consecutive_failures,
+                            )
+                            await self._eventbus.publish(
+                                BotStepCompletedEvent(
+                                    bot_id=self.bot_id,
+                                    account_id=self.config.account_id,
+                                    result="signal_overflow",
+                                    message=overflow_msg,
+                                    signal_count=len(signals),
+                                    duration_ms=step_duration_ms,
+                                )
+                            )
+                            await self._eventbus.publish(
+                                BotErrorEvent(
+                                    bot_id=self.bot_id,
+                                    account_id=self.config.account_id,
+                                    error_message=overflow_msg,
+                                )
+                            )
+                            if (
+                                self._consecutive_failures
+                                >= self._max_consecutive_failures
+                            ):
+                                logger.error(
+                                    "연속 Signal 초과 한도 — 봇 중지: %s",
+                                    self.bot_id,
+                                )
+                                await self.stop()
+                                should_return = True
+                            else:
+                                should_sleep = True
+                        else:
+                            # 정상 실행 — 카운터 리셋
+                            self._consecutive_failures = 0
+
+                            await self._publish_signals(signals)
+
+                            actions = self._ctx._drain_actions()
+                            await self._publish_actions(actions)
+
+                            await self._eventbus.publish(
+                                BotStepCompletedEvent(
+                                    bot_id=self.bot_id,
+                                    account_id=self.config.account_id,
+                                    result="success",
+                                    message=f"signals={len(signals)}",
+                                    signal_count=len(signals),
+                                    duration_ms=step_duration_ms,
+                                )
+                            )
+                            should_sleep = True
+
+                # lock 밖 — interval sleep(starvation 회피) + 제어 흐름.
+                if should_return:
+                    return
+                if should_sleep:
                     await asyncio.sleep(self.config.interval_seconds)
                     continue
-
-                # Signal 수 상한 검증
-                max_signals = self.config.max_signals_per_step
-                if len(signals) > max_signals:
-                    self._consecutive_failures += 1
-                    overflow_msg = (
-                        f"Signal count exceeded: {len(signals)} > {max_signals}"
-                    )
-                    logger.warning(
-                        "Signal 수 초과: %s (%d > %d, 연속 %d/%d)",
-                        self.bot_id,
-                        len(signals),
-                        max_signals,
-                        self._consecutive_failures,
-                        self._max_consecutive_failures,
-                    )
-                    await self._eventbus.publish(
-                        BotStepCompletedEvent(
-                            bot_id=self.bot_id,
-                            account_id=self.config.account_id,
-                            result="signal_overflow",
-                            message=overflow_msg,
-                            signal_count=len(signals),
-                            duration_ms=step_duration_ms,
-                        )
-                    )
-                    await self._eventbus.publish(
-                        BotErrorEvent(
-                            bot_id=self.bot_id,
-                            account_id=self.config.account_id,
-                            error_message=overflow_msg,
-                        )
-                    )
-                    if self._consecutive_failures >= self._max_consecutive_failures:
-                        logger.error(
-                            "연속 Signal 초과 한도 — 봇 중지: %s",
-                            self.bot_id,
-                        )
-                        await self.stop()
-                        return
-                    await asyncio.sleep(self.config.interval_seconds)
-                    continue
-
-                # 정상 실행 — 카운터 리셋
-                self._consecutive_failures = 0
-
-                await self._publish_signals(signals)
-
-                actions = self._ctx._drain_actions()
-                await self._publish_actions(actions)
-
-                await self._eventbus.publish(
-                    BotStepCompletedEvent(
-                        bot_id=self.bot_id,
-                        account_id=self.config.account_id,
-                        result="success",
-                        message=f"signals={len(signals)}",
-                        signal_count=len(signals),
-                        duration_ms=step_duration_ms,
-                    )
-                )
-
-                await asyncio.sleep(self.config.interval_seconds)
 
         except asyncio.CancelledError:
             raise
@@ -426,6 +462,19 @@ class Bot:
         """외부 시그널 수신 → 전략의 on_data()로 전달.
 
         accepts_external_signals=False인 전략은 시그널을 무시한다.
+
+        #2337 F3 직렬화: ``on_data`` + ``_publish_signals(follow_up)`` span 을
+        ``self._signal_lock`` 으로 감싼다. 같은 lock 이 ``_run_loop`` 의 on_step
+        drain span 도 감싸므로, on_step() 과 external on_data() 가 동시에
+        ``_ctx._pending_actions`` 를 만지는(append↔copy+clear) 인터리브가
+        차단된다. ``_drain_actions`` 는 **추가 호출하지 않는다** — 다음 on_step
+        drain 이 처리한다.
+
+        **non-reentrancy 감사(asyncio.Lock 은 non-reentrant)**: lock 보유 중
+        ``_publish_signals`` 가 publish 하는 ``OrderRequestEvent`` 의 핸들러가
+        동일 bot ``ExternalSignalEvent`` 를 재발행하지 않는다(재발행하면
+        deadlock). ``ExternalSignalEvent`` 는 오직 IPC ``_handle_signal`` 에서만
+        publish 된다(grep invariant).
         """
         from ante.eventbus.events import ExternalSignalEvent
 
@@ -442,18 +491,30 @@ class Bot:
             )
             return
 
-        follow_up = await self.strategy.on_data(
-            {
-                "signal_id": event.signal_id,
-                "symbol": event.symbol,
-                "action": event.action,
-                "reason": event.reason,
-                "confidence": event.confidence,
-                "metadata": event.metadata,
-                "timestamp": event.timestamp,
-            }
-        )
-        await self._publish_signals(follow_up or [])
+        # 상태 재검증(#2333/#2337): 핸드셰이크와 시그널 도착 사이에 봇이
+        # RUNNING 을 벗어났으면(STOPPING/STOPPED/ERROR) on_data 를 발화하지
+        # 않는다 — 종료 중 전략에 시그널이 새는 경로 차단.
+        if self.status != BotStatus.RUNNING:
+            logger.warning(
+                "외부 시그널 거부: 봇 %s 상태 %s (RUNNING 아님)",
+                self.bot_id,
+                self.status.value,
+            )
+            return
+
+        async with self._signal_lock:
+            follow_up = await self.strategy.on_data(
+                {
+                    "signal_id": event.signal_id,
+                    "symbol": event.symbol,
+                    "action": event.action,
+                    "reason": event.reason,
+                    "confidence": event.confidence,
+                    "metadata": event.metadata,
+                    "timestamp": event.timestamp,
+                }
+            )
+            await self._publish_signals(follow_up or [])
 
     async def _publish_signals(self, signals: list[Signal]) -> None:
         """Signal → OrderRequestEvent 변환 + EventBus 발행."""

--- a/src/ante/bot/exceptions.py
+++ b/src/ante/bot/exceptions.py
@@ -20,6 +20,11 @@ BOT_IMMUTABLE_FIELD_CODE = "BOT_IMMUTABLE_FIELD"
 # SSOT(error-taxonomy.md) 의 공통 ``SERVICE_NOT_CONFIGURED`` 를 재사용한다.
 INVALID_SIGNAL_KEY_CODE = "INVALID_SIGNAL_KEY"
 BOT_NOT_RUNNING_CODE = "BOT_NOT_RUNNING"
+# Refs #2334 / #2337 (PR#2): bot_id 당 단일 connect 정책. 같은 봇에 이미 active
+# session 이 있을 때 두 번째 핸드셰이크를 거부하는 stable code. PR#1 은 상수-only
+# 로 ErrorSpec 만 등록했고, raiser(``SignalChannelRegistry.register``)와
+# ``EXCEPTION_TO_SPEC`` typed entry 는 본 PR 에서 추가한다.
+BOT_SIGNAL_CHANNEL_BUSY_CODE = "BOT_SIGNAL_CHANNEL_BUSY"
 
 
 class BotError(Exception):
@@ -170,3 +175,39 @@ class SignalKeyManagerNotConfigured(BotError):  # noqa: N818
 
     def __init__(self) -> None:
         super().__init__("SignalKeyManager not configured: signal_key_manager")
+
+
+class BotSignalChannelBusy(BotError):  # noqa: N818
+    """``signal.connect`` 단일-connect 정책 — active session 존재 (#2334/#2337).
+
+    ``SignalChannelRegistry.register`` 가 같은 ``bot_id`` 에 대해 두 번째
+    핸드셰이크를 atomic check-and-insert 로 거부할 때 raise 한다. ack write
+    **전** 핸드셰이크 핸들러에서 raise 되어 IPC ``server.py`` 의
+    ``getattr(e, "code", ...)`` 가 안정 코드 ``BOT_SIGNAL_CHANNEL_BUSY`` 로
+    변환한 Phase-B error envelope 으로 거부된다(stream 미진입).
+
+    **redaction 불변**: 메시지에 ``bot_id``/``session_id``/키를 절대
+    interpolate 하지 않는다. ``__init__`` 인자를 0개로 강제해 식별자가 새는
+    경로를 차단한다(``InvalidSignalKey`` 선례 미러, error-taxonomy.md
+    ``state_conflict`` 카테고리).
+    """
+
+    code: str = BOT_SIGNAL_CHANNEL_BUSY_CODE
+
+    def __init__(self) -> None:
+        super().__init__("Bot already has an active signal channel session")
+
+
+class SignalChannelRegistryFrozen(BotError):  # noqa: N818
+    """``SignalChannelRegistry`` 가 freeze 된 후 register 시도 (#2334/#2337).
+
+    shutdown sweep(``freeze()`` → ``close_all('draining')``) 진입 후 들어온
+    핸드셰이크가 새 session 을 등록하려 할 때 ``register`` 가 raise 한다.
+    re-register leak(sweep 이후 채널 누적)을 차단하는 내부 가드다.
+
+    **EXCEPTION_TO_SPEC 미등록(코드 없음)**: 정상 운영에서는 발생하지 않는
+    shutdown-only 경로이고, raise 시점은 핸드셰이크 핸들러 내부라 IPC
+    ``_dispatch`` 의 generic ``EXECUTION_ERROR`` fallback 으로 충분하다(전용
+    안정 코드를 발명하지 않는다). adopt-time generation re-check 의 즉시
+    self-close 분기와 동형 — 외부 표면에 stable code 를 노출할 계약이 없다.
+    """

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -31,6 +31,7 @@ from ante.bot.exceptions import (
 if TYPE_CHECKING:
     from ante.account.service import AccountService
     from ante.bot.context_factory import StrategyContextFactory
+    from ante.bot.signal_channel_registry import SignalChannelRegistry
     from ante.bot.signal_key import SignalKeyManager  # noqa: F811
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
@@ -140,6 +141,7 @@ class BotManager:
         account_service: AccountService | None = None,
         treasury_manager: TreasuryManager | None = None,
         trade_service: TradeService | None = None,
+        signal_channel_registry: SignalChannelRegistry | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._db = db
@@ -151,6 +153,11 @@ class BotManager:
         self._account_service = account_service
         self._treasury_manager = treasury_manager
         self._trade_service = trade_service
+        # #2337: signal.connect lifecycle 권위 레지스트리(rotate/delete/bot-stopped
+        # teardown 의 close_bot 대상). main.py 가 ServiceRegistry·IPCServer 와
+        # 동일 인스턴스를 주입한다. 테스트/headless 는 ``None`` 이며 teardown
+        # hook 은 None-guard no-op.
+        self._signal_channel_registry = signal_channel_registry
         self._bots: dict[str, Bot] = {}
         self._suppress_notification_bot_ids: set[str] = set()
         self._restart_counts: dict[str, int] = {}
@@ -161,6 +168,20 @@ class BotManager:
         # ``_get_update_lock`` 으로만 노출하여 외부에서 직접 dict 를 만지지
         # 않도록 한다.
         self._bot_update_locks: dict[str, asyncio.Lock] = {}
+        # #2337 F3: per-bot 직렬화 lock 저장소. on_step()+drain span(``_run_loop``)
+        # 과 on_external_signal span(on_data+_publish_signals)을 같은 lock 으로
+        # 직렬화해 ``_ctx._pending_actions`` 인터리브를 차단한다. stable bot_id
+        # 키라 restart 를 생존하며 ``create_bot`` 이 Bot 에 주입한다.
+        self._bot_signal_locks: dict[str, asyncio.Lock] = {}
+
+    def _get_signal_lock(self, bot_id: str) -> asyncio.Lock:
+        """``on_step`` ↔ ``on_external_signal`` 직렬화용 per-bot lock(lazy, #2337).
+
+        stable ``bot_id`` 키로 lazy setdefault 한다 — restart 후에도 같은 lock
+        인스턴스를 재사용해 직렬화 불변을 유지한다(F3). ``create_bot`` 이 Bot
+        생성 시 주입하고, 봇 자신이 두 span 을 이 lock 으로 감싼다.
+        """
+        return self._bot_signal_locks.setdefault(bot_id, asyncio.Lock())
 
     def _get_update_lock(self, bot_id: str) -> asyncio.Lock:
         """``update_bot`` 직렬화용 per-bot lock 을 lazy 로 발급한다.
@@ -429,6 +450,8 @@ class BotManager:
             exchange=account.exchange if account else "",
             trading_mode=account.trading_mode.value if account else "",
             currency=account.currency if account else "",
+            # #2337 F3: on_step ↔ on_external_signal 직렬화 lock 주입(stable key).
+            signal_lock=self._get_signal_lock(config.bot_id),
         )
 
         self._register_bot_events(bot)
@@ -859,6 +882,13 @@ class BotManager:
             )
 
         bot = self._get_bot(bot_id)
+        # #2337: signal 채널 teardown 을 **bot.stop() 앞** 에 둔다(순서 BUG 수정,
+        # first-close-wins). delete 가 stop 보다 먼저 'deleted' 로 닫아야 후속
+        # BotStoppedEvent 의 'bot_stopped' close_bot 이 멱등 no-op(이미 closed)
+        # 가 되어 closed.reason='deleted' 가 보존된다. 동기·비-raise.
+        reg = self._signal_channel_registry
+        if reg is not None:
+            reg.close_bot(bot_id, "deleted")
         if bot.status == BotStatus.RUNNING:
             await bot.stop()
 
@@ -1176,6 +1206,13 @@ class BotManager:
 
         if not isinstance(event, BotStoppedEvent):
             return
+        # #2337 teardown 커버리지(lifecycle BLOCKER): 봇 중지 시 signal 채널을
+        # close_bot 한다. **suppress early-return 앞** 에 둬야 흔한 managed-stop
+        # 봇도 silent leak 하지 않는다. close_bot 은 동기·비-raise 라 bus swallow
+        # 로 notify 가 미실행되지 않는다.
+        reg = self._signal_channel_registry
+        if reg is not None:
+            reg.close_bot(event.bot_id, "bot_stopped")
         if event.bot_id in self._suppress_notification_bot_ids:
             self._suppress_notification_bot_ids.discard(event.bot_id)
             return
@@ -1194,6 +1231,16 @@ class BotManager:
 
         if not isinstance(event, BotErrorEvent):
             return
+
+        # #2337 teardown 커버리지(lifecycle BLOCKER): 자율 ERROR 전이는
+        # BotStoppedEvent 를 발화하지 않으므로 ``_on_bot_stopped`` 가 커버하지
+        # 못한다. **NotificationEvent publish·auto_restart early-return 앞** 에
+        # close_bot 을 둬 non-restart-error 봇의 channel leak 을 차단한다.
+        # reason 은 ``bot_stopped`` (closed.reason vocab; ERROR 도 동일 종료
+        # 시맨틱). 동기·비-raise.
+        reg = self._signal_channel_registry
+        if reg is not None:
+            reg.close_bot(event.bot_id, "bot_stopped")
 
         await self._eventbus.publish(
             NotificationEvent(
@@ -1387,7 +1434,17 @@ class BotManager:
                 f"bot_id={bot_id}, strategy_id={bot.config.strategy_id}"
             )
 
-        return await self._signal_key_manager.rotate(bot_id)
+        # #2337: rotate 성공 **후** signal 채널 teardown. ROLLBACK(rotate raise)
+        # 경로는 여기 도달 전 예외라 bump/close_bot 안 함(옛 키 채널 유지).
+        # ``bump_generation`` 으로 rotate-in-window 핸드셰이크를 adopt-time
+        # re-check self-close 시키고, ``close_bot('rotated')`` 로 활성 세션을
+        # 닫는다. teardown 은 SignalKeyManager.rotate 가 아니라 여기서만 한다.
+        new_key = await self._signal_key_manager.rotate(bot_id)
+        reg = self._signal_channel_registry
+        if reg is not None:
+            reg.bump_generation(bot_id)
+            reg.close_bot(bot_id, "rotated")
+        return new_key
 
     def get_restart_count(self, bot_id: str) -> int:
         """봇의 현재 재시작 시도 횟수."""

--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -16,11 +16,20 @@ from uuid import uuid4
 from ante.eventbus.fill_dedup_guard import FillDedupGuard
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ante.bot.bot import Bot
     from ante.eventbus.bus import EventBus
     from ante.strategy.context import StrategyContext
 
 logger = logging.getLogger(__name__)
+
+# Refs #2334 §14 (#2337): ExternalSignal metadata bound (비치명 drop). 외부
+# 에이전트가 거대 metadata 를 실어 publish 파이프라인을 부풀리는 경로를 막는다.
+# key-count/size 둘 중 하나라도 초과하면 ``{type:error}`` 후 publish 하지 않고
+# drop 한다(known-limitation — 정밀 byte 산정이 아닌 보수적 상한).
+SIGNAL_METADATA_MAX_KEYS = 64
+SIGNAL_METADATA_MAX_BYTES = 16_384
 
 
 class SignalChannel:
@@ -38,7 +47,14 @@ class SignalChannel:
         ctx: StrategyContext,
         input_stream: TextIO | None = None,
         output_stream: TextIO | None = None,
+        *,
+        sink: Callable[[dict[str, Any]], None] | None = None,
+        is_full: Callable[[], bool] | None = None,
+        on_lagged: Callable[[], None] | None = None,
     ) -> None:
+        # 기존 위치/이름 인자(bot/eventbus/ctx/input_stream/output_stream)는
+        # 불변이다(4 테스트 + cli/commands/signal.py 의존). 신규 데몬 데이터플레인
+        # seam 은 keyword-only-with-default 로만 추가한다(#2337 백워드 호환).
         self._bot = bot
         self._eventbus = eventbus
         self._ctx = ctx
@@ -51,13 +67,67 @@ class SignalChannel:
         # 자체 dedup 도 가능하다.
         self._fill_dedup_guard = FillDedupGuard()
 
+        # #2337 데몬 데이터플레인 seam:
+        # - ``_sink``: newline 없는 dict enqueue 콜백(데몬 writer_task 가 framing).
+        #   ``None`` 이면 legacy ``_write``(stdin/stdout, ``+'\n'``) 로 폴백한다.
+        # - ``_is_full``: out_queue full 여부(disconnect-laggard 게이트).
+        # - ``_on_lagged``: laggard 감지 시 teardown 트리거(call_soon 위임).
+        self._sink = sink
+        self._is_full = is_full
+        self._on_lagged = on_lagged
+        # 데몬-위임 종료/회전 가드. ``_closed`` 는 stale-publish layer2(첫 줄
+        # no-op), ``_accepting`` 은 rotate admit-gate(``_handle_message``).
+        self._closed = False
+        self._accepting = True
+        # F2: read_task 가 실행 중인 in-flight publish task. close 오케스트레이터가
+        # grace 동안 await 후 read_task 만 cancel 하기 위해 추적한다.
+        self._inflight: asyncio.Task[Any] | None = None
+
     def _write(self, data: dict[str, Any]) -> None:
-        """JSON Line 출력."""
+        """JSON Line 출력 (legacy stdin/stdout 경로 — ``sink=None`` 일 때만)."""
         try:
             self._output.write(json.dumps(data, default=str) + "\n")
             self._output.flush()
         except (BrokenPipeError, OSError):
             self._running = False
+
+    def _emit(self, data: dict[str, Any]) -> None:
+        """출력 seam — sink 주입 시 newline-free dict enqueue, 아니면 legacy write.
+
+        데몬 경로(``sink`` 주입)는 framing 을 writer_task 가 단독 소유하므로
+        newline 을 붙이지 않는다(INV-OUT-1 1:1 framing). legacy 경로(``sink=None``)
+        는 기존 ``_write``(``+'\n'``+flush)로 byte-identical 폴백한다.
+        """
+        if self._sink is not None:
+            self._sink(data)
+        else:
+            self._write(data)
+
+    def mark_closed(self) -> None:
+        """채널을 닫힘으로 표시 (동기·idempotent). ``_unsubscribe_events`` 전 호출.
+
+        ``_closed`` (stale-publish layer2) 와 ``_accepting`` (rotate admit-gate)
+        를 set 한다. ``ChannelHandle.on_closed`` 로 바인딩되어 daemon-initiated
+        close 가 await 없이 호출한다.
+        """
+        self._closed = True
+        self._accepting = False
+
+    def _schedule_lagged(self) -> None:
+        """laggard 감지 → teardown 트리거 (idempotent, await 없음).
+
+        out_queue full 로 프레임을 drop 해야 할 때 1회 호출한다. ``_closed`` 를
+        flip 해 이후 ``_on_fill``/``_on_order_update`` 가 첫 줄 no-op 하게 하고,
+        ``_on_lagged`` 콜백으로 데몬 supervisor 의 disconnect-laggard 를 깨운다.
+        bus 핸들러 inline 에서 호출되므로 socket I/O await 은 하지 않는다
+        (INV-OUT-2/6 — teardown 은 daemon ``call_soon`` 위임).
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._accepting = False
+        if self._on_lagged is not None:
+            self._on_lagged()
 
     async def run(self) -> None:
         """채널 실행 루프. stdin에서 읽고 처리."""
@@ -84,31 +154,89 @@ class SignalChannel:
         self._unsubscribe_events()
 
     async def _handle_line(self, line: str) -> None:
-        """수신 메시지 파싱 및 라우팅."""
+        """legacy stdin 라인 파싱 → ``_handle_message`` 위임.
+
+        ``json.loads`` 만 담당하고(empty-guard·``JSONDecodeError``) routing 은
+        ``_handle_message(dict)`` 가 한다. ``run()``(legacy connect_read_pipe)
+        은 본 메서드 경유라 투명하다. 데몬 경로(``_run_signal_stream``)는
+        protocol.decode 로 이미 dict 를 얻으므로 ``_handle_message`` 를 직접
+        호출한다(json.loads 중복 회피).
+        """
         if not line:
             return
 
         try:
             msg = json.loads(line)
         except json.JSONDecodeError:
-            self._write({"type": "error", "message": "Invalid JSON"})
+            self._emit({"type": "error", "message": "Invalid JSON"})
             return
 
-        msg_type = msg.get("type", "")
-        if msg_type == "signal":
-            await self._handle_signal(msg)
-        elif msg_type == "query":
-            await self._handle_query(msg)
-        elif msg_type == "ping":
-            self._write({"type": "pong"})
-        else:
-            self._write({"type": "error", "message": f"Unknown type: {msg_type}"})
+        await self._handle_message(msg)
+
+    async def _handle_message(self, msg: Any) -> None:
+        """디코드된 프레임 라우팅 (#2337 데몬/legacy 공통 진입점).
+
+        (1) 비-dict 프레임은 비치명 격리: ``{type:error,'Invalid JSON'}`` 후
+        return(daemon read loop 비전파).
+        (2) rotate admit-gate — ``_accepting=False`` 면 ``{type:error,
+        'channel closing'}`` 후 return(at-most-one trailing). close 가
+        ``_accepting`` 만 끄고 in-flight 는 shield 로 보호한다(F2).
+        (3) per-frame ``try`` 래핑 routing(signal/query/ping/unknown). 핸들러
+        예외는 ``{type:error,str(e)}`` 로 격리해 daemon read 루프로 전파하지
+        않는다.
+        """
+        if not isinstance(msg, dict):
+            self._emit({"type": "error", "message": "Invalid JSON"})
+            return
+
+        if not self._accepting:
+            self._emit({"type": "error", "message": "channel closing"})
+            return
+
+        try:
+            msg_type = msg.get("type", "")
+            if msg_type == "signal":
+                await self._handle_signal(msg)
+            elif msg_type == "query":
+                await self._handle_query(msg)
+            elif msg_type == "ping":
+                self._emit({"type": "pong"})
+            else:
+                self._emit({"type": "error", "message": f"Unknown type: {msg_type}"})
+        except Exception as e:  # noqa: BLE001 — daemon read loop 비전파 격리.
+            self._emit({"type": "error", "message": str(e)})
 
     async def _handle_signal(self, msg: dict[str, Any]) -> None:
-        """외부 시그널 → ExternalSignalEvent 발행."""
+        """외부 시그널 → ExternalSignalEvent 발행.
+
+        F2(rotate shield, #2337): publish 를 ``_inflight`` task 로 분리하고
+        read_task 는 ``asyncio.shield`` 로 await 한다. read_task 가 close
+        오케스트레이터에 의해 cancel 돼도 in-flight publish(별도 task)는 shield
+        로 보호되어 백그라운드 완료한다 — ``strategy.on_data`` 체인에 cancellation
+        주입으로 인한 상태 손상을 막는다. metadata 는 publish 전 key-count/size
+        로 bound 한다(§14 비치명 drop).
+        """
         from ante.eventbus.events import ExternalSignalEvent
 
         signal_id = f"sig-{uuid4().hex[:12]}"
+
+        metadata = {
+            k: v
+            for k, v in msg.items()
+            if k not in ("type", "symbol", "side", "action", "reason", "confidence")
+        }
+        # metadata bound(§14): key-count/size 초과 시 비치명 drop(publish 안 함).
+        if len(metadata) > SIGNAL_METADATA_MAX_KEYS or (
+            len(json.dumps(metadata, default=str).encode("utf-8"))
+            > SIGNAL_METADATA_MAX_BYTES
+        ):
+            self._emit(
+                {
+                    "type": "error",
+                    "message": "signal metadata too large",
+                }
+            )
+            return
 
         event = ExternalSignalEvent(
             account_id=self._bot.config.account_id,
@@ -118,15 +246,20 @@ class SignalChannel:
             action=msg.get("side", msg.get("action", "")),
             reason=msg.get("reason", "external_signal"),
             confidence=float(msg.get("confidence", 0.0)),
-            metadata={
-                k: v
-                for k, v in msg.items()
-                if k not in ("type", "symbol", "side", "action", "reason", "confidence")
-            },
+            metadata=metadata,
         )
 
-        await self._eventbus.publish(event)
-        self._write({"type": "ack", "signal_id": signal_id})
+        self._inflight = asyncio.ensure_future(self._eventbus.publish(event))
+        try:
+            # shield: read_task 가 cancel 돼도 inflight publish 는 계속 진행한다.
+            await asyncio.shield(self._inflight)
+        except asyncio.CancelledError:
+            # read_task cancel 이 여기로 전파돼도 inflight(별도 task)는 shield 로
+            # 보호되어 백그라운드 완료한다 — at-most-one trailing 보장.
+            raise
+        finally:
+            self._inflight = None
+        self._emit({"type": "ack", "signal_id": signal_id})
 
     async def _handle_query(self, msg: dict[str, Any]) -> None:
         """데이터 조회 요청 처리."""
@@ -152,12 +285,12 @@ class SignalChannel:
                 )
                 data = df.to_dicts()
             else:
-                self._write({"type": "error", "message": f"Unknown method: {method}"})
+                self._emit({"type": "error", "message": f"Unknown method: {method}"})
                 return
 
-            self._write({"type": "result", "method": method, "data": data})
+            self._emit({"type": "result", "method": method, "data": data})
         except Exception as e:
-            self._write({"type": "error", "message": str(e)})
+            self._emit({"type": "error", "message": str(e)})
 
     # ── EventBus 구독 (Ante → 외부 이벤트 전달) ──────
 
@@ -238,36 +371,54 @@ class SignalChannel:
         """
         from ante.eventbus.events import OrderFilledEvent
 
+        # #2337 단일 await-free 임계구역. dedup-mark-after-enqueue(INV-OUT-4):
+        # read-only ``__contains__`` 게이트 → ``_emit`` → ``seen_or_add`` 커밋.
+        # full-drop 시 미마킹(재전달 보존). bus 핸들러 inline 이라 socket await
+        # 0(INV-OUT-2).
+        # ① stale-publish layer2 — close 가 await 전 ``_closed`` set(첫 줄 no-op).
+        if self._closed:
+            return
+        # ② isinstance + bot_id 필터.
         if not isinstance(event, OrderFilledEvent):
             return
         if event.bot_id != self._bot.bot_id:
             return
 
-        # 비빈키만 dedup. seen_or_add 는 await 없는 동기 원자 구간(#1957).
-        if event.fill_dedup_key and self._fill_dedup_guard.seen_or_add(
-            event.fill_dedup_key
-        ):
+        # ③ payload 구성(byte-identical).
+        key = event.fill_dedup_key
+        payload = {
+            "type": "fill",
+            "order_id": event.order_id,
+            "symbol": event.symbol,
+            "side": event.side,
+            "quantity": event.quantity,
+            "price": event.price,
+            "commission": event.commission,
+            "timestamp": event.timestamp,
+            "fill_dedup_key": key,
+        }
+        # ④ 비빈키 read-only dedup 게이트(non-committing). 이미 처리된 키면 skip.
+        if key and key in self._fill_dedup_guard:
             return
-
-        self._write(
-            {
-                "type": "fill",
-                "order_id": event.order_id,
-                "symbol": event.symbol,
-                "side": event.side,
-                "quantity": event.quantity,
-                "price": event.price,
-                "commission": event.commission,
-                "timestamp": event.timestamp,
-                "fill_dedup_key": event.fill_dedup_key,
-            }
-        )
+        # ⑤ disconnect-laggard — full 이면 schedule_lagged + return(seen 미마킹,
+        #    재전달 보존). legacy(sink=None, is_full=None)는 skip → 항상 성공.
+        if self._is_full is not None and self._is_full():
+            self._schedule_lagged()
+            return
+        # ⑥ enqueue.
+        self._emit(payload)
+        # ⑦ enqueue 성공 **후** dedup 커밋(full-drop 시 미마킹).
+        if key:
+            self._fill_dedup_guard.seen_or_add(key)
 
     async def _on_order_update(self, event: object) -> None:
         """주문 상태 변경 → 외부 전달.
 
         Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
         """
+        # #2337 ① stale-publish layer2(첫 줄 no-op) → ② bot_id 필터.
+        if self._closed:
+            return
         bot_id = getattr(event, "bot_id", None)
         if bot_id != self._bot.bot_id:
             return
@@ -329,7 +480,12 @@ class SignalChannel:
             reason = event.reason
 
         if status:
-            self._write(
+            # disconnect-laggard — full 이면 schedule_lagged + return(dedup 없음).
+            # legacy(is_full=None)는 skip → 항상 _emit.
+            if self._is_full is not None and self._is_full():
+                self._schedule_lagged()
+                return
+            self._emit(
                 {
                     "type": "order_update",
                     "order_id": order_id,

--- a/src/ante/bot/signal_channel_registry.py
+++ b/src/ante/bot/signal_channel_registry.py
@@ -1,0 +1,277 @@
+"""SignalChannelRegistry — signal.connect 채널 생명주기 권위 레지스트리 (#2334/#2337).
+
+bot_id 당 단일 connect 정책과 daemon-위임 teardown 을 강제하는 동기 코어다.
+
+설계 불변 (F1+F4 상태 전이표, 이슈 #2337):
+
+- **동기 메서드는 내부에서 ``await`` 하지 않는다.** ``register``/``unregister``/
+  ``close_bot``/``freeze``/``get``/``current_generation``/``bump_generation`` 는
+  단일-스레드 이벤트 루프 한 틱 안에서 끊김 없이 실행된다. check↔insert 사이에
+  ``await`` 가 없어야 단일-connect TOCTOU 가 닫힌다. ``close_all`` 만 async 다 —
+  각 채널의 정리 task 를 await-to-completion 해야 하기 때문이며, register/
+  unregister/close_bot/freeze 의 동기 계약과 분리된다(스펙 §7 reconciliation).
+
+- **ChannelHandle 2단계 생명주기(placeholder → adopted).** ``register`` 는
+  핸드셰이크 핸들러에서 ack write **전** 호출되므로, 그 시점에는 데이터플레인
+  (out_queue/read_task/writer_task/on_closed/closing_event)이 아직 없다 — stream
+  코루틴 진입 후 ``adopt`` 한다. placeholder 단계의 ``close(reason)`` 은 reason 만
+  ``_pending_close_reason`` 으로 래치하고, adopt 가 이를 감지해 즉시 self-close
+  한다. 이로써 register-and-ack-fail 또는 rotate-in-window 누수를 차단한다.
+
+- **generation counter.** key re-validation(DB await)이 아니라 동기 카운터로
+  rotate-in-window 를 결정적으로 감지한다. ``register`` 가 현재 generation 을
+  스냅샷하고, adopt 시점에 ``current_generation`` 과 비교해 불일치면 self-close.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from ante.bot.exceptions import BotSignalChannelBusy, SignalChannelRegistryFrozen
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChannelHandle:
+    """단일 signal.connect 세션의 레지스트리 핸들 (#2337 F1+F4).
+
+    register 시점(placeholder)에는 데이터플레인 4필드(``out_queue``/``read_task``/
+    ``writer_task``/``on_closed``)와 ``closing_event`` 가 모두 ``None`` 이며,
+    ``_run_signal_stream`` 진입 후 adopt 가 채운다.
+
+    ``close(reason)`` 는 **동기·idempotent·non-raising** 이다. 어떤 컨텍스트
+    (close_bot/rotate/delete/BotStopped/close_all/adopt self-close)에서 호출돼도
+    안전하도록 ``await`` 가 없다:
+
+    - first-wins: 이미 ``closed`` 면 ``False`` 반환(no-op).
+    - ``on_closed(reason)`` 으로 channel 의 ``_closed``/``_accepting`` 을 set.
+    - 데이터플레인이 있으면(adopted) ``{type:closed,reason}`` 을 out_queue 에
+      force-slot 으로 enqueue(QueueFull → 1개 drop 후 재시도) + ``closing_event``
+      set 으로 stream supervisor 의 async teardown(``_initiate_close``)을 깨운다.
+    - 데이터플레인이 없으면(placeholder) reason 만 ``_pending_close_reason`` 에
+      래치 → adopt 가 감지해 self-close.
+
+    **strategy/ctx hard-ref 미보유** — 봇 생명주기 너머로 전략 객체를 잡지 않는다.
+    """
+
+    session_id: str
+    bot_id: str
+    generation: int = 0
+    out_queue: asyncio.Queue[dict[str, Any]] | None = None
+    read_task: asyncio.Task[Any] | None = None
+    writer_task: asyncio.Task[Any] | None = None
+    on_closed: Callable[[], None] | None = None
+    closing_event: asyncio.Event | None = None
+    closed: bool = False
+    close_reason: str = ""
+    _pending_close_reason: str | None = None
+
+    def close(self, reason: str) -> bool:
+        """채널을 동기·idempotent 로 닫는다. first-close-wins.
+
+        Returns:
+            첫 close 면 ``True``, 이미 닫혔으면 ``False`` (멱등 no-op).
+        """
+        if self.closed:
+            return False
+        self.closed = True
+        self.close_reason = reason
+
+        # channel 의 _closed/_accepting set (stale-publish layer2 + admit-gate).
+        # on_closed 는 await-free 동기 콜백(channel.mark_closed) 이다.
+        if self.on_closed is not None:
+            self.on_closed()
+
+        out_queue = self.out_queue
+        if out_queue is not None:
+            # adopted: closed frame 을 force-slot 으로 넣는다. QueueFull 이면
+            # 가장 오래된 1개를 drop 하고 재시도 — teardown frame 은 반드시
+            # 전달되어야 한다(INV-OUT-8 teardown frame 보장).
+            self._force_enqueue(out_queue, {"type": "closed", "reason": reason})
+            if self.closing_event is not None:
+                # stream supervisor 의 async teardown 을 깨운다.
+                self.closing_event.set()
+        else:
+            # placeholder: reason 만 래치 → adopt 가 감지해 self-close.
+            self._pending_close_reason = reason
+        return True
+
+    def _force_enqueue(
+        self, queue: asyncio.Queue[dict[str, Any]], frame: dict[str, Any]
+    ) -> None:
+        """``frame`` 을 force-slot 으로 enqueue. QueueFull 이면 1개 drop 후 재시도."""
+        try:
+            queue.put_nowait(frame)
+        except asyncio.QueueFull:
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                queue.put_nowait(frame)
+            except asyncio.QueueFull:
+                # 동시 producer 와의 극단 race — best-effort 로 포기(다음
+                # supervisor tick 이 closing_event 로 teardown 을 진행한다).
+                logger.warning("closed frame force-slot 실패: bot=%s", self.bot_id)
+
+    # close_all join 이 supervisor 의 flush-before-cancel 를 양보하는 grace.
+    JOIN_GRACE_SECONDS = 3.0
+
+    async def join(self) -> None:
+        """read_task/writer_task 가 정리될 때까지 대기 (``close_all`` 이 await).
+
+        ``close()`` 가 ``closing_event`` 를 set 한 뒤 stream supervisor 가
+        ``_initiate_close`` 로 read/writer task 를 flush-before-cancel(closed
+        frame 전달 후 cancel)·join 한다(정상 경로). 본 메서드는 그 두 task 가
+        **grace 안에 자연 정리되도록 먼저 await** 해 supervisor 의 closed-frame
+        flush 를 양보하고(client 가 ``{closed,reason}`` 을 받음), grace 초과 시
+        (supervisor 미진행 등)만 직접 cancel 후 await 한다 — close_all 이 외부
+        supervisor wiring 에 의존하지 않으면서 deadlock-free 로 await-to-
+        completion 하도록 보장한다(suppress CancelledError). task 가 없으면
+        (placeholder, adopt 전) 즉시 반환한다.
+        """
+        tasks = [t for t in (self.read_task, self.writer_task) if t is not None]
+        if not tasks:
+            return
+        # supervisor 의 flush-before-cancel 를 grace 동안 양보.
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(asyncio.gather(*tasks, return_exceptions=True)),
+                timeout=self.JOIN_GRACE_SECONDS,
+            )
+            return
+        except TimeoutError:
+            pass
+        # grace 초과 — 직접 cancel 후 await(deadlock 회피).
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+class SignalChannelRegistry:
+    """bot_id 당 단일 connect + daemon-위임 teardown 의 단일 권위 레지스트리 (#2337).
+
+    ``_sessions``: ``{bot_id: {session_id: ChannelHandle}}``. 단일-connect 정책상
+    inner dict 는 최대 1개의 active handle 만 갖지만, unregister race 멱등성을 위해
+    session_id 키 dict 를 유지한다.
+
+    ``_generations``: ``{bot_id: int}``. rotate/delete teardown 이 bump 해 adopt-time
+    re-check 로 rotate-in-window 핸드셰이크를 self-close 시킨다.
+
+    ``_frozen``: shutdown sweep 진입 후 ``True`` — 이후 ``register`` 는
+    ``SignalChannelRegistryFrozen`` 을 raise 해 re-register leak 을 차단한다.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, dict[str, ChannelHandle]] = {}
+        self._generations: dict[str, int] = {}
+        self._frozen = False
+
+    # ── 단일-connect atomic 게이트 (await 금지) ──────────────────────────
+
+    def register(self, handle: ChannelHandle) -> None:
+        """핸들을 atomic check-and-insert 로 등록한다.
+
+        **check↔insert 사이에 ``await`` 가 없다** — 단일-connect TOCTOU 를 닫는
+        권위 게이트. frozen 이면 ``SignalChannelRegistryFrozen``, 같은 bot_id 에
+        이미 active session 이 있으면 ``BotSignalChannelBusy`` (둘 다 ack write
+        **전** 핸드셰이크 핸들러에서 raise → Phase-B envelope, stream 미진입).
+        """
+        if self._frozen:
+            raise SignalChannelRegistryFrozen(
+                "signal channel registry is frozen (shutting down)"
+            )
+        bot_sessions = self._sessions.get(handle.bot_id)
+        if bot_sessions:
+            # 이미 active session 존재 → 단일-connect 거부.
+            raise BotSignalChannelBusy()
+        self._sessions[handle.bot_id] = {handle.session_id: handle}
+
+    def has_active_session(self, bot_id: str) -> bool:
+        """advisory peek — 권위 게이트는 ``register`` 의 atomic check 다."""
+        return bool(self._sessions.get(bot_id))
+
+    def get(self, bot_id: str, session_id: str) -> ChannelHandle | None:
+        """등록된 핸들을 조회한다 (adopt 가 placeholder 를 회수할 때 사용)."""
+        bot_sessions = self._sessions.get(bot_id)
+        if not bot_sessions:
+            return None
+        return bot_sessions.get(session_id)
+
+    def unregister(self, bot_id: str, session_id: str) -> None:
+        """핸들을 제거한다 — **missing-key no-op** (멱등).
+
+        ``_run_signal_stream`` finally 와 ack-fail upgrade-except 가 둘 다 호출할
+        수 있으므로 missing-key 에 raise 하지 않는다. inner dict 가 비면 outer
+        에서도 정리한다.
+        """
+        bot_sessions = self._sessions.get(bot_id)
+        if not bot_sessions:
+            return
+        bot_sessions.pop(session_id, None)
+        if not bot_sessions:
+            self._sessions.pop(bot_id, None)
+
+    # ── generation (rotate-in-window 감지) ───────────────────────────────
+
+    def current_generation(self, bot_id: str) -> int:
+        """현재 generation. register 가 스냅샷하고 adopt 가 re-check 한다."""
+        return self._generations.get(bot_id, 0)
+
+    def bump_generation(self, bot_id: str) -> None:
+        """generation 을 1 증가 — rotate teardown 이 adopt-time self-close 유도."""
+        self._generations[bot_id] = self._generations.get(bot_id, 0) + 1
+
+    # ── teardown (snapshot 순회·idempotent·unregister 안 함) ──────────────
+
+    def close_bot(self, bot_id: str, reason: str) -> int:
+        """봇의 모든 active session 을 닫는다. 닫은(first-close) 개수 반환.
+
+        **snapshot 순회** — ``list(...).values()`` 로 복사 후 각 ``close(reason)``
+        를 호출한다(순회 중 dict 변형 회피). **unregister 는 하지 않는다** —
+        unregister 는 각 채널의 ``_run_signal_stream`` finally 가 정확히 1회
+        소유한다(INV-OUT-9). idempotent: 이미 닫힌 핸들은 ``close`` 가 ``False``
+        라 count 에 포함되지 않는다.
+        """
+        bot_sessions = self._sessions.get(bot_id)
+        if not bot_sessions:
+            return 0
+        count = 0
+        for handle in list(bot_sessions.values()):
+            if handle.close(reason):
+                count += 1
+        return count
+
+    def freeze(self) -> None:
+        """레지스트리를 freeze — 이후 ``register`` 는 raise (shutdown sweep)."""
+        self._frozen = True
+
+    async def close_all(self, reason: str) -> None:
+        """전체 active session 을 닫고 정리 task 를 await-to-completion 한다.
+
+        shutdown sweep 의 단독 async 메서드. 전체 핸들을 snapshot 한 뒤 각
+        ``close(reason)`` (동기) 로 closed frame + closing_event 를 발화하고,
+        ``gather(*join, return_exceptions=True)`` 로 read/writer task 가 모두
+        정리될 때까지 await 한다 — 단순 cancel 이 아니라 grace-aware teardown
+        의 완료를 기다린다(스펙 §7: query 코루틴이 db.close 너머 생존 금지).
+        """
+        handles: list[ChannelHandle] = [
+            handle
+            for bot_sessions in list(self._sessions.values())
+            for handle in list(bot_sessions.values())
+        ]
+        for handle in handles:
+            handle.close(reason)
+        if handles:
+            await asyncio.gather(
+                *(handle.join() for handle in handles),
+                return_exceptions=True,
+            )

--- a/src/ante/contracts/error_registry.py
+++ b/src/ante/contracts/error_registry.py
@@ -210,18 +210,18 @@ baseline 으로 그대로 유지된다 (#1842 ``AccountError`` 와 동일 패턴
 ``SignalKeyManagerNotConfigured`` (``.code="SERVICE_NOT_CONFIGURED"``) 를 도입해
 이 상수를 ``EXCEPTION_TO_SPEC`` 한 줄 entry 로 wiring 한다(전용 코드 미발명).
 
-#2336 (PR#1) signal.connect 핸드셰이크 신규 4코드:
+#2336 (PR#1) / #2337 (PR#2) signal.connect 핸드셰이크 신규 4코드:
 
 - ``INVALID_SIGNAL_KEY`` (validation) — ``InvalidSignalKey`` typed entry.
 - ``BOT_NOT_RUNNING`` (state_conflict) — ``BotNotRunning`` typed entry.
 - ``MALFORMED_REQUEST`` (validation) — server.py 가 비-dict 첫 프레임에 inline
   envelope 으로 발화. typed exception 없음 → 상수-only(entry 미등록).
 - ``BOT_SIGNAL_CHANNEL_BUSY`` (state_conflict) — bot_id 당 단일 connect 거부.
-  raiser 는 PR#2(#2337) ``SignalChannelRegistry`` 이며, 본 PR 은 ErrorSpec
-  상수만 등록해 #2335 contract-drift 를 종료한다(상수-only, PR#1 raiser 없음).
+  raiser 는 PR#2(#2337) ``SignalChannelRegistry.register`` 이며, PR#2 가
+  ``BotSignalChannelBusy`` typed entry 를 추가한다(PR#1 은 상수-only 였음).
 
-즉 typed-2(``INVALID_SIGNAL_KEY``/``BOT_NOT_RUNNING``) + inline-2
-(``MALFORMED_REQUEST``/``BOT_SIGNAL_CHANNEL_BUSY``) split. typed-2 의
+즉 PR#2 머지 후 typed-3(``INVALID_SIGNAL_KEY``/``BOT_NOT_RUNNING``/
+``BOT_SIGNAL_CHANNEL_BUSY``) + inline-1(``MALFORMED_REQUEST``) split. typed-3 의
 ``EXCEPTION_TO_SPEC`` entry 는 helper 의 bare-``.code``→``internal`` wrap 을
 회피해 category 정확성을 lock 하는 load-bearing 이다.
 
@@ -258,6 +258,7 @@ from ante.bot.exceptions import (
     BotNotAcceptingSignals,
     BotNotFoundError,
     BotNotRunning,
+    BotSignalChannelBusy,
     BotStateConflict,
     BotStrategyAlreadyRunningError,
     InvalidSignalKey,
@@ -552,12 +553,13 @@ _BOT_IMMUTABLE_FIELD_SPEC: Final[ErrorSpec] = ErrorSpec(
 #
 # error-taxonomy.md 가 신규 4코드를 분류한다: ``INVALID_SIGNAL_KEY``=validation,
 # ``BOT_NOT_RUNNING``=state_conflict, ``MALFORMED_REQUEST``=validation,
-# ``BOT_SIGNAL_CHANNEL_BUSY``=state_conflict. 이 중 typed exception 이 존재하는
-# 2코드(``INVALID_SIGNAL_KEY``/``BOT_NOT_RUNNING``)만 ``EXCEPTION_TO_SPEC`` 에
-# entry 를 갖고, 나머지 2코드는 상수-only(``MALFORMED_REQUEST`` 는 server.py 가
-# 비-dict 첫 프레임에 대해 inline envelope 으로 발화, ``BOT_SIGNAL_CHANNEL_BUSY``
-# 의 raiser 는 단일-connect 정책으로 PR#2(#2337)). ``_MALFORMED_REQUEST_SPEC``
-# 와 동형으로 ``_SERVICE_NOT_CONFIGURED_SPEC`` reserved 선례를 따른다.
+# ``BOT_SIGNAL_CHANNEL_BUSY``=state_conflict. PR#2(#2337) 머지 후 typed
+# exception 이 존재하는 3코드(``INVALID_SIGNAL_KEY``/``BOT_NOT_RUNNING``/
+# ``BOT_SIGNAL_CHANNEL_BUSY``)가 ``EXCEPTION_TO_SPEC`` entry 를 갖고, 나머지
+# 1코드(``MALFORMED_REQUEST``)는 상수-only(server.py 가 비-dict 첫 프레임에 대해
+# inline envelope 으로 발화). ``BOT_SIGNAL_CHANNEL_BUSY`` 의 raiser 는 단일-connect
+# 정책으로 PR#2 의 ``SignalChannelRegistry.register`` 다. ``_MALFORMED_REQUEST_SPEC``
+# 는 ``_SERVICE_NOT_CONFIGURED_SPEC`` reserved 선례를 따른다(typed 없음).
 
 # ``signal.connect`` 게이트① — signal key 검증 실패. 입력 계약 위반이므로
 # ``validation`` 카테고리. server.py:446 ``getattr(e, "code", ...)`` 가
@@ -586,8 +588,9 @@ _MALFORMED_REQUEST_SPEC: Final[ErrorSpec] = ErrorSpec(
 
 # 같은 봇에 이미 active session 이 있을 때 두 번째 핸드셰이크 거부 (bot_id 당
 # 단일 connect). 운영 상태 충돌이므로 ``state_conflict``. raiser 는 PR#2
-# (#2337) 의 ``SignalChannelRegistry`` 이며, 본 PR 은 ErrorSpec 상수만 등록해
-# #2335 contract-drift 를 종료한다(상수-only, PR#1 에 raiser 없음 — 의도적).
+# (#2337) 의 ``SignalChannelRegistry.register`` (atomic check-and-insert) 이며,
+# PR#2 가 ``BotSignalChannelBusy`` typed entry 를 ``EXCEPTION_TO_SPEC`` 에
+# wiring 해 category 정확성(``internal`` wrap 회피)을 lock 한다(PR#1 상수-only).
 _BOT_SIGNAL_CHANNEL_BUSY_SPEC: Final[ErrorSpec] = ErrorSpec(
     code="BOT_SIGNAL_CHANNEL_BUSY",
     category="state_conflict",
@@ -880,13 +883,17 @@ EXCEPTION_TO_SPEC: Final[dict[type[BaseException], ErrorSpec]] = {
     BotStrategyAlreadyRunningError: _BOT_STRATEGY_ALREADY_RUNNING_SPEC,
     # ── #2282 bot account_id 불변 lock (Account 선례 미러) ────────────────
     BotImmutableFieldError: _BOT_IMMUTABLE_FIELD_SPEC,
-    # ── #2336/#2334 PR#1 signal.connect 핸드셰이크 (typed 2 + 재사용 1) ────
-    # ``MALFORMED_REQUEST``/``BOT_SIGNAL_CHANNEL_BUSY`` 는 typed exception 이
-    # 없어 entry 를 두지 않는다(추가 시 NameError — ``_SERVICE_NOT_CONFIGURED_SPEC``
-    # 상수-only 선례). ``SignalKeyManagerNotConfigured`` 는 기존
-    # ``_SERVICE_NOT_CONFIGURED_SPEC`` 를 재사용해 category 정확성을 wiring.
+    # ── #2336/#2334 PR#1 + #2337 PR#2 signal.connect 핸드셰이크 (typed 3 + 재사용 1) ─
+    # ``MALFORMED_REQUEST`` 만 typed exception 이 없어 entry 를 두지 않는다(상수-only,
+    # ``_SERVICE_NOT_CONFIGURED_SPEC`` 선례 — server.py inline 발화). PR#2 가
+    # ``BotSignalChannelBusy`` (``SignalChannelRegistry.register`` raiser) typed
+    # entry 를 추가했다(PR#1 은 ``_BOT_SIGNAL_CHANNEL_BUSY_SPEC`` 상수-only).
+    # ``SignalKeyManagerNotConfigured`` 는 기존 ``_SERVICE_NOT_CONFIGURED_SPEC`` 를
+    # 재사용해 category 정확성을 wiring. ``SignalChannelRegistryFrozen`` 은
+    # shutdown-only 내부 가드라 EXCEPTION_TO_SPEC 미등록(generic EXECUTION_ERROR).
     InvalidSignalKey: _INVALID_SIGNAL_KEY_SPEC,
     BotNotRunning: _BOT_NOT_RUNNING_SPEC,
+    BotSignalChannelBusy: _BOT_SIGNAL_CHANNEL_BUSY_SPEC,
     SignalKeyManagerNotConfigured: _SERVICE_NOT_CONFIGURED_SPEC,
     # ── #1843 sub-PR 4 treasury 7 sub-class (실측 .code mirror) ───────────
     TreasuryInvalidAmountError: _TREASURY_INVALID_AMOUNT_SPEC,

--- a/src/ante/core/registry.py
+++ b/src/ante/core/registry.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from ante.approval.service import ApprovalService
     from ante.audit.logger import AuditLogger
     from ante.bot.manager import BotManager
+    from ante.bot.signal_channel_registry import SignalChannelRegistry
     from ante.config.dynamic import DynamicConfigService
     from ante.eventbus import EventBus
     from ante.member.service import MemberService
@@ -50,3 +51,10 @@ class ServiceRegistry:
     audit_logger: AuditLogger | Any = field(default=None)
     trade_service: TradeService | Any = field(default=None)
     member_service: MemberService | Any = field(default=None)
+    # Refs #2334 / #2337 (PR#2): signal.connect lifecycle 의 단일 권위 레지스트리.
+    # 핸드셰이크 핸들러(``_handle_signal_connect``)가 atomic ``register`` 로
+    # 단일-connect 게이트를 걸고, ``_run_signal_stream`` 이 adopt/unregister 하며,
+    # ``BotManager`` 가 rotate/delete/bot-stopped teardown 으로 ``close_bot`` 한다.
+    # ``audit_logger`` 와 동형의 optional 필드 — legacy/headless 환경(테스트, CLI
+    # cold-path)은 ``None`` 이며 핸들러는 ``getattr(svc, ..., None)`` no-op 한다.
+    signal_channel_registry: SignalChannelRegistry | Any = field(default=None)

--- a/src/ante/eventbus/fill_dedup_guard.py
+++ b/src/ante/eventbus/fill_dedup_guard.py
@@ -37,6 +37,19 @@ class FillDedupGuard:
         self._order: deque[str] = deque(maxlen=maxlen)
         self._seen: set[str] = set()
 
+    def __contains__(self, key: str) -> bool:
+        """read-only 멤버십 검사 (#2337 INV-OUT-4).
+
+        ``seen_or_add`` 와 달리 가드 상태를 **변경하지 않는다**. SignalChannel
+        ``_on_fill`` 가 enqueue **전** dedup 게이트로 비-커밋 검사를 하기 위한
+        seam 이다 — full-drop(enqueue 실패) 시 키를 마킹하지 않아 다음 재전달이
+        보존되도록 하려면, 검사 시점에는 커밋하지 않고 ``_emit`` 성공 **후**
+        별도로 ``seen_or_add`` 를 호출해야 한다(dedup-mark-after-enqueue).
+
+        ``await`` 없는 동기 read 이며 ``self._seen`` 멤버십만 조회한다.
+        """
+        return key in self._seen
+
     def seen_or_add(self, key: str) -> bool:
         """키를 원자적으로 검사+추가한다.
 

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -689,12 +689,21 @@ async def _handle_signal_connect(
       ``BotNotAcceptingSignals``.
 
     ``account_id`` 는 LIVE ``bot.config`` 에서만 취하고 ``args`` 의 spoof 값은
-    무시한다. ``audit_action=None`` (자동 audit OFF) — 단일 manual connect-audit
-    는 PR#2(#2337) lifecycle 소관이다. 키는 로깅/반환에 노출하지 않는다.
+    무시한다. ``audit_action=None`` (자동 audit OFF) — 본 PR(#2337)이 게이트
+    통과 후 단일 manual connect-audit 를 직접 1회 발화한다(actor sentinel
+    ``"ipc"``). 키는 로깅/반환에 노출하지 않는다.
 
-    PR#2(#2337) 경계: routing/``SignalChannel``/out_queue/teardown/단일-connect
-    ``BOT_SIGNAL_CHANNEL_BUSY`` raise 는 본 PR 범위 밖이다.
+    #2337 register happen-before ack (F1+F4): gate-4 통과 후 ``_stream``
+    반환 **전** ``SignalChannelRegistry.register`` 를 atomic check-and-insert
+    로 호출한다(``BotSignalChannelBusy``/``SignalChannelRegistryFrozen`` 둘 다
+    ack write **전** raise → Phase-B envelope, stream 미진입). 이 시점의
+    ``ChannelHandle`` 은 placeholder(데이터플레인 None) 이며 ``generation`` 을
+    스냅샷한다 — ``_run_signal_stream`` 진입 후 adopt 가 데이터플레인을 채우고
+    generation re-check 로 rotate-in-window 를 self-close 한다. ``reg`` 가
+    ``None`` (headless/legacy)이면 register 를 스킵하고 session_id 만 전달한다.
     """
+    from uuid import uuid4
+
     from ante.bot.config import BotStatus
     from ante.bot.exceptions import (
         BotNotAcceptingSignals,
@@ -727,9 +736,37 @@ async def _handle_signal_connect(
     if not bot.strategy or not bot.strategy.meta.accepts_external_signals:
         raise BotNotAcceptingSignals(f"Bot {bot_id} does not accept external signals")
 
+    # 단일 manual connect-audit 1회 (#2334 §8, #2337). actor sentinel ``"ipc"``.
+    # ``required_services`` 에 audit_logger 를 추가하지 않는다(headless 호환) —
+    # getattr None-guard 로 부재 시 no-op. 키/식별 토큰은 detail 에 싣지 않는다.
+    audit_logger = getattr(svc, "audit_logger", None)
+    if audit_logger is not None:
+        await audit_logger.log(
+            member_id="ipc",
+            action="signal.connect",
+            resource=f"bot:{bot_id}",
+            detail="",
+            ip="",
+        )
+
+    # register happen-before ack (#2337 F1+F4). placeholder ChannelHandle 을
+    # generation 스냅샷과 함께 atomic 등록한다. busy/frozen 은 ack 전 raise.
+    session_id = uuid4().hex
+    reg = getattr(svc, "signal_channel_registry", None)
+    if reg is not None:
+        from ante.bot.signal_channel_registry import ChannelHandle
+
+        handle = ChannelHandle(
+            session_id=session_id,
+            bot_id=bot_id,
+            generation=reg.current_generation(bot_id),
+        )
+        reg.register(handle)
+
     return {
         "bot_id": bot_id,
         "account_id": bot.config.account_id,
+        "session_id": session_id,
         "_stream": "signal.connect",
     }
 

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -10,8 +10,11 @@ Refs #1184: lifecycle state machine을 도입해 shutdown 중 mutating
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
 import logging
 import os
+import struct
 import uuid
 from enum import Enum
 from pathlib import Path
@@ -25,6 +28,45 @@ if TYPE_CHECKING:
     from ante.ipc.registry import CommandRegistry
 
 logger = logging.getLogger(__name__)
+
+# Refs #2334 §14 (#2337): signal.connect outbound out_queue 의 bounded 상한.
+# 초과(laggard)면 disconnect-laggard 로 ``{closed,reason:lagged}`` 후 종료한다.
+# config 화는 §14 follow-up(본 PR 은 상수, known-limitation).
+SIGNAL_OUT_QUEUE_MAX = 512
+# Refs #2337 F2: daemon-initiated close 가 in-flight on_data publish 를 grace
+# 동안 await 한 뒤 read_task 를 cancel 한다(at-most-one trailing). 초과분은
+# 백그라운드 publish 계속 + read_task cancel(§14 tunable, known-limitation).
+SIGNAL_INFLIGHT_GRACE = 2.0
+# Refs #2337: signal.connect 핸드셰이크의 expected typed-validation 거부 코드.
+# ``_dispatch`` 가 이 집합의 코드는 traceback 없는 구조화 WARNING 으로 로깅해
+# 키/args 노출과 가짜 ERROR traceback 을 회피한다(그 외는 logger.exception).
+_EXPECTED_DISPATCH_REJECT_CODES = frozenset(
+    {
+        "INVALID_SIGNAL_KEY",
+        "BOT_NOT_RUNNING",
+        "BOT_NOT_ACCEPTING_SIGNALS",
+        "BOT_SIGNAL_CHANNEL_BUSY",
+        "MALFORMED_REQUEST",
+    }
+)
+
+
+def _encode_signal_frame(frame: dict) -> bytes:
+    """signal.connect outbound 프레임을 length-prefixed 바이트로 직렬화 (#2337).
+
+    ``protocol.encode`` 와 동일한 ``[4바이트 빅엔디안 길이][JSON]`` framing 이되,
+    legacy ``SignalChannel._write`` 와 byte-identical 한 페이로드를 위해
+    ``json.dumps(..., default=str)`` 를 쓴다(``timestamp`` 등 datetime 을 ISO
+    문자열로 — legacy stdout 경로의 ``default=str`` 와 정합, INV-OUT-1). 1MB
+    초과는 ``MessageTooLargeError`` (outbound non-fatal 처리 대상).
+    """
+    payload = json.dumps(frame, default=str, ensure_ascii=False).encode("utf-8")
+    if len(payload) > protocol.MAX_MESSAGE_SIZE:
+        raise MessageTooLargeError(
+            f"메시지 크기({len(payload)} bytes)가 "
+            f"최대 제한({protocol.MAX_MESSAGE_SIZE} bytes)을 초과"
+        )
+    return struct.pack("!I", len(payload)) + payload
 
 
 class IPCServerState(Enum):
@@ -101,6 +143,11 @@ class IPCServer:
         """
         path = Path(self._socket_path)
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Refs #2334 §보안 (#2337): runtime dir 0o700(소유자만 접근). umask
+        # 독립적으로 기존 dir 에도 재적용한다 — server.start 가 단독 0o700
+        # 소유자다(main.py 의 mkdir 은 chmod 하지 않음). socket 0o600 과 함께
+        # 외부 프로세스의 signal.connect UDS 접근면을 닫는다.
+        os.chmod(path.parent, 0o700)
 
         # 잔존 소켓 파일 정리
         if path.exists():
@@ -254,10 +301,26 @@ class IPCServer:
                 ):
                     # wire 전송 직전 센티넬 strip (절대 노출 안 됨).
                     result.pop("_stream", None)
-                    ack = await protocol.encode(response)
-                    writer.write(ack)
-                    await writer.drain()
-                    await self._run_signal_stream(reader, writer, result["bot_id"])
+                    session_id = result["session_id"]
+                    bot_id = result["bot_id"]
+                    # #2337 F1+F4 (3): ack write/drain 실패 시 register 누수 차단.
+                    # register 는 핸드셰이크 핸들러(ack 전 happen-before)에서 이미
+                    # 성공했으나, ack write 실패 시 ``_run_signal_stream`` 미진입
+                    # → finally 부재 → handle 누수. 여기서 unregister(missing-key
+                    # no-op 라 stream finally 와 멱등)로 차단한 뒤 re-raise 해
+                    # ``_handle_connection`` finally 가 writer teardown 을 소유한다.
+                    reg = getattr(
+                        self._service_registry, "signal_channel_registry", None
+                    )
+                    try:
+                        ack = await protocol.encode(response)
+                        writer.write(ack)
+                        await writer.drain()
+                    except Exception:
+                        if reg is not None:
+                            reg.unregister(bot_id, session_id)
+                        raise
+                    await self._run_signal_stream(reader, writer, bot_id, session_id)
                     # break 아님 — hijack 연결은 lockstep 재진입 금지. finally 가
                     # teardown(writer close) 를 단일 소유한다.
                     return
@@ -488,13 +551,20 @@ class IPCServer:
                 "result": result,
             }
         except Exception as e:
-            logger.exception("IPC 커맨드 실행 오류: %s", command)
             # 예외 인스턴스/클래스에 ``code`` 속성이 있으면 안정 코드로
             # 노출한다 (#1144 invariant S5). 기존 예외(account.suspend/activate
             # 등)는 ``code`` 속성이 없어 자동으로 ``EXECUTION_ERROR``로
             # 폴백된다 — 회귀 없음. Refs #1850: ``InvalidAccountIdError``
             # (``code="VALIDATION_ERROR"``) 도 본 경로로 envelope 변환된다.
             error_code = getattr(e, "code", "EXECUTION_ERROR")
+            # Refs #2337: signal.connect 핸드셰이크의 expected typed-validation
+            # 거부는 traceback/args 를 노출하지 않는 구조화 WARNING 으로 로깅한다
+            # (invalid-key caplog 에 ``sk_`` 부재, expected-exc ERROR traceback
+            # 부재). 그 외(internal/unexpected)는 기존 ``logger.exception`` 유지.
+            if error_code in _EXPECTED_DISPATCH_REJECT_CODES:
+                logger.warning("IPC handshake rejected: %s (%s)", command, error_code)
+            else:
+                logger.exception("IPC 커맨드 실행 오류: %s", command)
             return {
                 "id": request_id,
                 "status": "error",
@@ -509,38 +579,342 @@ class IPCServer:
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
         bot_id: str,
+        session_id: str,
     ) -> None:
-        """signal.connect Phase-C 스트림 바디 루프 (#2334 / #2336 PR#1 스켈레톤).
+        """signal.connect Phase-C 스트림 host (#2334 §6/§7, #2337 PR#2).
 
         핸드셰이크 OK 후 동일 연결을 hijack 해 long-lived 양방향 스트림으로
-        운반한다. PR#1 은 call seam + per-read timeout 없는 read-until-EOF 루프만
-        제공한다. 시그니처 ``(reader, writer, bot_id)`` 는 PR#2(#2337) relay 가
-        그대로 쓰도록 고정한다.
+        운반한다. host 구성:
+
+        - **bounded out_queue + 단일 writer_task**: ``asyncio.Queue(maxsize=
+          SIGNAL_OUT_QUEUE_MAX)`` + write_lock 으로 ack(inbound)·fill(eventbus)
+          프레임 순서를 보존한다(INV-OUT-3). writer 는 FIFO drain →
+          ``protocol.encode`` → write+drain.
+        - **read_task**: ``protocol.decode`` → ``channel._handle_message``. per-read
+          timeout 없음(idle 정상). inbound >1MB 는 **terminal close**(decode 가
+          body read 전 raise → framing desync, continue 금지, INV-OUT-7).
+        - **adopt + self-close re-check (F1+F4)**: register 된 placeholder handle
+          을 회수해 데이터플레인을 채운다. adopt 시점에 ``handle.closed`` 또는
+          generation 불일치(rotate-in-window)면 read/writer 풀 루프 미진입 →
+          single closed frame flush 후 self-close.
+        - **closing supervisor (F2)**: ``handle.close()``(동기, daemon-initiated)
+          가 set 한 ``closing_event`` 를 감지하면 ``_initiate_close`` async 순서를
+          실행(await-inflight grace → read_task cancel → writer join).
+        - **finally(INV-OUT-9)**: ``mark_closed`` → ``_unsubscribe_events`` →
+          ``reg.unregister`` 정확히 1회(register 성공 후 모든 경로). writer 는
+          **절대 직접 close 안 함** — ``_handle_connection`` finally 단독 소유.
 
         Phase-C read 에는 per-read timeout 을 **절대** 적용하지 않는다 — idle
-        스트림(무전송 대기)은 정상이며 liveness 는 app-level ``{ping→pong}``
-        heartbeat 로 확인한다(ipc.md §"Timeout 계약"). EOF(client close)에는
-        ``IncompleteReadError`` 로 graceful 종료한다.
+        스트림은 정상이며 liveness 는 app-level ``{ping→pong}`` 로 확인한다.
 
-        PR#2(#2337) 이연(known-limitation):
+        headless(reg=None): adopt/self-close/unregister 를 스킵하고 channel
+        데이터플레인만 구동한다.
+        """
+        from ante.bot.signal_channel import SignalChannel
 
-        * inbound 프레임 routing/ack/pong → 현재는 read+discard.
-        * >1MB 프레임 비치명 ``{"type":"error","message":"result_too_large"}``
-          후 스트림 유지 → 현재는 ``MessageTooLargeError`` 로 close. PR#1 은
-          Phase-C 의존 client 가 없어 close 허용.
-        * ``SignalChannel``/bounded ``out_queue``/writer_task/eventbus
-          subscribe·relay/``SignalChannelRegistry``/teardown = 전부 PR#2.
+        reg = getattr(self._service_registry, "signal_channel_registry", None)
+        svc = self._service_registry
+        bot = svc.bot_manager.get_bot(bot_id)
+        if bot is None:
+            # 핸드셰이크와 stream 진입 사이에 봇이 사라진 극단 race — register
+            # 누수만 정리하고 종료(writer 는 _handle_connection finally 소유).
+            if reg is not None:
+                reg.unregister(bot_id, session_id)
+            return
 
-        ``writer`` 를 직접 close 하지 않는다 — ``_handle_connection`` finally 가
-        teardown 을 단일 소유한다.
+        out_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=SIGNAL_OUT_QUEUE_MAX)
+        write_lock = asyncio.Lock()
+        flush_done = asyncio.Event()
+        # daemon-initiated close ↔ async teardown 브릿지(F2). handle.close(sync)
+        # 와 laggard 가 이 event 를 set 하고, supervisor 가 _initiate_close 를
+        # 실행한다. headless(reg=None)에서도 laggard teardown 이 동작하도록 항상
+        # 생성한다.
+        closing_event = asyncio.Event()
+
+        def _force_closed_frame(reason: str) -> None:
+            """``{closed,reason}`` force-slot enqueue(QueueFull→1 drop 후 재시도)."""
+            frame = {"type": "closed", "reason": reason}
+            try:
+                out_queue.put_nowait(frame)
+            except asyncio.QueueFull:
+                try:
+                    out_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+                with contextlib.suppress(asyncio.QueueFull):
+                    out_queue.put_nowait(frame)
+
+        def _trigger_lagged() -> None:
+            """disconnect-laggard teardown (INV-OUT-6). idempotent.
+
+            out_queue full 로 프레임 drop 시 1회 호출. channel ``_closed`` flip
+            (이후 _on_fill/_on_order_update no-op) + ``{error,stream_lagged}``
+            best-effort(QueueFull drop 허용) + ``{closed,lagged}`` force-slot +
+            closing_event set 으로 supervisor 의 daemon_close teardown 진입.
+            socket I/O await 없음(bus 핸들러 inline 안전).
+            """
+            if closing_event.is_set():
+                return
+            channel.mark_closed()
+            with contextlib.suppress(asyncio.QueueFull):
+                out_queue.put_nowait({"type": "error", "message": "stream_lagged"})
+            _force_closed_frame("lagged")
+            closing_event.set()
+
+        def _enqueue(frame: dict) -> None:
+            """sink 콜백 — newline-free dict 를 out_queue 에 put_nowait.
+
+            laggard-aware: QueueFull 이면 채널 laggard teardown 을 트리거한다
+            (raw put_nowait 금지 — INV-OUT-6 backpressure swallow 우회 명시체크).
+            """
+            try:
+                out_queue.put_nowait(frame)
+            except asyncio.QueueFull:
+                _trigger_lagged()
+
+        channel = SignalChannel(
+            bot,
+            svc.eventbus,
+            bot._ctx,
+            sink=_enqueue,
+            is_full=out_queue.full,
+            on_lagged=_trigger_lagged,
+        )
+        channel._subscribe_events()
+
+        # adopt (F1+F4 step 4) — placeholder handle 데이터플레인 채우기. handle.
+        # closing_event 를 stream-local event 와 동일 객체로 바인딩해 sync
+        # handle.close()가 supervisor 를 깨우게 한다.
+        handle = reg.get(bot_id, session_id) if reg is not None else None
+        if handle is not None:
+            handle.out_queue = out_queue
+            handle.on_closed = channel.mark_closed
+            handle.closing_event = closing_event
+
+        # F4 self-close 재확인: adopt 직후 이미 닫혔거나(register 후 ack 전
+        # close_bot/rotate) generation 불일치(rotate-in-window)면 풀 루프 미진입.
+        # handle is not None ⇒ reg is not None(handle 은 reg.get 유래)이나 명시
+        # 가드로 mypy union-attr 을 좁힌다.
+        if reg is not None and handle is not None:
+            rotated = reg.current_generation(bot_id) != handle.generation
+            if handle.closed or rotated:
+                if rotated and not handle.closed:
+                    handle.close("rotated")
+                reason = (
+                    handle._pending_close_reason or handle.close_reason or "rotated"
+                )
+                await self._self_close_signal_stream(
+                    channel, writer, reason, reg, bot_id, session_id
+                )
+                return
+
+        try:
+            await self._drive_signal_stream(
+                reader,
+                writer,
+                channel,
+                out_queue,
+                write_lock,
+                flush_done,
+                closing_event,
+                handle,
+            )
+        finally:
+            # INV-OUT-9: 모든 종료 경로 정확히 1회.
+            channel.mark_closed()
+            channel._unsubscribe_events()
+            if reg is not None:
+                reg.unregister(bot_id, session_id)
+
+    async def _self_close_signal_stream(
+        self,
+        channel: object,
+        writer: asyncio.StreamWriter,
+        reason: str,
+        reg: object,
+        bot_id: str,
+        session_id: str,
+    ) -> None:
+        """adopt-time self-close (F4) — single closed frame flush 후 정리.
+
+        read/writer 풀 루프를 띄우지 않고 ``{type:closed,reason}`` 1프레임만
+        wire 로 내보낸 뒤 ``mark_closed`` → ``_unsubscribe_events`` →
+        ``unregister`` 한다(INV-OUT-9 정확히 1회). writer 는 직접 close 안 함.
         """
         try:
+            try:
+                frame = _encode_signal_frame({"type": "closed", "reason": reason})
+                writer.write(frame)
+                await writer.drain()
+            except (BrokenPipeError, OSError, MessageTooLargeError):
+                pass
+        finally:
+            channel.mark_closed()  # type: ignore[attr-defined]
+            channel._unsubscribe_events()  # type: ignore[attr-defined]
+            if reg is not None:
+                reg.unregister(bot_id, session_id)  # type: ignore[attr-defined]
+
+    async def _drive_signal_stream(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        channel: object,
+        out_queue: asyncio.Queue[dict],
+        write_lock: asyncio.Lock,
+        flush_done: asyncio.Event,
+        closing_event: asyncio.Event,
+        handle: object,
+    ) -> None:
+        """read_task + writer_task + closing supervisor 를 구동·정리한다.
+
+        writer 는 FIFO drain → encode → write. ``frame.type=='closed'`` 면 write
+        후 ``flush_done.set()`` + return(INV-OUT-8 flush-before-cancel).
+        outbound >1MB 는 ``{type:error,result_too_large}`` non-fatal continue
+        (INV-OUT-7). read_task 는 EOF/inbound-1MB 에 return. closing supervisor 는
+        ``handle.closing_event`` 또는 read/writer 완료를 감지해 ``_initiate_close``
+        async teardown 을 실행한다(F2 sync close ↔ async teardown 브릿지).
+        """
+
+        async def _writer_loop() -> None:
             while True:
-                # PR#1: routing 없음 — 프레임을 읽어 discard.
-                await protocol.decode(reader)
-        except asyncio.IncompleteReadError:
-            # EOF (어느 쪽이든 소켓 close) — graceful 종료.
-            return
-        except MessageTooLargeError:
-            # PR#1: close. PR#2 에서 비치명 result_too_large 로 스트림 유지.
-            return
+                frame = await out_queue.get()
+                try:
+                    data = _encode_signal_frame(frame)
+                except MessageTooLargeError:
+                    # outbound >1MB 비치명: result_too_large 후 stream 유지.
+                    try:
+                        data = _encode_signal_frame(
+                            {"type": "error", "message": "result_too_large"}
+                        )
+                    except MessageTooLargeError:
+                        continue
+                    async with write_lock:
+                        writer.write(data)
+                        await writer.drain()
+                    continue
+                async with write_lock:
+                    writer.write(data)
+                    await writer.drain()
+                if frame.get("type") == "closed":
+                    # teardown frame write 완료 → grace supervisor 깨우고 종료.
+                    flush_done.set()
+                    return
+
+        async def _reader_loop() -> None:
+            while True:
+                try:
+                    msg = await protocol.decode(reader)
+                except asyncio.IncompleteReadError:
+                    return  # EOF — graceful 종료.
+                except MessageTooLargeError:
+                    return  # inbound >1MB — terminal close(framing desync 회피).
+                await channel._handle_message(msg)  # type: ignore[attr-defined]
+
+        read_task = asyncio.ensure_future(_reader_loop())
+        writer_task = asyncio.ensure_future(_writer_loop())
+        if handle is not None:
+            handle.read_task = read_task  # type: ignore[attr-defined]
+            handle.writer_task = writer_task  # type: ignore[attr-defined]
+
+        closing_waiter = asyncio.ensure_future(closing_event.wait())
+        try:
+            # read/writer 중 하나라도 종료하거나, daemon-initiated close(또는
+            # laggard)가 closing_event 를 set 하면 teardown 으로 진입한다.
+            await asyncio.wait(
+                [read_task, writer_task, closing_waiter],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            # daemon-initiated close 여부: closing_event 가 set 됐으면(rotate/
+            # close_bot/shutdown/laggard — closed frame force-slot 됨) flush-
+            # before-cancel grace 순서, 아니면 자연 종료(EOF/writer-exit)라 즉시
+            # sibling cancel.
+            daemon_close = closing_event.is_set()
+            await self._initiate_close(
+                channel,
+                read_task,
+                writer_task,
+                flush_done,
+                daemon_close=daemon_close,
+            )
+        finally:
+            if not closing_waiter.done():
+                closing_waiter.cancel()
+            # 남은 task 강제 정리(중복 cancel/await 는 멱등).
+            for task in (read_task, writer_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(
+                read_task,
+                writer_task,
+                closing_waiter,
+                return_exceptions=True,
+            )
+
+    async def _initiate_close(
+        self,
+        channel: object,
+        read_task: asyncio.Task,
+        writer_task: asyncio.Task,
+        flush_done: asyncio.Event,
+        *,
+        daemon_close: bool,
+    ) -> None:
+        """teardown async 순서 (F2, INV-OUT-8).
+
+        ``daemon_close=True`` (rotate/close_bot/shutdown — ``handle.close`` 가
+        ``closing_event`` set + closed frame force-slot):
+
+        1. channel ``_accepting``/``_closed`` set(sync close 가 이미 했을 수
+           있으나 멱등) — NEW admit 거부 + ``_on_fill`` no-op.
+        2. in-flight on_data publish 를 grace 동안 await(``asyncio.shield`` 로
+           grace 타임아웃이 publish 자체를 중단시키지 않게 방어). 초과면 publish
+           는 백그라운드 계속, read_task 만 cancel(at-most-one trailing).
+        3. read_task cancel.
+        4. writer 가 closed frame 을 flush(``flush_done``)할 때까지 grace 대기 후
+           writer join(flush-before-cancel). 미flush 면 grace 후 cancel.
+
+        ``daemon_close=False`` (자연 종료 — EOF/writer-exit/laggard): flush 할
+        teardown frame 이 없으므로 in-flight 만 grace await 후 sibling 을 즉시
+        cancel(불필요한 grace 대기 회피).
+        """
+        channel.mark_closed()  # type: ignore[attr-defined]
+
+        inflight = getattr(channel, "_inflight", None)
+        if inflight is not None and not inflight.done():
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(inflight), timeout=SIGNAL_INFLIGHT_GRACE
+                )
+            except (TimeoutError, Exception):  # noqa: BLE001
+                # grace 초과/publish 예외 — publish 는 백그라운드 계속, 진행.
+                pass
+
+        if not read_task.done():
+            read_task.cancel()
+
+        if daemon_close and not writer_task.done():
+            # closed frame flush-before-cancel(INV-OUT-8). flush_done 은 writer 가
+            # closed frame 을 write 한 직후 set 된다 — grace 안에 set 되면 join,
+            # 아니면(극단 stall) cancel.
+            if flush_done.is_set():
+                with contextlib.suppress(Exception):
+                    await writer_task
+            else:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(flush_done.wait()),
+                        timeout=SIGNAL_INFLIGHT_GRACE,
+                    )
+                    with contextlib.suppress(Exception):
+                        await writer_task
+                except TimeoutError:
+                    writer_task.cancel()
+        elif not writer_task.done():
+            # 자연 종료 — flush 할 frame 없음. 즉시 cancel.
+            writer_task.cancel()
+
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await read_task
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await writer_task

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -160,6 +160,9 @@ class Services:
     fill_outbox: Any = None
     fill_outbox_publisher: Any = None
     bot_manager: Any = None
+    # #2337: signal.connect lifecycle 권위 레지스트리. _init_trading 에서 1개
+    # 인스턴스를 만들어 BotManager·ServiceRegistry·IPCServer 3곳에 동일 주입한다.
+    signal_channel_registry: Any = None
     virtual_executor: Any = None
     live_portfolio: Any = None
     strategy_snapshot: Any = None
@@ -553,6 +556,14 @@ async def _init_trading(s: Services) -> None:
     signal_key_manager = SignalKeyManager(db=s.db)
     await signal_key_manager.initialize()
 
+    # #2337: signal.connect lifecycle 권위 레지스트리를 BotManager 생성 **전**
+    # 만들어, BotManager·ServiceRegistry(_init_ipc)·IPCServer 3곳에 동일 인스턴스
+    # 를 주입한다. zero-arg(구독은 BotManager 소관). shutdown 에서 freeze →
+    # close_all('draining') 으로 sweep 한다.
+    from ante.bot.signal_channel_registry import SignalChannelRegistry
+
+    s.signal_channel_registry = SignalChannelRegistry()
+
     s.bot_manager = BotManager(
         eventbus=s.eventbus,
         db=s.db,
@@ -562,6 +573,7 @@ async def _init_trading(s: Services) -> None:
         treasury_manager=s.treasury_manager,
         trade_service=s.trade_service,
         signal_key_manager=signal_key_manager,
+        signal_channel_registry=s.signal_channel_registry,
     )
     await s.bot_manager.initialize()
 
@@ -1838,6 +1850,10 @@ async def _init_ipc(s: Services) -> None:
         # ``trade_service`` 를 주입한다. ``audit_logger`` 와 동형의 optional
         # 필드이며, ``enrich_bot_info`` 가 None 시 positions 키를 부재시킨다.
         trade_service=s.trade_service,
+        # Refs #2337: signal.connect 핸드셰이크 핸들러가 atomic register 로
+        # 단일-connect 게이트를 걸고 ``_run_signal_stream`` 이 adopt/unregister
+        # 하도록 BotManager 와 동일 인스턴스를 주입한다.
+        signal_channel_registry=s.signal_channel_registry,
     )
 
     command_registry = CommandRegistry()
@@ -1951,6 +1967,17 @@ async def _shutdown(s: Services) -> None:
     if s.ipc_server:
         await s.ipc_server.stop_accepting()
         logger.info("IPCServer 새 연결 수락 중지")
+
+    # Refs #2337: signal.connect 채널 sweep. stop_accepting 직후·stop_all/
+    # db.close **앞**(channels-before-bots-before-db). **freeze 먼저**(새
+    # register window 차단 — signal.connect 는 is_mutating=False 라 SHUTTING_DOWN
+    # 핸드셰이크 통과) → close_all('draining') 으로 await-to-completion(단순
+    # cancel 이 아니라 read/writer 정리 완료까지 대기 — query 코루틴이 db.close
+    # 너머 생존 금지). None-safe.
+    if s.signal_channel_registry:
+        s.signal_channel_registry.freeze()
+        await s.signal_channel_registry.close_all("draining")
+        logger.info("SignalChannelRegistry sweep 완료 — 모든 시그널 채널 종료")
 
     if s.daily_report_scheduler:
         await s.daily_report_scheduler.stop()

--- a/tests/integration/test_signal_connect_repro_2333.py
+++ b/tests/integration/test_signal_connect_repro_2333.py
@@ -1,0 +1,176 @@
+"""#2333 daemon-side repro (#2334/#2337 T5).
+
+RUNNING + accepts_external_signals=True 봇을 ``BotManager.create_bot`` 로 만들고,
+``_run_signal_stream`` 에 in-memory reader 로 signal 프레임 1개를 흘려 (1) ack
+반환, (2) ``strategy.on_data`` 호출됨, (3) **OrderRequestEvent 정확히 1건이 daemon
+EventBus history**(manager 의 기존 ExternalSignalEvent→on_external_signal→
+_publish_signals 경유)를 검증한다. CLP의 import-removal 절반(CLI 자체 EventBus/
+BotManager 미구성 단언)은 #2338 PR#3 소관 — 본 PR 은 daemon-side repro 만.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+
+from ante.bot.config import BotConfig, BotStatus
+from ante.bot.manager import BotManager
+from ante.bot.signal_channel_registry import ChannelHandle, SignalChannelRegistry
+from ante.core.database import Database
+from ante.core.registry import ServiceRegistry
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import OrderRequestEvent
+from ante.ipc.server import IPCServer
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+pytestmark = pytest.mark.asyncio
+
+
+class _AcceptingStrategy(Strategy):
+    """on_data → 1 Signal(OrderRequestEvent 1건 유발) 전략."""
+
+    on_data_calls: list[dict] = []
+
+    meta = StrategyMeta(
+        name="accepting-repro",
+        version="1.0.0",
+        description="accepts external signals",
+        accepts_external_signals=True,
+    )
+
+    async def on_step(self, context: dict) -> list[Signal]:
+        return []
+
+    async def on_data(self, data: dict) -> list[Signal]:
+        type(self).on_data_calls.append(data)
+        return [
+            Signal(
+                symbol=data["symbol"],
+                side=data["action"],
+                quantity=1.0,
+                reason="external_repro",
+            )
+        ]
+
+
+def _frame_bytes(obj: dict) -> bytes:
+    payload = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+    return struct.pack("!I", len(payload)) + payload
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
+
+    def frames(self) -> list[dict]:
+        out: list[dict] = []
+        view = memoryview(self.buffer)
+        i = 0
+        while i + 4 <= len(view):
+            (length,) = struct.unpack("!I", view[i : i + 4])
+            i += 4
+            if i + length > len(view):
+                break
+            out.append(json.loads(bytes(view[i : i + length]).decode("utf-8")))
+            i += length
+        return out
+
+
+async def test_daemon_side_signal_to_order_request_repro_2333() -> None:
+    _AcceptingStrategy.on_data_calls = []
+
+    db = Database(":memory:")
+    await db.connect()
+    try:
+        bus = EventBus()
+        reg = SignalChannelRegistry()
+        manager = BotManager(
+            eventbus=bus,
+            db=db,
+            signal_channel_registry=reg,
+        )
+        await manager.initialize()
+
+        ctx = MagicMock()
+        ctx.get_positions.return_value = {}
+        ctx.get_balance.return_value = {"available": 1_000_000.0}
+
+        await manager.create_bot(
+            config=BotConfig(
+                bot_id="bot-1",
+                strategy_id="stg-1",
+                interval_seconds=60,
+                account_id="acc-test",
+            ),
+            strategy_cls=_AcceptingStrategy,
+            ctx=ctx,
+        )
+        bot = manager.get_bot("bot-1")
+        bot.strategy = _AcceptingStrategy(ctx=ctx)
+        bot.status = BotStatus.RUNNING
+
+        svc = ServiceRegistry(
+            account=MagicMock(),
+            bot_manager=manager,
+            treasury_manager=MagicMock(),
+            dynamic_config=MagicMock(),
+            approval=MagicMock(),
+            reconciler=MagicMock(),
+            eventbus=bus,
+            signal_channel_registry=reg,
+            audit_logger=None,
+        )
+        server = IPCServer("/tmp/unused.sock", svc, MagicMock())
+
+        reg.register(ChannelHandle(session_id="s1", bot_id="bot-1", generation=0))
+
+        reader = asyncio.StreamReader()
+        writer = _FakeWriter()
+        reader.feed_data(
+            _frame_bytes(
+                {"type": "signal", "symbol": "005930", "side": "buy", "confidence": 0.9}
+            )
+        )
+
+        task = asyncio.ensure_future(
+            server._run_signal_stream(reader, writer, "bot-1", "s1")  # type: ignore[arg-type]
+        )
+        # ack + on_data + OrderRequestEvent 가 나타날 때까지 yield(sleep 동기화 금지).
+        for _ in range(200):
+            await asyncio.sleep(0)
+            if any(f.get("type") == "ack" for f in writer.frames()):
+                break
+
+        reader.feed_eof()
+        await asyncio.wait_for(task, timeout=3.0)
+
+        # (1) ack 반환.
+        frames = writer.frames()
+        assert any(f.get("type") == "ack" for f in frames)
+        # (2) strategy.on_data 호출됨.
+        assert len(_AcceptingStrategy.on_data_calls) == 1
+        assert _AcceptingStrategy.on_data_calls[0]["symbol"] == "005930"
+        # (3) OrderRequestEvent 정확히 1건 daemon EventBus history.
+        history = bus.get_history(OrderRequestEvent)
+        assert len(history) == 1
+        assert history[0].bot_id == "bot-1"
+        assert history[0].symbol == "005930"
+        assert history[0].side == "buy"
+    finally:
+        await db.close()

--- a/tests/integration/test_signal_connect_stream.py
+++ b/tests/integration/test_signal_connect_stream.py
@@ -1,0 +1,304 @@
+"""signal.connect real-UDS 왕복 통합 (#2334/#2337 T4).
+
+real ``asyncio.start_unix_server`` IPCServer 위에서 핸드셰이크 wire strip → ack
+→ ping/pong, fill 왕복(타 bot_id 미도착·1:1 no-`\\n`), idle 무-timeout, daemon
+close('rotated'/'draining') closed frame 후 EOF, writer grace join(no hang) 을
+검증한다. sleep 동기화 금지(asyncio.Event/wait_for), /tmp UDS, settle teardown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ante.bot.config import BotConfig, BotStatus
+from ante.bot.manager import BotManager
+from ante.bot.signal_channel_registry import SignalChannelRegistry
+from ante.core.database import Database
+from ante.core.registry import ServiceRegistry
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import OrderFilledEvent
+from ante.ipc.registry import CommandRegistry, _handle_signal_connect
+from ante.ipc.server import IPCServer
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+pytestmark = pytest.mark.asyncio
+
+
+class _AcceptingStrategy(Strategy):
+    meta = StrategyMeta(
+        name="accepting",
+        version="1.0.0",
+        description="accepts external signals",
+        accepts_external_signals=True,
+    )
+
+    async def on_step(self, context: dict) -> list[Signal]:
+        return []
+
+    async def on_data(self, data: dict) -> list[Signal]:
+        return []
+
+
+async def _read_frame(reader: asyncio.StreamReader) -> dict:
+    raw = await reader.readexactly(4)
+    (length,) = struct.unpack("!I", raw)
+    body = await reader.readexactly(length)
+    return json.loads(body.decode("utf-8"))
+
+
+async def _read_frame_bytes(reader: asyncio.StreamReader) -> bytes:
+    raw = await reader.readexactly(4)
+    (length,) = struct.unpack("!I", raw)
+    return await reader.readexactly(length)
+
+
+async def _write_frame(writer: asyncio.StreamWriter, obj: dict) -> None:
+    payload = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+    writer.write(struct.pack("!I", len(payload)) + payload)
+    await writer.drain()
+
+
+class _Harness:
+    def __init__(self) -> None:
+        self.db: Database | None = None
+        self.server: IPCServer | None = None
+        self.bus = EventBus()
+        self.reg = SignalChannelRegistry()
+        self.manager: BotManager | None = None
+
+    async def setup(self, socket_path: str, *, signal_key: str = "sk_test") -> None:
+        self.db = Database(":memory:")
+        await self.db.connect()
+
+        skm = MagicMock()
+        skm.validate_signal_key = None  # 사용 안 함(아래 manager 직접 mock).
+        self.manager = BotManager(
+            eventbus=self.bus,
+            db=self.db,
+            signal_channel_registry=self.reg,
+        )
+        await self.manager.initialize()
+
+        ctx = MagicMock()
+        ctx.get_positions.return_value = {}
+        ctx.get_balance.return_value = {"available": 1_000_000.0}
+
+        await self.manager.create_bot(
+            config=BotConfig(
+                bot_id="bot-1",
+                strategy_id="stg-1",
+                interval_seconds=60,
+                account_id="acc-test",
+            ),
+            strategy_cls=_AcceptingStrategy,
+            ctx=ctx,
+        )
+        bot = self.manager.get_bot("bot-1")
+        bot.strategy = _AcceptingStrategy(ctx=ctx)
+        bot.status = BotStatus.RUNNING
+
+        # signal key 검증을 고정 키로 mock(키 관리는 본 테스트 범위 밖).
+        async def _validate(key: str) -> str | None:
+            return "bot-1" if key == signal_key else None
+
+        self.manager.validate_signal_key = _validate  # type: ignore[method-assign]
+
+        svc = ServiceRegistry(
+            account=MagicMock(),
+            bot_manager=self.manager,
+            treasury_manager=MagicMock(),
+            dynamic_config=MagicMock(),
+            approval=MagicMock(),
+            reconciler=MagicMock(),
+            eventbus=self.bus,
+            signal_channel_registry=self.reg,
+            audit_logger=None,
+        )
+        cmd_reg = CommandRegistry()
+        cmd_reg.register(
+            "signal.connect",
+            _handle_signal_connect,
+            is_mutating=False,
+            result_kind="stream",
+            required_services=frozenset({"bot_manager"}),
+            account_id_policy="none",
+        )
+        self.server = IPCServer(socket_path, svc, cmd_reg)
+        await self.server.start()
+
+    async def teardown(self) -> None:
+        if self.server is not None:
+            await self.server.stop()
+        if self.db is not None:
+            await self.db.close()
+
+
+@pytest.fixture
+def socket_path() -> str:
+    td = tempfile.mkdtemp(prefix="sig-int", dir="/tmp")
+    return str(Path(td) / "t.sock")
+
+
+async def _handshake(
+    socket_path: str, key: str = "sk_test"
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, dict]:
+    reader, writer = await asyncio.open_unix_connection(socket_path)
+    await _write_frame(
+        writer, {"id": "h1", "command": "signal.connect", "args": {"key": key}}
+    )
+    ack = await asyncio.wait_for(_read_frame(reader), timeout=2.0)
+    return reader, writer, ack
+
+
+# ── 핸드셰이크 + ping/pong ───────────────────────────────────────────
+
+
+async def test_handshake_ack_then_ping_pong(socket_path: str) -> None:
+    h = _Harness()
+    await h.setup(socket_path)
+    try:
+        reader, writer, ack = await _handshake(socket_path)
+        assert ack["status"] == "ok"
+        assert ack["result"]["bot_id"] == "bot-1"
+        assert "_stream" not in ack["result"]  # 센티넬 strip.
+
+        await _write_frame(writer, {"type": "ping"})
+        pong = await asyncio.wait_for(_read_frame(reader), timeout=2.0)
+        assert pong["type"] == "pong"
+
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        await h.teardown()
+
+
+# ── fill 왕복(타 bot_id 미도착·1:1 no-newline) ───────────────────────
+
+
+async def test_fill_roundtrip_isolated_by_bot_id(socket_path: str) -> None:
+    h = _Harness()
+    await h.setup(socket_path)
+    try:
+        reader, writer, _ = await _handshake(socket_path)
+
+        # bot-1 fill → 도착.
+        await h.bus.publish(
+            OrderFilledEvent(
+                order_id="ORD-1",
+                bot_id="bot-1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=58200.0,
+                commission=1.0,
+                account_id="acc-test",
+                fill_dedup_key="K1",
+            )
+        )
+        raw = await asyncio.wait_for(_read_frame_bytes(reader), timeout=2.0)
+        # 1:1 framing — payload 에 embedded newline 없음.
+        assert b"\n" not in raw
+        frame = json.loads(raw.decode("utf-8"))
+        assert frame["type"] == "fill"
+        assert frame["order_id"] == "ORD-1"
+
+        # 타 bot_id fill → 미도착(다음 read 가 timeout).
+        await h.bus.publish(
+            OrderFilledEvent(
+                order_id="ORD-OTHER",
+                bot_id="bot-999",
+                symbol="000660",
+                side="sell",
+                quantity=5.0,
+                price=100.0,
+                commission=0.5,
+                account_id="acc-test",
+                fill_dedup_key="K2",
+            )
+        )
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(reader.readexactly(4), timeout=0.3)
+
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        await h.teardown()
+
+
+# ── idle 무-timeout ──────────────────────────────────────────────────
+
+
+async def test_idle_stream_no_timeout(socket_path: str) -> None:
+    h = _Harness()
+    await h.setup(socket_path)
+    try:
+        reader, writer, _ = await _handshake(socket_path)
+        # 무전송 idle — daemon 이 close/EOF 하지 않는다.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(reader.read(1), timeout=0.3)
+        assert not reader.at_eof()
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        await h.teardown()
+
+
+# ── daemon close('rotated') → closed frame 후 EOF ────────────────────
+
+
+async def test_close_bot_rotated_emits_closed_then_eof(socket_path: str) -> None:
+    h = _Harness()
+    await h.setup(socket_path)
+    try:
+        reader, writer, _ = await _handshake(socket_path)
+        # adopt 완료 대기 — registry 에 active session.
+        for _ in range(100):
+            await asyncio.sleep(0)
+            handle = h.reg.get("bot-1", next(iter(h.reg._sessions["bot-1"])))
+            if handle is not None and handle.out_queue is not None:
+                break
+
+        h.reg.close_bot("bot-1", "rotated")
+        closed = await asyncio.wait_for(_read_frame(reader), timeout=2.0)
+        assert closed == {"type": "closed", "reason": "rotated"}
+        # closed frame 후 EOF(서버측 read_task 종료 → 연결 정리).
+        eof = await asyncio.wait_for(reader.read(), timeout=2.0)
+        assert eof == b""
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        await h.teardown()
+
+
+# ── shutdown sweep → {closed,draining} + drain ───────────────────────
+
+
+async def test_shutdown_sweep_draining(socket_path: str) -> None:
+    h = _Harness()
+    await h.setup(socket_path)
+    try:
+        reader, writer, _ = await _handshake(socket_path)
+        for _ in range(100):
+            await asyncio.sleep(0)
+            if h.reg.has_active_session("bot-1"):
+                handle = h.reg.get("bot-1", next(iter(h.reg._sessions["bot-1"])))
+                if handle is not None and handle.out_queue is not None:
+                    break
+
+        # shutdown sweep: freeze → close_all('draining') await-to-completion.
+        h.reg.freeze()
+        await asyncio.wait_for(h.reg.close_all("draining"), timeout=2.0)
+
+        closed = await asyncio.wait_for(_read_frame(reader), timeout=2.0)
+        assert closed == {"type": "closed", "reason": "draining"}
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        await h.teardown()

--- a/tests/unit/test_external_signal_subscription.py
+++ b/tests/unit/test_external_signal_subscription.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ante.bot.bot import Bot
-from ante.bot.config import BotConfig
+from ante.bot.config import BotConfig, BotStatus
 from ante.bot.manager import BotManager
 from ante.bot.signal_channel import SignalChannel
 from ante.core.database import Database
@@ -154,6 +154,10 @@ class TestBotManagerSignalSubscription:
         )
         # 전략 인스턴스 설정 (start() 없이도 on_external_signal 테스트 가능)
         bot.strategy = _AcceptingStrategy(ctx=ctx)
+        # #2337: on_external_signal 이 상태 재검증(RUNNING 아니면 거부)한다(#2333
+        # daemon-side fix). start() 없이 on_data 발화를 테스트하므로 RUNNING 을
+        # 명시한다(이전엔 default CREATED 였으나 가드 미존재로 통과했다).
+        bot.status = BotStatus.RUNNING
 
         event = ExternalSignalEvent(
             account_id="acc-test",

--- a/tests/unit/test_external_signals.py
+++ b/tests/unit/test_external_signals.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ante.account.errors import InvalidAccountIdError
+from ante.bot.config import BotStatus
 from ante.eventbus.events import ExternalSignalEvent
 from ante.strategy.base import Signal, Strategy, StrategyMeta
 from ante.strategy.validator import StrategyValidator
@@ -172,6 +173,10 @@ def _make_bot(strategy_cls: type[Strategy]) -> MagicMock:
 
     bot = Bot(config=config, strategy_cls=strategy_cls, ctx=ctx, eventbus=eventbus)
     bot.strategy = strategy_cls(ctx=ctx)
+    # #2337: on_external_signal 이 상태 재검증(RUNNING 아니면 거부)한다(#2333
+    # daemon-side fix). start() 없이 on_data 발화를 테스트하려면 RUNNING 을
+    # 명시해야 한다(이전엔 default CREATED 였으나 가드 미존재로 통과했다).
+    bot.status = BotStatus.RUNNING
 
     return bot
 

--- a/tests/unit/test_ipc_server_signal_stream.py
+++ b/tests/unit/test_ipc_server_signal_stream.py
@@ -1,0 +1,256 @@
+"""IPCServer._run_signal_stream host 단위 (#2334/#2337 T2/T3).
+
+in-memory reader/writer 로 host 를 구동해 ack 왕복, fill relay, finally
+teardown(mark_closed→_unsubscribe→unregister 정확히 1회), daemon-initiated
+close(rotated/draining) closed frame, EOF graceful 종료를 lock 한다. real
+socket 은 integration(T4) 에서 검증. sleep 금지.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+
+from ante.bot.signal_channel_registry import ChannelHandle, SignalChannelRegistry
+from ante.core.registry import ServiceRegistry
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import OrderFilledEvent
+from ante.ipc.server import IPCServer
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeWriter:
+    """write+drain 캡처용 fake StreamWriter (frame bytes 누적)."""
+
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+    def frames(self) -> list[dict]:
+        """누적 buffer 를 length-prefixed 프레임 dict 리스트로 디코드."""
+        out: list[dict] = []
+        view = memoryview(self.buffer)
+        i = 0
+        while i + 4 <= len(view):
+            (length,) = struct.unpack("!I", view[i : i + 4])
+            i += 4
+            if i + length > len(view):
+                break
+            out.append(json.loads(bytes(view[i : i + length]).decode("utf-8")))
+            i += length
+        return out
+
+
+def _frame_bytes(obj: dict) -> bytes:
+    payload = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+    return struct.pack("!I", len(payload)) + payload
+
+
+def _make_bot(bus: EventBus) -> MagicMock:
+    bot = MagicMock()
+    bot.bot_id = "bot-1"
+    bot.config.account_id = "acc-test"
+    bot._ctx = MagicMock()
+    return bot
+
+
+def _make_server(
+    bus: EventBus, reg: SignalChannelRegistry | None, bot: MagicMock
+) -> IPCServer:
+    bm = MagicMock()
+    bm.get_bot = MagicMock(return_value=bot)
+    svc = ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=bm,
+        treasury_manager=MagicMock(),
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=bus,
+        signal_channel_registry=reg,
+    )
+    return IPCServer("/tmp/unused.sock", svc, MagicMock())
+
+
+# ── ack 왕복 + fill relay ────────────────────────────────────────────
+
+
+async def test_signal_frame_acked_and_fill_relayed() -> None:
+    bus = EventBus()
+    reg = SignalChannelRegistry()
+    bot = _make_bot(bus)
+    # 전략 on_external_signal 구독은 본 테스트 범위 밖 — daemon-side relay 만 검증.
+    handle = ChannelHandle(session_id="s1", bot_id="bot-1", generation=0)
+    reg.register(handle)
+    server = _make_server(bus, reg, bot)
+
+    reader = asyncio.StreamReader()
+    writer = _FakeWriter()
+    # signal 프레임 1개 후 EOF.
+    reader.feed_data(_frame_bytes({"type": "ping"}))
+
+    async def _drive() -> None:
+        await server._run_signal_stream(reader, writer, "bot-1", "s1")  # type: ignore[arg-type]
+
+    task = asyncio.ensure_future(_drive())
+    # ping → pong relay 가 buffer 에 나타날 때까지 폴링 대신 짧은 yield.
+    for _ in range(50):
+        await asyncio.sleep(0)
+        if any(f.get("type") == "pong" for f in writer.frames()):
+            break
+
+    # fill publish → daemon relay 로 fill 프레임 enqueue.
+    await bus.publish(
+        OrderFilledEvent(
+            order_id="ORD-1",
+            bot_id="bot-1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=58200.0,
+            commission=1.0,
+            account_id="acc-test",
+            fill_dedup_key="K1",
+        )
+    )
+    for _ in range(50):
+        await asyncio.sleep(0)
+        if any(f.get("type") == "fill" for f in writer.frames()):
+            break
+
+    reader.feed_eof()
+    await asyncio.wait_for(task, timeout=2.0)
+
+    frames = writer.frames()
+    assert any(f.get("type") == "pong" for f in frames)
+    assert any(f.get("type") == "fill" and f.get("order_id") == "ORD-1" for f in frames)
+    # finally: unregister 정확히 1회 → _sessions 비움.
+    assert reg.has_active_session("bot-1") is False
+
+
+# ── finally teardown — EOF 경로 정확히 1회 ───────────────────────────
+
+
+async def test_eof_finally_unsubscribes_and_unregisters_once() -> None:
+    bus = EventBus()
+    reg = SignalChannelRegistry()
+    bot = _make_bot(bus)
+    handle = ChannelHandle(session_id="s1", bot_id="bot-1", generation=0)
+    reg.register(handle)
+    server = _make_server(bus, reg, bot)
+
+    reader = asyncio.StreamReader()
+    writer = _FakeWriter()
+    reader.feed_eof()  # 즉시 EOF.
+
+    await asyncio.wait_for(
+        server._run_signal_stream(reader, writer, "bot-1", "s1"),  # type: ignore[arg-type]
+        timeout=2.0,
+    )
+    # unregister 1회 — 세션 비움. 잔여 핸들러 0(unsubscribe).
+    assert reg.has_active_session("bot-1") is False
+    assert len(bus._handlers.get(OrderFilledEvent, [])) == 0
+
+
+# ── daemon-initiated close → closed frame ────────────────────────────
+
+
+async def test_close_bot_emits_closed_frame_and_unregisters() -> None:
+    bus = EventBus()
+    reg = SignalChannelRegistry()
+    bot = _make_bot(bus)
+    handle = ChannelHandle(session_id="s1", bot_id="bot-1", generation=0)
+    reg.register(handle)
+    server = _make_server(bus, reg, bot)
+
+    reader = asyncio.StreamReader()
+    writer = _FakeWriter()
+
+    task = asyncio.ensure_future(
+        server._run_signal_stream(reader, writer, "bot-1", "s1")  # type: ignore[arg-type]
+    )
+    # adopt 가 끝날 때까지 yield(handle.out_queue 바인딩 대기).
+    for _ in range(50):
+        await asyncio.sleep(0)
+        if handle.out_queue is not None:
+            break
+
+    # daemon-initiated close — closed frame force-slot + closing_event set.
+    reg.close_bot("bot-1", "rotated")
+
+    await asyncio.wait_for(task, timeout=2.0)
+    frames = writer.frames()
+    assert frames[-1] == {"type": "closed", "reason": "rotated"}
+    assert reg.has_active_session("bot-1") is False
+
+
+# ── adopt-time generation re-check self-close (F4) ───────────────────
+
+
+async def test_rotate_in_window_self_close_on_adopt() -> None:
+    """register 후 stream 진입 전 generation bump → adopt 가 self-close(rotated)."""
+    bus = EventBus()
+    reg = SignalChannelRegistry()
+    bot = _make_bot(bus)
+    # register 시 generation 0 스냅샷.
+    handle = ChannelHandle(
+        session_id="s1", bot_id="bot-1", generation=reg.current_generation("bot-1")
+    )
+    reg.register(handle)
+    # rotate-in-window: stream 진입 전 generation bump.
+    reg.bump_generation("bot-1")
+    server = _make_server(bus, reg, bot)
+
+    reader = asyncio.StreamReader()
+    writer = _FakeWriter()
+
+    await asyncio.wait_for(
+        server._run_signal_stream(reader, writer, "bot-1", "s1"),  # type: ignore[arg-type]
+        timeout=2.0,
+    )
+    frames = writer.frames()
+    # 풀 루프 미진입 — single closed frame(rotated) 후 종료.
+    assert frames == [{"type": "closed", "reason": "rotated"}]
+    assert reg.has_active_session("bot-1") is False
+    assert len(bus._handlers.get(OrderFilledEvent, [])) == 0
+
+
+# ── headless (reg=None) — adopt/unregister 스킵, crash 없음 ───────────
+
+
+async def test_headless_no_registry_drives_and_eof() -> None:
+    bus = EventBus()
+    bot = _make_bot(bus)
+    server = _make_server(bus, None, bot)
+
+    reader = asyncio.StreamReader()
+    writer = _FakeWriter()
+    reader.feed_data(_frame_bytes({"type": "ping"}))
+
+    task = asyncio.ensure_future(
+        server._run_signal_stream(reader, writer, "bot-1", "s1")  # type: ignore[arg-type]
+    )
+    for _ in range(50):
+        await asyncio.sleep(0)
+        if any(f.get("type") == "pong" for f in writer.frames()):
+            break
+    reader.feed_eof()
+    await asyncio.wait_for(task, timeout=2.0)
+    assert any(f.get("type") == "pong" for f in writer.frames())

--- a/tests/unit/test_signal_channel_outbound.py
+++ b/tests/unit/test_signal_channel_outbound.py
@@ -1,0 +1,206 @@
+"""SignalChannel 데몬 outbound 데이터플레인 단위 (#2334/#2337 T3).
+
+sink/is_full/on_lagged seam, ``_closed`` no-op(stale-publish layer2), full-laggard
+(seen 미마킹·재전달 보존), ``__contains__`` non-mutating, dedup-after-enqueue,
+real EventBus + full queue 무stall(INV-OUT-2/6) 를 lock 한다. sleep 금지.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ante.bot.signal_channel import SignalChannel
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import OrderFilledEvent, OrderRejectedEvent
+from ante.eventbus.fill_dedup_guard import FillDedupGuard
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_channel(
+    *,
+    sink: list[dict] | None = None,
+    is_full: bool = False,
+    on_lagged_calls: list[int] | None = None,
+):
+    """sink 콜백을 list append 로, is_full 을 상수 콜백으로 주입한 채널."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    bot = MagicMock()
+    bot.bot_id = "bot-001"
+    bot.config.account_id = "acc-test"
+    eventbus = MagicMock()
+    eventbus.publish = AsyncMock()
+    eventbus.subscribe = MagicMock()
+    eventbus.unsubscribe = MagicMock()
+    ctx = MagicMock()
+
+    captured = sink if sink is not None else []
+    lagged = on_lagged_calls if on_lagged_calls is not None else []
+
+    def _on_lagged() -> None:
+        lagged.append(1)
+
+    ch = SignalChannel(
+        bot,
+        eventbus,
+        ctx,
+        sink=captured.append,
+        is_full=lambda: is_full,
+        on_lagged=_on_lagged,
+    )
+    return ch, captured, lagged
+
+
+def _fill(key: str = "K1") -> OrderFilledEvent:
+    return OrderFilledEvent(
+        order_id="ORD-1",
+        bot_id="bot-001",
+        symbol="005930",
+        side="buy",
+        quantity=10.0,
+        price=58200.0,
+        commission=87.3,
+        account_id="acc-test",
+        fill_dedup_key=key,
+    )
+
+
+# ── _closed no-op (stale-publish layer2) ─────────────────────────────
+
+
+async def test_closed_channel_on_fill_no_op() -> None:
+    ch, captured, _ = _make_channel()
+    ch.mark_closed()
+    await ch._on_fill(_fill())
+    assert captured == []  # sink 미호출.
+
+
+async def test_closed_channel_on_order_update_no_op() -> None:
+    ch, captured, _ = _make_channel()
+    ch.mark_closed()
+    await ch._on_order_update(
+        OrderRejectedEvent(
+            order_id="ORD-2", bot_id="bot-001", reason="x", account_id="acc-test"
+        )
+    )
+    assert captured == []
+
+
+# ── full-laggard (seen 미마킹·재전달 보존) ───────────────────────────
+
+
+async def test_full_queue_schedules_lagged_and_does_not_mark_seen() -> None:
+    lagged: list[int] = []
+    ch, captured, lagged = _make_channel(is_full=True, on_lagged_calls=lagged)
+    await ch._on_fill(_fill(key="K1"))
+    # full → schedule_lagged 1회, sink 미호출, seen 미마킹.
+    assert captured == []
+    assert len(lagged) == 1
+    assert "K1" not in ch._fill_dedup_guard  # 재전달 보존.
+
+
+async def test_lagged_redelivery_after_recovery() -> None:
+    """full 로 drop 됐던 fill 은 seen 미마킹이라 큐 회복 후 재전달된다."""
+    captured: list[dict] = []
+    # 1차: full → drop(미마킹).
+    ch, captured, _ = _make_channel(sink=captured, is_full=True)
+    await ch._on_fill(_fill(key="K1"))
+    assert captured == []
+    # _schedule_lagged 가 _closed 를 flip 하므로 회복 재현은 새 채널로 검증.
+    ch2, captured2, _ = _make_channel(is_full=False)
+    await ch2._on_fill(_fill(key="K1"))
+    assert len(captured2) == 1
+    assert captured2[0]["fill_dedup_key"] == "K1"
+
+
+# ── __contains__ non-mutating ────────────────────────────────────────
+
+
+async def test_contains_is_non_mutating() -> None:
+    guard = FillDedupGuard()
+    assert ("K1" in guard) is False
+    # 단순 멤버십 조회는 상태를 바꾸지 않는다 — 반복 조회 후에도 미마킹.
+    assert ("K1" in guard) is False
+    assert guard.seen_or_add("K1") is False  # 처음 추가.
+    assert ("K1" in guard) is True
+    assert guard.seen_or_add("K1") is True  # 이미 처리됨.
+
+
+# ── dedup-after-enqueue (INV-OUT-4) ──────────────────────────────────
+
+
+async def test_dedup_mark_after_enqueue_commits_on_success() -> None:
+    ch, captured, _ = _make_channel(is_full=False)
+    await ch._on_fill(_fill(key="K1"))
+    await ch._on_fill(_fill(key="K1"))
+    # enqueue 성공 후 seen 커밋 → 두 번째는 read-only 게이트에서 skip.
+    assert len(captured) == 1
+    assert "K1" in ch._fill_dedup_guard
+
+
+async def test_empty_key_not_deduped() -> None:
+    ch, captured, _ = _make_channel(is_full=False)
+    await ch._on_fill(_fill(key=""))
+    await ch._on_fill(_fill(key=""))
+    assert len(captured) == 2  # 빈키는 dedup 비대상.
+
+
+# ── real EventBus + full queue 무stall (INV-OUT-2/6) ─────────────────
+
+
+async def test_real_eventbus_full_queue_does_not_stall_publish() -> None:
+    """real EventBus 핸들러 inline 에서 out_queue full 이어도 publish 무stall·미전파."""
+    bus = EventBus()
+
+    from unittest.mock import MagicMock
+
+    bot = MagicMock()
+    bot.bot_id = "bot-001"
+    bot.config.account_id = "acc-test"
+    ctx = MagicMock()
+
+    out_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=1)
+    out_queue.put_nowait({"type": "filler"})  # 미리 채워 full.
+    lagged: list[int] = []
+
+    def _enqueue(frame: dict) -> None:
+        try:
+            out_queue.put_nowait(frame)
+        except asyncio.QueueFull:
+            lagged.append(1)
+
+    ch = SignalChannel(
+        bot,
+        bus,
+        ctx,
+        sink=_enqueue,
+        is_full=out_queue.full,
+        on_lagged=lambda: lagged.append(1),
+    )
+    ch._subscribe_events()
+
+    # full queue 에서 fill publish — 핸들러 inline 이 QueueFull 을 격리(미전파).
+    await asyncio.wait_for(bus.publish(_fill(key="K1")), timeout=1.0)
+    # publish 가 정상 완료(예외 미전파) + is_full 게이트가 schedule_lagged 발화.
+    assert len(lagged) >= 1
+    ch._unsubscribe_events()
+
+
+# ── writer MessageTooLargeError non-fatal (INV-OUT-7) ────────────────
+
+
+async def test_metadata_too_large_dropped_non_fatal() -> None:
+    """거대 metadata signal 은 publish 안 하고 비치명 error 후 채널 유지."""
+    ch, captured, _ = _make_channel(is_full=False)
+    huge = {"type": "signal", "symbol": "005930", "side": "buy"}
+    # 64 keys 초과 metadata.
+    for i in range(100):
+        huge[f"k{i}"] = i
+    await ch._handle_message(huge)
+    # publish 안 함 — eventbus.publish 미호출.
+    ch._eventbus.publish.assert_not_called()  # type: ignore[attr-defined]
+    # 비치명 error 1프레임.
+    assert any(f.get("type") == "error" for f in captured)

--- a/tests/unit/test_signal_channel_registry.py
+++ b/tests/unit/test_signal_channel_registry.py
@@ -1,0 +1,202 @@
+"""SignalChannelRegistry / ChannelHandle 단위 테스트 (#2334/#2337 T2).
+
+register atomic check-and-insert(단일-connect), unregister inner-dict 정리,
+close_bot snapshot 순회·idempotent, freeze, generation, ChannelHandle 2단계
+생명주기(placeholder close → reason 래치, adopted close → frame+event), close_all
+join-to-completion 을 lock 한다. sleep 금지(asyncio.Event/Queue + wait_for).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ante.bot.exceptions import BotSignalChannelBusy, SignalChannelRegistryFrozen
+from ante.bot.signal_channel_registry import ChannelHandle, SignalChannelRegistry
+
+pytestmark = pytest.mark.asyncio
+
+
+def _handle(
+    bot_id: str = "bot-1", session_id: str = "s1", generation: int = 0
+) -> ChannelHandle:
+    return ChannelHandle(session_id=session_id, bot_id=bot_id, generation=generation)
+
+
+# ── register / has_active_session / unregister ───────────────────────
+
+
+async def test_register_then_has_active_session() -> None:
+    reg = SignalChannelRegistry()
+    assert reg.has_active_session("bot-1") is False
+    reg.register(_handle())
+    assert reg.has_active_session("bot-1") is True
+    assert reg.get("bot-1", "s1") is not None
+
+
+async def test_second_same_bot_register_raises_busy() -> None:
+    reg = SignalChannelRegistry()
+    reg.register(_handle(session_id="s1"))
+    with pytest.raises(BotSignalChannelBusy) as ei:
+        reg.register(_handle(session_id="s2"))
+    # keyless 메시지(bot_id/session_id 비노출) + stable code.
+    assert ei.value.code == "BOT_SIGNAL_CHANNEL_BUSY"
+    assert "bot-1" not in str(ei.value)
+    assert "s2" not in str(ei.value)
+
+
+async def test_register_frozen_raises() -> None:
+    reg = SignalChannelRegistry()
+    reg.freeze()
+    with pytest.raises(SignalChannelRegistryFrozen):
+        reg.register(_handle())
+    # 누수 0 — 등록 안 됨.
+    assert reg.has_active_session("bot-1") is False
+
+
+async def test_unregister_cleans_inner_dict() -> None:
+    reg = SignalChannelRegistry()
+    reg.register(_handle())
+    reg.unregister("bot-1", "s1")
+    assert reg.has_active_session("bot-1") is False
+    # inner dict 정리로 같은 bot 재등록 가능(BUSY 아님).
+    reg.register(_handle())
+    assert reg.has_active_session("bot-1") is True
+
+
+async def test_unregister_missing_key_no_op() -> None:
+    reg = SignalChannelRegistry()
+    # 미등록 bot/session — raise 안 함(멱등).
+    reg.unregister("bot-x", "s-x")
+    reg.register(_handle())
+    reg.unregister("bot-1", "s1")
+    # 두 번째 unregister 도 no-op.
+    reg.unregister("bot-1", "s1")
+    assert reg.has_active_session("bot-1") is False
+
+
+# ── generation (rotate-in-window) ────────────────────────────────────
+
+
+async def test_generation_starts_zero_and_bumps() -> None:
+    reg = SignalChannelRegistry()
+    assert reg.current_generation("bot-1") == 0
+    reg.bump_generation("bot-1")
+    assert reg.current_generation("bot-1") == 1
+    reg.bump_generation("bot-1")
+    assert reg.current_generation("bot-1") == 2
+
+
+# ── close_bot (snapshot·idempotent·unregister 안 함) ──────────────────
+
+
+async def test_close_bot_counts_and_idempotent() -> None:
+    reg = SignalChannelRegistry()
+    reg.register(_handle())
+    assert reg.close_bot("bot-1", "rotated") == 1
+    # 2nd close — first-wins, 0건.
+    assert reg.close_bot("bot-1", "rotated") == 0
+    # close_bot 은 unregister 하지 않는다(스트림 finally 소유).
+    assert reg.has_active_session("bot-1") is True
+
+
+async def test_close_bot_missing_bot_returns_zero() -> None:
+    reg = SignalChannelRegistry()
+    assert reg.close_bot("bot-x", "deleted") == 0
+
+
+# ── ChannelHandle 2단계 생명주기 ─────────────────────────────────────
+
+
+async def test_placeholder_close_latches_pending_reason() -> None:
+    """adopt 전(데이터플레인 None) close → reason 만 래치(frame/event 없음)."""
+    handle = _handle()
+    assert handle.out_queue is None
+    assert handle.close("rotated") is True
+    assert handle.closed is True
+    assert handle.close_reason == "rotated"
+    assert handle._pending_close_reason == "rotated"
+    # 2nd close — first-wins.
+    assert handle.close("deleted") is False
+    assert handle.close_reason == "rotated"
+
+
+async def test_adopted_close_force_slots_frame_and_sets_event() -> None:
+    """adopt 후 close → on_closed 호출 + closed frame force-slot + closing_event."""
+    handle = _handle()
+    out_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=4)
+    closing_event = asyncio.Event()
+    closed_flag = {"called": False}
+
+    def _on_closed() -> None:
+        closed_flag["called"] = True
+
+    handle.out_queue = out_queue
+    handle.on_closed = _on_closed
+    handle.closing_event = closing_event
+
+    assert handle.close("rotated") is True
+    assert closed_flag["called"] is True
+    assert closing_event.is_set() is True
+    frame = out_queue.get_nowait()
+    assert frame == {"type": "closed", "reason": "rotated"}
+
+
+async def test_adopted_close_queue_full_drops_one_then_enqueues() -> None:
+    """out_queue full 이어도 closed frame 은 force-slot(1 drop 후 enqueue)."""
+    handle = _handle()
+    out_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=2)
+    out_queue.put_nowait({"type": "fill", "n": 1})
+    out_queue.put_nowait({"type": "fill", "n": 2})
+    handle.out_queue = out_queue
+    handle.closing_event = asyncio.Event()
+
+    assert handle.close("lagged") is True
+    # 가장 오래된 1개 drop → 두 번째 fill + closed frame.
+    frames = [out_queue.get_nowait(), out_queue.get_nowait()]
+    assert {"type": "fill", "n": 2} in frames
+    assert {"type": "closed", "reason": "lagged"} in frames
+
+
+# ── close_all (await-to-completion) ──────────────────────────────────
+
+
+async def test_close_all_closes_and_joins_to_completion() -> None:
+    """close_all → 각 handle close(draining) + read/writer task join-to-completion.
+
+    supervisor 를 모사해 ``closing_event`` set 시 read_task 가 자연 종료하도록
+    한다(flush-before-cancel 양보). join 은 grace 안에 자연 정리를 await 한다.
+    """
+    reg = SignalChannelRegistry()
+    handle = _handle()
+    handle.out_queue = asyncio.Queue(maxsize=8)
+    closing_event = asyncio.Event()
+    handle.closing_event = closing_event
+
+    started = asyncio.Event()
+    naturally_exited = asyncio.Event()
+
+    async def _fake_read() -> None:
+        started.set()
+        # supervisor 모사 — closing_event set 되면 자연 종료.
+        await closing_event.wait()
+        naturally_exited.set()
+
+    read_task = asyncio.ensure_future(_fake_read())
+    handle.read_task = read_task
+    reg.register(handle)
+
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    # close_all 은 close(draining)(closing_event set) + join(자연 정리 await).
+    await asyncio.wait_for(reg.close_all("draining"), timeout=2.0)
+
+    assert handle.closed is True
+    assert handle.close_reason == "draining"
+    assert read_task.done()
+    assert naturally_exited.is_set() is True
+
+
+async def test_close_all_empty_registry_no_error() -> None:
+    reg = SignalChannelRegistry()
+    await asyncio.wait_for(reg.close_all("draining"), timeout=1.0)

--- a/tests/unit/test_signal_connect_audit.py
+++ b/tests/unit/test_signal_connect_audit.py
@@ -1,0 +1,117 @@
+"""signal.connect manual connect-audit + redaction (#2334 §8 / #2337).
+
+핸드셰이크-OK 시 정확히 1회 ``log(member_id='ipc', action='signal.connect',
+resource='bot:<id>')``, 게이트 실패 시 0회, headless 무크래시, invalid-key
+caplog 에 ``sk_`` 미등장 + expected-exc ERROR traceback 부재를 lock 한다.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.bot.config import BotStatus
+from ante.bot.exceptions import InvalidSignalKey
+from ante.bot.signal_channel_registry import SignalChannelRegistry
+from ante.core.registry import ServiceRegistry
+from ante.ipc.registry import _handle_signal_connect
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_bot() -> MagicMock:
+    bot = MagicMock()
+    bot.config.account_id = "acc-live"
+    bot.status = BotStatus.RUNNING
+    bot.strategy.meta.accepts_external_signals = True
+    return bot
+
+
+def _svc(*, audit_logger: object | None, valid_key: bool = True) -> ServiceRegistry:
+    bm = MagicMock()
+    bm.validate_signal_key = AsyncMock(return_value="bot-1" if valid_key else None)
+    bm.get_bot = MagicMock(return_value=_make_bot())
+    return ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=bm,
+        treasury_manager=MagicMock(),
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=MagicMock(),
+        signal_channel_registry=SignalChannelRegistry(),
+        audit_logger=audit_logger,
+    )
+
+
+async def test_handshake_ok_logs_connect_audit_once() -> None:
+    audit = MagicMock()
+    audit.log = AsyncMock()
+    svc = _svc(audit_logger=audit)
+
+    await _handle_signal_connect(svc, {"key": "sk_secret"}, "ipc")
+
+    audit.log.assert_awaited_once()
+    kwargs = audit.log.await_args.kwargs
+    assert kwargs["member_id"] == "ipc"
+    assert kwargs["action"] == "signal.connect"
+    assert kwargs["resource"] == "bot:bot-1"
+    # detail 에 키 비노출.
+    assert "sk_" not in str(kwargs)
+
+
+async def test_gate_failure_does_not_log_audit() -> None:
+    audit = MagicMock()
+    audit.log = AsyncMock()
+    svc = _svc(audit_logger=audit, valid_key=False)
+
+    with pytest.raises(InvalidSignalKey):
+        await _handle_signal_connect(svc, {"key": "sk_bad"}, "ipc")
+
+    audit.log.assert_not_awaited()
+
+
+async def test_headless_no_audit_logger_no_crash() -> None:
+    svc = _svc(audit_logger=None)
+    result = await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+    assert result["bot_id"] == "bot-1"
+
+
+async def test_invalid_key_dispatch_warns_without_sk_or_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """invalid-key 거부는 구조화 WARNING — caplog 에 sk_ 미등장·ERROR traceback 부재."""
+    from ante.ipc.registry import CommandRegistry
+    from ante.ipc.server import IPCServer, IPCServerState
+
+    svc = _svc(audit_logger=None, valid_key=False)
+    cmd_reg = CommandRegistry()
+    cmd_reg.register(
+        "signal.connect",
+        _handle_signal_connect,
+        is_mutating=False,
+        result_kind="stream",
+        required_services=frozenset({"bot_manager"}),
+        account_id_policy="none",
+    )
+    server = IPCServer("/tmp/unused.sock", svc, cmd_reg)
+    server._state = IPCServerState.RUNNING
+
+    with caplog.at_level(logging.WARNING, logger="ante.ipc.server"):
+        resp = await server._dispatch(
+            {"id": "h1", "command": "signal.connect", "args": {"key": "sk_bad"}}
+        )
+
+    assert resp["error"]["code"] == "INVALID_SIGNAL_KEY"
+    # expected-exc 는 WARNING 1줄(traceback 없는 구조화). ERROR/exception 부재.
+    assert any(
+        rec.levelno == logging.WARNING and "handshake rejected" in rec.message
+        for rec in caplog.records
+    )
+    assert not any(rec.levelno >= logging.ERROR for rec in caplog.records)
+    # caplog 전체에 sk_ 미등장(키 비노출).
+    assert "sk_" not in caplog.text
+    # expected-exc 는 exc_info(traceback) 미부착.
+    assert all(rec.exc_info is None for rec in caplog.records)

--- a/tests/unit/test_signal_connect_busy.py
+++ b/tests/unit/test_signal_connect_busy.py
@@ -1,0 +1,123 @@
+"""signal.connect 단일-connect Phase-B BUSY envelope (#2334/#2337).
+
+핸드셰이크 핸들러가 register atomic check-and-insert 로 같은 bot 의 두 번째
+핸드셰이크를 ``BotSignalChannelBusy`` 로 거부하고, IPC ``_dispatch`` 가
+``BOT_SIGNAL_CHANNEL_BUSY`` envelope(stable code, 키/식별자 비노출)으로 변환함을
+lock 한다. frozen 거부도 검증한다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.bot.exceptions import BotSignalChannelBusy, SignalChannelRegistryFrozen
+from ante.bot.signal_channel_registry import SignalChannelRegistry
+from ante.core.registry import ServiceRegistry
+from ante.ipc.registry import _handle_signal_connect
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_bot(*, account_id: str = "acc-live") -> MagicMock:
+    bot = MagicMock()
+    bot.config.account_id = account_id
+    from ante.bot.config import BotStatus
+
+    bot.status = BotStatus.RUNNING
+    bot.strategy.meta.accepts_external_signals = True
+    return bot
+
+
+def _svc(reg: SignalChannelRegistry | None) -> ServiceRegistry:
+    bm = MagicMock()
+    bm.validate_signal_key = AsyncMock(return_value="bot-1")
+    bm.get_bot = MagicMock(return_value=_make_bot())
+    return ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=bm,
+        treasury_manager=MagicMock(),
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=MagicMock(),
+        signal_channel_registry=reg,
+        audit_logger=None,
+    )
+
+
+async def test_first_connect_registers_and_returns_session() -> None:
+    reg = SignalChannelRegistry()
+    svc = _svc(reg)
+    result = await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+    assert result["bot_id"] == "bot-1"
+    assert result["_stream"] == "signal.connect"
+    assert "session_id" in result
+    assert reg.has_active_session("bot-1") is True
+
+
+async def test_second_connect_raises_busy() -> None:
+    reg = SignalChannelRegistry()
+    svc = _svc(reg)
+    await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+    with pytest.raises(BotSignalChannelBusy) as ei:
+        await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+    assert ei.value.code == "BOT_SIGNAL_CHANNEL_BUSY"
+
+
+async def test_busy_envelope_via_dispatch_redacts_identifiers() -> None:
+    """server _dispatch 가 BUSY → BOT_SIGNAL_CHANNEL_BUSY envelope(키 비노출)."""
+    import json
+
+    from ante.ipc.registry import CommandRegistry
+    from ante.ipc.server import IPCServer
+
+    reg = SignalChannelRegistry()
+    svc = _svc(reg)
+    cmd_reg = CommandRegistry()
+    cmd_reg.register(
+        "signal.connect",
+        _handle_signal_connect,
+        is_mutating=False,
+        result_kind="stream",
+        required_services=frozenset({"bot_manager"}),
+        account_id_policy="none",
+    )
+    server = IPCServer("/tmp/unused.sock", svc, cmd_reg)
+    # _dispatch lifecycle gate 통과를 위해 RUNNING 으로 둔다(start() 없이 단위).
+    from ante.ipc.server import IPCServerState
+
+    server._state = IPCServerState.RUNNING
+
+    # 1st OK.
+    ok = await server._dispatch(
+        {"id": "h1", "command": "signal.connect", "args": {"key": "sk_x"}}
+    )
+    assert ok["status"] == "ok"
+    # 2nd → BUSY envelope.
+    busy = await server._dispatch(
+        {"id": "h2", "command": "signal.connect", "args": {"key": "sk_x"}}
+    )
+    assert busy["status"] == "error"
+    assert busy["error"]["code"] == "BOT_SIGNAL_CHANNEL_BUSY"
+    # 키/식별자 비노출.
+    assert "sk_" not in json.dumps(busy)
+    assert "bot-1" not in busy["error"]["message"]
+
+
+async def test_frozen_registry_rejects_connect() -> None:
+    reg = SignalChannelRegistry()
+    reg.freeze()
+    svc = _svc(reg)
+    with pytest.raises(SignalChannelRegistryFrozen):
+        await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+    assert reg.has_active_session("bot-1") is False
+
+
+async def test_headless_no_registry_returns_session_no_register() -> None:
+    """reg=None → register 스킵, session_id 만 전달(crash 없음)."""
+    svc = _svc(None)
+    result = await _handle_signal_connect(svc, {"key": "sk_x"}, "ipc")
+    assert "session_id" in result
+    assert result["_stream"] == "signal.connect"


### PR DESCRIPTION
Closes #2337 (스펙 #2334 §15 구현 PR#2)

## Summary
daemon-위임 `signal.connect`의 **outbound + registry + lifecycle**(PR#2, 가장 복잡한 동시성 조각). 스펙 #2334 §6/§7의 INV-OUT 불변 + 10 blocker 해소를 구현한다.

- **신규 `bot/signal_channel_registry.py`**: `SignalChannelRegistry`(atomic register/close_bot snapshot/freeze/generation) + `ChannelHandle`(placeholder→adopt 2단계, closing_event 브릿지).
- **`ipc/server.py` `_run_signal_stream` host**: bounded out_queue(512) + writer/reader task + supervisor(closing_event). adopt-time `handle.closed`/generation self-close(F4), `_initiate_close`(F2: mark_closed→await shield(inflight) grace→read cancel→writer flush-before-cancel join), finally unsubscribe+unregister 정확히 1회(INV-OUT-9), ack-fail upgrade-except 누수차단(F1). daemon-local `_encode_signal_frame`(datetime default=str — 공유 encoder 미변경).
- **`bot/signal_channel.py`**: `_handle_message` 분리·`_accepting` admit-gate·`_inflight` shield(F2)·dedup-after-enqueue(INV-OUT-4)·full-laggard.
- **`bot/manager.py` + `bot/bot.py`**: per-bot `_signal_lock`(on_step~drain ↔ on_external_signal 직렬화, F3·non-reentrancy invariant), `_on_bot_stopped`+`_on_bot_error` 둘 다 close_bot, rotate/delete teardown hook, on_external_signal 상태 재검증(#2333 불변).
- **`main.py`**: registry 3곳 배선 + shutdown freeze→close_all('draining'). single-connect → `BotSignalChannelBusy`(raiser 추가, PR#1 const-only→typed).

## Concurrency seam (Codex Plan Review 3R 수렴)
워크플로 25건(9 blocker+16 major) 사전해소 + seam 정밀계약: F1+F4 상태전이표 / F2 shield+closing_event 브릿지 / F3 lock span. 이슈 본문 `### 동시성 seam 정밀 계약` 참조.

## Scope / Non-Goals
- PR#3(#2338): CLI `signal.py` thin relay + test_cli migration → **#2333 unblock**. 미변경.

## Test Plan
- 신규 7테스트 42 passed(T2 registry·T3 outbound·server-host·busy·audit·T4 integration·**T5 #2333 daemon-side repro**)
- 기존 `test_signal_channel*.py` 무수정 35 passed, 광역 1534 passed, contracts 181 passed
- non-reentrancy invariant: ExternalSignalEvent publish 단일 사이트(0 위반)
- `uv run ruff check`/`ruff format --check`/`mypy src/`(232 files) PASS
- 편차: daemon-local `_encode_signal_frame`(공유 encoder datetime 버그 회피, byte-identical), 기존 테스트 2건에 `bot.status=RUNNING` 보강(상태재검증 불변 현실화, on_data 단언 유지)

## Plan / Review
- plan-preflight:done, Codex Plan Review: approve-implement(3R: v1 4 blocking→v2 F2→v3 approve)
- Codex 브랜치 리뷰: PASS (head 1e654053)

🤖 Generated with [Claude Code](https://claude.com/claude-code)