### PR TITLE
feat(notification): #2377 텔레그램 알림 종목코드 전 지점 종목명 병기 — InstrumentService.format_label SSOT

### DIFF
--- a/docs/specs/broker-adapter/17-notification-events.md
+++ b/docs/specs/broker-adapter/17-notification-events.md
@@ -22,10 +22,18 @@ level: critical
 title: 포지션 불일치
 category: broker
 
-계좌: `{account_id}` · 봇: `{bot_id}` · 종목: `{symbol}`
+계좌: `{account_id}` · 봇: `{bot_id}` · 종목: `{symbol}` ({name})
 내부: {internal_qty}주 · 브로커: {broker_qty}주
 사유: {reason}
 ```
+
+> 종목 표기는 `InstrumentService.format_label(symbol, markdown=True)`로 생성한다
+> ([instrument.md](../instrument/instrument.md#instrumentservice), #2377). 종목명
+> 조회가 가능하면 `` 종목: `{symbol}` ({name}) ``로 병기하고, 조회 불가(미적재·
+> 테이블 부재·빈 name·`name == symbol`) 시 `` 종목: `{symbol}` ``로 폴백한다.
+> `PositionReconciler`에 `instrument_service`가 미주입(`None`)이면 항상
+> symbol-only로 표기한다. reconciler payload에는 exchange가 없어 KRX 기본값으로
+> 조회한다.
 
 ### 2. 서킷 브레이커 차단
 

--- a/docs/specs/instrument/instrument.md
+++ b/docs/specs/instrument/instrument.md
@@ -86,6 +86,7 @@ CREATE INDEX IF NOT EXISTS idx_instruments_name ON instruments(name);
 | `initialize` | — | None | 스키마 생성 + 전체 캐시 워밍 |
 | `get` | symbol: str, exchange: str = "KRX" | Instrument \| None | 캐시에서 조회 |
 | `get_name` | symbol: str, exchange: str = "KRX" | str | 동기 종목명 조회. 캐시 미스 또는 name이 빈 문자열이면 symbol 반환 |
+| `format_label` | symbol: str, exchange: str = "KRX", *, markdown: bool = False | str | 동기 알림용 `{symbol} (종목명)` 병기 라벨. `markdown=False`(plain): 조회 성공 시 `069500 (KODEX 200)`, 실패 시 `069500`. `markdown=True`: 조회 성공 시 `` `069500` (KODEX 200) ``, 실패 시 `` `069500` `` (백틱 안 monospace 가독성 위해 종목명은 괄호 밖). `get_name`과 동일하게 캐시 dict만 동기 조회(무예외·무IO) — 캐시 미스·테이블 부재·빈 name·`name == symbol` 시 종목명 병기 없이 symbol-only 폴백 |
 | `search` | keyword: str, limit: int = 20, listed_only: bool = False | list[Instrument] | name, name_en, symbol LIKE 검색. listed_only=True이면 상장 종목만 반환 |
 | `bulk_upsert` | instruments: list[Instrument] | int | 대량 등록/갱신 + 캐시 갱신. 처리 건수 반환 |
 
@@ -146,6 +147,6 @@ CSV/JSON 파일에서 종목 데이터를 일괄 등록/갱신한다. 파일 확
 
 ## 타 모듈 설계 시 참고
 
-- **Notification**: `NotificationService`에 `instrument_service` 주입 시 체결 알림에 종목명 병기
+- **Notification**: 종목코드를 직접 포맷하는 **알림 발행자**(`TradeRecorder`·`PositionReconciler`·`FillReconcileScheduler`·`RuleEngine` 등)에 `instrument_service`를 선택 주입(`instrument_service: InstrumentService | None = None`)하고, 발행 지점에서 `format_label`로 `{symbol} (종목명)`을 병기한다. 표기 SSOT는 `format_label` 한 곳이며, 각 발행자가 `get_name`을 개별 조합하지 않는다. 미주입(`None`)이면 종목코드만 표기하는 기존 경로를 유지한다(`NotificationService` 자체가 아니라 발행자 측 주입 — #2377).
 - **Data Pipeline**: 시세 데이터 수집 시 종목 메타데이터도 함께 갱신하는 설계 고려
 - **CLI**: 종목 검색/조회 명령은 InstrumentService를 통해 구현한다.

--- a/src/ante/broker/fill_scheduler.py
+++ b/src/ante/broker/fill_scheduler.py
@@ -43,6 +43,7 @@ from ante.broker.exceptions import APIError, CircuitOpenError
 if TYPE_CHECKING:
     from ante.broker.base import BrokerAdapter
     from ante.eventbus.bus import EventBus
+    from ante.instrument.service import InstrumentService
     from ante.trade.fill_applier import FillApplier
     from ante.trade.order_tracker import OrderTracker, OrderTrackerRecord
     from ante.trade.service import TradeService
@@ -182,6 +183,7 @@ class FillReconcileScheduler:
         trade_service: TradeService | None = None,
         eventbus: EventBus | None = None,
         fallback_enabled: bool = True,
+        instrument_service: InstrumentService | None = None,
     ) -> None:
         """계좌별 체결 백스톱 폴러.
 
@@ -202,6 +204,8 @@ class FillReconcileScheduler:
             fallback_enabled: position-derived fallback **마스터 disable flag**
                 (#2316 §11.6). KIS paper 기본 활성을 두되 ``False`` 로 rollback
                 가능. 실제 적용은 추가로 ``broker.is_paper`` 가 true 여야 한다.
+            instrument_service: #2377 over-attribution 의심 알림의 종목명 병기용.
+                ``None`` 이면 종목코드만 표기하는 기존 경로를 유지한다(폴백).
         """
         require_account_id(account_id, context="fill_scheduler.__init__")
         self._broker = broker
@@ -212,6 +216,9 @@ class FillReconcileScheduler:
         self._trade_service = trade_service
         self._eventbus = eventbus
         self._fallback_enabled = fallback_enabled
+        # #2377: over-attribution 의심 알림 종목명 병기용. 미주입(None)이면
+        # 종목코드만 표기하는 기존 경로를 유지한다.
+        self._instrument_service = instrument_service
         self._task: asyncio.Task[None] | None = None
         self._running = False
         # #2318 Finding ②: fallback 이 filled(terminal)로 올린 주문의 사후 ccld
@@ -635,12 +642,21 @@ class FillReconcileScheduler:
                 ),
             )
         )
+        # #2377: 자연 문장(``... {symbol} 주문(odno=...)을 ...``) 안에 종목코드가
+        # 임베딩된 지점이므로, 문장 흐름을 깨는 백틱 monospace 대신 plain 병기
+        # (``069500 (KODEX 200)``)를 사용한다. exchange 는 alert payload 에 없어
+        # KRX 기본값. 미주입/조회 불가 시 symbol-only 로 폴백한다.
+        symbol_label = (
+            self._instrument_service.format_label(record.symbol)
+            if self._instrument_service is not None
+            else record.symbol
+        )
         await self._eventbus.publish(
             NotificationEvent(
                 level="warning",
                 title="체결 over-attribution 의심 (모의 fallback)",
                 message=(
-                    f"잔고 역도출 fallback 이 {record.symbol} 주문(odno="
+                    f"잔고 역도출 fallback 이 {symbol_label} 주문(odno="
                     f"{broker_order_id})을 recorded={recorded} 로 올렸으나, 이후 "
                     f"ccld 가 더 낮은 누적={observed_cumulative} (diff={diff})를 "
                     "반환했습니다. 비가역이라 정정되지 않으며 협소 외부 매수 흡수 "

--- a/src/ante/instrument/service.py
+++ b/src/ante/instrument/service.py
@@ -115,6 +115,37 @@ class InstrumentService:
         inst = self._cache.get((symbol, exchange))
         return inst.name if inst and inst.name else symbol
 
+    def format_label(
+        self, symbol: str, exchange: str = "KRX", *, markdown: bool = False
+    ) -> str:
+        """알림용 ``{symbol} (종목명)`` 병기 라벨을 동기 반환한다 (#2377).
+
+        텔레그램 알림에서 종목코드만 노출되는 지점들이 각자 ``get_name`` 을
+        조합하지 않고 이 헬퍼만 사용해 표기를 SSOT 로 단일화한다. 발행자가
+        완성된 label 을 받아 백틱/괄호 조립 실수를 차단한다.
+
+        반환 계약:
+
+        - ``markdown=False`` (plain): 조회 성공 시 ``069500 (KODEX 200)``,
+          실패 시 ``069500``.
+        - ``markdown=True``: 조회 성공 시 ``` `069500` (KODEX 200) ```,
+          실패 시 ``` `069500` ``` (백틱 안에 종목명을 넣으면 텔레그램
+          monospace 로 가독성이 떨어지므로 종목명은 백틱 밖 괄호에 둔다).
+
+        sync·무예외·무IO — ``get_name`` 과 동일하게 메모리 캐시 dict 만 동기
+        조회한다(``get()``/``_ensure_cache()`` 의 async DB fetch 를 경유하지
+        않는다). 백그라운드 태스크(reconciler·fill_scheduler)에서 ``await``
+        없이 호출되므로 알림 경로에 IO·지연을 추가하지 않는다. 캐시
+        미스·테이블 부재(빈 캐시)·빈 name·``name == symbol`` 은 모두 종목명
+        병기 없이 symbol-only 로 폴백한다.
+        """
+        base = f"`{symbol}`" if markdown else symbol
+        inst = self._cache.get((symbol, exchange))
+        name = inst.name if inst else ""
+        if not name or name == symbol:
+            return base
+        return f"{base} ({name})"
+
     async def search(
         self,
         keyword: str,

--- a/src/ante/instrument/service.py
+++ b/src/ante/instrument/service.py
@@ -138,13 +138,34 @@ class InstrumentService:
         없이 호출되므로 알림 경로에 IO·지연을 추가하지 않는다. 캐시
         미스·테이블 부재(빈 캐시)·빈 name·``name == symbol`` 은 모두 종목명
         병기 없이 symbol-only 로 폴백한다.
+
+        반환 라벨은 발행자→NotificationService 를 거쳐 텔레그램
+        ``parse_mode="Markdown"`` (legacy) 로 전송된다. name 에 legacy Markdown
+        특수문자(``_`` ``*`` ```` ` ```` ``[``)가 있으면 텔레그램 parse 가 실패해
+        해당 알림 발송 자체가 실패할 수 있으므로(불변식: 발송 실패 금지),
+        name 부분을 백슬래시로 escape 한다(markdown=True/plain 양 모드 — 두 모드
+        다 최종적으로 Markdown parse 메시지에 삽입되기 때문). symbol 은
+        영숫자(종목코드)라 escape 비대상이다.
         """
         base = f"`{symbol}`" if markdown else symbol
         inst = self._cache.get((symbol, exchange))
         name = inst.name if inst else ""
         if not name or name == symbol:
             return base
-        return f"{base} ({name})"
+        return f"{base} ({self._escape_markdown(name)})"
+
+    @staticmethod
+    def _escape_markdown(text: str) -> str:
+        """텔레그램 legacy Markdown parse 실패 방지(불변식: 발송 실패 금지).
+
+        legacy Markdown 특수문자(``_`` ``*`` ```` ` ```` ``[``)를 백슬래시로 escape
+        한다. 종목명에 이 문자가 들어가면(예: ``FOO_BAR``, ``ACME [ADR]``)
+        텔레그램 ``parse_mode="Markdown"`` 가 entity parse 에 실패해 알림 발송이
+        실패하므로 라벨 삽입 전 무력화한다.
+        """
+        for ch in ("_", "*", "`", "["):
+            text = text.replace(ch, f"\\{ch}")
+        return text
 
     async def search(
         self,

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -445,7 +445,12 @@ async def _init_trading(s: Services) -> None:
     s.position_history = PositionHistory(db=s.db)
     await s.position_history.initialize()
 
-    s.trade_recorder = TradeRecorder(db=s.db, position_history=s.position_history)
+    s.trade_recorder = TradeRecorder(
+        db=s.db,
+        position_history=s.position_history,
+        # #2377: 체결 알림 종목명 병기 소스(L297 에서 생성·워밍 완료).
+        instrument_service=s.instrument_service,
+    )
     await s.trade_recorder.initialize()
     s.trade_recorder.subscribe(s.eventbus)
 
@@ -520,6 +525,9 @@ async def _init_trading(s: Services) -> None:
         # #2045: modify_rejected 의 symbol/side 보강용 권위 주문 메타 소스.
         # OrderTracker 는 상단(#1946)에서 이미 생성되어 있다.
         order_tracker=s.order_tracker,
+        # #2377: 생성하는 모든 RuleEngine 에 Rule violation 알림 종목명 병기
+        # 소스를 pass-through 한다(L297 에서 생성·워밍 완료).
+        instrument_service=s.instrument_service,
     )
     await s.rule_engine_manager.initialize_all(
         accounts, config=s.config, dynamic_config=s.dynamic_config
@@ -782,6 +790,8 @@ async def _init_fill_recovery_schedulers(s: Services, accounts: list[Any]) -> No
             trade_service=s.trade_service,
             eventbus=s.eventbus,
             fallback_enabled=fallback_enabled,
+            # #2377: over-attribution 의심 알림 종목명 병기 소스.
+            instrument_service=s.instrument_service,
         )
         # 기동 카치업 — barrier. reconcile 보다 반드시 선행.
         # CatchUpResult.succeeded 로 폴 실패와 "정상 0건/open-없음" 을 구분한다.
@@ -862,6 +872,9 @@ async def _init_reconcile_scheduler(s: Services) -> None:
         # #1950: broker > internal(외부 매수 후보) 분기에서 ante 미반영 체결
         # (self-submitted)을 외부 매수와 구분하기 위한 OrderTracker self-check.
         order_tracker=s.order_tracker,
+        # #2377: 포지션 불일치/동기화 지연 알림 종목명 병기 소스. IPC 수동
+        # reconcile 경로(아래 _start_ipc_server)와 동일하게 주입한다(두 경로 정합).
+        instrument_service=s.instrument_service,
     )
 
     accounts = await s.account_service.list()
@@ -1833,6 +1846,8 @@ async def _init_ipc(s: Services) -> None:
         # #1950: IPC 수동 reconcile 경로도 OrderTracker self-check 를 갖도록
         # scheduler 경로와 동일하게 주입한다(두 경로 정합).
         order_tracker=s.order_tracker,
+        # #2377: 종목명 병기 소스도 스케줄러 경로와 동일하게 주입한다(두 경로 정합).
+        instrument_service=s.instrument_service,
     )
 
     service_registry = ServiceRegistry(

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from ante.account.models import Account
     from ante.account.service import AccountService
     from ante.eventbus.bus import EventBus
+    from ante.instrument.service import InstrumentService
     from ante.trade.order_tracker import OrderTracker
     from ante.trade.service import TradeService
     from ante.treasury.treasury import Treasury
@@ -270,6 +271,7 @@ class RuleEngine:
         order_tracker: OrderTracker | None = None,
         unrecovered_buy_guard_min_age: float = 60.0,
         allow_unrecovered_buy_overlap: bool = False,
+        instrument_service: InstrumentService | None = None,
     ) -> None:
         from ante.account.scoping import require_account_id
 
