### PR TITLE
fix(broker): #2344 KIS order-cash body에 EXCG_ID_DVSN_CD 추가 (공식 현행 계약 정합)

### DIFF
--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -21,7 +21,7 @@ class KISDomesticAdapter(KISBaseAdapter):
 |------|------|
 | `currency` | `"KRW"` 반환 |
 | API 경로 | `/uapi/domestic-stock/v1/` |
-| 주문 파라미터 | `ORD_DVSN`, `PDNO` (6자리 종목코드) |
+| 주문 파라미터 | `ORD_DVSN`, `PDNO` (6자리 종목코드), `EXCG_ID_DVSN_CD` (`KRX`) |
 | 잔고 조회 | 원화 단일 (`TTTC8434R`) |
 | 시세 조회 | `fid_cond_mrkt_div_code: "J"` |
 | 심볼 정규화 | 6자리 숫자 (`005930`) |
@@ -48,6 +48,24 @@ class KISDomesticAdapter(KISBaseAdapter):
 | 실전 | `TTTC0012U` | `TTTC0011U` |
 
 > 출처: [KIS open-trading-api `order_cash.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_cash/order_cash.py) 및 KIS Developers 포털(2축 검증). 구버전 TR ID(`VTTC0802U`/`TTTC0802U`/`VTTC0801U`/`TTTC0311U`)는 deprecated 되어 모의 매수 시 `40910000 모의투자 주문이 불가한 계좌입니다`로 거절되므로 현행 매핑으로 갱신했다(#2342).
+
+### order-cash 주문 바디 계약 (#2344)
+
+주문 접수(`order-cash`, `place_order` → `_build_order_data`)는 `is_paper` × `side` × `order_type` 무관하게 아래 바디를 전송한다. **order-cash 한정**이며 취소/정정(`order-rvsecncl`)·잔고·현재가 등은 이 표의 범위 밖이다. `EXCG_ID_DVSN_CD`는 모듈 레벨 상수 `DEFAULT_EXCG_ID_DVSN_CD="KRX"`로 주입한다(에픽 #2354 일관성 목표의 공유 단일 출처 — 후속 이슈가 재사용).
+
+| 필드 | 값 | 설명 |
+|------|------|------|
+| `CANO` | `account_no[:8]` | 종합계좌번호 |
+| `ACNT_PRDT_CD` | `account_no[8:10]` | 계좌상품코드 |
+| `PDNO` | `normalize_symbol(symbol)` (6자리) | 종목코드 |
+| `ORD_DVSN` | `order_type` 매핑(시장가 `'01'`/지정가 `'00'` 등) | 주문구분 |
+| `ORD_QTY` | `str(int(quantity))` | 주문수량 |
+| `ORD_UNPR` | 시장가 `'0'` / 지정가 `str(int(price))` | 주문단가 |
+| `EXCG_ID_DVSN_CD` | `'KRX'` | 거래소ID구분코드(국내 KRX 기본·NXT/SOR 미지원) |
+
+- **출처**: [KIS open-trading-api `order_cash.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_cash/order_cash.py). 공식 예제는 `order_cash()` 인자로 `excg_id_dvsn_cd`를 필수로 받고 누락 시 `ValueError`로 가드하며, 요청 바디에 `"EXCG_ID_DVSN_CD": excg_id_dvsn_cd`로 포함한다. ante 이전 바디에는 이 필드가 빠져 공식 현행 계약과 drift 상태였다.
+- **`40910000` 인과 caveat**: 2026-06-11 KST 모의 smoke에서 #2342 TR ID 갱신 후에도 모의 매수가 `40910000 모의투자 주문이 불가한 계좌입니다`로 실패했다. 본 계약 정합이 그 실패의 직접 원인인지는 **미확정**이며, 머지 후 다음 거래일 모의 smoke(`buy 1 → fill/position → sell 1 → flatten`)로 검증한다. 지속 실패 시 계좌 자격/provisioning 가설은 별도 이슈로 분리한다(본 이슈는 contract drift 해소로 종결).
+- **비목표(`SLL_TYPE`/`CNDT_PRIC`)**: 공식 예제 바디에는 `SLL_TYPE`(매도유형)·`CNDT_PRIC`(조건가격)이 존재하나, 필수 `ValueError` 가드는 `EXCG_ID_DVSN_CD`에만 있고 거절 근거 관측이 없어 본 PR 비목표다. 추측성 빈 문자열 필드 추가는 행동 변화 위험만 있으므로 제외하며, 거절 근거가 관측되면 후속 이슈로 다룬다.
 
 ### order-rvsecncl 취소 바디 계약 (#2345)
 

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -80,6 +80,12 @@ _ORDER_TR_IDS = frozenset(
     }
 )
 
