### PR TITLE
fix(cli): #2373 broker status 폴백에 adapter.disconnect 추가 — sibling 대칭 session 정리

### DIFF
--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -142,8 +142,16 @@ def status(ctx: click.Context, account_id: str) -> None:
                         "exchange": adapter.exchange,
                     }
                 finally:
-                    if db:
-                        await db.close()
+                    # sibling(balance/positions/reconcile)과 대칭으로 connect 성공
+                    # 이후 adapter session 을 정리한다 (#2373). disconnect 가 raise
+                    # 해도 db.close() 가 실행되도록 내부 try/finally 로 중첩 —
+                    # aiosqlite 스레드 누수(hang) 방지를 disconnect 예외보다 우선
+                    # 보장한다.
+                    try:
+                        await adapter.disconnect()
+                    finally:
+                        if db:
+                            await db.close()
             except AccountNotFoundError:
                 raise
             except Exception as e:

--- a/tests/unit/cli/test_broker_missing_account.py
+++ b/tests/unit/cli/test_broker_missing_account.py
@@ -555,6 +555,115 @@ class TestStatusAndReconcileFollowupScope:
         assert "broker connection refused" in str(payload["error"]), payload
 
 
+# ── status 폴백 adapter.disconnect 대칭 (#2373) ─────────────────────────────
+
+
+class TestStatusFallbackDisconnectsAdapter:
+    """``broker status`` 직접 연결 폴백이 connect 성공 이후 ``adapter.disconnect()``
+    를 수행해 sibling(balance/positions/reconcile)과 대칭으로 session 을 정리하는지
+    검증한다 (#2373).
+
+    회귀 모델:
+        status 폴백 ``_run_status()`` 는 connect 성공 후 ``health_check()`` 만 하고
+        ``finally`` 에서 ``db.close()`` 만 호출 — ``adapter.disconnect()`` 부재로
+        KIS adapter 의 aiohttp session 이 프로세스 종료까지 잔존했다(``Unclosed
+        client session`` 경고). #2368 은 connect **실패** 경로를, 본 이슈는
+        connect **성공** 경로의 비대칭 누수를 닫는다.
+
+    설계:
+        ``_get_broker`` 를 직접 patch 해 ``disconnect = AsyncMock()`` 을 가진 mock
+        adapter 를 반환하게 하고, IPC 우선 시도는 ``ClickException`` 으로 막아
+        폴백 분기를 강제한다(``_patch_balance_fallback_raises`` 와 동형 하네스).
+        성공 경로와 ``health_check`` 예외 경로 양쪽에서 ``disconnect()`` 가 정확히
+        한 번 await 됨을 단언한다 — sibling 의 검증된 미러.
+    """
+
+    def _run_status_fallback(
+        self,
+        runner: CliRunner,
+        *,
+        health_check: AsyncMock,
+    ) -> tuple[object, AsyncMock]:
+        """IPC 미가용을 강제하고 ``_get_broker`` 를 mock adapter 로 patch 한 뒤
+        ``broker status --account acc-1`` 을 호출한다.
+
+        Returns:
+            (CliRunner result, disconnect AsyncMock) — disconnect 호출 검증용.
+        """
+        import click
+
+        from ante.broker.base import BrokerAdapter
+        from ante.cli.commands import broker as broker_cmd
+
+        async def _raise_click(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise click.ClickException("server unavailable")
+
+        mock_adapter = MagicMock(spec=BrokerAdapter)
+        mock_adapter.is_connected = True
+        mock_adapter.exchange = "KRX"
+        mock_adapter.health_check = health_check
+        mock_adapter.disconnect = AsyncMock(return_value=None)
+
+        async def _fake_get_broker(account_id=None):  # noqa: ANN001, ANN202
+            return mock_adapter, None
+
+        with (
+            patch.object(broker_cmd, "_ipc_broker_command", new=_raise_click),
+            patch.object(broker_cmd, "_get_broker", new=_fake_get_broker),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "broker",
+                    "status",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+        return result, mock_adapter.disconnect
+
+    def test_status_fallback_success_disconnects_adapter(
+        self, runner: CliRunner
+    ) -> None:
+        """health_check 성공 경로: status 폴백이 ``adapter.disconnect()`` 를 정확히
+        한 번 호출한다 (main RED — 현재 disconnect 미호출)."""
+        result, disconnect = self._run_status_fallback(
+            runner, health_check=AsyncMock(return_value=True)
+        )
+
+        assert result.exit_code == 0, (
+            f"expected exit 0, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        payload = json.loads(result.stdout)
+        assert payload["connected"] is True, payload
+        assert payload["healthy"] is True, payload
+        disconnect.assert_awaited_once()
+
+    def test_status_fallback_health_check_error_disconnects_adapter(
+        self, runner: CliRunner
+    ) -> None:
+        """health_check 예외 경로: finally 가 disconnect 후 기존 ``except
+        Exception`` 분기(``connected:False``)에 도달한다. disconnect 호출 +
+        connected:False 변환이 모두 유지되어야 한다."""
+        result, disconnect = self._run_status_fallback(
+            runner,
+            health_check=AsyncMock(side_effect=RuntimeError("health probe failed")),
+        )
+
+        assert result.exit_code == 0, (
+            f"expected exit 0 (generic 실패 swallow 계약), got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        payload = json.loads(result.stdout)
+        assert payload["connected"] is False, payload
+        assert payload["healthy"] is False, payload
+        assert "health probe failed" in str(payload["error"]), payload
+        disconnect.assert_awaited_once()
+
+
 # ── #1636 / #1623 Split C: invalid account_id ingress → VALIDATION_ERROR ────
 
 

--- a/tests/unit/contracts/factory_drift_allowlist.yaml
+++ b/tests/unit/contracts/factory_drift_allowlist.yaml
@@ -25,7 +25,7 @@ direct_database_construction:
     line: 34
     reason: "broker live state — _create_account_service factory body (runtime_ipc cold_path fallback)"
   - path: src/ante/cli/commands/broker.py
-    line: 354
+    line: 362
     reason: "broker reconcile — adapter_db fallback (runtime_ipc cold_path branch)"
 
   # signal connect — #2338 PR#3 에서 CLI `_run_connect` 를 thin IPC relay 로


### PR DESCRIPTION
Closes #2373

## Summary
- `ante broker status`의 직접 연결 폴백(`_run_status`)이 connect 성공 후 `adapter.disconnect()` 없이 종료해 aiohttp session이 잔존하던 비대칭 누수 수정 — sibling(balance/positions/reconcile)과 동일 패턴으로 정렬
- disconnect가 raise해도 `db.close()`가 실행되도록 내부 try/finally 중첩(Codex Plan Review advisory)
- IPC-우선 경로·AccountNotFoundError·connected:False 변환 기존 동작 불변. allowlist는 기존 callsite 줄번호 이동 정합만(신규 직접 생성 없음)
- 회귀 2건: health_check 성공/예외 경로 모두 disconnect 1회 호출

## Review Trail
- Codex Plan Review: r1 **approve-implement**
- Codex 브랜치 리뷰: **PASS** (attempt 1, head 96b26b0)

## Test Plan
- `pytest tests/unit/test_broker.py tests/unit/test_cli_broker_account_not_found.py tests/unit/cli/test_broker_missing_account.py tests/unit/test_broker_cli_ipc_error_equivalence.py` (92 passed)
- `pytest` 전체 (7254 passed, 2 skipped)
- `ruff check` / `ruff format --check` / `mypy src/` 전체 PASS
- main RED 재현: `Expected disconnect to have been awaited once. Awaited 0 times.` 2건 확인 후 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)