### PR TITLE
fix(trade): #2371 trades.timestamp 단일 isoformat invariant — save_adjustment 정규화 + v005 마이그레이션

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -277,7 +277,8 @@ src/ante/
 │   │   ├── v001_baseline.py
 │   │   ├── v002_parquet_migration.py
 │   │   ├── v003_broker_config.py
-│   │   └── v004_strategy_status_simplify.py
+│   │   ├── v004_strategy_status_simplify.py
+│   │   └── v005_trades_timestamp_isoformat.py
 │   ├── __init__.py
 │   ├── backup.py
 │   └── migrations.py

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -399,11 +399,12 @@ exit code 1로 거부한다(빈 결과 반환 금지). 한쪽만 지정·둘 다
 --to 2026-06-12`처럼 같은 날짜를 지정하면 그 날 발생한 거래가 모두 포함된다
 (`treasury transactions`·`bot logs`·`audit list`의 날짜 필터 경계 동작과 일치).
 
-> known-limitation: 대사 보정(`adjustment`) 행은 `timestamp`가 공백 구분
-> 포맷(`YYYY-MM-DD HH:MM:SS`)으로 저장되어, `--from`을 지정하면 같은 날 보정
-> 행이 시작일 경계(`00:00:00`)에서 누락될 수 있다. 본 이슈 대상인 실거래
-> 행(ISO 8601 UTC 포맷)은 영향받지 않으며, 보정 행의 `--from` 경계 해소는
-> 저장 포맷 정규화 follow-up으로 분리한다.
+대사 보정(`adjustment`) 행을 포함한 모든 거래 행은 `timestamp`를 UTC-aware
+ISO 8601 isoformat(`YYYY-MM-DDTHH:MM:SS[.ffffff]+00:00`) 단일 포맷으로 저장하므로
+(`trades.timestamp` invariant — [trade/03-05-sqlite-schema.md](../trade/03-05-sqlite-schema.md)),
+`--from` 당일 경계에서 보정 행이 누락되지 않는다. 과거 공백 구분 포맷
+(`YYYY-MM-DD HH:MM:SS`)으로 저장된 행은 마이그레이션 v005가 isoformat UTC로
+정규화한 뒤 동일하게 조회된다(v005 적용 전제).
 
 ### `ante strategy` — 전략 관리
 

--- a/docs/specs/trade/03-02-trade-recorder.md
+++ b/docs/specs/trade/03-02-trade-recorder.md
@@ -22,6 +22,10 @@
 | `save` | `record: TradeRecord` | `None` | 거래 기록 저장 (Reconciler용 public wrapper) |
 | `save_adjustment` | `bot_id: str`, `symbol: str`, `old_quantity: float`, `new_quantity: float`, `reason: str` | `None` | 대사 보정 이력 기록 |
 
+`save_adjustment`는 `timestamp`를 `datetime.now(UTC).isoformat()`(UTC-aware ISO 8601)
+으로 저장한다 — `save`/`_save`와 동일 포맷이며 `trades.timestamp` 단일 포맷
+invariant([03-05-sqlite-schema.md](03-05-sqlite-schema.md))를 따른다.
+
 **설계 근거**:
 
 1. **이벤트 구독 방식 (EventBus 자동 기록)**

--- a/docs/specs/trade/03-05-sqlite-schema.md
+++ b/docs/specs/trade/03-05-sqlite-schema.md
@@ -38,6 +38,16 @@ CREATE INDEX idx_trades_status ON trades(status);
 fallback을 두지 않는다. `TradeRecorder`는 저장 직전과 명시 account 조회
 필터에서 Account ID scoping helper로 `None`, 빈 문자열, `default`를 거부한다.
 
+`trades.timestamp`는 **단일 포맷 invariant**를 가진다: UTC-aware ISO 8601
+isoformat(`YYYY-MM-DDTHH:MM:SS[.ffffff]+00:00`, 예: `2026-06-12T04:43:53+00:00`)
+으로만 저장한다. 모든 쓰기 경로(`save_trade`/`_save_trade`/`save_adjustment`)는
+`datetime.now(UTC).isoformat()` 동일 포맷을 쓰며, SQLite `datetime('now')`의 공백
+구분 포맷(`YYYY-MM-DD HH:MM:SS`)을 `timestamp` 값으로 저장하지 않는다. 이 invariant는
+TEXT lexical 비교에서 공백(`0x20`) < `T`(`0x54`)로 인한 날짜/정렬 쿼리 누락
+(`trade list --from` 당일 경계 등)을 차단한다. 과거 공백 포맷으로 저장된 행은
+마이그레이션 v005(`v005_trades_timestamp_isoformat`)가 isoformat UTC로 정규화한다.
+(`created_at` 등 다른 컬럼은 각자 계약이며 이 invariant는 `timestamp` 한정이다.)
+
 봇별 종목 포지션 현재 상태:
 ```sql
 CREATE TABLE positions (

--- a/src/ante/db/migrations.py
+++ b/src/ante/db/migrations.py
@@ -31,6 +31,7 @@ from ante.db.versions import (
     v002_parquet_migration,
     v003_broker_config,
     v004_strategy_status_simplify,
+    v005_trades_timestamp_isoformat,
 )
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,7 @@ MIGRATIONS: list[tuple[int, str, MigrateFn]] = [
     (2, "0.7.0", v002_parquet_migration.migrate),
     (3, "0.8.0", v003_broker_config.migrate),
     (4, "0.8.0", v004_strategy_status_simplify.migrate),
+    (5, "0.10.1", v005_trades_timestamp_isoformat.migrate),
 ]
 
 

--- a/src/ante/db/versions/v005_trades_timestamp_isoformat.py
+++ b/src/ante/db/versions/v005_trades_timestamp_isoformat.py
@@ -1,0 +1,46 @@
+"""v005: trades.timestamp 공백 구분 포맷 → UTC-aware isoformat 정규화 (#2371).
+
+과거 ``save_adjustment`` 가 SQLite ``datetime('now')`` 로 저장한 보정 행의
+``timestamp`` 는 공백 구분 포맷(``YYYY-MM-DD HH:MM:SS``, UTC, 19자)이다. 나머지
+쓰기 경로(save_trade/_save_trade)는 UTC-aware isoformat(``...T...+00:00``)을
+저장하므로 포맷이 혼재했고, TEXT lexical 비교에서 공백(``0x20``) < ``'T'``
+(``0x54``) 이라 ``trade list --from`` 당일 경계에서 보정 행이 누락됐다.
+
+본 마이그레이션은 기존 공백 19자 행만 isoformat UTC 로 협소 변환해 단일 포맷
+invariant(``docs/specs/trade/03-05-sqlite-schema.md``)를 충족시킨다.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+
+async def migrate(db: Database) -> None:
+    """공백 구분 19자 UTC 행을 ``...T...+00:00`` isoformat 으로 변환한다.
+
+    - **테이블 부재 가드**: fresh install(빈 DB)은 DDL 에 이미 trades 가 포함되며
+      ``run_migrations`` 전체 실행 경로를 보존하기 위해 trades 부재 시 no-op.
+    - **협소 변환**: ``datetime('now')`` 산출물(정확히 19자 ``YYYY-MM-DD
+      HH:MM:SS``)만 변환한다. ``+09:00`` 변형, trailing/다중 공백, 임의 텍스트
+      행은 GLOB/length 가드에서 미일치하여 불변(invalid timestamp 생성 차단).
+      UTC 가정은 이 협소 가드 위에서만 성립한다.
+    - **멱등**: 변환 후 19자 공백 패턴 행이 없어 재실행 no-op. isoformat 행
+      (``T`` 구분)은 패턴 미일치로 불변.
+    """
+    row = await db.fetch_one(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='trades'"
+    )
+    if row is None:
+        return  # trades 테이블이 없으면 스킵 (신규 설치 시 DDL에 이미 포함)
+
+    await db.execute(
+        "UPDATE trades "
+        "SET timestamp = replace(timestamp, ' ', 'T') || '+00:00' "
+        "WHERE length(timestamp) = 19 "
+        "AND timestamp GLOB "
+        "'[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] "
+        "[0-9][0-9]:[0-9][0-9]:[0-9][0-9]'"
+    )

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -285,18 +285,24 @@ class TradeRecorder:
         account_id = require_account_id(
             account_id, context="trade_recorder.save_adjustment"
         )
+        # #2371: timestamp 는 save_trade/_save_trade 와 동일한 UTC-aware isoformat 으로
+        # 저장한다(과거 SQLite ``datetime('now')`` 공백 구분 포맷 금지). lexical
+        # 비교에서 공백(0x20) < 'T'(0x54) 라 ``trade list --from`` 당일 경계에서
+        # 보정 행이 누락되던 단일-포맷 invariant 위반을 닫는다.
+        timestamp = datetime.now(UTC).isoformat()
         await self._db.execute(
             """INSERT INTO trades
                (trade_id, bot_id, strategy_id, symbol, side, quantity, price,
                 status, order_type, reason, timestamp, account_id)
                VALUES (?, ?, '', ?, 'adjustment', ?, 0.0, 'adjusted', '', ?,
-                       datetime('now'), ?)""",
+                       ?, ?)""",
             (
                 str(uuid4()),
                 bot_id,
                 symbol,
                 abs(new_quantity - old_quantity),
                 reason,
+                timestamp,
                 account_id,
             ),
         )

