### PR TITLE
feat(cli): #2338 signal connect thin IPC relay + test migration (#2333 해소)

### DIFF
--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -129,38 +129,15 @@ class SignalChannel:
         if self._on_lagged is not None:
             self._on_lagged()
 
-    async def run(self) -> None:
-        """채널 실행 루프. stdin에서 읽고 처리."""
-        self._running = True
-        self._subscribe_events()
-
-        loop = asyncio.get_event_loop()
-        reader = asyncio.StreamReader()
-        protocol = asyncio.StreamReaderProtocol(reader)
-        await loop.connect_read_pipe(lambda: protocol, self._input)
-
-        while self._running:
-            try:
-                line = await reader.readline()
-                if not line:
-                    break
-                await self._handle_line(line.decode("utf-8").strip())
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.exception("채널 메시지 처리 오류")
-
-        self._running = False
-        self._unsubscribe_events()
-
     async def _handle_line(self, line: str) -> None:
-        """legacy stdin 라인 파싱 → ``_handle_message`` 위임.
+        """stdin 라인 파싱 → ``_handle_message`` 위임.
 
         ``json.loads`` 만 담당하고(empty-guard·``JSONDecodeError``) routing 은
-        ``_handle_message(dict)`` 가 한다. ``run()``(legacy connect_read_pipe)
-        은 본 메서드 경유라 투명하다. 데몬 경로(``_run_signal_stream``)는
+        ``_handle_message(dict)`` 가 한다. 데몬 경로(``_run_signal_stream``)는
         protocol.decode 로 이미 dict 를 얻으므로 ``_handle_message`` 를 직접
