### PR TITLE
feat(notification): #2379 텔레그램 결재 인라인 버튼 전용화 — /approve·/reject 텍스트 명령 스펙아웃

### DIFF
--- a/docs/specs/approval/02-design-decisions.md
+++ b/docs/specs/approval/02-design-decisions.md
@@ -25,15 +25,15 @@ Agent: 리포트 제출 (근거 자료)
 
 **흐름:**
 1. 결재 요청 생성 시, Notification이 Telegram으로 요약 메시지를 전송한다.
-2. 메시지에는 인라인 버튼(승인/거절) 또는 응답 명령어(`/approve <id>`, `/reject <id>`)가 포함된다.
-3. 사용자가 응답하면 Notification 어댑터가 이를 수신하여 `ApprovalService.approve()` 또는 `reject()`를 호출한다.
+2. 메시지에는 인라인 버튼(승인/거절)이 포함된다.
+3. 사용자가 버튼을 탭하면 Notification 어댑터가 `callback_query`를 수신하여 `ApprovalService.approve()` 또는 `reject()`를 호출한다.
 
 **Notification 어댑터 현황:**
 
 Notification 모듈은 양방향 통신을 지원한다. `TelegramAdapter`가 발송을, `TelegramCommandReceiver`가 getUpdates 폴링 기반 명령 수신을 담당한다.
 
 - **발송**: `ApprovalService`가 `NotificationEvent`(category=`approval`, 승인/거절 버튼 포함)를 직접 발행하고, `NotificationService`가 `NotificationEvent`를 구독해 결재 요약 + 인라인 버튼(승인/거절)을 전송
-- **수신**: 인라인 버튼 `callback_query` 또는 `/approve <id>`, `/reject <id>` 명령어 → `ApprovalService` 호출
+- **수신**: 인라인 버튼 `callback_query`(`approve:{id}`/`reject:{id}`) → `ApprovalService` 호출 (텔레그램 결재는 인라인 버튼 단일 경로; 텍스트 명령 `/approve`·`/reject`는 지원하지 않음)
 
 **인라인 버튼 결재 흐름:**
 
@@ -52,7 +52,7 @@ Notification 모듈은 양방향 통신을 지원한다. `TelegramAdapter`가 �
     → 처리 결과 메시지 응답
 ```
 
-인라인 버튼으로 거절 시 기본 사유("사용자 거절")를 사용한다. 상세 사유가 필요하면 `/reject <id> <reason>` 명령어를 직접 입력한다.
+인라인 버튼으로 거절 시 기본 사유("사용자 거절")를 사용한다. 상세 사유가 필요하면 CLI(`ante approval reject <id> --reason <reason>`)로 처리한다.
 
 **보안**: `TELEGRAM_CHAT_ID`와 일치하는 사용자만 명령을 실행할 수 있다. 개인 홈서버 환경에서는 이 수준이면 충분하다.
 

--- a/docs/specs/approval/11-notification-events.md
+++ b/docs/specs/approval/11-notification-events.md
@@ -46,7 +46,7 @@ ID: `{id}`
 - `reject_reason` → 거절 사유 (거절 시)
 - 예외 발생 여부 → executor 실행 실패, 이미 처리됨, 만료됨, ID 없음
 
-**중복 알림 방지 정책**: 텔레그램 명령(`/approve`, `/reject`, 인라인 버튼)으로 처리된 경우 직접 응답(reply)만 발송하고 NotificationEvent는 발행하지 않는다. CLI 등 텔레그램 외 채널에서 처리된 경우에만 NotificationEvent를 발행한다. 이를 통해 사용자는 어떤 채널에서 처리하든 정확히 1번만 메시지를 수신한다.
+**중복 알림 방지 정책**: 텔레그램에서 처리된 경우(결재 인라인 버튼 callback `approve:{id}`/`reject:{id}`)는 직접 응답(reply)만 발송하고 NotificationEvent는 발행하지 않는다. CLI 등 텔레그램 외 채널에서 처리된 경우에만 NotificationEvent를 발행한다. 이를 통해 사용자는 어떤 채널에서 처리하든 정확히 1번만 메시지를 수신한다.
 
 **NotificationEvent 발행** (CLI 등 텔레그램 외 채널에서 처리 시):
 
@@ -61,9 +61,9 @@ category: approval
 ID: `{id}`
 ```
 
