### PR TITLE
fix(notification): #2378 텔레그램 /balance TreasuryManager 주입 — 전 계좌 자금 현황 요약

### DIFF
--- a/docs/specs/notification/notification.md
+++ b/docs/specs/notification/notification.md
@@ -147,7 +147,7 @@ CRITICAL 알림은 `telegram_enabled=false`, `min_level`, `quiet_hours`, dedup�
 | `polling_interval` | float | 3.0 | 폴링 간격 (초) |
 | `confirm_timeout` | float | 30.0 | 위험 명령 확인 대기 시간 (초) |
 | `bot_manager` | BotManager \| None | None | 봇 관리용 |
-| `treasury` | Treasury \| None | None | 자금 현황 조회용 |
+| `treasury_manager` | TreasuryManager \| None | None | 자금 현황 조회용 (전 계좌) |
 | `account_service` | AccountService \| None | None | 계좌 상태 제어용 |
 | `approval_service` | ApprovalService \| None | None | 결재 승인/거절 처리용 |
 
@@ -158,7 +158,7 @@ CRITICAL 알림은 `telegram_enabled=false`, `min_level`, `quiet_hours`, dedup�
 | `/help` | 사용 가능한 명령어 목록 | - |
 | `/status` | 시스템 상태 요약 (거래 상태, 봇 현황) | - |
 | `/bots` | 봇 목록 + 상태 | - |
-| `/balance` | 자금 현황 요약 (계좌 잔고, 할당/미할당) | - |
+| `/balance` | 전 계좌 자금 현황 요약 (계좌별 잔고, 할당/미할당) | - |
 | `/halt [reason]` | 전체 거래 중지 (모든 ACTIVE 계좌를 SUSPENDED로 전환) | 2단계 확인 |
 | `/clear_halt` | 전역 정지 해제 (모든 SUSPENDED 계좌를 ACTIVE로 복구; 봇 자동 재시작 아님) | 2단계 확인 |
 | `/stop <bot_id>` | 특정 봇 중지 | 2단계 확인 |

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1806,6 +1806,7 @@ async def _init_notification(s: Services) -> None:
             polling_interval=3.0,
             confirm_timeout=30.0,
             bot_manager=s.bot_manager,
+            treasury_manager=s.treasury_manager,
             account_service=s.account_service,
             approval_service=s.approval_service,
         )

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from ante.approval.service import ApprovalService
     from ante.bot.manager import BotManager
     from ante.notification.telegram import TelegramAdapter
-    from ante.treasury.treasury import Treasury
+    from ante.treasury.manager import TreasuryManager
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class TelegramCommandReceiver:
         polling_interval: float = 3.0,
         confirm_timeout: float = 30.0,
         bot_manager: BotManager | None = None,
-        treasury: Treasury | None = None,
+        treasury_manager: TreasuryManager | None = None,
         account_service: AccountService | None = None,
         approval_service: ApprovalService | None = None,
     ) -> None:
@@ -43,7 +43,7 @@ class TelegramCommandReceiver:
         self._polling_interval = polling_interval
         self._confirm_timeout = confirm_timeout
         self._bot_manager = bot_manager
-        self._treasury = treasury
+        self._treasury_manager = treasury_manager
         self._account_service = account_service
         self._approval_service = approval_service
 
@@ -439,11 +439,34 @@ class TelegramCommandReceiver:
         return f"\U0001f916 봇 목록 ({running}/{total} 실행 중)\n" + "\n".join(lines)
 
     def _cmd_balance(self, args: list[str]) -> str:
-        """자금 현황."""
-        if not self._treasury:
-            return "Treasury가 연결되지 않았습니다."
+        """자금 현황 — 전 계좌 요약.
 
-        summary = self._treasury.get_summary()
+        SSOT: ``docs/specs/notification/notification.md`` 지원 명령 표.
+        ``TreasuryManager.list_all()`` (sync) 으로 등록된 모든 계좌의 잔고를
+        계좌별 섹션으로 렌더링한다 (#2378 — 단일 ``Treasury`` 주입 결함 정정).
+        """
+        if not self._treasury_manager:
+            return "TreasuryManager가 연결되지 않았습니다."
+
+        treasuries = self._treasury_manager.list_all()
+        if not treasuries:
+            return "등록된 계좌가 없습니다."
+
+        sections: list[str] = []
+        for treasury in treasuries:
+            sections.append(
+                f"계좌: {treasury.account_id}\n"
+                + self._render_account_balance(treasury.get_summary())
+            )
+
+        return "ℹ️ 자금 현황\n\n" + "\n\n".join(sections)
+
+    @staticmethod
+    def _render_account_balance(summary: dict[str, Any]) -> str:
+        """단일 계좌 자금 현황 본문 렌더링 (타이틀 제외).
+
+        예수금/매수가능/Ante 관리 종목(조건부)/봇 할당/미할당 포맷.
+        """
         balance = summary.get("account_balance", 0)
         purchasable = summary.get("purchasable_amount", 0)
         ante_purchase = summary.get("ante_purchase_amount", 0)
