### PR TITLE
fix(core): #2365 Database writer 직렬화 + 트랜잭션 owner 추적 — 태스크 간 중첩 트랜잭션 race 제거

### DIFF
--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -35,7 +35,7 @@ canonical DB 경로이다. 기본값은 `<config_dir>/db/ante.db`이며, CWD 기
 | `execute` | sql: str, params: tuple = () | None | INSERT/UPDATE/DELETE 실행 (writer 사용, 자동 커밋) |
 | `fetch_one` | sql: str, params: tuple = () | dict \| None | 단일 행 조회 (reader 사용). dict(컬럼명 → 값) 반환 |
 | `fetch_all` | sql: str, params: tuple = () | list[dict] | 다중 행 조회 (reader 사용) |
-| `execute_script` | sql: str | None | DDL 스크립트 실행 (테이블 생성 등, writer 사용) |
+| `execute_script` | sql: str | None | DDL 스크립트 실행 (테이블 생성 등, writer 사용). **트랜잭션 안에서 호출 금지** — schema/lifecycle 전용 |
 
 ### SQLite PRAGMA 설정
 
@@ -55,6 +55,48 @@ canonical DB 경로이다. 기본값은 `<config_dir>/db/ante.db`이며, CWD 기
 2. **aiosqlite 래핑**: asyncio 기반 시스템에서 DB I/O가 이벤트 루프를 차단하지 않도록 비동기 래퍼 사용
 3. **dict 반환**: `aiosqlite.Row`를 dict로 변환하여 모듈 간 데이터 전달을 단순화
 4. **자동 커밋**: `execute()` 호출 시 자동 커밋으로 트랜잭션 관리 단순화
+
+### 동시성·트랜잭션 invariant (#2365)
+
+단일 writer 연결을 여러 asyncio 태스크가 공유한다(예: 체결 폴 태스크의 자동커밋
+쓰기와 outbox publisher 태스크의 `Treasury` 정산 트랜잭션). `execute*()`의 implicit
+BEGIN과 commit 사이 await 경계에서 태스크가 전환되면 트랜잭션 상태가 어긋나
+정합성이 깨진다. Database는 다음 invariant로 이를 차단한다:
+
+1. **writer 직렬화**: writer 쓰기 API(`execute`/`execute_fetch_one`/
+   `execute_fetch_all`/`execute_script`)와 `transaction()`은 내부 `asyncio.Lock`으로
+   **태스크 간 직렬화**된다. 한 태스크의 implicit BEGIN↔commit 사이에 다른 태스크가
+   끼어들어 같은 connection에서 `BEGIN`을 실행하는 race(`cannot start a transaction
+   within a transaction`)를 제거한다.
+2. **트랜잭션 합류는 소유 태스크 한정**: `transaction()`은 진입한 태스크를 트랜잭션
+   소유 태스크로 등록한다. **소유 태스크의** `execute*()`만 commit을 skip하고 같은
+   트랜잭션에 합류한다. 다른 태스크의 writer 쓰기는 lock에서 대기해 독립 커밋되며,
+   소유 태스크의 트랜잭션에 합류하지 않는다(rollback 시 무관한 쓰기 소실 방지).
+3. **중첩 트랜잭션 금지**: 같은 태스크가 `transaction()`에 재진입하면 `RuntimeError`
+   (`중첩 트랜잭션은 지원하지 않습니다`). 재진입 검사는 lock 획득 **전**에 수행한다
+   (자기 자신이 보유한 lock 재획득 deadlock 방지). savepoint는 범위 밖이다.
+4. **트랜잭션 블록 안 child task / `asyncio.gather` DB write 금지**: `transaction()`
+   블록 안에서 별도 태스크(`asyncio.create_task`/`asyncio.gather`)로 DB write를 시작하고
+   그 완료를 블록 안에서 await하면, child는 소유 태스크가 아니라 lock 대기에 빠지고
+   owner는 child를 기다려 **교착**한다. 트랜잭션 본문의 모든 DB write는 소유 태스크가
+   직접 순차 await로 수행한다.
+5. **`execute_script`는 트랜잭션 밖 schema/lifecycle 전용**: Python `executescript`는
+   실행 전에 열린 트랜잭션을 암묵 COMMIT하므로, `transaction()` 소유 태스크가 호출하면
+   진행 중인 트랜잭션을 의도치 않게 커밋해 원자성을 깨뜨린다. 소유 태스크 호출은
+   `RuntimeError`로 차단한다. 마이그레이션·schema 부트스트랩은 트랜잭션 밖에서만
+   `execute_script`를 호출한다.
+6. **cancellation-safety**: `transaction()` COMMIT/자동커밋 commit이 cancel돼도
+   cleanup ROLLBACK을 무조건 시도해 implicit 트랜잭션 잔존을 막는다(다음 lock holder의
+   `BEGIN` 보호). cleanup ROLLBACK은 `except` 진입 직후 suspension 없이 곧바로
+   `await conn.execute("ROLLBACK")`에 도달한다 — asyncio cancellation은 suspension
+   point에서만 전달되고 aiosqlite는 첫 suspension 이전 동기 구간에서 SQL을 worker
+   FIFO에 enqueue하므로, ROLLBACK은 enqueue가 보장되고 worker FIFO 직렬성에 의해
+   다음 SQL보다 먼저 settle된다. `asyncio.shield`는 사용하지 않는다.
+   - **bounded known-limitation**: cancellation-during-COMMIT ack 모호성(COMMIT
+     enqueue 후 await 취소 → DB는 커밋됐는데 호출자는 취소 경로)은 별개의 pre-existing
+     invariant다. fill 정산 경로는 outbox at-least-once 재전달 + `treasury_fill_dedup`
+     멱등 + 재기동 시 메모리 상태 DB 재구축으로 **재기동 시** 자가 수렴한다(즉시 수렴
+     아님). 본 절은 이 모호성을 해소하지 않는다.
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조
 