@@ -291,6 +293,9 @@ class RuleEngine:
         # 기존 호출자(테스트 fixture 등) 호환을 위해 ``None`` 허용 — None일 때
         # reload 경로는 helper를 우회하여 stored 그대로 적용한다 (#1296).
         self._account = account
+        # #2377: Rule violation NOTIFY 알림 종목명 병기용. 미주입(None)이면
+        # 종목코드만 표기하는 기존 경로를 유지한다(CLI 생성 경로는 미주입).
+        self._instrument_service = instrument_service
 
         # #2315: 미복구 self-order 반복 매수 가드 설정.
         # ``unrecovered_buy_guard_min_age``는 미복구 outstanding buy 주문이 차단
@@ -1253,11 +1258,20 @@ class RuleEngine:
 
         for action in actions:
             if action == RuleAction.NOTIFY:
+                # #2377: Rule violation 메시지의 종목코드에 종목명 병기. 백틱 없는
+                # plain 메시지 형식이므로 plain label(``069500 (KODEX 200)``)을
+                # 사용한다. OrderRequestEvent 는 exchange 를 보유하므로 명시
+                # 전달한다. 미주입/조회 불가 시 symbol-only 로 폴백한다.
+                symbol_label = (
+                    self._instrument_service.format_label(event.symbol, event.exchange)
+                    if self._instrument_service is not None
+                    else event.symbol
+                )
                 await self._eventbus.publish(
                     NotificationEvent(
                         level="error",
                         message=(
-                            f"Rule violation for bot {event.bot_id}: {event.symbol}"
+                            f"Rule violation for bot {event.bot_id}: {symbol_label}"
                         ),
                     )
                 )