-**텔레그램 명령 직접 응답** (텔레그램에서 처리 시, 명령 발신자에게 reply):
+**텔레그램 버튼 처리 직접 응답** (인라인 버튼 callback으로 처리 시, 사용자에게 reply):
 
-| 결과 | `/approve` 응답 | `/reject` 응답 |
+| 결과 | 승인(`approve:{id}`) 응답 | 거절(`reject:{id}`) 응답 |
 |------|-----------------|----------------|
 | 성공 | `✅ 결재 승인 완료\n제목: {title}\nID: {id}` | `❌ 결재 거절 완료\n제목: {title}\nID: {id}\n사유: {reason}` |
 | executor 실행 실패 | `⚠️ 승인되었으나 실행 실패\n제목: {title}\nID: {id}\n사유: {error}` | — |
@@ -71,4 +71,4 @@ ID: `{id}`
 | 만료됨 | `ℹ️ 만료된 결재입니다\nID: {id}` | 동일 |
 | ID 없음 | `❌ 결재를 찾을 수 없습니다\nID: {id}` | 동일 |
 
-> 인라인 버튼으로 거절 시 사유는 기본값(`"사용자 거절"`)을 사용한다. 상세 사유가 필요하면 `/reject <id> <reason>` 명령어를 직접 입력한다.
+> 인라인 버튼으로 거절 시 사유는 기본값(`"사용자 거절"`)을 사용한다. 상세 사유가 필요하면 CLI(`ante approval reject <id> --reason <reason>`)로 처리한다.

--- a/docs/specs/notification/notification.md
+++ b/docs/specs/notification/notification.md
@@ -163,10 +163,10 @@ CRITICAL 알림은 `telegram_enabled=false`, `min_level`, `quiet_hours`, dedup�
 | `/clear_halt` | 전역 정지 해제 (모든 SUSPENDED 계좌를 ACTIVE로 복구; 봇 자동 재시작 아님) | 2단계 확인 |
 | `/stop <bot_id>` | 특정 봇 중지 | 2단계 확인 |
 | `/confirm` | 위험 명령 확인 | - |
-| `/approve <id>` | 결재 승인 | 인라인 버튼 또는 명령어 |
-| `/reject <id> [reason]` | 결재 거절 | 인라인 버튼 또는 명령어 |
 
 **2단계 확인**: `halt`, `clear_halt`, `stop` 명령은 `_DANGEROUS_COMMANDS`로 분류되며, `/confirm` 입력 후 `confirm_timeout` 내에서만 실행된다. `/clear_halt`는 계좌 상태만 ACTIVE로 복구하며 봇을 자동 재시작하지 않는다.
