### PR TITLE
fix(account): #2372 get_broker connect-성공-후-캐시 + per-account lock — 미연결 adapter 캐시 잔존 제거

### DIFF
--- a/docs/specs/account/04-account-service.md
+++ b/docs/specs/account/04-account-service.md
@@ -23,7 +23,8 @@ AccountService(db: Database, eventbus: EventBus)
 | `suspend` | `account_id: str, reason: str, suspended_by: str` | `None` | status → SUSPENDED. 이미 SUSPENDED이면 `AccountAlreadySuspendedError` (409). `AccountSuspendedEvent` 발행 + 소속 봇 중지 트리거 |
 | `activate` | `account_id: str, activated_by: str` | `None` | status → ACTIVE. DELETED 계좌는 활성화 불가. `AccountActivatedEvent` 발행 |
 | `delete` | `account_id: str, deleted_by: str` | `None` | 소프트 딜리트 (status=DELETED). **cold-path 전용**. active Ante runtime이 살아 있으면 거부. 진입 직후 `bots` 테이블을 검사해 동일 `account_id`의 활성(non-deleted) 봇이 남아 있으면 `AccountHasActiveBotsError`로 차단(orphan bot 무결성). 1.0 정책상 `AccountDeletedEvent`는 발행하지 않는다 |
-| `get_broker` | `account_id: str` | `BrokerAdapter` | 계좌의 BrokerAdapter 인스턴스 반환. lazy init + 캐싱 |
+| `get_broker` | `account_id: str` | `BrokerAdapter` | 계좌의 BrokerAdapter 인스턴스 반환. lazy init. 최초 호출 시 생성하고 `connect()`를 수행하여 **연결에 성공한 경우에만 캐싱**한다. 연결 실패 시 캐시에 남기지 않고 예외를 전파하므로(미연결 어댑터 잔존 차단), 일시적 인증/네트워크 실패는 다음 호출에서 자연 회복한다. cache-hit은 connect 없이 즉시 반환. cache-miss는 per-account lock으로 직렬화하여 동시 호출 시에도 단일 인스턴스·단일 connect를 보장한다 |
+| `get_cached_broker` | `account_id: str` | `BrokerAdapter \| None` | 이미 캐시된 BrokerAdapter만 반환(build/connect 없음). 미캐시면 `None`. 종료 루프처럼 "이미 연결된 어댑터만 끊는" 경로 전용 — 미캐시 계좌를 끊기 위해 새로 연결하는 회귀를 차단한다(동기 메서드) |
 | `create_default_test_account` | — | `Account` | 테스트 계좌 자동 생성 (`ante init` 시 호출). 이미 존재하면 스킵 |
 | `suspend_all` | `reason: str, suspended_by: str` | `int` | 모든 ACTIVE 계좌를 SUSPENDED로 전환. 전환된 수 반환 (시스템 전체 Kill Switch) |
 | `activate_all` | `activated_by: str` | `int` | 모든 SUSPENDED 계좌를 ACTIVE로 복구. DELETED 계좌는 대상 제외 |
@@ -33,6 +34,12 @@ AccountService(db: Database, eventbus: EventBus)
 ### 브로커 인스턴스 생성
 
 `get_broker()`는 `broker_type`으로 `BROKER_REGISTRY`에서 어댑터 클래스를 조회하고, Account의 `credentials`, `broker_config`, `buy_commission_rate`, `sell_commission_rate`를 어댑터 config로 전달하여 인스턴스를 생성한다. 최초 호출 시 생성하고 이후 캐싱한다.
+
+**캐시-연결 의미론**: `get_broker()`는 최초 생성 경로에서 어댑터의 `connect()`를 수행하고 **연결 성공 후에만 캐시에 기록**한다. connect가 실패하면 캐시에 어댑터를 남기지 않고 예외를 그대로 전파한다 — 일시적 인증/네트워크 실패로 `is_connected=False`인 미연결 어댑터가 캐시에 잔존해 장기 실행 runtime의 후속 소비자가 이를 재사용하는 일을 막는다. 이 원칙은 재연결 경로(`_reconnect_broker`)의 connect-성공-후-캐시 의미론과 동일하다. cache-hit 경로(런타임 hot-path)는 connect 호출 없이 캐시된 인스턴스를 즉시 반환한다.
+
+**connect 멱등**: 모든 BrokerAdapter의 `connect()`는 멱등이다 — 이미 연결된 상태(`is_connected`이고 활성 세션 보유)면 새 세션을 만들지 않고 no-op으로 반환한다. 따라서 `get_broker()`가 connect한 어댑터에 호출자가 `connect()`를 재호출해도 세션 교체로 인한 누수가 없다. cache-miss 경로는 per-account 락으로 직렬화하고 락 안에서 캐시를 재검사(double-checked)하므로, 동일 계좌의 동시 `get_broker()` 호출도 단일 인스턴스·단일 connect로 수렴한다.
+
+**cached-only 조회**: `get_cached_broker()`는 이미 캐시된 어댑터만 반환하며(build/connect 없음), 미캐시면 `None`을 반환한다. 종료 루프처럼 "이미 연결된 어댑터만 끊으면 되는" 경로는 이 접근자를 사용해, 미캐시 계좌를 끊기 위해 새로 인증/연결하는 회귀를 피한다(미캐시 = 끊을 연결도 없음).
 
 > **`trading_mode`와 `broker_config`의 분리**: `trading_mode`는 시스템이 브로커 API를 실제로 호출할지 결정한다 (VIRTUAL=가상거래, LIVE=실거래). `broker_config`는 브로커 내부 동작 설정을 담는다. 예를 들어 KIS 브로커의 `is_paper`는 모의투자/실전투자 엔드포인트를 결정하는 브로커 내부 관심사이므로 `broker_config`에 속한다. `get_broker()`는 `trading_mode`로부터 `is_paper`를 파생하지 않는다.
 

--- a/docs/specs/account/04-account-service.md
+++ b/docs/specs/account/04-account-service.md
@@ -24,7 +24,7 @@ AccountService(db: Database, eventbus: EventBus)
 | `activate` | `account_id: str, activated_by: str` | `None` | status → ACTIVE. DELETED 계좌는 활성화 불가. `AccountActivatedEvent` 발행 |
 | `delete` | `account_id: str, deleted_by: str` | `None` | 소프트 딜리트 (status=DELETED). **cold-path 전용**. active Ante runtime이 살아 있으면 거부. 진입 직후 `bots` 테이블을 검사해 동일 `account_id`의 활성(non-deleted) 봇이 남아 있으면 `AccountHasActiveBotsError`로 차단(orphan bot 무결성). 1.0 정책상 `AccountDeletedEvent`는 발행하지 않는다 |
 | `get_broker` | `account_id: str` | `BrokerAdapter` | 계좌의 BrokerAdapter 인스턴스 반환. lazy init. 최초 호출 시 생성하고 `connect()`를 수행하여 **연결에 성공한 경우에만 캐싱**한다. 연결 실패 시 캐시에 남기지 않고 예외를 전파하므로(미연결 어댑터 잔존 차단), 일시적 인증/네트워크 실패는 다음 호출에서 자연 회복한다. cache-hit은 connect 없이 즉시 반환. cache-miss는 per-account lock으로 직렬화하여 동시 호출 시에도 단일 인스턴스·단일 connect를 보장한다 |