--- a/src/ante/rule/manager.py
+++ b/src/ante/rule/manager.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from ante.account.models import Account
     from ante.account.service import AccountService
     from ante.eventbus.bus import EventBus
+    from ante.instrument.service import InstrumentService
     from ante.trade.order_tracker import OrderTracker
     from ante.trade.service import TradeService
     from ante.treasury import TreasuryManager as TreasuryManagerType
@@ -31,6 +32,7 @@ class RuleEngineManager:
         order_tracker: OrderTracker | None = None,
         unrecovered_buy_guard_min_age: float = 60.0,
         allow_unrecovered_buy_overlap: bool = False,
+        instrument_service: InstrumentService | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._account_service = account_service
@@ -45,6 +47,9 @@ class RuleEngineManager:
         # 로 별도 등록한다.
         self._unrecovered_buy_guard_min_age = unrecovered_buy_guard_min_age
         self._allow_unrecovered_buy_overlap = allow_unrecovered_buy_overlap
+        # #2377: 생성하는 모든 RuleEngine 에 Rule violation 알림 종목명 병기
+        # 소스를 pass-through 한다. None 이면 종목코드만 표기(하위 호환).
+        self._instrument_service = instrument_service
         self._engines: dict[str, RuleEngine] = {}
 
     def create_engine(
@@ -86,6 +91,7 @@ class RuleEngineManager:
             order_tracker=self._order_tracker,
             unrecovered_buy_guard_min_age=self._unrecovered_buy_guard_min_age,
             allow_unrecovered_buy_overlap=self._allow_unrecovered_buy_overlap,
+            instrument_service=self._instrument_service,
         )
 
         if rule_configs:

--- a/src/ante/trade/reconciler.py
+++ b/src/ante/trade/reconciler.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ante.eventbus.bus import EventBus
+    from ante.instrument.service import InstrumentService
     from ante.trade.order_tracker import OrderTracker
     from ante.trade.service import TradeService
 
@@ -37,6 +38,7 @@ class PositionReconciler:
         trade_service: TradeService,
         eventbus: EventBus,
         order_tracker: OrderTracker | None = None,
+        instrument_service: InstrumentService | None = None,
     ) -> None:
         self._trade_service = trade_service
         self._eventbus = eventbus
@@ -45,6 +47,21 @@ class PositionReconciler:
         # 미주입(None)이면 self-check 를 생략하고 기존 "외부 매수" 분류로 동작한다
         # (하위 호환 — 다만 main.py 의 두 배선 경로는 항상 주입한다).
         self._order_tracker = order_tracker