--- a/tests/unit/test_cli_inverted_date_range.py
+++ b/tests/unit/test_cli_inverted_date_range.py
@@ -522,6 +522,45 @@ async def _seed_trades_db(db_path: str, rows: list[dict]) -> None:
         await db.close()
 
 
+async def _seed_adjustment_via_recorder(db_path: str, *, account_id: str) -> str:
+    """실제 ``TradeRecorder.save_adjustment()`` 로 보정 행 1건을 생성하고 날짜 반환.
+
+    #2371: 보정 행 timestamp 가 ``save_trade`` 와 동일한 UTC-aware isoformat 으로
+    저장됨을 CLI 실경로로 검증하기 위해, raw INSERT 가 아니라 실제 서비스 메서드를
+    경유한다. wall-clock 비결정(UTC 자정 경계)은 호출자가 **저장된 timestamp 에서
+    날짜를 읽어** 동일 날짜로 조회하므로 제거된다. 저장 날짜(``YYYY-MM-DD``)를
+    반환한다.
+    """
+    from ante.core.database import Database
+    from ante.trade.position import PositionHistory
+    from ante.trade.recorder import TradeRecorder
+
+    db = Database(db_path)
+    await db.connect()
+    try:
+        ph = PositionHistory(db)
+        await ph.initialize()
+        rec = TradeRecorder(db, ph)
+        await rec.initialize()
+        await rec.save_adjustment(
+            bot_id="bot1",
+            symbol="005930",
+            old_quantity=10.0,
+            new_quantity=15.0,
+            reason="broker mismatch",
+            account_id=account_id,
+        )
+        row = await db.fetch_one(
+            "SELECT timestamp FROM trades WHERE status = 'adjusted'"
+        )
+        assert row is not None
+        ts: str = row["timestamp"]
+        # 저장 날짜(달력일)만 추출 — isoformat 의 'T' 앞 날짜 부분.
+        return ts[:10]
+    finally:
+        await db.close()
+
+
 def _trade_list_ids(runner, tmp_path, *cli_args: str) -> list[str]:
     """``trade list --format json`` 을 실제 시드 DB 에 대해 실행, trade_id 집합 반환.
 
@@ -638,66 +677,39 @@ class TestTradeListToEndOfDayBoundary:
             f"다음날 자정 행은 제외, 당일 행만 포함돼야 한다. ids={ids}"
         )
 
-    def test_blank_format_adjustment_row_included_in_to_only_query(
+    def test_adjustment_row_included_in_to_only_query(
         self, runner, tmp_path, _seed_db_path
     ):
-        """공백 구분 포맷(adjustment 행)이 ``--to D``(from 미지정) 쿼리에 포함.
+        """#2371: 실 ``save_adjustment()`` 보정 행이 ``--to D``(from 미지정)에 포함.
 
-        ``save_adjustment`` 는 SQLite ``datetime('now')`` 로 ``'YYYY-MM-DD
-        HH:MM:SS'`` (공백 구분) 포맷을 저장한다. 실호출은 wall-clock(UTC 자정
-        경계 비결정)이므로 **고정 ``'2026-06-12 09:30:00'`` 행을 직접 주입**
-        한다. ``--to 2026-06-12`` 상한(``...T23:59:59.999999+00:00``)과의
-        lexical 비교에서 ``' '(0x20) < 'T'(0x54)`` 이므로 param 보다 작아
-        포함된다.
+        보정 행은 ``save_trade`` 와 동일한 UTC-aware isoformat 으로 저장된다.
+        wall-clock 비결정(UTC 자정 경계)은 **저장된 timestamp 의 날짜를 읽어**
+        그 날짜로 ``--to`` 상한(``...T23:59:59.999999+00:00``)을 지정해 제거한다.
         """
