### PR TITLE
chore(broker): #2346 KIS 취소 tr_id 신세대 0013U + EXCG_ID_DVSN_CD (라이브 A/B both_ok)

### DIFF
--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -40,7 +40,7 @@ class KISDomesticAdapter(KISBaseAdapter):
 
 ### order-cash TR ID 매핑
 
-주문 접수(`order-cash`) 호출 시 `place_order`는 `is_paper` × `side` 조합으로 아래 KIS 공식 현행 TR ID를 전송한다. **order-cash 한정**이며, 취소/정정(`order-rvsecncl`, `VTTC0803U`/`TTTC0803U`)·잔고·현재가 등 다른 TR ID는 이 표의 범위 밖이다.
+주문 접수(`order-cash`) 호출 시 `place_order`는 `is_paper` × `side` 조합으로 아래 KIS 공식 현행 TR ID를 전송한다. **order-cash 한정**이며, 취소/정정(`order-rvsecncl`, `VTTC0013U`/`TTTC0013U`)·잔고·현재가 등 다른 TR ID는 이 표의 범위 밖이다.
 
 | 환경 | 매수 | 매도 |
 |------|------|------|
@@ -67,9 +67,9 @@ class KISDomesticAdapter(KISBaseAdapter):
 - **`40910000` 인과 caveat**: 2026-06-11 KST 모의 smoke에서 #2342 TR ID 갱신 후에도 모의 매수가 `40910000 모의투자 주문이 불가한 계좌입니다`로 실패했다. 본 계약 정합이 그 실패의 직접 원인인지는 **미확정**이며, 머지 후 다음 거래일 모의 smoke(`buy 1 → fill/position → sell 1 → flatten`)로 검증한다. 지속 실패 시 계좌 자격/provisioning 가설은 별도 이슈로 분리한다(본 이슈는 contract drift 해소로 종결). 한편 `40910000`은 계좌 자격/모의 신청 상태 거절이라 재시도해도 결과가 동일하므로 PERMANENT(`is_retryable_msg_code → False`)로 분류한다(#2361: 3세션 일관 관측, 무익 재시도 차단).
 - **비목표(`SLL_TYPE`/`CNDT_PRIC`)**: 공식 예제 바디에는 `SLL_TYPE`(매도유형)·`CNDT_PRIC`(조건가격)이 존재하나, 필수 `ValueError` 가드는 `EXCG_ID_DVSN_CD`에만 있고 거절 근거 관측이 없어 본 PR 비목표다. 추측성 빈 문자열 필드 추가는 행동 변화 위험만 있으므로 제외하며, 거절 근거가 관측되면 후속 이슈로 다룬다.
 
-### order-rvsecncl 취소 바디 계약 (#2345)
+### order-rvsecncl 취소 바디 계약 (#2345, #2346)
 