+        # #2377: 포지션 불일치/동기화 지연 알림 종목명 병기용. 미주입(None)이면
+        # 종목코드만 표기하는 기존 경로를 유지한다. reconciler payload 에는
+        # exchange 가 없어 KRX 기본값으로 조회한다(schema 미확장).
+        self._instrument_service = instrument_service
+
+    def _symbol_label(self, symbol: str) -> str:
+        """#2377: 알림 메시지용 ``\\`{symbol}\\` (종목명)`` 병기 라벨(markdown).
+
+        미주입/조회 불가 시 backtick symbol-only 로 폴백한다(format_label 폴백
+        내장 — sync·무예외·무IO). reconciler payload 에 exchange 가 없어 KRX
+        기본값으로 조회한다.
+        """
+        if self._instrument_service is not None:
+            return self._instrument_service.format_label(symbol, markdown=True)
+        return f"`{symbol}`"
 
     async def reconcile(
         self,
@@ -280,7 +297,7 @@ class PositionReconciler:
                     title="포지션 불일치",
                     message=(
                         f"계좌: `{account_id}` · 봇: `{bot_id}` · "
-                        f"종목: `{symbol}`\n"
+                        f"종목: {self._symbol_label(symbol)}\n"
                         f"내부: {i_qty:.0f}주 · 브로커: {b_qty:.0f}주\n"
                         f"사유: {reason}"
                     ),
@@ -448,7 +465,7 @@ class PositionReconciler:
                     level="critical",
                     title="계좌 단위 포지션 불일치",
                     message=(
-                        f"계좌: `{account_id}` · 종목: `{symbol}`\n"
+                        f"계좌: `{account_id}` · 종목: {self._symbol_label(symbol)}\n"
                         f"내부 합산: {i_qty:.0f}주 · 브로커: {b_qty:.0f}주\n"
                         "사유: 계좌 단위 수량 불일치 (다중봇 귀속 ambiguous — "
                         "자동 보정 보류, 수동 확인 필요)"
@@ -513,7 +530,7 @@ class PositionReconciler:
                 title="포지션 동기화 지연",
                 message=(
                     f"계좌: `{account_id}` · 봇: `{bot_id}` · "
-                    f"종목: `{symbol}`\n"
+                    f"종목: {self._symbol_label(symbol)}\n"
                     f"내부: {i_qty:.0f}주 · 브로커: {b_qty:.0f}주\n"
                     f"사유: {REASON_SELF_SUBMITTED} "
                     "(체결 반영 대기 — 자동 보정 없음)"

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -128,6 +128,15 @@ class TradeRecorder:
             )
             # #2377: 종목코드만 노출하던 라인에 종목명 병기. 미주입/조회 불가 시
             # symbol-only 로 폴백한다(format_label 이 폴백을 내장 — 무예외·무IO).
+            #
+            # known-limitation(#2377): OrderFilledEvent.exchange 는 일부
+            # producer(durable fill 의 FillApplier._build_filled_payload,
+            # VirtualProvider)에서 기본값 KRX 로 들어올 수 있다. 이 경우 비-KRX
+            # 종목은 instrument cache((symbol, exchange) 키) 미스로 symbol-only
+            # 폴백된다(병기 누락이지 오표기 아님 — 다른 종목명 표기 안 함, #2377
+            # 불변식 보존). producer exchange 전파(account_id 기반 역추적)는
+            # plan 의 "schema 확장 금지"·"비-KRX 거래소 이름 소스 확장 비목표"에
+            # 따라 후속 이슈 영역.
             symbol_label = (
                 self._instrument_service.format_label(
                     event.symbol, event.exchange, markdown=True

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -15,6 +15,7 @@ from ante.trade.models import TradeRecord, TradeStatus
 if TYPE_CHECKING:
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
+    from ante.instrument.service import InstrumentService
     from ante.trade.position import PositionHistory
 
 logger = logging.getLogger(__name__)
@@ -50,9 +51,17 @@ CREATE INDEX IF NOT EXISTS idx_trades_status ON trades(status);
 class TradeRecorder:
     """EventBus 이벤트를 구독하여 거래를 자동 기록."""
 
-    def __init__(self, db: Database, position_history: PositionHistory) -> None:
+    def __init__(
+        self,
+        db: Database,
+        position_history: PositionHistory,
+        instrument_service: InstrumentService | None = None,
+    ) -> None:
         self._db = db
         self._position_history = position_history
+        # #2377: 체결 알림 종목명 병기용. 미주입(None)이면 종목코드만 표기하는
+        # 기존 경로를 유지한다(CLI 생성 경로는 미주입 — 알림 미발행).
+        self._instrument_service = instrument_service
         self._eventbus: EventBus | None = None
         # #1957: 체결 이벤트 bounded 멱등 가드. trades 는 INSERT OR IGNORE 로
         # 이미 DB-멱등이나, NotificationEvent 재발행은 effect 비멱등이라 outbox
@@ -117,9 +126,18 @@ class TradeRecorder:
             position = await self._position_history.get_current(
                 event.bot_id, event.symbol, account_id=event.account_id
             )
+            # #2377: 종목코드만 노출하던 라인에 종목명 병기. 미주입/조회 불가 시
+            # symbol-only 로 폴백한다(format_label 이 폴백을 내장 — 무예외·무IO).
+            symbol_label = (
+                self._instrument_service.format_label(
+                    event.symbol, event.exchange, markdown=True
+                )
+                if self._instrument_service is not None
+                else f"`{event.symbol}`"
+            )
             base_msg = (
                 f"봇 `{event.bot_id}`\n"
-                f"종목: `{event.symbol}`\n"
+                f"종목: {symbol_label}\n"
                 f"{side_label} {event.quantity}주 @ {event.price:,.0f}원"
             )
             if event.side == "buy":

--- a/tests/unit/test_fill_scheduler.py
+++ b/tests/unit/test_fill_scheduler.py
@@ -903,7 +903,14 @@ def _pos(symbol: str, quantity: float, avg_price: float = 1000.0) -> dict:
 
 
 def _make_fallback_sched(
-    broker, tracker, app, svc, *, eventbus=None, fallback_enabled=True
+    broker,
+    tracker,
+    app,
+    svc,
+    *,
+    eventbus=None,
+    fallback_enabled=True,
+    instrument_service=None,
 ):
     return FillReconcileScheduler(
         broker=broker,
@@ -913,6 +920,7 @@ def _make_fallback_sched(
         trade_service=svc,
         eventbus=eventbus,
         fallback_enabled=fallback_enabled,
+        instrument_service=instrument_service,
     )
 
 
@@ -1190,6 +1198,68 @@ async def test_late_ccld_lower_cumulative_emits_reconcile_alert_via_poll(
     # 포지션은 불변(비가역 no-op).
     pos = await ph.get_current("bot-1", "069500", account_id=ACCT)
     assert pos["quantity"] == 2.0
+    # #2377: instrument_service 미주입 경로(plain 폴백) — 종목코드만 표기.
+    assert "069500 주문(odno=" in notifs[0].message
+    assert "(KODEX 200)" not in notifs[0].message
+
+
+async def test_late_ccld_over_attribution_alert_includes_name(
+    fallback_applier, tracker
+):
+    """#2377: instrument_service 적재 시 over-attribution 알림에 종목명 plain 병기.
+
+    자연 문장 안 임베딩 지점이라 백틱 없는 plain(``069500 (KODEX 200)``)을 사용한다.
+    """
+    from unittest.mock import MagicMock
+
+    from ante.eventbus.events import NotificationEvent
+    from ante.instrument.models import Instrument
+    from ante.instrument.service import InstrumentService
+
+    app, _ph, eb, svc = fallback_applier
+    notifs: list[NotificationEvent] = []
+    eb.subscribe(
+        NotificationEvent,
+        lambda e: notifs.append(e) if isinstance(e, NotificationEvent) else None,
+    )
+
+    # format_label 은 캐시 dict 만 동기 조회하므로 db 는 미사용(MagicMock).
+    instrument_service = InstrumentService(db=MagicMock())
+    instrument_service._cache = {
+        ("069500", "KRX"): Instrument(symbol="069500", exchange="KRX", name="KODEX 200")
+    }
+
+    await tracker.open(
+        order_id="ord-fb",
+        account_id=ACCT,
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        broker_order_id="0001",
+        symbol="069500",
+        side="buy",
+        order_type="market",
+        ordered_qty=2.0,
+        submitted_date=DATE,
+    )
+    broker = FallbackBroker(history=[], positions=[_pos("069500", 2.0)])
+    sched = _make_fallback_sched(
+        broker, tracker, app, svc, eventbus=eb, instrument_service=instrument_service
+    )
+    await sched.catch_up_once()
+    broker.set_history(
+        [
+            {
+                "order_id": "0001",
+                "filled_quantity": 1.0,
+                "price": 1000.0,
+                "timestamp": DATE,
+            }
+        ]
+    )
+    await sched._poll_and_apply()
+
+    assert len(notifs) == 1
+    assert "069500 (KODEX 200) 주문(odno=" in notifs[0].message
 
 
 async def test_late_ccld_alert_not_emitted_when_ccld_higher_or_equal_via_poll(

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -201,6 +201,57 @@ class TestInstrumentServiceFormatLabel:
         assert svc.format_label("069500") == "069500"
         assert svc.format_label("069500", markdown=True) == "`069500`"
 
+    # ── #2377 Codex P2: name Markdown escape (텔레그램 발송 실패 방지) ──
+
+    def test_format_label_escapes_underscore_plain(self, db):
+        """name 의 ``_`` 를 백슬래시 escape (plain 모드도 최종 Markdown parse).
+
+        텔레그램 ``parse_mode="Markdown"`` 에서 ``_`` 는 italic entity 를
+        연다. escape 하지 않으면 parse 실패로 알림 발송 자체가 실패한다
+        (#2377 불변식: 발송 실패 금지).
+        """
+        svc = InstrumentService(db=db)
+        svc._cache = {
+            ("FOO", "KRX"): Instrument(symbol="FOO", exchange="KRX", name="FOO_BAR")
+        }
+        assert svc.format_label("FOO") == "FOO (FOO\\_BAR)"
+
+    def test_format_label_escapes_underscore_markdown(self, db):
+        """markdown 모드 — name 의 ``_`` escape, symbol(백틱)은 불변."""
+        svc = InstrumentService(db=db)
+        svc._cache = {
+            ("FOO", "KRX"): Instrument(symbol="FOO", exchange="KRX", name="FOO_BAR")
+        }
+        assert svc.format_label("FOO", markdown=True) == "`FOO` (FOO\\_BAR)"
+
+    def test_format_label_escapes_bracket(self, db):
+        """name 의 ``[`` escape (inline link entity 시작 방지)."""
+        svc = InstrumentService(db=db)
+        svc._cache = {
+            ("ACME", "KRX"): Instrument(
+                symbol="ACME", exchange="KRX", name="ACME [ADR]"
+            )
+        }
+        assert svc.format_label("ACME") == "ACME (ACME \\[ADR])"
+        assert svc.format_label("ACME", markdown=True) == "`ACME` (ACME \\[ADR])"
+
+    def test_format_label_escapes_all_legacy_specials(self, db):
+        """``_`` ``*`` `````` ``[`` 전부 백슬래시 prefix (한 번에)."""
+        svc = InstrumentService(db=db)
+        svc._cache = {
+            ("X", "KRX"): Instrument(symbol="X", exchange="KRX", name="a_b*c`d[e")
+        }
+        assert svc.format_label("X") == "X (a\\_b\\*c\\`d\\[e)"
+
+    @pytest.mark.asyncio
+    async def test_format_label_korean_name_unchanged(self, service):
+        """회귀 고정 — 특수문자 없는 한글 name 은 출력 불변(escape 무영향)."""
+        inst = Instrument(symbol="005930", exchange="KRX", name="삼성전자")
+        await service.bulk_upsert([inst])
+
+        assert service.format_label("005930") == "005930 (삼성전자)"
+        assert service.format_label("005930", markdown=True) == "`005930` (삼성전자)"
+
     def test_format_label_no_db_io(self, db):
         """no-IO 회귀 고정 — format_label 은 DB fetch / await 를 일으키지 않는다.
 

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -129,6 +129,108 @@ class TestInstrumentServiceGetName:
         assert service.get_name("005930") == "005930"
 
 
+class TestInstrumentServiceFormatLabel:
+    """#2377: 텔레그램 알림용 ``{symbol} (종목명)`` 병기 라벨 헬퍼.
+
+    sync·무예외·무IO — 알림 핸들러(백그라운드 태스크 포함)에서 await 없이 호출한다.
+    조회 실패(미적재·테이블 부재·빈 name·name==symbol) 시 symbol-only 폴백한다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_format_label_plain_loaded(self, service):
+        """적재 성공 — plain: ``069500 (KODEX 200)``."""
+        inst = Instrument(symbol="069500", exchange="KRX", name="KODEX 200")
+        await service.bulk_upsert([inst])
+
+        assert service.format_label("069500") == "069500 (KODEX 200)"
+
+    @pytest.mark.asyncio
+    async def test_format_label_markdown_loaded(self, service):
+        """적재 성공 — markdown: backtick symbol + 괄호 종목명."""
+        inst = Instrument(symbol="069500", exchange="KRX", name="KODEX 200")
+        await service.bulk_upsert([inst])
+
+        assert service.format_label("069500", markdown=True) == "`069500` (KODEX 200)"
+
+    @pytest.mark.asyncio
+    async def test_format_label_explicit_exchange(self, service):
+        """exchange 명시 전달 경로(체결 이벤트 등)."""
+        inst = Instrument(symbol="005930", exchange="KRX", name="삼성전자")
+        await service.bulk_upsert([inst])
+
+        assert service.format_label("005930", "KRX") == "005930 (삼성전자)"
+        assert (
+            service.format_label("005930", "KRX", markdown=True)
+            == "`005930` (삼성전자)"
+        )
+
+    def test_format_label_cold_empty_cache_plain(self, service):
+        """fresh service / cold 빈 캐시 — symbol-only 폴백 (plain)."""
+        # service fixture 는 initialize 만 호출(빈 instruments 테이블) → 빈 캐시.
+        assert service.format_label("069500") == "069500"
+
+    def test_format_label_cold_empty_cache_markdown(self, service):
+        """cold 빈 캐시 — markdown 폴백은 backtick symbol 만."""
+        assert service.format_label("069500", markdown=True) == "`069500`"
+
+    def test_format_label_missing_table_normalized_cache(self, db):
+        """missing-table 정규화(빈 캐시) — symbol-only 폴백."""
+        # load_readonly 가 'no such table' 를 빈 캐시로 정규화한 상태와 동치.
+        svc = InstrumentService(db=db)
+        svc._cache = {}
+        assert svc.format_label("069500") == "069500"
+        assert svc.format_label("069500", markdown=True) == "`069500`"
+
+    @pytest.mark.asyncio
+    async def test_format_label_empty_name(self, service):
+        """빈 name — symbol-only 폴백."""
+        inst = Instrument(symbol="005930", exchange="KRX", name="")
+        await service.bulk_upsert([inst])
+
+        assert service.format_label("005930") == "005930"
+        assert service.format_label("005930", markdown=True) == "`005930`"
+
+    def test_format_label_name_equals_symbol(self, db):
+        """name == symbol — 병기하지 않고 symbol-only."""
+        svc = InstrumentService(db=db)
+        svc._cache = {
+            ("069500", "KRX"): Instrument(
+                symbol="069500", exchange="KRX", name="069500"
+            )
+        }
+        assert svc.format_label("069500") == "069500"
+        assert svc.format_label("069500", markdown=True) == "`069500`"
+
+    def test_format_label_no_db_io(self, db):
+        """no-IO 회귀 고정 — format_label 은 DB fetch / await 를 일으키지 않는다.
+
+        _warm_cache / _ensure_cache / get 을 호출하면 RuntimeError 로 즉시 실패하게
+        막아, format_label 이 캐시 dict 만 동기 조회함을 강제한다(알림 경로 IO 금지).
+        """
+
+        async def _explode(*_a, **_k):  # pragma: no cover - 호출되면 실패
+            raise RuntimeError("format_label 은 DB IO / await 를 호출해서는 안 된다")
+
+        svc = InstrumentService(db=db)
+        svc._cache = {
+            ("069500", "KRX"): Instrument(
+                symbol="069500", exchange="KRX", name="KODEX 200"
+            )
+        }
+        # async 경로를 전부 폭발시켜 동기-캐시-only 조회임을 고정.
+        svc._warm_cache = _explode  # type: ignore[method-assign]
+        svc._ensure_cache = _explode  # type: ignore[method-assign]
+        svc.get = _explode  # type: ignore[method-assign]
+        # DB 도 직접 건드리지 않음을 보장.
+        svc._db.fetch_all = _explode  # type: ignore[method-assign]
+        svc._db.fetch_one = _explode  # type: ignore[method-assign]
+
+        assert svc.format_label("069500") == "069500 (KODEX 200)"
+        assert svc.format_label("069500", markdown=True) == "`069500` (KODEX 200)"
+        # 미적재 symbol 도 동기 폴백(여전히 DB 비접근).
+        assert svc.format_label("999999") == "999999"
+
+
 class TestInstrumentServiceSearch:
     @pytest.mark.asyncio
     async def test_search_by_name(self, service):

--- a/tests/unit/test_module_notification_events.py
+++ b/tests/unit/test_module_notification_events.py
@@ -12,6 +12,8 @@ import pytest
 
 from ante.eventbus import EventBus
 from ante.eventbus.events import NotificationEvent
+from ante.instrument.models import Instrument
+from ante.instrument.service import InstrumentService
 
 
 def _collect_notifications(eventbus: EventBus) -> list[NotificationEvent]:
@@ -24,6 +26,20 @@ def _collect_notifications(eventbus: EventBus) -> list[NotificationEvent]:
 
     eventbus.subscribe(NotificationEvent, _handler)
     return collected
+
+
+def _instrument_service_with(*pairs: tuple[str, str]) -> InstrumentService:
+    """#2377: 캐시만 채운 InstrumentService stub (DB 접근 없음, 동기 조회용).
+
+    ``pairs`` 는 ``(symbol, name)`` 튜플. format_label 은 메모리 캐시 dict 만
+    동기 조회하므로 DB/initialize 없이도 종목명 병기를 검증할 수 있다.
+    """
+    svc = InstrumentService(db=MagicMock())
+    svc._cache = {
+        (symbol, "KRX"): Instrument(symbol=symbol, exchange="KRX", name=name)
+        for symbol, name in pairs
+    }
+    return svc
 
 
 # ── bot/manager.py (4건) ──────────────────────────
@@ -207,6 +223,99 @@ class TestTradeRecorderNotifications:
         assert notifications[0].category == "trade"
         assert "취소 실패" in notifications[0].title
         assert "Already filled" in notifications[0].message
+
+    # ── #2377: 체결 알림 종목명 병기 ──────────────────────
+
+    @pytest.fixture
+    async def recorder_with_instrument(self, eventbus, tmp_path):
+        """instrument_service 가 주입된 TradeRecorder (종목명 병기 경로)."""
+        from ante.core.database import Database
+        from ante.trade.position import PositionHistory
+        from ante.trade.recorder import TradeRecorder
+
+        db = Database(str(tmp_path / "test.db"))
+        await db.connect()
+        ph = PositionHistory(db)
+        await ph.initialize()
+        instrument_service = _instrument_service_with(("005930", "삼성전자"))
+        rec = TradeRecorder(
+            db=db,
+            position_history=ph,
+            instrument_service=instrument_service,
+        )
+        await rec.initialize()
+        rec.subscribe(eventbus)
+        try:
+            yield rec
+        finally:
+            await db.close()
+
+    async def test_filled_notification_includes_name(
+        self, recorder_with_instrument, eventbus, notifications
+    ):
+        """#2377: 적재 시 체결 알림에 종목코드+종목명 병기 (markdown backtick)."""
+        from ante.eventbus.events import OrderFilledEvent
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                order_id="o1",
+                bot_id="bot-1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=100.0,
+                price=72000.0,
+                order_type="market",
+                account_id="acc-test",
+            )
+        )
+        assert len(notifications) == 1
+        assert "종목: `005930` (삼성전자)" in notifications[0].message
+
+    async def test_filled_notification_fallback_unknown_symbol(
+        self, recorder_with_instrument, eventbus, notifications
+    ):
+        """#2377: 미적재 종목은 종목코드만 (symbol-only 폴백)."""
+        from ante.eventbus.events import OrderFilledEvent
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                order_id="o9",
+                bot_id="bot-1",
+                strategy_id="s1",
+                symbol="999999",
+                side="buy",
+                quantity=10.0,
+                price=1000.0,
+                order_type="market",
+                account_id="acc-test",
+            )
+        )
+        assert len(notifications) == 1
+        assert "종목: `999999`\n" in notifications[0].message
+        assert "(" not in notifications[0].message.split("종목: ")[1].split("\n")[0]
+
+    async def test_filled_notification_no_instrument_service(
+        self, recorder, eventbus, notifications
+    ):
+        """#2377: 미주입(None)이면 기존 종목코드 표기 유지(하위 호환)."""
+        from ante.eventbus.events import OrderFilledEvent
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                order_id="o1",
+                bot_id="bot-1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=100.0,
+                price=72000.0,
+                order_type="market",
+                account_id="acc-test",
+            )
+        )
+        assert len(notifications) == 1
+        assert "종목: `005930`\n" in notifications[0].message
 
 
 # ── main.py (2건) ──────────────────────────
@@ -402,6 +511,153 @@ class TestReconcilerNotification:
         assert "계좌: `acc-test`" in notifs[0].message
         assert "bot-1" in notifs[0].message
         assert "005930" in notifs[0].message
+
+    # ── #2377: 포지션 불일치/동기화 지연 알림 종목명 병기 ──────
+
+    async def test_position_mismatch_includes_name(self):
+        """#2377: 적재 시 포지션 불일치 알림에 종목명 병기 (markdown backtick)."""
+        eventbus = EventBus()
+        collected = _collect_notifications(eventbus)
+
+        trade_service = AsyncMock()
+        mock_position = MagicMock()
+        mock_position.symbol = "005930"
+        mock_position.quantity = 100.0
+        mock_position.avg_entry_price = 70000.0
+        trade_service.get_positions.return_value = [mock_position]
+        trade_service.correct_position.return_value = {
+            "symbol": "005930",
+            "old_qty": 100.0,
+            "new_qty": 50.0,
+        }
+
+        from ante.trade.reconciler import PositionReconciler
+
+        reconciler = PositionReconciler(
+            trade_service=trade_service,
+            eventbus=eventbus,
+            instrument_service=_instrument_service_with(("005930", "삼성전자")),
+        )
+        await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 50.0, "avg_price": 70000}
+            ],
+            account_id="acc-test",
+        )
+
+        notifs = [n for n in collected if n.category == "broker"]
+        assert len(notifs) == 1
+        assert "종목: `005930` (삼성전자)" in notifs[0].message
+
+    async def test_position_mismatch_fallback_unknown_symbol(self):
+        """#2377: 미적재 종목은 종목코드만 (symbol-only 폴백)."""
+        eventbus = EventBus()
+        collected = _collect_notifications(eventbus)
+
+        trade_service = AsyncMock()
+        mock_position = MagicMock()
+        mock_position.symbol = "005930"
+        mock_position.quantity = 100.0
+        mock_position.avg_entry_price = 70000.0
+        trade_service.get_positions.return_value = [mock_position]
+        trade_service.correct_position.return_value = {
+            "symbol": "005930",
+            "old_qty": 100.0,
+            "new_qty": 50.0,
+        }
+
+        from ante.trade.reconciler import PositionReconciler
+
+        # 빈 캐시 instrument_service → 폴백.
+        reconciler = PositionReconciler(
+            trade_service=trade_service,
+            eventbus=eventbus,
+            instrument_service=_instrument_service_with(),
+        )
+        await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 50.0, "avg_price": 70000}
+            ],
+            account_id="acc-test",
+        )
+
+        notifs = [n for n in collected if n.category == "broker"]
+        assert len(notifs) == 1
+        assert "종목: `005930`\n" in notifs[0].message
+        assert "(" not in notifs[0].message.split("종목: ")[1].split("\n")[0]
+
+    async def test_position_mismatch_no_instrument_service(self):
+        """#2377: 미주입(None)이면 기존 종목코드 표기 유지(하위 호환)."""
+        eventbus = EventBus()
+        collected = _collect_notifications(eventbus)
+
+        trade_service = AsyncMock()
+        mock_position = MagicMock()
+        mock_position.symbol = "005930"
+        mock_position.quantity = 100.0
+        mock_position.avg_entry_price = 70000.0
+        trade_service.get_positions.return_value = [mock_position]
+        trade_service.correct_position.return_value = {
+            "symbol": "005930",
+            "old_qty": 100.0,
+            "new_qty": 50.0,
+        }
+
+        from ante.trade.reconciler import PositionReconciler
+
+        reconciler = PositionReconciler(trade_service=trade_service, eventbus=eventbus)
+        await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 50.0, "avg_price": 70000}
+            ],
+            account_id="acc-test",
+        )
+
+        notifs = [n for n in collected if n.category == "broker"]
+        assert len(notifs) == 1
+        assert "종목: `005930`\n" in notifs[0].message
+
+    async def test_sync_delay_includes_name(self):
+        """#2377: 동기화 지연(self-submitted) info 알림에도 종목명 병기."""
+        eventbus = EventBus()
+        collected = _collect_notifications(eventbus)
+
+        trade_service = AsyncMock()
+        mock_position = MagicMock()
+        mock_position.symbol = "005930"
+        mock_position.quantity = 50.0
+        mock_position.avg_entry_price = 70000.0
+        trade_service.get_positions.return_value = [mock_position]
+
+        order_tracker = AsyncMock()
+        open_order = MagicMock()
+        open_order.ordered_qty = 30.0
+        open_order.recorded_filled_qty = 0.0
+        order_tracker.get_open_orders_for.return_value = [open_order]
+
+        from ante.trade.reconciler import PositionReconciler
+
+        reconciler = PositionReconciler(
+            trade_service=trade_service,
+            eventbus=eventbus,
+            order_tracker=order_tracker,
+            instrument_service=_instrument_service_with(("005930", "삼성전자")),
+        )
+        await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 80.0, "avg_price": 70000}
+            ],
+            account_id="acc-test",
+        )
+
+        notifs = [n for n in collected if n.category == "broker"]
+        assert len(notifs) == 1
+        assert "포지션 동기화 지연" in notifs[0].title
+        assert "종목: `005930` (삼성전자)" in notifs[0].message
 
 
 # ── approval/service.py (2건) ──────────────────────────

