### PR TITLE
fix(broker): #2350 late-ccld TimeoutError 차단기 회계 제외 + fill 폴 steady-state cooldown

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-06-04 (KST)
+> 마지막 생성 시점: 2026-06-12 (KST)
 
 ## 최상위 구조
 
@@ -100,7 +100,8 @@ src/ante/
 │   │   └── __init__.py
 │   ├── __init__.py
 │   ├── cold_path.py
-│   └── info.py
+│   ├── info.py
+│   └── signal_channel_registry.py
 ├── strategy/
 │   ├── base.py                       # Strategy ABC, StrategyMeta, TradeHistoryView
 │   ├── context.py                    # StrategyContext — 전략 실행 컨텍스트 (파일 접근, 로깅, 거래 이력)
@@ -440,7 +441,8 @@ tests/
 │   │   ├── test_cli_registry_ipc_cross_ref.py
 │   │   ├── test_docs_taxonomy_drift.py
 │   │   ├── test_member_admin_ipc_wiring.py
-│   │   └── test_treasury_account_scoping.py
+│   │   ├── test_treasury_account_scoping.py
+│   │   └── test_server_signal_connect.py
 │   ├── specs/
 │   │   ├── __init__.py
 │   │   ├── test_cold_path_terminology.py
@@ -637,7 +639,8 @@ tests/
 │   │   ├── factory_drift_allowlist.yaml
 │   │   ├── docs_drift_allowlist.yaml
 │   │   ├── test_cli_registry_docs_drift.py
-│   │   └── test_cli_registry_guide_sync.py
+│   │   ├── test_cli_registry_guide_sync.py
+│   │   └── test_signal_connect_codes.py
 │   ├── test_account_cli_ipc_error_equivalence.py
 │   ├── test_member_cli_ipc_error_equivalence.py
 │   ├── test_approval_cli_ipc_error_equivalence.py
@@ -708,8 +711,22 @@ tests/
 │   ├── test_report_validation_detail_json.py
 │   ├── test_rule_engine_unrecovered_buy_guard.py
 │   ├── test_rule_modify_enrich.py