+# 거래소ID구분코드(EXCG_ID_DVSN_CD) 기본값.
+# 에픽 #2354 일관성 목표의 공유 단일 출처 — order-cash(#2344) 외 후속 이슈
+# (inquire-daily-ccld #2349 등)가 재사용할 예정이다. 국내 KRX 주문 기본값으로,
+# NXT/SOR 등 다른 거래소 라우팅은 현재 미지원(요구 발생 시 config 표면화는 후속).
+DEFAULT_EXCG_ID_DVSN_CD = "KRX"
+
 # 인증 경로
 _AUTH_PATH = "/oauth2/tokenP"
 
@@ -878,6 +884,10 @@ class KISDomesticAdapter(KISBaseAdapter):
             "ORD_DVSN": self._map_order_type(order_type),
             "ORD_QTY": str(int(quantity)),
             "ORD_UNPR": "0",
+            # 거래소ID구분코드 — KIS 공식 order-cash 현행 계약의 필수 필드(#2344).
+            # 공식 order_cash.py 가 excg_id_dvsn_cd 누락 시 ValueError 로 가드한다.
+            # market/limit·side 무관 공통(국내 KRX 기본).
+            "EXCG_ID_DVSN_CD": DEFAULT_EXCG_ID_DVSN_CD,
         }
         if order_type == "limit" and price is not None:
             data["ORD_UNPR"] = str(int(price))

--- a/tests/unit/test_kis_order_tr_id.py
+++ b/tests/unit/test_kis_order_tr_id.py
@@ -17,11 +17,26 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from ante.broker.kis import KISDomesticAdapter
+from ante.broker.kis import DEFAULT_EXCG_ID_DVSN_CD, KISDomesticAdapter
 
 # 구버전(deprecated) order-cash TR ID — 회귀 lock 대상.
 _DEPRECATED_ORDER_TR_IDS = frozenset(
     {"VTTC0802U", "TTTC0802U", "VTTC0801U", "TTTC0311U"}
+)
+
+# order-cash 요청 바디의 정확한 키 집합(#2344). 국내 KRX 주문에서
+# EXCG_ID_DVSN_CD 가 필수이며, SLL_TYPE/CNDT_PRIC 등 추가 필드 혼입을
+# 차단하기 위해 포함 단언이 아닌 exact 키 집합으로 회귀 lock 한다.
+_EXPECTED_ORDER_BODY_KEYS = frozenset(
+    {
+        "CANO",
+        "ACNT_PRDT_CD",
+        "PDNO",
+        "ORD_DVSN",
+        "ORD_QTY",
+        "ORD_UNPR",
+        "EXCG_ID_DVSN_CD",
+    }
 )
 
 