--- a/tests/unit/test_module_notification_events.py
+++ b/tests/unit/test_module_notification_events.py
@@ -317,6 +317,71 @@ class TestTradeRecorderNotifications:
         assert len(notifications) == 1
         assert "종목: `005930`\n" in notifications[0].message
 
+    @pytest.fixture
+    async def recorder_with_nyse_instrument(self, eventbus, tmp_path):
+        """비-KRX 캐시(NYSE)만 적재된 TradeRecorder (exchange 기본값 폴백 고정용)."""
+        from ante.core.database import Database
+        from ante.trade.position import PositionHistory
+        from ante.trade.recorder import TradeRecorder
+
+        db = Database(str(tmp_path / "test.db"))
+        await db.connect()
+        ph = PositionHistory(db)
+        await ph.initialize()
+        # ("AAPL", "NYSE") 만 적재 — KRX 키는 부재.
+        instrument_service = InstrumentService(db=MagicMock())
+        instrument_service._cache = {
+            ("AAPL", "NYSE"): Instrument(
+                symbol="AAPL", exchange="NYSE", name="Apple Inc."
+            )
+        }
+        rec = TradeRecorder(
+            db=db,
+            position_history=ph,
+            instrument_service=instrument_service,
+        )
+        await rec.initialize()
+        rec.subscribe(eventbus)
+        try:
+            yield rec
+        finally:
+            await db.close()
+
+    async def test_filled_notification_exchange_default_krx_fallback(
+        self, recorder_with_nyse_instrument, eventbus, notifications
+    ):
+        """#2377 Codex P2-1: exchange 기본값(KRX) 폴백 고정 — 오표기 없음 불변식.
+
+        cache 에는 ``("AAPL", "NYSE")`` 만 적재. durable fill /
+        VirtualProvider 경로처럼 ``OrderFilledEvent.exchange`` 가 dataclass
+        기본값 ``KRX`` 로 들어오면 ``(AAPL, KRX)`` cache 미스 →  symbol-only
+        폴백된다(병기 누락, 오표기 아님). 발행은 정상 성공하고 라벨에는
+        다른 종목명("Apple Inc." 등)이 절대 섞이지 않는다(invariant).
+        """
+        from ante.eventbus.events import OrderFilledEvent
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                order_id="o-nyse",
+                bot_id="bot-1",
+                strategy_id="s1",
+                symbol="AAPL",
+                side="buy",
+                quantity=10.0,
+                price=190.0,
+                order_type="market",
+                account_id="acc-test",
+                # exchange 미지정 → dataclass 기본값 "KRX" 적용(폴백 트리거).
+            )
+        )
+        # 알림 발행이 성공(불변식: 발행 실패/지연 금지).
+        assert len(notifications) == 1
+        msg = notifications[0].message
+        # symbol-only 폴백 — 종목명 병기 없음.
+        assert "종목: `AAPL`\n" in msg
+        # 오표기 없음 — 다른 거래소(NYSE) 종목명이 라벨에 섞이지 않는다.
+        assert "Apple Inc." not in msg
+
 
 # ── main.py (2건) ──────────────────────────
 

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -1575,3 +1575,57 @@ class TestAccountLevelDetection:
                 [{"symbol": "005930", "quantity": 10}],
                 account_id="default",
             )