--- a/src/ante/core/database.py
+++ b/src/ante/core/database.py
@@ -63,7 +63,34 @@ class Database:
         self._read_only = read_only
         self._writer: aiosqlite.Connection | None = None
         self._reader: aiosqlite.Connection | None = None
-        self._in_transaction: bool = False
+        # writer 직렬화 + 트랜잭션 소유 태스크 추적(#2365).
+        #
+        # 단일 writer 연결을 여러 asyncio 태스크가 공유하면, ``execute*()`` 의
+        # implicit BEGIN(``conn.execute(sql)``)과 ``conn.commit()`` 사이 await
+        # 경계에서 태스크가 전환돼 두 종류의 race 가 난다:
+        #   - race A: 다른 태스크가 이미 열린 SQLite 트랜잭션 위에서
+        #     ``transaction()`` 의 ``BEGIN`` 을 실행 → "cannot start a
+        #     transaction within a transaction".
+        #   - race B: standalone ``execute()`` 가 진행 중인 트랜잭션에 합류 →
+        #     owner rollback 시 무관한 쓰기가 조용히 소실.
+        # ``_write_lock`` 으로 모든 writer 쓰기/트랜잭션을 태스크 간 직렬화하고,
+        # ``_txn_owner`` 로 현재 트랜잭션을 소유한 태스크를 추적해 그 태스크의
+        # 쓰기만 트랜잭션에 합류(commit skip)시킨다.
+        self._write_lock = asyncio.Lock()
+        self._txn_owner: asyncio.Task | None = None
+
+    @property
+    def _in_transaction(self) -> bool:
+        """현재 호출 태스크가 트랜잭션 owner 인지(같은 태스크 합류 판정).
+
+        ``_txn_owner`` 기반으로 단순화한다(외부 production 참조 없음). 트랜잭션은
+        소유 태스크 한정으로만 합류하므로, **현재 태스크가 owner 일 때만** True.
+        owner 가 아닌 태스크에서 보면 트랜잭션이 진행 중이어도 False 다(독립
+        자동커밋 경로). 회귀 테스트(``test_transaction_rollback_failure_
+        preserves_original_exception``)가 ``finally`` 해제를 직접 관측한다.
+        """
+        owner = self._txn_owner
+        return owner is not None and owner is asyncio.current_task()
 
     @staticmethod
     async def _drain_failed_conn(conn: aiosqlite.Connection) -> None:
@@ -287,12 +314,45 @@ class Database:
             raise RuntimeError("DB 연결되지 않음. connect()를 먼저 호출하세요.")
         return self._reader
 
+    @staticmethod
+    async def _best_effort_rollback(conn: aiosqlite.Connection) -> None:
+        """non-owner 자동커밋 경로의 cleanup ROLLBACK(best-effort, #2365).
+
+        cancellation-safety invariant: 이 메서드는 ``except BaseException`` 진입
+        **직후** suspension 없이 곧바로 ``await conn.execute("ROLLBACK")`` 에
+        도달해야 한다. asyncio cancellation 은 suspension point 에서만 전달되고,
+        aiosqlite ``Connection.execute(...)`` 는 첫 suspension(``await future``)
+        **이전 동기 구간에서 SQL 을 worker FIFO 에 ``put_nowait``** 하므로, await
+        문이 실행을 시작하면 ROLLBACK 은 반드시 enqueue 된다(취소는 결과 대기만
+        abandon). ROLLBACK 자체 실패는 swallow 한다 — 원본 예외 보존이 우선.
+        """
+        try:
+            await conn.execute("ROLLBACK")
+        except BaseException:
+            # rollback 실패도 swallow — 원본 예외 보존이 우선.
+            pass
+
     async def execute(self, sql: str, params: tuple = ()) -> None:
-        """INSERT/UPDATE/DELETE 실행."""
+        """INSERT/UPDATE/DELETE 실행.
+
+        현재 태스크가 트랜잭션 owner 면 lock 없이 인라인 실행 + commit skip
+        (같은 태스크 트랜잭션 합류). 아니면 ``_write_lock`` 안에서 실행 후
+        독립 commit 한다(태스크 간 직렬화 — #2365).
+        """
         conn = self._get_writer()
-        await conn.execute(sql, params)
-        if not self._in_transaction:
-            await conn.commit()
+        if self._in_transaction:
+            await conn.execute(sql, params)
+            return
+        async with self._write_lock:
+            try:
+                await conn.execute(sql, params)
+                await conn.commit()
+            except BaseException:
+                # cancellation 등으로 commit 전에 중단되면 implicit 트랜잭션이
+                # 잔존해 다음 lock holder 의 BEGIN 을 깨뜨린다 — best-effort
+                # ROLLBACK 으로 정리(직전 suspension 없이 곧바로 진입).
+                await self._best_effort_rollback(conn)
+                raise
 
     async def fetch_one(self, sql: str, params: tuple = ()) -> dict | None:
         """단일 행 조회. dict(컬럼명 → 값) 반환."""
