### PR TITLE
fix(trade): #2352 단일봇 미귀속 보유(carryover) 외부매수 force-write 제거 — capacity==0 detect-only

### DIFF
--- a/docs/specs/broker-adapter/15-reconciliation.md
+++ b/docs/specs/broker-adapter/15-reconciliation.md
@@ -64,11 +64,28 @@ CREATE INDEX IF NOT EXISTS idx_order_registry_account_bot
 
 ReconcileScheduler는 `PositionReconciler`(Trade 모듈), `BrokerAdapter`(실제 잔고 조회), `BotManager`(활성 봇 목록), `EventBus`를 positional 인자로 주입받는다. 추가로 keyword-only 인자를 받는다:
 
-- `broker_account_id`(필수): 이 스케줄러 인스턴스가 바인딩된 broker 계좌의 account_id. 빈 값이면 `ValueError`. `run_once()`는 이 account_id에 일치하는 활성(running) 봇만 대사하고, 다른 계좌의 봇은 명시적으로 skip한다(SPLIT-1 단일 broker 바인딩 가드). multi-broker pool은 SPLIT-3에서 도입한다(`src/ante/main.py`의 `_init_reconcile_scheduler`가 활성 broker별 스케줄러를 생성·관리).
+- `broker_account_id`(필수): 이 스케줄러 인스턴스가 바인딩된 broker 계좌의 account_id. 빈 값이면 `ValueError`. `run_once()`는 이 account_id에 일치하는 봇만 대사 대상으로 삼고, 다른 계좌의 봇은 명시적으로 skip한다(SPLIT-1 단일 broker 바인딩 가드). multi-broker pool은 SPLIT-3에서 도입한다(`src/ante/main.py`의 `_init_reconcile_scheduler`가 활성 broker별 스케줄러를 생성·관리).
 - `interval_seconds`(기본 `DEFAULT_INTERVAL_SECONDS` = 1800초 = 30분): 대사 반복 주기.
-- `skip_initial_external_buy`(기본 `False`): True면 `start()`의 **기동 즉시 1회 대사에서만** "외부 매수" 분류 보정을 건너뛴다(이후 주기 대사는 정상 처리).
+- `skip_initial_external_buy`(기본 `False`): True면 `start()`의 **기동 즉시 1회 대사에서만** "외부 매수" 분류 보정을 건너뛴다(이후 주기 대사는 정상 처리). 단일봇+running 보정 경로에만 적용된다.
 
 `start()`는 시작 즉시 1회 대사(`run_once(skip_external_buy=self._skip_initial_external_buy)`)를 수행한 뒤 `interval_seconds` 주기로 대사 루프를 돈다. 불일치 감지 시 로그 경고와 함께 `NotificationEvent`를 발행한다.