+
+    async def test_account_level_mismatch_includes_name(
+        self, service, eventbus, order_tracker, position_history
+    ):
+        """#2377: 적재 시 계좌 단위 불일치 알림에 종목명 병기."""
+        from unittest.mock import MagicMock
+
+        from ante.instrument.models import Instrument
+        from ante.instrument.service import InstrumentService
+
+        # format_label 은 캐시 dict 만 동기 조회하므로 db 는 미사용(MagicMock).
+        instrument_service = InstrumentService(db=MagicMock())
+        instrument_service._cache = {
+            ("005930", "KRX"): Instrument(
+                symbol="005930", exchange="KRX", name="삼성전자"
+            )
+        }
+        reconciler = PositionReconciler(
+            trade_service=service,
+            eventbus=eventbus,
+            order_tracker=order_tracker,
+            instrument_service=instrument_service,
+        )
+        await _set_position(position_history, "bot-1", "005930", 30, 50000)
+        await _set_position(position_history, "bot-2", "005930", 50, 50000)
+
+        notif_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        await reconciler.detect_account_level(
+            [{"symbol": "005930", "quantity": 100, "avg_price": 50000}],
+            account_id="acc-test",
+        )
+
+        assert len(notif_events) == 1
+        assert "종목: `005930` (삼성전자)" in notif_events[0].message
+
+    async def test_account_level_mismatch_fallback_no_instrument(
+        self, reconciler, position_history, eventbus
+    ):
+        """#2377: 미주입(None)이면 종목코드만 표기 유지(하위 호환)."""
+        await _set_position(position_history, "bot-1", "005930", 30, 50000)
+        await _set_position(position_history, "bot-2", "005930", 50, 50000)
+
+        notif_events: list = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        await reconciler.detect_account_level(
+            [{"symbol": "005930", "quantity": 100, "avg_price": 50000}],
+            account_id="acc-test",
+        )
+
+        assert len(notif_events) == 1
+        assert "종목: `005930`\n" in notif_events[0].message

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -923,6 +923,89 @@ class TestRuleEngineEventBus:
         assert received[0].bot_id == "bot1"
         assert received[0].reason == "Rule violation"
 