@@ -310,13 +370,24 @@ class Database:
         중인 writer 트랜잭션의 uncommitted row를 보지 못하므로, CAS 후
         ``RETURNING`` 으로 결과를 원자적으로 읽어야 하는 경로는 이 메서드를
         쓴다. ``_in_transaction`` 이 아니면 ``execute`` 와 동일하게 commit한다.
+
+        현재 태스크가 트랜잭션 owner 면 인라인 실행 + commit skip(합류). 아니면
+        ``_write_lock`` 안에서 실행 후 독립 commit 한다(태스크 간 직렬화 — #2365).
         """
         conn = self._get_writer()
-        async with conn.execute(sql, params) as cursor:
-            row = await cursor.fetchone()
-            result = dict(row) if row else None
-        if not self._in_transaction:
-            await conn.commit()
+        if self._in_transaction:
+            async with conn.execute(sql, params) as cursor:
+                row = await cursor.fetchone()
+                return dict(row) if row else None
+        async with self._write_lock:
+            try:
+                async with conn.execute(sql, params) as cursor:
+                    row = await cursor.fetchone()
+                    result = dict(row) if row else None
+                await conn.commit()
+            except BaseException:
+                await self._best_effort_rollback(conn)
+                raise
         return result
 
     async def execute_fetch_all(self, sql: str, params: tuple = ()) -> list[dict]:
@@ -328,13 +399,24 @@ class Database:
         연결을 쓰는 ``fetch_all`` 은 진행 중인 writer 트랜잭션의 uncommitted row 를
         보지 못하므로, 영향 행 집합을 RETURNING 으로 받아야 하는 경로는 이 메서드를
         쓴다. ``_in_transaction`` 이 아니면 ``execute`` 와 동일하게 commit한다.
+
+        현재 태스크가 트랜잭션 owner 면 인라인 실행 + commit skip(합류). 아니면
+        ``_write_lock`` 안에서 실행 후 독립 commit 한다(태스크 간 직렬화 — #2365).
         """
         conn = self._get_writer()
-        async with conn.execute(sql, params) as cursor:
-            rows = await cursor.fetchall()
-            result = [dict(row) for row in rows]
-        if not self._in_transaction:
-            await conn.commit()
+        if self._in_transaction:
+            async with conn.execute(sql, params) as cursor:
+                rows = await cursor.fetchall()
+                return [dict(row) for row in rows]
+        async with self._write_lock:
+            try:
+                async with conn.execute(sql, params) as cursor:
+                    rows = await cursor.fetchall()
+                    result = [dict(row) for row in rows]
+                await conn.commit()
+            except BaseException:
+                await self._best_effort_rollback(conn)
+                raise
         return result
 
     async def fetch_all(self, sql: str, params: tuple = ()) -> list[dict]:
@@ -345,35 +427,79 @@ class Database:
             return [dict(row) for row in rows]
 
     async def execute_script(self, sql: str) -> None:
-        """DDL 스크립트 실행 (테이블 생성 등)."""
+        """DDL 스크립트 실행 (schema/lifecycle 전용 — 테이블 생성 등).
+
+        **트랜잭션 안에서 호출 금지**: Python ``executescript`` 는 실행 전에
+        열린 트랜잭션을 암묵 COMMIT 하므로, ``transaction()`` owner 태스크가
+        호출하면 진행 중인 트랜잭션을 의도치 않게 커밋해 원자성을 깨뜨린다.
+        owner 태스크 호출은 ``RuntimeError`` 로 차단한다(#2365). schema 부트
+        스트랩/마이그레이션은 트랜잭션 밖에서만 호출한다 — ``db/migrations.py``
+        모듈 docstring 의 작성 규칙 참조.
+
+        non-owner(트랜잭션 밖) 호출은 ``_write_lock`` 안에서 실행한다(태스크 간
+        직렬화). ``executescript`` 자체가 암묵 COMMIT 으로 끝나므로 별도
+        ``conn.commit()`` 는 하지 않는다(기존 시맨틱 유지).
+        """
+        if self._in_transaction:
+            raise RuntimeError(
+                "트랜잭션 안에서는 execute_script 를 호출할 수 없습니다 "
+                "(executescript 의 암묵 COMMIT 이 열린 트랜잭션을 깨뜨립니다)"
+            )
         conn = self._get_writer()
-        await conn.executescript(sql)
+        async with self._write_lock:
+            await conn.executescript(sql)
 
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator["Database"]:
         """트랜잭션 컨텍스트 매니저.
+
+        ``_write_lock`` 안에서 현재 태스크를 ``_txn_owner`` 로 등록하고
+        ``BEGIN`` → yield → ``COMMIT`` 한다. owner 태스크의 ``execute*()`` 만
+        commit 을 skip 하고 트랜잭션에 합류하며, 다른 태스크의 writer 쓰기는
+        lock 에서 대기해 직렬화된다(#2365).
 
         asyncio.CancelledError / KeyboardInterrupt / SystemExit 포함 모든
         BaseException 경로에서 ROLLBACK을 시도한 뒤 원본 예외를 재전파한다.
         ROLLBACK 자체 실패는 swallow하여 원본 예외(특히 CancelledError) 보존을
         우선한다.
 
-        nested transaction은 지원하지 않는다. savepoint는 본 구현 범위 외.
+        cancellation-safety invariant(#2365): cleanup ROLLBACK 은 ``except
+        BaseException`` 진입 **직후 suspension 없이** 곧바로 ``await
+        conn.execute("ROLLBACK")`` 에 도달한다. asyncio cancellation 은
+        suspension point 에서만 전달되고, aiosqlite ``Connection.execute`` 는
+        첫 suspension 이전 동기 구간에서 SQL 을 worker FIFO 에 ``put_nowait``
+        하므로, ``COMMIT`` await 이 cancel 돼도 ROLLBACK 은 enqueue 되어 worker
+        FIFO 직렬성에 의해 다음 lock holder 의 SQL 보다 먼저 settle 된다.
+        ``BEGIN`` 도 "await 문 실행 시작 = enqueue 보장" 으로 취급해, cancellation
+        -during-BEGIN 에서도 cleanup ROLLBACK 을 **무조건 시도**한다(``begun``
+        플래그로 건너뛰는 패턴 금지, ``asyncio.shield`` 미사용).
+
+        nested transaction은 지원하지 않는다(같은 태스크 재진입은 lock 획득
+        **전** RuntimeError 로 차단 — 재획득 deadlock 방지). savepoint는 본
+        구현 범위 외.
         """
-        if self._in_transaction:
+        # 같은 태스크 재진입 = 중첩 트랜잭션. lock 획득 전에 검사해야 자기 자신이
+        # 보유한 lock 을 재획득하려다 deadlock 하는 일을 막는다.
+        if self._txn_owner is asyncio.current_task():
             raise RuntimeError("중첩 트랜잭션은 지원하지 않습니다")
         conn = self._get_writer()
-        self._in_transaction = True
-        try:
-            await conn.execute("BEGIN")
-            yield self
-            await conn.execute("COMMIT")
-        except BaseException:
+        async with self._write_lock:
+            self._txn_owner = asyncio.current_task()
             try:
-                await conn.execute("ROLLBACK")
+                await conn.execute("BEGIN")
+                yield self
+                # COMMIT 결과를 관찰한 뒤 정상 반환한다(enqueue 만 하고 결과를
+                # 버리지 않는다 — r2-①). 비취소 예외/취소 모두 아래 except 로.
+                await conn.execute("COMMIT")
             except BaseException:
-                # rollback 실패도 swallow — 원본 예외 보존이 우선
-                pass
-            raise
-        finally:
-            self._in_transaction = False
+                # cancellation 포함 모든 경로에서 cleanup ROLLBACK 을 무조건
+                # 시도한다 — 진입 직후 suspension 없이 곧바로 ROLLBACK await
+                # 에 도달한다(직전 cancellation-safety invariant 참조).
+                try:
+                    await conn.execute("ROLLBACK")
+                except BaseException:
+                    # rollback 실패도 swallow — 원본 예외 보존이 우선
+                    pass
+                raise
+            finally:
+                self._txn_owner = None

--- a/src/ante/db/migrations.py
+++ b/src/ante/db/migrations.py
@@ -2,6 +2,18 @@
 
 schema_version 테이블을 관리하며, 등록된 마이그레이션을 순차 실행한다.
 DB 마이그레이션과 Parquet 데이터 마이그레이션을 모두 지원한다.
+
+마이그레이션 작성 규칙 (#2365)
+------------------------------
+각 마이그레이션은 ``run_migrations`` 의 ``async with db.transaction():`` 블록
+안에서 실행되어 schema_version INSERT 와 원자 커밋된다. **마이그레이션 본문에서
+``Database.execute_script`` 를 호출하지 않는다** — Python ``executescript`` 는
+실행 전에 열린 트랜잭션을 암묵 COMMIT 하므로 진행 중인 마이그레이션 트랜잭션을
+의도치 않게 커밋해 원자성을 깨뜨린다(트랜잭션 owner 태스크의 ``execute_script``
+호출은 ``Database`` 가 ``RuntimeError`` 로 차단한다). DDL 은 트랜잭션 안에서
+``db.execute(...)`` 로 문장 단위로 실행한다(상세: ``docs/specs/core/core.md`` Database
+동시성·트랜잭션 invariant). schema 부트스트랩처럼 ``execute_script`` 가 필요한
+초기화는 트랜잭션 밖에서 수행한다.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -548,3 +548,262 @@ async def test_read_only_connect_failure_drains_worker_thread(tmp_path):
 
     leaked = set(_live_worker_threads()) - before
     assert not leaked, f"ro connect 실패 후 worker thread 누수: {leaked} (#1965)"
+
+
+# --- writer 태스크 간 직렬화 + 트랜잭션 owner 추적 (#2365) ---
+#
+# 같은 writer 연결을 여러 asyncio 태스크가 공유할 때, ``execute*()`` 의
+# implicit BEGIN(``conn.execute(sql)``)과 ``conn.commit()`` 사이 await 경계에서
+# 태스크가 전환되면, 다른 태스크의 ``transaction()`` 이 이미 열린 SQLite
+# 트랜잭션 위에서 ``BEGIN`` 을 실행해 ``cannot start a transaction within a
+# transaction`` 으로 실패한다(race A). 역방향(race B)에서는 standalone
+# ``execute()`` 가 진행 중인 트랜잭션에 합류해 무관한 쓰기가 rollback 으로
+# 소실된다. 아래 테스트는 commit 지점을 ``asyncio.Event`` barrier 로 결정적으로
+# 고정해 두 race 를 재현한다(stress 비사용).
+
+
+def _install_commit_barrier(db):
+    """writer 연결의 ``commit()`` 을 asyncio.Event barrier 로 가로챈다.
+
+    반환된 ``released`` Event 를 set 하기 전까지 ``commit()`` 호출은
+    ``reached`` Event 를 set 한 뒤 대기한다. 이로써 자동커밋 ``execute()`` 를
+    "``execute`` 완료 후 ``commit`` 직전" 윈도우에 결정적으로 고정할 수 있다.
+    원래 ``commit`` 은 ``released`` 후 정상 실행된다.
+    """
+    writer = db._get_writer()
+    real_commit = writer.commit
+    reached = asyncio.Event()
+    released = asyncio.Event()
+
+    async def gated_commit(*args, **kwargs):
+        reached.set()
+        await released.wait()
+        return await real_commit(*args, **kwargs)
+
+    patcher = patch.object(writer, "commit", side_effect=gated_commit)
+    patcher.start()
+    return reached, released, patcher
+
+
+async def test_concurrent_autocommit_then_transaction_race_a(db):
+    """race A: 태스크1 자동커밋 write 가 commit 직전 고정된 윈도우에서 태스크2가
+    ``transaction()`` 을 진입해도 중첩 트랜잭션 오류 없이 성공하고, 태스크1의
+    write 도 보존된다.
+
+    수정 전(main): 태스크2 ``transaction()`` 의 ``BEGIN`` 이 태스크1이 연
+    implicit 트랜잭션 위에서 실행돼 ``sqlite3.OperationalError: cannot start a
+    transaction within a transaction`` (a 실패), 그리고 ``transaction()`` 의
+    BaseException ROLLBACK 이 태스크1의 implicit write 를 되돌려 소실(b 실패) →
+    둘 다 RED.
+    """
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    reached, released, patcher = _install_commit_barrier(db)
+    try:
+        # 태스크1: 자동커밋 INSERT — execute 완료 후 commit 직전에서 고정된다.
+        task1 = asyncio.create_task(
+            db.execute("INSERT INTO t (id, val) VALUES (1, 'task1')")
+        )
+        # 태스크1 이 commit barrier 에 도달할 때까지 대기.
+        await asyncio.wait_for(reached.wait(), timeout=5.0)
+
+        # 윈도우 안에서 태스크2 가 transaction() 진입 (내부 write 포함).
+        async def task2_body():
+            async with db.transaction():
+                await db.execute("INSERT INTO t (id, val) VALUES (2, 'task2')")
+
+        task2 = asyncio.create_task(task2_body())
+
+        # 태스크2 가 lock 대기(또는 실패)에 도달할 시간을 준 뒤 barrier 해제.
+        await asyncio.sleep(0.05)
+        released.set()
+
+        # (a) 태스크2 트랜잭션이 예외 없이 성공해야 한다.
+        await asyncio.wait_for(task2, timeout=5.0)
+        await asyncio.wait_for(task1, timeout=5.0)
+    finally:
+        patcher.stop()
+
+    # (a) 태스크2 행 커밋 + (b) 태스크1 write 보존.
+    rows = await db.fetch_all("SELECT id, val FROM t ORDER BY id")
+    assert [(r["id"], r["val"]) for r in rows] == [(1, "task1"), (2, "task2")]
+
+
+async def test_concurrent_transaction_then_autocommit_race_b(db):
+    """race B: 태스크1 ``transaction()`` 진행 중 태스크2 standalone ``execute()`` 가
+    트랜잭션에 합류하지 않고 독립 커밋되며, 태스크1 rollback 시 태스크1 행만
+    소실된다.
+
+    수정 전(main): 태스크2 ``execute()`` 가 ``_in_transaction`` 플래그를 보고
+    commit 을 skip → 태스크1 트랜잭션에 합류 → 태스크1 rollback 으로 태스크2
+    행까지 소실(RED).
+    """
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    task2_may_start = asyncio.Event()
+    task2_inserted = asyncio.Event()
+
+    async def task1_body():
+        with pytest.raises(ValueError, match="의도적 예외"):
+            async with db.transaction():
+                await db.execute("INSERT INTO t (id, val) VALUES (1, 'task1')")
+                # 태스크2 가 standalone execute 를 시도하도록 양보.
+                task2_may_start.set()
+                await asyncio.wait_for(task2_inserted.wait(), timeout=5.0)
+                raise ValueError("의도적 예외")
+
+    async def task2_body():
+        await asyncio.wait_for(task2_may_start.wait(), timeout=5.0)
+        # owner 태스크가 아니므로 transaction 합류 금지 → lock 대기 후 독립 커밋.
+        # owner 트랜잭션이 lock 을 쥐고 있으므로 task1 이 commit/rollback 으로
+        # lock 을 놓을 때까지 여기서 대기한다(교착 없음 — task1 은 task2 완료를
+        # 직접 await 하지 않고 Event 로만 동기화).
+        insert = asyncio.create_task(
+            db.execute("INSERT INTO t (id, val) VALUES (2, 'task2')")
+        )
+        # task1 이 rollback 으로 진행하도록 신호.
+        task2_inserted.set()
+        await asyncio.wait_for(insert, timeout=5.0)
+
+    await asyncio.gather(task1_body(), task2_body())
+
+    # 태스크2 행만 커밋 유지, 태스크1 행은 rollback 으로 소실.
+    rows = await db.fetch_all("SELECT id, val FROM t ORDER BY id")
+    assert [(r["id"], r["val"]) for r in rows] == [(2, "task2")]
+
+
+async def test_autocommit_cancel_leaves_no_open_transaction(db):
+    """자동커밋 ``execute()`` 가 commit 대기 중 cancel 돼도 implicit 트랜잭션이
+    잔존하지 않아 이후 ``transaction()`` 이 정상 동작한다(#2365)."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    reached, released, patcher = _install_commit_barrier(db)
+    try:
+        task1 = asyncio.create_task(
+            db.execute("INSERT INTO t (id, val) VALUES (1, 'task1')")
+        )
+        await asyncio.wait_for(reached.wait(), timeout=5.0)
+        # execute 완료 후 commit 대기 중에 cancel.
+        task1.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task1
+    finally:
+        # barrier 를 풀어 cleanup ROLLBACK(또는 commit) 이 진행되도록 한다.
+        released.set()
+        patcher.stop()
+
+    # implicit 트랜잭션 잔존이 없어야 — 새 transaction() 이 BEGIN 에서 실패하면 안 됨.
+    async with db.transaction():
+        await db.execute("INSERT INTO t (id, val) VALUES (2, 'after')")
+    rows = await db.fetch_all("SELECT id, val FROM t ORDER BY id")
+    assert [(r["id"], r["val"]) for r in rows] == [(2, "after")]
+
+
+async def test_double_cancel_during_commit_and_rollback_releases_lock(db):
+    """``transaction()`` COMMIT 대기 중 cancel → cleanup ROLLBACK 대기 중 재-cancel
+    해도 lock 이 해제되고 다음 ``transaction()``/``execute()`` 가 정상 동작한다
+    (enqueue-before-release invariant 검증, #2365 r2-②)."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    writer = db._get_writer()
+    real_execute = writer.execute
+    commit_reached = asyncio.Event()
+    rollback_reached = asyncio.Event()
+    release_commit = asyncio.Event()
+    release_rollback = asyncio.Event()
+
+    async def gated_execute(sql, *args, **kwargs):
+        upper = sql.strip().upper()
+        if upper.startswith("COMMIT"):
+            # COMMIT 은 enqueue 전 barrier — 1차 cancel 이 COMMIT 결과 대기를
+            # abandon 하게 한다(자동커밋 race 와 동형).
+            commit_reached.set()
+            await release_commit.wait()
+            return await real_execute(sql, *args, **kwargs)
+        if upper.startswith("ROLLBACK"):
+            # enqueue-before-release invariant 충실 재현: cleanup ROLLBACK 은
+            # real_execute 로 **먼저 실행(enqueue+settle)** 한 뒤 barrier 로
+            # 추가 대기한다. 그래야 2차 cancel 이 "ROLLBACK 이 worker FIFO 에
+            # 들어가 settle 된 후 결과 후처리 대기만 abandon" 하는 실제 코드의
+            # invariant 와 동형이 된다(release 전에 cancel 해 enqueue 자체를
+            # 막으면 프록시가 실제 조건을 왜곡 — 금지).
+            result = await real_execute(sql, *args, **kwargs)
+            rollback_reached.set()
+            await release_rollback.wait()
+            return result
+        return await real_execute(sql, *args, **kwargs)
+
+    async def txn_body():
+        async with db.transaction():
+            await db.execute("INSERT INTO t (id, val) VALUES (1, 'x')")
+
+    with patch.object(writer, "execute", side_effect=gated_execute):
+        task = asyncio.create_task(txn_body())
+        # COMMIT 대기 진입까지 대기 후 1차 cancel.
+        await asyncio.wait_for(commit_reached.wait(), timeout=5.0)
+        task.cancel()
+        # cancel 이 COMMIT await 에 전달돼 cleanup ROLLBACK 으로 진입할 시간을 준다.
+        release_commit.set()
+        # cleanup ROLLBACK 대기 진입까지 대기 후 2차 cancel.
+        await asyncio.wait_for(rollback_reached.wait(), timeout=5.0)
+        task.cancel()
+        release_rollback.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    # lock 이 해제되어 다음 트랜잭션/자동커밋이 정상 동작해야 한다.
+    async with db.transaction():
+        await db.execute("INSERT INTO t (id, val) VALUES (2, 'next')")
+    await db.execute("INSERT INTO t (id, val) VALUES (3, 'auto')")
+    rows = await db.fetch_all("SELECT id FROM t ORDER BY id")
+    assert [r["id"] for r in rows] == [2, 3]
+
+
+async def test_child_task_execute_does_not_join_owner_transaction(db):
+    """owner ``transaction()`` 블록 안에서 생성된 child task 의 ``execute()`` 는
+    owner 트랜잭션에 합류하지 않고 lock 대기 → owner commit 후 독립 커밋된다.
+
+    owner 는 child 완료를 블록 안에서 직접 await 하지 않는다(교착 경로는 문서
+    invariant 로 금지). owner 가 commit 으로 lock 을 놓은 뒤 child 가 커밋된다.
+    """
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    child: asyncio.Task | None = None
+
+    async with db.transaction():
+        await db.execute("INSERT INTO t (id, val) VALUES (1, 'owner')")
+        # child task 는 별도 태스크 → owner 가 아니므로 lock 대기.
+        child = asyncio.create_task(
+            db.execute("INSERT INTO t (id, val) VALUES (2, 'child')")
+        )
+        # owner 는 child 완료를 직접 await 하지 않는다(교착 방지). child 가 lock
+        # 대기 상태에 도달하도록 잠깐 양보만 한다.
+        await asyncio.sleep(0.05)
+        # child 는 아직 commit 되지 않았어야 한다(owner 가 lock 보유).
+        assert not child.done()
+
+    # owner commit 으로 lock 해제 → child 가 독립 커밋.
+    await asyncio.wait_for(child, timeout=5.0)
+    rows = await db.fetch_all("SELECT id, val FROM t ORDER BY id")
+    assert [(r["id"], r["val"]) for r in rows] == [(1, "owner"), (2, "child")]
+
+
+async def test_execute_script_inside_transaction_raises(db):
+    """``transaction()`` owner 태스크가 ``execute_script()`` 를 호출하면 RuntimeError.
+
+    Python ``executescript`` 의 암묵 COMMIT 이 열린 트랜잭션을 임의 커밋하는
+    사고를 차단한다(schema/lifecycle 전용).
+    """
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY);")
+    async with db.transaction():
+        with pytest.raises(RuntimeError, match="트랜잭션 안에서는"):
+            await db.execute_script("CREATE TABLE t2 (id INTEGER)")
+
+
+async def test_execute_script_outside_transaction_still_works(db):
+    """트랜잭션 밖에서는 ``execute_script()`` 가 기존대로 동작한다."""
+    await db.execute_script("CREATE TABLE t3 (id INTEGER PRIMARY KEY, v TEXT);")
+    await db.execute("INSERT INTO t3 (v) VALUES ('ok')")
+    row = await db.fetch_one("SELECT v FROM t3")
+    assert row is not None
+    assert row["v"] == "ok"

--- a/tests/unit/test_treasury_fill_dedup.py
+++ b/tests/unit/test_treasury_fill_dedup.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -407,3 +408,110 @@ class TestTreasuryEmptyKeyNotDeduped:
             "SELECT * FROM treasury_fill_dedup WHERE fill_dedup_key = ''"
         )
         assert empty_rows == []
+
+
+class TestTreasuryFillOutboxDrainUnderConcurrentWrite:
+    """fill 경로 통합 회귀: 실제 ``Treasury._on_order_filled`` EventBus 구독 +
+    ``FillOutboxPublisher.catch_up_once()`` drain 이, 같은 writer 연결을 공유하는
+    백그라운드 자동커밋 write 와 동시에 진행돼도 중첩 트랜잭션 오류 없이 정산을
+    완료한다(#2365).
+
+    EventBus 가 핸들러 예외를 swallow 하므로 예외를 기대하지 않고, drain 후
+    상태를 직접 검증한다: ``treasury_fill_dedup`` row 수 = fill 수, budget
+    정산 반영, ``fill_outbox.published=1``.
+    """
+
+    async def test_fill_drain_settles_under_concurrent_autocommit(
+        self, treasury, order_tracker, db, eventbus
+    ):
+        from ante.trade.fill_outbox import (
+            FillOutbox,
+            FillOutboxPublisher,
+            make_fill_dedup_key,
+        )
+
+        outbox = FillOutbox(db)
+        await outbox.initialize()
+        publisher = FillOutboxPublisher(outbox=outbox, eventbus=eventbus)
+
+        # 보조 테이블(백그라운드 자동커밋 write 대상).
+        await db.execute_script("CREATE TABLE bg (id INTEGER PRIMARY KEY, val TEXT);")
+
+        # buy fill 예산/예약 준비.
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_100.0)
+        await _seed_tracker(
+            order_tracker, order_id="ord1", bot_id="bot1", ordered_qty=10.0
+        )
+        await order_tracker.record_fill("ord1", 10.0, 50_000.0)
+
+        key = make_fill_dedup_key("ord1", 10.0)
+        payload = {
+            "account_id": ACCOUNT_ID,
+            "order_id": "ord1",
+            "broker_order_id": "bk-ord1",
+            "bot_id": "bot1",
+            "strategy_id": "s1",
+            "symbol": "005930",
+            "side": "buy",
+            "quantity": 10.0,
+            "price": 50_000.0,
+            "commission": 75.0,
+            "order_type": "limit",
+            "fill_dedup_key": key,
+        }
+        # outbox 에 fill row enqueue (트랜잭션 밖 자동커밋).
+        await outbox.enqueue(fill_dedup_key=key, payload=payload)
+
+        # 백그라운드 자동커밋 write 를 commit 직전에 고정해 race 윈도우를 만든다.
+        writer = db._get_writer()
+        real_commit = writer.commit
+        reached = asyncio.Event()
+        released = asyncio.Event()
+        first = {"gated": False}
+
+        async def gated_commit(*args, **kwargs):
+            # 첫 commit(백그라운드 write)만 barrier 로 고정한다.
+            if not first["gated"]:
+                first["gated"] = True
+                reached.set()
+                await released.wait()
+            return await real_commit(*args, **kwargs)
+
+        with patch.object(writer, "commit", side_effect=gated_commit):
+            bg = asyncio.create_task(
+                db.execute("INSERT INTO bg (id, val) VALUES (1, 'bg')")
+            )
+            await asyncio.wait_for(reached.wait(), timeout=5.0)
+
+            # 윈도우 안에서 outbox drain → Treasury._on_order_filled 가
+            # transaction() 진입(수정 전: 중첩 트랜잭션 오류로 정산 누락).
+            drain = asyncio.create_task(publisher.catch_up_once())
+            await asyncio.sleep(0.05)
+            released.set()
+
+            published_count = await asyncio.wait_for(drain, timeout=5.0)
+            await asyncio.wait_for(bg, timeout=5.0)
+
+        # 발행 1건.
+        assert published_count == 1
+
+        # dedup row 수 = fill 수(1).
+        assert await _fill_dedup_count(db, key) == 1
+        # budget 정산 반영(spent = 500,000 + 75).
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.spent == pytest.approx(500_075.0)
+        assert budget.reserved == pytest.approx(0.0)
+        _assert_invariant(treasury, "bot1")
+        # fill tx 1건.
+        assert await _tx_fill_count(db, "bot1") == 1
+        # outbox published=1.
+        rows = await db.fetch_all(
+            "SELECT published FROM fill_outbox WHERE fill_dedup_key = ?", (key,)
+        )
+        assert len(rows) == 1
+        assert rows[0]["published"] == 1
+        # 백그라운드 write 도 보존.
+        bg_rows = await db.fetch_all("SELECT id, val FROM bg")
+        assert [(r["id"], r["val"]) for r in bg_rows] == [(1, "bg")]


