### PR TITLE
chore(broker): #2349 KIS inquire-daily-ccld tr_id 신세대 4코드(0081R/9215R) 분기 + EXCG_ID_DVSN_CD

### DIFF
--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -92,6 +92,22 @@ class KISDomesticAdapter(KISBaseAdapter):
 
 > 출처: [KIS open-trading-api `order_rvsecncl.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_rvsecncl/order_rvsecncl.py) 및 공식 레거시/Postman PAPER 샘플(`VTTC0803U`/`TTTC0803U`에서 `KRX_FWDG_ORD_ORGNO`를 원주문별 값으로 전송). 취소 tr_id `0803U→0013U` 마이그레이션과 `EXCG_ID_DVSN_CD`는 별도 live-gated 이슈(#2346) 범위다.
 
+### inquire-daily-ccld TR ID 매핑 (#2349)
+
+주문/체결 이력 조회(`inquire-daily-ccld`, `get_order_history`)는 `is_paper` × **3개월 경계**(inner/before) 조합으로 아래 KIS 공식 현행 TR ID를 전송한다. **inquire-daily-ccld 한정**이며, order-cash·취소·잔고·현재가 등 다른 엔드포인트 TR ID는 이 표의 범위 밖이다.
+
+| 구분 | 실전 | 모의 |
+|------|------|------|
+| 3개월 이내 (inner) | `TTTC0081R` | `VTTC0081R` |
+| 3개월 이전 (before) | `CTSC9215R` | `VTSC9215R` |
+
+- **3개월 경계 판정 (ante 로컬 normative 정책)**: 공식 예제는 `pd_dv=inner\|before`를 호출자 인자로 받을 뿐 경계를 계산하지 않으므로, ante가 경계 정책을 소유한다(공식 산식 미러 아님). **cutoff = KST 오늘 기준 달력 3개월 전 동일 일자**(예: KST 2026-06-11 → cutoff 2026-03-11). 대상 월에 동일 일자가 없으면 그 월 말일로 보정한다(예: 2026-05-31 → cutoff 2026-02-28). **판정은 `INQR_STRT_DT`(start-date) 단독 기준**: `>= cutoff`이면 inner(cutoff 당일 포함), `< cutoff`이면 before. 기본 `from_date`(now-7d)는 항상 inner다(레거시 `VTTC8001R`/`TTTC8001R` 단일 코드 대신 inner `0081R` 계열로 교체). 레거시 before `VTSC9115R`/`CTSC9115R`은 비채택이다.
+- **교차 구간(`from < cutoff <= to`) bounded known-limitation**: cutoff를 가로지르는 창은 split query 없이 start-date 기준 before 단일 쿼리로 처리한다(완전성은 known-limitation). 현행 호출자(`FillReconcileScheduler`)는 항상 ≤7일 창이라 실제 운영 경로는 inner 고정이며, before 분기는 caller가 3개월 이전 `from_date`를 줄 때만 활성화된다.
+- **`EXCG_ID_DVSN_CD`는 hard-required가 아님 (hygiene)**: 이 엔드포인트에서 `EXCG_ID_DVSN_CD`(`'KRX'`, 모듈 상수 `DEFAULT_EXCG_ID_DVSN_CD` 재사용)는 데이터 완전성/NXT 누락 방지를 위한 **optional hygiene**으로 주입한다. 공식 예제도 조건부 append이며 `ValueError` 가드가 없다. 이는 order-cash의 `40910000` 거절-fix(#2342/#2345)와 **다른 프레임**이다(거절-fix가 아닌 데이터 완전성 보강).
+- **신 tr_id 효과**: 레거시 `VTTC8001R`은 모의 당일 체결을 반환하지 못하나(0행), 신 `VTTC0081R`은 당일 체결을 반환함이 #2317 라이브 A/B로 확인됐다(`docs/specs/broker-adapter/18-fill-recovery.md` §2.1).
+
+> 출처: [KIS open-trading-api `inquire_daily_ccld.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/inquire_daily_ccld/inquire_daily_ccld.py)(공식 예제가 inner/before별 4코드와 조건부 `EXCG_ID_DVSN_CD` append를 정의) + #2314 근본원인 조사 + #2317 라이브 측정.
+
 ### KIS 주문 유형 매핑
 
 KISDomesticAdapter는 `order_type` 문자열을 KIS ORD_DVSN 코드로 매핑한다. `stop`/`stop_limit`이 전달되면 `ValueError`를 발생시킨다 (상위 계층에서 변환 후 호출해야 함).