+    # ── #2377: Rule violation NOTIFY 종목명 병기 (plain) ──────
+
+    def _notify_event(self):
+        from ante.eventbus.events import OrderRequestEvent
+
+        return OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            price=50000.0,
+        )
+
+    async def test_notify_action_includes_name(self, eventbus, mock_account_service):
+        """#2377: 적재 시 Rule violation NOTIFY 메시지에 종목명 plain 병기."""
+        from unittest.mock import MagicMock
+
+        from ante.eventbus.events import NotificationEvent
+        from ante.instrument.models import Instrument
+        from ante.instrument.service import InstrumentService
+
+        instrument_service = InstrumentService(db=MagicMock())
+        instrument_service._cache = {
+            ("005930", "KRX"): Instrument(
+                symbol="005930", exchange="KRX", name="삼성전자"
+            )
+        }
+        engine = RuleEngine(
+            eventbus=eventbus,
+            account_id="domestic",
+            account_service=mock_account_service,
+            instrument_service=instrument_service,
+        )
+
+        received: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: received.append(e))
+
+        await engine._execute_actions([RuleAction.NOTIFY], self._notify_event())
+
+        assert len(received) == 1
+        assert received[0].message == "Rule violation for bot bot1: 005930 (삼성전자)"
+
+    async def test_notify_action_fallback_unknown_symbol(
+        self, eventbus, mock_account_service
+    ):
+        """#2377: 미적재 종목은 종목코드만 (symbol-only 폴백)."""
+        from unittest.mock import MagicMock
+
+        from ante.eventbus.events import NotificationEvent
+        from ante.instrument.service import InstrumentService
+
+        # 빈 캐시 → 폴백.
+        instrument_service = InstrumentService(db=MagicMock())
+        engine = RuleEngine(
+            eventbus=eventbus,
+            account_id="domestic",
+            account_service=mock_account_service,
+            instrument_service=instrument_service,
+        )
+
+        received: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: received.append(e))
+
+        await engine._execute_actions([RuleAction.NOTIFY], self._notify_event())
+
+        assert len(received) == 1
+        assert received[0].message == "Rule violation for bot bot1: 005930"
+
+    async def test_notify_action_no_instrument_service(self, engine, eventbus):
+        """#2377: 미주입(None)이면 기존 종목코드 표기 유지(하위 호환)."""
+        from ante.eventbus.events import NotificationEvent
+
+        received: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: received.append(e))
+
+        await engine._execute_actions([RuleAction.NOTIFY], self._notify_event())
+
+        assert len(received) == 1
+        assert received[0].message == "Rule violation for bot bot1: 005930"
+
     async def test_rule_engine_rejects_invalid_signal_side(
         self, engine, eventbus, monkeypatch
     ):

