### PR TITLE
fix(cli): #2367 trade list --to 날짜를 end-of-day 포함 경계로 — 당일 거래 조회 빈 결과 수정

### DIFF
--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -394,6 +394,17 @@ ante trade info <trade_id>         # 거래 상세
 exit code 1로 거부한다(빈 결과 반환 금지). 한쪽만 지정·둘 다 미지정·동일
 날짜는 정상 처리한다.
 
+`--from`은 시작일 `00:00:00`부터, `--to`는 종료일 당일 끝(end-of-day,
+`23:59:59.999999` 포함)까지를 경계로 조회한다. 따라서 `--from 2026-06-12
+--to 2026-06-12`처럼 같은 날짜를 지정하면 그 날 발생한 거래가 모두 포함된다
+(`treasury transactions`·`bot logs`·`audit list`의 날짜 필터 경계 동작과 일치).
+
+> known-limitation: 대사 보정(`adjustment`) 행은 `timestamp`가 공백 구분
+> 포맷(`YYYY-MM-DD HH:MM:SS`)으로 저장되어, `--from`을 지정하면 같은 날 보정
+> 행이 시작일 경계(`00:00:00`)에서 누락될 수 있다. 본 이슈 대상인 실거래
+> 행(ISO 8601 UTC 포맷)은 영향받지 않으며, 보정 행의 `--from` 경계 해소는
+> 저장 포맷 정규화 follow-up으로 분리한다.
+
 ### `ante strategy` — 전략 관리
 
 ```bash

--- a/src/ante/cli/commands/trade.py
+++ b/src/ante/cli/commands/trade.py
@@ -6,7 +6,7 @@ import asyncio
 import sqlite3
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import UTC, date, datetime, time
 from typing import TYPE_CHECKING
 
 import click
@@ -116,8 +116,28 @@ def trade_list(
     async def _run_list() -> list[dict]:
         # ``_create_trade_service`` async context manager lifecycle.
         async with _create_trade_service(ctx=ctx) as (service, _):
+            # ``--from`` 은 naive ``T00:00:00`` 하한을 그대로 유지한다(비변경).
+            #   - aware fd 로 바꾸면, 자정 정각에 저장된 naive isoformat 행
+            #     (``'D'`` prefix-shorter)이 lexical 비교에서 의도치 않게
+            #     제외되는 반례가 생긴다.
+            #   - 공백 구분 포맷(``save_adjustment`` 의 ``'D HH:MM:SS'``)의 당일
+            #     ``--from`` 경계 제외(``' '(0x20) < 'T'(0x54)``)는 main 기존재
+            #     known-limitation 이며 본 수정은 도입·악화하지 않는다
+            #     (#2367 Non-Goals — 저장 포맷 정규화 follow-up).
             fd = datetime.fromisoformat(from_date) if from_date else None
-            td = datetime.fromisoformat(to_date) if to_date else None
+            # ``--to D`` 는 date-only 일 때 당일 end-of-day(``23:59:59.999999``)
+            # UTC-aware 상한으로 변환한다. date-only 를 ``fromisoformat`` 으로
+            # 그대로 넘기면 ``T00:00:00`` 이 되어 당일 장중 거래가
+            # ``timestamp <= ?`` 에서 전부 제외된다(#2367). ``bot.py:941``
+            # (``_parse_log_datetime`` end-of-day)의 ``time.max, tzinfo=UTC``
+            # 선례를 1:1 미러한다. isoformat aware 저장(당일 마지막 microsecond
+            # equal 포함, 다음날 제외) / 공백 포맷 저장(``' ' < 'T'`` 포함, 다음날
+            # 날짜 prefix 제외) 두 포맷 모두 lexical 상한이 정확하다.
+            td = (
+                datetime.combine(date.fromisoformat(to_date), time.max, tzinfo=UTC)
+                if to_date
+                else None
+            )
             trades = await service.get_trades(
                 bot_id=bot_id,
                 strategy_id=strategy_id,

--- a/tests/unit/test_cli_inverted_date_range.py
+++ b/tests/unit/test_cli_inverted_date_range.py
@@ -28,6 +28,7 @@ Non-Goals: web audit/treasury sibling 위험(별도 follow-up), 4곳 date
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 from unittest.mock import patch
@@ -458,3 +459,283 @@ class TestFormatInvalidPathPreserved:
         result = runner.invoke(cli, args)
         assert result.exit_code != 0
         assert "INVALID_DATE_RANGE" not in result.output
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #2367: ``trade list --to <날짜>`` end-of-day 경계 (실제 DB seed + recorder
+# SQL 실경로). ``--to D`` 가 ``T00:00:00`` (date-only ``fromisoformat``) 으로
+# 들어가 당일 장중 거래가 ``timestamp <= ?`` 에서 전부 제외되던 회귀를 닫는다.
+#
+# 본 클래스는 위 inverted-range 매트릭스의 ``mock service`` 패턴과 달리
+# **실제 ``Database`` seed + 실제 ``TradeService.get_trades`` SQL 실경로** 를
+# 거친다 (mocked service 금지 — 경계 lexical 비교가 SQL 단계에서 검증돼야
+# 한다). ``--config-dir <tmp>`` → ``get_db_path`` → ``<tmp>/db/ante.db`` 를
+# 시드 DB 와 동일 경로로 가리키게 해 CLI 가 시드된 DB 를 그대로 읽는다.
+
+
+async def _seed_trades_db(db_path: str, rows: list[dict]) -> None:
+    """실제 ``Database`` 로 ``<tmp>/db/ante.db`` 에 trades 행을 직접 seed.
+
+    ``TradeRecorder``/``PositionHistory`` 의 ``initialize()`` 로 schema 를
+    부트스트랩한 뒤, 각 행을 raw SQL 로 INSERT 한다. ``timestamp`` 는
+    호출자가 지정한 저장 문자열을 **그대로** 쓴다 (isoformat aware,
+    공백 구분 포맷 등 저장 포맷별 lexical 경계를 그대로 검증하기 위함).
+    """
+    from ante.core.database import Database
+    from ante.trade.position import PositionHistory
+    from ante.trade.recorder import TradeRecorder
+
+    db = Database(db_path)
+    await db.connect()
+    try:
+        ph = PositionHistory(db)
+        await ph.initialize()
+        rec = TradeRecorder(db, ph)
+        await rec.initialize()
+        for row in rows:
+            await db.execute(
+                "INSERT INTO trades "
+                "(trade_id, bot_id, strategy_id, symbol, side, quantity, price, "
+                " status, order_type, reason, commission, timestamp, order_id, "
+                " account_id, currency, exchange) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    row["trade_id"],
+                    row.get("bot_id", "bot1"),
+                    row.get("strategy_id", "s1"),
+                    row.get("symbol", "005930"),
+                    row.get("side", "buy"),
+                    row.get("quantity", 10.0),
+                    row.get("price", 50000.0),
+                    row.get("status", "filled"),
+                    row.get("order_type", "market"),
+                    row.get("reason", "seed"),
+                    row.get("commission", 0.0),
+                    row["timestamp"],
+                    row.get("order_id", row["trade_id"]),
+                    row.get("account_id", "acc-real"),
+                    row.get("currency", "KRW"),
+                    row.get("exchange", "KRX"),
+                ),
+            )
+    finally:
+        await db.close()
+
+
+def _trade_list_ids(runner, tmp_path, *cli_args: str) -> list[str]:
+    """``trade list --format json`` 을 실제 시드 DB 에 대해 실행, trade_id 집합 반환.
+
+    ``--config-dir <tmp_path>`` 로 시드 DB(``<tmp_path>/db/ante.db``) 를
+    가리키고, 실제 ``TradeService.get_trades`` SQL 경로를 거친다 (mock 없음).
+    CliRunner 가 동기 경계에서 내부적으로 ``asyncio.run`` 을 호출하므로 본
+    헬퍼는 await 없이 동기로 호출된다.
+    """
+    result = runner.invoke(
+        cli,
+        [
+            "--config-dir",
+            str(tmp_path),
+            "--format",
+            "json",
+            "trade",
+            "list",
+            "--limit",
+            "50",
+            *cli_args,
+        ],
+    )
+    assert result.exit_code == 0, _stdout(result)
+    payload = json.loads(_stdout(result))
+    trades = payload.get("trades", [])
+    return [t["trade_id"] for t in trades]
+
+
+@pytest.fixture
+def _seed_db_path(tmp_path):
+    """``<tmp_path>/db/ante.db`` 경로 (디렉토리 보장)."""
+    db_dir = tmp_path / "db"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    return str(db_dir / "ante.db")
+
+
+class TestTradeListToEndOfDayBoundary:
+    """#2367: ``--to D`` 가 당일 end-of-day(``23:59:59.999999+00:00``) 포함 경계."""
+
+    def test_same_day_intraday_isoformat_row_returned(
+        self, runner, tmp_path, _seed_db_path
+    ):
+        """isoformat 장중 행(``2026-06-12T04:43:53+00:00``)이 동일-날짜 범위에 포함.
+
+        수정 전(main): ``--to 2026-06-12`` → ``T00:00:00`` 상한 → 장중 행이
+        ``timestamp <= ?`` 에서 제외돼 **빈 결과(RED)**. 수정 후: end-of-day
+        상한으로 포함(GREEN).
+        """
+        asyncio.run(
+            _seed_trades_db(
+                _seed_db_path,
+                [
+                    {
+                        "trade_id": "11111111-1111-1111-1111-111111111111",
+                        "timestamp": "2026-06-12T04:43:53+00:00",
+                    }
+                ],
+            )
+        )
+        ids = _trade_list_ids(
+            runner, tmp_path, "--from", "2026-06-12", "--to", "2026-06-12"
+        )
+        assert ids == ["11111111-1111-1111-1111-111111111111"], (
+            f"동일-날짜 범위에 장중 isoformat 행이 포함돼야 한다. ids={ids}"
+        )
+
+    def test_end_of_day_boundary_row_included(self, runner, tmp_path, _seed_db_path):
+        """당일 ``23:59:59.999999+00:00`` 행 포함 (naive ``time.max`` 반례).
+
+        ``--to`` 상한이 UTC-aware ``23:59:59.999999+00:00`` 여야 동일 포맷의
+        당일 마지막 microsecond 행이 equal 포함된다. 만약 상한이 naive
+        ``time.max`` (``...T23:59:59.999999`` tz 없음)였다면 aware 저장값과의
+        lexical 비교에서 제외되는 반례 — 본 케이스가 그 회귀를 고정한다.
+        """
+        asyncio.run(
+            _seed_trades_db(
+                _seed_db_path,
+                [
+                    {
+                        "trade_id": "22222222-2222-2222-2222-222222222222",
+                        "timestamp": "2026-06-12T23:59:59.999999+00:00",
+                    }
+                ],
+            )
+        )
+        ids = _trade_list_ids(
+            runner, tmp_path, "--from", "2026-06-12", "--to", "2026-06-12"
+        )
+        assert ids == ["22222222-2222-2222-2222-222222222222"], (
+            f"당일 end-of-day microsecond 경계 행이 포함돼야 한다. ids={ids}"
+        )
+
+    def test_next_day_midnight_row_excluded(self, runner, tmp_path, _seed_db_path):
+        """다음날 자정 ``2026-06-13T00:00:00+00:00`` 행은 ``--to 2026-06-12`` 제외."""
+        asyncio.run(
+            _seed_trades_db(
+                _seed_db_path,
+                [
+                    {
+                        "trade_id": "33333333-3333-3333-3333-333333333333",
+                        "timestamp": "2026-06-12T10:00:00+00:00",
+                    },
+                    {
+                        "trade_id": "44444444-4444-4444-4444-444444444444",
+                        "timestamp": "2026-06-13T00:00:00+00:00",
+                    },
+                ],
+            )
+        )
+        ids = _trade_list_ids(
+            runner, tmp_path, "--from", "2026-06-12", "--to", "2026-06-12"
+        )
+        assert ids == ["33333333-3333-3333-3333-333333333333"], (
+            f"다음날 자정 행은 제외, 당일 행만 포함돼야 한다. ids={ids}"
+        )
+
+    def test_blank_format_adjustment_row_included_in_to_only_query(
+        self, runner, tmp_path, _seed_db_path
+    ):
+        """공백 구분 포맷(adjustment 행)이 ``--to D``(from 미지정) 쿼리에 포함.
+
+        ``save_adjustment`` 는 SQLite ``datetime('now')`` 로 ``'YYYY-MM-DD
+        HH:MM:SS'`` (공백 구분) 포맷을 저장한다. 실호출은 wall-clock(UTC 자정
+        경계 비결정)이므로 **고정 ``'2026-06-12 09:30:00'`` 행을 직접 주입**
+        한다. ``--to 2026-06-12`` 상한(``...T23:59:59.999999+00:00``)과의
+        lexical 비교에서 ``' '(0x20) < 'T'(0x54)`` 이므로 param 보다 작아
+        포함된다.
+        """
+        asyncio.run(
+            _seed_trades_db(
+                _seed_db_path,
+                [
+                    {
+                        "trade_id": "55555555-5555-5555-5555-555555555555",
+                        "side": "adjustment",
+                        "status": "adjusted",
+                        "timestamp": "2026-06-12 09:30:00",
+                    }
+                ],
+            )
+        )
+        ids = _trade_list_ids(runner, tmp_path, "--to", "2026-06-12")
+        assert ids == ["55555555-5555-5555-5555-555555555555"], (
+            f"공백 포맷 당일 adjustment 행이 --to 쿼리에 포함돼야 한다. ids={ids}"
+        )
+
+    def test_blank_format_adjustment_row_excluded_when_from_specified(
+        self, runner, tmp_path, _seed_db_path
+    ):
+        """known-limitation 가드: 공백 포맷 행은 ``--from D`` 지정 시 제외(현재 동작).
+
+        ``--from 2026-06-12`` 는 naive ``T00:00:00`` 하한으로 들어가고, 공백
+        포맷 당일 행 ``'2026-06-12 09:30:00'`` 은 ``' '(0x20) < 'T'(0x54)`` 라
+        param 보다 작아 ``timestamp >= ?`` 에서 제외된다. 이는 main 기존재
+        known-limitation(이슈 본문 Non-Goals — 저장 포맷 정규화 follow-up)
+        이며, 본 수정이 도입·악화하지 않는다. 의도치 않은 변화를 감지하는
+        회귀 가드로 현재 동작을 고정한다.
+        """
+        asyncio.run(
+            _seed_trades_db(
+                _seed_db_path,
+                [
+                    {
+                        "trade_id": "66666666-6666-6666-6666-666666666666",
+                        "side": "adjustment",
+                        "status": "adjusted",
+                        "timestamp": "2026-06-12 09:30:00",
+                    }
+                ],
+            )
+        )
+        ids = _trade_list_ids(
+            runner, tmp_path, "--from", "2026-06-12", "--to", "2026-06-12"
+        )
+        assert ids == [], (
+            f"known-limitation: --from 지정 시 공백 포맷 당일 행은 제외. ids={ids}"
+        )
+
+    def test_from_only_returns_same_day_intraday(self, runner, tmp_path, _seed_db_path):
+        """``--from`` 만 지정 시 당일 장중 isoformat 행 반환(기존 동작 보존)."""
+        asyncio.run(
+            _seed_trades_db(
+                _seed_db_path,
+                [
+                    {
+                        "trade_id": "77777777-7777-7777-7777-777777777777",
+                        "timestamp": "2026-06-12T04:43:53+00:00",
+                    }
+                ],
+            )
+        )
+        ids = _trade_list_ids(runner, tmp_path, "--from", "2026-06-12")
+        assert ids == ["77777777-7777-7777-7777-777777777777"], (
+            f"--from-only 는 당일 장중 행을 반환해야 한다. ids={ids}"
+        )
+
+    def test_to_next_day_includes_same_day_intraday(
+        self, runner, tmp_path, _seed_db_path
+    ):
+        """``--to`` 를 다음날로 밀면 당일 장중 행 포함(기존 동작 보존)."""
+        asyncio.run(
+            _seed_trades_db(
+                _seed_db_path,
+                [
+                    {
+                        "trade_id": "88888888-8888-8888-8888-888888888888",
+                        "timestamp": "2026-06-12T04:43:53+00:00",
+                    }
+                ],
+            )
+        )
+        ids = _trade_list_ids(
+            runner, tmp_path, "--from", "2026-06-12", "--to", "2026-06-13"
+        )
+        assert ids == ["88888888-8888-8888-8888-888888888888"], (
+            f"--to 다음날 범위에 당일 장중 행이 포함돼야 한다. ids={ids}"
+        )


### PR DESCRIPTION
Closes #2367

## Summary
- `ante trade list --from D --to D`(같은 날짜)가 당일 거래가 있어도 빈 결과를 반환하던 문제 수정: `--to` date-only 값이 `datetime.fromisoformat`으로 `T00:00:00`이 되어 recorder SQL `timestamp <= ?`에서 장중 거래가 전부 제외됐음
- `--to` 변환을 `datetime.combine(date.fromisoformat(to_date), time.max, tzinfo=UTC)`(`...T23:59:59.999999+00:00`)로 수정 — `bot logs`(bot.py:941)의 검증된 동형 선례 1:1 미러. UTC-aware 상한은 isoformat aware 저장값(당일 마지막 microsecond 경계 포함)과 공백 구분 저장값(adjustment 행) 모두에서 lexical 비교가 정확함을 Codex Plan Review 3라운드로 검증
- `--from`은 비변경(naive 유지 — aware 전환 시 naive 저장값 자정 경계 반례). 공백 포맷 adjustment 행의 `--from` 당일 경계 제외는 main 기존재 known-limitation으로 spec 각주 명시, 저장 포맷 정규화 follow-up 분리
- `docs/specs/cli/03-commands.md`에 날짜 경계 시맨틱 명시(treasury transactions·bot logs·audit list와 일치)
- 실제 CliRunner + 실제 DB seed(recorder SQL 실경로) 경계 회귀 8케이스

## Review Trail
- Codex Plan Review: r1 revise-plan → r2 revise-plan → r3 **approve-implement** (이슈 본문 Implementation Plan r3 = canonical)
- Codex 브랜치 리뷰: **PASS** (attempt 1, head 259522d, base 196e05e4 rebase 후)
- known-limitation/follow-up(이슈 코멘트 기록): `save_adjustment`의 `datetime('now')` 공백 포맷 → isoformat UTC 정규화

## Test Plan
- `pytest tests/unit/test_trade.py tests/unit/test_cli_inverted_date_range.py tests/unit/test_trade_success_output_drift.py` (130 passed)
- `pytest` 전체 (7248 passed, 2 skipped)
- `ruff check` / `ruff format --check` / `mypy src/` 전체 PASS / generated 산출물 불변 확인
- main 기준 RED 재현: 당일 장중 행 빈 결과 + 당일 23:59:59.999999+00:00 경계 제외 확인 후 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)