### PR TITLE
fix(notification): #2385 KIS 실운용·/stop 종목명 병기 누락 수정 — _sync_instruments 전 계좌 동기화 + TelegramCommandReceiver format_label

### DIFF
--- a/docs/specs/instrument/instrument.md
+++ b/docs/specs/instrument/instrument.md
@@ -148,5 +148,6 @@ CSV/JSON 파일에서 종목 데이터를 일괄 등록/갱신한다. 파일 확
 ## 타 모듈 설계 시 참고
 
 - **Notification**: 종목코드를 직접 포맷하는 **알림 발행자**(`TradeRecorder`·`PositionReconciler`·`FillReconcileScheduler`·`RuleEngine` 등)에 `instrument_service`를 선택 주입(`instrument_service: InstrumentService | None = None`)하고, 발행 지점에서 `format_label`로 `{symbol} (종목명)`을 병기한다. 표기 SSOT는 `format_label` 한 곳이며, 각 발행자가 `get_name`을 개별 조합하지 않는다. 미주입(`None`)이면 종목코드만 표기하는 기존 경로를 유지한다(`NotificationService` 자체가 아니라 발행자 측 주입 — #2377).
+  - **직접 reply consumer (`TelegramCommandReceiver` `/stop`)**: 위 발행자들은 `NotificationEvent`를 `parse_mode="Markdown"`으로 전송하므로 `format_label`을 `markdown=True`로 호출하지만, `TelegramCommandReceiver`는 `/stop` 보유종목 응답을 `_reply()`로 **직접 전송**하며 `parse_mode`를 설정하지 않는 **plain transport**다. 따라서 `format_label(symbol, exchange, markdown=False)`(plain 모드)로 호출한다(#2385). exchange는 `bot.config.account_id` → `account_service.get(...).exchange`로 해석하되 실패/미주입 시 `KRX`로 폴백하고, `instrument_service` 미주입 시 종목코드만 표기하는 기존 경로를 유지한다. plain 모드도 종목명을 Markdown 특수문자 escape 처리하므로(발행자 측 plain 라벨이 `NotificationEvent` Markdown 전송에 삽입되는 경로의 발송 실패 방지 계약 공유), 특수문자를 포함한 종목명은 plain reply에서 백슬래시가 리터럴로 보일 수 있다(bounded known-limitation — KRX 주식/ETF 종목명은 실무상 `_ * [` 백틱을 쓰지 않으며 종목코드는 항상 정확).
 - **Data Pipeline**: 시세 데이터 수집 시 종목 메타데이터도 함께 갱신하는 설계 고려
 - **CLI**: 종목 검색/조회 명령은 InstrumentService를 통해 구현한다.

--- a/docs/specs/notification/notification.md
+++ b/docs/specs/notification/notification.md
@@ -150,6 +150,7 @@ CRITICAL 알림은 `telegram_enabled=false`, `min_level`, `quiet_hours`, dedup�
 | `treasury_manager` | TreasuryManager \| None | None | 자금 현황 조회용 (전 계좌) |
 | `account_service` | AccountService \| None | None | 계좌 상태 제어용 |
 | `approval_service` | ApprovalService \| None | None | 결재 승인/거절 처리용 |
+| `instrument_service` | InstrumentService \| None | None | `/stop` 보유종목 종목명 병기용 (#2385) |
 
 **지원 명령:**
 
@@ -165,6 +166,8 @@ CRITICAL 알림은 `telegram_enabled=false`, `min_level`, `quiet_hours`, dedup�
 | `/confirm` | 위험 명령 확인 | - |
 
 **2단계 확인**: `halt`, `clear_halt`, `stop` 명령은 `_DANGEROUS_COMMANDS`로 분류되며, `/confirm` 입력 후 `confirm_timeout` 내에서만 실행된다. `/clear_halt`는 계좌 상태만 ACTIVE로 복구하며 봇을 자동 재시작하지 않는다.
+
+**`/stop` 보유종목 출력 (#2385)**: 봇 중지 후 유지되는 보유종목을 표기할 때 종목코드만 나열하지 않고 `InstrumentService.format_label` SSOT(`docs/specs/instrument/instrument.md` 참조)를 따라 `{symbol} (종목명)`을 병기한다. `_reply()`는 `parse_mode`를 설정하지 않는 **plain transport**이므로 `format_label(symbol, exchange, markdown=False)`로 호출한다. exchange는 `bot.config.account_id` → `account_service.get(...).exchange`로 해석하되 실패/미주입 시 `KRX`로 폴백한다. `instrument_service` 미주입 시 종목코드만 표기하는 기존 경로를 유지한다(graceful fallback). plain 모드도 종목명을 escape하므로 특수문자를 포함한 종목명은 백슬래시가 리터럴로 보일 수 있으나, 이는 bounded known-limitation으로 수용한다(`_reply` transport 및 `format_label` escape 계약은 multi-consumer 표면이라 본 범위 비목표).
 
 **결재 처리**: 결재 승인/거절은 텍스트 명령이 아니라 결재 요청 알림에 첨부된 인라인 [승인]/[거절] 버튼 callback으로만 처리한다 (아래 [결재 인라인 버튼](#결재-인라인-버튼) 참조). 텔레그램 텍스트 명령 `/approve`·`/reject`는 지원하지 않는다.
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1039,12 +1039,28 @@ async def _init_stream_integration(
 
 
 async def _sync_instruments(s: Services, accounts: list) -> None:
-    """종목 마스터 동기화 (연결된 첫 번째 Broker 사용)."""
+    """종목 마스터 동기화 (전 계좌의 unique exchange 단위로 순회).
+
+    #2385: 과거에는 첫 번째 성공 broker 에서 ``return`` 했으나, 계좌 순서가
+    ``test``(TEST) → ``oracle-paper``(KRX) 인 환경에서 TEST 더미 종목이 KIS/KRX
+    종목 마스터 적재를 선점해 종목명 병기(#2377)가 전부 symbol-only 로
+    폴백되는 회귀가 있었다. 이제 전 계좌를 순회하되 이미 동기화한 exchange
+    는 ``synced_exchanges`` 로 건너뛰어 같은 exchange 를 중복 조회하지 않는다.
+    빈 결과(``get_instruments() == []``)는 synced 처리하지 않고 ``continue`` 하여
+    같은 exchange 의 후속 계좌가 여전히 동기화를 시도할 수 있게 한다.
+    ``bulk_upsert`` 성공 시에만 exchange 를 synced 로 표시한다. 전 계좌 순회
+    후 아무 것도 동기화하지 못하면 기존 경고를 유지한다.
+    """
+    synced_exchanges: set[str] = set()
     for account in accounts:
+        if account.exchange in synced_exchanges:
+            continue
         try:
             broker = await s.account_service.get_broker(account.account_id)
             raw_instruments = await broker.get_instruments()
             if not raw_instruments:
+                # 빈 결과는 synced 처리하지 않는다 — 같은 exchange 의 다른
+                # 계좌가 여전히 동기화를 시도할 수 있어야 한다.
                 continue
             from ante.instrument.models import Instrument
 
@@ -1060,19 +1076,21 @@ async def _sync_instruments(s: Services, accounts: list) -> None:
                 for item in raw_instruments
             ]
             count = await s.instrument_service.bulk_upsert(instruments_to_upsert)
+            synced_exchanges.add(account.exchange)
             logger.info(
-                "종목 동기화 완료: account=%s, %d건 갱신",
+                "종목 동기화 완료: account=%s, exchange=%s, %d건 갱신",
                 account.account_id,
+                account.exchange,
                 count,
             )
-            return  # 첫 번째 성공한 Broker로 동기화
         except Exception:
             logger.warning(
                 "종목 동기화 실패: account=%s — 다음 계좌 시도",
                 account.account_id,
                 exc_info=True,
             )
-    logger.warning("종목 동기화 실패 — 기존 캐시 데이터로 운영")
+    if not synced_exchanges:
+        logger.warning("종목 동기화 실패 — 기존 캐시 데이터로 운영")
 
 
 def _init_context_factory(s: Services) -> None:
@@ -1822,6 +1840,7 @@ async def _init_notification(s: Services) -> None:
             treasury_manager=s.treasury_manager,
             account_service=s.account_service,
             approval_service=s.approval_service,
+            instrument_service=s.instrument_service,
         )
         s.telegram_receiver.start()
         logger.info("TelegramCommandReceiver 시작 (chat_id=%s)", chat_id)

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from ante.account.service import AccountService
     from ante.approval.service import ApprovalService
     from ante.bot.manager import BotManager
+    from ante.instrument.service import InstrumentService
     from ante.notification.telegram import TelegramAdapter
     from ante.treasury.manager import TreasuryManager
 
@@ -37,6 +38,7 @@ class TelegramCommandReceiver:
         treasury_manager: TreasuryManager | None = None,
         account_service: AccountService | None = None,
         approval_service: ApprovalService | None = None,
+        instrument_service: InstrumentService | None = None,
     ) -> None:
         self._adapter = adapter
         self._allowed_user_ids = set(allowed_user_ids or [])
@@ -46,6 +48,7 @@ class TelegramCommandReceiver:
         self._treasury_manager = treasury_manager
         self._account_service = account_service
         self._approval_service = approval_service
+        self._instrument_service = instrument_service
 
         self._offset: int = 0
         self._task: asyncio.Task[None] | None = None
@@ -576,16 +579,51 @@ class TelegramCommandReceiver:
         # amount 부재로 0원 오표시였으므로, 건수 표시가 의미상 정확한 정정이다.
         pending_count = len(open_orders)
 
+        # #2385: 보유종목 표기를 InstrumentService.format_label SSOT로 단일화한다
+        # (#2377 "전 지점 종목명 병기"). instrument_service 미주입이면 기존
+        # symbol-only 경로를 유지한다(graceful fallback). _reply 는 parse_mode 를
+        # 설정하지 않는 plain transport 이므로 markdown=False 로 포맷한다.
+        held_line = await self._format_held_symbols(bot, symbols)
+
         lines = [
             header,
             "",
             f"⚠️ 보유 종목 {len(symbols)}개가 유지됩니다.",
             "중지 후 포지션을 직접 관리해야 합니다.",
             "",
-            f"보유: {', '.join(symbols)}",
+            f"보유: {held_line}",
             f"체결대기 주문: {pending_count}건",
         ]
         return "\n".join(lines)
+
+    async def _format_held_symbols(self, bot: Any, symbols: list[str]) -> str:
+        """보유종목 표기 라인을 구성한다 (#2385).
+
+        ``instrument_service`` 미주입 시 기존 ``', '.join(symbols)`` 를 유지한다.
+        주입 시 ``format_label(symbol, exchange, markdown=False)`` 로 종목명을
+        병기한다. exchange 해석(``bot.config.account_id`` → ``account_service.get``)
+        은 try/except 로 감싸 계좌 조회 실패가 stop 성공 후 reply 실패로 번지지
+        않게 하며, 실패/미주입 시 기본 ``"KRX"`` 로 폴백한다.
+        """
+        if self._instrument_service is None:
+            return ", ".join(symbols)
+
+        exchange = "KRX"
+        try:
+            account_id = bot.config.account_id
+            if account_id and self._account_service is not None:
+                account = await self._account_service.get(account_id)
+                exchange = account.exchange
+        except Exception:
+            logger.warning(
+                "보유종목 exchange 해석 실패 — KRX 기본값 사용", exc_info=True
+            )
+            exchange = "KRX"
+
+        return ", ".join(
+            self._instrument_service.format_label(symbol, exchange, markdown=False)
+            for symbol in symbols
+        )
 
     # ── 유틸 ────────────────────────────────────────
 

--- a/tests/unit/test_main_init_notification.py
+++ b/tests/unit/test_main_init_notification.py
@@ -246,6 +246,12 @@ async def test_enabled_with_secrets_initializes_service(
     sentinel_treasury_manager = object()
     s.treasury_manager = sentinel_treasury_manager  # type: ignore[assignment]
 
+    # #2385: `_init_notification`이 TelegramCommandReceiver에 instrument_service를
+    # 주입하는지 회귀 가드(#2378 동형). 주입 누락 시 `/stop` 보유종목이 런타임에서
+    # 항상 종목코드만 표기하는 버그가 발생한다(format_label SSOT 미적용).
+    sentinel_instrument_service = object()
+    s.instrument_service = sentinel_instrument_service  # type: ignore[assignment]
+
     try:
         await _init_notification(s)
     finally:
@@ -257,4 +263,7 @@ async def test_enabled_with_secrets_initializes_service(
     assert len(captured_kwargs) == 1, "TelegramCommandReceiver 생성자 호출 누락"
     assert captured_kwargs[0]["treasury_manager"] is s.treasury_manager, (
         "TelegramCommandReceiver에 s.treasury_manager가 주입되어야 한다"
+    )
+    assert captured_kwargs[0]["instrument_service"] is s.instrument_service, (
+        "TelegramCommandReceiver에 s.instrument_service가 주입되어야 한다 (#2385)"
     )

--- a/tests/unit/test_main_startup_ordering.py
+++ b/tests/unit/test_main_startup_ordering.py
@@ -206,3 +206,165 @@ async def test_main_removes_marker_on_init_failure(
     config = Config.load(config_dir=tmp_path)
     assert not main_module._starting_marker_path(config).exists()
     assert not config.runtime_pid_path().exists()
+
+
+# ── #2385: _sync_instruments 전 계좌 unique exchange 동기화 ────────────────
+
+
+def _make_sync_account(account_id: str, exchange: str) -> Any:
+    """``account_id``/``exchange`` property 만 갖는 Account 더블."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(account_id=account_id, exchange=exchange)
+
+
+def _make_sync_services(broker_instruments: dict[str, Any]) -> tuple[Any, list[Any]]:
+    """``_sync_instruments`` 용 Services 더블 + bulk_upsert 호출 기록.
+
+    ``broker_instruments`` 는 account_id → broker.get_instruments() 반환값
+    (list[dict] 또는 raise 할 Exception 인스턴스) 매핑이다.
+    """
+    from unittest.mock import AsyncMock
+
+    import ante.main as main_module
+
+    s = main_module.Services()
+
+    upsert_calls: list[Any] = []
+
+    async def _bulk_upsert(instruments: list[Any]) -> int:
+        upsert_calls.append(instruments)
+        return len(instruments)
+
+    instrument_service = AsyncMock()
+    instrument_service.bulk_upsert = AsyncMock(side_effect=_bulk_upsert)
+    s.instrument_service = instrument_service  # type: ignore[assignment]
+
+    async def _get_broker(account_id: str) -> Any:
+        result = broker_instruments[account_id]
+        broker = AsyncMock()
+
+        async def _get_instruments() -> Any:
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        broker.get_instruments = AsyncMock(side_effect=_get_instruments)
+        return broker
+
+    account_service = AsyncMock()
+    account_service.get_broker = AsyncMock(side_effect=_get_broker)
+    s.account_service = account_service  # type: ignore[assignment]
+
+    return s, upsert_calls
+
+
+@pytest.mark.asyncio
+async def test_sync_instruments_does_not_stop_at_first_broker() -> None:
+    """(a) [test(TEST), oracle-paper(KRX)] 순서에서 KRX 069500 이 적재된다.
+
+    과거 첫 성공 broker `return` 구조에서는 TEST 더미가 KRX 마스터 적재를
+    선점했다(#2385 회귀). 첫 broker return 제거를 잠근다.
+    """
+    import ante.main as main_module
+
+    accounts = [
+        _make_sync_account("test", "TEST"),
+        _make_sync_account("oracle-paper", "KRX"),
+    ]
+    s, upsert_calls = _make_sync_services(
+        {
+            "test": [{"symbol": "000001", "name": "알파전자"}],
+            "oracle-paper": [{"symbol": "069500", "name": "KODEX 200"}],
+        }
+    )
+
+    await main_module._sync_instruments(s, accounts)
+
+    # 두 exchange 모두 동기화되어야 한다 (첫 broker return 제거).
+    assert len(upsert_calls) == 2
+    upserted = {inst.symbol: inst for batch in upsert_calls for inst in batch}
+    assert "069500" in upserted, "KRX 069500 마스터가 적재되어야 한다"
+    krx = upserted["069500"]
+    assert krx.exchange == "KRX"
+    assert krx.name == "KODEX 200"
+
+
+@pytest.mark.asyncio
+async def test_sync_instruments_dedupes_same_exchange() -> None:
+    """(b) 동일 exchange 2계좌 → 해당 exchange 는 1회만 sync."""
+    import ante.main as main_module
+
+    accounts = [
+        _make_sync_account("kis-1", "KRX"),
+        _make_sync_account("kis-2", "KRX"),
+    ]
+    s, upsert_calls = _make_sync_services(
+        {
+            "kis-1": [{"symbol": "069500", "name": "KODEX 200"}],
+            "kis-2": [{"symbol": "102110", "name": "TIGER 200"}],
+        }
+    )
+
+    await main_module._sync_instruments(s, accounts)
+
+    # 첫 계좌가 KRX 를 동기화했으므로 둘째 계좌는 skip → bulk_upsert 1회.
+    assert len(upsert_calls) == 1
+    # 둘째 계좌의 broker 는 조회조차 되지 않아야 한다.
+    s.account_service.get_broker.assert_awaited_once_with("kis-1")
+
+
+@pytest.mark.asyncio
+async def test_sync_instruments_empty_result_not_marked_synced() -> None:
+    """(c) 빈 결과 → synced 처리 금지(같은 exchange 후속 계좌가 여전히 sync)."""
+    import ante.main as main_module
+
+    accounts = [
+        _make_sync_account("kis-empty", "KRX"),
+        _make_sync_account("kis-real", "KRX"),
+    ]
+    s, upsert_calls = _make_sync_services(
+        {
+            "kis-empty": [],  # 빈 결과 → continue, synced 처리 금지
+            "kis-real": [{"symbol": "069500", "name": "KODEX 200"}],
+        }
+    )
+
+    await main_module._sync_instruments(s, accounts)
+
+    # 빈 결과는 synced 처리되지 않아 후속 계좌가 KRX 를 동기화해야 한다.
+    assert len(upsert_calls) == 1
+    upserted = {inst.symbol for batch in upsert_calls for inst in batch}
+    assert "069500" in upserted
+    # 두 계좌 모두 broker 조회됨 (빈 결과 계좌가 KRX 를 점유하지 않음).
+    assert s.account_service.get_broker.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_instruments_all_fail_keeps_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(d) 전 계좌 실패 → "종목 동기화 실패 — 기존 캐시 데이터로 운영" 경고 보존."""
+    import logging
+
+    import ante.main as main_module
+
+    accounts = [
+        _make_sync_account("kis-1", "KRX"),
+        _make_sync_account("kis-2", "KOSDAQ"),
+    ]
+    s, upsert_calls = _make_sync_services(
+        {
+            "kis-1": RuntimeError("broker down"),
+            "kis-2": RuntimeError("broker down"),
+        }
+    )
+
+    with caplog.at_level(logging.WARNING, logger="ante.main"):
+        await main_module._sync_instruments(s, accounts)
+
+    assert len(upsert_calls) == 0
+    assert any(
+        "종목 동기화 실패 — 기존 캐시 데이터로 운영" in rec.message
+        for rec in caplog.records
+    ), "전 계좌 실패 시 기존 경고가 보존되어야 한다"

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -26,6 +26,7 @@ def _make_running_bot(
     name: str = "테스트봇",
     positions: dict | None = None,
     open_orders: list | None = None,
+    account_id: str = "test",
 ):
     """RUNNING 상태의 Bot mock 생성 헬퍼."""
     from ante.bot.config import BotStatus
@@ -34,6 +35,7 @@ def _make_running_bot(
     bot.bot_id = bot_id
     bot.status = BotStatus.RUNNING
     bot.config.name = name
+    bot.config.account_id = account_id
     bot._ctx.get_positions.return_value = positions or {}
     bot._ctx.get_open_orders.return_value = open_orders or []
     return bot
@@ -106,11 +108,41 @@ def account_service():
             }
         ]
     )
+    # #2385: /stop exchange 해석용 — account.exchange 기본 KRX.
+    mock.get = AsyncMock(
+        return_value=SimpleNamespace(account_id="test", exchange="KRX")
+    )
     return mock
 
 
 @pytest.fixture
-def receiver(adapter, bot_manager, treasury_manager, account_service):
+def instrument_service():
+    """InstrumentService mock — format_label SSOT (#2385).
+
+    KRX 캐시에 005930/035720 만 존재. 다른 (symbol, exchange) 는 symbol-only
+    폴백을 흉내낸다(실제 ``format_label`` 의 캐시 미스 계약과 동형).
+    """
+    names = {
+        ("005930", "KRX"): "삼성전자",
+        ("035720", "KRX"): "카카오",
+    }
+
+    def _format_label(symbol: str, exchange: str = "KRX", *, markdown: bool = False):
+        base = f"`{symbol}`" if markdown else symbol
+        name = names.get((symbol, exchange))
+        if not name or name == symbol:
+            return base
+        return f"{base} ({name})"
+
+    mock = MagicMock()
+    mock.format_label.side_effect = _format_label
+    return mock
+
+
+@pytest.fixture
+def receiver(
+    adapter, bot_manager, treasury_manager, account_service, instrument_service
+):
     return TelegramCommandReceiver(
         adapter=adapter,
         allowed_user_ids=[12345],
@@ -119,6 +151,7 @@ def receiver(adapter, bot_manager, treasury_manager, account_service):
         bot_manager=bot_manager,
         treasury_manager=treasury_manager,
         account_service=account_service,
+        instrument_service=instrument_service,
     )
 
 
@@ -406,9 +439,79 @@ class TestCommands:
         assert "봇 중지" in result
         assert "보유 종목 2개가 유지됩니다" in result
         assert "포지션을 직접 관리" in result
-        assert "005930" in result
-        assert "035720" in result
+        # #2385: format_label SSOT 로 종목명 병기 (plain transport).
+        assert "005930 (삼성전자)" in result
+        assert "035720 (카카오)" in result
         assert "체결대기 주문: 2건" in result
+
+    async def test_stop_bot_label_uses_account_exchange(
+        self, receiver, bot_manager, account_service, instrument_service
+    ):
+        """#2385: exchange 는 bot.config.account_id → account.exchange 로 해석."""
+        account_service.get.return_value = SimpleNamespace(
+            account_id="oracle-paper", exchange="KRX"
+        )
+        bot = _make_running_bot(
+            account_id="oracle-paper",
+            positions={
+                "005930": {"symbol": "005930", "quantity": 1, "avg_entry_price": 70000},
+            },
+        )
+        bot_manager.get_bot.return_value = bot
+        result = await receiver._cmd_stop(["bot-1"])
+        assert "005930 (삼성전자)" in result
+        # bot.config.account_id 로 계좌를 조회해 exchange 를 얻는다.
+        account_service.get.assert_awaited_once_with("oracle-paper")
+        instrument_service.format_label.assert_any_call("005930", "KRX", markdown=False)
+
+    async def test_stop_bot_label_cache_miss_no_name(self, receiver, bot_manager):
+        """#2385: TEST/non-KRX(캐시 미스) → 이름 누락·오표기 없이 symbol-only."""
+        bot = _make_running_bot(
+            positions={
+                # 캐시에 없는 TEST 더미 종목 → 종목명 병기 없이 코드만.
+                "000001": {"symbol": "000001", "quantity": 1, "avg_entry_price": 1000},
+            },
+        )
+        bot_manager.get_bot.return_value = bot
+        result = await receiver._cmd_stop(["bot-1"])
+        assert "보유: 000001" in result
+        # 괄호 종목명 병기가 붙지 않아야 한다 (오표기 금지).
+        assert "000001 (" not in result
+
+    async def test_stop_bot_label_exchange_lookup_failure_falls_back_to_krx(
+        self, receiver, bot_manager, account_service, instrument_service
+    ):
+        """#2385: account 조회 실패 → KRX 폴백, stop 성공이 reply 실패로 번지지 않음."""
+        account_service.get.side_effect = RuntimeError("account lookup down")
+        bot = _make_running_bot(
+            positions={
+                "005930": {"symbol": "005930", "quantity": 1, "avg_entry_price": 70000},
+            },
+        )
+        bot_manager.get_bot.return_value = bot
+        # 예외 없이 응답을 구성해야 한다.
+        result = await receiver._cmd_stop(["bot-1"])
+        assert "봇 중지" in result
+        # KRX 폴백으로 종목명 병기 성공.
+        assert "005930 (삼성전자)" in result
+        instrument_service.format_label.assert_any_call("005930", "KRX", markdown=False)
+
+    async def test_stop_bot_label_no_instrument_service_fallback(
+        self, receiver, bot_manager
+    ):
+        """#2385: instrument_service=None → 기존 ', '.join(symbols) fallback 회귀."""
+        receiver._instrument_service = None
+        bot = _make_running_bot(
+            positions={
+                "005930": {"symbol": "005930", "quantity": 1, "avg_entry_price": 70000},
+                "035720": {"symbol": "035720", "quantity": 5, "avg_entry_price": 50000},
+            },
+        )
+        bot_manager.get_bot.return_value = bot
+        result = await receiver._cmd_stop(["bot-1"])
+        # 종목명 병기 없이 코드만 콤마 결합.
+        assert "보유: 005930, 035720" in result
+        assert "(삼성전자)" not in result
 
     async def test_stop_bot_already_stopped(self, receiver, bot_manager):
         """이미 중지된 봇은 안내 메시지 반환."""


### PR DESCRIPTION
Closes #2385

## Summary
- **`_sync_instruments`** (원인 1): 첫 성공 broker `return` 제거 → 전 계좌 unique exchange 순회(`synced_exchanges` set, 빈 결과 non-synced, all-fail 경고 보존). `test` 계좌가 먼저 있어도 KIS/KRX 종목 마스터(`069500`)가 적재됨.
- **`TelegramCommandReceiver`** (원인 2): `__init__`에 `instrument_service` 주입, `/stop` 보유종목 출력이 `format_label`(plain) 병기(`_format_held_symbols`; exchange `try/except` KRX 폴백, `None` graceful fallback). `main._init_notification` 주입.
- **spec**: `instrument.md`/`notification.md`에 command-reply 경로(plain transport, parse-mode 상이) 주입처 명시.
- **known-limitation**: `format_label` plain escape는 NotificationEvent 발행자(`fill_scheduler`/`rule_engine`)에 필수라 미변경 → `/stop` 특수문자 종목명 백슬래시 노출은 bounded known-limitation으로 spec에 명시.

## Test Plan
- `ruff check src/ante tests` — PASS
- `ruff format --check src/ante tests` — PASS
- `mypy src/` (233 files) — PASS
- `pytest tests/unit/{test_telegram_receiver,test_main_init_notification,test_main_startup_ordering}.py` — 82 passed
- 회귀(전부 수정 전 FAIL 확인): `_sync_instruments` 4엣지(KRX 적재/동일 exchange 1회/빈 결과 non-synced/all-fail 경고), `/stop` 병기·캐시미스·exchange 실패 폴백·`None` 폴백, `_init_notification` 주입 가드
- Codex 브랜치 리뷰: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