-        호출한다(json.loads 중복 회피).
+        호출한다(json.loads 중복 회피). CLI relay(#2338) 전환 후 in-process
+        ``connect_read_pipe`` 루프(구 ``run()``)는 제거됐고, 본 메서드는 단위
+        테스트의 라인-레벨 진입점으로만 남는다.
         """
         if not line:
             return

--- a/src/ante/cli/commands/signal.py
+++ b/src/ante/cli/commands/signal.py
@@ -3,14 +3,22 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
 import sys
+from pathlib import Path
 from typing import NoReturn
+from uuid import uuid4
 
 import click
 
-from ante.bot.exceptions import BOT_NOT_FOUND_CODE
+from ante.cli.commands.ipc_helpers import get_socket_path
 from ante.cli.formatter import OutputFormatter, format_option
-from ante.cli.middleware import require_auth
+from ante.cli.middleware import get_member_id, require_auth
+from ante.ipc import protocol
+
+# ``ipc_helpers.py:81`` SSOT verbatim — 서버 미기동/소켓 부재 시 사용자 메시지.
+_SERVER_DOWN_MSG = "서버가 실행 중이 아닙니다. 'ante system start'로 시작하세요."
 
 
 @click.group()
@@ -29,75 +37,165 @@ def signal_connect(ctx: click.Context, key: str) -> None:
 
 
 async def _run_connect(ctx: click.Context, key: str) -> None:
-    """시그널 채널 연결 및 실행.
+    """시그널 채널을 데몬으로 위임하는 thin IPC relay.
 
-    본 명령은 ``SignalChannel`` 을 통해 외부 시그널 소스 (HTTP/WS 등) 와
-    long-lived loop 를 형성한다. ``Database`` lifecycle 이 external process
-    runtime 과 엮여 있어 단순 ``open_cli_db`` async-context wrap 으로 동치
-    변환이 불가능하다 — 별도 spec 정렬 PR (#1818 follow-up) 에서 다룬다.
+    본 명령은 더 이상 in-process 로 ``Database``/``EventBus``/``BotManager``/
+    ``SignalChannel`` 을 구성하지 않는다(#2333 회귀 원인). 대신 실행 중인 데몬의
+    ``ante.sock`` 으로 ``signal.connect`` 핸드셰이크를 보내고(Phase A/B), OK 면
+    동일 연결을 long-lived 스트림으로 전환해 stdin↔socket(``_pump_in``) /
+    socket↔stdout(``_pump_out``) 만 양방향 relay 한다(Phase C). 4-게이트 검증·
+    봇 상태·이벤트 구독은 전부 데몬이 소유하며, 핸드셰이크 거부는 #1705 envelope
+    을 그대로 ``_fail`` 로 passthrough 한다.
     """
-    from ante.bot.config import BotStatus
-    from ante.bot.manager import BotManager
-    from ante.bot.signal_channel import SignalChannel
-    from ante.bot.signal_key import SignalKeyManager
-    from ante.cli.main import get_db_path, get_formatter
-    from ante.core.database import Database
-    from ante.eventbus.bus import EventBus
+    from ante.cli.main import get_config_dir, get_formatter
 
     fmt = get_formatter(ctx)
-    db = Database(get_db_path())
-    await db.connect()
+    actor = get_member_id(ctx)
+    socket_path = get_socket_path(get_config_dir(ctx))
+
+    if not Path(socket_path).exists():
+        _fail(fmt, _SERVER_DOWN_MSG, "IPC_SERVER_NOT_RUNNING")
 
     try:
-        skm = SignalKeyManager(db)
-        await skm.initialize()
+        reader, writer = await asyncio.open_unix_connection(socket_path)
+    except (ConnectionRefusedError, OSError):
+        # ``FileNotFoundError`` ⊂ ``OSError`` — 소켓 파일 부재/연결 거부 모두
+        # 서버 미기동으로 매핑한다.
+        _fail(fmt, _SERVER_DOWN_MSG, "IPC_SERVER_NOT_RUNNING")
 
-        # 1. 키 검증
-        bot_id = await skm.validate_key(key)
-        if not bot_id:
-            _fail(fmt, "Invalid signal key", "INVALID_SIGNAL_KEY")
+    try:
+        # Phase A — 핸드셰이크 요청 (key 는 args.key 에만, actor 동봉).
+        req = {
+            "id": str(uuid4()),
+            "command": "signal.connect",
+            "args": {"key": key},
+            "actor": actor,
+        }
+        writer.write(await protocol.encode(req))
+        await writer.drain()
 
-        # 2. 봇 존재 및 상태 확인
-        eventbus = EventBus()
-        manager = BotManager(eventbus=eventbus, db=db, signal_key_manager=skm)
-        await manager.initialize()
+        # Phase B — 핸드셰이크 응답. handshake decode 에만 30s bounded timeout.
+        try:
+            resp = await asyncio.wait_for(protocol.decode(reader), timeout=30.0)
+        except TimeoutError:
+            # py3.11+: ``asyncio.TimeoutError`` 는 builtin ``TimeoutError`` alias.
+            _fail(fmt, "서버 응답 시간 초과", "IPC_TIMEOUT")
+        except asyncio.IncompleteReadError:
+            # 핸드셰이크 중 데몬이 연결을 닫음.
+            _fail(fmt, _SERVER_DOWN_MSG, "IPC_SERVER_NOT_RUNNING")
 
-        bot = manager.get_bot(bot_id)
-        if not bot:
-            _fail(fmt, f"Bot not found: {bot_id}", BOT_NOT_FOUND_CODE)
+        if resp.get("status") == "error":
+            # 데몬 nested envelope ``{id,status:error,error:{code,message}}`` 를
+            # #1705 flattened surface 로 추출 후 ``_fail`` 라우팅(raw echo 금지).
+            err = resp["error"]
+            _fail(fmt, err["message"], err["code"])
 
-        if bot.status != BotStatus.RUNNING:
-            _fail(
-                fmt,
-                f"Bot is not running: {bot_id} (status: {bot.status.value})",
-                "BOT_NOT_RUNNING",
-            )
-
-        # 3. accepts_external_signals 확인
-        if not bot.strategy or not bot.strategy.meta.accepts_external_signals:
-            _fail(
-                fmt,
-                f"Bot {bot_id} does not accept external signals",
-                "BOT_NOT_ACCEPTING_SIGNALS",
-            )
-
-        # 4. 채널 수립 (informational stderr 유지)
+        # OK — 동일 연결을 Phase C 스트림으로 전환. informational stderr 2줄을
+        # handshake OK **이후** 방출한다.
+        bot_id = resp["result"]["bot_id"]
         _err(f"Connected to bot {bot_id}")
         _err("Ready for JSON Lines communication on stdin/stdout")
 
-        channel = SignalChannel(
-            bot=bot,
-            eventbus=eventbus,
-            ctx=bot._ctx,
+        # Phase C — 양방향 relay. 한쪽 pump 가 완료하면 sibling 을 cancel 한다
+        # (plain gather 는 idle stdin readline 에서 영구 hang).
+        pump_in = asyncio.ensure_future(_pump_in(writer))
+        pump_out = asyncio.ensure_future(_pump_out(reader))
+        done, pending = await asyncio.wait(
+            {pump_in, pump_out}, return_when=asyncio.FIRST_COMPLETED
         )
-        await channel.run()
-
+        for task in pending:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
     finally:
-        await db.close()
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+
+async def _pump_in(writer: asyncio.StreamWriter) -> None:
+    """stdin → socket relay. JSON Lines 를 length-prefixed 프레임으로 전달한다.
+
+    stdin 의 각 줄을 ``json.loads`` 로 검사(``JSONDecodeError`` 는 투명하게
+    skip)한 뒤 ``protocol.encode`` 로 framing 해 socket 에 write 한다. stdin EOF
+    면 ``write_eof`` 로 half-close 하여 ``_pump_out`` 은 유지한다. write 예외는
+    swallow 해 exit 0 으로 종료한다.
+    """
+    loop = asyncio.get_event_loop()
+    reader = asyncio.StreamReader()
+    stdin_protocol = asyncio.StreamReaderProtocol(reader)
+    try:
+        transport, _ = await loop.connect_read_pipe(lambda: stdin_protocol, sys.stdin)
+    except (ValueError, OSError):
+        # stdin 이 실제 파이프/터미널이 아니거나(테스트 하니스 등) read pipe 로
+        # 등록할 수 없는 경우, inbound relay 를 비활성화하고 ``_pump_out`` 이
+        # 종료를 주도하도록 영구 대기한다(취소될 때까지). 데몬→stdout 단방향
+        # relay 는 그대로 유지된다.
+        await asyncio.Event().wait()
+        return
+
+    try:
+        while True:
+            line = await reader.readline()
+            if not line:
+                # stdin EOF → half-close. socket→stdout pump 는 계속 동작.
+                with contextlib.suppress(
+                    BrokenPipeError, ConnectionResetError, OSError
+                ):
+                    writer.write_eof()
+                return
+
+            text = line.decode("utf-8").strip()
+            if not text:
+                continue
+            try:
+                msg = json.loads(text)
+            except json.JSONDecodeError:
+                # relay 투명성 — 비-JSON 줄은 그대로 무시한다.
+                continue
+
+            try:
+                writer.write(await protocol.encode(msg))
+                await writer.drain()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                return
+    finally:
+        # cancel/return 양 경로 모두에서 stdin read transport 를 닫아 fd 누수와
+        # ResourceWarning 을 방지한다.
+        with contextlib.suppress(Exception):
+            transport.close()
+
+
+async def _pump_out(reader: asyncio.StreamReader) -> None:
+    """socket → stdout relay. 데몬 프레임을 정확히 1개 ``\\n`` 부착해 출력한다.
+
+    ``protocol.decode`` 는 **per-read timeout 없이** 호출한다(Phase-C idle
+    스트림은 정상 — ipc.md Timeout 계약). socket EOF(``IncompleteReadError``)
+    면 return(exit 0). ``{"type":"closed"}`` 프레임이면 informational stderr 후
+    return(exit 0). mid-stream ``{"type":"error"}`` 프레임은 종료하지 않고 투명
+    passthrough 한다.
+    """
+    while True:
+        try:
+            frame = await protocol.decode(reader)
+        except asyncio.IncompleteReadError:
+            # socket EOF — 정상 종료.
+            return
+
+        try:
+            # 데몬 프레임은 embedded newline 0 — stdout 에서 ``\n`` 정확히 1회.
+            sys.stdout.write(json.dumps(frame) + "\n")
+            sys.stdout.flush()
+        except (BrokenPipeError, OSError):
+            return
+
+        if frame.get("type") == "closed":
+            _err(f"channel closed: {frame.get('reason', '')}")
+            return
 
 
 def _fail(fmt: OutputFormatter, msg: str, code: str) -> NoReturn:
-    """validation 오류 종료.
+    """validation/transport 오류 종료 (단일 chokepoint).
 
     JSON 모드는 stdout envelope (``{status,code,message}``),
     text 모드는 기존 ``_err()`` raw stderr 동작을 그대로 보존한다

--- a/src/ante/cli/commands/signal.py
+++ b/src/ante/cli/commands/signal.py
@@ -96,17 +96,27 @@ async def _run_connect(ctx: click.Context, key: str) -> None:
         _err(f"Connected to bot {bot_id}")
         _err("Ready for JSON Lines communication on stdin/stdout")
 
-        # Phase C — 양방향 relay. 한쪽 pump 가 완료하면 sibling 을 cancel 한다
-        # (plain gather 는 idle stdin readline 에서 영구 hang).
+        # Phase C — 양방향 relay. teardown 은 **비대칭** 이다(plain gather 는 idle
+        # stdin readline 에서 영구 hang, 대칭 cancel 은 잔여 프레임 drain 을 끊음).
         pump_in = asyncio.ensure_future(_pump_in(writer))
         pump_out = asyncio.ensure_future(_pump_out(reader))
-        done, pending = await asyncio.wait(
+        done, _pending = await asyncio.wait(
             {pump_in, pump_out}, return_when=asyncio.FIRST_COMPLETED
         )
-        for task in pending:
-            task.cancel()
+        if pump_out in done:
+            # ``_pump_out`` 이 먼저 종료(daemon closed 프레임 또는 socket EOF) →
+            # idle stdin 무한 대기 방지를 위해 ``_pump_in`` 을 cancel 한다.
+            pump_in.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await task
+                await pump_in
+        else:
+            # stdin EOF(``write_eof`` half-close) 로 ``_pump_in`` 이 먼저 종료 →
+            # ``_pump_out`` 을 cancel 하지 **않고** await 하여 데몬의 잔여 ack/
+            # closed 프레임을 socket EOF 까지 drain 한 뒤 종료한다.
+            await pump_out
+        # ``_pump_in``/``_pump_out`` 은 write/read 예외를 내부에서 이미 swallow
+        # (BrokenPipe/OSError/IncompleteReadError → 정상 return)하므로 정상 경로에서
+        # 추가 예외는 없다. ``await pump_out`` 도 동일 swallow 로 예외 없이 종료한다.
     finally:
         writer.close()
         with contextlib.suppress(Exception):

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -1842,9 +1842,10 @@ AUDIT_CONTRACTS: tuple[CliCommandContract, ...] = (
 # 일반 ``fmt.success`` / ``fmt.output`` 단일 envelope dump 는 *발생하지
 # 않는다* — validation 실패 분기 (``_fail``) 만 JSON 모드에서 ``fmt.error(
 # msg, code=...)`` envelope 을 dump 하고 즉시 SystemExit 한다 (signal.py:93-
-# 104). 채널 수립 후에는 ``SignalChannel.run()`` 이 JSON Lines stream 을
-# 직접 stdin/stdout 으로 처리한다 — fmt 계열 호출 없음. envelope SSOT
-# (#1821) 의 ``ContractKind = "stream"`` 으로 분류한다.
+# 104). 핸드셰이크 OK 후에는 CLI 가 데몬과 양방향 relay(``_pump_in`` /
+# ``_pump_out``) 만 수행해 JSON Lines stream 을 stdin/stdout 위로 운반한다
+# (#2338 thin IPC relay — in-process ``SignalChannel`` 미구성). fmt 계열 호출
+# 없음. envelope SSOT (#1821) 의 ``ContractKind = "stream"`` 으로 분류한다.
 #
 # envelope 표기: 본 leaf 는 단일 envelope dump 가 없으므로 ``raw_legacy``
 # 로 표시한다 — 일반 success/data envelope 이 부재하다는 의미를 본 registry
@@ -1859,9 +1860,11 @@ AUDIT_CONTRACTS: tuple[CliCommandContract, ...] = (
 # execution 분류 (``docs/specs/cli/03-commands.md`` SSOT — signal connect
 # 는 long-running / streaming 분류):
 # - ``long_running`` (1 개, 전체): ``connect``. ``asyncio.run(_run_connect)``
-#   로 ``SignalChannel.run()`` (stream loop) 을 실행. 본 registry 의
-#   ExecutionClass vocab 매핑 (모듈 docstring normative 표) 에 따라
-#   ``"long_running"`` 으로 분류 (streaming 도 흡수).
+#   가 데몬으로 ``signal.connect`` 핸드셰이크를 보낸 뒤 OK 면 동일 연결 위에서
+#   ``gather(pump_in, pump_out)`` 양방향 relay (stream loop) 를 실행한다 (#2338
+#   thin IPC relay — daemon-위임). 본 registry 의 ExecutionClass vocab 매핑
+#   (모듈 docstring normative 표) 에 따라 ``"long_running"`` 으로 분류 (streaming
+#   도 흡수).
 SIGNAL_CONTRACTS: tuple[CliCommandContract, ...] = (
     CliCommandContract(
         path=("signal", "connect"),

--- a/tests/integration/test_signal_connect_cli_repro_2333.py
+++ b/tests/integration/test_signal_connect_cli_repro_2333.py
@@ -1,0 +1,244 @@
+"""#2333 CLI end-to-end repro — thin IPC relay → real daemon (#2338 T15).
+
+재작성된 CLI ``_run_connect`` (thin IPC relay) 를 **unmocked**
+``asyncio.open_unix_connection`` 으로 real ``IPCServer`` (RUNNING +
+``accepts_external_signals=True`` 봇 + signal_key_manager) 의 UDS 에 연결해,
+``signal.connect`` 핸드셰이크가 ``status=="ok"`` 로 통과하고 ``BOT_NOT_FOUND``
+가 **발생하지 않음** 을 end-to-end 로 단언한다 (=#2333 회귀 lock).
+
+과거(in-process) CLI 는 자체 ``Database``/``BotManager`` 를 새로 구성해 데몬과
+다른 상태(빈 bot registry)를 봤기에 RUNNING 봇에도 ``BOT_NOT_FOUND`` 를 냈다.
+relay 전환 후 CLI 는 데몬의 LIVE 상태를 그대로 위임받으므로 회귀가 해소된다.
+
+T7 anti-flakiness: sleep 동기화 금지(asyncio.Event/wait_for), ``mkdtemp(dir=
+"/tmp")`` UDS, server try/finally stop + settle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from ante.bot.config import BotConfig, BotStatus
+from ante.bot.manager import BotManager
+from ante.bot.signal_channel_registry import SignalChannelRegistry
+from ante.cli.commands.signal import _run_connect
+from ante.cli.formatter import OutputFormatter
+from ante.core.database import Database
+from ante.core.registry import ServiceRegistry
+from ante.eventbus.bus import EventBus
+from ante.ipc.registry import CommandRegistry, _handle_signal_connect
+from ante.ipc.server import IPCServer
+from ante.member.models import Member, MemberRole, MemberType
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+pytestmark = pytest.mark.asyncio
+
+_SIGNAL_KEY = "sk_repro_2333"
+
+_MASTER = Member(
+    member_id="m-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Master",
+    status="active",
+    scopes=[],
+)
+
+
+class _AcceptingStrategy(Strategy):
+    meta = StrategyMeta(
+        name="accepting-cli-repro",
+        version="1.0.0",
+        description="accepts external signals",
+        accepts_external_signals=True,
+    )
+
+    async def on_step(self, context: dict) -> list[Signal]:
+        return []
+
+    async def on_data(self, data: dict) -> list[Signal]:
+        return []
+
+
+class _Harness:
+    def __init__(self) -> None:
+        self.db: Database | None = None
+        self.server: IPCServer | None = None
+        self.bus = EventBus()
+        self.reg = SignalChannelRegistry()
+        self.manager: BotManager | None = None
+
+    async def setup(self, socket_path: str) -> None:
+        self.db = Database(":memory:")
+        await self.db.connect()
+
+        self.manager = BotManager(
+            eventbus=self.bus,
+            db=self.db,
+            signal_channel_registry=self.reg,
+        )
+        await self.manager.initialize()
+
+        ctx = MagicMock()
+        ctx.get_positions.return_value = {}
+        ctx.get_balance.return_value = {"available": 1_000_000.0}
+
+        await self.manager.create_bot(
+            config=BotConfig(
+                bot_id="bot-1",
+                strategy_id="stg-1",
+                interval_seconds=60,
+                account_id="acc-test",
+            ),
+            strategy_cls=_AcceptingStrategy,
+            ctx=ctx,
+        )
+        bot = self.manager.get_bot("bot-1")
+        bot.strategy = _AcceptingStrategy(ctx=ctx)
+        bot.status = BotStatus.RUNNING
+
+        async def _validate(key: str) -> str | None:
+            return "bot-1" if key == _SIGNAL_KEY else None
+
+        self.manager.validate_signal_key = _validate  # type: ignore[method-assign]
+
+        svc = ServiceRegistry(
+            account=MagicMock(),
+            bot_manager=self.manager,
+            treasury_manager=MagicMock(),
+            dynamic_config=MagicMock(),
+            approval=MagicMock(),
+            reconciler=MagicMock(),
+            eventbus=self.bus,
+            signal_channel_registry=self.reg,
+            audit_logger=None,
+        )
+        cmd_reg = CommandRegistry()
+        cmd_reg.register(
+            "signal.connect",
+            _handle_signal_connect,
+            is_mutating=False,
+            result_kind="stream",
+            required_services=frozenset({"bot_manager"}),
+            account_id_policy="none",
+        )
+        self.server = IPCServer(socket_path, svc, cmd_reg)
+        await self.server.start()
+
+    async def teardown(self) -> None:
+        if self.server is not None:
+            await self.server.stop()
+        if self.db is not None:
+            await self.db.close()
+
+
+@pytest.fixture
+def socket_path() -> str:
+    td = tempfile.mkdtemp(prefix="sig-cli-repro", dir="/tmp")
+    return str(Path(td) / "ante.sock")
+
+
+def _make_ctx(fmt: str = "text") -> click.Context:
+    """``_run_connect`` 가 요구하는 ctx (formatter/member/config_dir) 구성."""
+    ctx = MagicMock(spec=click.Context)
+    ctx.obj = {
+        "formatter": OutputFormatter(fmt),
+        "member": _MASTER,
+        "config_dir": None,
+    }
+    return ctx
+
+
+async def _drive_run_connect(
+    ctx: click.Context, socket_path: str, key: str
+) -> list[str]:
+    """재작성된 CLI ``_run_connect`` 를 unmocked open_unix_connection 으로 구동.
+
+    ``get_socket_path`` 만 테스트 UDS 로 고정하고(실제 connect 는 unmocked),
+    ``_pump_in`` 은 idle stub 으로 패치해(pytest stdin connect_read_pipe 부작용
+    회피) ``_pump_out`` 이 데몬 close 로 종료를 주도하게 한다. stderr 라인을
+    수집해 informational/거부 메시지를 검사한다.
+    """
+    stderr_lines: list[str] = []
+
+    async def _idle_pump_in(_writer):  # noqa: ANN001, ANN202
+        await asyncio.Event().wait()
+
+    def _capture_err(msg: str) -> None:
+        stderr_lines.append(msg)
+
+    with (
+        patch(
+            "ante.cli.commands.signal.get_socket_path",
+            return_value=socket_path,
+        ),
+        patch("ante.cli.commands.signal._pump_in", _idle_pump_in),
+        patch("ante.cli.commands.signal._err", _capture_err),
+    ):
+        await _run_connect(ctx, key)
+
+    return stderr_lines
+
+
+async def test_cli_relay_handshake_ok_no_bot_not_found(socket_path: str) -> None:
+    """valid key + RUNNING + accepts_external_signals 봇 → handshake OK,
+    BOT_NOT_FOUND 미발생 (#2333 회귀 lock)."""
+    h = _Harness()
+    await h.setup(socket_path)
+    ctx = _make_ctx("text")
+
+    drive = asyncio.ensure_future(_drive_run_connect(ctx, socket_path, _SIGNAL_KEY))
+    try:
+        # adopt 완료(데이터플레인 채워짐) 대기 — sleep 동기화 금지.
+        for _ in range(500):
+            await asyncio.sleep(0)
+            if h.reg.has_active_session("bot-1"):
+                sid = next(iter(h.reg._sessions["bot-1"]))
+                handle = h.reg.get("bot-1", sid)
+                if handle is not None and handle.out_queue is not None:
+                    break
+        else:
+            pytest.fail("relay 가 active session 을 수립하지 못함(handshake 실패 의심)")
+
+        # 데몬 주도 close → _pump_out 이 closed frame 수신 후 종료.
+        h.reg.close_bot("bot-1", "bot_stopped")
+        stderr_lines = await asyncio.wait_for(drive, timeout=3.0)
+    finally:
+        if not drive.done():
+            drive.cancel()
+            with pytest.raises((asyncio.CancelledError, Exception)):
+                await drive
+        await h.teardown()
+
+    joined = "\n".join(stderr_lines)
+    # handshake OK informational.
+    assert "Connected to bot bot-1" in joined, stderr_lines
+    assert "Ready for JSON Lines communication on stdin/stdout" in stderr_lines
+    # #2333 회귀 lock — relay→real-daemon 경계에서 BOT_NOT_FOUND 미발생.
+    assert "Bot not found" not in joined, stderr_lines
+    assert "BOT_NOT_FOUND" not in joined, stderr_lines
+
+
+async def test_cli_relay_invalid_key_rejected_no_bot_not_found(
+    socket_path: str,
+) -> None:
+    """invalid key → 데몬 Phase-B INVALID_SIGNAL_KEY 거부(exit 1), BOT_NOT_FOUND
+    미발생. relay 가 데몬 envelope 을 그대로 surface 함을 lock."""
+    h = _Harness()
+    await h.setup(socket_path)
+    ctx = _make_ctx("text")
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            await _drive_run_connect(ctx, socket_path, "sk_wrong")
+    finally:
+        await h.teardown()
+
+    assert exc_info.value.code == 1

--- a/tests/unit/cli/test_factory_drift_check.py
+++ b/tests/unit/cli/test_factory_drift_check.py
@@ -153,7 +153,8 @@ class TestGetDbPathWithoutCtxLegacyCountReport:
 
     # 현재 코드 baseline (배치 시점 grep 검증 기준):
     # - broker.py:34, 354 — runtime_ipc cold_path fallback (live state)
-    # - signal.py:48 — long_running stream channel
+    # (signal.py:48 은 #2338 PR#3 에서 thin IPC relay 전환으로 직접 Database
+    #  생성이 제거되어 baseline 에서 함께 삭제됐다.)
     #
     # 본 list 가 동일하게 잡히는지 sanity 만 단언한다. 신규 callsite 발견 시
     # FAIL 하지 않고 report 만 한다.
@@ -161,7 +162,6 @@ class TestGetDbPathWithoutCtxLegacyCountReport:
         {
             ("src/ante/cli/commands/broker.py", 34),
             ("src/ante/cli/commands/broker.py", 354),
-            ("src/ante/cli/commands/signal.py", 48),
         }
     )
 

--- a/tests/unit/contracts/factory_drift_allowlist.yaml
+++ b/tests/unit/contracts/factory_drift_allowlist.yaml
@@ -28,14 +28,10 @@ direct_database_construction:
     line: 354
     reason: "broker reconcile — adapter_db fallback (runtime_ipc cold_path branch)"
 
-  # signal connect — long_running / streaming external process.
-  # SignalChannel.run() 이 stdin/stdout JSON Lines stream loop 를 형성한다.
-  # Database lifecycle 이 external process runtime 과 엮여 있어 단순
-  # `open_cli_db` async-context wrap 으로 동치 변환이 불가능하다 (signal.py:35-38
-  # 주석 invariant).
-  - path: src/ante/cli/commands/signal.py
-    line: 48
-    reason: "signal connect — long_running stream channel (external process lifecycle)"
+  # signal connect — #2338 PR#3 에서 CLI `_run_connect` 를 thin IPC relay 로
+  # 재작성하며 in-process `Database(...)` 직접 생성이 제거됐다(데몬-위임). 더
+  # 이상 callsite 가 없으므로 allowlist 엔트리도 함께 삭제한다(drift test 의
+  # `stale_baseline` sanity 와 정합).
 
   # report domain — `report list` / `report view` 는 `offline` read 명령이며
   # #2114 에서 `open_cli_db` (read_only) 로 마이그레이션되어 직접 Database 생성

--- a/tests/unit/test_cli_missing_resource_exit.py
+++ b/tests/unit/test_cli_missing_resource_exit.py
@@ -41,12 +41,18 @@ running / 시그널 미수용)는 모두 동일 invariant("signal connect 연결
 (#1557 narrow-scope 선례: 동일 결함 분기 일괄 정렬, half-fix 회피).
 4개 가드 전부 ``raise SystemExit(1)``로 정렬되며, ``_err`` stderr 메시지·
 문구는 그대로 유지(streaming 명령 — JSON envelope 비대상)되고, 정상 경로
-(``_err("Connected ...")`` 안내 후 ``channel.run()`` 정상 반환 → exit 0)는
-불변임을 ``TestSignalConnect*`` 에서 회귀 보장한다.
+(``_err("Connected ...")`` 안내 후 채널 종료 → exit 0)는 불변임을
+``TestSignalConnect*`` 에서 회귀 보장한다.
 
-``signal_connect``는 ``asyncio.run(_run_connect(key))``만 호출하므로
-``SystemExit(1)``이 ``finally: await db.close()`` 실행 후 asyncio.run
-경계를 통해 process exit code 1로 전파됨을 CliRunner exit_code로 확인한다.
+#2338 마이그레이션: ``signal connect`` 가 in-process ``Database``/``BotManager``/
+``SignalChannel`` 구성에서 **데몬-위임 thin IPC relay** 로 재작성됐다. 따라서
+본 #1560 invariant 테스트도 4 게이트의 in-process patch(Database/SignalKey
+Manager/BotManager/SignalChannel)를 **IPC-layer mock** 으로 repoint 한다 —
+``asyncio.open_unix_connection`` 을 fake reader/writer 로 교체하고, 데몬
+Phase-B 응답 프레임(error/ok)을 직접 주입해 exit-1(가드)·exit-0(정상 종료)
+invariant 를 byte-identical 로 유지한다. ``signal_connect`` 가
+``asyncio.run(_run_connect)`` 만 호출하므로 ``SystemExit(1)`` 이 asyncio.run
+경계를 통해 process exit code 1 로 전파됨을 CliRunner exit_code 로 확인한다.
 """
 
 from __future__ import annotations
@@ -1054,6 +1060,56 @@ class TestMemberInfoMissingExit:
 # ── signal connect 연결 실패 exit code (#1560) ────────────
 
 
+def _signal_frame(d: dict) -> bytes:
+    """dict → length-prefixed wire 프레임 ([4B big-endian len][UTF-8 JSON])."""
+    import struct
+
+    payload = json.dumps(d, ensure_ascii=False).encode("utf-8")
+    return struct.pack("!I", len(payload)) + payload
+
+
+class _SignalFakeReader:
+    """미리 framed bytes 를 ``readexactly`` 로 슬라이스 제공하는 reader 대역.
+
+    소진 시 ``IncompleteReadError`` 를 raise 해 socket EOF 를 모사한다.
+    """
+
+    def __init__(self, frames: list[bytes]) -> None:
+        import asyncio
+
+        self._asyncio = asyncio
+        self._buf = b"".join(frames)
+        self._pos = 0
+
+    async def readexactly(self, n: int):  # noqa: ANN202
+        if self._pos + n > len(self._buf):
+            partial = self._buf[self._pos :]
+            self._pos = len(self._buf)
+            raise self._asyncio.IncompleteReadError(partial, n)
+        chunk = self._buf[self._pos : self._pos + n]
+        self._pos += n
+        return chunk
+
+
+class _SignalFakeWriter:
+    """write/drain/write_eof/close/wait_closed no-op writer 대역."""
+
+    def write(self, data: bytes) -> None:
+        return None
+
+    async def drain(self) -> None:
+        return None
+
+    def write_eof(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
+
+
 def _invoke_signal_connect(
     runner: CliRunner,
     *,
@@ -1061,49 +1117,92 @@ def _invoke_signal_connect(
     bot: object | None,
     channel_runs: bool = False,
 ) -> object:
-    """``signal connect``의 의존성을 mock한 뒤 invoke한다.
+    """``signal connect`` 의 IPC transport 를 mock 한 뒤 invoke 한다 (#2338).
 
-    ``_run_connect``는 함수 로컬 import로 ``Database``/``SignalKeyManager``/
-    ``BotManager``/``SignalChannel``/``get_db_path``를 resolve하므로 각 원본
-    모듈 속성을 패치하면 결정적으로 가드 분기를 탄다.
+    재작성된 ``_run_connect`` 는 데몬-위임 thin relay 이므로 in-process
+    Database/SignalKeyManager/BotManager/SignalChannel patch 대신, 데몬이
+    보냈을 **Phase-B 응답 프레임** 을 ``asyncio.open_unix_connection`` fake
+    transport 로 주입한다. ``bot_id``/``bot`` 인자는 어느 게이트가 발화했을지를
+    결정해 그에 대응하는 데몬 error envelope(byte-identical code/message)을
+    구성한다 — exit-1(가드)·exit-0(정상) invariant 는 유지된다.
 
     Args:
-        bot_id: ``SignalKeyManager.validate_key`` 반환값. ``None``이면
-            invalid-key 가드.
-        bot: ``BotManager.get_bot`` 반환값. ``None``이면 bot-not-found 가드.
-            객체면 status/strategy 속성으로 나머지 가드를 제어한다.
-        channel_runs: ``True``면 ``SignalChannel.run``을 정상 반환 mock으로
-            교체해 정상 경로(exit 0)를 검증한다.
+        bot_id: invalid-key 게이트 결정. ``None`` 이면 ``INVALID_SIGNAL_KEY``.
+        bot: bot-not-found / 상태 게이트 결정. ``None`` 이면 ``BOT_NOT_FOUND``,
+            객체면 status/strategy 속성으로 BOT_NOT_RUNNING /
+            BOT_NOT_ACCEPTING_SIGNALS 를 결정한다.
+        channel_runs: ``True`` 면 OK + closed frame 을 주입해 정상 종료(exit 0).
     """
-    mock_db = MagicMock()
-    mock_db.connect = AsyncMock()
-    mock_db.close = AsyncMock()
+    import asyncio
 
-    mock_skm = MagicMock()
-    mock_skm.initialize = AsyncMock()
-    mock_skm.validate_key = AsyncMock(return_value=bot_id)
+    from ante.bot.config import BotStatus
 
-    mock_manager = MagicMock()
-    mock_manager.initialize = AsyncMock()
-    mock_manager.get_bot = MagicMock(return_value=bot)
+    # 데몬 4-게이트 동형으로 어느 거부 프레임을 주입할지 결정한다.
+    if bot_id is None:
+        frame = {
+            "id": "h1",
+            "status": "error",
+            "error": {"code": "INVALID_SIGNAL_KEY", "message": "Invalid signal key"},
+        }
+    elif bot is None:
+        frame = {
+            "id": "h1",
+            "status": "error",
+            "error": {
+                "code": "BOT_NOT_FOUND",
+                "message": f"Bot not found: {bot_id}",
+            },
+        }
+    elif getattr(bot, "status", None) != BotStatus.RUNNING:
+        status_value = bot.status.value
+        frame = {
+            "id": "h1",
+            "status": "error",
+            "error": {
+                "code": "BOT_NOT_RUNNING",
+                "message": f"Bot is not running: {bot_id} (status: {status_value})",
+            },
+        }
+    elif not getattr(bot.strategy.meta, "accepts_external_signals", False):
+        frame = {
+            "id": "h1",
+            "status": "error",
+            "error": {
+                "code": "BOT_NOT_ACCEPTING_SIGNALS",
+                "message": f"Bot {bot_id} does not accept external signals",
+            },
+        }
+    else:
+        # 모든 게이트 통과 — OK handshake.
+        frame = {
+            "id": "h1",
+            "status": "ok",
+            "result": {"bot_id": bot_id, "account_id": "acc", "session_id": "s1"},
+        }
 
-    mock_channel = MagicMock()
-    mock_channel.run = AsyncMock(return_value=None)
+    frames = [_signal_frame(frame)]
+    if channel_runs:
+        frames.append(_signal_frame({"type": "closed", "reason": "eof"}))
+
+    reader = _SignalFakeReader(frames)
+    writer = _SignalFakeWriter()
+
+    async def _open(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+        return reader, writer
+
+    async def _idle_pump_in(_writer):  # noqa: ANN001, ANN202
+        # 정상 경로(channel_runs)에서 가짜 stdin 의 connect_read_pipe 부작용을
+        # 피하고 ``_pump_out`` 이 closed frame 으로 종료를 주도하게 한다.
+        await asyncio.Event().wait()
 
     with (
-        patch("ante.core.database.Database", return_value=mock_db),
+        patch("ante.cli.commands.signal.Path.exists", return_value=True),
         patch(
-            "ante.bot.signal_key.SignalKeyManager",
-            return_value=mock_skm,
+            "ante.cli.commands.signal.get_socket_path",
+            return_value="/tmp/test-ante.sock",
         ),
-        patch(
-            "ante.bot.manager.BotManager",
-            return_value=mock_manager,
-        ),
-        patch(
-            "ante.bot.signal_channel.SignalChannel",
-            return_value=mock_channel,
-        ),
+        patch("asyncio.open_unix_connection", _open),
+        patch("ante.cli.commands.signal._pump_in", _idle_pump_in),
     ):
         return runner.invoke(cli, ["signal", "connect", "--key", "sk_probe"])
 

--- a/tests/unit/test_cli_signal_connect.py
+++ b/tests/unit/test_cli_signal_connect.py
@@ -1,24 +1,33 @@
-"""CLI ``ante signal connect`` JSON envelope 회귀 (#1705).
+"""CLI ``ante signal connect`` thin IPC relay 회귀 (#1705 + #2338).
 
-기존 4 validation 오류 경로 — invalid key / bot not found / bot not running /
-bot not accepting signals — 가 raw stderr 로만 발화하여 ``--format json`` 호출이
-``Error: No such option: --format`` 으로 거부되거나 JSON envelope 으로 normalize
-되지 않던 ingress drift를 닫는다.
+#2338 에서 ``signal connect`` 가 in-process ``Database``/``BotManager``/
+``SignalChannel`` 구성에서 **데몬-위임 thin IPC relay** 로 재작성됐다. 4-게이트
+검증은 데몬이 소유하고, CLI 는 ``signal.connect`` 핸드셰이크(Phase A/B)를 보낸
+뒤 OK 면 stdin↔socket / socket↔stdout 양방향 relay 만 수행한다(Phase C).
 
-본 파일은 #1701 ``test_cli_format_option.py`` 의 ``runner`` 인증 fixture 패턴을
-미러하여, ``ante.cli.main.authenticate_member`` 를 monkeypatch 해 leaf callback
-의 ``require_auth`` 가드를 통과시킨다.
+본 파일은 in-process mock 을 **IPC-layer mock** 으로 마이그레이트한다:
+``asyncio.open_unix_connection`` 을 fake reader/writer 로 교체하고, 데몬 Phase-B
+응답 프레임을 직접 주입해 #1705 의 11 관측 출력(4 validation JSON + 4 text-no-
+``Error:`` prefix + 2 informational + auth_required)을 **byte-identical** 로
+회귀 lock 한다. 추가로 신규 transport terminal(IPC_SERVER_NOT_RUNNING /
+IPC_TIMEOUT)을 JSON/text 양 모드에서 lock 한다.
+
+``runner`` 인증 fixture 는 #1701 ``test_cli_format_option.py`` 패턴을 미러해
+``ante.cli.main.authenticate_member`` 를 monkeypatch 한다.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+import struct
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
-from ante.bot.config import BotStatus
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 
@@ -31,6 +40,11 @@ _MOCK_MASTER = Member(
     status="active",
     scopes=[],
 )
+
+# patch site SSOT — 재작성된 signal.py 의 실제 binding 과 일치해야 한다.
+_OPEN_CONN_TARGET = "asyncio.open_unix_connection"
+_SOCKET_TARGET = "ante.cli.commands.signal.get_socket_path"
+_PATH_EXISTS_TARGET = "ante.cli.commands.signal.Path.exists"
 
 
 @pytest.fixture()
@@ -53,71 +67,126 @@ def runner() -> CliRunner:
     return r
 
 
-def _mock_db() -> MagicMock:
-    db = MagicMock()
-    db.connect = AsyncMock()
-    db.close = AsyncMock()
-    return db
+# ──────────────────────────────────────────────────────────────
+# IPC-layer fakes — protocol.decode/encode wire framing 재현
+# ──────────────────────────────────────────────────────────────
 
 
-def _patch_signal_deps(
-    *,
-    bot_id_for_key: str | None,
-    bot: MagicMock | None,
-):
-    """signal_connect 실행 환경의 Database/SignalKeyManager/BotManager mock 컨텍스트.
+def _frame(d: dict) -> bytes:
+    """dict → length-prefixed wire 프레임 ([4B big-endian len][UTF-8 JSON])."""
+    payload = json.dumps(d, ensure_ascii=False).encode("utf-8")
+    return struct.pack("!I", len(payload)) + payload
 
-    Args:
-        bot_id_for_key: ``validate_key(key)`` 반환값. ``None`` 이면 invalid key.
-        bot: ``BotManager.get_bot()`` 반환값. ``None`` 이면 bot not found.
+
+class FakeReader:
+    """미리 framed bytes 버퍼를 슬라이스로 제공하는 ``StreamReader`` 대역.
+
+    ``protocol.decode`` 는 ``readexactly(4)`` 로 길이를 읽고 ``readexactly(n)``
+    로 payload 를 읽는다. 버퍼가 소진되면 ``IncompleteReadError`` 를 raise 해
+    socket EOF 를 모사한다.
     """
-    db = _mock_db()
-    skm = MagicMock()
-    skm.initialize = AsyncMock()
-    skm.validate_key = AsyncMock(return_value=bot_id_for_key)
 
-    manager = MagicMock()
-    manager.initialize = AsyncMock()
-    manager.get_bot = MagicMock(return_value=bot)
+    def __init__(self, frames: list[bytes]) -> None:
+        self._buf = b"".join(frames)
+        self._pos = 0
 
-    patchers = [
-        patch("ante.core.database.Database", return_value=db),
-        patch("ante.bot.signal_key.SignalKeyManager", return_value=skm),
-        patch("ante.bot.manager.BotManager", return_value=manager),
-        patch("ante.eventbus.bus.EventBus", return_value=MagicMock()),
-        patch("ante.cli.main.get_db_path", return_value=":memory:"),
-    ]
-    return patchers
+    async def readexactly(self, n: int) -> bytes:
+        if self._pos + n > len(self._buf):
+            partial = self._buf[self._pos :]
+            self._pos = len(self._buf)
+            raise asyncio.IncompleteReadError(partial, n)
+        chunk = self._buf[self._pos : self._pos + n]
+        self._pos += n
+        return chunk
 
 
-def _make_bot(
+class HangingReader(FakeReader):
+    """handshake 응답을 영구 보류해 Phase-B ``wait_for`` timeout 을 유발."""
+
+    async def readexactly(self, n: int) -> bytes:
+        await asyncio.Event().wait()  # 영원히 대기 → wait_for TimeoutError.
+        raise AssertionError("unreachable")
+
+
+class FakeWriter:
+    """write/drain/write_eof/close/wait_closed no-op ``StreamWriter`` 대역."""
+
+    def __init__(self) -> None:
+        self.written = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.written.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def write_eof(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+@contextmanager
+def _patch_ipc(
     *,
-    status: BotStatus = BotStatus.RUNNING,
-    accepts_external_signals: bool = True,
-    bot_id: str = "bot-1705",
-) -> MagicMock:
-    """validation-path mock Bot.
+    response_frames: list[dict] | None = None,
+    connect_exc: BaseException | None = None,
+    handshake_timeout: bool = False,
+) -> Iterator[FakeWriter]:
+    """IPC transport 를 mock 하는 컨텍스트.
 
-    status + strategy.meta.accepts_external_signals 만 사용.
+    - ``Path.exists`` → True (server-down pre-check 통과).
+    - ``get_socket_path`` → 고정 경로.
+    - ``open_unix_connection`` → (FakeReader, FakeWriter) 또는 ``connect_exc``.
+    - ``handshake_timeout`` → HangingReader 로 Phase-B ``wait_for`` timeout.
     """
-    bot = MagicMock()
-    bot.status = status
-    if accepts_external_signals:
-        strategy = MagicMock()
-        strategy.meta = MagicMock()
-        strategy.meta.accepts_external_signals = True
-        bot.strategy = strategy
+    writer = FakeWriter()
+
+    if connect_exc is not None:
+
+        async def _open(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+            raise connect_exc
     else:
-        strategy = MagicMock()
-        strategy.meta = MagicMock()
-        strategy.meta.accepts_external_signals = False
-        bot.strategy = strategy
-    bot._ctx = MagicMock()
-    return bot
+        if handshake_timeout:
+            reader: FakeReader = HangingReader([])
+        else:
+            frames = [_frame(d) for d in (response_frames or [])]
+            reader = FakeReader(frames)
+
+        async def _open(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+            return reader, writer
+
+    with (
+        patch(_PATH_EXISTS_TARGET, return_value=True),
+        patch(_SOCKET_TARGET, return_value="/tmp/test-ante.sock"),
+        patch(_OPEN_CONN_TARGET, _open),
+    ):
+        yield writer
+
+
+def _error_frame(code: str, message: str) -> dict:
+    """데몬 Phase-B nested error envelope."""
+    return {"id": "h1", "status": "error", "error": {"code": code, "message": message}}
+
+
+def _ok_frame(bot_id: str = "bot-1705") -> dict:
+    """데몬 Phase-B OK envelope (result 에 bot_id/account_id/session_id)."""
+    return {
+        "id": "h1",
+        "status": "ok",
+        "result": {"bot_id": bot_id, "account_id": "acct", "session_id": "s1"},
+    }
+
+
+_CLOSED_FRAME = {"type": "closed", "reason": "eof"}
 
 
 # ──────────────────────────────────────────────────────────────
-# A. 4 validation × JSON mode
+# A. 4 validation × JSON mode (#1705 byte-lock)
 # ──────────────────────────────────────────────────────────────
 
 
@@ -125,17 +194,13 @@ class TestSignalConnectJsonEnvelope1705:
     """``--format json`` 모드: stdout JSON envelope + stderr empty + exit 1."""
 
     def test_invalid_key(self, runner: CliRunner) -> None:
-        patchers = _patch_signal_deps(bot_id_for_key=None, bot=None)
-        for p in patchers:
-            p.start()
-        try:
+        with _patch_ipc(
+            response_frames=[_error_frame("INVALID_SIGNAL_KEY", "Invalid signal key")]
+        ):
             result = runner.invoke(
                 cli,
                 ["signal", "connect", "--key", "sk_invalid", "--format", "json"],
             )
-        finally:
-            for p in patchers:
-                p.stop()
 
         assert result.exit_code == 1, (result.stdout, result.stderr)
         payload = json.loads(result.stdout)
@@ -147,17 +212,15 @@ class TestSignalConnectJsonEnvelope1705:
         assert result.stderr == ""
 
     def test_bot_not_found(self, runner: CliRunner) -> None:
-        patchers = _patch_signal_deps(bot_id_for_key="bot-missing", bot=None)
-        for p in patchers:
-            p.start()
-        try:
+        with _patch_ipc(
+            response_frames=[
+                _error_frame("BOT_NOT_FOUND", "Bot not found: bot-missing")
+            ]
+        ):
             result = runner.invoke(
                 cli,
                 ["signal", "connect", "--key", "sk_ok", "--format", "json"],
             )
-        finally:
-            for p in patchers:
-                p.stop()
 
         assert result.exit_code == 1, (result.stdout, result.stderr)
         payload = json.loads(result.stdout)
@@ -169,18 +232,18 @@ class TestSignalConnectJsonEnvelope1705:
         assert result.stderr == ""
 
     def test_bot_not_running(self, runner: CliRunner) -> None:
-        bot = _make_bot(status=BotStatus.STOPPED, bot_id="bot-1705")
-        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
-        for p in patchers:
-            p.start()
-        try:
+        with _patch_ipc(
+            response_frames=[
+                _error_frame(
+                    "BOT_NOT_RUNNING",
+                    "Bot is not running: bot-1705 (status: stopped)",
+                )
+            ]
+        ):
             result = runner.invoke(
                 cli,
                 ["signal", "connect", "--key", "sk_ok", "--format", "json"],
             )
-        finally:
-            for p in patchers:
-                p.stop()
 
         assert result.exit_code == 1, (result.stdout, result.stderr)
         payload = json.loads(result.stdout)
@@ -192,22 +255,18 @@ class TestSignalConnectJsonEnvelope1705:
         assert result.stderr == ""
 
     def test_bot_not_accepting_signals(self, runner: CliRunner) -> None:
-        bot = _make_bot(
-            status=BotStatus.RUNNING,
-            accepts_external_signals=False,
-            bot_id="bot-1705",
-        )
-        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
-        for p in patchers:
-            p.start()
-        try:
+        with _patch_ipc(
+            response_frames=[
+                _error_frame(
+                    "BOT_NOT_ACCEPTING_SIGNALS",
+                    "Bot bot-1705 does not accept external signals",
+                )
+            ]
+        ):
             result = runner.invoke(
                 cli,
                 ["signal", "connect", "--key", "sk_ok", "--format", "json"],
             )
-        finally:
-            for p in patchers:
-                p.stop()
 
         assert result.exit_code == 1, (result.stdout, result.stderr)
         payload = json.loads(result.stdout)
@@ -227,67 +286,57 @@ class TestSignalConnectJsonEnvelope1705:
 class TestSignalConnectTextMode1705:
     """default text 모드: stderr raw text + stdout empty + exit 1.
 
-    ``Error: `` prefix 가 붙지 않아야 하며, 기존 ``_err()`` 동작
-    (raw stderr + ``\\n``) 을 회귀 lock 한다.
+    ``Error: `` prefix 가 붙지 않아야 하며, ``_err()`` raw stderr + ``\\n``
+    동작을 회귀 lock 한다.
     """
 
     def test_invalid_key_text(self, runner: CliRunner) -> None:
-        patchers = _patch_signal_deps(bot_id_for_key=None, bot=None)
-        for p in patchers:
-            p.start()
-        try:
+        with _patch_ipc(
+            response_frames=[_error_frame("INVALID_SIGNAL_KEY", "Invalid signal key")]
+        ):
             result = runner.invoke(cli, ["signal", "connect", "--key", "sk_invalid"])
-        finally:
-            for p in patchers:
-                p.stop()
 
         assert result.exit_code == 1, (result.stdout, result.stderr)
         assert result.stderr == "Invalid signal key\n"
         assert result.stdout == ""
 
     def test_bot_not_found_text(self, runner: CliRunner) -> None:
-        patchers = _patch_signal_deps(bot_id_for_key="bot-missing", bot=None)
-        for p in patchers:
-            p.start()
-        try:
+        with _patch_ipc(
+            response_frames=[
+                _error_frame("BOT_NOT_FOUND", "Bot not found: bot-missing")
+            ]
+        ):
             result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
-        finally:
-            for p in patchers:
-                p.stop()
 
         assert result.exit_code == 1, (result.stdout, result.stderr)
         assert result.stderr == "Bot not found: bot-missing\n"
         assert result.stdout == ""
 
     def test_bot_not_running_text(self, runner: CliRunner) -> None:
-        bot = _make_bot(status=BotStatus.STOPPED, bot_id="bot-1705")
-        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
-        for p in patchers:
-            p.start()
-        try:
+        with _patch_ipc(
+            response_frames=[
+                _error_frame(
+                    "BOT_NOT_RUNNING",
+                    "Bot is not running: bot-1705 (status: stopped)",
+                )
+            ]
+        ):
             result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
-        finally:
-            for p in patchers:
-                p.stop()
 
         assert result.exit_code == 1, (result.stdout, result.stderr)
         assert result.stderr == "Bot is not running: bot-1705 (status: stopped)\n"
         assert result.stdout == ""
 
     def test_bot_not_accepting_signals_text(self, runner: CliRunner) -> None:
-        bot = _make_bot(
-            status=BotStatus.RUNNING,
-            accepts_external_signals=False,
-            bot_id="bot-1705",
-        )
-        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
-        for p in patchers:
-            p.start()
-        try:
+        with _patch_ipc(
+            response_frames=[
+                _error_frame(
+                    "BOT_NOT_ACCEPTING_SIGNALS",
+                    "Bot bot-1705 does not accept external signals",
+                )
+            ]
+        ):
             result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
-        finally:
-            for p in patchers:
-                p.stop()
 
         assert result.exit_code == 1, (result.stdout, result.stderr)
         assert result.stderr == "Bot bot-1705 does not accept external signals\n"
@@ -300,54 +349,44 @@ class TestSignalConnectTextMode1705:
 
 
 class TestSignalConnectInformationalStderr1705:
-    """정상 path (valid key + running + accepts_external_signals) 에서
-    ``Connected to bot ...`` / ``Ready for JSON Lines ...`` 메시지가
-    stderr 에 그대로 출력됨을 lock. ``channel.run()`` 은 mock 해
-    채널 수립 직후 즉시 종료시킨다.
+    """정상 path (handshake OK) 에서 ``Connected to bot ...`` / ``Ready for
+    JSON Lines ...`` 메시지가 stderr 에 그대로 출력됨을 lock.
+
+    Phase-B OK frame 다음에 ``{type:closed}`` frame 을 주입해 ``_pump_out`` 이
+    즉시 break(exit 0) 하도록 한다. ``_pump_in`` 은 빈 stdin EOF 로 종료한다.
     """
 
     def test_informational_messages_to_stderr(self, runner: CliRunner) -> None:
-        bot = _make_bot(
-            status=BotStatus.RUNNING,
-            accepts_external_signals=True,
-            bot_id="bot-1705",
-        )
-        patchers = _patch_signal_deps(bot_id_for_key="bot-1705", bot=bot)
-        # SignalChannel.run() 을 즉시 종료시킨다.
-        mock_channel = MagicMock()
-        mock_channel.run = AsyncMock(return_value=None)
-        signal_channel_patch = patch(
-            "ante.bot.signal_channel.SignalChannel", return_value=mock_channel
-        )
-        for p in patchers:
-            p.start()
-        signal_channel_patch.start()
-        try:
-            result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
-        finally:
-            signal_channel_patch.stop()
-            for p in patchers:
-                p.stop()
+        # ``_pump_in`` 은 stub(영구 대기)으로 패치 — 테스트 하니스의 가짜 stdin
+        # 을 ``connect_read_pipe`` 로 등록하면 broken transport 가 생긴다. 본
+        # 케이스의 lock 대상은 inbound relay 가 아니라 handshake OK 후 2
+        # informational stderr 와 exit 0 이므로, ``_pump_out`` 이 closed frame
+        # 으로 종료를 주도하게 한다(현실 프로덕션 경로와 동형).
+        async def _idle_pump_in(_writer):  # noqa: ANN001, ANN202
+            await asyncio.Event().wait()
+
+        with _patch_ipc(response_frames=[_ok_frame("bot-1705"), _CLOSED_FRAME]):
+            with patch("ante.cli.commands.signal._pump_in", _idle_pump_in):
+                result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
 
         assert result.exit_code == 0, (result.stdout, result.stderr)
-        assert "Connected to bot bot-1705" in result.stderr
-        assert "Ready for JSON Lines communication on stdin/stdout" in result.stderr
+        assert "Connected to bot bot-1705\n" in result.stderr
+        assert "Ready for JSON Lines communication on stdin/stdout\n" in result.stderr
 
 
 # ──────────────────────────────────────────────────────────────
-# D. Optional auth-fail regression — root-level --format json
+# D. auth-fail regression — root-level --format json (pre-IPC)
 # ──────────────────────────────────────────────────────────────
 
 
 class TestSignalConnectAuthFail1705:
     """no-token + root-level ``--format json signal connect`` →
-    stdout ``auth_required`` JSON envelope (root-level Workaround sibling 정합).
+    stdout ``auth_required`` JSON envelope. ``@require_auth`` 가 socket 열기
+    전에 발화하므로 IPC mock 불필요.
     """
 
     def test_auth_required_json_envelope(self) -> None:
         r = CliRunner(mix_stderr=False)
-        # authenticate_member 가 ctx.obj["member"] 를 채우지 않도록 monkeypatch.
-        # require_auth 가드는 member is None 시 _emit_auth_error 로 종료.
         with patch("ante.cli.main.authenticate_member") as mock_auth:
 
             def _no_member(ctx):  # noqa: ANN001
@@ -371,3 +410,113 @@ class TestSignalConnectAuthFail1705:
         payload = json.loads(result.stdout)
         assert payload["status"] == "error"
         assert payload["code"] == "auth_required"
+
+
+# ──────────────────────────────────────────────────────────────
+# E. 신규 transport terminal (#2338) — IPC_SERVER_NOT_RUNNING / IPC_TIMEOUT
+# ──────────────────────────────────────────────────────────────
+
+
+_SERVER_DOWN_MSG = "서버가 실행 중이 아닙니다. 'ante system start'로 시작하세요."
+
+
+class TestSignalConnectIpcTerminals:
+    """thin relay 가 추가한 transport 종료 — server-absent / handshake timeout.
+
+    과거 broken-but-non-erroring 데몬-down 경로를 명시적 exit 1 terminal 로
+    잠근다(#2334 §10). #1705 외 신규 (code,message) lock 이다.
+    """
+
+    def test_server_not_running_connection_refused_json(
+        self, runner: CliRunner
+    ) -> None:
+        with _patch_ipc(connect_exc=ConnectionRefusedError()):
+            result = runner.invoke(
+                cli,
+                ["signal", "connect", "--key", "sk_ok", "--format", "json"],
+            )
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "status": "error",
+            "code": "IPC_SERVER_NOT_RUNNING",
+            "message": _SERVER_DOWN_MSG,
+        }
+        assert result.stderr == ""
+
+    def test_server_not_running_connection_refused_text(
+        self, runner: CliRunner
+    ) -> None:
+        with _patch_ipc(connect_exc=ConnectionRefusedError()):
+            result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        assert result.stderr == _SERVER_DOWN_MSG + "\n"
+        assert result.stdout == ""
+
+    def test_server_not_running_file_not_found_json(self, runner: CliRunner) -> None:
+        # ``FileNotFoundError`` ⊂ ``OSError`` — 동일 terminal 로 매핑.
+        with _patch_ipc(connect_exc=FileNotFoundError()):
+            result = runner.invoke(
+                cli,
+                ["signal", "connect", "--key", "sk_ok", "--format", "json"],
+            )
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload["code"] == "IPC_SERVER_NOT_RUNNING"
+        assert payload["message"] == _SERVER_DOWN_MSG
+        assert result.stderr == ""
+
+    def test_server_missing_socket_precheck_json(self, runner: CliRunner) -> None:
+        # ``Path.exists`` False → open_unix_connection 도달 전 pre-check terminal.
+        with (
+            patch(_PATH_EXISTS_TARGET, return_value=False),
+            patch(_SOCKET_TARGET, return_value="/tmp/test-ante.sock"),
+        ):
+            result = runner.invoke(
+                cli,
+                ["signal", "connect", "--key", "sk_ok", "--format", "json"],
+            )
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload["code"] == "IPC_SERVER_NOT_RUNNING"
+        assert payload["message"] == _SERVER_DOWN_MSG
+
+    def test_handshake_timeout_json(self, runner: CliRunner) -> None:
+        with _patch_ipc(handshake_timeout=True):
+            with patch("asyncio.wait_for", side_effect=_immediate_timeout):
+                result = runner.invoke(
+                    cli,
+                    ["signal", "connect", "--key", "sk_ok", "--format", "json"],
+                )
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "status": "error",
+            "code": "IPC_TIMEOUT",
+            "message": "서버 응답 시간 초과",
+        }
+        assert result.stderr == ""
+
+    def test_handshake_timeout_text(self, runner: CliRunner) -> None:
+        with _patch_ipc(handshake_timeout=True):
+            with patch("asyncio.wait_for", side_effect=_immediate_timeout):
+                result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
+
+        assert result.exit_code == 1, (result.stdout, result.stderr)
+        assert result.stderr == "서버 응답 시간 초과\n"
+        assert result.stdout == ""
+
+
+async def _immediate_timeout(coro, timeout):  # noqa: ANN001, ANN202
+    """``asyncio.wait_for`` 대역 — 즉시 ``TimeoutError`` (HangingReader 대기 회피).
+
+    실제 30s 대기 없이 Phase-B timeout 분기를 결정적으로 검증한다. 보류 중인
+    coroutine 은 close 해 ``RuntimeWarning`` 을 피한다.
+    """
+    coro.close()
+    raise TimeoutError

--- a/tests/unit/test_cli_signal_connect.py
+++ b/tests/unit/test_cli_signal_connect.py
@@ -108,6 +108,29 @@ class HangingReader(FakeReader):
         raise AssertionError("unreachable")
 
 
+class DeferredFrameReader(FakeReader):
+    """handshake OK 이후의 Phase-C 프레임을 ``_pump_in`` 완료 **뒤** 에 도착시키는
+    ``StreamReader`` 대역.
+
+    ``boundary_pos`` (handshake 프레임 끝 byte offset) 이후의 첫 read 마다 짧은
+    ``asyncio.sleep(0)`` 양보를 끼워, 데몬 잔여 프레임이 stdin EOF(=``_pump_in``
+    완료) 직후 비동기적으로 도착하는 현실 타이밍을 모사한다. 이로써 **비대칭
+    teardown** (pump_in 먼저 done → pump_out drain) 이 실제로 잔여 프레임을 stdout
+    으로 흘려보내는지 회귀-lock 한다. 대칭 cancel 회귀였다면 이 프레임들이 누락된다.
+    """
+
+    def __init__(self, frames: list[bytes], boundary_pos: int) -> None:
+        super().__init__(frames)
+        self._boundary = boundary_pos
+
+    async def readexactly(self, n: int) -> bytes:
+        if self._pos >= self._boundary:
+            # Phase-C 영역 — 잔여 프레임 도착을 이벤트루프 양보 뒤로 미룬다.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+        return await super().readexactly(n)
+
+
 class FakeWriter:
     """write/drain/write_eof/close/wait_closed no-op ``StreamWriter`` 대역."""
 
@@ -372,6 +395,63 @@ class TestSignalConnectInformationalStderr1705:
         assert result.exit_code == 0, (result.stdout, result.stderr)
         assert "Connected to bot bot-1705\n" in result.stderr
         assert "Ready for JSON Lines communication on stdin/stdout\n" in result.stderr
+
+
+# ──────────────────────────────────────────────────────────────
+# C2. EOF-drain regression — pump_in 먼저 종료 시 pump_out 잔여 프레임 drain
+# ──────────────────────────────────────────────────────────────
+
+
+class TestSignalConnectEofDrain2338:
+    """**비대칭** Phase-C teardown 회귀 lock (#2338 Codex 브랜치 리뷰 FAIL).
+
+    stdin EOF 로 ``_pump_in`` 이 먼저 완료해도 ``_pump_out`` 을 cancel 하지 않고
+    await 하여, 데몬의 잔여 ack/``{type:closed}`` 프레임을 socket EOF 까지 stdout
+    으로 drain 한 뒤 exit 0 임을 단언한다.
+
+    회귀(대칭 ``for task in pending: task.cancel()``) 였다면 ``_pump_in`` 이 먼저
+    done 인 순간 ``_pump_out`` 이 즉시 cancel 되어 잔여 프레임이 stdout 에 누락된다.
+    ``_pump_in`` 은 **idle stub 으로 가리지 않고** stdin EOF 를 실제로 모사하는
+    stub(``write_eof`` 후 즉시 return)으로 패치해 EOF→drain 경로를 노출한다.
+    """
+
+    def test_residual_frames_drained_after_stdin_eof(self, runner: CliRunner) -> None:
+        ack_frame = {"type": "ack", "signal_id": "sig-1"}
+
+        # OK handshake 프레임 끝 byte offset = boundary. 이후(ack/closed)는
+        # ``_pump_in`` 완료 뒤 비동기 도착(DeferredFrameReader).
+        ok = _frame(_ok_frame("bot-1705"))
+        boundary = len(ok)
+        frames = [ok, _frame(ack_frame), _frame(_CLOSED_FRAME)]
+        reader = DeferredFrameReader(frames, boundary_pos=boundary)
+        writer = FakeWriter()
+
+        async def _open(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+            return reader, writer
+
+        # stdin EOF 를 실제로 모사: half-close 후 즉시 return → ``_pump_in`` 이
+        # ``_pump_out`` 보다 먼저 done 이 되어 비대칭 else-분기(await pump_out)를
+        # 트리거한다.
+        async def _eof_pump_in(w):  # noqa: ANN001, ANN202
+            w.write_eof()
+
+        with (
+            patch(_PATH_EXISTS_TARGET, return_value=True),
+            patch(_SOCKET_TARGET, return_value="/tmp/test-ante.sock"),
+            patch(_OPEN_CONN_TARGET, _open),
+            patch("ante.cli.commands.signal._pump_in", _eof_pump_in),
+        ):
+            result = runner.invoke(cli, ["signal", "connect", "--key", "sk_ok"])
+
+        assert result.exit_code == 0, (result.stdout, result.stderr)
+
+        # stdin EOF 이후에도 잔여 ack 프레임이 stdout 으로 drain 되어야 한다.
+        out_lines = [ln for ln in result.stdout.splitlines() if ln]
+        decoded = [json.loads(ln) for ln in out_lines]
+        assert ack_frame in decoded, result.stdout
+        assert _CLOSED_FRAME in decoded, result.stdout
+        # closed 프레임 informational stderr 도 방출된다.
+        assert "channel closed: eof\n" in result.stderr
 
 
 # ──────────────────────────────────────────────────────────────

--- a/tests/unit/test_signal_success_output_drift.py
+++ b/tests/unit/test_signal_success_output_drift.py
@@ -15,8 +15,16 @@ callsite 의 envelope shape 사이의 drift 를 lock 한다.
 위로 수립한다 (long-running / streaming). ``fmt.success`` / ``fmt.output``
 단일 envelope dump 는 *발생하지 않는다*. validation 실패 분기 (``_fail``)
 만 JSON 모드에서 ``fmt.error(msg, code=...)`` envelope 을 dump 하고 즉시
-SystemExit (signal.py:93-104). success-output drift test 의 일반 envelope
-매칭 scope 밖이며, 본 모듈은 registry envelope 분류기 sanity 만 lock.
+SystemExit 한다. success-output drift test 의 일반 envelope 매칭 scope 밖이며,
+본 모듈은 registry envelope 분류기 sanity 만 lock.
+
+#2338 마이그레이션: ``signal connect`` 가 데몬-위임 thin IPC relay 로 재작성
+되어 invalid key 거부는 더 이상 in-process ``validate_key`` 가 아니라 데몬의
+**Phase-B error frame** 으로 도착한다. 본 모듈의 invalid-key JSON drift lock
+도 in-process ``Database``/``SignalKeyManager`` patch 에서 IPC-layer mock
+(``asyncio.open_unix_connection`` + ``INVALID_SIGNAL_KEY`` Phase-B frame)으로
+repoint 한다 — relay 가 ``resp["error"]`` 를 ``_fail`` 로 flatten 해 동일한
+``fmt.error`` envelope 을 byte-identical 로 dump 함을 lock 한다.
 
 3 시나리오 (registry sanity +1 + validation error envelope +1 + connect
 가 fmt.success 를 호출하지 않음 +1):
@@ -34,7 +42,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -147,29 +155,65 @@ def _load_json_payload(output: str) -> Any:
 def test_signal_connect_invalid_key_emits_error_envelope(tmp_path: Path) -> None:
     """``signal connect`` invalid key: ``fmt.error`` JSON envelope 발화.
 
-    signal.py:50-52: ``validate_key`` 가 ``None`` 반환 시 ``_fail(fmt,
-    "Invalid signal key", "INVALID_SIGNAL_KEY")``. JSON 모드는 stdout 으로
-    ``{status: "error", code, message}`` envelope 을 dump 하고 exit 1.
+    #2338 데몬-위임 relay: invalid key 는 데몬 Phase-B error frame
+    (``{status:error, error:{code:INVALID_SIGNAL_KEY, message:...}}``)으로
+    도착하고, relay 가 이를 ``_fail`` 로 flatten 해 JSON 모드 stdout 으로
+    ``{status:error, code, message}`` envelope 을 dump 하고 exit 1.
 
     본 시나리오는 success-output drift 의 일반 envelope 매칭 scope 밖이지만,
     signal connect 의 유일한 stdout JSON dump 경로이므로 본 모듈이 함께
     lock 한다 (registry stream leaf 의 "success envelope 부재" 를 보완).
     """
-    db = MagicMock()
-    db.connect = AsyncMock()
-    db.close = AsyncMock()
-    skm = MagicMock()
-    skm.initialize = AsyncMock()
-    skm.validate_key = AsyncMock(return_value=None)
+    import asyncio
+    import struct
 
-    # signal.py 는 ``_run_connect`` 내부에서 lazy import 하므로 원본 모듈을
-    # 직접 patch 한다.
+    payload = json.dumps(
+        {
+            "id": "h1",
+            "status": "error",
+            "error": {"code": "INVALID_SIGNAL_KEY", "message": "Invalid signal key"},
+        },
+        ensure_ascii=False,
+    ).encode("utf-8")
+    frame = struct.pack("!I", len(payload)) + payload
+
+    class _Reader:
+        def __init__(self) -> None:
+            self._buf = frame
+            self._pos = 0
+
+        async def readexactly(self, n: int):  # noqa: ANN202
+            if self._pos + n > len(self._buf):
+                partial = self._buf[self._pos :]
+                self._pos = len(self._buf)
+                raise asyncio.IncompleteReadError(partial, n)
+            chunk = self._buf[self._pos : self._pos + n]
+            self._pos += n
+            return chunk
+
+    class _Writer:
+        def write(self, _data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    async def _open(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+        return _Reader(), _Writer()
+
     with (
-        patch("ante.core.database.Database", return_value=db),
+        patch("ante.cli.commands.signal.Path.exists", return_value=True),
         patch(
-            "ante.bot.signal_key.SignalKeyManager",
-            return_value=skm,
+            "ante.cli.commands.signal.get_socket_path",
+            return_value="/tmp/test-ante.sock",
         ),
+        patch("asyncio.open_unix_connection", _open),
     ):
         result = _invoke(
             [
@@ -188,11 +232,11 @@ def test_signal_connect_invalid_key_emits_error_envelope(tmp_path: Path) -> None
     assert result.exit_code == 1, result.stdout
 
     # JSON envelope 는 stdout 에 dump 된다 (fmt.error).
-    payload = _load_json_payload(result.stdout)
-    assert isinstance(payload, dict)
-    assert payload.get("status") == "error"
-    assert payload.get("code") == "INVALID_SIGNAL_KEY"
-    assert "message" in payload
+    payload_out = _load_json_payload(result.stdout)
+    assert isinstance(payload_out, dict)
+    assert payload_out.get("status") == "error"
+    assert payload_out.get("code") == "INVALID_SIGNAL_KEY"
+    assert "message" in payload_out
 
 
 # ── 2. signal.py callsite 부재 단언 (success envelope 미생성) ───────────


### PR DESCRIPTION
Closes #2338
Closes #2333

## Summary
daemon-위임 `signal.connect`의 **최종 PR#3 (CLI thin relay + test migration)**. CLI `ante signal connect`를 별도 프로세스 in-process 구성에서 **daemon IPC relay**로 재작성한다. 이 PR이 **#2333**(signal connect가 RUNNING 봇을 BOT_NOT_FOUND로 거부)을 end-to-end로 해소한다.

- **`cli/commands/signal.py` _run_connect → thin relay**: `@require_auth` 유지 → `get_member_id`(middleware) → `get_socket_path(get_config_dir(ctx))` → Path.exists pre-check → `asyncio.open_unix_connection`(ConnectionRefused/OSError→IPC_SERVER_NOT_RUNNING) → handshake `{id,command:signal.connect,args:{key},actor}` → Phase-B `wait_for(decode,30)`(TimeoutError→IPC_TIMEOUT, IncompleteReadError→IPC_SERVER_NOT_RUNNING) → error→`_fail`(#1705 nested→flat passthrough) → OK→informational 2줄 + **비대칭** `wait(FIRST_COMPLETED)` pump_in/pump_out(pump_out-first→pump_in cancel; pump_in-first(stdin EOF)→pump_out drain). `_pump_out`은 raw `protocol.decode` **per-read timeout 없음**.
- **`bot/signal_channel.py`**: orphan `run()` 삭제(daemon은 _handle_message 직접 구동).
- daemon-side(PR#1/#2)·생성물 미변경. `BOT_NOT_FOUND_CODE` import 제거.

## #2333 해소 증명
`tests/integration/test_signal_connect_cli_repro_2333.py`: real `IPCServer` + UDS + RUNNING/`accepts_external_signals=True` 봇 + **unmocked `open_unix_connection`** → CLI relay handshake `status==ok`, `Connected to bot bot-1`, **`BOT_NOT_FOUND` 미발생** 단언(회귀 lock).

## Test Plan
- 11 byte-lock(#1705) byte-identical 유지(daemon Phase-B passthrough), 신규 IPC_SERVER_NOT_RUNNING/IPC_TIMEOUT terminal
- T15 #2333 end-to-end repro 2 passed, **TestSignalConnectEofDrain2338**(비대칭 EOF-drain 회귀 lock)
- blast-radius 마이그레이트: test_cli_signal_connect / test_cli_missing_resource_exit / test_signal_success_output_drift(IPC-layer mock), factory_drift_allowlist signal.py:48 제거 + test_factory_drift_check(CI-gate), cli_registry prose(SIGNAL_CONTRACTS 불변)
- ruff/mypy PASS, 광역 `-k 'signal or cli'` 2314 passed, daemon-side signal_channel 무수정 49 passed
- 잔여 in-process patcher 0(전수 grep)

## Plan / Review
- plan-preflight:done, Codex Plan Review: approve-implement(11-에이전트 워크플로 10건 + CI-gate blast-radius 사전해소, v1 revise 2건→v2 approve)
- Codex 브랜치 리뷰: attempt 1 FAIL(EOF 대칭 teardown)→**attempt 2 PASS**(비대칭 수정, head 5de89569)

🤖 Generated with [Claude Code](https://claude.com/claude-code)