### PR TITLE
fix(trade): #2351 reconciler sell-side self-check 대칭 확장 — self 매도 외부 오라벨링/force-write 방지

### DIFF
--- a/docs/specs/broker-adapter/18-fill-recovery.md
+++ b/docs/specs/broker-adapter/18-fill-recovery.md
@@ -48,6 +48,14 @@ ante가 제출한 주문은 (모의투자·실전투자, 스트림 유무와 무
 - 반면 잔고(`inquire-balance`/`get_positions`, tr_id `VTTC8434R`)는 **체결기준
   이라 당일 즉시 반영**된다.
 
+**이 모의 당일 ccld 지연은 방향 무관(#2351)**이다. 매수뿐 아니라 **매도**도 동일하게
+잔고는 즉시 반영(매도 시 잔고 수량 즉시 감소)되나 ccld 는 당일 0건을 줄 수 있다.
+따라서 미반영 self **매도**도 잔고와 내부 원장이 어긋나는 지연창을 만든다 —
+`broker_qty < internal_qty`. 이 sell-side gap 의 처리는 **reconciler 가 소유**한다:
+position-derived fallback(§11)은 **buy-only**(§11/§11.3 명시 한정)이고, 미반영 self
+매도의 외부 오라벨링/force-write 방지는 `../trade/03-07-position-reconciler.md`
+의 **sell-side self-check 대칭 확장(#2351)**이 담당한다(§11.7 sell-side 항목 참조).
+
 따라서 모의 당일 체결에 한해 백스톱은 **유일 SSOT가 아니다**. 백스톱(확정 정합)
 + 잔고-역도출 fallback(당일 보수적 수렴, bounded)의 **이중 입력 모델**로
 보강한다(§11). fallback은 본 §의 FillApplier 멱등 모델을 재사용하며 **새 권위자를
@@ -438,6 +446,18 @@ crash window가 잔존하고 빈 `fill_dedup_key`를 쓴다.)
 본 절의 normative 문장은 **KIS paper(`is_paper=true`) 한정 기본 활성**을 전제로
 한다(§11.6). live 적용 범위는 §11.6·#2317에 따른다.
 
+**fallback 방향 한정 — buy-only (normative, #2351):** 본 fallback 은 **매수(buy)
+방향에만 적용**한다. 잔고 excess(`broker_qty - internal_account_qty > 0`)에서 미반영
+self **매수**를 역도출하며, `(account_id, symbol, side="buy")` 의 추적 open buy 만
+귀속 대상이다(§11.3). **매도(sell) 방향으로는 fallback 을 적용하지 않는다.** 잔고
+총량 감소에서 매도 체결을 합성(synthesize)하는 것은 buy-side 보다 비가역 위험이
+크고(CAS 단조 advance 의 매도판이 잘못된 차감을 되돌릴 수 없음), 신 tr_id
+(`VTTC0081R`, #2349) 적용 후 모의 당일 ccld 가 행을 반환해 지연창이 폴 주기 수준으로
+축소되므로 효익도 작다. 미반영 self **매도**의 외부 오라벨링/force-write 방지는
+position-derived fallback 이 아니라 **reconciler 의 sell-side self-check 대칭
+확장(#2351, `../trade/03-07-position-reconciler.md`)**이 담당하며, 실제 매도 체결
+복구는 ccld 백스톱에 위임한다. sell-side 항목 상세는 §11.7 참조.
+
 ### 11.1 account-level excess 산식 (overfill 금지)
 
 fallback의 관측 누적량 산출 기준은 **계좌 수준 excess**다:
@@ -470,11 +490,14 @@ ccld가 당일 체결을 주는 정상 환경에서는 ccld가 `recorded_filled_
 `excess == 0`이다; 부분 체결된 open 주문은 capacity>0이어도 excess가 0이면
 fallback이 취하지 않는다). 즉 fallback은 모의 당일 0건 gap에서만 실효한다.
 
-### 11.3 self-order capacity 매칭 — full-fill 정확매칭 한정 (비귀속 보수)
+### 11.3 self-order capacity 매칭 — full-fill 정확매칭 한정 (비귀속 보수, buy-only)
 
 fallback의 귀속 대상은 OrderTracker의 self-order capacity로 한정하되, **잔고
 excess가 그 유일 주문의 주문 수량과 정확히 일치하는 full-fill 케이스에만**
-적용한다(#1950 self/external 경계 재사용):
+적용한다(#1950 self/external 경계 재사용). **귀속 대상은 `side="buy"` 추적 주문에
+한정한다(buy-only 명시 한정, #2351)** — 매도 방향 합성은 비채택이며(§11 도입부),
+미반영 self 매도는 reconciler sell-side self-check(`../trade/03-07-position-reconciler.md`)
+가 처리한다:
 
 - `capacity = Σ(ordered_qty - recorded_filled_qty)` — `(account_id, symbol,
   side="buy")`의 **non-terminal**(`open`·`partially_filled`) 추적 주문 미체결 잔량.
@@ -603,6 +626,18 @@ D+1 ccld 백스톱으로 반영되며, fallback이 외부분을 흡수하지 않
   재구성하지 못한다. fallback은 `recorded_filled_qty == 0`인 미복구 주문에
   한해 `excess == ordered_qty`일 때만 full fill로 advance하며, 그 외 partial
   excess는 D+1 ccld 백스톱에 위임한다(미적용).
+- **sell-side fallback 미적용 (buy-only 명시 한정, #2351)**: position-derived
+  fallback 은 **매수 방향에만** 적용한다(§11/§11.3). 모의 ccld 지연은 방향 무관
+  (§2.1)이라 미반영 self **매도**도 `broker_qty < internal_qty` gap 을 만들지만,
+  잔고 총량 감소에서 매도 체결을 합성하는 것은 비가역 위험(CAS 단조 매도 advance
+  를 되돌릴 수 없음)이 커 **비채택**한다. 대신 이 sell-side gap 은 두 권위로 처리
+  한다: ① **reconciler sell-side self-check 대칭 확장**(`../trade/03-07-position-reconciler.md`,
+  #2351)이 미반영 self 매도를 외부 청산/일부 매도로 오라벨링·force-write 하지 않고
+  detect-only(보정 skip + info 이벤트)로 두며(buy-side #1950 대칭), ② 실제 매도
+  체결 복구는 **ccld 백스톱**(`get_order_history`)에 위임한다(매도 fill 합성 없음).
+  reconciler sell-side 의 bounded known-limitation(혼재 `0 < sell_capacity < deficit`
+  의 이중 차감/PnL 누락 잔존, 총량 기반 검출 지연 ≤ EOD)은 buy-side 협소 외부
+  흡수와 **동형**이며 그 문서에 선언한다.
 - **avg_price 정정 없음**(§11.4): 잔고 평단 근거 유지, ccld 실체결가로 사후
   정정 안 함.
 - **Treasury 비례 정산**: §9의 pre-existing 한계(부분 체결 비례 정산 미지원)는

--- a/docs/specs/trade/03-07-position-reconciler.md
+++ b/docs/specs/trade/03-07-position-reconciler.md
@@ -75,8 +75,78 @@ reconcile 에서 잔여 excess 가 **external 로 검출·보정**된다. → �
 주문 해소 시점(≤ EOD)** 까지. 포지션 총량 기반 분류의 한계는 본 bounded 선언으로 종결한다
 (완전 분해는 broker fill-level 데이터 계약이 필요한 out-of-scope).
 
-**무변경 분기:** 외부 청산(`broker_qty == 0 && internal_qty > 0`), 외부 일부 매도
-(`broker_qty < internal_qty`), 수량 불일치는 self-check 대상이 아니며 기존 동작을 유지한다.
+**sell-side 대칭 분기(#2351):** 외부 청산(`broker_qty == 0 && internal_qty > 0`)·외부
+일부 매도(`0 < broker_qty < internal_qty`)도 아래 "sell-side self / external 분류 정책
+(#2351)" 절의 self-check 대상이다(buy-side #1950 의 정확 대칭). 그 외 수량 불일치는
+self-check 대상이 아니며 기존 동작을 유지한다.
+
+> **정정(#2351):** 종전 본 절은 외부 청산/외부 일부 매도를 "self-check 대상이 아니며
+> 기존 동작 유지"로 기술했으나, **단일봇 + running(`dry_run=False`) 경로에서 외부
+> 청산/일부 매도 분류도 `correct_position(quantity=broker_qty)` force-write 를 호출**한다
+> (`dry_run=True` 에서만 보정 보류). 즉 이 분기는 detect-only 가 아니라 보정을 유발하는
+> 분기였고, KIS 모의 ccld 지연창에서 self 매도가 이 분기로 오라벨링되면 원장(trade
+> record/PnL)이 force-write 로 우회 수렴되는 결함이 있었다(#2314/#2351). 아래 sell-side
+> self-check 가 그 순수 self-sell 구간을 보정에서 제외해 이 결함을 닫는다.
+
+## sell-side self / external 분류 정책 (#2351, normative)
+
+`broker_qty < internal_qty`(외부 청산·외부 일부 매도 후보) 불일치는 **항상**
+self-submitted vs external 을 구분한다. **buy-side(#1950)의 정확한 방향 대칭**이다.
+
+KIS 모의투자에서 ante 가 직접 제출한 **매도(self 매도)**가 체결되면 잔고
+(`get_positions`, 체결기준)는 즉시 감소하나, 모의 `inquire-daily-ccld`
+(`get_order_history`)는 당일 0건을 주는 지연창 동안 내부 매도가 미반영
+(`internal_qty` 유지)된다. 그 결과 `broker_qty < internal_qty` 가 되어 reconciler 가
+이를 외부 청산/외부 일부 매도로 **오라벨링**하고, 단일봇 + running 경로에서
+`correct_position` force-write 로 원장을 우회 수렴시키는 결함(#2314)이 발생했다.
+
+**분류 규칙(normative):**
+
+- `deficit = internal_qty - broker_qty`.
+- `sell_capacity = Σ(ordered_qty - recorded_filled_qty)` — OrderTracker 에서
+  `(account_id, bot_id, symbol, side="sell")` 의 **non-terminal**(`open`·
+  `partially_filled`) 주문을 조회한 미체결 잔량 합. ante 미반영 self 매도는
+  FillApplier 가 아직 기록 못 한 상태이므로 해당 ante 매도 주문이 정확히 이 범위에
+  든다. (buy-side capacity 와는 `side` 로 분리되어 혼입되지 않는다.)
+- `deficit <= sell_capacity` (매칭 self 매도 존재) → **`self_submitted`** (사유:
+  `ante 미반영 체결` — 기존 `REASON_SELF_SUBMITTED` 재사용. 이 문구는 **방향 중립**
+  이며, 방향은 `internal_qty > broker_qty`(sell) vs `broker_qty > internal_qty`(buy) +
+  capacity side 로 판별된다).
+  - `correct_position` 자동 보정(force-write down)을 **skip** 한다.
+  - `PositionMismatchEvent`(reason=`ante 미반영 체결`) + `NotificationEvent`(level=
+    **info**)만 발행한다(buy-side self_submitted 분기와 **동일 계층**).
+  - 실제 포지션/체결 복구는 **FillApplier(#1946) 단일 권위 경로(ccld 백스톱)**가
+    수행한다. reconciler 는 복구하지 않는다 — **순수 self-sell 구간
+    (`deficit <= sell_capacity`)에 한해** 원장 우회·이중 차감 면을 제거한다.
+- `deficit > sell_capacity`·**매칭 sell 주문 없음**(진짜 외부 거래)·`order_tracker
+  is None`/조회 실패 → 기존 **외부 청산**(`broker_qty == 0`) / **외부 일부 매도**
+  (`0 < broker_qty < internal_qty`) 분류·보정을 그대로 유지한다(무회귀, level=critical).
+
+**self-check 와 `skip_external_buy` 의 직교(normative):** sell-side self-check 는
+`skip_external_buy`(#1946 기동 barrier, external-**buy** 타겟)와 **무관하게 항상**
+수행된다. 그 플래그는 external-buy 분류만 억제하므로 sell-side 분기에 영향을 주지
+않는다.
+
+**혼재 케이스 `0 < sell_capacity < deficit` 의 bounded known-limitation(normative):**
+self 매도와 진짜 외부 매도가 혼재하면(예: internal 50, ante 미체결 sell 20, 숨은 외부
+매도 30 → `deficit 50 > sell_capacity 20`) 잔고 **총량**만으로 self 매도분과 외부
+매도분을 분리 보정할 수 없다. 따라서 **분리 알고리즘(비례 배분·부분 귀속 등)은
+비채택**하고 기존 외부 분류(force-write down)를 유지한다. 이때 그 self 매도분이 이후
+ccld 로 적용되면 같은 매도를 ccld 가 다시 차감(이중 차감)하거나 force-write 가 PnL 을
+누락하는 면이 **잔존**한다. 이는 buy-side §11.7 협소 외부 흡수와 **동형**인 bounded
+known-limitation 이다. 위험창이 협소한 근거: 동일 종목 self 매도가 pending 인 동안
+**동시에** 같은 종목 외부 매도가 발생해야 하는 **이중 조건**이라 드물고, ccld 지연창
+자체가 신 tr_id(`VTTC0081R`, #2349) 적용 후 폴 주기 수준으로 축소된다. 완전 분해는
+broker fill-level 데이터 계약이 필요한 out-of-scope 다.
+
+**bounded known-limitation(총량 기반 검출 지연, normative):** broker 포지션은 **총량**
+만 제공하므로 "self 매도 vs 진짜 외부 청산"을 총량만으로 완전 분해할 수 없다 —
+buy-side #1950 R2-1 과 동형이다. `deficit <= sell_capacity` 로 self 로 분류된 구간 안에
+숨은 진짜 외부 매도(`internal_qty > broker_qty` + sell capacity 로 판별)는 즉시 external
+로 검출되지 않고, 매칭 ante 매도 주문이 해소(완전 체결 → `get_open_orders` 이탈, 또는
+EOD `expire_stale` → terminal)되는 시점까지 검출이 **지연**된다(bounded — 지연 ≤ EOD).
+이는 #1945 류 캐스케이드 회피·원장 우회 차단을 external-detection 완전성보다 우선하는
+보수적 trade-off 다. 포지션 총량 기반 분류의 한계는 본 bounded 선언으로 종결한다.
 
 ## 미귀속 보유 detect-only (#2352, normative)
 

--- a/docs/specs/trade/03-08-fill-recovery.md
+++ b/docs/specs/trade/03-08-fill-recovery.md
@@ -36,6 +36,7 @@ DB 트랜잭션으로 수행한다. 빠른 경로(실시간 체결 통보 스트
 | `record_fill(order_id, new_cumulative, avg_price)` | `RecordFillResult(delta, confirmed_cumulative)` | 원자 CAS advance. `delta = new_cumulative - 이전 recorded`; `<=0`이면 `delta=0`(no-op), `>0`이면 recorded 갱신 후 delta. `confirmed_cumulative` = CAS `RETURNING recorded_filled_qty` 확정값(체결 이벤트 outbox `fill_dedup_key` 산출 기준, #1949). **FillApplier 트랜잭션 내에서만 호출** |
 | `mark_terminal(order_id, status)` | `None` | 취소·거부·실패·만료 종료 표기 |
 | `get_open_orders(account_id)` | `list[OrderTrackerRecord]` | 계좌의 non-terminal 주문 |
+| `get_open_orders_for(account_id, bot_id, symbol, side)` | `list[OrderTrackerRecord]` | `(account_id, bot_id, symbol, side)` 의 non-terminal(open/partially_filled) 주문. PositionReconciler self-check 의 capacity 산출용 — `side="buy"`(#1950 외부 매수 후보·#2352 미귀속 보유 판정), `side="sell"`(#2351 외부 청산/일부 매도 후보 — 미반영 self 매도 capacity). `side` 필터로 buy/sell capacity 가 혼입되지 않는다 |
 | `lookup_order_id(account_id, broker_order_id, submitted_date)` | `str \| None` | 관측 → 내부 order_id 매핑(non-terminal/same-day) |
 | `expire_stale(account_id, before_date)` | `int` | EOD 경과 open → `expired`, 만료 건수 반환 |
 

--- a/src/ante/trade/reconciler.py
+++ b/src/ante/trade/reconciler.py
@@ -136,10 +136,43 @@ class PositionReconciler:
             # #2352: detect-only(보정 skip)로 분류되었으나 critical 관측은 유지하는
             # 미귀속 보유. is_external_buy 와 직교 — correct_position 만 건너뛴다.
             is_detect_only = False
-            if b_qty == 0 and i_qty > 0:
-                reason = REASON_EXTERNAL_LIQUIDATION
-            elif b_qty < i_qty:
-                reason = REASON_EXTERNAL_PARTIAL_SELL
+            if b_qty < i_qty:
+                # #2351: broker < internal — "외부 청산"(b_qty==0)·"외부 일부
+                # 매도"(0<b_qty<i_qty) 후보. #1950 buy-side 와 **정확히 대칭**으로
+                # ante 미반영 self 매도(self-submitted-unrecorded-fill)를 외부
+                # 매도와 구분하기 위해 **항상** sell-side self-check 를 수행한다
+                # (skip_external_buy 와 무관 — 그 플래그는 external-buy 만 타겟).
+                # KIS 모의 ccld 지연창(잔고는 매도 즉시 감소·ccld 당일 0건)에서
+                # FillApplier 가 아직 기록 못 한 self 매도가 정확히 이 범위에 든다.
+                if await self._is_self_submitted_fill(
+                    bot_id=bot_id,
+                    account_id=account_id,
+                    symbol=symbol,
+                    excess=i_qty - b_qty,
+                    side="sell",
+                ):
+                    # self 매도 미반영: 외부 거래가 아니므로 보정(force-write down)을
+                    # skip 한다. 복구는 FillApplier(ccld 백스톱) 단일 권위에 위임 —
+                    # 순수 self-sell 구간에 한해 원장 우회·이중 차감 면을 제거한다.
+                    self._log_self_submitted(bot_id, symbol, i_qty, b_qty)
+                    await self._publish_self_submitted(
+                        account_id=account_id,
+                        bot_id=bot_id,
+                        symbol=symbol,
+                        i_qty=i_qty,
+                        b_qty=b_qty,
+                    )
+                    continue
+                # #2351 혼재 케이스 `0 < sell_capacity < deficit`: self 매도와 진짜
+                # 외부 매도가 혼재하면 잔고 총량만으로 분리 보정이 불가하므로
+                # (비례 배분 등 분리 알고리즘 비채택) 기존 외부 분류·보정을
+                # 유지한다. 이때 self 매도분이 이후 ccld 로 적용되면 이중 차감/PnL
+                # 누락 면이 잔존한다 — buy-side §11.7 협소 외부 흡수와 동형인 bounded
+                # known-limitation 으로 03-07 에 선언한다.
+                if b_qty == 0:
+                    reason = REASON_EXTERNAL_LIQUIDATION
+                else:
+                    reason = REASON_EXTERNAL_PARTIAL_SELL
             elif b_qty > i_qty:
                 # #1950: broker > internal — "외부 매수" 후보. ante 미반영
                 # 체결(self-submitted)을 외부 매수와 구분하기 위해 **항상**
@@ -149,43 +182,19 @@ class PositionReconciler:
                     account_id=account_id,
                     symbol=symbol,
                     excess=b_qty - i_qty,
+                    side="buy",
                 ):
                     # self-submitted-unrecorded-fill: 외부 거래가 아니므로 자동
                     # 보정/매도를 유발하지 않는다. 실제 포지션 복구는
                     # FillApplier(#1946) 가 단일 권위자로 수행한다. reconciler 는
                     # info 알림만 내고 correct_position 을 호출하지 않는다.
-                    logger.info(
-                        "포지션 불일치 [%s] %s: 내부=%.2f, 브로커=%.2f → %s "
-                        "(ante 미반영 체결 — 보정 skip, FillApplier 위임)",
-                        bot_id,
-                        symbol,
-                        i_qty,
-                        b_qty,
-                        REASON_SELF_SUBMITTED,
-                    )
-                    await self._eventbus.publish(
-                        PositionMismatchEvent(
-                            account_id=account_id,
-                            bot_id=bot_id,
-                            symbol=symbol,
-                            internal_qty=i_qty,
-                            broker_qty=b_qty,
-                            reason=REASON_SELF_SUBMITTED,
-                        )
-                    )
-                    await self._eventbus.publish(
-                        NotificationEvent(
-                            level="info",
-                            title="포지션 동기화 지연",
-                            message=(
-                                f"계좌: `{account_id}` · 봇: `{bot_id}` · "
-                                f"종목: `{symbol}`\n"
-                                f"내부: {i_qty:.0f}주 · 브로커: {b_qty:.0f}주\n"
-                                f"사유: {REASON_SELF_SUBMITTED} "
-                                "(체결 반영 대기 — 자동 보정 없음)"
-                            ),
-                            category="broker",
-                        )
+                    self._log_self_submitted(bot_id, symbol, i_qty, b_qty)
+                    await self._publish_self_submitted(
+                        account_id=account_id,
+                        bot_id=bot_id,
+                        symbol=symbol,
+                        i_qty=i_qty,
+                        b_qty=b_qty,
                     )
                     continue
                 # #2352: self-check 미매칭 이후 — 미귀속 보유(carryover) 판정.
@@ -456,6 +465,63 @@ class PositionReconciler:
             )
         return mismatches
 
+    def _log_self_submitted(
+        self, bot_id: str, symbol: str, i_qty: float, b_qty: float
+    ) -> None:
+        """self-submitted 미반영 체결 info 로그 (방향 중립 — #1950 buy / #2351 sell)."""
+        logger.info(
+            "포지션 불일치 [%s] %s: 내부=%.2f, 브로커=%.2f → %s "
+            "(ante 미반영 체결 — 보정 skip, FillApplier 위임)",
+            bot_id,
+            symbol,
+            i_qty,
+            b_qty,
+            REASON_SELF_SUBMITTED,
+        )
+
+    async def _publish_self_submitted(
+        self,
+        *,
+        account_id: str,
+        bot_id: str,
+        symbol: str,
+        i_qty: float,
+        b_qty: float,
+    ) -> None:
+        """self-submitted 분기 공통 이벤트 발행 — `PositionMismatchEvent` +
+        info `NotificationEvent`. buy-side(#1950)·sell-side(#2351) 동일 계층.
+
+        reason 은 방향 중립 ``REASON_SELF_SUBMITTED`` 를 재사용한다. 방향은
+        ``internal_qty``/``broker_qty`` 대소(buy=broker>internal, sell=
+        internal>broker)로 판별된다.
+        """
+        from ante.eventbus.events import NotificationEvent, PositionMismatchEvent
+
+        await self._eventbus.publish(
+            PositionMismatchEvent(
+                account_id=account_id,
+                bot_id=bot_id,
+                symbol=symbol,
+                internal_qty=i_qty,
+                broker_qty=b_qty,
+                reason=REASON_SELF_SUBMITTED,
+            )
+        )
+        await self._eventbus.publish(
+            NotificationEvent(
+                level="info",
+                title="포지션 동기화 지연",
+                message=(
+                    f"계좌: `{account_id}` · 봇: `{bot_id}` · "
+                    f"종목: `{symbol}`\n"
+                    f"내부: {i_qty:.0f}주 · 브로커: {b_qty:.0f}주\n"
+                    f"사유: {REASON_SELF_SUBMITTED} "
+                    "(체결 반영 대기 — 자동 보정 없음)"
+                ),
+                category="broker",
+            )
+        )
+
     async def _is_self_submitted_fill(
         self,
         *,
@@ -463,24 +529,34 @@ class PositionReconciler:
         account_id: str,
         symbol: str,
         excess: float,
+        side: str,
     ) -> bool:
-        """broker 초과분(``excess``)이 ante 미반영 체결로 설명되는지 판정 (#1950).
+        """broker-internal 불일치(``excess``)가 ante 미반영 체결로 설명되는지 판정.
 
-        OrderTracker 에서 ``(account_id, bot_id, symbol, side="buy")`` 의
-        non-terminal(open/partially_filled) 주문을 조회하고, 그 미체결 잔량 합
-        (capacity = Σ(ordered_qty − recorded_filled_qty)) 과 ``excess`` 를 비교한다.
+        방향 대칭(#1950 buy / #2351 sell). OrderTracker 에서 ``(account_id, bot_id,
+        symbol, side)`` 의 non-terminal(open/partially_filled) 주문을 조회하고, 그
+        미체결 잔량 합(capacity = Σ(ordered_qty − recorded_filled_qty)) 과 ``excess``
+        를 비교한다.
+
+        - ``side="buy"`` (#1950): ``excess = broker_qty - internal_qty`` — 외부 매수
+          후보. 매칭되는 미반영 self 매수로 설명 가능한지 판정.
+        - ``side="sell"`` (#2351): ``excess = internal_qty - broker_qty``(deficit) —
+          외부 청산/일부 매도 후보. 매칭되는 미반영 self 매도로 설명 가능한지 판정.
+          KIS 모의 ccld 지연창(잔고는 매도 즉시 감소·ccld 당일 0건)에서 FillApplier 가
+          아직 기록 못 한 self 매도가 정확히 non-terminal sell capacity 에 든다.
 
         - ``excess <= capacity`` → True (self_submitted_unrecorded_fill).
           ante 가 제출했으나 FillApplier 가 아직 기록 못 한 체결로 설명 가능.
-        - ``excess > capacity`` 또는 매칭 주문 없음 → False (외부 매수로 분류).
-        - OrderTracker 미주입 → False (하위 호환 — 기존 "외부 매수" 동작).
+        - ``excess > capacity`` 또는 매칭 주문 없음 → False (외부 거래로 분류).
+        - OrderTracker 미주입 → False (하위 호환 — 기존 외부 분류 동작).
 
-        **bounded known-limitation (R2-1)**: broker 포지션은 총량만 주므로
-        ante 미체결 capacity 안에 숨은 진짜 외부 매수는 즉시 보정되지 않는다.
-        이는 #1945 auto-sell 캐스케이드 회피를 외부 검출 완전성보다 우선하는
-        보수적 trade-off다. 매칭 ante 주문이 해소(완전 체결→open set 이탈, 또는
-        EOD expire_stale→terminal)되면 다음 reconcile 에서 잔여 excess 가 external
-        로 검출된다. 상세: ``docs/specs/trade/03-07-position-reconciler.md``.
+        **bounded known-limitation (R2-1, 방향 대칭)**: broker 포지션은 총량만
+        주므로 capacity 안에 숨은 진짜 외부 거래(buy: 외부 매수 / sell: 외부 매도)는
+        즉시 보정되지 않는다. 이는 #1945 auto-sell 캐스케이드 회피를 외부 검출
+        완전성보다 우선하는 보수적 trade-off다. 매칭 ante 주문이 해소(완전 체결→open
+        set 이탈, 또는 EOD expire_stale→terminal)되면 다음 reconcile 에서 잔여
+        excess 가 external 로 검출된다. 상세:
+        ``docs/specs/trade/03-07-position-reconciler.md``.
         """
         if self._order_tracker is None:
             return False
@@ -490,16 +566,18 @@ class PositionReconciler:
                 account_id=account_id,
                 bot_id=bot_id,
                 symbol=symbol,
-                side="buy",
+                side=side,
             )
         except Exception:
             # OrderTracker 조회 실패 시 self-check 를 포기하고 보수적으로 외부
-            # 매수로 분류한다(안전 보정 유지). 조회 자체가 reconcile 을 깨뜨리지
+            # 거래로 분류한다(안전 보정 유지). 조회 자체가 reconcile 을 깨뜨리지
             # 않도록 방어한다.
             logger.exception(
-                "self-check OrderTracker 조회 실패 [%s] %s — external 분류로 폴백",
+                "self-check OrderTracker 조회 실패 [%s] %s side=%s — "
+                "external 분류로 폴백",
                 bot_id,
                 symbol,
+                side,
             )
             return False
 

--- a/tests/unit/test_fill_recovery_integration.py
+++ b/tests/unit/test_fill_recovery_integration.py
@@ -87,11 +87,17 @@ async def stack(db, eventbus):
         db=db, order_tracker=tracker, position_history=ph, eventbus=eventbus
     )
     reconciler = PositionReconciler(trade_service=service, eventbus=eventbus)
+    # #2351: order_tracker 주입 reconciler — sell-side self-check 통합 검증용
+    # (운영 배선과 동형: main.py 의 두 배선 경로는 항상 OrderTracker 를 주입한다).
+    reconciler_with_tracker = PositionReconciler(
+        trade_service=service, eventbus=eventbus, order_tracker=tracker
+    )
     return {
         "ph": ph,
         "tracker": tracker,
         "applier": applier,
         "reconciler": reconciler,
+        "reconciler_with_tracker": reconciler_with_tracker,
         "service": service,
     }
 
@@ -462,6 +468,99 @@ async def test_1945_regression_paper_poll_recovery(stack, eventbus):
 
     pos2 = await stack["ph"].get_current(BOT, SYMBOL, account_id=ACCT)
     assert pos2["quantity"] == 0.0  # 정확히 청산.
+
+
+# ── #2351: sell-side self detect-only → ccld 단일 차감(이중 차감 없음) ──
+
+
+async def test_2351_self_sell_detect_only_then_ccld_single_decrement(stack, eventbus):
+    """#2351 통합: 모의 ccld 지연창의 self 매도가 reconciler 에서 detect-only 로
+    분류(보정 skip)된 뒤, ccld 가 그 매도를 적용해도 **이중 차감 없이** FillApplier
+    경로로 **정확히 1회만** 차감된다.
+
+    시나리오:
+    1) buy 100 복구 → positions=100(내부=브로커 일치).
+    2) ante 가 sell 100 self 제출(추적 seed) → 잔고는 즉시 0 으로 감소하나 ccld 는
+       당일 0건(모의 지연) → 내부 매도 미반영(positions 여전히 100).
+    3) reconcile(order_tracker 주입): deficit 100 == sell capacity 100 → self_submitted
+       detect-only. correct_position(force-write down) 미호출 → positions 100 유지.
+    4) ccld 가 sell 100 을 반환 → FillApplier 가 매도 1회 적용 → positions=0.
+       reconciler 가 force-write 하지 않았으므로 이중 차감(음수/0 중복)이 없다.
+    """
+    mismatches: list[PositionMismatchEvent] = []
+    fills: list[OrderFilledEvent] = []
+
+    async def _mh(e):
+        if isinstance(e, PositionMismatchEvent):
+            mismatches.append(e)
+
+    async def _fh(e):
+        if isinstance(e, OrderFilledEvent):
+            fills.append(e)
+
+    eventbus.subscribe(PositionMismatchEvent, _mh)
+    eventbus.subscribe(OrderFilledEvent, _fh)
+
+    # 1) buy 100 복구 → positions=100.
+    await _submit(
+        eventbus,
+        stack["tracker"],
+        order_id="ord-buy",
+        broker_order_id="0001",
+        qty=100.0,
+    )
+    broker = FakeBroker(
+        history=[_hist("0001", 100.0, 70000.0, side="buy")],
+        positions=[{"symbol": SYMBOL, "quantity": 100.0, "avg_price": 70000.0}],
+    )
+    fill_sched = FillReconcileScheduler(
+        broker=broker,  # type: ignore[arg-type]
+        order_tracker=stack["tracker"],
+        fill_applier=stack["applier"],
+        account_id=ACCT,
+    )
+    await fill_sched.catch_up_once()
+    assert (await stack["ph"].get_current(BOT, SYMBOL, account_id=ACCT))[
+        "quantity"
+    ] == 100.0
+
+    # 2) ante sell 100 self 제출(추적 seed). 잔고는 즉시 0, ccld 는 당일 0건.
+    await _submit(
+        eventbus,
+        stack["tracker"],
+        order_id="ord-sell",
+        broker_order_id="0002",
+        qty=100.0,
+        side="sell",
+    )
+    broker._history = []  # 모의 ccld 당일 0건(매도 미반영).
+    broker._positions = []  # 잔고는 매도 즉시 반영 → 0.
+
+    # 3) reconcile(order_tracker 주입): deficit 100 <= sell capacity 100 → self
+    #    detect-only. force-write down 미발생 → positions 100 유지.
+    corrections = await stack["reconciler_with_tracker"].reconcile(
+        bot_id=BOT,
+        broker_positions=await broker.get_account_positions(),
+        account_id=ACCT,
+    )
+    assert corrections == []  # 보정 skip(외부 청산 force-write 아님).
+    assert len(mismatches) == 1
+    assert mismatches[0].reason == "ante 미반영 체결"
+    # 내부 포지션은 reconciler 가 손대지 않아 100 유지(복구는 ccld 백스톱 위임).
+    assert (await stack["ph"].get_current(BOT, SYMBOL, account_id=ACCT))[
+        "quantity"
+    ] == 100.0
+
+    # 4) ccld 가 sell 100 을 반환 → FillApplier 가 매도를 1회 적용 → positions=0.
+    broker._history = [_hist("0002", 100.0, 71000.0, side="sell")]
+    await fill_sched.catch_up_once()
+
+    pos = await stack["ph"].get_current(BOT, SYMBOL, account_id=ACCT)
+    assert pos["quantity"] == 0.0  # 정확히 1회 차감 — 이중 차감 없음(음수/잔류 없음).
+    # 매도 체결 이벤트는 ccld 경로로 정확히 1회 발행(sell delta=100).
+    sell_fills = [f for f in fills if f.order_id == "ord-sell"]
+    assert len(sell_fills) == 1
+    assert sell_fills[0].quantity == 100.0
 
 
 # ── EOD 만료 ─────────────────────────────────────────

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -17,6 +17,8 @@ from ante.trade.performance import PerformanceTracker
 from ante.trade.position import PositionHistory
 from ante.trade.reconciler import (
     REASON_EXTERNAL_BUY,
+    REASON_EXTERNAL_LIQUIDATION,
+    REASON_EXTERNAL_PARTIAL_SELL,
     REASON_SELF_SUBMITTED,
     REASON_UNATTRIBUTED_HOLDING,
     PositionReconciler,
@@ -865,6 +867,388 @@ class TestUnattributedHolding:
         )
         assert len(corrections) == 1
         assert corrections[0]["reason"] == REASON_EXTERNAL_BUY
+
+
+# ── 시나리오 10: sell-side self-check 대칭 확장 (#2351) ──
+
+
+class TestSellSideSelfCheck:
+    """broker < internal(외부 청산/외부 일부 매도 후보) 분기에서 ante 미반영 self
+    매도(self-submitted-unrecorded-fill)를 외부 매도와 구분한다 (#2351 — #1950
+    buy-side 정확 대칭).
+
+    KIS 모의 ccld 지연창: 잔고(get_positions)는 매도 즉시 감소하나 ccld(당일 0건)가
+    내부 매도를 반영하지 못해 broker_qty < internal_qty 가 된다. deficit 이 ante
+    미반영 sell capacity 로 설명되면 외부 거래로 단정하지 않고 보정 skip + info
+    이벤트만 발행한다(복구는 FillApplier ccld 백스톱에 위임).
+    """
+
+    async def test_full_self_sell_within_capacity_skips_correction(
+        self, reconciler, position_history, order_tracker, eventbus
+    ):
+        """(a) b_qty == 0 전량 self 매도(deficit <= capacity) → 보정 미호출 · info
+        · reason="ante 미반영 체결".
+
+        구현 전 FAIL 회귀 락: 현행 코드는 이를 '외부 청산'(critical)으로 분류 +
+        correct_position(quantity=0) force-write 했다.
+        """
+        # 내부 50주 보유, ante self 매도 50주 미체결(open sell), 브로커 0주.
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-sell",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=50,
+            side="sell",
+        )
+
+        mismatch_events: list = []
+        notif_events: list = []
+        reconcile_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+        eventbus.subscribe(ReconcileEvent, lambda e: reconcile_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],  # 브로커 0주.
+            account_id="acc-test",
+        )
+
+        # 보정 skip — FillApplier(ccld 백스톱)에 위임. force-write 없음.
+        assert corrections == []
+        # 포지션 보정 안 됨 (50 유지 — 외부 청산이라면 0 으로 force-write).
+        pos = await position_history.get_current("bot-1", "005930")
+        assert pos["quantity"] == 50
+        # PositionMismatchEvent 는 self-submitted 사유(외부 청산 아님)로 발행.
+        assert len(mismatch_events) == 1
+        assert mismatch_events[0].reason == REASON_SELF_SUBMITTED
+        assert mismatch_events[0].internal_qty == 50
+        assert mismatch_events[0].broker_qty == 0
+        # NotificationEvent 는 info(자동 보정 유발 안 함 — critical 아님).
+        assert len(notif_events) == 1
+        assert notif_events[0].level == "info"
+        # 보정 0건 → ReconcileEvent 미발행.
+        assert reconcile_events == []
+
+    async def test_partial_self_sell_within_capacity_skips_correction(
+        self, reconciler, position_history, order_tracker, eventbus
+    ):
+        """(b) 0 < b_qty < i_qty 부분 self 매도(deficit <= capacity) → detect-only.
+
+        현행: '외부 일부 매도'(critical) + correct_position(quantity=b_qty).
+        """
+        # 내부 50주, ante self 매도 30주 미체결, 브로커 20주(deficit 30 <= cap 30).
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-sell",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=30,
+            side="sell",
+        )
+
+        notif_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 20, "avg_price": 50000},
+            ],
+            account_id="acc-test",
+        )
+
+        assert corrections == []
+        pos = await position_history.get_current("bot-1", "005930")
+        assert pos["quantity"] == 50  # 보정 안 됨(외부 일부 매도라면 20).
+        assert len(notif_events) == 1
+        assert notif_events[0].level == "info"
+
+    async def test_partial_fill_capacity_exact(
+        self, reconciler, position_history, order_tracker
+    ):
+        """(c) partial capacity(recorded_filled_qty>0) 정확 계산.
+
+        sell 50주 주문 중 30주 이미 기록 → 잔여 sell capacity = 20. deficit 20 ==
+        capacity 20 → self(보정 skip). 단 잔여분만 capacity 로 잡힘을 고정.
+        """
+        # 내부 50주, ante sell 50 주문 중 30 기록 → 잔여 capacity 20.
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-sell",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=50,
+            side="sell",
+            recorded_filled_qty=30,
+        )
+        # 브로커 30주 → deficit 20 == capacity 20 → self.
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 30, "avg_price": 50000},
+            ],
+            account_id="acc-test",
+        )
+        assert corrections == []
+
+    async def test_deficit_over_capacity_is_external_mixed(
+        self, reconciler, position_history, order_tracker
+    ):
+        """(d) 혼재 `0 < capacity < deficit` → 기존 외부 보정 유지(bounded
+        known-limitation 경계 고정).
+
+        self 매도 + 진짜 외부 매도 혼재는 잔고 총량만으로 분리 보정 불가 — 분리
+        알고리즘 비채택, 기존 외부 분류(force-write)를 유지한다.
+        """
+        # 내부 50주, ante sell 20주 미체결, 브로커 10주 → deficit 40 > capacity 20.
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-sell",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=20,
+            side="sell",
+        )
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 10, "avg_price": 50000},
+            ],
+            account_id="acc-test",
+        )
+        # deficit > capacity → 기존 외부 일부 매도 분류·보정 유지.
+        assert len(corrections) == 1
+        assert corrections[0]["reason"] == REASON_EXTERNAL_PARTIAL_SELL
+        assert corrections[0]["new_quantity"] == 10
+
+    async def test_full_liquidation_deficit_over_capacity_stays_external(
+        self, reconciler, position_history, order_tracker
+    ):
+        """(d') b_qty==0 인데 deficit > sell capacity → 외부 청산 유지(무회귀)."""
+        # 내부 50주, ante sell 20주 미체결, 브로커 0주 → deficit 50 > capacity 20.
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-sell",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=20,
+            side="sell",
+        )
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+        )
+        assert len(corrections) == 1
+        assert corrections[0]["reason"] == REASON_EXTERNAL_LIQUIDATION
+        assert corrections[0]["new_quantity"] == 0
+
+    async def test_no_matching_sell_order_is_external_liquidation(
+        self, reconciler, position_history, order_tracker
+    ):
+        """(e) 매칭 sell 주문 없음 → 진짜 외부 청산 무회귀(보정 유지)."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        # sell capacity 0 (추적 open sell 전무).
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+        )
+        assert len(corrections) == 1
+        assert corrections[0]["reason"] == REASON_EXTERNAL_LIQUIDATION
+        assert corrections[0]["new_quantity"] == 0
+
+    async def test_no_matching_sell_order_is_external_partial_sell(
+        self, reconciler, position_history, order_tracker
+    ):
+        """(e') 매칭 sell 주문 없음 → 진짜 외부 일부 매도 무회귀(보정 유지)."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 30, "avg_price": 50000},
+            ],
+            account_id="acc-test",
+        )
+        assert len(corrections) == 1
+        assert corrections[0]["reason"] == REASON_EXTERNAL_PARTIAL_SELL
+        assert corrections[0]["new_quantity"] == 30
+
+    async def test_buy_order_does_not_satisfy_sell_self_check(
+        self, reconciler, position_history, order_tracker
+    ):
+        """(e'') side="buy" open 주문은 sell capacity 에 잡히지 않음 → 외부 청산
+        유지. self-check 는 side 별 분리(buy/sell capacity 비혼입)임을 고정.
+        """
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        # buy 주문 50주는 sell-side self-check 의 capacity 가 아니다.
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-buy",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=50,
+            side="buy",
+        )
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+        )
+        assert len(corrections) == 1
+        assert corrections[0]["reason"] == REASON_EXTERNAL_LIQUIDATION
+
+    async def test_other_bot_sell_order_does_not_match(
+        self, reconciler, position_history, order_tracker
+    ):
+        """(e''') 다른 봇의 sell 주문은 매칭 안 됨 → 외부 청산 유지(무회귀)."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-sell",
+            bot_id="bot-2",
+            symbol="005930",
+            ordered_qty=50,
+            side="sell",
+        )
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+        )
+        assert len(corrections) == 1
+        assert corrections[0]["reason"] == REASON_EXTERNAL_LIQUIDATION
+
+    async def test_self_sell_check_runs_when_skip_external_buy_true(
+        self, reconciler, position_history, order_tracker, eventbus
+    ):
+        """(f-경계) sell self-check 는 skip_external_buy 와 직교 — 그 플래그가 켜져도
+        외부 청산/일부 매도 분기의 sell self-check 는 수행되고 self 는 detect-only.
+        """
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-sell",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=50,
+            side="sell",
+        )
+        notif_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+            skip_external_buy=True,  # external-buy 만 타겟 — sell 분기 무영향.
+        )
+        assert corrections == []
+        assert len(notif_events) == 1
+        assert notif_events[0].level == "info"
+
+    async def test_buy_side_self_check_unaffected_regression(
+        self, reconciler, position_history, order_tracker, eventbus
+    ):
+        """(f) buy-side self-check(#1950) 무회귀 — sell-side 확장이 buy capacity 를
+        오염시키지 않는다. broker > internal + buy capacity → 여전히 self.
+        """
+        await _seed_open_order(
+            order_tracker,
+            order_id="ord-buy",
+            bot_id="bot-1",
+            symbol="005930",
+            ordered_qty=20,
+            side="buy",
+        )
+        notif_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 20, "avg_price": 55000},
+            ],
+            account_id="acc-test",
+        )
+        assert corrections == []
+        assert len(notif_events) == 1
+        assert notif_events[0].level == "info"
+
+    async def test_unattributed_holding_unaffected_regression(
+        self, reconciler, position_history, order_tracker, eventbus
+    ):
+        """(f) 미귀속 보유(#2352) 무회귀 — broker > internal && internal==0 &&
+        buy capacity==0 은 여전히 미귀속 보유 detect-only(sell-side 변경 무영향).
+        """
+        mismatch_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "069500", "quantity": 2, "avg_price": 30000},
+            ],
+            account_id="acc-test",
+        )
+        assert corrections == []
+        assert len(mismatch_events) == 1
+        assert mismatch_events[0].reason == REASON_UNATTRIBUTED_HOLDING
+
+    async def test_no_order_tracker_keeps_external_liquidation(self, service, eventbus):
+        """(g) order_tracker 미주입 → sell self-check 생략 → 기존 외부 청산 분류·보정
+        fallback(하위 호환).
+        """
+        rec = PositionReconciler(trade_service=service, eventbus=eventbus)
+        # 내부 50주를 직접 seed (service.position_history 경유).
+        await rec._trade_service.correct_position(
+            bot_id="bot-1",
+            symbol="005930",
+            quantity=50,
+            avg_price=50000,
+            reason="seed",
+            account_id="acc-test",
+        )
+        corrections = await rec.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+        )
+        assert len(corrections) == 1
+        assert corrections[0]["reason"] == REASON_EXTERNAL_LIQUIDATION
+        assert corrections[0]["new_quantity"] == 0
+
+    async def test_order_tracker_query_failure_falls_back_to_external(
+        self, service, eventbus, order_tracker, position_history, monkeypatch
+    ):
+        """(g) OrderTracker 조회 실패 → sell self-check 포기 → 기존 외부 청산 분류
+        fallback(reconcile 을 깨뜨리지 않는 방어).
+        """
+        rec = PositionReconciler(
+            trade_service=service, eventbus=eventbus, order_tracker=order_tracker
+        )
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("tracker query failed")
+
+        monkeypatch.setattr(order_tracker, "get_open_orders_for", _boom)
+
+        corrections = await rec.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+        )
+        # 조회 실패 → 보수적으로 외부 청산 분류·보정 유지.
+        assert len(corrections) == 1
+        assert corrections[0]["reason"] == REASON_EXTERNAL_LIQUIDATION
 
 
 # ── #2058: account-scoped 승격 (account_id 전파 + entry validation) ──────


### PR DESCRIPTION
Closes #2351

## Summary
- `PositionReconciler`의 `b_qty == 0`(외부 청산)·`b_qty < i_qty`(외부 일부 매도) 분기에 **#1950 buy-side와 정확 대칭인 sell-side self-check** 추가: `deficit = i_qty - b_qty`가 sell capacity(`get_open_orders_for(..., side="sell")` non-terminal 미체결 잔량 합) 이내면 `ante 미반영 체결`(info)로 분류하고 **보정 skip** — 복구는 FillApplier(ccld 백스톱) 단일 권위에 위임
- 효과: 모의 ccld 지연 중 self 매도가 '외부 청산'으로 오라벨링된 채 `correct_position` force-write로 원장 우회 수렴되는 결함(#2317 canary 2026-06-05 12:47) 제거 + 순수 self-sell 구간의 이중 차감 면 제거(통합 테스트 고정)
- 혼재 `0 < sell_capacity < deficit`는 분리 보정 비채택(기존 외부 보정 유지) — bounded known-limitation으로 스펙 선언
- fallback(§11)은 **buy-only 명시 한정** 선언(매도 fill 합성 비채택), buy-side(#1950)·미귀속 보유(#2352) 무회귀
- 스펙: 03-07(sell-side 대칭 normative + :78-79 사실 정정 + 동형 bounded 블록), 18-fill-recovery(§2.1 방향 무관·§11/§11.3 buy-only·§11.7 sell-side 항목), 03-08(get_open_orders_for 계약 문서화)

## Verification
- Plan Preflight: approve-implement (Codex R3) / 브랜치 리뷰: PASS (attempt 1)
- `pytest tests/unit -q`: 7215 passed, 2 skipped / `mypy src/`: Success (232 files) / ruff 통과
- failing check: (a)(b)(c) 케이스가 수정 전 FAIL → 수정 후 PASS. 신규 파일 없음(generated 산출물 무영향)

## Test Plan
- `pytest tests/unit/test_reconciler.py tests/unit/test_fill_recovery_integration.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)