### PR DESCRIPTION
Closes #2365

## Summary
- `Database`에 `_write_lock`(asyncio.Lock) + `_txn_owner`(트랜잭션 소유 태스크) 추적을 추가해 여러 asyncio 태스크가 공유하는 writer connection의 두 가지 race를 클래스 단위로 제거:
  - **race A(관측)**: 자동커밋 쓰기의 implicit BEGIN↔commit 사이 await 윈도우에서 다른 태스크의 `transaction()` BEGIN이 `cannot start a transaction within a transaction`으로 실패(stage/KIS 모의 fill-heavy에서 Treasury 정산 2/2 누락) + BEGIN-실패 ROLLBACK이 타 태스크 write를 소실시키는 추가 face
  - **race B(역방향)**: 타 태스크 트랜잭션 진행 중 자동커밋 쓰기가 플래그만 보고 commit skip → 남의 트랜잭션 합류, rollback 시 무관한 쓰기 소실
- non-owner 자동커밋 경로에 BaseException best-effort ROLLBACK cleanup(취소 시 implicit txn 잔존 차단), COMMIT 결과 관찰 후 분기, cleanup 경로 "직전 suspension 없음" invariant(asyncio cancellation은 suspension point 한정 + aiosqlite 동기 구간 put_nowait로 enqueue 구조 보장)
- `execute_script`는 트랜잭션 owner 호출 시 RuntimeError 가드(executescript 암묵 COMMIT 사고 차단), migration 작성 규칙 docstring 명시
- `docs/specs/core/core.md`에 Database 동시성·cancellation invariant 추가
- 회귀 테스트 7종(전부 결정적 barrier, stress 비사용): race A/B, 자동커밋 cancellation, 이중-cancel, child-task 비합류, execute_script 가드, fill 경로 통합(실제 `Treasury._on_order_filled` 구독 + outbox drain + 동시 writer — `treasury_fill_dedup`/budget/published 상태 직접 검증)

## Review Trail
- Codex Plan Review: r1 revise-plan → r2 revise-plan → r3 **approve-implement** (이슈 본문 Implementation Plan r3 = canonical)
- Codex 브랜치 리뷰: **PASS** (attempt 1, head c7dfce1) — 차단 이슈 없음
- known-limitation(normative): cancellation-during-COMMIT ack 모호성은 main 기존재 별개 invariant — outbox at-least-once + dedup 멱등으로 재기동 수렴, 후속 이슈 후보로 분리

## Test Plan
- `pytest tests/unit/test_database.py tests/unit/test_treasury_fill_dedup.py` (41 passed)
- 인접 소비자: `pytest tests/unit/test_fill_outbox.py tests/unit/test_fill_applier.py tests/unit/test_fill_scheduler.py tests/unit/test_order_tracker.py tests/unit/test_treasury.py` (249 passed)
- `pytest` 전체 (7241 passed, 2 skipped)
- `ruff check src tests` / `ruff format --check src tests` / `mypy src/` 전체 PASS
- main 기준 RED 재현 확인: race A(이슈 traceback 동일 OperationalError), race B(타 태스크 행 소실), 통합(`treasury_fill_dedup=0`) 등 6 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)