### PR TITLE
fix(broker): #2345 KIS order-rvsecncl 취소 body에 KRX_FWDG_ORD_ORGNO 추가

### DIFF
--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -49,6 +49,31 @@ class KISDomesticAdapter(KISBaseAdapter):
 
 > 출처: [KIS open-trading-api `order_cash.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_cash/order_cash.py) 및 KIS Developers 포털(2축 검증). 구버전 TR ID(`VTTC0802U`/`TTTC0802U`/`VTTC0801U`/`TTTC0311U`)는 deprecated 되어 모의 매수 시 `40910000 모의투자 주문이 불가한 계좌입니다`로 거절되므로 현행 매핑으로 갱신했다(#2342).
 
+### order-rvsecncl 취소 바디 계약 (#2345)
+
+주문 취소(`order-rvsecncl`, `cancel_order`)는 레거시 TR ID `VTTC0803U`(모의)/`TTTC0803U`(실전)로 아래 바디를 전송한다. **취소 한정**이며 정정(modify)·order-cash·잔고 등은 이 표의 범위 밖이다.
+
+| 필드 | 값 | 설명 |
+|------|------|------|
+| `CANO` | `account_no[:8]` | 종합계좌번호 |
+| `ACNT_PRDT_CD` | `account_no[8:10]` | 계좌상품코드 |
+| `ORGN_ODNO` | `order_id` | 원주문번호(ODNO) |
+| `ORD_DVSN` | `'01'` | 주문구분 |
+| `RVSE_CNCL_DVSN_CD` | `'02'` | 정정취소구분(02=취소) |
+| `ORD_QTY` | `'0'` | 주문수량(전량취소 시 0) |
+| `ORD_UNPR` | `'0'` | 주문단가 |
+| `QTY_ALL_ORD_YN` | `'Y'` | 잔량전부주문여부 |
+| `KRX_FWDG_ORD_ORGNO` | 원주문 캡처값(조건부) | 한국거래소전송주문조직번호 |
+
+`KRX_FWDG_ORD_ORGNO`(한국거래소전송주문조직번호)는 원주문별 값으로, 누락 시 mis-route/거절 위험이 있다. ante는 이 값을 다음 규칙으로 처리한다:
+
+- **원천**: 원주문 접수(`order-cash`) 성공 응답 `output`의 동일 필드명 `KRX_FWDG_ORD_ORGNO`를 직접 캡처한다(공식 order-cash 결과 컬럼에 `ODNO`/`ORD_TMD`와 함께 정의). `inquire-psbl-rvsecncl` 조회의 `ord_gno_brno`(주문채번지점번호)는 동일성 미보장(오값 위험)이라 **사용하지 않는다**.
+- **캐시 키 scope**: 어댑터 인스턴스(=계좌, `gateway._get_broker(account_id)`로 계좌별 분리) + 제출 KST 영업일(YYYYMMDD). KIS `odno`는 영업일 재사용이 가능하므로 영업일까지 키에 포함해 재사용 odno에 과거 조직번호를 붙이는 오값을 차단한다.
+- **주입/생략**: `cancel_order`는 캐시 hit & 영업일 일치 시에만 `KRX_FWDG_ORD_ORGNO`를 주입한다. 캐시 miss(인메모리 미보존)·응답에 필드 없음·영업일 불일치 시에는 **필드를 생략**(기존 8필드 동작 유지)하고 debug 로그를 남긴다. 취소 경로에서 **추가 조회/네트워크 호출은 하지 않는다**(순수 dict 연산).
+- **bounded / known-limitation**: 캐시는 `OrderedDict` + maxlen으로 무한 증가·stale 누적을 막는다. **in-process 한정**이라 재기동 시 캐시가 소실되며, 그 경우 miss로 처리되어 필드를 생략한다(추정값을 전송하지 않으므로 안전). cross-process/외부주문 취소의 원천 확보는 영속화(Option A) 또는 검증된 조회 원천을 별도 이슈로 다룬다.
+
+> 출처: [KIS open-trading-api `order_rvsecncl.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_rvsecncl/order_rvsecncl.py) 및 공식 레거시/Postman PAPER 샘플(`VTTC0803U`/`TTTC0803U`에서 `KRX_FWDG_ORD_ORGNO`를 원주문별 값으로 전송). 취소 tr_id `0803U→0013U` 마이그레이션과 `EXCG_ID_DVSN_CD`는 별도 live-gated 이슈(#2346) 범위다.
+
 ### KIS 주문 유형 매핑
 
 KISDomesticAdapter는 `order_type` 문자열을 KIS ORD_DVSN 코드로 매핑한다. `stop`/`stop_limit`이 전달되면 `ValueError`를 발생시킨다 (상위 계층에서 변환 후 호출해야 함).

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 from abc import abstractmethod
+from collections import OrderedDict
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -34,6 +35,7 @@ from ante.broker.exceptions import (
     OrderNotFoundError,
     RateLimitError,
 )
+from ante.broker.fill_scheduler import business_date_kst
 from ante.broker.models import CommissionInfo
 
 if TYPE_CHECKING:
@@ -80,6 +82,11 @@ _ORDER_TR_IDS = frozenset(
 
 # 인증 경로
 _AUTH_PATH = "/oauth2/tokenP"
+
+# 취소(order-rvsecncl) 시 전송할 KRX_FWDG_ORD_ORGNO 캐시 상한.
+# 어댑터 인스턴스(=계좌)당 미체결 주문 수를 넉넉히 덮으면서 무한 증가를 막는다.
+# 초과 시 가장 오래된 항목부터 제거(LRU 근사: insertion-order eviction).
+_KRX_FWDG_ORGNO_CACHE_MAXLEN = 1024
 
 
 class KISErrorClassifier:
@@ -711,6 +718,19 @@ class KISDomesticAdapter(KISBaseAdapter):
             + config.get("sell_tax_rate", 0.0018),
         )
 
+        # order-cash 응답에서 캡처한 KRX_FWDG_ORD_ORGNO 캐시 (#2345).
+        # 취소(order-rvsecncl)는 원주문별 한국거래소전송주문조직번호를 전송해야
+        # 한다. place_order 성공 응답의 output.KRX_FWDG_ORD_ORGNO(non-empty)를
+        # (값, 제출 KST 영업일)로 broker_order_id(ODNO)에 매핑해 둔다. cancel_order
+        # 는 순수 dict 조회(네트워크 없음)로 이를 주입한다.
+        #
+        # scope: 어댑터 인스턴스(=계좌, gateway._get_broker(account_id))당 분리.
+        #   추가로 KIS odno 는 영업일 재사용 가능(OrderTracker 문서)하므로 캐시
+        #   값에 제출 영업일을 함께 두고 취소 시 영업일 불일치면 miss 로 처리한다.
+        # bounded: OrderedDict + maxlen 으로 무한 증가/stale 누적을 막는다.
+        # known-limitation: in-process 한정(재기동 시 소실 → miss=필드 생략, 안전).
+        self._krx_fwdg_orgno_cache: OrderedDict[str, tuple[str, str]] = OrderedDict()
+
     # ── 계좌 정보 조회 ─────────────────────────────
 
     def _balance_params(self) -> dict[str, str]:
@@ -809,7 +829,13 @@ class KISDomesticAdapter(KISBaseAdapter):
         order_data = self._build_order_data(symbol, side, quantity, order_type, price)
 
         result = await self._request("POST", url, tr_id, json_data=order_data)
-        broker_order_id = result["output"]["ODNO"]
+        output = result["output"]
+        broker_order_id = output["ODNO"]
+        # 취소 시 전송할 KRX_FWDG_ORD_ORGNO 를 order-cash 응답에서 직접 캡처한다
+        # (#2345). 공식 order-cash 결과 컬럼(chk_order_cash.py)에 ODNO/ORD_TMD 와
+        # 함께 KRX_FWDG_ORD_ORGNO 가 정의되어 있다. 응답 구조 변동에 방어적으로
+        # 대응하기 위해 .get() 으로 읽고, non-empty 일 때만 캐시한다(오값 전송 금지).
+        self._cache_krx_fwdg_orgno(broker_order_id, output.get("KRX_FWDG_ORD_ORGNO"))
         logger.info(
             "주문 접수: %s %s %s %.0f주 → %s",
             side,
@@ -819,6 +845,22 @@ class KISDomesticAdapter(KISBaseAdapter):
             broker_order_id,
         )
         return broker_order_id
+
+    def _cache_krx_fwdg_orgno(self, broker_order_id: str, orgno: str | None) -> None:
+        """order-cash 응답의 KRX_FWDG_ORD_ORGNO 를 제출 영업일과 함께 캐시 (#2345).
+
+        non-empty 값만 저장한다. broker_order_id(ODNO) 키로 (값, 제출 KST 영업일)
+        을 매핑하며, bounded(OrderedDict + maxlen)로 무한 증가를 막는다.
+        취소 시 cancel_order 가 영업일 일치 여부까지 확인해 주입한다.
+        """
+        if not orgno:
+            # 응답에 필드가 없거나 빈 값이면 캐시하지 않는다 → 취소 시 miss(생략).
+            return
+        cache = self._krx_fwdg_orgno_cache
+        cache[broker_order_id] = (orgno, business_date_kst())
+        cache.move_to_end(broker_order_id)
+        while len(cache) > _KRX_FWDG_ORGNO_CACHE_MAXLEN:
+            cache.popitem(last=False)
 
     def _build_order_data(
         self,
@@ -865,7 +907,14 @@ class KISDomesticAdapter(KISBaseAdapter):
         return mapping.get(status_code, "unknown")
 
     async def cancel_order(self, order_id: str) -> bool:
-        """주문 취소."""
+        """주문 취소.
+
+        취소(order-rvsecncl) body 에 원주문별 ``KRX_FWDG_ORD_ORGNO``
+        (한국거래소전송주문조직번호)를 전송한다(#2345). 값은 place_order 시
+        order-cash 응답에서 캡처해 둔 인메모리 캐시에서 가져오며, 순수 dict
+        조회로 네트워크/추가 조회를 하지 않는다. 캐시 miss 또는 제출 영업일
+        불일치(odno 재사용 등) 시에는 필드를 생략한다(기존 동작 유지).
+        """
         tr_id = "VTTC0803U" if self.is_paper else "TTTC0803U"
         url = f"{self.base_url}/uapi/domestic-stock/v1/trading/order-rvsecncl"
         cancel_data = {
@@ -878,6 +927,15 @@ class KISDomesticAdapter(KISBaseAdapter):
             "ORD_UNPR": "0",
             "QTY_ALL_ORD_YN": "Y",
         }
+        cached = self._krx_fwdg_orgno_cache.get(order_id)
+        if cached is not None and cached[1] == business_date_kst():
+            cancel_data["KRX_FWDG_ORD_ORGNO"] = cached[0]
+        else:
+            logger.debug(
+                "취소 KRX_FWDG_ORD_ORGNO 생략: %s (cache=%s)",
+                order_id,
+                "miss" if cached is None else "stale-date",
+            )
         await self._request("POST", url, tr_id, json_data=cancel_data)
         logger.info("주문 취소 성공: %s", order_id)
         return True

--- a/tests/unit/test_kis_cancel_krx_fwdg_ord_orgno.py
+++ b/tests/unit/test_kis_cancel_krx_fwdg_ord_orgno.py
@@ -1,0 +1,188 @@
+"""KIS 국내주식 취소(order-rvsecncl) body의 KRX_FWDG_ORD_ORGNO 계약 테스트 (#2345).
+
+``KISDomesticAdapter`` 는 원주문 접수(order-cash) 응답의
+``KRX_FWDG_ORD_ORGNO``(한국거래소전송주문조직번호)를 인메모리 캐시에 보존하고,
+취소 시 같은 broker_order_id(ODNO)·같은 KST 영업일이면 cancel body 에 주입한다.
+캐시 miss / 응답에 필드 없음 / 영업일 불일치(odno 재사용) 시에는 필드를 생략한다
+(기존 8필드 동작 유지, 네트워크/추가 조회 없음).
+
+캡처 원천: 공식 order-cash 결과 컬럼(chk_order_cash.py)에 ODNO/ORD_TMD 와 함께
+``KRX_FWDG_ORD_ORGNO`` 가 정의되어 있어, place_order 가 읽는 동일 ``output`` dict
+에서 직접 캡처한다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ante.broker.fill_scheduler import business_date_kst
+from ante.broker.kis import KISDomesticAdapter
+
+_ORGNO = "00950"
+
+
+def _make_adapter(*, is_paper: bool = False) -> KISDomesticAdapter:
+    """네트워크 없이 place/cancel body 만 검증하기 위한 어댑터."""
+    config = {
+        "app_key": "test-key",
+        "app_secret": "test-secret",
+        "account_no": "1234567890",
+        "is_paper": is_paper,
+    }
+    return KISDomesticAdapter(config=config)
+
+
+def _stub_request(adapter: KISDomesticAdapter, response: dict) -> AsyncMock:
+    """``_request`` 와 인증/레이트리밋을 stub 하고 mock 을 반환한다."""
+    adapter._ensure_authenticated = AsyncMock()  # type: ignore[method-assign]
+    adapter._rate_limit_wait = AsyncMock()  # type: ignore[method-assign]
+    request = AsyncMock(return_value=response)
+    adapter._request = request  # type: ignore[method-assign]
+    return request
+
+
+def _captured_cancel_body(request: AsyncMock) -> dict:
+    """캡처된 cancel POST 의 json_data(키워드 인자)를 반환한다."""
+    return request.call_args.kwargs["json_data"]
+
+
+async def test_place_then_cancel_includes_krx_fwdg_ord_orgno() -> None:
+    """(a) place 응답에 필드 포함 → 같은 영업일 cancel body 에 캐시값 주입."""
+    adapter = _make_adapter()
+    request = _stub_request(
+        adapter, {"output": {"ODNO": "0001234567", "KRX_FWDG_ORD_ORGNO": _ORGNO}}
+    )
+
+    order_id = await adapter.place_order("005930", "buy", 10, "market")
+    assert order_id == "0001234567"
+
+    result = await adapter.cancel_order(order_id)
+    assert result is True
+
+    body = _captured_cancel_body(request)
+    assert body["KRX_FWDG_ORD_ORGNO"] == _ORGNO
+    assert body["ORGN_ODNO"] == order_id
+
+
+async def test_cancel_cache_miss_omits_field_and_succeeds() -> None:
+    """(b) 캐시에 없는 order_id 취소 → 필드 생략 + 취소 정상(True)."""
+    adapter = _make_adapter()
+    request = _stub_request(adapter, {"output": {}})
+
+    result = await adapter.cancel_order("9999999999")
+    assert result is True
+
+    body = _captured_cancel_body(request)
+    assert "KRX_FWDG_ORD_ORGNO" not in body
+
+
+async def test_place_without_orgno_field_not_cached() -> None:
+    """(c) place 응답에 KRX_FWDG_ORD_ORGNO 없음 → 캐시 안 함 → cancel 시 생략."""
+    adapter = _make_adapter()
+    request = _stub_request(adapter, {"output": {"ODNO": "0001234567"}})
+
+    order_id = await adapter.place_order("005930", "buy", 10, "market")
+    await adapter.cancel_order(order_id)
+
+    body = _captured_cancel_body(request)
+    assert "KRX_FWDG_ORD_ORGNO" not in body
+
+
+async def test_place_with_empty_orgno_not_cached() -> None:
+    """(c') place 응답 필드가 빈 문자열 → 캐시 안 함(오값 전송 금지)."""
+    adapter = _make_adapter()
+    request = _stub_request(
+        adapter, {"output": {"ODNO": "0001234567", "KRX_FWDG_ORD_ORGNO": ""}}
+    )
+
+    order_id = await adapter.place_order("005930", "buy", 10, "market")
+    await adapter.cancel_order(order_id)
+
+    body = _captured_cancel_body(request)
+    assert "KRX_FWDG_ORD_ORGNO" not in body
+
+
+async def test_cancel_stale_business_day_omits_field() -> None:
+    """(d) 영업일 불일치(재사용 odno, 과거 영업일 캐시) → 필드 생략."""
+    adapter = _make_adapter()
+    request = _stub_request(adapter, {"output": {}})
+
+    # 과거 영업일로 직접 캐시를 seed 해 odno 재사용 상황을 재현한다.
+    adapter._krx_fwdg_orgno_cache["0001234567"] = (_ORGNO, "20200101")
+    assert business_date_kst() != "20200101"
+
+    result = await adapter.cancel_order("0001234567")
+    assert result is True
+
+    body = _captured_cancel_body(request)
+    assert "KRX_FWDG_ORD_ORGNO" not in body
+
+
+async def test_cancel_body_regression_lock() -> None:
+    """(e) 기존 cancel body 8필드 회귀 lock (캐시 hit 시에도 기존 필드 불변)."""
+    adapter = _make_adapter()
+    request = _stub_request(
+        adapter, {"output": {"ODNO": "0001234567", "KRX_FWDG_ORD_ORGNO": _ORGNO}}
+    )
+
+    order_id = await adapter.place_order("005930", "buy", 10, "market")
+    await adapter.cancel_order(order_id)
+
+    body = _captured_cancel_body(request)
+    assert body["CANO"] == "12345678"
+    assert body["ACNT_PRDT_CD"] == "90"
+    assert body["ORGN_ODNO"] == order_id
+    assert body["ORD_DVSN"] == "01"
+    assert body["RVSE_CNCL_DVSN_CD"] == "02"
+    assert body["ORD_QTY"] == "0"
+    assert body["ORD_UNPR"] == "0"
+    assert body["QTY_ALL_ORD_YN"] == "Y"
+    # 신규 필드 1개만 추가되어 총 9필드.
+    assert set(body) == {
+        "CANO",
+        "ACNT_PRDT_CD",
+        "ORGN_ODNO",
+        "ORD_DVSN",
+        "RVSE_CNCL_DVSN_CD",
+        "ORD_QTY",
+        "ORD_UNPR",
+        "QTY_ALL_ORD_YN",
+        "KRX_FWDG_ORD_ORGNO",
+    }
+
+
+async def test_cache_is_bounded() -> None:
+    """캐시는 maxlen 으로 bounded — 무한 증가하지 않고 오래된 항목부터 evict."""
+    from ante.broker.kis import _KRX_FWDG_ORGNO_CACHE_MAXLEN
+
+    adapter = _make_adapter()
+    today = business_date_kst()
+    for i in range(_KRX_FWDG_ORGNO_CACHE_MAXLEN + 50):
+        adapter._cache_krx_fwdg_orgno(f"odno-{i}", _ORGNO)
+
+    assert len(adapter._krx_fwdg_orgno_cache) == _KRX_FWDG_ORGNO_CACHE_MAXLEN
+    # 가장 오래된 항목들이 evict 됨.
+    assert "odno-0" not in adapter._krx_fwdg_orgno_cache
+    # 최신 항목은 유지되고 영업일도 함께 저장됨.
+    last_key = f"odno-{_KRX_FWDG_ORGNO_CACHE_MAXLEN + 49}"
+    assert adapter._krx_fwdg_orgno_cache[last_key] == (_ORGNO, today)
+
+
+@pytest.mark.parametrize("is_paper", [True, False])
+async def test_cancel_works_for_paper_and_live(is_paper: bool) -> None:
+    """모의/실전 모두 캐시 hit 시 cancel body 에 필드 주입."""
+    adapter = _make_adapter(is_paper=is_paper)
+    request = _stub_request(
+        adapter, {"output": {"ODNO": "0001234567", "KRX_FWDG_ORD_ORGNO": _ORGNO}}
+    )
+
+    order_id = await adapter.place_order("005930", "buy", 10, "market")
+    await adapter.cancel_order(order_id)
+
+    body = _captured_cancel_body(request)
+    assert body["KRX_FWDG_ORD_ORGNO"] == _ORGNO
+    # tr_id 도 환경별로 올바른지(취소 tr_id 회귀): 0803U 유지.
+    cancel_tr_id = request.call_args_list[-1].args[2]
+    assert cancel_tr_id == ("VTTC0803U" if is_paper else "TTTC0803U")


### PR DESCRIPTION
Closes #2345

## Summary
KIS 국내주식 취소(`order-rvsecncl`) body에 누락돼 있던 `KRX_FWDG_ORD_ORGNO`(한국거래소전송주문조직번호)를 추가한다. 공식 KIS 계약은 ante가 쓰는 레거시 tr_id `VTTC0803U`/`TTTC0803U`에서도 이 필드를 원주문별 값으로 요구한다(공식 레거시/Postman/python-kis/신 0013U 예제 4축 일치).

설계(Codex Plan Review `narrow-scope` 반영):
- `place_order` 성공 응답 `output`의 권위 있는 동일 필드명 `KRX_FWDG_ORD_ORGNO`를 직접 캡처(추정 금지).
- 어댑터 인메모리 캐시(`OrderedDict`, maxlen 1024)에 `(orgno, 제출 KST 영업일)`로 저장. account/paper-live는 어댑터 인스턴스가 계좌별이라 구조적 분리, KIS `odno` 영업일 재사용은 제출 영업일 비교로 차단.
- `cancel_order`는 캐시 hit & 영업일 일치 시에만 주입, miss/날짜불일치 시 생략(현 동작) — 순수 dict 조회로 네트워크/추가 조회 없음. fallback이라 downside는 현 동작과 동일.
- `cancel_order`/`place_order`/`BrokerAdapter` 시그니처 불변. 취소 tr_id 0803U→0013U + EXCG_ID_DVSN_CD(#2346), DB 영속화(Option A)는 비목표.

스펙: `docs/specs/broker-adapter/08-kis-domestic-adapter.md`에 취소 바디 SSOT 신규.

## Test Plan
- 신규 `tests/unit/test_kis_cancel_krx_fwdg_ord_orgno.py` (9 passed): place→당일 cancel 시 필드 주입 / 캐시 miss 생략 / 응답에 필드 없음 시 미캐시 / 영업일 불일치(재사용 odno) 생략 / 기존 cancel body 8필드 회귀 lock.
- `uv run --extra dev pytest tests/unit -k "kis or broker" -q` → 478 passed
- `uv run --extra dev ruff check` / `ruff format --check` / `mypy src/ante/broker/kis.py` → PASS
- Codex 브랜치 리뷰(`/codex:review --base main`) PASS (head 5f5d8a1b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