@@ -63,3 +78,48 @@ async def test_place_order_sends_official_order_cash_tr_id(
     assert sent_tr_id == expected_tr_id
     # 회귀 lock: 구버전 order-cash TR ID 가 전송되지 않음.
     assert sent_tr_id not in _DEPRECATED_ORDER_TR_IDS
+
+
+@pytest.mark.parametrize("is_paper", [True, False])
+@pytest.mark.parametrize("side", ["buy", "sell"])
+@pytest.mark.parametrize(
+    ("order_type", "price", "expected_ord_dvsn", "expected_ord_unpr"),
+    [
+        ("market", None, "01", "0"),
+        ("limit", 70000.0, "00", "70000"),
+    ],
+)
+async def test_place_order_body_includes_excg_id_dvsn_cd(
+    is_paper: bool,
+    side: str,
+    order_type: str,
+    price: float | None,
+    expected_ord_dvsn: str,
+    expected_ord_unpr: str,
+) -> None:
+    """order-cash 바디가 EXCG_ID_DVSN_CD 를 포함한 exact 7키만 전송한다 (#2344).
+
+    모의/실전 × buy/sell × market/limit 전 조합에서 국내 KRX 주문 필수 필드
+    EXCG_ID_DVSN_CD="KRX" 가 side·order_type 무관하게 포함되며, SLL_TYPE/
+    CNDT_PRIC 등 비목표 필드가 혼입되지 않음을 exact 키 집합으로 lock 한다.
+    """
+    adapter = _make_adapter(is_paper=is_paper)
+    adapter._ensure_authenticated = AsyncMock()  # type: ignore[method-assign]
+    adapter._rate_limit_wait = AsyncMock()  # type: ignore[method-assign]
+    request = AsyncMock(return_value={"output": {"ODNO": "123"}})
+    adapter._request = request  # type: ignore[method-assign]
+
+    await adapter.place_order("005930", side, 10, order_type, price)
+
+    # _request(method, url, tr_id, json_data=...) — 바디는 json_data 키워드 인자.
+    body = request.call_args.kwargs["json_data"]
+    # 포함 단언 금지: exact 7키 집합으로 추가/누락 필드를 모두 회귀 lock.
+    assert set(body) == _EXPECTED_ORDER_BODY_KEYS
+    assert body["CANO"] == "12345678"
+    assert body["ACNT_PRDT_CD"] == "90"
+    assert body["PDNO"] == "005930"
+    assert body["ORD_DVSN"] == expected_ord_dvsn
+    assert body["ORD_QTY"] == "10"
+    assert body["ORD_UNPR"] == expected_ord_unpr
+    # 국내 KRX 주문 필수 필드(#2344) — side·order_type 무관 상수.
+    assert body["EXCG_ID_DVSN_CD"] == DEFAULT_EXCG_ID_DVSN_CD == "KRX"


### PR DESCRIPTION
Closes #2344

## Summary
- `src/ante/broker/kis.py`에 모듈 레벨 공유 상수 `DEFAULT_EXCG_ID_DVSN_CD = "KRX"` 신설(에픽 #2354 단일 출처 — #2349/#2346 재사용 예정)
- `_build_order_data()` body에 `EXCG_ID_DVSN_CD` 주입(market/limit·side 무관) — KIS 공식 현행 `order_cash.py` 필수 필드 계약 정합
- `tests/unit/test_kis_order_tr_id.py`에 모의/실전 × buy/sell × market/limit **exact 7-key dict** 회귀 lock(SLL_TYPE/CNDT_PRIC 혼입 차단)
- `docs/specs/broker-adapter/08-kis-domestic-adapter.md`에 order-cash 주문 바디 계약 H3 신설(+상단 주문 파라미터 요약 갱신, 40910000 인과 미확정 caveat)

## Verification
- Plan Preflight: approve-implement (Codex R2) / Codex 브랜치 리뷰: PASS (attempt 1)
- `pytest tests/unit -q`: 7170 passed, 2 skipped 무회귀
- `mypy src/`: Success (232 files) / `ruff check`·`format --check` 통과
- 라이브 검증(머지 후): 다음 거래일 모의 fill-heavy smoke에서 buy→fill→sell 재검증. 40910000 지속 시 계좌 자격 가설 별도 이슈 분리

## Test Plan
- `pytest tests/unit/test_kis_order_tr_id.py tests/unit/test_broker_adapter_split.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)