-| `get_cached_broker` | `account_id: str` | `BrokerAdapter \| None` | 이미 캐시된 BrokerAdapter만 반환(build/connect 없음). 미캐시면 `None`. 종료 루프처럼 "이미 연결된 어댑터만 끊는" 경로 전용 — 미캐시 계좌를 끊기 위해 새로 연결하는 회귀를 차단한다(동기 메서드) |
+| `get_cached_broker` | `account_id: str` | `BrokerAdapter \| None` | 이미 캐시된 BrokerAdapter만 반환(build/connect 없음). 미캐시면 `None`. 종료 루프처럼 "이미 연결된 어댑터만 끊는" 경로 전용 — 미캐시 계좌를 끊기 위해 새로 연결하는 회귀를 차단한다. **async 메서드**: per-account lock으로 in-flight 초기 연결을 drain한 뒤 조회하므로, 종료 중 in-flight connect가 끝난 직후 캐시되어 disconnect를 놓치는 세션 잔존을 막는다 |
 | `create_default_test_account` | — | `Account` | 테스트 계좌 자동 생성 (`ante init` 시 호출). 이미 존재하면 스킵 |
 | `suspend_all` | `reason: str, suspended_by: str` | `int` | 모든 ACTIVE 계좌를 SUSPENDED로 전환. 전환된 수 반환 (시스템 전체 Kill Switch) |
 | `activate_all` | `activated_by: str` | `int` | 모든 SUSPENDED 계좌를 ACTIVE로 복구. DELETED 계좌는 대상 제외 |
@@ -39,7 +39,7 @@ AccountService(db: Database, eventbus: EventBus)
 
 **connect 멱등**: 모든 BrokerAdapter의 `connect()`는 멱등이다 — 이미 연결된 상태(`is_connected`이고 활성 세션 보유)면 새 세션을 만들지 않고 no-op으로 반환한다. 따라서 `get_broker()`가 connect한 어댑터에 호출자가 `connect()`를 재호출해도 세션 교체로 인한 누수가 없다. cache-miss 경로는 per-account 락으로 직렬화하고 락 안에서 캐시를 재검사(double-checked)하므로, 동일 계좌의 동시 `get_broker()` 호출도 단일 인스턴스·단일 connect로 수렴한다.
 
-**cached-only 조회**: `get_cached_broker()`는 이미 캐시된 어댑터만 반환하며(build/connect 없음), 미캐시면 `None`을 반환한다. 종료 루프처럼 "이미 연결된 어댑터만 끊으면 되는" 경로는 이 접근자를 사용해, 미캐시 계좌를 끊기 위해 새로 인증/연결하는 회귀를 피한다(미캐시 = 끊을 연결도 없음).
+**cached-only 조회**: `get_cached_broker()`는 이미 캐시된 어댑터만 반환하며(build/connect 없음), 미캐시면 `None`을 반환한다. 종료 루프처럼 "이미 연결된 어댑터만 끊으면 되는" 경로는 이 접근자를 사용해, 미캐시 계좌를 끊기 위해 새로 인증/연결하는 회귀를 피한다(미캐시 = 끊을 연결도 없음). 조회는 `get_broker()`/`_reconnect_broker()`와 동일한 per-account lock 안에서 수행하여 in-flight 초기 연결을 drain한 뒤 캐시를 재확인한다(async 메서드). 동기 즉시 조회였다면, 종료 중 cache-miss `get_broker()`가 lock을 쥔 채 `connect()`를 대기하는 in-flight 구간을 `None`으로 보고 skip하고, 그 connect가 직후 성공해 disconnect 루프 종료 뒤 캐시에 기록된 세션이 DB close 이후까지 잔존했다 — lock 대기로 connect 완료를 기다린 뒤 조회해 이 윈도를 닫는다(연결 성공 시 캐시된 어댑터 반환→disconnect, 실패 시 `None`).
 
 > **`trading_mode`와 `broker_config`의 분리**: `trading_mode`는 시스템이 브로커 API를 실제로 호출할지 결정한다 (VIRTUAL=가상거래, LIVE=실거래). `broker_config`는 브로커 내부 동작 설정을 담는다. 예를 들어 KIS 브로커의 `is_paper`는 모의투자/실전투자 엔드포인트를 결정하는 브로커 내부 관심사이므로 `broker_config`에 속한다. `get_broker()`는 `trading_mode`로부터 `is_paper`를 파생하지 않는다.
 

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime
@@ -166,6 +167,10 @@ class AccountService:
         self._eventbus = eventbus
         self._accounts: dict[str, Account] = {}
         self._brokers: dict[str, BrokerAdapter] = {}
+        # cache-miss 직렬화용 per-account lock (#2372). 동시 miss 가 각각
+        # build+connect 해 세션을 누수하고 마지막만 캐시되는 race 를 차단한다.
+        # lock dict 항목 생성은 await 없는 동기 구간이라 그 자체로 race-free.
+        self._broker_locks: dict[str, asyncio.Lock] = {}
         # 런타임 인지 플래그(#1144 invariant S1).
         # boot mutation 종료 직후(``main._init_account`` 마지막)
         # ``mark_runtime_started()``로 True가 되며, 이후 cold-path 전용 메서드/필드
@@ -999,18 +1004,56 @@ class AccountService:
     # ── 브로커 인스턴스 ──────────────────────────────────
 
     async def get_broker(self, account_id: str) -> BrokerAdapter:
-        """계좌의 BrokerAdapter 인스턴스를 반환. lazy init + 캐싱.
+        """계좌의 BrokerAdapter 인스턴스를 반환. lazy init + 연결-성공-후-캐싱.
+
+        최초 호출 시 어댑터를 생성하고 ``connect()`` 를 수행하며, **연결에
+        성공한 경우에만** 캐시에 기록한 뒤 반환한다. connect 가 실패하면
+        캐시에 남기지 않고 예외를 전파하므로(#2372), 일시적 인증/네트워크
+        오류로 미연결 adapter 가 캐시에 잔존해 후속 소비자가 재사용하는 일이
+        없다. 이는 재연결 경로(:meth:`_reconnect_broker`)의 connect-성공-후-캐시
+        원칙과 동일하다 — 초기 경로의 비대칭을 제거한다.
+
+        cache-hit 경로(런타임 hot-path)는 connect 없이 캐시된 인스턴스를 즉시
+        반환한다(connect 는 멱등이므로 호출자가 이후 connect 를 재호출해도
+        no-op). cache-miss 경로는 per-account :class:`asyncio.Lock` 으로
+        직렬화하고 lock 안에서 캐시를 double-check 하여, 동일 계좌의 동시
+        miss 가 각각 build+connect 해 세션을 누수하고 마지막만 캐시되는 race
+        를 차단한다.
 
         Raises:
             AccountNotFoundError: 계좌를 찾을 수 없음.
             InvalidBrokerTypeError: broker_type이 BROKER_REGISTRY에 등록되지 않음.
         """
-        if account_id in self._brokers:
-            return self._brokers[account_id]
+        # lock-free fast path: cache-hit 면 lock 없이 즉시 반환.
+        broker = self._brokers.get(account_id)
+        if broker is not None:
+            return broker
 
-        broker = await self._build_broker_adapter(account_id)
-        self._brokers[account_id] = broker
-        return broker
+        # per-account lock 으로 miss 경로 직렬화. dict 항목 생성은 await 없는
+        # 동기 구간이므로 setdefault 자체로 race-free 하다.
+        lock = self._broker_locks.setdefault(account_id, asyncio.Lock())
+        async with lock:
+            # double-checked: lock 대기 중 선행 태스크가 캐시했으면 재사용.
+            broker = self._brokers.get(account_id)
+            if broker is not None:
+                return broker
+
+            broker = await self._build_broker_adapter(account_id)
+            # connect 성공 후에만 캐시에 기록한다. 실패 시 캐시 미기록 +
+            # 예외 전파(connect 내부에서 session cleanup 수행, #2368).
+            await broker.connect()
+            self._brokers[account_id] = broker
+            return broker
+
+    def get_cached_broker(self, account_id: str) -> BrokerAdapter | None:
+        """이미 캐시된 BrokerAdapter 만 반환한다 (build/connect 없음, #2372).
+
+        캐시에 없으면 ``None`` 을 반환하며 새 어댑터를 생성하거나 연결하지
+        않는다. 종료(shutdown) 루프처럼 "이미 연결된 어댑터만 끊으면 되는"
+        경로에서 사용한다 — 미캐시 계좌를 끊기 위해 새로 인증/연결하는 회귀를
+        차단한다(미캐시 = 끊을 연결도 없음).
+        """
+        return self._brokers.get(account_id)
 
     async def _build_broker_adapter(self, account_id: str) -> BrokerAdapter:
         """현재 DB 상태로 BrokerAdapter를 생성한다 (캐시하지 않음).

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -673,6 +673,21 @@ class AccountService:
         불린 적 없는 구간)에는 의미가 없고, 다음 `get_broker()` 호출이 새
         설정으로 lazy init한다.
 
+        **동시성 (#2372):** 캐시 부재 조기 반환 검사를 포함한 본문 전체를
+        ``get_broker()`` 와 **동일한 per-account lock**
+        (:meth:`_broker_lock_for`) 안에서 수행한다. lock 없이 조기 반환하면,
+        초기 ``get_broker()`` 가 lock 을 쥐고 ``connect()`` 를 대기하는 동안
+        (아직 캐시가 비어 있는 in-flight 구간) update() 가 본 메서드를
+        호출했을 때 캐시가 비었다고 판단해 조용히 반환하고, 직후
+        ``get_broker()`` 가 **구 설정으로 만든 어댑터를 캐시에 기록**해
+        DB(신 설정)와 런타임 캐시(구 설정)가 영구 어긋난다. lock 으로
+        직렬화하면 reconnect 가 in-flight connect 의 완료를 기다린 뒤 진입하므로
+        ``in self._brokers`` 가 true 가 되어 신 설정으로 rebuild + connect 후
+        swap 한다(역순으로 reconnect 가 선점해도 get_broker 의 double-check 로
+        정합). ``_build_broker_adapter`` / ``connect()`` 는 ``get_broker()`` 를
+        재진입하지 않으므로 lock 재귀 deadlock 이 없다. update() 경로가 이
+        lock 대기로 connect 시간만큼 블록될 수 있으나 admin-path 라 수용한다.
+
         실패 의미론:
         - 새 어댑터 생성(`_build_broker_adapter`) 실패 → 캐시는 기존 브로커를
           그대로 유지하고, `BrokerReconnectFailedError`를 올려 update() 호출자가
@@ -692,36 +707,40 @@ class AccountService:
         재시작 시점까지 살려둔다. consumer에 새 어댑터를 주입하는 이벤트
         기반 경로는 후속 작업으로 분리한다 (#1100의 범위를 넘어선다).
         """
-        if account_id not in self._brokers:
-            return
+        async with self._broker_lock_for(account_id):
+            # in-flight 초기 connect 가 있으면 이 lock 대기로 직렬화된다. 캐시
+            # 부재 검사를 lock 안에서 수행해야, 구-설정 adapter 가 캐시된 뒤에
+            # reconnect 가 진입해 신-설정으로 rebuild + swap 한다 (#2372).
+            if account_id not in self._brokers:
+                return
 
-        try:
-            new_broker = await self._build_broker_adapter(account_id)
-        except Exception as exc:
-            logger.error(
-                "브로커 어댑터 생성 실패: account=%s — 기존 캐시를 유지합니다.",
-                account_id,
-                exc_info=True,
-            )
-            raise BrokerReconnectFailedError(
-                f"계좌 '{account_id}'의 새 브로커 어댑터 생성에 실패했습니다."
-            ) from exc
+            try:
+                new_broker = await self._build_broker_adapter(account_id)
+            except Exception as exc:
+                logger.error(
+                    "브로커 어댑터 생성 실패: account=%s — 기존 캐시를 유지합니다.",
+                    account_id,
+                    exc_info=True,
+                )
+                raise BrokerReconnectFailedError(
+                    f"계좌 '{account_id}'의 새 브로커 어댑터 생성에 실패했습니다."
+                ) from exc
 
-        try:
-            await new_broker.connect()
-        except Exception as exc:
-            logger.error(
-                "브로커 재연결 실패: account=%s — 기존 캐시를 유지합니다.",
-                account_id,
-                exc_info=True,
-            )
-            raise BrokerReconnectFailedError(
-                f"계좌 '{account_id}'의 새 브로커 connect()에 실패했습니다."
-            ) from exc
+            try:
+                await new_broker.connect()
+            except Exception as exc:
+                logger.error(
+                    "브로커 재연결 실패: account=%s — 기존 캐시를 유지합니다.",
+                    account_id,
+                    exc_info=True,
+                )
+                raise BrokerReconnectFailedError(
+                    f"계좌 '{account_id}'의 새 브로커 connect()에 실패했습니다."
+                ) from exc
 
-        # connect 성공 후에만 캐시를 원자적으로 교체한다.
-        # 이전 어댑터는 의도적으로 disconnect하지 않는다 (docstring 참고).
-        self._brokers[account_id] = new_broker
+            # connect 성공 후에만 캐시를 원자적으로 교체한다.
+            # 이전 어댑터는 의도적으로 disconnect하지 않는다 (docstring 참고).
+            self._brokers[account_id] = new_broker
 
     # ── 상태 전이 ──────────────────────────────────────
 
@@ -1003,6 +1022,18 @@ class AccountService:
 
     # ── 브로커 인스턴스 ──────────────────────────────────
 
+    def _broker_lock_for(self, account_id: str) -> asyncio.Lock:
+        """계좌별 브로커 직렬화 lock 을 반환한다 (없으면 생성, #2372).
+
+        ``get_broker()`` 의 cache-miss build+connect 경로와
+        ``_reconnect_broker()`` 의 rebuild+connect 경로가 **동일한** lock
+        인스턴스를 공유해야, 초기 connect 가 in-flight 인 동안 설정 변경
+        reconnect 가 끼어들어 구-설정 adapter 가 캐시에 영구 고착되는 race 를
+        차단할 수 있다. dict 항목 생성은 ``await`` 없는 동기 구간이므로
+        ``setdefault`` 자체로 race-free 하다.
+        """
+        return self._broker_locks.setdefault(account_id, asyncio.Lock())
+
     async def get_broker(self, account_id: str) -> BrokerAdapter:
         """계좌의 BrokerAdapter 인스턴스를 반환. lazy init + 연결-성공-후-캐싱.
 
@@ -1029,10 +1060,10 @@ class AccountService:
         if broker is not None:
             return broker
 
-        # per-account lock 으로 miss 경로 직렬화. dict 항목 생성은 await 없는
-        # 동기 구간이므로 setdefault 자체로 race-free 하다.
-        lock = self._broker_locks.setdefault(account_id, asyncio.Lock())
-        async with lock:
+        # per-account lock 으로 miss 경로 직렬화. _reconnect_broker 와 **동일한**
+        # lock 인스턴스를 재사용해(``_broker_lock_for``) in-flight 초기 connect 와
+        # 설정 변경 reconnect 가 서로 직렬화되도록 한다 (#2372).
+        async with self._broker_lock_for(account_id):
             # double-checked: lock 대기 중 선행 태스크가 캐시했으면 재사용.
             broker = self._brokers.get(account_id)
             if broker is not None:

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -1076,15 +1076,30 @@ class AccountService:
             self._brokers[account_id] = broker
             return broker
 
-    def get_cached_broker(self, account_id: str) -> BrokerAdapter | None:
+    async def get_cached_broker(self, account_id: str) -> BrokerAdapter | None:
         """이미 캐시된 BrokerAdapter 만 반환한다 (build/connect 없음, #2372).
 
         캐시에 없으면 ``None`` 을 반환하며 새 어댑터를 생성하거나 연결하지
         않는다. 종료(shutdown) 루프처럼 "이미 연결된 어댑터만 끊으면 되는"
         경로에서 사용한다 — 미캐시 계좌를 끊기 위해 새로 인증/연결하는 회귀를
         차단한다(미캐시 = 끊을 연결도 없음).
+
+        **동시성 (#2372 Codex P2):** 조회를 ``get_broker()`` /
+        ``_reconnect_broker()`` 와 **동일한** per-account lock
+        (:meth:`_broker_lock_for`) 안에서 수행해, in-flight 한 초기
+        ``connect()`` 의 완료를 기다린 뒤(= drain) 캐시를 재확인한다. 동기
+        즉시 조회였다면, 종료 중 cache-miss ``get_broker()`` 가 lock 을 쥔 채
+        ``connect()`` 를 대기하는 in-flight 구간(아직 캐시 미기록)에서
+        shutdown 루프가 이를 ``None`` 으로 보고 skip 하고, 직후 connect 가
+        성공해 **disconnect 루프가 끝난 뒤에** 연결된 adapter 가 캐시에 기록돼
+        세션이 DB close 이후까지 잔존했다. lock 대기로 drain 하면, in-flight
+        connect 가 성공한 경우 캐시된 adapter 를 반환(→ shutdown 이
+        disconnect)하고, 실패한 경우 캐시 미기록이므로 ``None`` 을 반환한다.
+        새 adapter 생성/connect 는 일으키지 않는다(lock 안에서 단순 조회).
+        lock 보유 중 본 메서드를 호출하는 경로가 없어 재귀 deadlock 도 없다.
         """
-        return self._brokers.get(account_id)
+        async with self._broker_lock_for(account_id):
+            return self._brokers.get(account_id)
 
     async def _build_broker_adapter(self, account_id: str) -> BrokerAdapter:
         """현재 DB 상태로 BrokerAdapter를 생성한다 (캐시하지 않음).

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -310,7 +310,16 @@ class KISBaseAdapter(BrokerAdapter):
     # ── 연결 ───────────────────────────────────────
 
     async def connect(self) -> None:
-        """KIS API 연결 및 인증."""
+        """KIS API 연결 및 인증.
+
+        멱등(#2372): 이미 연결된 상태(``is_connected`` 이고 활성 session 보유)면
+        새 session 을 만들지 않고 즉시 반환한다. ``get_broker`` 가 connect-성공-후
+        -캐시하므로, 호출자(CLI ``_get_broker``·runtime startup)가 캐시된
+        어댑터에 connect 를 재호출해도 기존 session 교체로 인한 누수가 없다.
+        """
+        if self.is_connected and self._session is not None:
+            return
+
         try:
             import aiohttp
         except ImportError as e:

--- a/src/ante/broker/mock.py
+++ b/src/ante/broker/mock.py
@@ -100,7 +100,9 @@ class MockBrokerAdapter(BrokerAdapter):
     # ── 연결 ──────────────────────────────────────────
 
     async def connect(self) -> None:
-        """Mock 연결 (항상 성공)."""
+        """Mock 연결 (항상 성공). 멱등(#2372): 이미 연결됐으면 no-op."""
+        if self.is_connected:
+            return
         self.is_connected = True
         logger.info("Mock Broker 연결됨")
 

--- a/src/ante/broker/test.py
+++ b/src/ante/broker/test.py
@@ -247,7 +247,9 @@ class TestBrokerAdapter(BrokerAdapter):
     # ── 연결 ──────────────────────────────────────────────
 
     async def connect(self) -> None:
-        """Test 브로커 연결 (항상 성공)."""
+        """Test 브로커 연결 (항상 성공). 멱등(#2372): 이미 연결됐으면 no-op."""
+        if self.is_connected:
+            return
         self.is_connected = True
         logger.info(
             "Test Broker 연결됨 (seed=%d, cash=%.0f)",

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -2058,12 +2058,18 @@ async def _shutdown(s: Services) -> None:
         s.ipc_server.stop_dispatching()
         logger.info("IPCServer dispatch 거부 시작")
 
-    # 각 계좌의 BrokerAdapter disconnect
+    # 각 계좌의 BrokerAdapter disconnect.
+    # 종료 경로는 cached-only 접근자를 사용한다(#2372). get_broker 는
+    # connect-gate 가 되어 미캐시 계좌를 새로 인증/연결한 뒤 끊는 회귀를
+    # 일으키므로, 종료 중에는 이미 연결된(캐시된) 어댑터만 끊는다.
+    # 미캐시 계좌는 끊을 연결도 없으므로 skip 한다.
     if s.account_service:
         accounts = await s.account_service.list()
         for account in accounts:
+            broker = s.account_service.get_cached_broker(account.account_id)
+            if broker is None:
+                continue
             try:
-                broker = await s.account_service.get_broker(account.account_id)
                 await broker.disconnect()
                 logger.info("Broker 연결 해제: account=%s", account.account_id)
             except Exception:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -2063,10 +2063,15 @@ async def _shutdown(s: Services) -> None:
     # connect-gate 가 되어 미캐시 계좌를 새로 인증/연결한 뒤 끊는 회귀를
     # 일으키므로, 종료 중에는 이미 연결된(캐시된) 어댑터만 끊는다.
     # 미캐시 계좌는 끊을 연결도 없으므로 skip 한다.
+    # get_cached_broker 는 per-account lock 으로 in-flight 초기 connect 를
+    # drain 한 뒤 조회한다(#2372 Codex P2). 동기 즉시 조회였다면 cache-miss
+    # connect 가 in-flight 인 계좌를 None 으로 skip 하고, 그 connect 가 직후
+    # 성공해 이 루프가 끝난 뒤 캐시에 기록된 세션이 DB close 이후까지
+    # 잔존했다 — lock 대기로 그 윈도를 닫는다.
     if s.account_service:
         accounts = await s.account_service.list()
         for account in accounts:
-            broker = s.account_service.get_cached_broker(account.account_id)
+            broker = await s.account_service.get_cached_broker(account.account_id)
             if broker is None:
                 continue
             try:

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -916,6 +916,155 @@ async def test_broker_operations_work_after_credentials_update(service):
 
 
 @pytest.mark.asyncio
+async def test_get_broker_connect_failure_not_cached(service, monkeypatch):
+    """초기 get_broker connect 실패 시 캐시에 미기록 + 예외 전파 + 재시도.
+
+    회귀 방지 (#2372): get_broker 의 최초 생성 경로가 connect 성공을 확인하기
+    전에 캐시에 어댑터를 기록하면, 일시적 인증/네트워크 실패로 미연결 adapter
+    가 캐시에 잔존해 장기 실행 runtime 의 후속 소비자가 그대로 재사용한다.
+    재연결 경로(`_reconnect_broker`)는 connect 성공 후 캐시 원칙을 이미 지키며,
+    초기 경로도 동일해야 한다.
+    """
+    await service.create(_make_account())
+
+    from ante.broker.test import TestBrokerAdapter
+
+    call_count = {"connect": 0}
+    original_connect = TestBrokerAdapter.connect
+
+    async def fail_then_succeed(self):  # noqa: ANN001
+        call_count["connect"] += 1
+        if call_count["connect"] == 1:
+            raise RuntimeError("connect 실패 — 시뮬레이션 (일시적 인증 오류)")
+        await original_connect(self)
+
+    monkeypatch.setattr(TestBrokerAdapter, "connect", fail_then_succeed)
+
+    # 1) 첫 호출: connect 실패 → 예외 전파.
+    with pytest.raises(RuntimeError, match="connect 실패"):
+        await service.get_broker("main")
+
+    # 2) 실패한 adapter 는 캐시에 남지 않는다 (미연결 adapter 잔존 차단).
+    assert "main" not in service._brokers
+
+    # 3) 재호출 시 새 adapter 를 생성하고 connect 를 재시도해 자연 회복한다.
+    recovered = await service.get_broker("main")
+    assert recovered.is_connected is True
+    assert call_count["connect"] == 2
+    assert service._brokers["main"] is recovered
+
+
+@pytest.mark.asyncio
+async def test_get_broker_connect_called_once_on_miss_zero_on_hit(service):
+    """cache-miss 에서 connect 정확히 1회 + 이후 cache-hit 에서 추가 connect 0회.
+
+    회귀 방지 (#2372): 초기 get_broker 가 connect 를 수행하되, 이후 cache-hit
+    경로(hot-path)는 connect 없이 동일 인스턴스를 즉시 반환해야 한다.
+    """
+    await service.create(_make_account())
+
+    from ante.broker.test import TestBrokerAdapter
+
+    call_count = {"connect": 0}
+    original_connect = TestBrokerAdapter.connect
+
+    async def counting_connect(self):  # noqa: ANN001
+        call_count["connect"] += 1
+        await original_connect(self)
+
+    import unittest.mock
+
+    with unittest.mock.patch.object(TestBrokerAdapter, "connect", counting_connect):
+        # cache-miss: connect 1회 + 연결된 adapter 반환.
+        broker1 = await service.get_broker("main")
+        assert broker1.is_connected is True
+        assert call_count["connect"] == 1
+
+        # cache-hit: 추가 connect 없이 동일 인스턴스 반환.
+        broker2 = await service.get_broker("main")
+        assert broker2 is broker1
+        assert call_count["connect"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_broker_concurrent_miss_single_instance_single_connect(service):
+    """동일 계좌 동시 get_broker → 단일 인스턴스·connect 총 1회 (per-account lock).
+
+    회귀 방지 (#2372): cache-miss 경로를 직렬화하지 않으면 동시 miss 2건이
+    각각 adapter 를 만들고 connect 해 세션을 누수하며 마지막 것만 캐시된다.
+    per-account asyncio.Lock + double-checked 재검사로 단일 build+connect 보장.
+    """
+    await service.create(_make_account())
+
+    from ante.broker.test import TestBrokerAdapter
+
+    call_count = {"connect": 0}
+    original_connect = TestBrokerAdapter.connect
+
+    async def slow_connect(self):  # noqa: ANN001
+        call_count["connect"] += 1
+        # 동시 진입 윈도를 벌려 race 를 드러낸다.
+        import asyncio as _asyncio
+
+        await _asyncio.sleep(0.02)
+        await original_connect(self)
+
+    import asyncio
+    import unittest.mock
+
+    with unittest.mock.patch.object(TestBrokerAdapter, "connect", slow_connect):
+        broker_a, broker_b = await asyncio.gather(
+            service.get_broker("main"),
+            service.get_broker("main"),
+        )
+
+    assert broker_a is broker_b
+    assert call_count["connect"] == 1
+    assert service._brokers["main"] is broker_a
+    assert broker_a.is_connected is True
+
+
+@pytest.mark.asyncio
+async def test_get_cached_broker_returns_none_when_uncached(service):
+    """get_cached_broker: 미캐시 계좌는 build/connect 없이 None 반환.
+
+    회귀 방지 (#2372): shutdown 루프가 get_broker 로 미캐시 계좌를 새로
+    인증/연결 후 끊는 회귀를 차단하기 위한 cached-only 접근자. 미캐시 계좌는
+    끊을 연결도 없으므로 None 을 반환하고 connect 를 일으키지 않는다.
+    """
+    await service.create(_make_account())
+    assert "main" not in service._brokers
+
+    from ante.broker.test import TestBrokerAdapter
+
+    call_count = {"connect": 0}
+    original_connect = TestBrokerAdapter.connect
+
+    async def counting_connect(self):  # noqa: ANN001
+        call_count["connect"] += 1
+        await original_connect(self)
+
+    import unittest.mock
+
+    with unittest.mock.patch.object(TestBrokerAdapter, "connect", counting_connect):
+        cached = service.get_cached_broker("main")
+
+    assert cached is None
+    assert call_count["connect"] == 0
+    assert "main" not in service._brokers
+
+
+@pytest.mark.asyncio
+async def test_get_cached_broker_returns_instance_after_get_broker(service):
+    """get_cached_broker: get_broker 로 캐시된 후에는 동일 인스턴스 반환."""
+    await service.create(_make_account())
+
+    built = await service.get_broker("main")
+    cached = service.get_cached_broker("main")
+    assert cached is built
+
+
+@pytest.mark.asyncio
 async def test_create_account_with_broker_config(service):
     """생성 시 broker_config가 DB에 저장/로드."""
     account = _make_account(broker_config={"is_paper": True, "hts_id": "myid"})

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -1047,7 +1047,7 @@ async def test_get_cached_broker_returns_none_when_uncached(service):
     import unittest.mock
 
     with unittest.mock.patch.object(TestBrokerAdapter, "connect", counting_connect):
-        cached = service.get_cached_broker("main")
+        cached = await service.get_cached_broker("main")
 
     assert cached is None
     assert call_count["connect"] == 0
@@ -1060,8 +1060,112 @@ async def test_get_cached_broker_returns_instance_after_get_broker(service):
     await service.create(_make_account())
 
     built = await service.get_broker("main")
-    cached = service.get_cached_broker("main")
+    cached = await service.get_cached_broker("main")
     assert cached is built
+
+
+@pytest.mark.asyncio
+async def test_get_cached_broker_drains_inflight_connect(service):
+    """get_cached_broker: in-flight 초기 connect 를 drain 후 캐시된 adapter 반환.
+
+    회귀 방지 (#2372 Codex P2): 종료(shutdown) 루프가 cached-only 접근자로
+    "이미 연결된 어댑터만 끊을" 때, 동기 즉시 조회였다면 cache-miss
+    ``get_broker()`` 가 per-account lock 을 쥔 채 ``connect()`` 를 대기하는
+    in-flight 구간(아직 캐시 미기록)을 ``None`` 으로 보고 skip 하고, 그 connect
+    가 직후 성공해 disconnect 루프가 끝난 뒤 캐시에 기록된 세션이 DB close
+    이후까지 잔존했다.
+
+    본 테스트는 connect 를 ``asyncio.Event`` 로 게이트해 그 윈도를 결정적으로
+    재현한다: T1 ``get_broker()`` 가 connect 에서 정지(in-flight·캐시 미기록)한
+    사이 T2 ``get_cached_broker()`` 를 태스크로 시작해 같은 lock 대기에
+    진입시킨 뒤 게이트를 푼다. async lock-drain 구현에서는 T2 가 in-flight
+    connect 완료를 기다린 뒤 조회하므로 **연결된 adapter 를 반환**(None 아님)
+    해야 한다. 동기 즉시 조회(전 HEAD)였다면 T2 가 캐시 미기록 시점에 ``None``
+    을 반환해 RED.
+    """
+    import asyncio
+    import unittest.mock
+
+    await service.create(_make_account())
+
+    from ante.broker.test import TestBrokerAdapter
+
+    connect_started = asyncio.Event()
+    release_connect = asyncio.Event()
+    original_connect = TestBrokerAdapter.connect
+
+    async def gated_connect(self):  # noqa: ANN001
+        connect_started.set()
+        await release_connect.wait()
+        await original_connect(self)
+
+    with unittest.mock.patch.object(TestBrokerAdapter, "connect", gated_connect):
+        # T1: 초기 get_broker — adapter build 후 connect 에서 정지(캐시 미기록).
+        get_task = asyncio.create_task(service.get_broker("main"))
+        await asyncio.wait_for(connect_started.wait(), timeout=2.0)
+        assert "main" not in service._brokers  # in-flight: 아직 캐시 미기록
+
+        # T2: get_cached_broker — 같은 per-account lock 대기에 진입한다.
+        cached_task = asyncio.create_task(service.get_cached_broker("main"))
+        # T2 가 lock 대기에 진입할 시간을 준다(즉시 None 반환하지 않아야 함).
+        await asyncio.sleep(0.05)
+        assert not cached_task.done(), (
+            "동기 즉시 조회면 lock 대기 없이 None 으로 즉시 완료 → drain 누락"
+        )
+
+        # 게이트 해제 → T1 connect 완료·캐시 기록·lock 해제 → T2 진입.
+        release_connect.set()
+
+        built = await asyncio.wait_for(get_task, timeout=2.0)
+        cached = await asyncio.wait_for(cached_task, timeout=2.0)
+
+    # drain 후 조회: in-flight connect 가 성공했으므로 캐시된 adapter 반환.
+    assert cached is not None
+    assert cached is built
+    assert cached.is_connected is True
+
+
+@pytest.mark.asyncio
+async def test_get_cached_broker_returns_none_when_inflight_connect_fails(service):
+    """get_cached_broker: in-flight 초기 connect 가 실패하면 drain 후 None (#2372).
+
+    connect 실패 시 ``get_broker()`` 는 캐시에 기록하지 않으므로(connect-성공-
+    후-캐시), in-flight 구간을 drain 한 ``get_cached_broker()`` 는 ``None`` 을
+    반환해야 한다 — 미연결/세션-누수 adapter 를 종료 루프가 잡지 않는다.
+    """
+    import asyncio
+    import unittest.mock
+
+    await service.create(_make_account())
+
+    from ante.broker.test import TestBrokerAdapter
+
+    connect_started = asyncio.Event()
+    release_connect = asyncio.Event()
+
+    async def failing_connect(self):  # noqa: ANN001
+        connect_started.set()
+        await release_connect.wait()
+        raise RuntimeError("연결 실패")
+
+    with unittest.mock.patch.object(TestBrokerAdapter, "connect", failing_connect):
+        get_task = asyncio.create_task(service.get_broker("main"))
+        await asyncio.wait_for(connect_started.wait(), timeout=2.0)
+        assert "main" not in service._brokers
+
+        cached_task = asyncio.create_task(service.get_cached_broker("main"))
+        await asyncio.sleep(0.05)
+        assert not cached_task.done()  # lock 대기로 drain 중
+
+        release_connect.set()
+
+        with pytest.raises(RuntimeError):
+            await asyncio.wait_for(get_task, timeout=2.0)
+        cached = await asyncio.wait_for(cached_task, timeout=2.0)
+
+    # connect 실패 → 캐시 미기록 → drain 후 None.
+    assert cached is None
+    assert "main" not in service._brokers
 
 
 @pytest.mark.asyncio
@@ -1125,7 +1229,7 @@ async def test_reconnect_during_inflight_get_broker_connect_uses_new_config(
         await asyncio.wait_for(update_task, timeout=2.0)
 
     # 최종 캐시 adapter 는 신 설정으로 생성·연결되어야 한다.
-    cached = service.get_cached_broker("main")
+    cached = await service.get_cached_broker("main")
     assert cached is not None
     assert cached.config.get("app_key") == "new"
     assert cached.is_connected is True
@@ -1176,7 +1280,7 @@ async def test_reconnect_broker_direct_serializes_with_inflight_get_broker(servi
         await asyncio.wait_for(get_task, timeout=2.0)
         await asyncio.wait_for(reconnect_task, timeout=2.0)
 
-    cached = service.get_cached_broker("main")
+    cached = await service.get_cached_broker("main")
     assert cached is not None
     assert cached.config.get("app_key") == "new"
     assert cached.is_connected is True

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -1065,6 +1065,124 @@ async def test_get_cached_broker_returns_instance_after_get_broker(service):
 
 
 @pytest.mark.asyncio
+async def test_reconnect_during_inflight_get_broker_connect_uses_new_config(
+    service,
+):
+    """in-flight 초기 connect ↔ 설정 변경 race: 최종 캐시는 신 설정 (#2372).
+
+    회귀 방지 (#2372 Codex P2): 초기 ``get_broker()`` 가 per-account lock 을
+    쥔 채 ``connect()`` 를 대기하는 in-flight 구간(아직 캐시 미기록)에서
+    ``update(credentials=...)`` → ``_reconnect_broker()`` 가 들어오면, lock
+    없이 캐시 부재 조기 반환하던 구현은 reconnect 를 조용히 건너뛰고 직후
+    get_broker 가 **구 설정 adapter 를 캐시에 기록**해 DB(신 설정)와 캐시(구
+    설정)가 영구 어긋났다.
+
+    본 테스트는 connect 를 ``asyncio.Event`` 로 게이트해 그 윈도를 결정적으로
+    재현한다: 구 설정(app_key='test') connect 가 정지한 사이 update 를 시작해
+    reconnect 가 같은 lock 대기에 진입하게 만든 뒤 게이트를 풀어, lock 직렬화
+    구현에서는 reconnect 가 in-flight connect 완료 후 진입해 신 설정으로
+    rebuild + swap 하므로 **최종 캐시 adapter 의 app_key == 'new'** 가 되어야
+    한다. lock 직렬화 전(현 HEAD)에는 'test' 로 남아 RED.
+    """
+    import asyncio
+    import unittest.mock
+
+    await service.create(_make_account())
+
+    from ante.broker.test import TestBrokerAdapter
+
+    old_connect_started = asyncio.Event()
+    release_old_connect = asyncio.Event()
+    original_connect = TestBrokerAdapter.connect
+
+    async def gated_connect(self):  # noqa: ANN001
+        # 구 설정(초기 get_broker) connect 만 게이트해 in-flight 윈도를 벌린다.
+        # 신 설정(reconnect) connect 는 즉시 통과시킨다.
+        if self.config.get("app_key") == "test":
+            old_connect_started.set()
+            await release_old_connect.wait()
+        await original_connect(self)
+
+    with unittest.mock.patch.object(TestBrokerAdapter, "connect", gated_connect):
+        # T1: 초기 get_broker — 구 설정 adapter 를 build 하고 connect 에서 정지.
+        get_task = asyncio.create_task(service.get_broker("main"))
+
+        # 구 설정 connect 가 in-flight(캐시 미기록·lock 보유)에 도달할 때까지 대기.
+        await asyncio.wait_for(old_connect_started.wait(), timeout=2.0)
+        assert "main" not in service._brokers  # 아직 캐시 미기록
+
+        # T2: 설정 변경 — _reconnect_broker 가 같은 lock 대기에 진입한다.
+        update_task = asyncio.create_task(
+            service.update("main", credentials={"app_key": "new", "app_secret": "new"})
+        )
+        # reconnect 가 lock 대기 상태에 진입할 시간을 준다.
+        await asyncio.sleep(0.05)
+
+        # 게이트 해제 → T1 완료(구 adapter 캐시) → lock 해제 → T2 reconnect 진입.
+        release_old_connect.set()
+
+        await asyncio.wait_for(get_task, timeout=2.0)
+        await asyncio.wait_for(update_task, timeout=2.0)
+
+    # 최종 캐시 adapter 는 신 설정으로 생성·연결되어야 한다.
+    cached = service.get_cached_broker("main")
+    assert cached is not None
+    assert cached.config.get("app_key") == "new"
+    assert cached.is_connected is True
+
+
+@pytest.mark.asyncio
+async def test_reconnect_broker_direct_serializes_with_inflight_get_broker(service):
+    """`_reconnect_broker` 직접 호출도 in-flight connect 와 lock 직렬화 (#2372).
+
+    update() 우회로 ``_reconnect_broker`` 를 직접 호출하는 경로도 동일 lock
+    으로 직렬화되는지 격리 검증한다. 구 설정 adapter 의 connect 가 정지한 채
+    DB credentials 만 신 설정으로 갱신한 뒤 reconnect 를 호출하면, lock 직렬화
+    구현에서는 in-flight connect 완료 후 reconnect 가 진입해 신 설정으로
+    rebuild + swap 하므로 최종 캐시 adapter 의 app_key == 'new' 여야 한다.
+    """
+    import asyncio
+    import unittest.mock
+
+    await service.create(_make_account())
+
+    from ante.broker.test import TestBrokerAdapter
+
+    old_connect_started = asyncio.Event()
+    release_old_connect = asyncio.Event()
+    original_connect = TestBrokerAdapter.connect
+
+    async def gated_connect(self):  # noqa: ANN001
+        if self.config.get("app_key") == "test":
+            old_connect_started.set()
+            await release_old_connect.wait()
+        await original_connect(self)
+
+    with unittest.mock.patch.object(TestBrokerAdapter, "connect", gated_connect):
+        get_task = asyncio.create_task(service.get_broker("main"))
+        await asyncio.wait_for(old_connect_started.wait(), timeout=2.0)
+        assert "main" not in service._brokers
+
+        # DB·인메모리 계좌 캐시의 credentials 를 신 설정으로 직접 갱신한 뒤
+        # _reconnect_broker 를 호출한다(update() 경로 우회, lock 직렬화만 검증).
+        account = await service.get("main")
+        account.credentials = {"app_key": "new", "app_secret": "new"}
+        service._accounts["main"] = account
+
+        reconnect_task = asyncio.create_task(service._reconnect_broker("main"))
+        await asyncio.sleep(0.05)
+
+        release_old_connect.set()
+        await asyncio.wait_for(get_task, timeout=2.0)
+        await asyncio.wait_for(reconnect_task, timeout=2.0)
+
+    cached = service.get_cached_broker("main")
+    assert cached is not None
+    assert cached.config.get("app_key") == "new"
+    assert cached.is_connected is True
+
+
+@pytest.mark.asyncio
 async def test_create_account_with_broker_config(service):
     """생성 시 broker_config가 DB에 저장/로드."""
     account = _make_account(broker_config={"is_paper": True, "hts_id": "myid"})

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -606,3 +606,44 @@ class TestKISAdapterConnectCleanup:
         session.close.assert_awaited_once()
         assert adapter._session is None
         assert adapter.is_connected is False
+
+    async def test_connect_idempotent_keeps_existing_session(self, monkeypatch):
+        """이미 연결된 adapter 에 connect 재호출 → 기존 session 유지·새 session 미생성.
+
+        회귀 방지 (#2372): connect() 가 호출마다 새 ClientSession 을 생성하면,
+        get_broker 직후 호출자(CLI _get_broker·runtime startup)가 connect 를
+        재호출할 때 기존 session 이 교체되며 누수된다. 연결 상태면 no-op 으로
+        멱등하게 동작해야 한다.
+        """
+        adapter = KISAdapter(KIS_CONFIG)
+
+        async def _ok() -> None:
+            adapter.access_token = "test_token"
+
+        monkeypatch.setattr(adapter, "_authenticate", _ok)
+
+        # ClientSession 생성 횟수 추적.
+        import aiohttp
+
+        created_sessions: list[MagicMock] = []
+
+        def _make_session(*args, **kwargs):  # noqa: ANN002, ANN003
+            s = MagicMock(name=f"ClientSession-{len(created_sessions)}")
+            s.close = AsyncMock()
+            created_sessions.append(s)
+            return s
+
+        monkeypatch.setattr(aiohttp, "ClientSession", _make_session)
+
+        # 1) 첫 connect: session 1개 생성·연결 성공.
+        await adapter.connect()
+        first_session = adapter._session
+        assert first_session is created_sessions[0]
+        assert adapter.is_connected is True
+        assert len(created_sessions) == 1
+
+        # 2) 재호출(멱등): 새 session 미생성, 기존 session 그대로 유지.
+        await adapter.connect()
+        assert adapter._session is first_session
+        assert len(created_sessions) == 1
+        first_session.close.assert_not_called()


### PR DESCRIPTION
Closes #2372

## Summary
- `AccountService.get_broker`가 adapter를 connect 전에 캐시해 연결 실패 adapter가 잔존하던 결함 수정: cache-miss 경로를 build → connect → **성공 시에만 캐시**로 전환(실패 시 미기록+전파, 다음 호출이 신 설정으로 재시도). cache-hit hot-path 비용 불변
- **per-account asyncio.Lock**: cache-miss 직렬화(double-checked) — 동시 miss의 이중 connect/세션 누수 차단. `_reconnect_broker`도 동일 lock에 편입(in-flight connect ↔ 설정 변경 race 제거)
- **`get_cached_broker`(lock-drain async)** 추가 + shutdown 루프 전환 — 종료 중 in-flight connect를 drain 후 캐시 재확인(미캐시=skip, 신규 생성 없음)
- **connect 멱등 가드**: KIS(연결 상태면 no-op — 이중 호출 세션 교체 누수 차단)·Mock·TestBrokerAdapter 정렬. 기존 호출자의 명시적 connect()는 no-op으로 동작 동일(시그니처 비변경)
- `main.py:653` stream-init은 connect-gate가 됨(미연결 계좌의 스트림 초기화 skip — per-account try/except 격리, 의도된 개선)
- 스펙: account/04-account-service.md에 캐시-연결 의미론·멱등·cached-only drain 명시

## Review Trail
- Codex Plan Review: r1 revise-plan(shutdown cached-only·동시성 race) → r2 **approve-implement**
- Codex 브랜치 리뷰: attempt 1 FAIL(설정 race → reconnect lock 편입) → attempt 2 FAIL(shutdown drain → lock-drain 조회) → attempt 3 FAIL(이론 race) → **11a 메타 리뷰**(@code-reviewer): attempt 3은 lock 수렴(테스트 고정) + broker_invalidating ⊆ STRUCTURAL_FIELDS·boot 순차성으로 **런타임 도달 불가** — bounded-scope 종결 판정, main 대비 신규 회귀 없음(main은 lock-free로 더 넓은 race) → attempt 4 **PASS**(adjudicated, Codex가 사실 주장 독립 검증)
- known-limitation/follow-up 후보(이슈 코멘트 기록): update() in-place mutation → 새 객체 swap 패턴(boot-only 이론 윈도), _broker_locks delete 시 정리

## Test Plan
- 동시성 회귀 9건(전부 결정적 Event 게이트, main RED 확인): connect 실패 미캐시·KIS 멱등·miss1/hit0·concurrent miss·shutdown drain 2건·설정 변경 race 2건 등
- `pytest` 전체 (7270 passed, 2 skipped) / `ruff check` / `ruff format --check` / `mypy src/` 전체 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)