@@ -465,7 +488,6 @@ class TelegramCommandReceiver:
             pl_emoji = "➖"
 
         lines = [
-            "ℹ️ 자금 현황",
             f"계좌 예수금: {balance:,.0f}원",
             f"매수 가능: {purchasable:,.0f}원",
         ]

--- a/tests/unit/test_main_init_notification.py
+++ b/tests/unit/test_main_init_notification.py
@@ -228,14 +228,23 @@ async def test_enabled_with_secrets_initializes_service(
         notification_mod, "NotificationService", _StubNotificationService
     )
 
+    captured_kwargs: list[dict[str, Any]] = []
+
     class _StubReceiver:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             self.started = False
+            captured_kwargs.append(kwargs)
 
         def start(self) -> None:
             self.started = True
 
     monkeypatch.setattr(notification_mod, "TelegramCommandReceiver", _StubReceiver)
+
+    # #2378: `_init_notification`이 TelegramCommandReceiver에 자금 조회
+    # 의존성(TreasuryManager)을 주입하는지 회귀 가드. 주입 누락 시
+    # `/balance`가 런타임에서 항상 fallback 문구를 반환하는 버그가 발생한다.
+    sentinel_treasury_manager = object()
+    s.treasury_manager = sentinel_treasury_manager  # type: ignore[assignment]
 
     try:
         await _init_notification(s)