--- a/docs/specs/broker-adapter/18-fill-recovery.md
+++ b/docs/specs/broker-adapter/18-fill-recovery.md
@@ -37,11 +37,14 @@ ante가 제출한 주문은 (모의투자·실전투자, 스트림 유무와 무
 원장이 당일 반영되는 환경을 전제로 한다**. **KIS 모의투자(`is_paper=true`)에서는
 이 전제가 거짓이다**:
 
-- KIS 모의 `inquire-daily-ccld`(`get_order_history`, tr_id `VTTC8001R`)는 **일별
-  정산/결제기준 원장**이라 **당일 체결이 지연 반영(0건)**된다(KIS 공식 POSTMAN
-  v1.6: *"일별 조회로, 당일 주문내역은 지연될 수 있습니다"* + 한국투자증권
-  attention_23 확정). 그 동안 `recorded_filled_qty=0`이 고정되어 #1945류
-  미반영 캐스케이드 위험이 재현된다.
+- KIS 모의 `inquire-daily-ccld`(`get_order_history`)는 **일별 정산/결제기준
+  원장**이라 잠재적 당일 지연 반영 위험이 KIS 공식 근거로 남아 있다(KIS 공식
+  POSTMAN v1.6: *"일별 조회로, 당일 주문내역은 지연될 수 있습니다"* + 한국투자증권
+  attention_23). 다만 **이 지연은 tr_id 세대에 의존한다**: 레거시 `VTTC8001R`은
+  모의 당일 체결을 0건으로 반환하나(#2317 라이브 A/B로 장중·마감후·D+6 3시점
+  일관 입증), 현행 신 tr_id `VTTC0081R`(#2349)은 **당일 체결을 반환함이 #2317
+  라이브로 확인**됐다. 레거시 경로에서는 `recorded_filled_qty=0`이 고정되어
+  #1945류 미반영 캐스케이드 위험이 재현되었다.
 - 반면 잔고(`inquire-balance`/`get_positions`, tr_id `VTTC8434R`)는 **체결기준
   이라 당일 즉시 반영**된다.
 
@@ -524,10 +527,11 @@ D+1 ccld 백스톱으로 반영되며, fallback이 외부분을 흡수하지 않
 
 - **KIS paper(`is_paper=true`) 한정 기본 활성**. 모의 당일 ccld 지연이 확정된
   환경이므로 기본 켠다.
-- **live는 capability/config flag로 분리**한다. 라이브 ccld 지연 폭(D+1 vs
-  장중 분 단위), `EXCG_ID_DVSN_CD`·신 tr_id(`VTTC0081R`)의 당일 반영 개선 여부가
-  외부 문서로 닫히지 않아, 라이브 활성은 **canary 후속(#2317)** 검증 뒤에만
-  허용한다(known-limitation §11.7).
+- **live는 capability/config flag로 분리**한다. `EXCG_ID_DVSN_CD`·신
+  tr_id(`VTTC0081R`)의 **당일 반영 효과는 #2317 라이브 A/B로 확인됐다**(레거시
+  `VTTC8001R` 0행 vs 신 `VTTC0081R` 당일 반영, #2349 적용). 다만 라이브 ccld
+  지연 폭(D+1 vs 장중 분 단위) 등 잔여 라이브 의존 항목은 여전히 닫히지 않아,
+  라이브 활성은 그 잔여 검증 뒤에만 허용한다(known-limitation §11.7).
 
 ### 11.7 bounded known-limitation
 
@@ -560,9 +564,11 @@ D+1 ccld 백스톱으로 반영되며, fallback이 외부분을 흡수하지 않
   정정 안 함.
 - **Treasury 비례 정산**: §9의 pre-existing 한계(부분 체결 비례 정산 미지원)는
   fallback이 악화시키지 않으며 별도 후속 이슈로 둔다.
-- **라이브 의존(#2317)**: 지연 폭 확정, multi-order/partial 식별 가능성,
-  `EXCG_ID_DVSN_CD`·신 tr_id 효과는 라이브 검증이 필요하다. live 활성·다중 귀속
-  완화는 #2317 결과 뒤 재검토한다.
+- **라이브 의존(#2317)**: `EXCG_ID_DVSN_CD`·신 tr_id(`VTTC0081R`, #2349)의 당일
+  반영 효과는 **#2317 라이브 A/B로 확인 완료**다(레거시 `8001R` 0행 vs 신
+  `0081R` 당일 반영). 다만 지연 폭 확정, multi-order/partial 식별 가능성(#2353),
+  live 활성·다중 귀속 완화는 **여전히 라이브 의존**으로 남으며 #2317 결과 뒤
+  재검토한다.
 
 ### 11.8 FillApplier 단일 권위 (직접 수정 금지)
 

--- a/docs/specs/trade/03-07-position-reconciler.md
+++ b/docs/specs/trade/03-07-position-reconciler.md
@@ -142,8 +142,11 @@ force-write 로 인한 실거래 오매도를 영구 방지). carryover 의 수�
 
 ## position-derived fallback 과의 관계 (#2314, normative)
 
-KIS 모의 당일 체결은 `get_order_history`(결제기준)가 0건을 주는 동안 잔고
-(`get_positions`, 체결기준)만 즉시 반영된다. 이 모의 당일 gap을 닫기 위해
+KIS 모의 당일 체결은 레거시 tr_id `VTTC8001R` 의 `get_order_history`(결제기준)가
+0건을 주는 동안 잔고(`get_positions`, 체결기준)만 즉시 반영된다(신 tr_id
+`VTTC0081R`(#2349)은 당일 체결을 반환함이 #2317 라이브로 확인됨 — 단,
+position-derived fallback 은 백스톱 지연/유실에 무관히 멱등 백업으로 유지된다).
+이 모의 당일 gap을 닫기 위해
 broker-adapter 측에 **잔고-역도출 fallback**(position-derived bounded fallback,
 [`../broker-adapter/18-fill-recovery.md`](../broker-adapter/18-fill-recovery.md) §11)이 정의된다. 이 fallback 은 reconciler 의
 self/external 분류 정책과 **충돌하지 않으며**, 다음 경계를 유지한다:

--- a/src/ante/broker/fill_scheduler.py
+++ b/src/ante/broker/fill_scheduler.py
@@ -16,9 +16,12 @@ rate budget 보호:
 
 position-derived bounded fallback (#2314·#2316 §11):
 - KIS 모의 ``inquire-daily-ccld``(``get_order_history``)는 일별 결제기준 원장이라
-  당일 체결을 0건으로 지연 반영한다. 반면 잔고(``get_positions``)는 체결기준
-  즉시반영이다. 백스톱이 당일 0건을 줄 때 잔고 증분(``broker_qty -
-  internal_account_qty``)에서 self-submitted 체결을 **보수적 역도출**해
+  당일 체결을 지연 반영할 수 있다. 레거시 tr_id(``*8001R`` 세대)는 모의 당일 체결을
+  0건으로 반환했으나, 신 tr_id ``VTTC0081R``(#2349)은 당일 체결을 반환함이 #2317
+  라이브로 확인됐다(백스톱 지연/유실에 무관히 fallback 은 멱등 백업으로 유지).
+  반면 잔고(``get_positions``)는 체결기준 즉시반영이다. 백스톱이 당일 0건을 줄 때
+  잔고 증분(``broker_qty - internal_account_qty``)에서 self-submitted 체결을
+  **보수적 역도출**해
   ``FillApplier.apply_cumulative`` 로 멱등 수렴한다(§11.8 단일 권위 — 새 권위자
   미생성). **KIS paper 한정 기본 활성**(§11.6), disable flag 로 rollback 가능.
 

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -12,6 +12,7 @@ KIS REST API를 통해 주문, 조회를 처리한다.
 from __future__ import annotations
 
 import asyncio
+import calendar
 import json
 import logging
 from abc import abstractmethod
@@ -86,6 +87,22 @@ _ORDER_TR_IDS = frozenset(
 # NXT/SOR 등 다른 거래소 라우팅은 현재 미지원(요구 발생 시 config 표면화는 후속).
 DEFAULT_EXCG_ID_DVSN_CD = "KRX"
 
+# inquire-daily-ccld(주문/체결 이력) TR ID 매핑 (#2349).
+# KIS 공식 현행은 3개월 경계(inner/before) × 모의/실전 4코드로 분기한다. 레거시
+# 단일 코드(`*8001R` 세대)와 레거시 before(`*9115R` 세대)는 비채택.
+# 출처: KIS open-trading-api examples_llm/domestic_stock/inquire_daily_ccld.
+#   - inner(조회 기준일로부터 3개월 이내): 모의 VTTC0081R / 실전 TTTC0081R
+#   - before(3개월 이전): 모의 VTSC9215R / 실전 CTSC9215R
+_CCLD_TR_ID_INNER_PAPER = "VTTC0081R"
+_CCLD_TR_ID_INNER_LIVE = "TTTC0081R"
+_CCLD_TR_ID_BEFORE_PAPER = "VTSC9215R"
+_CCLD_TR_ID_BEFORE_LIVE = "CTSC9215R"
+
+# inquire-daily-ccld inner/before 판정의 3개월 경계(ante 로컬 normative 정책).
+# 공식 예제는 pd_dv=inner|before 를 호출자 인자로 받을 뿐 경계를 계산하지 않으므로
+# ante 가 정책을 소유한다(#2349). KST 오늘 기준 달력 3개월 전 동일 일자가 cutoff.
+_CCLD_BOUNDARY_MONTHS = 3
+
 # 인증 경로
 _AUTH_PATH = "/oauth2/tokenP"
 
@@ -93,6 +110,30 @@ _AUTH_PATH = "/oauth2/tokenP"
 # 어댑터 인스턴스(=계좌)당 미체결 주문 수를 넉넉히 덮으면서 무한 증가를 막는다.
 # 초과 시 가장 오래된 항목부터 제거(LRU 근사: insertion-order eviction).
 _KRX_FWDG_ORGNO_CACHE_MAXLEN = 1024
+
+
+def _ccld_three_month_cutoff(today_kst: str) -> str:
+    """inquire-daily-ccld inner/before 경계 cutoff ``YYYYMMDD`` (#2349, normative).
+
+    KST 오늘(``today_kst``, ``YYYYMMDD``) 기준 **달력 3개월 전 동일 일자**를
+    cutoff 로 산출한다. 대상 월에 동일 일자가 없으면(예: 5/31 → 2/31 부재) 그
+    월의 **말일**로 보정한다(예: 2026-05-31 → 2026-02-28).
+
+    ``INQR_STRT_DT >= cutoff`` 이면 inner(cutoff 당일 포함), ``< cutoff`` 이면
+    before 로 판정한다(start-date 단독 기준). 공식 예제는 ``pd_dv`` 인자를 받을
+    뿐 경계를 계산하지 않으므로 본 cutoff 산식은 ante 로컬 정책이다.
+    """
+    year = int(today_kst[:4])
+    month = int(today_kst[4:6])
+    day = int(today_kst[6:8])
+    # 달력 3개월 전 (year, month) 산출.
+    total = (year * 12 + (month - 1)) - _CCLD_BOUNDARY_MONTHS
+    target_year, target_month = divmod(total, 12)
+    target_month += 1
+    # 말일 보정: 대상 월에 동일 일자가 없으면 그 월 말일로 clamp.
+    last_day = calendar.monthrange(target_year, target_month)[1]
+    target_day = min(day, last_day)
+    return f"{target_year:04d}{target_month:02d}{target_day:02d}"
 
 
 class KISErrorClassifier:
@@ -1140,16 +1181,37 @@ class KISDomesticAdapter(KISBaseAdapter):
         from_date: str | None = None,
         to_date: str | None = None,
     ) -> list[dict[str, Any]]:
-        """주문/체결 이력 조회 (CTX_AREA 연속조회로 전 페이지 누적 후 fold)."""
-        tr_id = "VTTC8001R" if self.is_paper else "TTTC8001R"
+        """주문/체결 이력 조회 (CTX_AREA 연속조회로 전 페이지 누적 후 fold).
+
+        tr_id 는 KST 3개월 경계(inner/before) × 모의/실전 4코드로 분기한다(#2349).
+        조회 시작일(``INQR_STRT_DT``)이 KST 오늘 기준 3개월 전 cutoff 이상이면
+        inner(``*0081R``), 미만이면 before(``*9215R``)다(start-date 단독 기준).
+        교차 구간(``from < cutoff <= to``)은 split query 없이 start-date 기준
+        before 단일 쿼리로 처리하며, 그 완전성은 bounded known-limitation 이다
+        (현행 호출자 FillReconcileScheduler 는 항상 ≤7일 창이라 inner 고정).
+        """
+        # 기본 날짜 산출은 UTC 현행 유지(기존 동작 invariant). KST 는 경계 판정에만.
+        now = datetime.now(UTC)
+        start_date = from_date or (now - timedelta(days=7)).strftime("%Y%m%d")
+        end_date = to_date or now.strftime("%Y%m%d")
+
+        # 3개월 경계 판정: KST 오늘 기준 cutoff 와 start_date 비교(start-date 단독).
+        cutoff = _ccld_three_month_cutoff(business_date_kst())
+        is_inner = start_date >= cutoff
+        if is_inner:
+            tr_id = _CCLD_TR_ID_INNER_PAPER if self.is_paper else _CCLD_TR_ID_INNER_LIVE
+        else:
+            tr_id = (
+                _CCLD_TR_ID_BEFORE_PAPER if self.is_paper else _CCLD_TR_ID_BEFORE_LIVE
+            )
+
         url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-daily-ccld"
 
-        now = datetime.now(UTC)
         params = {
             "CANO": self.account_no[:8],
             "ACNT_PRDT_CD": self.account_no[8:10],
-            "INQR_STRT_DT": from_date or (now - timedelta(days=7)).strftime("%Y%m%d"),
-            "INQR_END_DT": to_date or now.strftime("%Y%m%d"),
+            "INQR_STRT_DT": start_date,
+            "INQR_END_DT": end_date,
             "SLL_BUY_DVSN_CD": "00",
             "INQR_DVSN": "00",
             "PDNO": "",
@@ -1158,6 +1220,10 @@ class KISDomesticAdapter(KISBaseAdapter):
             "ODNO": "",
             "INQR_DVSN_3": "00",
             "INQR_DVSN_1": "",
+            # 거래소ID구분코드 hygiene(#2349). order-cash(#2344)의 40910000
+            # 거절-fix 와 달리 이 엔드포인트는 hard-required 가 아니며, 데이터
+            # 완전성(NXT 누락 방지)을 위한 optional 주입이다(공식 조건부 append).
+            "EXCG_ID_DVSN_CD": DEFAULT_EXCG_ID_DVSN_CD,
             "CTX_AREA_FK100": "",
             "CTX_AREA_NK100": "",
         }

--- a/tests/unit/test_kis_pagination.py
+++ b/tests/unit/test_kis_pagination.py
@@ -20,7 +20,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ante.broker.kis import DEFAULT_MAX_PAGINATION_PAGES, KISDomesticAdapter
+from ante.broker.kis import (
+    DEFAULT_EXCG_ID_DVSN_CD,
+    DEFAULT_MAX_PAGINATION_PAGES,
+    KISDomesticAdapter,
+)
 
 _CONFIG = {
     "app_key": "test-key",
@@ -440,3 +444,153 @@ async def test_request_with_cont_empty_header_not_injected() -> None:
 
     # 최초 요청: tr_cont 헤더는 빈 문자열이거나 부재(어느 쪽도 KIS 최초조회로 동작).
     assert captured["headers"].get("tr_cont", "") == ""
+
+
+# ── inquire-daily-ccld tr_id 4코드 분기 + EXCG_ID_DVSN_CD (#2349) ──
+#
+# get_order_history 가 KST 3개월 경계(start-date 단독 기준)로 inner/before 를
+# 판정하고, is_paper × inner/before 4코드로 tr_id 를 선택하는지, 그리고
+# EXCG_ID_DVSN_CD hygiene 파라미터를 주입하는지 검증한다. 서버측 효과
+# (레거시 0행 vs 신 4행)는 #2317 라이브로 닫혀 있으므로 mock 하지 않고,
+# 클라이언트 측 tr_id/param 선택 로직만 단언한다.
+
+# 레거시 tr_id — 회귀 lock 대상(더 이상 전송되지 않음).
+_LEGACY_CCLD_TR_IDS = frozenset({"VTTC8001R", "TTTC8001R", "VTSC9115R", "CTSC9115R"})
+
+
+def _make_ccld_adapter(*, is_paper: bool) -> KISDomesticAdapter:
+    """inquire-daily-ccld tr_id/param 선택만 검증하기 위한 어댑터."""
+    config = dict(_CONFIG)
+    config["is_paper"] = is_paper
+    return KISDomesticAdapter(config=config)
+
+
+def _capture_ccld_call(
+    adapter: KISDomesticAdapter,
+) -> dict[str, Any]:
+    """get_order_history 가 _request_paginated 에 넘긴 tr_id/params 를 캡처한다."""
+    captured: dict[str, Any] = {}
+
+    async def fake_paginated(method, url, tr_id, params, row_key="output1"):  # type: ignore[no-untyped-def]
+        captured["tr_id"] = tr_id
+        captured["params"] = dict(params)
+        return []
+
+    adapter._request_paginated = fake_paginated  # type: ignore[method-assign]
+    return captured
+
+
+@pytest.mark.parametrize("is_paper", [True, False])
+@pytest.mark.parametrize(
+    ("from_date", "expected_kind"),
+    [
+        # cutoff 당일(2026-03-11) 포함 → inner.
+        ("20260311", "inner"),
+        # cutoff 익일(이내) → inner.
+        ("20260312", "inner"),
+        # cutoff 전일(3개월보다 더 과거) → before.
+        ("20260310", "before"),
+    ],
+)
+async def test_get_order_history_selects_tr_id_by_kst_three_month_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    is_paper: bool,
+    from_date: str,
+    expected_kind: str,
+) -> None:
+    """KST cutoff 당일/익일/전일 × 모의/실전 4매핑 tr_id 선택을 clock 고정으로 단언.
+
+    KST today=2026-06-11 → cutoff=2026-03-11(달력 3개월 전 동일 일자).
+    INQR_STRT_DT >= cutoff → inner(0081R 계열), < cutoff → before(9215R 계열).
+    """
+    # clock 고정: KST 영업일 = 2026-06-11.
+    monkeypatch.setattr("ante.broker.kis.business_date_kst", lambda *a, **k: "20260611")
+
+    expected = {
+        ("inner", True): "VTTC0081R",
+        ("inner", False): "TTTC0081R",
+        ("before", True): "VTSC9215R",
+        ("before", False): "CTSC9215R",
+    }[(expected_kind, is_paper)]
+
+    adapter = _make_ccld_adapter(is_paper=is_paper)
+    captured = _capture_ccld_call(adapter)
+
+    await adapter.get_order_history(from_date=from_date, to_date="20260611")
+
+    assert captured["tr_id"] == expected
+    # 레거시 tr_id 회귀 lock.
+    assert captured["tr_id"] not in _LEGACY_CCLD_TR_IDS
+    # EXCG_ID_DVSN_CD hygiene 파라미터 주입(상수 재사용).
+    assert captured["params"]["EXCG_ID_DVSN_CD"] == DEFAULT_EXCG_ID_DVSN_CD == "KRX"
+
+
+@pytest.mark.parametrize("is_paper", [True, False])
+async def test_get_order_history_default_from_date_is_inner(
+    monkeypatch: pytest.MonkeyPatch, is_paper: bool
+) -> None:
+    """기본 from_date(now-7d, UTC 현행 유지)는 항상 inner(0081R 계열) 회귀.
+
+    호출자가 from_date 를 명시하지 않으면 종전과 동일하게 inner 경로로 동작해야
+    한다(tr_id 만 0081R 계열로 교체). UTC 기본 날짜 산출은 무변경이다.
+    """
+    monkeypatch.setattr("ante.broker.kis.business_date_kst", lambda *a, **k: "20260611")
+    expected = "VTTC0081R" if is_paper else "TTTC0081R"
+
+    adapter = _make_ccld_adapter(is_paper=is_paper)
+    captured = _capture_ccld_call(adapter)
+
+    await adapter.get_order_history()
+
+    assert captured["tr_id"] == expected
+    assert captured["params"]["EXCG_ID_DVSN_CD"] == "KRX"
+
+
+async def test_get_order_history_crossing_window_uses_single_before_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """교차 구간(from<cutoff<=to)은 split 없이 before 단일 쿼리(start-date 기준).
+
+    bounded known-limitation: cutoff 를 가로지르는 창은 start-date 기준으로
+    before 단일 코드를 선택하며, split query 를 발행하지 않는다(_request_paginated
+    1회 호출).
+    """
+    monkeypatch.setattr("ante.broker.kis.business_date_kst", lambda *a, **k: "20260611")
+    adapter = _make_ccld_adapter(is_paper=True)
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def fake_paginated(method, url, tr_id, params, row_key="output1"):  # type: ignore[no-untyped-def]
+        calls.append((tr_id, dict(params)))
+        return []
+
+    adapter._request_paginated = fake_paginated  # type: ignore[method-assign]
+
+    # from(03-01) < cutoff(03-11) <= to(06-11) — 교차 구간.
+    await adapter.get_order_history(from_date="20260301", to_date="20260611")
+
+    # split 없이 단일 before 쿼리.
+    assert len(calls) == 1
+    assert calls[0][0] == "VTSC9215R"
+    assert calls[0][1]["INQR_STRT_DT"] == "20260301"
+    assert calls[0][1]["INQR_END_DT"] == "20260611"
+
+
+async def test_get_order_history_month_end_boundary_clamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """말일 보정: 대상 월에 동일 일자가 없으면 그 월 말일을 cutoff 로 쓴다.
+
+    KST today=2026-05-31 → 3개월 전 동일 일자(02-31)는 부재 → 02-28(2026 비윤년)
+    말일로 보정. INQR_STRT_DT=20260228 은 cutoff 당일이라 inner.
+    """
+    monkeypatch.setattr("ante.broker.kis.business_date_kst", lambda *a, **k: "20260531")
+    adapter = _make_ccld_adapter(is_paper=True)
+    captured = _capture_ccld_call(adapter)
+
+    # cutoff = 2026-02-28(말일 보정). 당일은 inner.
+    await adapter.get_order_history(from_date="20260228", to_date="20260531")
+    assert captured["tr_id"] == "VTTC0081R"
+
+    # cutoff 전일(02-27)은 before.
+    await adapter.get_order_history(from_date="20260227", to_date="20260531")
+    assert captured["tr_id"] == "VTSC9215R"


### PR DESCRIPTION
Closes #2349

## Summary
- `get_order_history()` tr_id를 레거시 단일 `8001R`에서 **KST 3개월 경계(start-date 기준) × 모의/실전 4코드**로 교체: inner `VTTC0081R`/`TTTC0081R`, before `VTSC9215R`/`CTSC9215R` — #2317 라이브 A/B로 신세대 효과 입증(레거시 0행 vs 신세대 4행)
- `_ccld_three_month_cutoff()` 로컬 normative 경계 헬퍼(KST 달력 3개월·말일 보정·교차 구간 before 단일 쿼리 known-limitation). 기본 from/to 날짜 산출은 UTC 현행 유지
- `EXCG_ID_DVSN_CD` hygiene 주입(#2344 공유 상수 `DEFAULT_EXCG_ID_DVSN_CD` 재사용)
- `_fold_order_history`·`_request_paginated`·반환 스키마 무변경 invariant 유지(FillApplier/FillReconcileScheduler 무영향)
- 스펙: 08(inquire-daily-ccld TR ID H3 신설), 18-fill-recovery(§2.1/§11.6/§11.7 신 tr_id 라이브 확인 갱신 — 잔여 라이브 의존 #2353 유지), 03-07·fill_scheduler docstring 레거시 세대 한정 구분

## Verification
- Plan Preflight: approve-implement (Codex R2) / 브랜치 리뷰: PASS (attempt 1)
- `pytest tests/unit -q`: 7189 passed, 2 skipped / `mypy src/`: Success (232 files) / ruff 통과
- clock 고정 cutoff 당일/전일/익일 × 모의/실전 4매핑 테스트 10건(구현 전 FAIL 확인)
- `grep VTTC8001R\|TTTC8001R src/` → 0건

## Test Plan
- `pytest tests/unit/test_kis_pagination.py tests/unit/test_fill_scheduler.py tests/unit/test_kis_order_tr_id.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)