### PR TITLE
fix(broker): #2342 KIS order-cash TR ID를 공식 현행(0011/0012)으로 갱신

### DIFF
--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -38,6 +38,17 @@ class KISDomesticAdapter(KISBaseAdapter):
 | 주문 취소/정정 | `/uapi/domestic-stock/v1/trading/order-rvsecncl` | POST |
 | 미체결 조회 | `/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl` | GET |
 
+### order-cash TR ID 매핑
+
+주문 접수(`order-cash`) 호출 시 `place_order`는 `is_paper` × `side` 조합으로 아래 KIS 공식 현행 TR ID를 전송한다. **order-cash 한정**이며, 취소/정정(`order-rvsecncl`, `VTTC0803U`/`TTTC0803U`)·잔고·현재가 등 다른 TR ID는 이 표의 범위 밖이다.
+
+| 환경 | 매수 | 매도 |
+|------|------|------|
+| 모의(paper) | `VTTC0012U` | `VTTC0011U` |
+| 실전(live) | `TTTC0012U` | `TTTC0011U` |
+
+> 출처: [KIS open-trading-api `order_cash.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_cash/order_cash.py) 및 KIS Developers 포털(2축 검증). 구버전 TR ID(`VTTC0802U`/`TTTC0802U`/`VTTC0801U`/`TTTC0311U`)는 deprecated 되어 모의 매수 시 `40910000 모의투자 주문이 불가한 계좌입니다`로 거절되므로 현행 매핑으로 갱신했다(#2342).
+
 ### KIS 주문 유형 매핑
 
 KISDomesticAdapter는 `order_type` 문자열을 KIS ORD_DVSN 코드로 매핑한다. `stop`/`stop_limit`이 전달되면 `ValueError`를 발생시킨다 (상위 계층에서 변환 후 호출해야 함).

--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -44,8 +44,8 @@ class KISDomesticAdapter(KISBaseAdapter):
 
 | 환경 | 매수 | 매도 |
 |------|------|------|
-| 모의(paper) | `VTTC0012U` | `VTTC0011U` |
-| 실전(live) | `TTTC0012U` | `TTTC0011U` |
+| 모의 | `VTTC0012U` | `VTTC0011U` |
+| 실전 | `TTTC0012U` | `TTTC0011U` |
 
 > 출처: [KIS open-trading-api `order_cash.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_cash/order_cash.py) 및 KIS Developers 포털(2축 검증). 구버전 TR ID(`VTTC0802U`/`TTTC0802U`/`VTTC0801U`/`TTTC0311U`)는 deprecated 되어 모의 매수 시 `40910000 모의투자 주문이 불가한 계좌입니다`로 거절되므로 현행 매핑으로 갱신했다(#2342).
 

--- a/docs/specs/broker-adapter/09-kis-overseas-adapter.md
+++ b/docs/specs/broker-adapter/09-kis-overseas-adapter.md
@@ -13,7 +13,7 @@ KISBaseAdapter를 상속하여 해외주식 전용 로직을 구현할 예정이
 | 항목 | KISDomesticAdapter | KISOverseasAdapter |
 |------|-------------------|-------------------|
 | API 경로 | `/uapi/domestic-stock/v1/` | `/uapi/overseas-stock/v1/` |
-| TR ID 매핑 | `TTTC0802U` (매수) 등 | `TTTT1002U` (매수) 등, **거래소별** |
+| TR ID 매핑 | `TTTC0012U` (매수) 등 | `TTTT1002U` (매수) 등, **거래소별** |
 | 주문 파라미터 | `ORD_DVSN`, `PDNO` (6자리) | `OVRS_EXCG_CD`, `TR_CRCY_CD`, 티커 |
 | 잔고 조회 | 원화 단일 | 통화별 분리 (`wcrc_frcr_dvsn_cd`) |
 | 시세 조회 | `fid_cond_mrkt_div_code: "J"` | `EXCD: "NAS"` 등 |

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -69,10 +69,10 @@ DEFAULT_MAX_PAGINATION_PAGES = 100
 # 주문 관련 tr_id (재시도 횟수 분류용)
 _ORDER_TR_IDS = frozenset(
     {
-        "VTTC0802U",
-        "TTTC0802U",  # 매수
-        "VTTC0801U",
-        "TTTC0311U",  # 매도
+        "VTTC0012U",
+        "TTTC0012U",  # 매수
+        "VTTC0011U",
+        "TTTC0011U",  # 매도
         "VTTC0803U",
         "TTTC0803U",  # 취소
     }
@@ -801,9 +801,9 @@ class KISDomesticAdapter(KISBaseAdapter):
             )
 
         if side == "buy":
-            tr_id = "VTTC0802U" if self.is_paper else "TTTC0802U"
+            tr_id = "VTTC0012U" if self.is_paper else "TTTC0012U"
         else:
-            tr_id = "VTTC0801U" if self.is_paper else "TTTC0311U"
+            tr_id = "VTTC0011U" if self.is_paper else "TTTC0011U"
 
         url = f"{self.base_url}/uapi/domestic-stock/v1/trading/order-cash"
         order_data = self._build_order_data(symbol, side, quantity, order_type, price)

--- a/tests/unit/test_kis_order_tr_id.py
+++ b/tests/unit/test_kis_order_tr_id.py
@@ -1,0 +1,65 @@
+"""KIS 국내주식 order-cash TR ID 매핑 회귀 테스트 (#2342).
+
+``KISDomesticAdapter.place_order`` 가 KIS 공식 현행 order-cash TR ID 를
+``is_paper`` × ``side`` 4조합으로 정확히 전송하는지 검증한다.
+
+공식 현행 매핑(KIS open-trading-api examples_llm + Developers 포털 2축 검증):
+    - 모의(paper) 매수: VTTC0012U / 모의 매도: VTTC0011U
+    - 실전(live)  매수: TTTC0012U / 실전 매도: TTTC0011U
+
+구버전(deprecated) order-cash TR ID(VTTC0802U/TTTC0802U/VTTC0801U/TTTC0311U)
+가 더 이상 전송되지 않음을 회귀 lock 한다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ante.broker.kis import KISDomesticAdapter
+
+# 구버전(deprecated) order-cash TR ID — 회귀 lock 대상.
+_DEPRECATED_ORDER_TR_IDS = frozenset(
+    {"VTTC0802U", "TTTC0802U", "VTTC0801U", "TTTC0311U"}
+)
+
+
+def _make_adapter(*, is_paper: bool) -> KISDomesticAdapter:
+    """네트워크 없이 place_order TR ID 선택만 검증하기 위한 어댑터."""
+    config = {
+        "app_key": "test-key",
+        "app_secret": "test-secret",
+        "account_no": "1234567890",
+        "is_paper": is_paper,
+    }
+    return KISDomesticAdapter(config=config)
+
+
+@pytest.mark.parametrize(
+    ("is_paper", "side", "expected_tr_id"),
+    [
+        (True, "buy", "VTTC0012U"),
+        (True, "sell", "VTTC0011U"),
+        (False, "buy", "TTTC0012U"),
+        (False, "sell", "TTTC0011U"),
+    ],
+)
+async def test_place_order_sends_official_order_cash_tr_id(
+    is_paper: bool, side: str, expected_tr_id: str
+) -> None:
+    """place_order 가 is_paper × side 별 공식 현행 order-cash TR ID 를 전송한다."""
+    adapter = _make_adapter(is_paper=is_paper)
+    adapter._ensure_authenticated = AsyncMock()  # type: ignore[method-assign]
+    adapter._rate_limit_wait = AsyncMock()  # type: ignore[method-assign]
+    request = AsyncMock(return_value={"output": {"ODNO": "123"}})
+    adapter._request = request  # type: ignore[method-assign]
+
+    order_id = await adapter.place_order("005930", side, 10, "market")
+
+    assert order_id == "123"
+    # _request(method, url, tr_id, ...) — tr_id 는 3번째 positional 인자.
+    sent_tr_id = request.call_args.args[2]
+    assert sent_tr_id == expected_tr_id
+    # 회귀 lock: 구버전 order-cash TR ID 가 전송되지 않음.
+    assert sent_tr_id not in _DEPRECATED_ORDER_TR_IDS

--- a/tests/unit/test_kis_pagination.py
+++ b/tests/unit/test_kis_pagination.py
@@ -372,7 +372,7 @@ async def test_request_returns_body_only() -> None:
     adapter._ensure_authenticated = AsyncMock()  # type: ignore[method-assign]
     adapter._rate_limit_wait = AsyncMock()  # type: ignore[method-assign]
 
-    result = await adapter._request("POST", "url", "TTTC0802U", json_data={"x": "1"})
+    result = await adapter._request("POST", "url", "TTTC0012U", json_data={"x": "1"})
 
     assert result == body
     assert isinstance(result, dict)


### PR DESCRIPTION
Closes #2342

## Summary
KIS 국내주식 `order-cash`가 구버전 TR ID를 사용해 모의 매수가 `40910000 모의투자 주문이 불가한 계좌입니다`로 거절되던 버그를 수정. KIS 공식 현행 매핑(open-trading-api examples_llm + KIS Developers 포털 2축 검증)으로 갱신.

- `KISDomesticAdapter.place_order`(kis.py:803-806): 매수 `VTTC0012U`(모의)/`TTTC0012U`(실전), 매도 `VTTC0011U`(모의)/`TTTC0011U`(실전).
- `_ORDER_TR_IDS`(kis.py:69-77): order-cash 4개 교체, **취소 `VTTC0803U`/`TTTC0803U` 유지**(retry 분류·order timeout 보존).
- 구버전 `VTTC0802U`/`TTTC0802U`/`VTTC0801U`/`TTTC0311U`는 production에서 제거(테스트/스펙의 deprecated negative-reference로만 잔존).

## 검증 (이슈 진실성)
- 코드 대조 + KIS 공식 2축으로 이슈가 진실(REAL)임을 확인 후 수정.
- live 주문 TR ID도 동반 갱신(공식 현행 기준; 기존 live 값 `TTTC0802U`/`TTTC0311U`도 deprecated — paper만 고치면 드리프트). legacy fallback은 별도 follow-up(Non-Goal).

## Spec
- `08-kis-domestic-adapter.md`: order-cash TR ID SSOT 표 신규(order-cash 한정 명시 + 공식 출처 링크 + #2342 근거) — drift 재발 차단.
- `09-kis-overseas-adapter.md:16`: stale 예시 `TTTC0802U`→`TTTC0012U`.

## Test Plan
- 신규 `test_kis_order_tr_id.py`: `place_order`의 `is_paper × side` 4조합 tr_id 검증 + 구버전 4개 미전송 회귀 lock (4 passed)
- `test_kis_pagination.py:375` stale 샘플 갱신
- `uv run pytest tests/unit -k 'kis or broker'` → 469 passed, ruff/mypy PASS

## Plan / Review
- plan-preflight:done, Codex Plan Review: approve-implement
- Codex 브랜치 리뷰: PASS (head 094e79e5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)