+
+**`run_once()` 라우팅 (`bot_count==1` vs `2+`, normative):** `run_once()`는 자기
+`broker_account_id` 계좌의 broker 총합을 1회 조회한 뒤, **봇 귀속 ambiguity(status 무관 봇
+count)** 와 **correction 실행 범위(running 봇)** 를 분리해 분기한다(#2118/#2119/#2270). 과거
+스펙의 "활성(running) 봇만 대사하는 단일 경로" 기술은 stale 이며, 실제 라우팅은 다음과 같다:
+
+| 계좌 봇 수(status 무관) | 봇 상태 | 동작 |
+|---|---|---|
+| 1봇 | `running` | `reconcile(dry_run=False)` — self-check/skip_external_buy/external-buy 분류 그대로 보정(#1946/#1950). 단, **미귀속 보유(internal_qty==0 && capacity==0)는 detect-only** 로 보정 제외([../trade/03-07-position-reconciler.md](../trade/03-07-position-reconciler.md), #2352). |
+| 1봇 | `stopped`/`error`(미-running) | `reconcile(dry_run=True)` detect-only — scheduler 가 비활성 봇을 자동 보정하지 않는다(lifecycle 범위 보존, #2118 v4). |
+| 2+봇 | (무관) | `detect_account_level` — `correct_position` 미호출. 계좌 총합 vs 전 봇 합산 비교로 #2118/#2120 false external-buy 제거. bot-scoped `PositionMismatchEvent`/`ReconcileEvent` 대신 account-scoped `NotificationEvent` 만 발행. |
+
+ambiguity 판정 count 는 **status 무관**이다(#2119). 즉 `stopped`/`error` 봇도 count 에
+포함되므로, 2+봇이면 일부만 running 이어도 detect-only 로 귀결된다. 다른 계좌의 봇과
+`account_id` 누락 봇은 count 에서 제외된다(WARNING). 수동 대사(IPC `broker reconcile`)도
+동일한 count 분기를 쓰되, user-initiated 라 봇 상태와 무관하게 단일봇 귀속이 자명하므로
+`dry_run = not fix` 로 동작한다([../ipc/ipc.md](../ipc/ipc.md) Broker 절).
 
 **#1946 fill 복구 barrier**: 서버 기동 시(`src/ante/main.py`) 각 계좌의 `FillReconcileScheduler.catch_up_once()`가 await 완료된 뒤에야 `ReconcileScheduler.start()`가 호출된다. fill 복구가 position 대사에 선행해야 미복구 ante 체결이 "외부 매수"로 오분류되지 않기 때문이다. fill 카치업에 **실패한** 계좌(`s.fill_catch_up_failed_accounts`)는 `skip_initial_external_buy=True`로 생성되어, 그 계좌의 기동 즉시 1회 대사에서만 external-buy 분류 보정을 건너뛴다.
 

--- a/docs/specs/broker-adapter/18-fill-recovery.md
+++ b/docs/specs/broker-adapter/18-fill-recovery.md
@@ -260,10 +260,18 @@ pagination)를 **1회** 폴해 다운타임 중 발생한 체결을 `FillApplier
 invariant**다. EOD 만료를 폴 **앞**에 두면, 전일 open이 다운타임 중 체결됐어도
 복구 전에 `expired`로 전이되어 폴이 0콜로 끝나고, `catch_up_once`가
 `succeeded=True`(applied=0)를 반환해 barrier의 external-buy 차단이 무력화된다.
-그 결과 미복구 ante 체결(internal=0, broker>0)이 "외부 매수"로 오분류된다
-(#1945 회귀). poll-first는 이를 구조적으로 막는다. `succeeded=True`는 폴이 실제
-실행돼 다운타임 체결을 흡수했음을 의미하며, "만료로 open이 비어 0콜"은 성공으로
-취급하지 않는다.
+그 결과 미복구 ante 체결(internal=0, broker>0)이 reconciler 의 self/external 분류로
+**오귀속**된다(#1945 회귀). poll-first는 이를 구조적으로 막는다. `succeeded=True`는
+폴이 실제 실행돼 다운타임 체결을 흡수했음을 의미하며, "만료로 open이 비어 0콜"은
+성공으로 취급하지 않는다.
+
+> 참고(#2352): 위 회귀에서 매칭 open 주문이 `expired`(terminal)로 사라지면
+> reconciler 입장에서 `internal_qty == 0 && capacity == 0` 이 되어, 그 보유는
+> "외부 매수" force-write 가 아니라 **미귀속 보유 detect-only**(보정 skip · critical
+> 알림)로 분류된다([../trade/03-07-position-reconciler.md](../trade/03-07-position-reconciler.md)
+> 미귀속 보유 절). 따라서 barrier 무력화의 잔여 위험은 "잘못된 force-write/자동
+> 매도"가 아니라 "복구 지연된 보유의 오귀속 알림"으로 좁혀진다 — poll-first 순서
+> invariant 가 근본 차단을 담당한다는 사실은 변하지 않는다.
 
 ## 7. barrier ordering (재기동 무오분류)
 

--- a/docs/specs/trade/03-07-position-reconciler.md
+++ b/docs/specs/trade/03-07-position-reconciler.md
@@ -28,7 +28,7 @@
 3. 불일치 감지 시 분류(아래) 후 `PositionMismatchEvent` 발행 + (외부 거래만) `TradeService.correct_position()` 호출로 보정
 4. 보정 건이 있으면 `ReconcileEvent` 발행
 
-**불일치 유형:** 외부 청산, 외부 일부 매도, 외부 매수, 수량 불일치, **ante 미반영 체결(self-submitted)**
+**불일치 유형:** 외부 청산, 외부 일부 매도, 외부 매수, 수량 불일치, **ante 미반영 체결(self-submitted)**, **미귀속 보유(unattributed-holding, #2352 detect-only)**
 
 ## self / external 분류 정책 (#1950, normative)
 
@@ -77,6 +77,68 @@ reconcile 에서 잔여 excess 가 **external 로 검출·보정**된다. → �
 
 **무변경 분기:** 외부 청산(`broker_qty == 0 && internal_qty > 0`), 외부 일부 매도
 (`broker_qty < internal_qty`), 수량 불일치는 self-check 대상이 아니며 기존 동작을 유지한다.
+
+## 미귀속 보유 detect-only (#2352, normative)
+
+`broker_qty > internal_qty` 분기에서 self-check 가 self_submitted 로 매칭되지 **않은**
+뒤, 추가로 **`internal_qty == 0` 이고 `capacity == 0`**(= `(account_id, bot_id, symbol,
+side="buy")` 의 non-terminal open buy 가 **전무**)인 보유는 **미귀속 보유**(사유:
+`미귀속 보유`)로 분류하고 **detect-only** 처리한다.
+
+**분류 규칙(normative):**
+
+- 판정: self-check 미매칭(self_submitted 아님) → `internal_qty == 0` → `(account_id,
+  bot_id, symbol, side="buy")` 의 non-terminal open buy 가 **하나도 없음**(capacity == 0).
+  세 조건을 모두 만족하면 미귀속 보유다.
+- `correct_position` 자동 보정을 **호출하지 않는다**(force-write 없음). 단일봇이라는
+  이유만으로 그 봇이 거래(추적)한 적 없는 보유를 그 봇 소유로 단정하지 않는다.
+- `PositionMismatchEvent`(reason=`미귀속 보유`) + `NotificationEvent`(level=**critical**)는
+  **기존대로 발행**한다. 운영자 관측 가능성을 줄이지 않는다(detect-only ≠ 침묵). 경고
+  로그에 미귀속(force-write 보류)을 명시한다.
+- `skip_external_buy` 와 **직교**한다: 미귀속 보유는 외부 매수(`is_external_buy`)가
+  아니므로 #1946 barrier 가 그 이벤트 발행을 억제하지 않는다. `dry_run` 여부와도
+  무관하게(보정 모드에서도) `correct_position` 을 호출하지 않는다 — 보정 정책 자체가
+  "귀속 불가 보유는 보정하지 않는다"이기 때문이다.
+
+**근거(결함 판정, #2317 canary):** 단일봇 force-write 경로(#2118/#2119/#2270)의 설계
+근거는 "봇 **간** 귀속 ambiguity 부재"이지 "어느 봇도 거래하지 않은 보유를 그 봇 소유로
+단정"이 아니다. 미거래 carryover(영업일 이월·계좌 원래 잔고)를 그 봇의 외부 매수로
+force-write 하면 전략이 미보유 종목을 자기 포지션으로 인식해 **실거래 오매도**를 접수한다
+(#2317 런타임에서 입증: `069500` 내부 0 → 브로커 2 force-write → 전략 'sell all' → KIS
+모의 `sell market 069500 2`). #1945/#1950 의 보수적 trade-off("해로운 자동 매도 회피 >
+external-detection 완전성")와 동일 방향이며, 보정 skip + 관측(이벤트/알림) 유지는 침묵
+결함이 아니다.
+
+**reason 명칭의 보수적 분류 성격:** "미귀속 보유"는 "이월"이 아닌 보수적 분류명이다 —
+현재 자료(internal 0, 추적 open buy 전무)로 **귀속 불가**한 보유를 가리키며, 영업일
+이월뿐 아니라 ante 가 추적하지 않은 외부 신규 매수까지 포함한다. 어느 쪽이든 그 봇
+소유라는 보장이 없으므로 동일하게 detect-only 로 둔다.
+
+**#1950 경계 보존(normative):** `capacity > 0`(추적 open buy 존재)인 모든 케이스는 #1950
+normative 를 그대로 따른다 — `excess <= capacity` → self_submitted(보정 skip + info
+이벤트), `excess > capacity` → **외부 매수 force-write**(`internal_qty == 0` 이어도). 즉
+미귀속 보유 분기는 #1950 이 규정하지 않은 `capacity == 0 && internal_qty == 0` 부분집합만
+변경한다. `internal_qty > 0`(잔존 보유 위 외부 매수)인 케이스도 기존 외부 매수 force-write
+를 유지한다.
+
+**#1950 bounded invariant 재서술(normative):** #1950 의 "매칭 ante 주문이 해소되면 다음
+reconcile 에서 잔여 excess 가 external 로 **검출·보정**된다"는 보장은 `internal_qty > 0 ||
+capacity > 0` 케이스에 **한정**된다. 주문이 해소된 뒤에도 `internal_qty == 0 && capacity
+== 0` 이면 그 보유는 미귀속 보유로 **영구 detect-only**(자동 보정 없음, critical 알림
+반복)로 전환된다. 이는 자동 귀속보다 **안전을 우선**하는 normative 결정이다(잘못된
+force-write 로 인한 실거래 오매도를 영구 방지). carryover 의 수동 채택(봇 귀속) UX 는
+정의되지 않은 별도 경로이며 필요 시 후속 이슈로 다룬다.
+
+**`order_tracker is None` 하위 호환(normative):** OrderTracker 미주입이면 capacity 를
+판정할 수 없으므로 미귀속 보유 분기를 적용하지 않고 **기존 외부 매수 동작을 유지**한다.
+`main.py` 의 두 배선 경로(ReconcileScheduler·IPC 수동 reconcile)는 항상 OrderTracker 를
+주입하므로 실제 운영 경로에서는 미귀속 보유 detect-only 가 항상 활성이다.
+
+**적용 경로:** 본 규칙은 `reconcile()` 내부 분류에서 적용되므로, 주기 대사
+(`ReconcileScheduler`)와 수동 대사(IPC `broker reconcile --fix`, `src/ante/ipc/registry.py`
+단일봇 경로) **모두** 동일하게 미귀속 보유를 보정에서 제외한다. 수동 대사의 `--fix` 에서도
+미귀속 보유는 `adjustments`(보정 내역)에 포함되지 않고 `mismatches` 에는 미보정 불일치로
+남아 보고된다.
 
 ## position-derived fallback 과의 관계 (#2314, normative)
 

--- a/src/ante/trade/reconciler.py
+++ b/src/ante/trade/reconciler.py
@@ -20,6 +20,13 @@ REASON_QTY_MISMATCH = "수량 불일치"
 # self-submitted-unrecorded-fill (#1950): ante 가 제출했으나 아직 내부에 반영되지
 # 않은 체결분. 외부 거래가 아니므로 자동 보정/매도를 유발하지 않고 info 알림만 낸다.
 REASON_SELF_SUBMITTED = "ante 미반영 체결"
+# 미귀속 보유 (#2352): broker > internal 이고 internal_qty == 0 이며 그 봇이 해당
+# 종목에 대해 추적 중인 non-terminal open buy 가 전무(capacity == 0)인 보유.
+# 어느 봇도 거래(추적)하지 않은 이월(carryover)·외부 신규 매수를 포함하는 보수적
+# 분류명이며, 단일봇이라는 이유만으로 그 봇 소유로 단정하지 않는다. force-write
+# (correct_position) 하지 않고 영구 detect-only(이벤트/알림만)로 둔다 — 전략이
+# 미보유 종목을 자기 포지션으로 인식해 실거래 오매도하는 것을 막는다(#2317 canary).
+REASON_UNATTRIBUTED_HOLDING = "미귀속 보유"
 
 
 class PositionReconciler:
@@ -126,6 +133,9 @@ class PositionReconciler:
 
             # 불일치 감지 — 분류
             is_external_buy = False
+            # #2352: detect-only(보정 skip)로 분류되었으나 critical 관측은 유지하는
+            # 미귀속 보유. is_external_buy 와 직교 — correct_position 만 건너뛴다.
+            is_detect_only = False
             if b_qty == 0 and i_qty > 0:
                 reason = REASON_EXTERNAL_LIQUIDATION
             elif b_qty < i_qty:
@@ -178,8 +188,30 @@ class PositionReconciler:
                         )
                     )
                     continue
-                reason = REASON_EXTERNAL_BUY
-                is_external_buy = True
+                # #2352: self-check 미매칭 이후 — 미귀속 보유(carryover) 판정.
+                # internal_qty == 0 이고 그 봇이 해당 종목에 대해 추적 중인
+                # non-terminal open buy 가 전무(capacity == 0)이면, 어느 봇도
+                # 거래한 적 없는 보유다. 단일봇이라는 이유만으로 그 봇 소유로
+                # force-write 하면 전략이 미보유 종목을 자기 포지션으로 인식해
+                # 실거래 오매도한다(#2317 canary). detect-only 로 보정만 skip 하고
+                # 이벤트/알림은 critical 로 유지한다.
+                #
+                # #1950 경계 보존: capacity > 0(추적 open buy 존재) 케이스는 위
+                # self-check 가 이미 self_submitted(excess<=capacity, continue) 또는
+                # 외부 매수(excess>capacity, 아래 fall-through)로 처리한다 — 본
+                # 분기는 capacity == 0 && internal_qty == 0 부분집합만 다룬다.
+                # order_tracker 미주입(capacity 판정 불가)이면 적용하지 않는다
+                # (하위 호환 — 기존 외부 매수 동작).
+                if i_qty == 0 and await self._is_unattributed_holding(
+                    bot_id=bot_id,
+                    account_id=account_id,
+                    symbol=symbol,
+                ):
+                    reason = REASON_UNATTRIBUTED_HOLDING
+                    is_detect_only = True
+                else:
+                    reason = REASON_EXTERNAL_BUY
+                    is_external_buy = True
             else:
                 reason = REASON_QTY_MISMATCH
 
@@ -199,14 +231,29 @@ class PositionReconciler:
                 )
                 continue
 
-            logger.warning(
-                "포지션 불일치 [%s] %s: 내부=%.2f, 브로커=%.2f → %s",
-                bot_id,
-                symbol,
-                i_qty,
-                b_qty,
-                reason,
-            )
+            if is_detect_only:
+                # #2352: 미귀속 보유 — 보정(correct_position)은 skip 하나 critical
+                # 관측(이벤트/알림)은 유지한다. 어느 봇에도 귀속할 수 없는 보유를
+                # 단일봇이라는 이유만으로 force-write 하지 않는다.
+                logger.warning(
+                    "포지션 불일치 [%s] %s: 내부=%.2f, 브로커=%.2f → %s "
+                    "(미귀속 보유 — 어느 봇도 추적하지 않은 보유, "
+                    "force-write 보류·detect-only)",
+                    bot_id,
+                    symbol,
+                    i_qty,
+                    b_qty,
+                    reason,
+                )
+            else:
+                logger.warning(
+                    "포지션 불일치 [%s] %s: 내부=%.2f, 브로커=%.2f → %s",
+                    bot_id,
+                    symbol,
+                    i_qty,
+                    b_qty,
+                    reason,
+                )
 
             await self._eventbus.publish(
                 PositionMismatchEvent(
@@ -231,6 +278,12 @@ class PositionReconciler:
                     category="broker",
                 )
             )
+
+            if is_detect_only:
+                # #2352: 미귀속 보유는 영구 detect-only — correct_position 미호출.
+                # dry_run 과 달리 보정 정책 자체가 "귀속 불가 보유는 보정하지
+                # 않는다"이므로 dry_run=False(보정 모드)에서도 skip 한다.
+                continue
 
             if dry_run:
                 # detect-only: 분류·이벤트는 위에서 발행했으나 실제 보정
@@ -457,3 +510,54 @@ class PositionReconciler:
             max(o.ordered_qty - o.recorded_filled_qty, 0.0) for o in open_orders
         )
         return excess <= capacity
+
+    async def _is_unattributed_holding(
+        self,
+        *,
+        bot_id: str,
+        account_id: str,
+        symbol: str,
+    ) -> bool:
+        """미귀속 보유(carryover) 시그니처인지 판정 (#2352).
+
+        ``b_qty > i_qty`` 분기에서 self-check(``_is_self_submitted_fill``)가
+        미매칭(False)으로 떨어진 뒤, ``internal_qty == 0`` 인 보유가 그 봇이
+        해당 종목에 대해 **추적 중인 non-terminal open buy 가 전무**(capacity == 0)
+        인지 확인한다. 그렇다면 어느 봇도 거래(추적)한 적 없는 이월/외부 신규 매수
+        보유이며, 단일봇 force-write 의 전제(봇 간 귀속 ambiguity 부재)가 성립하지
+        않으므로 detect-only 로 둔다.
+
+        - 매칭되는 non-terminal open buy 가 **하나도 없음** → True (미귀속 보유).
+        - open buy 가 존재(capacity > 0) → False. 이 경우는 self-check 가 이미
+          self_submitted(``excess <= capacity``) 또는 외부 매수(``excess >
+          capacity``)로 처리하므로(#1950 무변경), 본 분기 대상이 아니다.
+        - OrderTracker 미주입 → False (하위 호환 — 기존 "외부 매수" 동작).
+        - OrderTracker 조회 실패 → False (보수적으로 기존 외부 매수 분류 유지).
+
+        주의: ``_is_self_submitted_fill`` 은 "매칭 없음"과 "excess>capacity" 를
+        **모두 False** 로 반환하므로 그것만으로는 둘을 구분할 수 없다. 여기서는
+        capacity == 0(open buy 전무) 판정을 분리 구현해 미귀속 보유만 detect-only
+        로 좁힌다. 상세: ``docs/specs/trade/03-07-position-reconciler.md``.
+        """
+        if self._order_tracker is None:
+            return False
+
+        try:
+            open_orders = await self._order_tracker.get_open_orders_for(
+                account_id=account_id,
+                bot_id=bot_id,
+                symbol=symbol,
+                side="buy",
+            )
+        except Exception:
+            # 조회 실패 시 미귀속 판정을 포기하고 기존 외부 매수 분류를 유지한다
+            # (보수적 — 신규 detect-only 분기가 reconcile 을 깨뜨리지 않도록 방어).
+            logger.exception(
+                "미귀속 판정 OrderTracker 조회 실패 [%s] %s — 외부 매수 분류 유지",
+                bot_id,
+                symbol,
+            )
+            return False
+
+        # 추적 중인 non-terminal open buy 가 하나도 없음 = capacity 0 = 미귀속 보유.
+        return not open_orders

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -928,6 +928,120 @@ class TestHandleBrokerReconcileConditionalAudit:
         assert spec.audit_action is None
 
 
+# ── #2352: broker.reconcile --fix 에서 미귀속 보유 보정 제외 (real reconciler) ──
+
+
+class TestHandleBrokerReconcileUnattributedHolding:
+    """``broker.reconcile`` 수동 대사(IPC, registry.py:1545 단일봇 경로)에서
+    미귀속 보유(carryover)가 ``--fix`` 에도 보정되지 않고 ``mismatches`` 에는
+    그대로 보고되는지 **실제** PositionReconciler 로 검증한다(#2352).
+
+    핸들러는 ``svc.reconciler.reconcile(dry_run=not fix)`` 로 위임하므로
+    detect-only 정책은 reconcile() 내부 분류에서 적용된다. ``adjustments``(보정
+    내역)에서는 제외되고, 보정-이후 ``compute_account_diff`` 가 재계산한
+    ``mismatches`` 에는 미보정 불일치로 남는다(운영자 관측 보존).
+    """
+
+    @pytest.fixture
+    async def real_svc(self, tmp_path):
+        """1봇(acc-test) + 실제 PositionReconciler 를 가진 svc mock."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+        from ante.trade.order_tracker import OrderTracker
+        from ante.trade.performance import PerformanceTracker
+        from ante.trade.position import PositionHistory
+        from ante.trade.reconciler import PositionReconciler
+        from ante.trade.recorder import TradeRecorder
+        from ante.trade.service import TradeService
+
+        database = Database(str(tmp_path / "ipc-recon.db"))
+        await database.connect()
+
+        ph = PositionHistory(database)
+        await ph.initialize()
+        rec = TradeRecorder(database, ph)
+        await rec.initialize()
+        ot = OrderTracker(database)
+        await ot.initialize()
+        perf = PerformanceTracker(database)
+        service = TradeService(rec, ph, perf)
+        reconciler = PositionReconciler(
+            trade_service=service,
+            eventbus=EventBus(),
+            order_tracker=ot,
+        )
+
+        broker = AsyncMock()
+        broker.get_account_positions = AsyncMock(
+            return_value=[{"symbol": "069500", "quantity": 2, "avg_price": 30000}]
+        )
+        account_svc = AsyncMock()
+        account_svc.get_broker = AsyncMock(return_value=broker)
+
+        bot_manager = MagicMock()
+        bot_manager.list_bots = MagicMock(
+            return_value=[
+                {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
+            ]
+        )
+
+        audit_logger = MagicMock()
+        audit_logger.log = AsyncMock(return_value=None)
+
+        svc = MagicMock()
+        svc.account = account_svc
+        svc.bot_manager = bot_manager
+        svc.reconciler = reconciler
+        svc.audit_logger = audit_logger
+
+        yield svc
+        await database.close()
+
+    @pytest.mark.asyncio
+    async def test_fix_true_unattributed_holding_excluded_from_adjustments(
+        self, real_svc
+    ):
+        """--fix 여도 미귀속 보유는 adjustments(보정)에서 제외되고 mismatches 에
+        보고된다 + audit 미발화(상태변경 없음).
+        """
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        result = await _handle_broker_reconcile(
+            real_svc, {"account_id": "acc-test", "fix": True}, "cli-user"
+        )
+
+        # 미귀속 보유 → 보정 0건(force-write 없음).
+        assert result["adjustments"] == []
+        assert result["corrections"] == 0
+        # mismatch 는 그대로 보고(운영자 관측 보존) — 069500 내부0/브로커2.
+        assert len(result["mismatches"]) == 1
+        m = result["mismatches"][0]
+        assert m["symbol"] == "069500"
+        assert m["internal_qty"] == 0
+        assert m["broker_qty"] == 2
+        assert m["diff"] == 2
+        # bot_count==1 단일봇 경로.
+        assert result["bot_count"] == 1
+        # 상태변경(보정)이 없으므로 audit 미발화(#2109 조건부 audit).
+        real_svc.audit_logger.log.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fix_false_dry_run_also_reports_unattributed_mismatch(self, real_svc):
+        """--fix 미지정(detect-only)에서도 미귀속 보유가 mismatches 에 보고된다."""
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        result = await _handle_broker_reconcile(
+            real_svc, {"account_id": "acc-test", "fix": False}, "cli-user"
+        )
+
+        assert result["adjustments"] == []
+        assert len(result["mismatches"]) == 1
+        assert result["mismatches"][0]["symbol"] == "069500"
+        assert result["fix_applied"] is False
+
+
 # ── #1379 oracle A7: IPC config.set 핸들러도 서비스 경계 ValueError 전파 ──
 
 

--- a/tests/unit/test_reconcile_scheduler.py
+++ b/tests/unit/test_reconcile_scheduler.py
@@ -479,3 +479,109 @@ class TestBrokerAccountScoping:
         assert reconciler.reconcile.call_args.kwargs["bot_id"] == "bot-1"
         reconciler.detect_account_level.assert_not_called()
         assert any("bot-orphan" in rec.getMessage() for rec in caplog.records)
+
+
+# ── #2352: 단일봇+running 라우팅에서 미귀속 보유 carryover 제외 (real reconciler) ──
+
+
+class TestUnattributedHoldingRouting:
+    """단일봇+running 보정 경로에서 미귀속 보유(carryover)가 corrections 에
+    포함되지 않음을 **실제** PositionReconciler 로 검증한다(#2352).
+
+    scheduler 라우팅(bot_count==1 && running → reconcile(dry_run=False))은
+    무변경이며, detect-only 정책은 reconcile() 내부 분류에서 처리된다. 2+봇
+    detect_account_level 경로는 무변경 회귀로 함께 고정한다.
+    """
+
+    @pytest.fixture
+    async def real_db(self, tmp_path):
+        from ante.core.database import Database
+
+        database = Database(str(tmp_path / "sched.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    @pytest.fixture
+    async def real_reconciler(self, real_db, eventbus):
+        from ante.trade.order_tracker import OrderTracker
+        from ante.trade.performance import PerformanceTracker
+        from ante.trade.position import PositionHistory
+        from ante.trade.reconciler import PositionReconciler
+        from ante.trade.recorder import TradeRecorder
+        from ante.trade.service import TradeService
+
+        ph = PositionHistory(real_db)
+        await ph.initialize()
+        rec = TradeRecorder(real_db, ph)
+        await rec.initialize()
+        ot = OrderTracker(real_db)
+        await ot.initialize()
+        perf = PerformanceTracker(real_db)
+        service = TradeService(rec, ph, perf)
+        return PositionReconciler(
+            trade_service=service,
+            eventbus=eventbus,
+            order_tracker=ot,
+        )
+
+    async def test_single_running_bot_carryover_excluded_from_corrections(
+        self, real_reconciler, broker, bot_manager, eventbus
+    ):
+        """단일봇+running: 미거래 carryover(069500)가 corrections 에 미포함.
+
+        broker 가 069500 2주 보유(내부 0, 추적 open buy 전무)를 보고하나,
+        scheduler 의 dry_run=False 보정 경로에서도 미귀속 보유는 force-write 되지
+        않는다.
+        """
+        broker.get_account_positions.return_value = [
+            {"symbol": "069500", "quantity": 2, "avg_price": 30000},
+        ]
+        bot_manager.list_bots.return_value = [
+            {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
+        ]
+        sched = ReconcileScheduler(
+            reconciler=real_reconciler,
+            broker=broker,
+            bot_manager=bot_manager,
+            eventbus=eventbus,
+            broker_account_id="acc-test",
+            interval_seconds=0.1,
+        )
+
+        corrections = await sched.run_once()
+
+        # 미귀속 보유 → 보정 0건(force-write 없음).
+        assert corrections == []
+
+    async def test_multi_bot_detect_account_level_unchanged(
+        self, real_reconciler, broker, bot_manager, eventbus
+    ):
+        """2+봇 → detect_account_level 경로 무변경(보정 0, account 알림만)."""
+        notif_events: list = []
+        from ante.eventbus.events import NotificationEvent
+
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        broker.get_account_positions.return_value = [
+            {"symbol": "069500", "quantity": 2, "avg_price": 30000},
+        ]
+        bot_manager.list_bots.return_value = [
+            {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
+            {"bot_id": "bot-2", "status": "running", "account_id": "acc-test"},
+        ]
+        sched = ReconcileScheduler(
+            reconciler=real_reconciler,
+            broker=broker,
+            bot_manager=bot_manager,
+            eventbus=eventbus,
+            broker_account_id="acc-test",
+            interval_seconds=0.1,
+        )
+
+        corrections = await sched.run_once()
+
+        # 2+봇 detect-only — 보정 0건, account-scoped NotificationEvent 발행.
+        assert corrections == []
+        assert len(notif_events) == 1
+        assert notif_events[0].category == "broker"

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -18,6 +18,7 @@ from ante.trade.position import PositionHistory
 from ante.trade.reconciler import (
     REASON_EXTERNAL_BUY,
     REASON_SELF_SUBMITTED,
+    REASON_UNATTRIBUTED_HOLDING,
     PositionReconciler,
 )
 from ante.trade.recorder import TradeRecorder
@@ -249,8 +250,24 @@ class TestNoMismatch:
 
 
 class TestExternalBuy:
-    async def test_external_buy_detected(self, reconciler, position_history):
-        """내부 0주, 브로커 20주 → 외부 매수로 보정."""
+    async def test_external_buy_detected(
+        self, reconciler, position_history, order_tracker
+    ):
+        """내부 10주(잔존) + 추적 open buy 존재(capacity>0) & excess>capacity →
+        외부 매수로 보정 (#2352 재분류: i_qty>0 || capacity>0 만 외부 매수 보장).
+
+        ante open buy 5주 + 내부 10주, 브로커 20주 → excess 10 > capacity 5 →
+        외부 매수. internal_qty>0 이므로 미귀속 보유(#2352) 대상이 아니다.
+        """
+        await _set_position(position_history, "bot-1", "005930", 10, 50000)
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-eb",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=5,
+        )
+
         corrections = await reconciler.reconcile(
             bot_id="bot-1",
             broker_positions=[
@@ -261,14 +278,19 @@ class TestExternalBuy:
 
         assert len(corrections) == 1
         assert corrections[0]["new_quantity"] == 20
-        assert corrections[0]["reason"] == "외부 매수"
+        assert corrections[0]["reason"] == REASON_EXTERNAL_BUY
 
     async def test_external_buy_skipped_when_flag_set(
-        self, reconciler, position_history, eventbus
+        self, reconciler, position_history, order_tracker, eventbus
     ):
         """skip_external_buy=True 면 "외부 매수" 보정·이벤트를 건너뛴다
         (#1946 Finding 1 barrier).
+
+        #2352 재분류: barrier 가 적용되려면 외부 매수로 분류돼야 하므로,
+        internal_qty>0(잔존) 케이스로 구성한다(미귀속 보유와 직교).
         """
+        await _set_position(position_history, "bot-1", "005930", 10, 50000)
+
         mismatch_events: list = []
         eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
 
@@ -283,9 +305,9 @@ class TestExternalBuy:
 
         assert corrections == []  # external-buy 억제.
         assert mismatch_events == []  # 이벤트도 발행 안 함.
-        # 포지션도 보정되지 않음 (0 유지).
+        # 포지션도 보정되지 않음 (10 유지 — barrier 가 외부 매수 보정을 억제).
         pos = await position_history.get_current("bot-1", "005930")
-        assert pos["quantity"] == 0
+        assert pos["quantity"] == 10
 
     async def test_skip_external_buy_does_not_affect_other_classes(
         self, reconciler, position_history, eventbus
@@ -417,7 +439,12 @@ class TestSelfSubmittedFill:
     async def test_excess_over_capacity_is_external_buy(
         self, reconciler, order_tracker
     ):
-        """R1-3 (b): excess > capacity → 외부 매수 정상 보정."""
+        """R1-3 (b): excess > capacity → 외부 매수 정상 보정.
+
+        #2352 경계 보존: capacity > 0(추적 open buy 존재) 이면 internal_qty==0
+        이어도 미귀속 보유로 빠지지 않고 #1950 그대로 외부 매수 force-write 한다.
+        신규 detect-only 분기는 capacity==0 부분집합만 변경한다.
+        """
         # ante 미체결 10주, 브로커 30주(내부 0) → excess 30 > capacity 10.
         await _seed_open_order(
             order_tracker,
@@ -437,8 +464,14 @@ class TestSelfSubmittedFill:
         assert corrections[0]["reason"] == REASON_EXTERNAL_BUY
         assert corrections[0]["new_quantity"] == 30
 
-    async def test_no_matching_order_is_external_buy(self, reconciler, order_tracker):
-        """매칭 주문 없음 → 외부 매수."""
+    async def test_no_matching_order_is_unattributed_holding(
+        self, reconciler, order_tracker
+    ):
+        """매칭 주문 없음 + internal_qty==0 → 미귀속 보유 detect-only (#2352).
+
+        #2352 재분류: 과거에는 외부 매수 force-write 였으나, 어느 봇도 추적하지
+        않은 보유(capacity==0 && internal_qty==0)는 보정하지 않는다.
+        """
         corrections = await reconciler.reconcile(
             bot_id="bot-1",
             broker_positions=[
@@ -446,12 +479,16 @@ class TestSelfSubmittedFill:
             ],
             account_id="acc-test",
         )
-        assert len(corrections) == 1
-        assert corrections[0]["reason"] == REASON_EXTERNAL_BUY
+        assert corrections == []
 
-    async def test_bot_id_mismatch_is_external_buy(self, reconciler, order_tracker):
-        """R1-3: 다른 봇의 ante 주문은 매칭 안 됨 → 외부 매수."""
-        # bot-2 의 매수 주문은 bot-1 의 self-check 에 잡히지 않는다.
+    async def test_bot_id_mismatch_is_unattributed_holding(
+        self, reconciler, order_tracker
+    ):
+        """다른 봇의 ante 주문은 매칭 안 됨 + internal==0 → 미귀속 보유 (#2352).
+
+        bot-2 의 매수 주문은 bot-1 의 self-check 에 잡히지 않으므로 bot-1 입장에서
+        capacity==0. 과거 외부 매수 → 미귀속 보유 detect-only 로 재분류.
+        """
         await _seed_open_order(
             order_tracker,
             order_id="ord-1",
@@ -466,11 +503,14 @@ class TestSelfSubmittedFill:
             ],
             account_id="acc-test",
         )
-        assert len(corrections) == 1
-        assert corrections[0]["reason"] == REASON_EXTERNAL_BUY
+        assert corrections == []
 
-    async def test_sell_order_does_not_match(self, reconciler, order_tracker):
-        """side=sell 주문은 self-check(buy) 에 매칭 안 됨 → 외부 매수."""
+    async def test_sell_order_does_not_match_is_unattributed_holding(
+        self, reconciler, order_tracker
+    ):
+        """side=sell 주문은 self-check(buy) 에 매칭 안 됨 + internal==0 → 미귀속
+        보유 (#2352 재분류). buy capacity==0 이므로 미귀속.
+        """
         await _seed_open_order(
             order_tracker,
             order_id="ord-1",
@@ -486,8 +526,7 @@ class TestSelfSubmittedFill:
             ],
             account_id="acc-test",
         )
-        assert len(corrections) == 1
-        assert corrections[0]["reason"] == REASON_EXTERNAL_BUY
+        assert corrections == []
 
     async def test_self_check_runs_when_skip_external_buy_false(
         self, reconciler, position_history, order_tracker, eventbus
@@ -550,7 +589,11 @@ class TestSelfSubmittedFill:
         assert notif_events[0].level == "info"
 
     async def test_account_scoped_matching(self, reconciler, order_tracker):
-        """다른 account 의 ante 주문은 매칭 안 됨 → 외부 매수."""
+        """다른 account 의 ante 주문은 매칭 안 됨 + internal==0 → 미귀속 보유.
+
+        #2352 재분류: acc-other 의 주문은 acc-test self-check 에 잡히지 않아
+        capacity==0 이고 internal_qty==0 이므로 미귀속 보유 detect-only.
+        """
         await _seed_open_order(
             order_tracker,
             order_id="ord-1",
@@ -566,8 +609,7 @@ class TestSelfSubmittedFill:
             ],
             account_id="acc-test",
         )
-        assert len(corrections) == 1
-        assert corrections[0]["reason"] == REASON_EXTERNAL_BUY
+        assert corrections == []
 
 
 # ── 시나리오 7: R2-2 혼재(self + 숨은 외부) bounded ──────
@@ -575,16 +617,26 @@ class TestSelfSubmittedFill:
 
 class TestMixedBoundedCase:
     """R2-2: excess ≤ capacity 인 혼재(self + 숨은 외부)는 self_submitted 로
-    분류(보정 skip)되고, ante 주문 해소 후 다음 reconcile 에서 잔여 external 이
-    검출된다 (bounded known-limitation).
+    분류(보정 skip)되고, ante 주문 해소 후 다음 reconcile 에서의 거동을 검증한다.
+
+    #2352 재서술: #1950 의 "주문 해소 후 잔여 excess 가 external 로 검출·보정"
+    보장은 ``internal_qty > 0 || capacity > 0`` 케이스에 한정된다. 주문이 해소된
+    뒤에도 ``internal_qty == 0 && capacity == 0`` 이면 그 보유는 미귀속 보유로
+    영구 detect-only(force-write 보류)가 된다 — internal 이 0 인 채 capacity 가
+    사라진 보유는 어느 봇도 추적하지 않는 보유이므로 그 봇 소유로 단정하지 않는다.
     """
 
-    async def test_hidden_external_detected_after_order_resolves(
+    async def test_holding_unattributed_after_order_resolves_with_zero_internal(
         self, reconciler, position_history, order_tracker
     ):
-        """혼재 → self(보정 skip) → ante 주문 terminal 후 잔여 external 검출."""
-        # ante 미체결 buy 100주(open). 브로커 60주(내부 0): self 50 + 숨은 외부 10
-        # 가정 — excess 60 ≤ capacity 100 → 전량 self 로 분류(보정 skip).
+        """혼재 → self(보정 skip) → ante 주문 terminal & internal==0 → 미귀속 보유.
+
+        #2352: 주문 해소 후 internal 이 0 이고 capacity 도 0 이면 외부 매수
+        force-write 가 아니라 미귀속 보유 detect-only 다(#1950 bounded invariant
+        재서술).
+        """
+        # ante 미체결 buy 100주(open). 브로커 60주(내부 0) — excess 60 ≤ capacity
+        # 100 → self 로 분류(보정 skip).
         await _seed_open_order(
             order_tracker,
             order_id="ord-1",
@@ -607,7 +659,8 @@ class TestMixedBoundedCase:
         # ante 주문이 EOD expire_stale 로 해소(terminal) — open set 이탈.
         await order_tracker.mark_terminal("ord-1", "expired")
 
-        # 2차 reconcile: 매칭 open 주문 없음 → 잔여 excess(60) 가 external 로 검출.
+        # 2차 reconcile: 매칭 open 주문 없음(capacity==0) & internal==0 → 미귀속
+        # 보유 detect-only (force-write 안 함).
         corrections2 = await reconciler.reconcile(
             bot_id="bot-1",
             broker_positions=[
@@ -615,14 +668,17 @@ class TestMixedBoundedCase:
             ],
             account_id="acc-test",
         )
-        assert len(corrections2) == 1
-        assert corrections2[0]["reason"] == REASON_EXTERNAL_BUY
-        assert corrections2[0]["new_quantity"] == 60
+        assert corrections2 == []
 
-    async def test_external_detected_after_order_fully_filled(
+    async def test_residual_external_detected_when_internal_nonzero(
         self, reconciler, position_history, order_tracker
     ):
-        """ante 주문 완전 체결(filled→open set 이탈) 후 잔여 external 검출."""
+        """internal_qty > 0(잔존) 이면 주문 해소 후 잔여 excess 가 여전히 외부
+        매수로 검출·보정된다 (#2352: bounded invariant 의 internal>0 가지 보존).
+        """
+        # 내부 30주 잔존 + ante 미체결 buy 100주(open). 브로커 90주 →
+        # excess 60 ≤ capacity 100 → self(보정 skip).
+        await _set_position(position_history, "bot-1", "005930", 30, 50000)
         await _seed_open_order(
             order_tracker,
             order_id="ord-1",
@@ -630,29 +686,28 @@ class TestMixedBoundedCase:
             symbol="005930",
             ordered_qty=100,
         )
-        # 1차: self → 보정 skip.
         corrections = await reconciler.reconcile(
             bot_id="bot-1",
             broker_positions=[
-                {"symbol": "005930", "quantity": 60, "avg_price": 55000},
+                {"symbol": "005930", "quantity": 90, "avg_price": 55000},
             ],
             account_id="acc-test",
         )
         assert corrections == []
 
-        # ante 주문 완전 체결 → filled(terminal, open set 이탈).
-        await order_tracker.record_fill("ord-1", 100, 55000)
-
+        # ante 주문 해소(terminal) — capacity==0. 그러나 internal_qty==30(>0)
+        # 이므로 미귀속 보유 대상이 아니다 → 잔여 excess 가 외부 매수로 검출.
+        await order_tracker.mark_terminal("ord-1", "expired")
         corrections2 = await reconciler.reconcile(
             bot_id="bot-1",
             broker_positions=[
-                {"symbol": "005930", "quantity": 60, "avg_price": 55000},
+                {"symbol": "005930", "quantity": 90, "avg_price": 55000},
             ],
             account_id="acc-test",
         )
-        # 매칭 open 주문 없음 → 외부 매수로 검출.
         assert len(corrections2) == 1
         assert corrections2[0]["reason"] == REASON_EXTERNAL_BUY
+        assert corrections2[0]["new_quantity"] == 90
 
 
 # ── 시나리오 8: OrderTracker 미주입 하위 호환 ──────────
@@ -660,12 +715,151 @@ class TestMixedBoundedCase:
 
 class TestNoOrderTracker:
     async def test_external_buy_without_order_tracker(self, service, eventbus):
-        """order_tracker 미주입 시 self-check 생략 → 기존 외부 매수 동작."""
+        """order_tracker 미주입 시 self-check·미귀속 판정 생략 → 기존 외부 매수.
+
+        #2352 하위 호환: capacity 판정 불가(order_tracker None)이면 신규 미귀속
+        보유 detect-only 분기를 적용하지 않고 기존 외부 매수 force-write 를 유지한다.
+        """
         rec = PositionReconciler(trade_service=service, eventbus=eventbus)
         corrections = await rec.reconcile(
             bot_id="bot-1",
             broker_positions=[
                 {"symbol": "005930", "quantity": 20, "avg_price": 55000},
+            ],
+            account_id="acc-test",
+        )
+        assert len(corrections) == 1
+        assert corrections[0]["reason"] == REASON_EXTERNAL_BUY
+
+
+# ── 시나리오 9: 미귀속 보유 carryover detect-only (#2352) ──
+
+
+class TestUnattributedHolding:
+    """#2352: 단일봇 미거래 carryover(internal_qty==0 && capacity==0)는 그 봇의
+    '외부 매수' 로 force-write 되지 않고 detect-only(보정 skip, 이벤트/critical
+    알림 유지)로 처리된다 — 전략 오매도(#2317 canary) 방지.
+    """
+
+    async def test_unattributed_holding_skips_correction_keeps_events(
+        self, reconciler, position_history, order_tracker, eventbus
+    ):
+        """internal==0 && capacity==0(추적 open buy 전무) → correct_position 미호출
+        + reason="미귀속 보유" PositionMismatchEvent + critical NotificationEvent.
+        """
+        mismatch_events: list = []
+        notif_events: list = []
+        reconcile_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+        eventbus.subscribe(ReconcileEvent, lambda e: reconcile_events.append(e))
+
+        # 내부 0, 브로커 2주(이월/미거래). 추적 open buy 전무 → 미귀속 보유.
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "069500", "quantity": 2, "avg_price": 30000},
+            ],
+            account_id="acc-test",
+        )
+
+        # 보정 0건 — correct_position 미호출(force-write 없음).
+        assert corrections == []
+        # 포지션은 0 유지 (전략이 미보유 종목을 자기 포지션으로 인식하지 않는다).
+        pos = await position_history.get_current("bot-1", "069500")
+        assert pos["quantity"] == 0
+        # PositionMismatchEvent 는 미귀속 보유 사유로 발행(운영자 관측 유지).
+        assert len(mismatch_events) == 1
+        assert mismatch_events[0].reason == REASON_UNATTRIBUTED_HOLDING
+        assert mismatch_events[0].symbol == "069500"
+        assert mismatch_events[0].internal_qty == 0
+        assert mismatch_events[0].broker_qty == 2
+        # NotificationEvent 는 critical(미귀속 보유는 운영 안전 경로).
+        assert len(notif_events) == 1
+        assert notif_events[0].level == "critical"
+        # 보정 0건 → ReconcileEvent(보정 완료)는 발행 안 됨.
+        assert reconcile_events == []
+
+    async def test_canary_scenario_no_force_write(
+        self, reconciler, position_history, order_tracker
+    ):
+        """#2317 canary 재현 고정: 069500 내부 0 → 브로커 2 가 force-write 되지
+        않는다(과거: 외부 매수로 quantity=2 force-write → 전략 오매도).
+        """
+        await reconciler.reconcile(
+            bot_id="oracle-probe-bot",
+            broker_positions=[
+                {"symbol": "069500", "quantity": 2, "avg_price": 30000},
+            ],
+            account_id="acc-test",
+        )
+        pos = await position_history.get_current("oracle-probe-bot", "069500")
+        # 미보유 종목이 봇 포지션으로 기록되지 않음 — 오매도 방지.
+        assert pos["quantity"] == 0
+
+    async def test_unattributed_holding_skips_even_under_skip_external_buy(
+        self, reconciler, position_history, order_tracker, eventbus
+    ):
+        """미귀속 보유는 is_external_buy=False 이므로 skip_external_buy barrier 와
+        직교 — barrier 가 켜져도 critical 관측은 발행되고 보정은 여전히 skip.
+        """
+        mismatch_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "069500", "quantity": 2, "avg_price": 30000},
+            ],
+            account_id="acc-test",
+            skip_external_buy=True,
+        )
+
+        assert corrections == []
+        # external-buy barrier 와 직교 — 미귀속 보유 이벤트는 발행된다.
+        assert len(mismatch_events) == 1
+        assert mismatch_events[0].reason == REASON_UNATTRIBUTED_HOLDING
+
+    async def test_self_submitted_still_takes_precedence(
+        self, reconciler, position_history, order_tracker, eventbus
+    ):
+        """capacity>0(추적 open buy 존재, excess<=capacity)는 #1950 self_submitted
+        우선 — 미귀속 보유로 빠지지 않는다(경계 보존).
+        """
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-1",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=20,
+        )
+        notif_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 20, "avg_price": 55000},
+            ],
+            account_id="acc-test",
+        )
+
+        assert corrections == []
+        # self_submitted → info 알림(미귀속 보유 critical 아님).
+        assert len(notif_events) == 1
+        assert notif_events[0].level == "info"
+
+    async def test_no_order_tracker_keeps_external_buy_for_carryover(
+        self, service, eventbus
+    ):
+        """order_tracker 미주입이면 미귀속 판정 불가 → 기존 외부 매수 force-write
+        유지(하위 호환 — main.py 두 배선 경로는 항상 주입).
+        """
+        rec = PositionReconciler(trade_service=service, eventbus=eventbus)
+        corrections = await rec.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "069500", "quantity": 2, "avg_price": 30000},
             ],
             account_id="acc-test",
         )


### PR DESCRIPTION
Closes #2352

## Summary
- `PositionReconciler`에 **미귀속 보유**(`REASON_UNATTRIBUTED_HOLDING`) 분류 신설: self-check 미매칭 후 `internal_qty == 0 && capacity == 0`(추적 open buy 전무)이면 `correct_position` force-write를 하지 않는 **detect-only**(이벤트/critical 알림은 기존대로 발행)
- **#1950 경계 보존**: `capacity > 0` 전 케이스 무변경(`excess<=capacity`→self_submitted, `excess>capacity`→외부 매수 force-write 유지). `order_tracker is None` 하위호환 유지
- #2317 canary(미거래 carryover force-write → 전략 오매도 `sell market 069500 2`) 재발 방지 테스트 고정
- IPC 수동 `broker reconcile --fix`에서도 미귀속 보유 보정 제외 + mismatch 보고 유지
- 스펙: 03-07(미귀속 보유 normative + #1950 bounded invariant 재서술), 15-reconciliation(bot_count 1 vs 2+ 라우팅 동기화), 18-fill-recovery(caveat)

## Verification
- Plan Preflight: approve-implement (Codex R3) / 브랜치 리뷰: PASS (attempt 1)
- `pytest tests/unit -q`: 7179 passed, 2 skipped / `mypy src/`: Success (232 files) / ruff check·format 통과
- 기존 외부매수 테스트 8건은 `i_qty==0 && capacity==0` 시그니처에 한해 신규 정책 기대값으로 재분류

## Test Plan
- `pytest tests/unit/test_reconciler.py tests/unit/test_reconcile_scheduler.py tests/unit/ipc/test_registry.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)