--- a/tests/unit/test_rule_modify_enrich.py
+++ b/tests/unit/test_rule_modify_enrich.py
@@ -313,3 +313,32 @@ async def test_rule_engine_manager_injects_order_tracker(
     )
     engine = manager.create_engine("domestic")
     assert engine._order_tracker is tracker
+
+
+def test_rule_engine_manager_init_without_instrument_service(
+    mock_account_service: AsyncMock,
+) -> None:
+    """#2377: RuleEngineManager는 instrument_service 미전달로도 생성된다(무회귀)."""
+    manager = RuleEngineManager(
+        eventbus=EventBus(),
+        account_service=mock_account_service,
+    )
+    assert manager._instrument_service is None
+
+
+async def test_rule_engine_manager_injects_instrument_service(
+    mock_account_service: AsyncMock,
+) -> None:
+    """#2377: Manager가 생성하는 RuleEngine에 instrument_service가 전달되는지 잠근다."""
+    from unittest.mock import MagicMock
+
+    from ante.instrument.service import InstrumentService
+
+    instrument_service = InstrumentService(db=MagicMock())
+    manager = RuleEngineManager(
+        eventbus=EventBus(),
+        account_service=mock_account_service,
+        instrument_service=instrument_service,
+    )
+    engine = manager.create_engine("domestic")
+    assert engine._instrument_service is instrument_service


### PR DESCRIPTION
Closes #2377

## Summary
- `InstrumentService.format_label(symbol, exchange="KRX", *, markdown=False)` 신설 — 표기 SSOT 단일화 (sync·무예외·무IO, 캐시 미스/빈 name 시 symbol-only 폴백). 종목명은 Telegram legacy Markdown 특수문자(`_`/`*`/백틱/`[`) 이스케이프로 발송 실패 차단
- 6지점 전수 병기 적용: recorder 체결 완료, reconciler 3종(포지션 불일치/계좌 단위/동기화 지연), fill_scheduler over-attribution, rule engine NOTIFY (전수 재조사로 누락 0건 확인)
- 발행 5개 클래스에 `instrument_service` 선택 주입(하위 호환) + main.py 조립 5곳 wiring (RuleEngine은 RuleEngineManager pass-through, CLI 생성 경로는 미주입 유지)
- 스펙 2건 갱신: instrument.md(format_label API + 타 모듈 참고 절 정정), broker-adapter/17(포지션 불일치 병기 형식)
- known-limitation 고정: `OrderFilledEvent.exchange` 기본값 KRX 경로는 비-KRX 종목 symbol-only 폴백(오표기 아님) — 주석+invariant 테스트로 고정, producer 전파는 후속 영역

## Test Plan
- `uv run ruff check src tests` / `uv run ruff format --check src tests` — PASS
- `uv run mypy src/ante` 전체 — PASS (233 files)
- `uv run pytest tests/unit -q` — 7292 passed, 2 skipped
- TDD red 확인: format_label 9개 테스트 구현 전 AttributeError로 전부 fail → green. no-IO 고정 테스트(DB fetch/await 0회 강제) 포함
- grep invariant: src 직접 포맷 잔존 0건(전부 헬퍼 경유), docs/specs symbol-only 형식 정의 잔존 0건
- Codex 브랜치 리뷰: attempt 1 FAIL(P2 2건) → 수정 → attempt 2 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)