-│   └── test_strategy_summary_all_bots.py
-└── __init__.py
+│   ├── test_strategy_summary_all_bots.py
+│   ├── test_bot_signal_connect_exceptions.py
+│   ├── test_ipc_server_signal_stream.py
+│   ├── test_kis_cancel_krx_fwdg_ord_orgno.py
+│   ├── test_kis_cb_ccld_timeout_decoupling.py
+│   ├── test_kis_order_tr_id.py
+│   ├── test_signal_channel_outbound.py
+│   ├── test_signal_channel_registry.py
+│   ├── test_signal_connect_audit.py
+│   └── test_signal_connect_busy.py
+├── __init__.py
+└── integration/
+    ├── __init__.py
+    ├── test_signal_connect_cli_repro_2333.py
+    ├── test_signal_connect_repro_2333.py
+    └── test_signal_connect_stream.py
 ```
 
 ## deploy/ — 서비스 배포

--- a/docs/specs/broker-adapter/07-kis-base-adapter.md
+++ b/docs/specs/broker-adapter/07-kis-base-adapter.md
@@ -15,7 +15,7 @@ KISBaseAdapter는 한국투자증권 Open API의 국내/해외 공통 로직을 
 | OAuth2 인증 | 토큰 발급·갱신·만료 관리 (동일 APP KEY) |
 | HTTP 클라이언트 | aiohttp 세션, 헤더 구성, 에러 파싱 |
 | Rate Limiter 연동 | APIGateway의 rate limiter 사용 |
-| CircuitBreaker | 장애 감지·차단·복구 상태 머신 |
+| CircuitBreaker | 장애 감지·차단·복구 상태 머신. **어댑터 전역 단일**(주문 경로 보호 우선)이며 주문·조회 모든 경로가 공유한다. **late-ccld(`get_order_history`) `TimeoutError`는 회계에서 제외**(호출측 opt-out)되어 체결이력 폴 타임아웃이 무관한 treasury 동기화·주문 경로를 broker-wide 로 차단하지 않는다(#2350, [10-commission-info.md](10-commission-info.md)). |
 | 재시도 로직 | 지수 백오프 + 에러 분류 기반 재시도 |
 | Base URL 결정 | `broker_config.is_paper`에 따라 실전/모의 도메인 분기 |
 | `connect()` / `disconnect()` | API 연결·해제 |

--- a/docs/specs/broker-adapter/10-commission-info.md
+++ b/docs/specs/broker-adapter/10-commission-info.md
@@ -35,6 +35,25 @@ API 장애 시 연쇄 호출을 방지하는 서킷 브레이커. CLOSED → OPE
 
 상태 전환 시 `CircuitBreakerEvent`를 EventBus에 발행한다.
 
+**공유 범위 (normative, #2350)**: 차단기는 **어댑터 인스턴스(=계좌)당 단일**
+(`name="kis"`)이며, 주문·조회 모든 경로가 공유하는 `_request()`/`_request_with_cont()`
+흐름에 통합된다. 이 단일 차단기는 주문 연쇄 호출 방지(주문 경로 보호)를 1차
+목적으로 한다. 단일 인스턴스이므로 한 concern 의 실패 누적이 OPEN 을 유발하면 같은
+어댑터의 다른 concern(잔고/포지션 조회, 주문 등)도 `check()` 단계에서 함께 차단된다
+(blast radius 경계는 [15-reconciliation.md](15-reconciliation.md) §대사 참조).
+
+**late-ccld TimeoutError 회계 제외 (normative, #2350)**: 체결이력 조회
+(`get_order_history` → `inquire-daily-ccld`)의 `TimeoutError` 계열(aiohttp timeout
+포함, `TimeoutError` 하위)은 **차단기 회계에 기록되지 않는다**(호출측 opt-out
+`cb_exempt_timeout=True`). late-ccld 조회 타임아웃이 어댑터 전역 단일 차단기를
+OPEN 시켜 무관한 treasury 잔고/포지션 동기화·주문 경로까지 broker-wide 로 차단하는
+cross-concern 결합을 끊기 위함이다. 회계 제외는 **`get_order_history` 경로의
+`TimeoutError` 에 한정**되며, HTTP 5xx/`APIError` 등 다른 실패는 기존대로 기록한다
+(실제 KIS 서버 장애 보호 유지). 차단기 상태 머신·에러 분류(`KISErrorClassifier`)
+자체는 무변경이고, `check()` 통과는 그대로라 다른 concern 이 연 차단기에는 종속한다.
+체결 폴 루프의 steady-state cooldown 은 [18-fill-recovery.md](18-fill-recovery.md)
+참조.
+
 ### 에러 코드 분류
 
 > 소스: `src/ante/broker/error_codes.py`
@@ -49,7 +68,7 @@ KIS API 응답 코드를 영구 에러(재시도 불필요)와 일시 에러(재
 
 ### 에러 처리 및 재시도
 
-KISBaseAdapter는 지수 백오프 방식의 재시도 로직을 내장한다. 인증 토큰 만료 감지 시 자동 재인증을 수행하며, 토큰 만료 5분 전에 선제적으로 재발급한다. 모든 API 응답에서 `rt_cd != '0'`이면 `APIError`를 발생시킨다. CircuitBreaker가 `_request()` 흐름에 통합되어, 연속 실패 시 자동으로 요청을 차단한다.
+KISBaseAdapter는 지수 백오프 방식의 재시도 로직을 내장한다. 인증 토큰 만료 감지 시 자동 재인증을 수행하며, 토큰 만료 5분 전에 선제적으로 재발급한다. 모든 API 응답에서 `rt_cd != '0'`이면 `APIError`를 발생시킨다. CircuitBreaker가 `_request()` 흐름에 통합되어, 연속 실패 시 자동으로 요청을 차단한다. 회계 판정은 `to_api_error()` 변환 **전 raw 예외** 기준이며, 재시도 루프에서 `record_failure` 분류이면서 호출측 `cb_exempt_timeout`+`TimeoutError` 조합이 아닐 때만 `record_failure()`를 호출한다(#2350). 단, **late-ccld(`get_order_history`) 경로의 `TimeoutError`는 차단기 회계에서 제외**된다(위 CircuitBreaker 절·[18-fill-recovery.md](18-fill-recovery.md) 참조).
 
 **오퍼레이션별 기본값**:
 

--- a/docs/specs/broker-adapter/15-reconciliation.md
+++ b/docs/specs/broker-adapter/15-reconciliation.md
@@ -101,4 +101,14 @@ ambiguity 판정 count 는 **status 무관**이다(#2119). 즉 `stopped`/`error`
 사용한다. 서버 밖에서 별도 BrokerAdapter를 직접 생성해 대사하면 서버가 보유한
 연결 상태, circuit breaker, TradeService 인메모리 상태와 어긋날 수 있다.
 
+**blast radius 경계 (normative, #2350)**: 이 공유 circuit breaker 는 어댑터
+인스턴스(=계좌)당 단일이며, 같은 계좌의 `FillReconcileScheduler`(체결 폴)와
+treasury 실전 동기화(`get_account_balance`/`get_positions`)가 동일 어댑터를
+공유한다. 체결이력 폴(`get_order_history` → `inquire-daily-ccld`)의 `TimeoutError`
+는 차단기 회계에서 제외되므로, 체결 폴이 반복 타임아웃해도 차단기가 OPEN 되어
+treasury 잔고/포지션 동기화·주문 경로를 broker-wide 로 차단하지 않는다(cross-concern
+격리). 회계 제외는 late-ccld `TimeoutError` 에 한정되며 다른 실패(5xx/`APIError`)는
+그대로 차단기에 반영된다([10-commission-info.md](10-commission-info.md)·
+[18-fill-recovery.md](18-fill-recovery.md)).
+
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조

--- a/docs/specs/broker-adapter/18-fill-recovery.md
+++ b/docs/specs/broker-adapter/18-fill-recovery.md
@@ -276,6 +276,47 @@ invariant**다. EOD 만료를 폴 **앞**에 두면, 전일 open이 다운타임
 > 매도"가 아니라 "복구 지연된 보유의 오귀속 알림"으로 좁혀진다 — poll-first 순서
 > invariant 가 근본 차단을 담당한다는 사실은 변하지 않는다.
 
+### 6.2 steady-state 폴 루프 cooldown · late-ccld 차단기 회계 제외 (#2350)
+
+체결이력 폴(`get_order_history` → `inquire-daily-ccld`)은 어댑터 전역 단일
+`CircuitBreaker`를 주문·잔고 조회와 공유한다. 폴 타임아웃 누적이 차단기를 OPEN
+시키면 같은 어댑터를 공유하는 treasury 잔고/포지션 동기화·주문 경로까지
+broker-wide 로 차단된다(cross-concern 결합). 이를 끊기 위해 두 normative 규칙을
+둔다.
+
+**late-ccld `TimeoutError` 차단기 회계 제외 (normative)**: `get_order_history`
+경로의 `TimeoutError` 계열(aiohttp timeout 포함, `TimeoutError` 하위)은 차단기
+`record_failure()`에 **기록되지 않는다**(호출측 opt-out). 따라서 체결이력 폴이
+반복 타임아웃해도 차단기는 OPEN 되지 않으며, **차단기 상태 변경 이벤트/알림도
+발생하지 않는다**(`CircuitBreakerEvent`/`NotificationEvent`의 발생 조건을 좁힐 뿐
+스키마/종류는 무변경 — [16-eventbus-integration.md](16-eventbus-integration.md)·
+[17-notification-events.md](17-notification-events.md) unchanged). 회계 제외는
+**late-ccld `TimeoutError` 에 한정**되며, HTTP 5xx/`APIError` 등 다른 실패는
+기존대로 차단기에 기록된다(실제 KIS 서버 장애 보호 유지). 차단기 `check()` 통과는
+그대로라 다른 concern 이 연 차단기에는 종속한다(주문 경로 보호 무변경). 어댑터 측
+계약은 [10-commission-info.md](10-commission-info.md)·[07-kis-base-adapter.md](07-kis-base-adapter.md)
+참조.
+
+**steady-state cooldown (normative)**: 주기 루프(`_loop`)는 정상 사이클에서
+`poll_interval` 고정 주기를 유지하되, **연속 broker-transient 실패** 시 다음 사이클
+대기를 backoff 로 늘려 OPEN 갱신/타임아웃 연타를 흡수한다.
+
+- **sequence**: n번째 연속 실패 직후 다음 사이클 sleep = `poll_interval × min(2^n,
+  8)`. 즉 첫 실패 후 ×2, 이후 ×4, ×8(cap).
+- **cap 근거**: 기본 `poll_interval` 60s 기준 상한 480s(=60×8). 이는 CB
+  `recovery_timeout`(60s)·reconciler 주기(1800s)보다 짧아 복구 관측을 놓치지
+  않으면서 OPEN 을 60s 주기로 갱신·연장하지 않는다. fill 반영 지연 상한도 480s 로
+  bounded.
+- **reset**: `_poll_and_apply`가 예외 없이 정상 완료되면 연속 실패 카운터를 0 으로
+  리셋해 `poll_interval` 고정 주기로 복귀한다(성공 경로 주기 불변).
+- **실패 집계 범위**: broker-transient 예외(`TimeoutError`·`CircuitOpenError`·
+  `APIError`·`ConnectionError`/`OSError`)만 카운트한다. 그 외 예외(내부 버그류)는
+  cooldown 으로 은폐하지 않고 기존대로 즉시 다음 주기 + 경고 로그를 유지한다(현행
+  동작 보존).
+- **적용 범위**: cooldown 은 `_loop` steady-state 한정이다. 기동 카치업
+  `catch_up_once`의 bounded backoff(§6.1, `CATCH_UP_MAX_ATTEMPTS`)는 **무변경·
+  비간섭**이며, 기동 barrier(§7) 결정에 영향을 주지 않는다.
+
 ## 7. barrier ordering (재기동 무오분류)
 
 기존 `ReconcileScheduler.start()`는 즉시 `run_once()`로 position 대사를 돈다.

--- a/docs/specs/broker-adapter/18-fill-recovery.md
+++ b/docs/specs/broker-adapter/18-fill-recovery.md
@@ -311,8 +311,10 @@ broker-wide 로 차단된다(cross-concern 결합). 이를 끊기 위해 두 nor
   리셋해 `poll_interval` 고정 주기로 복귀한다(성공 경로 주기 불변).
 - **실패 집계 범위**: broker-transient 예외(`TimeoutError`·`CircuitOpenError`·
   `APIError`·`ConnectionError`/`OSError`)만 카운트한다. 그 외 예외(내부 버그류)는
-  cooldown 으로 은폐하지 않고 기존대로 즉시 다음 주기 + 경고 로그를 유지한다(현행
-  동작 보존).
+  cooldown 의 backoff 대상이 아니며, 발생 시 **연속 실패 카운터를 0 으로 리셋**한다.
+  따라서 선행 transient 실패로 backoff 가 올라가 있었더라도 내부 버그류 예외 직후의
+  다음 사이클은 base `poll_interval` 로 복귀한다(내부 결함을 이전 backoff 로 계속
+  잠재우지 않음). 경고 로그는 기존대로 남긴다(현행 동작 보존).
 - **적용 범위**: cooldown 은 `_loop` steady-state 한정이다. 기동 카치업
   `catch_up_once`의 bounded backoff(§6.1, `CATCH_UP_MAX_ATTEMPTS`)는 **무변경·
   비간섭**이며, 기동 barrier(§7) 결정에 영향을 주지 않는다.

--- a/src/ante/broker/fill_scheduler.py
+++ b/src/ante/broker/fill_scheduler.py
@@ -73,7 +73,8 @@ LOOP_BACKOFF_MULTIPLIER_CAP = 8
 
 # steady-state cooldown 집계 대상 broker-transient 예외(#2350). 이 부류만 연속 실패
 # 카운터에 누적해 cooldown 을 연장한다. 그 외 예외(내부 버그류)는 backoff 로 은폐하지
-# 않고 기존대로 즉시 다음 주기 + 경고 로그를 유지한다(현행 동작 보존).
+# 않고 카운터를 0 으로 리셋해 기존대로 즉시 다음 주기 + 경고 로그를 유지한다(현행
+# 동작 보존, #2350 Codex R1 P2).
 _LOOP_BACKOFF_EXCEPTIONS: tuple[type[Exception], ...] = (
     TimeoutError,
     CircuitOpenError,
@@ -308,8 +309,9 @@ class FillReconcileScheduler:
         이후 ×4, ×8 cap) late-ccld 타임아웃 연타로 차단기 OPEN 을 60s 주기로
         갱신·연장하지 않게 한다(#2350). 정상 완료 시 카운터를 0 으로 리셋해
         ``poll_interval`` 고정 주기로 복귀한다. broker-transient 가 아닌 예외(내부
-        버그류)는 backoff 로 은폐하지 않고 기존대로 즉시 다음 주기 + 경고 로그를
-        유지한다(현행 동작 보존). 이 cooldown 은 ``_loop`` steady-state 한정이며
+        버그류)는 backoff 로 은폐하지 않는다 — 연속 실패 카운터를 0 으로 리셋해(선행
+        transient 로 올라간 backoff 가 있으면 함께 해제) 즉시 다음 주기 + 경고 로그를
+        유지한다(#2350 Codex R1 P2). 이 cooldown 은 ``_loop`` steady-state 한정이며
         ``catch_up_once`` 의 bounded backoff 와 비간섭이다.
         """
         consecutive_transient_failures = 0
@@ -349,8 +351,11 @@ class FillReconcileScheduler:
                 )
             except Exception:
                 # broker-transient 가 아닌 예외(내부 버그류)는 cooldown 으로 은폐하지
-                # 않는다. 카운터를 건드리지 않아(연장 안 함) 기존대로 즉시 다음 주기에
-                # 멱등 재시도하고 경고 로그를 남긴다(현행 동작 보존, #2350).
+                # 않는다. 선행 transient 실패로 backoff 가 올라가 있었다면 카운터를 0
+                # 으로 리셋해 다음 사이클이 base poll_interval 로 복귀하게 한다(내부
+                # 결함을 이전 backoff 로 계속 잠재우지 않음, #2350 Codex R1 P2).
+                # 이후 경고 로그를 남기고 기존대로 즉시 다음 주기에 멱등 재시도한다.
+                consecutive_transient_failures = 0
                 logger.warning(
                     "FillReconcileScheduler 폴 오류 (account=%s) — 다음 사이클 재시도",
                     self._account_id,

--- a/src/ante/broker/fill_scheduler.py
+++ b/src/ante/broker/fill_scheduler.py
@@ -38,6 +38,7 @@ from datetime import UTC, datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from ante.account.scoping import require_account_id
+from ante.broker.exceptions import APIError, CircuitOpenError
 
 if TYPE_CHECKING:
     from ante.broker.base import BrokerAdapter
@@ -61,6 +62,25 @@ DEFAULT_POLL_INTERVAL = 60.0
 # 가 reconcile external-buy 분류를 건너뛰게 한다(미복구 체결 오분류 방지, #1946).
 CATCH_UP_MAX_ATTEMPTS = 3
 CATCH_UP_BACKOFF_BASE = 1.0
+
+# steady-state 폴 루프(_loop) 연속 실패 cooldown 상한 배수 (#2350).
+# n번째 연속 실패 직후 sleep = poll_interval × min(2^n, LOOP_BACKOFF_MULTIPLIER_CAP)
+# (첫 실패 ×2, 이후 ×4, ×8 cap). 기본 poll 60s 기준 상한 480s — CB
+# recovery_timeout(60s)·reconciler 주기(1800s)보다 짧아 복구 관측을 놓치지 않으면서
+# late-ccld 타임아웃 연타로 차단기 OPEN 을 60s 주기로 갱신·연장하지 않게 한다. fill
+# 반영 지연 상한도 480s 로 bounded. catch_up_once 의 bounded backoff 와는 비간섭.
+LOOP_BACKOFF_MULTIPLIER_CAP = 8
+
+# steady-state cooldown 집계 대상 broker-transient 예외(#2350). 이 부류만 연속 실패
+# 카운터에 누적해 cooldown 을 연장한다. 그 외 예외(내부 버그류)는 backoff 로 은폐하지
+# 않고 기존대로 즉시 다음 주기 + 경고 로그를 유지한다(현행 동작 보존).
+_LOOP_BACKOFF_EXCEPTIONS: tuple[type[Exception], ...] = (
+    TimeoutError,
+    CircuitOpenError,
+    APIError,
+    ConnectionError,
+    OSError,
+)
 
 
 def business_date_kst(when: datetime | None = None) -> str:
@@ -279,22 +299,66 @@ class FillReconcileScheduler:
             self._task = None
 
     async def _loop(self) -> None:
+        """steady-state 주기 폴 루프 (+ #2350 연속 실패 cooldown).
+
+        정상 사이클은 ``poll_interval`` 고정 주기로 ``_poll_and_apply`` 를 반복한다.
+        broker-transient 실패(``_LOOP_BACKOFF_EXCEPTIONS``: TimeoutError/
+        CircuitOpenError/APIError/Connection/OSError)가 **연속**되면 sleep 을
+        ``poll_interval × min(2^n, LOOP_BACKOFF_MULTIPLIER_CAP)`` 로 늘려(첫 실패 ×2,
+        이후 ×4, ×8 cap) late-ccld 타임아웃 연타로 차단기 OPEN 을 60s 주기로
+        갱신·연장하지 않게 한다(#2350). 정상 완료 시 카운터를 0 으로 리셋해
+        ``poll_interval`` 고정 주기로 복귀한다. broker-transient 가 아닌 예외(내부
+        버그류)는 backoff 로 은폐하지 않고 기존대로 즉시 다음 주기 + 경고 로그를
+        유지한다(현행 동작 보존). 이 cooldown 은 ``_loop`` steady-state 한정이며
+        ``catch_up_once`` 의 bounded backoff 와 비간섭이다.
+        """
+        consecutive_transient_failures = 0
         while self._running:
-            await asyncio.sleep(self._poll_interval)
+            # 연속 broker-transient 실패가 있으면 sleep 을 늘려 OPEN 갱신/타임아웃
+            # 연타를 흡수한다. 0 이면 기존 poll_interval 고정 주기(성공 경로 불변).
+            if consecutive_transient_failures > 0:
+                multiplier = min(
+                    2**consecutive_transient_failures, LOOP_BACKOFF_MULTIPLIER_CAP
+                )
+                sleep_for = self._poll_interval * multiplier
+            else:
+                sleep_for = self._poll_interval
+            await asyncio.sleep(sleep_for)
             if not self._running:
                 return
             try:
                 await self._poll_and_apply()
             except asyncio.CancelledError:
                 raise
+            except _LOOP_BACKOFF_EXCEPTIONS:
+                # broker-transient 폴 실패(CB open/rate/network/타임아웃)를 삼키고
+                # 다음 사이클에 멱등 재시도하되, 연속 실패 카운터를 올려 cooldown 을
+                # 연장한다(#2350). (startup 카치업과 달리 barrier 영향 없음.)
+                consecutive_transient_failures += 1
+                logger.warning(
+                    "FillReconcileScheduler 폴 오류 (account=%s, 연속실패=%d) — "
+                    "%.0fs 후 재시도",
+                    self._account_id,
+                    consecutive_transient_failures,
+                    self._poll_interval
+                    * min(
+                        2**consecutive_transient_failures,
+                        LOOP_BACKOFF_MULTIPLIER_CAP,
+                    ),
+                    exc_info=True,
+                )
             except Exception:
-                # 주기 루프는 폴 실패(CB/rate/network)를 삼키고 다음 사이클에
-                # 멱등 재시도한다. (startup 카치업과 달리 barrier 영향 없음.)
+                # broker-transient 가 아닌 예외(내부 버그류)는 cooldown 으로 은폐하지
+                # 않는다. 카운터를 건드리지 않아(연장 안 함) 기존대로 즉시 다음 주기에
+                # 멱등 재시도하고 경고 로그를 남긴다(현행 동작 보존, #2350).
                 logger.warning(
                     "FillReconcileScheduler 폴 오류 (account=%s) — 다음 사이클 재시도",
                     self._account_id,
                     exc_info=True,
                 )
+            else:
+                # 정상 완료 — cooldown 카운터 리셋, poll_interval 고정 주기 복귀.
+                consecutive_transient_failures = 0
 
     async def _poll_and_apply(self) -> int:
         """**poll-first**: open(만료 전) → history 1콜 → fallback → 그 후 EOD 만료.

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -522,6 +522,8 @@ class KISBaseAdapter(BrokerAdapter):
         params: dict[str, str] | None = None,
         json_data: dict[str, Any] | None = None,
         cont_header: str = "",
+        *,
+        cb_exempt_timeout: bool = False,
     ) -> tuple[dict[str, Any], str]:
         """API 요청 공통 래퍼 (circuit breaker + 재시도 + 타임아웃).
 
@@ -530,6 +532,16 @@ class KISBaseAdapter(BrokerAdapter):
         와 **동일하게 공유**한다 (로직 중복 금지). ``cont_header`` 는 KIS 연속
         조회 요청 헤더 ``tr_cont`` 값("" 최초 / "N" 다음)이며, 반환 두 번째
         값은 응답 헤더 ``tr_cont`` ("F"/"M"=다음 있음 / "D"/"E"=마지막)이다.
+
+        ``cb_exempt_timeout`` 은 **호출측 차단기 회계 opt-out** 이다(#2350).
+        ``True`` 면 ``TimeoutError`` 계열(aiohttp timeout 포함, ``TimeoutError``
+        하위)의 실패를 ``CircuitBreaker.record_failure()`` 에 **기록하지 않는다**.
+        late-ccld(``get_order_history``) 조회 타임아웃이 어댑터 전역 단일 차단기를
+        OPEN 시켜 무관한 treasury 잔고/포지션 동기화·주문 경로까지 broker-wide 로
+        차단하는 cross-concern blast radius 를 끊기 위함이다. 회계 제외는
+        ``TimeoutError`` 에 **한정**되며 HTTP 5xx/``APIError`` 등 다른 실패는
+        기본값(``False``) 호출자와 동일하게 그대로 기록된다. ``check()`` 는 여전히
+        통과하므로 다른 concern 이 연 차단기에는 종속한다(주문 경로 보호 무변경).
         """
         self._circuit_breaker.check()
         await self._ensure_authenticated()
@@ -553,8 +565,14 @@ class KISBaseAdapter(BrokerAdapter):
                 retryable, record_failure = KISErrorClassifier.classify(e)
                 if not retryable:
                     raise
+                # #2350: 차단기 회계 판정은 to_api_error() 변환 **전** raw 예외 e
+                # 기준이다. cb_exempt_timeout 이면서 raw 예외가 TimeoutError 계열
+                # (aiohttp timeout 포함 — TimeoutError 하위)일 때만 회계에서 제외하고,
+                # 그 외 실패(HTTP 5xx/APIError 등)는 기존대로 기록한다.
                 last_error = KISErrorClassifier.to_api_error(e, timeout)
-                if record_failure:
+                if record_failure and not (
+                    cb_exempt_timeout and isinstance(e, TimeoutError)
+                ):
                     self._circuit_breaker.record_failure()
                 if self._retry_handler.should_retry(attempt, max_retries):
                     await self._retry_handler.wait_and_log(
@@ -600,6 +618,8 @@ class KISBaseAdapter(BrokerAdapter):
         tr_id: str,
         base_params: dict[str, str],
         row_key: str,
+        *,
+        cb_exempt_timeout: bool = False,
     ) -> list[dict[str, Any]]:
         """KIS 연속조회(CTX_AREA + tr_cont)를 따라 전 페이지 행을 누적한다.
 
@@ -607,6 +627,11 @@ class KISBaseAdapter(BrokerAdapter):
         ``CTX_AREA_NK100`` 은 빈 문자열로 시작한다(호출자가 전달). ``row_key``
         로 지정한 단일 행 리스트(예: ``"output1"`` / ``"output"``)만 누적하며,
         ``output2`` 같은 summary/metadata 는 누적하지 않는다.
+
+        ``cb_exempt_timeout`` 은 ``_request_with_cont`` 로 그대로 전파되는 차단기
+        회계 opt-out 이다(#2350). late-ccld(``get_order_history``) 폴 경로만
+        ``True`` 로 호출해 조회 타임아웃이 어댑터 전역 단일 차단기를 OPEN 시키지
+        않게 한다. 다른 호출자는 기본값 ``False`` 로 무변경이다.
 
         연속 규약:
             - 최초 요청: 요청 헤더 ``tr_cont`` = "" + cursor = "".
@@ -627,7 +652,12 @@ class KISBaseAdapter(BrokerAdapter):
 
         for page in range(1, DEFAULT_MAX_PAGINATION_PAGES + 1):
             body, tr_cont = await self._request_with_cont(
-                method, url, tr_id, params=params, cont_header=cont_header
+                method,
+                url,
+                tr_id,
+                params=params,
+                cont_header=cont_header,
+                cb_exempt_timeout=cb_exempt_timeout,
             )
             page_rows = body.get(row_key) or []
             rows.extend(page_rows)
@@ -1228,8 +1258,13 @@ class KISDomesticAdapter(KISBaseAdapter):
             "CTX_AREA_NK100": "",
         }
 
+        # #2350: late-ccld 조회 타임아웃은 차단기 회계에서 제외한다. 체결이력 폴이
+        # 반복 타임아웃해도 어댑터 전역 단일 차단기가 OPEN 되지 않아, 같은 어댑터를
+        # 공유하는 treasury 잔고/포지션 동기화·주문 경로가 broker-wide 로 차단되지
+        # 않는다. 회계 제외는 TimeoutError 에 한정되며 5xx/APIError 등은 그대로
+        # 기록된다(주문 경로 보호 무변경).
         rows = await self._request_paginated(
-            "GET", url, tr_id, params, row_key="output1"
+            "GET", url, tr_id, params, row_key="output1", cb_exempt_timeout=True
         )
         return self._fold_order_history(rows)
 

--- a/tests/unit/test_fill_scheduler.py
+++ b/tests/unit/test_fill_scheduler.py
@@ -13,8 +13,10 @@ from datetime import UTC, datetime
 import pytest
 
 from ante.broker import fill_scheduler as fill_scheduler_module
+from ante.broker.exceptions import APIError, CircuitOpenError
 from ante.broker.fill_scheduler import (
     _KST,
+    LOOP_BACKOFF_MULTIPLIER_CAP,
     MIN_POLL_INTERVAL,
     CatchUpResult,
     FillReconcileScheduler,
@@ -361,6 +363,169 @@ async def test_periodic_loop_swallows_poll_failure(tracker, applier):
     except _asyncio.CancelledError:
         pass
     assert broker.call_count >= 1
+
+
+# ── #2350: steady-state 폴 루프 연속 실패 cooldown ──────────────
+
+
+def _cooldown_sched(poll_interval: float = MIN_POLL_INTERVAL) -> FillReconcileScheduler:
+    """_loop cooldown 만 단독 검증하기 위한 최소 스케줄러(의존성 미주입)."""
+    return FillReconcileScheduler(
+        broker=FakeBroker(),  # type: ignore[arg-type]
+        order_tracker=None,  # type: ignore[arg-type]
+        fill_applier=None,  # type: ignore[arg-type]
+        account_id=ACCT,
+        poll_interval=poll_interval,
+    )
+
+
+async def _drive_loop(
+    sched: FillReconcileScheduler,
+    *,
+    poll_outcomes: list[BaseException | None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[float]:
+    """_loop 를 ``poll_outcomes`` 길이만큼 결정적으로 돌리고 sleep 인자를 수집한다.
+
+    ``asyncio.sleep`` 을 가로채 실제 대기 없이 sleep 인자(=다음 사이클 대기시간)를
+    기록하고, ``_poll_and_apply`` 를 스크립트(None=정상 완료, Exception=발생)로
+    교체한다. 마지막 outcome 소진 후 ``_running`` 을 False 로 떨궈 루프를 종료한다.
+    """
+    import asyncio as _asyncio
+
+    sleeps: list[float] = []
+    outcomes = iter(poll_outcomes)
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(fill_scheduler_module.asyncio, "sleep", fake_sleep)
+
+    async def fake_poll() -> int:
+        try:
+            outcome = next(outcomes)
+        except StopIteration:
+            sched._running = False
+            return 0
+        if outcome is not None:
+            raise outcome
+        return 0
+
+    sched._poll_and_apply = fake_poll  # type: ignore[method-assign]
+    sched._running = True
+    await _asyncio.wait_for(sched._loop(), timeout=5.0)
+    return sleeps
+
+
+async def test_loop_success_path_keeps_fixed_interval(monkeypatch) -> None:
+    """정상 완료 경로는 poll_interval 고정 주기를 유지한다(cooldown 미발동)."""
+    sched = _cooldown_sched()
+    sleeps = await _drive_loop(
+        sched, poll_outcomes=[None, None, None], monkeypatch=monkeypatch
+    )
+    # 매 사이클 진입 전 sleep 은 항상 base poll_interval.
+    assert all(s == MIN_POLL_INTERVAL for s in sleeps)
+
+
+async def test_loop_consecutive_transient_failures_extend_sleep_with_cap(
+    monkeypatch,
+) -> None:
+    """연속 broker-transient 실패 시 sleep 이 ×2→×4→×8(cap) 로 연장된다(#2350).
+
+    n번째 연속 실패 후 다음 사이클 sleep = poll_interval × min(2^n, cap). 4회
+    연속 실패면 ×2, ×4, ×8, ×8(cap) 순으로 다음 sleep 이 늘어난다.
+    """
+    sched = _cooldown_sched()
+    # 5회 연속 TimeoutError → 6번째 진입 직전까지의 sleep 시퀀스를 본다.
+    outcomes: list[BaseException | None] = [TimeoutError("t")] * 5
+    sleeps = await _drive_loop(sched, poll_outcomes=outcomes, monkeypatch=monkeypatch)
+    base = MIN_POLL_INTERVAL
+    # sleeps[0] = 첫 사이클 진입 전(실패 0건) → base.
+    # sleeps[1] = 1실패 후 → ×2, sleeps[2]=×4, sleeps[3]=×8, sleeps[4]=×8(cap).
+    assert sleeps[0] == base
+    assert sleeps[1] == base * 2
+    assert sleeps[2] == base * 4
+    assert sleeps[3] == base * LOOP_BACKOFF_MULTIPLIER_CAP  # 8
+    assert sleeps[4] == base * LOOP_BACKOFF_MULTIPLIER_CAP  # 8 (cap 유지)
+    assert LOOP_BACKOFF_MULTIPLIER_CAP == 8
+
+
+async def test_loop_success_resets_cooldown_counter(monkeypatch) -> None:
+    """정상 완료 시 연속 실패 카운터가 0 으로 리셋돼 base 주기로 복귀한다(#2350)."""
+    sched = _cooldown_sched()
+    # 실패 2회 → 성공 1회(리셋) → 실패 1회.
+    outcomes: list[BaseException | None] = [
+        TimeoutError("t"),
+        TimeoutError("t"),
+        None,  # 성공 → 리셋.
+        TimeoutError("t"),
+    ]
+    sleeps = await _drive_loop(sched, poll_outcomes=outcomes, monkeypatch=monkeypatch)
+    base = MIN_POLL_INTERVAL
+    assert sleeps[0] == base  # 진입 전(실패 0).
+    assert sleeps[1] == base * 2  # 1실패 후.
+    assert sleeps[2] == base * 4  # 2실패 후.
+    # 성공이 카운터를 리셋 → 다음 진입 sleep 은 base 로 복귀.
+    assert sleeps[3] == base  # 리셋 후.
+
+
+async def test_loop_circuit_open_error_counts_as_transient(monkeypatch) -> None:
+    """CircuitOpenError 도 broker-transient 로 cooldown 카운트된다(#2350)."""
+    sched = _cooldown_sched()
+    outcomes: list[BaseException | None] = [
+        CircuitOpenError("open"),
+        CircuitOpenError("open"),
+    ]
+    sleeps = await _drive_loop(sched, poll_outcomes=outcomes, monkeypatch=monkeypatch)
+    base = MIN_POLL_INTERVAL
+    assert sleeps[0] == base
+    assert sleeps[1] == base * 2  # CircuitOpenError 1회 후 cooldown 연장.
+
+
+async def test_loop_api_error_counts_as_transient(monkeypatch) -> None:
+    """APIError 도 broker-transient 로 cooldown 카운트된다(#2350)."""
+    sched = _cooldown_sched()
+    outcomes: list[BaseException | None] = [
+        APIError("server busy", retryable=True),
+        APIError("server busy", retryable=True),
+    ]
+    sleeps = await _drive_loop(sched, poll_outcomes=outcomes, monkeypatch=monkeypatch)
+    base = MIN_POLL_INTERVAL
+    assert sleeps[0] == base
+    assert sleeps[1] == base * 2
+
+
+async def test_loop_non_transient_exception_does_not_extend_cooldown(
+    monkeypatch,
+) -> None:
+    """비-transient 예외(내부 버그류)는 cooldown 을 연장하지 않는다(현행 보존, #2350).
+
+    ValueError 등 broker-transient 가 아닌 예외는 연속 실패 카운터에 누적되지
+    않으므로, 다음 사이클 sleep 은 base poll_interval 을 유지한다(backoff 로
+    내부 결함을 은폐하지 않음).
+    """
+    sched = _cooldown_sched()
+    outcomes: list[BaseException | None] = [
+        ValueError("internal bug"),
+        ValueError("internal bug"),
+        ValueError("internal bug"),
+    ]
+    sleeps = await _drive_loop(sched, poll_outcomes=outcomes, monkeypatch=monkeypatch)
+    # 비-transient 예외는 카운터 미증가 → 항상 base 주기.
+    assert all(s == MIN_POLL_INTERVAL for s in sleeps)
+
+
+async def test_loop_cooldown_cap_below_recovery_and_reconciler_windows() -> None:
+    """cooldown 상한(기본 60s×8=480s)이 CB recovery(60s)·reconciler(1800s) 보다 짧다.
+
+    복구 관측을 놓치지 않는 bounded cap 임을 상수로 잠근다(#2350 근거 주석).
+    """
+    base = 60.0  # 기본 poll_interval.
+    cap_sleep = base * LOOP_BACKOFF_MULTIPLIER_CAP
+    assert cap_sleep == 480.0
+    # CB recovery_timeout(60s) 보다 길지만 reconciler 주기(1800s) 보다 짧아 복구
+    # 관측을 유지한다(상한이 reconciler 주기를 넘기지 않음).
+    assert cap_sleep < 1800.0
 
 
 # ── Finding 2: 폴 사이클의 EOD 만료 → 만료 주문 더는 폴 안 됨 ──

--- a/tests/unit/test_fill_scheduler.py
+++ b/tests/unit/test_fill_scheduler.py
@@ -515,6 +515,35 @@ async def test_loop_non_transient_exception_does_not_extend_cooldown(
     assert all(s == MIN_POLL_INTERVAL for s in sleeps)
 
 
+async def test_loop_non_transient_after_transient_resets_cooldown(
+    monkeypatch,
+) -> None:
+    """선행 transient 실패로 backoff 가 올라간 뒤 비-transient 예외는 카운터를 리셋한다.
+
+    Codex R1 [P2]: transient 실패 1회(backoff ×2) 후 반복되는 내부 오류(ValueError
+    등 비-transient)가 발생하면, 비-transient 분기가 카운터를 0 으로 리셋해 다음
+    사이클이 base `poll_interval` 로 복귀해야 한다. 리셋하지 않으면 이전 backoff
+    (최대 ×8)로 계속 잠들어 "내부 버그류는 cooldown 으로 은폐하지 않고 기존 주기로
+    재시도한다"는 §6.2 의도를 위반한다.
+    """
+    sched = _cooldown_sched()
+    # transient 1회(→ ×2) → 비-transient 3회(리셋되어 base 유지여야 함).
+    outcomes: list[BaseException | None] = [
+        TimeoutError("transient"),
+        ValueError("internal bug"),
+        ValueError("internal bug"),
+        ValueError("internal bug"),
+    ]
+    sleeps = await _drive_loop(sched, poll_outcomes=outcomes, monkeypatch=monkeypatch)
+    base = MIN_POLL_INTERVAL
+    assert sleeps[0] == base  # 진입 전(실패 0).
+    assert sleeps[1] == base * 2  # transient 1실패 후 → cooldown ×2.
+    # 비-transient 예외가 카운터를 리셋 → 이후 진입 sleep 은 모두 base 로 복귀.
+    # (리셋이 빠지면 sleeps[2] 가 ×2 로 남아 backoff 가 이어진다.)
+    assert sleeps[2] == base
+    assert sleeps[3] == base
+
+
 async def test_loop_cooldown_cap_below_recovery_and_reconciler_windows() -> None:
     """cooldown 상한(기본 60s×8=480s)이 CB recovery(60s)·reconciler(1800s) 보다 짧다.
 

--- a/tests/unit/test_kis_cb_ccld_timeout_decoupling.py
+++ b/tests/unit/test_kis_cb_ccld_timeout_decoupling.py
@@ -1,0 +1,220 @@
+"""KIS CircuitBreaker 광역 결합 해소 회귀 테스트 (#2350).
+
+late-ccld(``get_order_history``) 조회 타임아웃이 어댑터 전역 단일 차단기를 OPEN
+시켜, 같은 어댑터를 공유하는 treasury 잔고/포지션 동기화·주문 경로까지 broker-wide
+로 차단하던 cross-concern blast radius 를 끊는다(정책 (a): late-ccld TimeoutError
+차단기 회계 제외 — 호출측 opt-out).
+
+검증 축:
+    (결합 재현→해소) get_order_history raw TimeoutError 6회(임계 5 초과) 누적 후에도
+      차단기 CLOSED 유지 + get_account_balance/get_positions 정상 호출 가능.
+    (주문 경로 보호 불변식) order-cash 타임아웃은 기존대로 record_failure 누적 →
+      임계 도달 시 OPEN(무회귀).
+    (회계 범위) ccld 경로의 비-Timeout 실패(retryable APIError/5xx)는 기존대로 기록.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ante.broker.circuit_breaker import CircuitState
+from ante.broker.exceptions import APIError, CircuitOpenError
+from ante.broker.kis import KISDomesticAdapter
+
+_CONFIG = {
+    "app_key": "test-key",
+    "app_secret": "test-secret",
+    "account_no": "1234567890",
+    "is_paper": True,
+    # 임계는 기본 5. 6회 누적이 임계 초과임을 명시하기 위해 기본값을 그대로 둔다.
+}
+
+
+def _make_adapter() -> KISDomesticAdapter:
+    """네트워크/인증/rate-limit 없이 차단기 회계만 검증하는 어댑터.
+
+    ``_send_http`` 만 주입해 tr_id/url 별 성공/타임아웃/에러를 제어한다. 실제
+    ``_request_with_cont`` 의 차단기 check/record_success/record_failure 회계 경로는
+    그대로 돈다(opt-out 판정 포함).
+    """
+    adapter = KISDomesticAdapter(config=dict(_CONFIG))
+
+    async def _no_auth() -> None:
+        return None
+
+    async def _no_rate_limit() -> None:
+        return None
+
+    # 재시도 backoff 대기를 0 으로 만들어 테스트를 빠르게 수렴시킨다.
+    adapter._ensure_authenticated = _no_auth  # type: ignore[method-assign]
+    adapter._rate_limit_wait = _no_rate_limit  # type: ignore[method-assign]
+    adapter._backoff_base = 0.0
+    adapter._retry_handler._backoff_base = 0.0
+    return adapter
+
+
+def _balance_page() -> dict[str, Any]:
+    """잔고/포지션 조회 정상 응답(1페이지, 다음 없음)."""
+    return {
+        "rt_cd": "0",
+        "output1": [
+            {
+                "pdno": "005930",
+                "hldg_qty": "10",
+                "pchs_avg_pric": "70000",
+                "prpr": "71000",
+                "evlu_amt": "710000",
+                "evlu_pfls_amt": "10000",
+                "evlu_erng_rt": "1.4",
+            }
+        ],
+        "output2": [
+            {
+                "dnca_tot_amt": "1000000",
+                "tot_evlu_amt": "1710000",
+            }
+        ],
+        "ctx_area_fk100": "",
+        "ctx_area_nk100": "",
+    }
+
+
+def _order_ok_page() -> dict[str, Any]:
+    return {
+        "rt_cd": "0",
+        "output": {"ODNO": "0000123456", "KRX_FWDG_ORD_ORGNO": "06010"},
+    }
+
+
+# ── 결합 재현 → 해소 (failing check) ─────────────────────────
+
+
+async def test_ccld_timeout_does_not_open_cb_and_balance_positions_stay_callable() -> (
+    None
+):
+    """late-ccld TimeoutError 6회(임계 초과) 후에도 차단기 CLOSED + 잔고/포지션 정상.
+
+    수정 전(현행)에는 ccld 타임아웃이 record_failure 로 누적돼 임계 5에 도달, 차단기
+    OPEN → get_account_balance/get_positions 가 CircuitOpenError 로 차단됐다(결합
+    재현). #2350 opt-out 으로 ccld TimeoutError 가 회계에서 제외되면 차단기는 CLOSED
+    를 유지하고 두 조회는 정상 호출된다.
+    """
+    adapter = _make_adapter()
+    ccld_path = "inquire-daily-ccld"
+    balance_path = "inquire-balance"
+
+    async def fake_send_http(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, str] | None,
+        json_data: dict[str, Any] | None,
+        timeout: float,
+    ) -> tuple[dict[str, Any], str]:
+        if ccld_path in url:
+            # raw TimeoutError (to_api_error 변환 **전** 기준 — Codex R1 ③).
+            raise TimeoutError("ccld 조회 타임아웃")
+        if balance_path in url:
+            return _balance_page(), "D"
+        raise AssertionError(f"예상치 못한 url: {url}")
+
+    adapter._send_http = fake_send_http  # type: ignore[method-assign]
+
+    # get_order_history 6회 — 각 호출이 최초+재시도 2회=최대 3회 raw TimeoutError 를
+    # 던지므로, 회계가 됐다면 누적 record_failure 가 임계 5를 한참 초과한다.
+    for _ in range(6):
+        with pytest.raises(APIError):
+            await adapter.get_order_history(from_date="20260601", to_date="20260601")
+
+    # opt-out 으로 ccld TimeoutError 는 회계에서 제외 — 차단기 CLOSED 유지.
+    assert adapter.circuit_breaker.state == CircuitState.CLOSED
+    assert adapter.circuit_breaker.failure_count == 0
+
+    # 같은 어댑터의 무관 concern(treasury 잔고/포지션)은 차단되지 않고 정상 호출.
+    balance = await adapter.get_account_balance()
+    assert balance["cash"] == 1000000.0
+    positions = await adapter.get_positions()
+    assert positions[0]["symbol"] == "005930"
+    assert positions[0]["quantity"] == 10.0
+
+
+# ── 주문 경로 보호 불변식 (무회귀) ────────────────────────────
+
+
+async def test_order_timeout_still_records_failure_and_opens_cb() -> None:
+    """order-cash 타임아웃은 기존대로 record_failure 누적 → 임계 도달 시 OPEN.
+
+    주문 경로는 기본값 cb_exempt_timeout=False 라 회계 무변경이다. 주문 타임아웃이
+    반복되면 차단기가 OPEN 되어 연쇄 호출을 막는 본래 보호가 유지된다.
+    """
+    adapter = _make_adapter()
+
+    async def fake_send_http(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, str] | None,
+        json_data: dict[str, Any] | None,
+        timeout: float,
+    ) -> tuple[dict[str, Any], str]:
+        if "order-cash" in url:
+            raise TimeoutError("주문 타임아웃")
+        raise AssertionError(f"예상치 못한 url: {url}")
+
+    adapter._send_http = fake_send_http  # type: ignore[method-assign]
+
+    # 주문 1회 = 최초+재시도 3회 = 최대 4회 record_failure. 임계 5 에 도달하려면
+    # 2회 주문이면 충분하다. OPEN 전환 후 check() 가 CircuitOpenError 를 던진다.
+    opened = False
+    for _ in range(3):
+        try:
+            await adapter.place_order("005930", "buy", 1.0)
+        except CircuitOpenError:
+            opened = True
+            break
+        except APIError:
+            continue
+    assert opened, "주문 타임아웃 누적으로 차단기가 OPEN 되어야 한다"
+    assert adapter.circuit_breaker.state == CircuitState.OPEN
+
+
+# ── 회계 범위: ccld 비-Timeout 실패는 기존대로 기록 ───────────────
+
+
+async def test_ccld_non_timeout_retryable_failure_still_records() -> None:
+    """ccld 경로의 비-Timeout 실패(retryable APIError/5xx)는 기존대로 회계에 기록.
+
+    opt-out 은 TimeoutError 에 한정된다. retryable APIError(예: 5xx/server busy)는
+    cb_exempt_timeout=True 여도 record_failure 가 누적돼 임계 도달 시 OPEN 된다
+    (실제 KIS 서버 장애 보호 유지).
+    """
+    adapter = _make_adapter()
+
+    async def fake_send_http(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, str] | None,
+        json_data: dict[str, Any] | None,
+        timeout: float,
+    ) -> tuple[dict[str, Any], str]:
+        if "inquire-daily-ccld" in url:
+            raise APIError("server busy", retryable=True, status_code=503)
+        raise AssertionError(f"예상치 못한 url: {url}")
+
+    adapter._send_http = fake_send_http  # type: ignore[method-assign]
+
+    # ccld 1회 = 최초+재시도 2회 = 최대 3회 record_failure. 2회면 임계 5 도달.
+    opened = False
+    for _ in range(3):
+        try:
+            await adapter.get_order_history(from_date="20260601", to_date="20260601")
+        except CircuitOpenError:
+            opened = True
+            break
+        except APIError:
+            continue
+    assert opened, "ccld 비-Timeout retryable 실패는 회계에 기록되어 OPEN 되어야 한다"
+    assert adapter.circuit_breaker.state == CircuitState.OPEN

--- a/tests/unit/test_kis_pagination.py
+++ b/tests/unit/test_kis_pagination.py
@@ -88,7 +88,16 @@ async def test_two_pages_passes_cursor_and_accumulates() -> None:
     responses = iter([(page1, "F"), (page2, "D")])
     snapshots: list[tuple[str, str, str]] = []
 
-    async def fake(method, url, tr_id, params=None, json_data=None, cont_header=""):  # type: ignore[no-untyped-def]
+    async def fake(  # type: ignore[no-untyped-def]
+        method,
+        url,
+        tr_id,
+        params=None,
+        json_data=None,
+        cont_header="",
+        *,
+        cb_exempt_timeout=False,
+    ):
         snapshots.append(
             (
                 params["CTX_AREA_FK100"],
@@ -471,9 +480,14 @@ def _capture_ccld_call(
     """get_order_history 가 _request_paginated 에 넘긴 tr_id/params 를 캡처한다."""
     captured: dict[str, Any] = {}
 
-    async def fake_paginated(method, url, tr_id, params, row_key="output1"):  # type: ignore[no-untyped-def]
+    async def fake_paginated(  # type: ignore[no-untyped-def]
+        method, url, tr_id, params, row_key="output1", *, cb_exempt_timeout=False
+    ):
         captured["tr_id"] = tr_id
         captured["params"] = dict(params)
+        # #2350: get_order_history 는 late-ccld 차단기 회계 제외를 위해 항상
+        # cb_exempt_timeout=True 로 _request_paginated 를 호출한다.
+        captured["cb_exempt_timeout"] = cb_exempt_timeout
         return []
 
     adapter._request_paginated = fake_paginated  # type: ignore[method-assign]
@@ -523,6 +537,8 @@ async def test_get_order_history_selects_tr_id_by_kst_three_month_boundary(
     assert captured["tr_id"] not in _LEGACY_CCLD_TR_IDS
     # EXCG_ID_DVSN_CD hygiene 파라미터 주입(상수 재사용).
     assert captured["params"]["EXCG_ID_DVSN_CD"] == DEFAULT_EXCG_ID_DVSN_CD == "KRX"
+    # #2350: late-ccld 폴은 차단기 회계 제외(opt-out)로 호출된다.
+    assert captured["cb_exempt_timeout"] is True
 
 
 @pytest.mark.parametrize("is_paper", [True, False])
@@ -559,7 +575,9 @@ async def test_get_order_history_crossing_window_uses_single_before_query(
     adapter = _make_ccld_adapter(is_paper=True)
     calls: list[tuple[str, dict[str, Any]]] = []
 
-    async def fake_paginated(method, url, tr_id, params, row_key="output1"):  # type: ignore[no-untyped-def]
+    async def fake_paginated(  # type: ignore[no-untyped-def]
+        method, url, tr_id, params, row_key="output1", *, cb_exempt_timeout=False
+    ):
         calls.append((tr_id, dict(params)))
         return []
 


### PR DESCRIPTION
Closes #2350

## Summary
- **정책 (a)**: `_request_with_cont`/`_request_paginated`에 keyword-only `cb_exempt_timeout` 추가 — `get_order_history`(late-ccld)만 opt-in, **raw `TimeoutError` 한정** 차단기 회계 제외(to_api_error 변환 전 판정). 주문 경로·비-Timeout 실패의 차단기 보호는 무변경
- **steady-state cooldown**: `_loop` 연속 broker-transient 실패 시 sleep `poll_interval × min(2^n, 8)`(cap 480s), 성공/비-transient 예외 시 카운터 리셋(내부 버그 은폐 방지 — 리뷰 R1 P2 반영). `catch_up_once` bounded backoff 비간섭
- 효과: late-ccld 타임아웃 연타가 같은 어댑터의 treasury `get_account_balance`/`get_positions`를 더 이상 broker-wide 차단하지 않음(#2317 canary 2026-06-05 11:26/11:32/12:18 재발 방지)
- 스펙 4파일(18-fill-recovery cooldown normative·10-commission-info·07-kis-base-adapter·15-reconciliation) + generated project-structure.md 전체 재생성(별도 커밋 — #2336~#2348 pre-existing mechanical drift 동기화 포함)

## Verification
- Plan Preflight: approve-implement (Codex R2) / 브랜치 리뷰: attempt 1 FAIL(P2 1건) → 수정 → attempt 2 PASS
- `pytest tests/unit -q`: 7200 passed, 2 skipped / `mypy src/`: Success (232 files) / ruff 통과
- failing check: 결합 재현 테스트(ccld TimeoutError 6회 → CB OPEN → treasury 차단)가 수정 전 FAIL → 수정 후 PASS

## Test Plan
- `pytest tests/unit/test_kis_cb_ccld_timeout_decoupling.py tests/unit/test_fill_scheduler.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)