+
+**결재 처리**: 결재 승인/거절은 텍스트 명령이 아니라 결재 요청 알림에 첨부된 인라인 [승인]/[거절] 버튼 callback으로만 처리한다 (아래 [결재 인라인 버튼](#결재-인라인-버튼) 참조). 텔레그램 텍스트 명령 `/approve`·`/reject`는 지원하지 않는다.
 
 **보안**: `TELEGRAM_CHAT_ID`와 일치하지 않는 사용자의 명령은 무시하고 로그에 기록한다.
 
@@ -191,13 +191,13 @@ Approval 모듈이 NotificationEvent 발행 (buttons 포함)
       → answerCallbackQuery + 결과 메시지 발송
 ```
 
-**거절 사유 입력:** 인라인 버튼으로 거절 시 기본 사유("사용자 거절")를 사용한다. 상세 사유가 필요하면 `/reject <id> <reason>` 명령어를 직접 입력한다.
+**거절 사유 입력:** 인라인 버튼으로 거절 시 기본 사유("사용자 거절")를 사용한다. 상세 사유가 필요하면 CLI(`ante approval reject <id> --reason <reason>`)로 처리한다.
 
-### 텔레그램 명령 응답과 NotificationEvent 중복 방지
+### 텔레그램 처리 응답과 NotificationEvent 중복 방지
 
-텔레그램 명령(`/approve`, `/reject`, `/stop`, `/halt`, `/clear_halt` 등)으로 처리된 작업은 `TelegramCommandReceiver`가 직접 응답(reply)을 발송한다. 이때 동일 내용의 `NotificationEvent`를 발행하면 사용자가 같은 채널에서 메시지를 2번 수신하게 된다.
+텔레그램에서 처리된 작업(`/stop`, `/halt`, `/clear_halt` 등 명령 및 결재 인라인 버튼 callback `approve:{id}`/`reject:{id}`)은 `TelegramCommandReceiver`가 직접 응답(reply)을 발송한다. 이때 동일 내용의 `NotificationEvent`를 발행하면 사용자가 같은 채널에서 메시지를 2번 수신하게 된다.
 
-**정책**: 텔레그램 명령으로 트리거된 작업은 직접 응답만 발송하고, `NotificationEvent`는 발행하지 않는다. CLI 등 텔레그램 외 채널에서 처리된 경우에만 `NotificationEvent`를 발행한다.
+**정책**: 텔레그램에서 트리거된 작업은 직접 응답만 발송하고, `NotificationEvent`는 발행하지 않는다(`suppress_notification=True`). CLI 등 텔레그램 외 채널에서 처리된 경우에만 `NotificationEvent`를 발행한다. 즉 "1회 응답"은 NotificationEvent 중복을 억제한다는 의미이며, 직접 응답 자체의 횟수 제한이 아니다.
 
 ```
 텔레그램에서 처리 → 직접 응답(reply)만 발송, NotificationEvent 생략 → 1회

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -280,13 +280,13 @@ class TelegramCommandReceiver:
             return self._request_confirmation(command, args, user_id)
 
         # 즉시 실행 명령
+        # 결재 승인/거절은 인라인 버튼 callback(approve:{id}/reject:{id}) 전용이다
+        # (#2379). 텍스트 명령 /approve·/reject는 스펙아웃되어 unknown으로 폴스루한다.
         handlers: dict[str, Any] = {
             "help": self._cmd_help,
             "status": self._cmd_status,
             "bots": self._cmd_bots,
             "balance": self._cmd_balance,
-            "approve": self._cmd_approve,
-            "reject": self._cmd_reject,
         }
 
         handler = handlers.get(command)
@@ -379,8 +379,6 @@ class TelegramCommandReceiver:
             "/halt [reason] — 전체 거래 중지 (확인 필요)\n"
             "/clear_halt — 전역 정지 해제 (확인 필요; 봇은 자동 재시작되지 않음)\n"
             "/stop <bot_id> — 특정 봇 중지 (확인 필요)\n"
-            "/approve <id> — 결재 승인\n"
-            "/reject <id> [reason] — 결재 거절\n"
             "/help — 이 도움말"
         )
 
@@ -506,78 +504,6 @@ class TelegramCommandReceiver:
         lines.append(f"미할당: {unallocated:,.0f}원")
 
         return "\n".join(lines)
-
-    async def _cmd_approve(self, args: list[str]) -> str:
-        """결재 승인. /approve <id>"""
-        if not self._approval_service:
-            return "ApprovalService가 연결되지 않았습니다."
-        if not args:
-            return "결재 ID를 지정해 주세요. 예: /approve abc123"
-
-        approval_id = args[0]
-        try:
-            request = await self._approval_service.approve(
-                approval_id,
-                resolved_by="telegram",
-                suppress_notification=True,
-            )
-            if request.status == "execution_failed":
-                # executor 실행 실패 — history 마지막 항목에서 사유 추출
-                detail = ""
-                for entry in reversed(request.history):
-                    if entry.get("action") == "execution_failed":
-                        detail = entry.get("detail", "")
-                        break
-                return (
-                    f"⚠️ 승인되었으나 실행 실패\n"
-                    f"제목: {request.title}\n"
-                    f"ID: {approval_id}\n"
-                    f"사유: {detail}"
-                )
-            return f"✅ 결재 승인 완료\n제목: {request.title}\nID: {approval_id}"
-        except ValueError as e:
-            err = str(e)
-            if "찾을 수 없음" in err:
-                return f"❌ 결재를 찾을 수 없습니다\nID: {approval_id}"
-            if "만료" in err:
-                return f"ℹ️ 만료된 결재입니다\nID: {approval_id}"
-            return f"ℹ️ 이미 처리된 결재입니다 ({err})\nID: {approval_id}"
-        except Exception:
-            logger.exception("결재 승인 오류: %s", approval_id)
-            return "승인 처리 중 오류가 발생했습니다."
-
-    async def _cmd_reject(self, args: list[str]) -> str:
-        """결재 거절. /reject <id> [reason]"""
-        if not self._approval_service:
-            return "ApprovalService가 연결되지 않았습니다."
-        if not args:
-            return "결재 ID를 지정해 주세요. 예: /reject abc123 사유"
-
-        approval_id = args[0]
-        reason = " ".join(args[1:]) if len(args) > 1 else "사용자 거절"
-        try:
-            request = await self._approval_service.reject(
-                approval_id,
-                resolved_by="telegram",
-                reject_reason=reason,
-                suppress_notification=True,
-            )
-            return (
-                f"❌ 결재 거절 완료\n"
-                f"제목: {request.title}\n"
-                f"ID: {approval_id}\n"
-                f"사유: {reason}"
-            )
-        except ValueError as e:
-            err = str(e)
-            if "찾을 수 없음" in err:
-                return f"❌ 결재를 찾을 수 없습니다\nID: {approval_id}"
-            if "만료" in err:
-                return f"ℹ️ 만료된 결재입니다\nID: {approval_id}"
-            return f"ℹ️ 이미 처리된 결재입니다 ({err})\nID: {approval_id}"
-        except Exception:
-            logger.exception("결재 거절 오류: %s", approval_id)
-            return "거절 처리 중 오류가 발생했습니다."
 
     async def _cmd_halt(self, args: list[str]) -> str:
         """전체 거래 중지."""

--- a/tests/unit/test_telegram_approval.py
+++ b/tests/unit/test_telegram_approval.py
@@ -346,149 +346,69 @@ class TestCallbackQuery:
         assert "승인 완료" in receiver._reply.call_args[0][1]
 
 
-# ── /approve, /reject 명령어 ─────────────────────
+# ── /approve, /reject 텍스트 명령 스펙아웃 회귀 (#2379) ──
+# 텔레그램 결재는 인라인 버튼 callback 전용. 텍스트 명령 /approve·/reject는
+# public contract에서 제거되었고, 알 수 없는 명령으로 폴스루해야 한다.
+# (콜백 경로 approve:{id}/reject:{id}는 TestCallbackQuery에서 green 유지)
 
 
-class TestApproveRejectCommands:
-    """텍스트 명령어 /approve, /reject 테스트."""
+class TestApproveRejectTextCommandsRemoved:
+    """텍스트 명령 /approve, /reject 스펙아웃 회귀 (#2379)."""
 
-    async def test_approve_command(self, receiver, approval_service):
-        """/approve <id> 명령이 suppress_notification=True로 호출한다."""
-        result = await receiver._cmd_approve(["abc123"])
-        assert "✅ 결재 승인 완료" in result
-        approval_service.approve.assert_called_once_with(
-            "abc123", resolved_by="telegram", suppress_notification=True
-        )
+    async def test_approve_text_command_unknown(self, receiver, approval_service):
+        """/approve <id> 텍스트 명령은 알 수 없는 명령으로 응답한다."""
+        update = {
+            "message": {
+                "text": "/approve abc",
+                "from": {"id": 12345},
+                "chat": {"id": 100},
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
 
-    async def test_approve_response_format(self, receiver, approval_service):
-        """/approve 성공 시 제목과 ID를 포함한 스펙 형식 응답."""
-        approval_service.approve.return_value = _make_approval_request(
-            title="봇 중지 요청", status="approved"
-        )
-        result = await receiver._cmd_approve(["abc123"])
-        assert "✅ 결재 승인 완료" in result
-        assert "제목: 봇 중지 요청" in result
-        assert "ID: abc123" in result
+        reply_text = receiver._reply.call_args[0][1]
+        assert reply_text == "알 수 없는 명령입니다. /help를 입력해 주세요."
+        approval_service.approve.assert_not_called()
 
-    async def test_approve_execution_failed(self, receiver, approval_service):
-        """/approve executor 실행 실패 시 경고 형식 응답."""
-        approval_service.approve.return_value = _make_approval_request(
-            title="봇 중지 요청",
-            status="execution_failed",
-            history=[{"action": "execution_failed", "detail": "봇이 이미 중지됨"}],
-        )
-        result = await receiver._cmd_approve(["abc123"])
-        assert "⚠️ 승인되었으나 실행 실패" in result
-        assert "제목: 봇 중지 요청" in result
-        assert "사유: 봇이 이미 중지됨" in result
+    async def test_reject_text_command_unknown(self, receiver, approval_service):
+        """/reject <id> 텍스트 명령은 알 수 없는 명령으로 응답한다."""
+        update = {
+            "message": {
+                "text": "/reject abc 사유",
+                "from": {"id": 12345},
+                "chat": {"id": 100},
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
 
-    async def test_approve_no_args(self, receiver):
-        """/approve 인자 없으면 안내 메시지."""
-        result = await receiver._cmd_approve([])
-        assert "ID를 지정" in result
+        reply_text = receiver._reply.call_args[0][1]
+        assert reply_text == "알 수 없는 명령입니다. /help를 입력해 주세요."
+        approval_service.reject.assert_not_called()
 
-    async def test_approve_no_service(self, adapter):
-        """approval_service 없으면 안내 메시지."""
-        r = TelegramCommandReceiver(
-            adapter=adapter, allowed_user_ids=[12345], approval_service=None
-        )
-        result = await r._cmd_approve(["abc123"])
-        assert "연결되지 않았습니다" in result
+    async def test_execute_approve_unknown(self, receiver, approval_service):
+        """_execute 경로에서 approve 명령은 알 수 없는 명령으로 폴스루한다."""
+        result = await receiver._execute("approve", ["abc"], 12345, 100)
+        assert result == "알 수 없는 명령입니다. /help를 입력해 주세요."
+        approval_service.approve.assert_not_called()
 
-    async def test_approve_not_found(self, receiver, approval_service):
-        """존재하지 않는 결재 ID에 대한 에러 메시지."""
-        approval_service.approve.side_effect = ValueError(
-            "결재 요청을 찾을 수 없음: abc123"
-        )
-        result = await receiver._cmd_approve(["abc123"])
-        assert "결재를 찾을 수 없습니다" in result
-        assert "ID: abc123" in result
+    async def test_execute_reject_unknown(self, receiver, approval_service):
+        """_execute 경로에서 reject 명령은 알 수 없는 명령으로 폴스루한다."""
+        result = await receiver._execute("reject", ["abc"], 12345, 100)
+        assert result == "알 수 없는 명령입니다. /help를 입력해 주세요."
+        approval_service.reject.assert_not_called()
 
-    async def test_approve_already_processed(self, receiver, approval_service):
-        """이미 처리된 결재에 대한 에러 메시지."""
-        approval_service.approve.side_effect = ValueError(
-            "pending/execution_failed 상태에서만 승인 가능 (현재: approved)"
-        )
-        result = await receiver._cmd_approve(["abc123"])
-        assert "이미 처리된 결재입니다" in result
-        assert "ID: abc123" in result
-
-    async def test_reject_command(self, receiver, approval_service):
-        """/reject <id> [reason] 명령이 suppress_notification=True로 호출한다."""
-        result = await receiver._cmd_reject(["abc123", "리스크", "과다"])
-        assert "❌ 결재 거절 완료" in result
-        approval_service.reject.assert_called_once_with(
-            "abc123",
-            resolved_by="telegram",
-            reject_reason="리스크 과다",
-            suppress_notification=True,
-        )
-
-    async def test_reject_response_format(self, receiver, approval_service):
-        """/reject 성공 시 스펙 형식 응답."""
-        approval_service.reject.return_value = _make_approval_request(
-            title="예산 변경", status="rejected"
-        )
-        result = await receiver._cmd_reject(["abc123", "리스크", "과다"])
-        assert "❌ 결재 거절 완료" in result
-        assert "제목: 예산 변경" in result
-        assert "ID: abc123" in result
-        assert "사유: 리스크 과다" in result
-
-    async def test_reject_default_reason(self, receiver, approval_service):
-        """/reject <id> 사유 미지정 시 기본 사유."""
-        await receiver._cmd_reject(["abc123"])
-        approval_service.reject.assert_called_once_with(
-            "abc123",
-            resolved_by="telegram",
-            reject_reason="사용자 거절",
-            suppress_notification=True,
-        )
-
-    async def test_reject_no_args(self, receiver):
-        """/reject 인자 없으면 안내 메시지."""
-        result = await receiver._cmd_reject([])
-        assert "ID를 지정" in result
-
-    async def test_reject_no_service(self, adapter):
-        """approval_service 없으면 안내 메시지."""
-        r = TelegramCommandReceiver(
-            adapter=adapter, allowed_user_ids=[12345], approval_service=None
-        )
-        result = await r._cmd_reject(["abc123"])
-        assert "연결되지 않았습니다" in result
-
-    async def test_reject_not_found(self, receiver, approval_service):
-        """존재하지 않는 결재 ID에 대한 에러 메시지."""
-        approval_service.reject.side_effect = ValueError(
-            "결재 요청을 찾을 수 없음: abc123"
-        )
-        result = await receiver._cmd_reject(["abc123"])
-        assert "결재를 찾을 수 없습니다" in result
-
-    async def test_reject_already_processed(self, receiver, approval_service):
-        """이미 처리된 결재에 대한 에러 메시지."""
-        approval_service.reject.side_effect = ValueError(
-            "pending/execution_failed 상태에서만 거절 가능 (현재: rejected)"
-        )
-        result = await receiver._cmd_reject(["abc123"])
-        assert "이미 처리된 결재입니다" in result
-
-    async def test_help_includes_approval_commands(self, receiver):
-        """/help에 /approve, /reject 명령이 포함된다."""
+    async def test_help_excludes_approval_text_commands(self, receiver):
+        """/help에 /approve, /reject 텍스트 명령이 노출되지 않는다."""
         result = receiver._cmd_help([])
-        assert "/approve" in result
-        assert "/reject" in result
+        assert "/approve" not in result
+        assert "/reject" not in result
 
-    async def test_execute_approve(self, receiver, approval_service):
-        """_execute를 통해 /approve가 라우팅된다."""
-        result = await receiver._execute("approve", ["abc123"], 12345, 100)
-        assert "승인 완료" in result
-
-    async def test_execute_reject(self, receiver, approval_service):
-        """_execute를 통해 /reject가 라우팅된다."""
-        result = await receiver._execute("reject", ["abc123"], 12345, 100)
-        assert "거절 완료" in result
+    def test_cmd_approve_reject_methods_removed(self, receiver):
+        """_cmd_approve, _cmd_reject 메서드가 제거되었다."""
+        assert not hasattr(receiver, "_cmd_approve")
+        assert not hasattr(receiver, "_cmd_reject")
 
 
 # ── NotificationService 결재 이벤트 구독 ─────────


### PR DESCRIPTION
Closes #2379

## Summary
- 텔레그램 결재 처리를 인라인 [승인]/[거절] 버튼 전용으로 정리: `_execute()` handlers dict에서 `approve`/`reject` 제거, `_cmd_approve`/`_cmd_reject` 메서드 삭제, `_cmd_help` 안내 2행 제거 (제거 후 텍스트 명령은 '알 수 없는 명령' 폴스루)
- 버튼 callback path(`approve:{id}`/`reject:{id}`)는 변경 없음 — ApprovalService 직접 호출 경로 독립 검증 완료
- 스펙 3건 동기 갱신: notification.md (지원 명령 표·거절 사유 CLI 경로·중복 방지 정책), approval/11-notification-events.md, approval/02-design-decisions.md
- 범위 한정(Codex Plan Review): 텍스트 명령 public contract 제거에 한정 — `execution_failed` 상태의 버튼 기반 reject 가능성은 ApprovalService 계약상 잔존(후속 이슈 영역)

## Test Plan
- `uv run ruff check src tests` / `uv run ruff format --check src tests` — PASS
- `uv run mypy src/ante` 전체 — PASS (233 files)
- `uv run pytest tests/unit -q` — 7253 passed, 2 skipped
- TDD red 확인: 신규 회귀 클래스 6개 테스트가 구현 전 전부 fail (`_handle_update()`/`_execute()` 경로 + `approval_service` 미호출 검증)
- grep invariant: docs/specs 텔레그램 텍스트 명령 지원 표기 잔존 0건
- Codex 브랜치 리뷰 (`codex review --base main`): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)