-        asyncio.run(
-            _seed_trades_db(
-                _seed_db_path,
-                [
-                    {
-                        "trade_id": "55555555-5555-5555-5555-555555555555",
-                        "side": "adjustment",
-                        "status": "adjusted",
-                        "timestamp": "2026-06-12 09:30:00",
-                    }
-                ],
-            )
+        adj_date = asyncio.run(
+            _seed_adjustment_via_recorder(_seed_db_path, account_id="acc-real")
         )
-        ids = _trade_list_ids(runner, tmp_path, "--to", "2026-06-12")
-        assert ids == ["55555555-5555-5555-5555-555555555555"], (
-            f"공백 포맷 당일 adjustment 행이 --to 쿼리에 포함돼야 한다. ids={ids}"
+        ids = _trade_list_ids(runner, tmp_path, "--to", adj_date)
+        assert len(ids) == 1, (
+            f"보정 행이 --to {adj_date} 쿼리에 포함돼야 한다. ids={ids}"
         )
 
-    def test_blank_format_adjustment_row_excluded_when_from_specified(
+    def test_adjustment_row_included_when_from_specified(
         self, runner, tmp_path, _seed_db_path
     ):
-        """known-limitation 가드: 공백 포맷 행은 ``--from D`` 지정 시 제외(현재 동작).
+        """#2371: 실 ``save_adjustment()`` 보정 행이 ``--from D`` 당일 경계에 포함.
 
-        ``--from 2026-06-12`` 는 naive ``T00:00:00`` 하한으로 들어가고, 공백
-        포맷 당일 행 ``'2026-06-12 09:30:00'`` 은 ``' '(0x20) < 'T'(0x54)`` 라
-        param 보다 작아 ``timestamp >= ?`` 에서 제외된다. 이는 main 기존재
-        known-limitation(이슈 본문 Non-Goals — 저장 포맷 정규화 follow-up)
-        이며, 본 수정이 도입·악화하지 않는다. 의도치 않은 변화를 감지하는
-        회귀 가드로 현재 동작을 고정한다.
+        #2370 의 known-limitation(공백 포맷 행이 ``--from`` 당일 ``T00:00:00``
+        하한에서 lexical 제외)을 해소한다. 보정 행이 isoformat UTC 로 저장되므로
+        당일 ``--from``/``--to`` 동일 날짜 조회에 포함된다(**main RED**: 공백 포맷이라
+        제외). wall-clock 비결정은 저장 날짜를 읽어 동일 날짜로 조회해 제거한다.
         """
-        asyncio.run(
-            _seed_trades_db(
-                _seed_db_path,
-                [
-                    {
-                        "trade_id": "66666666-6666-6666-6666-666666666666",
-                        "side": "adjustment",
-                        "status": "adjusted",
-                        "timestamp": "2026-06-12 09:30:00",
-                    }
-                ],
-            )
+        adj_date = asyncio.run(
+            _seed_adjustment_via_recorder(_seed_db_path, account_id="acc-real")
         )
-        ids = _trade_list_ids(
-            runner, tmp_path, "--from", "2026-06-12", "--to", "2026-06-12"
-        )
-        assert ids == [], (
-            f"known-limitation: --from 지정 시 공백 포맷 당일 행은 제외. ids={ids}"
+        ids = _trade_list_ids(runner, tmp_path, "--from", adj_date, "--to", adj_date)
+        assert len(ids) == 1, (
+            f"보정 행이 --from/--to {adj_date} 당일 경계에 포함돼야 한다. ids={ids}"
         )
 
     def test_from_only_returns_same_day_intraday(self, runner, tmp_path, _seed_db_path):

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -15,7 +15,11 @@ from ante.db.migrations import (
     get_applied_seqs,
     run_migrations,
 )
-from ante.db.versions import v001_baseline, v002_parquet_migration
+from ante.db.versions import (
+    v001_baseline,
+    v002_parquet_migration,
+    v005_trades_timestamp_isoformat,
+)
 
 
 @pytest.fixture
@@ -325,3 +329,128 @@ class TestMigrationsCliDbPath:
             f"migrations 러너 실패: stdout={result.stdout} stderr={result.stderr}"
         )
         assert db_file.exists(), "ANTE_DB_PATH 로 전달한 파일이 생성돼야 합니다"
+
+
+async def _bootstrap_trades_schema(db: Database) -> None:
+    """trades 스키마를 부트스트랩한다 (TradeRecorder.initialize 경유)."""
+    from ante.trade.position import PositionHistory
+    from ante.trade.recorder import TradeRecorder
+
+    ph = PositionHistory(db)
+    await ph.initialize()
+    rec = TradeRecorder(db, ph)
+    await rec.initialize()
+
+
+async def _insert_trade_row(db: Database, trade_id: str, timestamp: str) -> None:
+    """trades 에 raw timestamp 행을 직접 주입한다 (마이그레이션 테스트 한정)."""
+    await db.execute(
+        "INSERT INTO trades "
+        "(trade_id, bot_id, strategy_id, symbol, side, quantity, price, status, "
+        " order_type, reason, commission, timestamp, order_id, account_id, "
+        " currency, exchange) "
+        "VALUES (?, 'bot1', 's1', '005930', 'buy', 10.0, 50000.0, 'filled', "
+        "'market', 'seed', 0.0, ?, ?, 'acc-real', 'KRW', 'KRX')",
+        (trade_id, timestamp, trade_id),
+    )
+
+
+class TestV005TradesTimestampIsoformat:
+    """#2371: v005 — trades.timestamp 공백 포맷 → UTC-aware isoformat 협소 변환."""
+
+    async def test_registered_in_migrations(self):
+        """v005 가 MIGRATIONS 리스트에 등록되어 있다."""
+        seqs = [seq for seq, _, _ in MIGRATIONS]
+        fns = [fn for _, _, fn in MIGRATIONS]
+        assert 5 in seqs
+        assert v005_trades_timestamp_isoformat.migrate in fns
+
+    async def test_blank_format_row_converted_others_unchanged(self, db: Database):
+        """공백 19자 행만 변환, isoformat 행·변형 행은 불변."""
+        await _bootstrap_trades_schema(db)
+        # (a) 공백 구분 19자 UTC 행 — 변환 대상.
+        await _insert_trade_row(
+            db, "11111111-1111-1111-1111-111111111111", "2026-06-12 09:30:00"
+        )
+        # (b) 이미 isoformat aware 행 — 불변.
+        await _insert_trade_row(
+            db, "22222222-2222-2222-2222-222222222222", "2026-06-12T04:43:53+00:00"
+        )
+        # (c) 변형 행: '+09:00' suffix(19자 아님, 텍스트) — 불변.
+        await _insert_trade_row(
+            db, "33333333-3333-3333-3333-333333333333", "2026-06-12 09:30:00+09:00"
+        )
+
+        await v005_trades_timestamp_isoformat.migrate(db)
+
+        rows = await db.fetch_all("SELECT trade_id, timestamp FROM trades")
+        ts_by_id = {r["trade_id"]: r["timestamp"] for r in rows}
+        # (a) 공백 19자 행 → isoformat UTC 로 변환.
+        assert (
+            ts_by_id["11111111-1111-1111-1111-111111111111"]
+            == "2026-06-12T09:30:00+00:00"
+        )
+        # (b) isoformat 행 불변.
+        assert (
+            ts_by_id["22222222-2222-2222-2222-222222222222"]
+            == "2026-06-12T04:43:53+00:00"
+        )
+        # (c) 변형 행 불변(19자 아님 + GLOB 미일치).
+        assert (
+            ts_by_id["33333333-3333-3333-3333-333333333333"]
+            == "2026-06-12 09:30:00+09:00"
+        )
+
+    async def test_idempotent_rerun(self, db: Database):
+        """재실행 멱등 — 변환 후 패턴 미일치라 두 번째 실행은 no-op."""
+        await _bootstrap_trades_schema(db)
+        await _insert_trade_row(
+            db, "11111111-1111-1111-1111-111111111111", "2026-06-12 09:30:00"
+        )
+
+        await v005_trades_timestamp_isoformat.migrate(db)
+        first = await db.fetch_one(
+            "SELECT timestamp FROM trades "
+            "WHERE trade_id = '11111111-1111-1111-1111-111111111111'"
+        )
+        assert first is not None
+        assert first["timestamp"] == "2026-06-12T09:30:00+00:00"
+
+        # 재실행 — 변환된 행은 패턴 미일치라 불변.
+        await v005_trades_timestamp_isoformat.migrate(db)
+        second = await db.fetch_one(
+            "SELECT timestamp FROM trades "
+            "WHERE trade_id = '11111111-1111-1111-1111-111111111111'"
+        )
+        assert second is not None
+        assert second["timestamp"] == "2026-06-12T09:30:00+00:00"
+
+    async def test_no_trades_table_noop(self, db: Database):
+        """trades 테이블 부재 DB 에서 no-op 통과(fresh install 가드)."""
+        # trades 스키마를 부트스트랩하지 않은 빈 DB.
+        row = await db.fetch_one(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='trades'"
+        )
+        assert row is None
+        # 예외 없이 통과해야 한다.
+        await v005_trades_timestamp_isoformat.migrate(db)
+
+    async def test_run_migrations_applies_v005(self, db: Database):
+        """run_migrations 전체 실행이 v005 를 적용하고 공백 행을 변환한다."""
+        await _bootstrap_trades_schema(db)
+        await _insert_trade_row(
+            db, "11111111-1111-1111-1111-111111111111", "2026-06-12 09:30:00"
+        )
+
+        applied = await run_migrations(db)
+        assert "005_0.10.1" in applied
+
+        row = await db.fetch_one(
+            "SELECT timestamp FROM trades "
+            "WHERE trade_id = '11111111-1111-1111-1111-111111111111'"
+        )
+        assert row is not None
+        assert row["timestamp"] == "2026-06-12T09:30:00+00:00"
+
+        applied_seqs = await get_applied_seqs(db)
+        assert 5 in applied_seqs

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -483,6 +483,38 @@ class TestTradeRecorder:
         assert len(rows) == 1
         assert rows[0]["quantity"] == 5  # abs(15-10)
 
+    async def test_save_adjustment_timestamp_isoformat_utc(self, recorder, db):
+        """#2371: 보정 행 timestamp 가 UTC-aware isoformat(``T`` 구분 + ``+00:00``).
+
+        save_trade/_save_trade 와 동일하게 ``datetime.now(UTC).isoformat()`` 포맷으로
+        저장돼야 한다(과거 SQLite ``datetime('now')`` 공백 구분 포맷 금지). lexical
+        비교에서 공백(``0x20``) < ``'T'``(``0x54``) 라 ``--from`` 당일 경계 누락을
+        유발하던 회귀를 닫는다.
+        """
+        before = datetime.now(UTC)
+        await recorder.save_adjustment(
+            bot_id="bot1",
+            symbol="005930",
+            old_quantity=10,
+            new_quantity=15,
+            reason="broker mismatch",
+            account_id="acc-test",
+        )
+        after = datetime.now(UTC)
+
+        rows = await db.fetch_all("SELECT * FROM trades WHERE status = 'adjusted'")
+        assert len(rows) == 1
+        ts_raw = rows[0]["timestamp"]
+        # 공백 구분 포맷 금지: 날짜/시각 구분자가 ``T`` 여야 한다.
+        assert " " not in ts_raw, f"공백 구분 포맷 금지, ts={ts_raw!r}"
+        assert "T" in ts_raw, f"isoformat ``T`` 구분자가 있어야 한다, ts={ts_raw!r}"
+        # UTC-aware suffix.
+        assert ts_raw.endswith("+00:00"), f"UTC-aware suffix 필요, ts={ts_raw!r}"
+        # round-trip 파싱 가능 + 호출 시각 범위 내.
+        parsed = datetime.fromisoformat(ts_raw)
+        assert parsed.tzinfo is not None
+        assert before <= parsed <= after
+
     async def test_eventbus_integration_rejected(self, recorder, eventbus, db):
         """EventBus 구독 통합 — 비-fill 상태(rejected)는 TradeRecorder 가 기록."""
         recorder.subscribe(eventbus)


### PR DESCRIPTION
Closes #2371

## Summary
- trades.timestamp 포맷 혼재 해소: `save_adjustment`만 SQL `datetime('now')` 공백 포맷(19자, UTC)으로 저장해 `trade list --from <날짜>`가 당일 보정 행을 lexical 비교(공백<'T')로 제외하던 known-limitation(#2370) 해소
- `save_adjustment`를 `datetime.now(UTC).isoformat()` 파라미터로 정규화(다른 쓰기 경로와 동일 포맷)
- **v005 마이그레이션** 신규: 테이블 부재 가드(v004 미러, fresh install 안전) + 협소 변환(`length=19` + 고정자리 GLOB — `datetime('now')` 산출물만 정확 포착, '+09:00' 변형·임의 텍스트 불변) + 멱등. 기존 백업/트랜잭션 프레임워크 경유, `execute_script` 미사용
- 스펙: trades.timestamp UTC-aware isoformat invariant 명시(03-05-sqlite-schema), save_adjustment normative(03-02), CLI known-limitation 각주 해소(03-commands)
- generated: 신규 v005 파일 반영해 project-structure.md 재생성(check 통과, pre-existing drift 없음)
- #2370의 known-limitation 가드 테스트를 실 `save_adjustment()` 경유 포함 검증으로 재작성

## Review Trail
- Codex Plan Review: r1 revise-plan(테이블 가드·협소 가드) → r2 **approve-implement**
- Codex 브랜치 리뷰: **PASS** (attempt 1, head 4a348b8)

## Test Plan
- `pytest tests/unit/test_migrations.py tests/unit/test_trade.py tests/unit/test_cli_inverted_date_range.py` (152 passed)
- `pytest` 전체 (7258 passed, 2 skipped)
- `ruff check` / `ruff format --check` / `mypy src/` 전체 / `generate_project_structure.py --check` PASS
- main RED 재현: save_adjustment 공백 포맷 + 당일 `--from` 제외 확인 후 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)