-주문 취소(`order-rvsecncl`, `cancel_order`)는 레거시 TR ID `VTTC0803U`(모의)/`TTTC0803U`(실전)로 아래 바디를 전송한다. **취소 한정**이며 정정(modify)·order-cash·잔고 등은 이 표의 범위 밖이다.
+주문 취소(`order-rvsecncl`, `cancel_order`)는 신세대 TR ID `VTTC0013U`(모의)/`TTTC0013U`(실전)로 아래 바디를 전송한다(레거시 `VTTC0803U`/`TTTC0803U`에서 마이그레이션 — #2346). 신세대 body는 `EXCG_ID_DVSN_CD`를 `[필수]`로 요구하며, 모듈 레벨 공유 상수 `DEFAULT_EXCG_ID_DVSN_CD="KRX"`로 주입한다(에픽 #2354 일관성 목표의 공유 단일 출처 — order-cash(#2344)·inquire-daily-ccld(#2349)와 동일 상수 재사용). **취소 한정**이며 정정(modify)·order-cash·잔고 등은 이 표의 범위 밖이다.
 
 | 필드 | 값 | 설명 |
 |------|------|------|
@@ -81,16 +81,18 @@ class KISDomesticAdapter(KISBaseAdapter):
 | `ORD_QTY` | `'0'` | 주문수량(전량취소 시 0) |
 | `ORD_UNPR` | `'0'` | 주문단가 |
 | `QTY_ALL_ORD_YN` | `'Y'` | 잔량전부주문여부 |
+| `EXCG_ID_DVSN_CD` | `'KRX'` | 거래소ID구분코드(신세대 필수·국내 KRX 기본·NXT/SOR 미지원) |
 | `KRX_FWDG_ORD_ORGNO` | 원주문 캡처값(조건부) | 한국거래소전송주문조직번호 |
 
 `KRX_FWDG_ORD_ORGNO`(한국거래소전송주문조직번호)는 원주문별 값으로, 누락 시 mis-route/거절 위험이 있다. ante는 이 값을 다음 규칙으로 처리한다:
 
 - **원천**: 원주문 접수(`order-cash`) 성공 응답 `output`의 동일 필드명 `KRX_FWDG_ORD_ORGNO`를 직접 캡처한다(공식 order-cash 결과 컬럼에 `ODNO`/`ORD_TMD`와 함께 정의). `inquire-psbl-rvsecncl` 조회의 `ord_gno_brno`(주문채번지점번호)는 동일성 미보장(오값 위험)이라 **사용하지 않는다**.
 - **캐시 키 scope**: 어댑터 인스턴스(=계좌, `gateway._get_broker(account_id)`로 계좌별 분리) + 제출 KST 영업일(YYYYMMDD). KIS `odno`는 영업일 재사용이 가능하므로 영업일까지 키에 포함해 재사용 odno에 과거 조직번호를 붙이는 오값을 차단한다.
-- **주입/생략**: `cancel_order`는 캐시 hit & 영업일 일치 시에만 `KRX_FWDG_ORD_ORGNO`를 주입한다. 캐시 miss(인메모리 미보존)·응답에 필드 없음·영업일 불일치 시에는 **필드를 생략**(기존 8필드 동작 유지)하고 debug 로그를 남긴다. 취소 경로에서 **추가 조회/네트워크 호출은 하지 않는다**(순수 dict 연산).
+- **주입/생략**: `cancel_order`는 캐시 hit & 영업일 일치 시에만 `KRX_FWDG_ORD_ORGNO`를 주입한다. 캐시 miss(인메모리 미보존)·응답에 필드 없음·영업일 불일치 시에는 **필드를 생략**(고정 9필드 — 8필드 + `EXCG_ID_DVSN_CD`)하고 debug 로그를 남긴다. 취소 경로에서 **추가 조회/네트워크 호출은 하지 않는다**(순수 dict 연산).
+- **신세대(0013U) 호환**: 2026-06-12 라이브 A/B에서 `VTTC0013U + EXCG_ID_DVSN_CD=KRX + KRX_FWDG_ORD_ORGNO`(cache-hit 경로)가 정상 접수(`40630000 취소 완료`)됨을 확인했다. 따라서 **cache-hit 경로의 신세대 정상 동작은 라이브 검증됨**이며, cache miss/stale 시 `KRX_FWDG_ORD_ORGNO` 생략은 기존 #2345 known-limitation을 그대로 유지한다(생략 시에도 신세대 0013U 자체는 정상 — '완전 호환' 단정이 아니라 cache-hit 정상 + miss/stale 기존 한계).
 - **bounded / known-limitation**: 캐시는 `OrderedDict` + maxlen으로 무한 증가·stale 누적을 막는다. **in-process 한정**이라 재기동 시 캐시가 소실되며, 그 경우 miss로 처리되어 필드를 생략한다(추정값을 전송하지 않으므로 안전). cross-process/외부주문 취소의 원천 확보는 영속화(Option A) 또는 검증된 조회 원천을 별도 이슈로 다룬다.
 
-> 출처: [KIS open-trading-api `order_rvsecncl.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_rvsecncl/order_rvsecncl.py) 및 공식 레거시/Postman PAPER 샘플(`VTTC0803U`/`TTTC0803U`에서 `KRX_FWDG_ORD_ORGNO`를 원주문별 값으로 전송). 취소 tr_id `0803U→0013U` 마이그레이션과 `EXCG_ID_DVSN_CD`는 별도 live-gated 이슈(#2346) 범위다.
+> 출처: [KIS open-trading-api `order_rvsecncl.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_rvsecncl/order_rvsecncl.py)의 demo 분기가 `VTTC0013U`(실전 `TTTC0013U`)를 사용하고 신세대 body에서 `EXCG_ID_DVSN_CD`를 `[필수]`로 가드한다. `KRX_FWDG_ORD_ORGNO`는 레거시였던 `VTTC0803U`/`TTTC0803U` 시절부터 원주문별 값으로 전송하던 필드로, 신세대 0013U body에서도 동일하게 사용한다. 취소 tr_id `0803U→0013U` 마이그레이션과 `EXCG_ID_DVSN_CD` 동반은 2026-06-12 라이브 A/B(both_ok — (A) 레거시 `0803U` 정상 / (B) 신세대 `0013U + EXCG_ID_DVSN_CD=KRX` 정상)로 검증해 단일 신세대 경로를 채택했다(#2346 — 레거시 fallback 이중화는 YAGNI 기각).
 
 ### inquire-daily-ccld TR ID 매핑 (#2349)
 

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -76,8 +76,8 @@ _ORDER_TR_IDS = frozenset(
         "TTTC0012U",  # 매수
         "VTTC0011U",
         "TTTC0011U",  # 매도
-        "VTTC0803U",
-        "TTTC0803U",  # 취소
+        "VTTC0013U",
+        "TTTC0013U",  # 취소 (#2346 라이브 A/B both_ok 2026-06-12, 신세대 0013U)
     }
 )
 
@@ -990,13 +990,18 @@ class KISDomesticAdapter(KISBaseAdapter):
     async def cancel_order(self, order_id: str) -> bool:
         """주문 취소.
 
-        취소(order-rvsecncl) body 에 원주문별 ``KRX_FWDG_ORD_ORGNO``
-        (한국거래소전송주문조직번호)를 전송한다(#2345). 값은 place_order 시
-        order-cash 응답에서 캡처해 둔 인메모리 캐시에서 가져오며, 순수 dict
-        조회로 네트워크/추가 조회를 하지 않는다. 캐시 miss 또는 제출 영업일
-        불일치(odno 재사용 등) 시에는 필드를 생략한다(기존 동작 유지).
+        취소(order-rvsecncl)는 신세대 tr_id ``VTTC0013U``(모의)/``TTTC0013U``
+        (실전)로 전송하며, 신세대 필수 필드 ``EXCG_ID_DVSN_CD``(공유 상수
+        ``DEFAULT_EXCG_ID_DVSN_CD="KRX"``)를 포함한다(#2346 라이브 A/B both_ok
+        2026-06-12).
+
+        body 에 원주문별 ``KRX_FWDG_ORD_ORGNO``(한국거래소전송주문조직번호)를
+        조건부로 전송한다(#2345). 값은 place_order 시 order-cash 응답에서 캡처해
+        둔 인메모리 캐시에서 가져오며, 순수 dict 조회로 네트워크/추가 조회를 하지
+        않는다. 캐시 miss 또는 제출 영업일 불일치(odno 재사용 등) 시에는 필드를
+        생략한다(기존 동작 유지).
         """
-        tr_id = "VTTC0803U" if self.is_paper else "TTTC0803U"
+        tr_id = "VTTC0013U" if self.is_paper else "TTTC0013U"
         url = f"{self.base_url}/uapi/domestic-stock/v1/trading/order-rvsecncl"
         cancel_data = {
             "CANO": self.account_no[:8],
@@ -1007,6 +1012,8 @@ class KISDomesticAdapter(KISBaseAdapter):
             "ORD_QTY": "0",
             "ORD_UNPR": "0",
             "QTY_ALL_ORD_YN": "Y",
+            # 신세대(0013U) 필수 필드 — 공유 상수 재사용("KRX" 리터럴 금지, #2344).
+            "EXCG_ID_DVSN_CD": DEFAULT_EXCG_ID_DVSN_CD,
         }
         cached = self._krx_fwdg_orgno_cache.get(order_id)
         if cached is not None and cached[1] == business_date_kst():

--- a/tests/unit/test_kis_cancel_krx_fwdg_ord_orgno.py
+++ b/tests/unit/test_kis_cancel_krx_fwdg_ord_orgno.py
@@ -4,7 +4,9 @@
 ``KRX_FWDG_ORD_ORGNO``(한국거래소전송주문조직번호)를 인메모리 캐시에 보존하고,
 취소 시 같은 broker_order_id(ODNO)·같은 KST 영업일이면 cancel body 에 주입한다.
 캐시 miss / 응답에 필드 없음 / 영업일 불일치(odno 재사용) 시에는 필드를 생략한다
-(기존 8필드 동작 유지, 네트워크/추가 조회 없음).
+(고정 9필드 — 8필드 + EXCG_ID_DVSN_CD, 네트워크/추가 조회 없음).
+
+신세대(0013U) tr_id·필수 EXCG_ID_DVSN_CD 회귀도 함께 lock 한다(#2346).
 
 캡처 원천: 공식 order-cash 결과 컬럼(chk_order_cash.py)에 ODNO/ORD_TMD 와 함께
 ``KRX_FWDG_ORD_ORGNO`` 가 정의되어 있어, place_order 가 읽는 동일 ``output`` dict
@@ -18,7 +20,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from ante.broker.fill_scheduler import business_date_kst
-from ante.broker.kis import KISDomesticAdapter
+from ante.broker.kis import (
+    _ORDER_TR_IDS,
+    DEFAULT_EXCG_ID_DVSN_CD,
+    KISDomesticAdapter,
+)
 
 _ORGNO = "00950"
 
@@ -121,7 +127,7 @@ async def test_cancel_stale_business_day_omits_field() -> None:
 
 
 async def test_cancel_body_regression_lock() -> None:
-    """(e) 기존 cancel body 8필드 회귀 lock (캐시 hit 시에도 기존 필드 불변)."""
+    """(e) cancel body 회귀 lock (캐시 hit 시 기존 필드 불변 + EXCG 추가, #2346)."""
     adapter = _make_adapter()
     request = _stub_request(
         adapter, {"output": {"ODNO": "0001234567", "KRX_FWDG_ORD_ORGNO": _ORGNO}}
@@ -139,7 +145,9 @@ async def test_cancel_body_regression_lock() -> None:
     assert body["ORD_QTY"] == "0"
     assert body["ORD_UNPR"] == "0"
     assert body["QTY_ALL_ORD_YN"] == "Y"
-    # 신규 필드 1개만 추가되어 총 9필드.
+    # 신세대(0013U) 필수 EXCG_ID_DVSN_CD — 공유 상수(#2344) 재사용.
+    assert body["EXCG_ID_DVSN_CD"] == DEFAULT_EXCG_ID_DVSN_CD == "KRX"
+    # 기존 8필드 + KRX_FWDG(조건부 hit) + EXCG = 총 10필드.
     assert set(body) == {
         "CANO",
         "ACNT_PRDT_CD",
@@ -150,6 +158,7 @@ async def test_cancel_body_regression_lock() -> None:
         "ORD_UNPR",
         "QTY_ALL_ORD_YN",
         "KRX_FWDG_ORD_ORGNO",
+        "EXCG_ID_DVSN_CD",
     }
 
 
@@ -183,6 +192,48 @@ async def test_cancel_works_for_paper_and_live(is_paper: bool) -> None:
 
     body = _captured_cancel_body(request)
     assert body["KRX_FWDG_ORD_ORGNO"] == _ORGNO
-    # tr_id 도 환경별로 올바른지(취소 tr_id 회귀): 0803U 유지.
+    # tr_id 도 환경별로 올바른지(취소 tr_id 회귀): 신세대 0013U (#2346).
     cancel_tr_id = request.call_args_list[-1].args[2]
-    assert cancel_tr_id == ("VTTC0803U" if is_paper else "TTTC0803U")
+    assert cancel_tr_id == ("VTTC0013U" if is_paper else "TTTC0013U")
+
+
+def test_cancel_tr_id_in_order_whitelist() -> None:
+    """취소 tr_id 가 ``_ORDER_TR_IDS`` 화이트리스트에 동기화돼 있는지 직접 단언 (#2346).
+
+    취소 본문 테스트는 ``_request`` 를 stub 하므로, ``_ORDER_TR_IDS`` 화이트리스트
+    교체가 누락돼도 본문 단언은 침묵 통과한다(Codex R1 ①). 이 화이트리스트는
+    재시도 상한(``_get_max_retries``)·요청 timeout(``_timeout_order`` vs
+    ``_timeout_query``) 선택을 결정하므로, 신세대 0013U 가 set 에 포함되고
+    레거시 0803U 가 제거됐는지 직접 lock 한다.
+    """
+    assert "VTTC0013U" in _ORDER_TR_IDS
+    assert "TTTC0013U" in _ORDER_TR_IDS
+    # 레거시 취소 tr_id 는 화이트리스트에서 제거됨(회귀 lock).
+    assert "VTTC0803U" not in _ORDER_TR_IDS
+    assert "TTTC0803U" not in _ORDER_TR_IDS
+
+
+@pytest.mark.parametrize("is_paper", [True, False])
+def test_cancel_tr_id_selects_order_retry_and_timeout(is_paper: bool) -> None:
+    """신세대 취소 tr_id 가 order(주문) 재시도 상한·timeout 을 선택하는지 단언 (#2346).
+
+    화이트리스트 동기화가 실제 재시도/timeout 분류로 이어지는지 행동 단언:
+    0013U 가 query 가 아닌 order 분류(``_max_retries_order``·``_timeout_order``)를
+    타야 한다. ``_ORDER_TR_IDS`` 에서 0013U 가 빠지면 query 분류로 fallback 되어
+    이 단언이 FAIL 한다(stub 침묵 통과 갭 차단).
+    """
+    adapter = _make_adapter(is_paper=is_paper)
+    cancel_tr_id = "VTTC0013U" if is_paper else "TTTC0013U"
+    url = f"{adapter.base_url}/uapi/domestic-stock/v1/trading/order-rvsecncl"
+
+    # 재시도 상한: order 분류(query 가 아님).
+    assert adapter._get_max_retries(url, cancel_tr_id) == adapter._max_retries_order
+    # timeout 선택: order 분류(query 가 아님). order/query 가 동일값이면
+    # 분류 회귀를 잡지 못하므로, 화이트리스트 membership 도 함께 단언한다.
+    assert cancel_tr_id in _ORDER_TR_IDS
+    selected_timeout = (
+        adapter._timeout_order
+        if cancel_tr_id in _ORDER_TR_IDS
+        else adapter._timeout_query
+    )
+    assert selected_timeout == adapter._timeout_order


### PR DESCRIPTION
Closes #2346

## Summary
- `cancel_order` tr_id `VTTC0803U/TTTC0803U` → `VTTC0013U/TTTC0013U` + cancel body에 `EXCG_ID_DVSN_CD`(공유 상수) 주입 — 2026-06-12 라이브 A/B로 **양 경로 정상(both_ok) 입증 후 un-gated 전환**(레거시 무경고 degrade 선례 #2342/#2349 예방 차원 신세대 채택)
- `_ORDER_TR_IDS` 화이트리스트 동기화(재시도 상한·order timeout 분류 단일 출처) + **직접 단언 테스트 신설**(stub 침묵 통과 갭 차단, 양쪽 레거시 부재 lock)
- `KRX_FWDG_ORD_ORGNO` 캐시(#2345) 무변경 — 스펙은 'cache-hit 라이브 정상 확인, miss/stale 생략은 기존 known-limitation 유지'로 한정 서술
- 08 스펙 취소 바디 계약 절 신세대 갱신(EXCG 행·출처·L43 괄호 언급)

## Verification
- Plan Preflight: approve-implement (Codex R3) / 브랜치 리뷰: PASS (attempt 1)
- `pytest tests/unit -q`: 7225 passed, 2 skipped / `mypy src/`: Success / ruff 통과
- `grep 0803U src/ tests/ docs/specs/`: 활성 사용 0건(부재-lock 단언·역사 인용만)
- 라이브 근거: 2026-06-12 10:31 KST A/B — legacy `40630000 취소 완료` / new(0013U+EXCG+KRX_FWDG) `40630000 취소 완료`

## Test Plan
- `pytest tests/unit/test_kis_cancel_krx_fwdg_ord_orgno.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)