@@ -245,3 +254,7 @@ async def test_enabled_with_secrets_initializes_service(
     assert len(created) == 1, "NotificationService 생성자 호출 누락"
     assert s.notification_service is not None
     assert s.telegram_receiver is not None
+    assert len(captured_kwargs) == 1, "TelegramCommandReceiver 생성자 호출 누락"
+    assert captured_kwargs[0]["treasury_manager"] is s.treasury_manager, (
+        "TelegramCommandReceiver에 s.treasury_manager가 주입되어야 한다"
+    )

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -51,10 +51,11 @@ def bot_manager():
     return mock
 
 
-@pytest.fixture
-def treasury():
+def _make_treasury(account_id: str = "test", summary: dict | None = None):
+    """``account_id`` property + sync ``get_summary()``를 갖는 Treasury mock."""
     mock = MagicMock()
-    mock.get_summary.return_value = {
+    mock.account_id = account_id
+    mock.get_summary.return_value = summary or {
         "account_balance": 10_000_000,
         "purchasable_amount": 7_000_000,
         "ante_purchase_amount": 2_500_000,
@@ -64,6 +65,14 @@ def treasury():
         "unallocated": 5_000_000,
         "bot_count": 2,
     }
+    return mock
+
+
+@pytest.fixture
+def treasury_manager():
+    """TreasuryManager mock — ``list_all()`` (sync) 가 단일 Treasury 반환."""
+    mock = MagicMock()
+    mock.list_all.return_value = [_make_treasury()]
     return mock
 
 
@@ -101,14 +110,14 @@ def account_service():
 
 
 @pytest.fixture
-def receiver(adapter, bot_manager, treasury, account_service):
+def receiver(adapter, bot_manager, treasury_manager, account_service):
     return TelegramCommandReceiver(
         adapter=adapter,
         allowed_user_ids=[12345],
         polling_interval=1.0,
         confirm_timeout=30.0,
         bot_manager=bot_manager,
-        treasury=treasury,
+        treasury_manager=treasury_manager,
         account_service=account_service,
     )
 
@@ -207,6 +216,7 @@ class TestCommands:
     async def test_balance(self, receiver):
         result = receiver._cmd_balance([])
         assert "자금 현황" in result
+        assert "계좌: test" in result
         assert "계좌 예수금: 10,000,000원" in result
         assert "매수 가능: 7,000,000원" in result
         assert "매입: 2,500,000원" in result
@@ -215,42 +225,98 @@ class TestCommands:
         assert "봇 할당: 5,000,000원 (2개)" in result
         assert "미할당: 5,000,000원" in result
 
-    async def test_balance_no_positions(self, receiver, treasury):
+    async def test_balance_no_positions(self, receiver, treasury_manager):
         """Ante 관리 종목이 없으면 해당 섹션 미표시."""
-        treasury.get_summary.return_value = {
-            "account_balance": 10_000_000,
-            "purchasable_amount": 10_000_000,
-            "ante_purchase_amount": 0,
-            "ante_eval_amount": 0,
-            "ante_profit_loss": 0,
-            "total_allocated": 0,
-            "unallocated": 10_000_000,
-            "bot_count": 0,
-        }
+        treasury_manager.list_all.return_value = [
+            _make_treasury(
+                summary={
+                    "account_balance": 10_000_000,
+                    "purchasable_amount": 10_000_000,
+                    "ante_purchase_amount": 0,
+                    "ante_eval_amount": 0,
+                    "ante_profit_loss": 0,
+                    "total_allocated": 0,
+                    "unallocated": 10_000_000,
+                    "bot_count": 0,
+                }
+            )
+        ]
         result = receiver._cmd_balance([])
         assert "자금 현황" in result
         assert "Ante 관리 종목" not in result
         assert "봇 할당: 0원 (0개)" in result
 
-    async def test_balance_negative_pl(self, receiver, treasury):
+    async def test_balance_negative_pl(self, receiver, treasury_manager):
         """손실 시 음수 부호."""
-        treasury.get_summary.return_value = {
-            "account_balance": 10_000_000,
-            "purchasable_amount": 7_000_000,
-            "ante_purchase_amount": 2_500_000,
-            "ante_eval_amount": 2_300_000,
-            "ante_profit_loss": -200_000,
-            "total_allocated": 5_000_000,
-            "unallocated": 5_000_000,
-            "bot_count": 2,
-        }
+        treasury_manager.list_all.return_value = [
+            _make_treasury(
+                summary={
+                    "account_balance": 10_000_000,
+                    "purchasable_amount": 7_000_000,
+                    "ante_purchase_amount": 2_500_000,
+                    "ante_eval_amount": 2_300_000,
+                    "ante_profit_loss": -200_000,
+                    "total_allocated": 5_000_000,
+                    "unallocated": 5_000_000,
+                    "bot_count": 2,
+                }
+            )
+        ]
         result = receiver._cmd_balance([])
         assert "-200,000원" in result
 
-    async def test_balance_no_treasury(self, receiver):
-        receiver._treasury = None
+    async def test_balance_multi_account(self, receiver, treasury_manager):
+        """다계좌 — 계좌별 섹션이 각각 렌더링된다 (#2378 전 계좌 요약)."""
+        treasury_manager.list_all.return_value = [
+            _make_treasury(
+                account_id="acct-a",
+                summary={
+                    "account_balance": 10_000_000,
+                    "purchasable_amount": 7_000_000,
+                    "ante_purchase_amount": 0,
+                    "ante_eval_amount": 0,
+                    "ante_profit_loss": 0,
+                    "total_allocated": 3_000_000,
+                    "unallocated": 4_000_000,
+                    "bot_count": 1,
+                },
+            ),
+            _make_treasury(
+                account_id="acct-b",
+                summary={
+                    "account_balance": 20_000_000,
+                    "purchasable_amount": 15_000_000,
+                    "ante_purchase_amount": 0,
+                    "ante_eval_amount": 0,
+                    "ante_profit_loss": 0,
+                    "total_allocated": 5_000_000,
+                    "unallocated": 10_000_000,
+                    "bot_count": 2,
+                },
+            ),
+        ]
         result = receiver._cmd_balance([])
-        assert "연결되지 않았습니다" in result
+        # 최상단 타이틀은 1회만 노출
+        assert result.count("ℹ️ 자금 현황") == 1
+        # 두 계좌 헤더와 각 본문이 모두 노출
+        assert "계좌: acct-a" in result
+        assert "계좌: acct-b" in result
+        assert "계좌 예수금: 10,000,000원" in result
+        assert "계좌 예수금: 20,000,000원" in result
+        assert "봇 할당: 3,000,000원 (1개)" in result
+        assert "봇 할당: 5,000,000원 (2개)" in result
+
+    async def test_balance_no_accounts(self, receiver, treasury_manager):
+        """등록된 계좌가 없으면 안내 메시지."""
+        treasury_manager.list_all.return_value = []
+        result = receiver._cmd_balance([])
+        assert "등록된 계좌가 없습니다" in result
+
+    async def test_balance_no_treasury_manager(self, receiver):
+        """TreasuryManager 미주입 시 fallback 문구."""
+        receiver._treasury_manager = None
+        result = receiver._cmd_balance([])
+        assert "TreasuryManager가 연결되지 않았습니다" in result
 
     async def test_unknown_command(self, receiver):
         result = await receiver._execute("unknown", [], 12345, 100)


### PR DESCRIPTION
Closes #2378

## Summary
- `TelegramCommandReceiver` 생성자 파라미터를 `treasury: Treasury | None` → `treasury_manager: TreasuryManager | None`으로 교체하고, `main.py` `_init_notification`에서 `treasury_manager=s.treasury_manager`를 주입해 운영 환경에서 `/balance`가 항상 미연결 fallback을 반환하던 wiring 결함을 수정
- `_cmd_balance`를 전 계좌 요약으로 재작성 (sync 유지): 계좌별 `계좌: {account_id}` 헤더 + 기존 단일 계좌 포맷 보존, 미주입 시 `TreasuryManager가 연결되지 않았습니다.`, 0계좌 시 `등록된 계좌가 없습니다.`
- 스펙 동기 갱신: `docs/specs/notification/notification.md` 생성자 파라미터 표 + `/balance` 전 계좌 범위 명시
- 계약 결정(adjudicated): 전 계좌 요약, `/balance [account_id]` 인자는 YAGNI 제외 — 이슈 코멘트 참조

## Test Plan
- `uv run ruff check src tests` / `uv run ruff format --check src tests` — PASS
- `uv run mypy src/ante` 전체 — PASS (233 files)
- `uv run pytest tests/unit -q` — 7264 passed, 2 skipped
- TDD red 확인: `_init_notification` kwargs 캡처 회귀 테스트가 구현 전 `KeyError: 'treasury_manager'`로 fail → 구현 후 green
- Codex 브랜치 리뷰 (`codex review --base main`): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)