### PR TITLE
docs(broker-adapter): #2387 purchasable_amount KIS 주문가능액 스펙 확정 — inquire-psbl-order get_buyable 계약 (#2384 선행)

### DIFF
--- a/docs/specs/broker-adapter/04-broker-adapter-interface.md
+++ b/docs/specs/broker-adapter/04-broker-adapter-interface.md
@@ -31,7 +31,8 @@ BrokerAdapter는 증권사 API 어댑터의 추상 기본 클래스다. 생성 �
 |----------|----------|--------|------|
 | `connect()` | — | `None` | API 연결 및 인증 |
 | `disconnect()` | — | `None` | 연결 해제 |
-| `get_account_balance()` | — | `Dict[str, float]` | 계좌 잔고 조회 (현금 + 주식 평가금액) |
+| `get_account_balance()` | — | `Dict[str, float]` | 계좌 잔고 조회 (현금 + 주식 평가금액). KIS 반환 키: `cash`, `total_assets`, `purchase_amount`, `eval_amount`, `total_profit_loss`, `substitute_amount`(예수금 대용가능금액=대용증권 평가 기반). **`purchasable_amount`(주문가능액)는 종목 컨텍스트가 필요해 이 메서드가 산출하지 않으며 반환 dict에 포함하지 않는다 — `get_buyable()` 참조** (#2384) |
+| `get_buyable()` | `symbol: str`, `price: Optional[float] = None`, `order_type: str = 'market'` | `Dict[str, float]` | 매수가능 조회 (KIS `inquire-psbl-order`, `@abstractmethod`). 반환 키: `order_buyable_amount`(미수없는 매수가능금액·**purchasable_amount SSOT**), `max_buyable_amount`, `order_cash`, `order_buyable_qty`, `max_buyable_qty`. **구현 #2384 merge 후 실행 가능** |
 | `get_positions()` | — | `List[Dict]` | 보유 포지션 조회 |
 | `get_current_price()` | `symbol: str` | `float` | 현재가 조회 |
 | `place_order()` | `symbol: str`, `side: str`, `quantity: float`, `order_type: str = 'market'`, `price: Optional[float] = None`, `stop_price: Optional[float] = None` | `str` | 주문 접수 (주문번호 반환) |
@@ -59,3 +60,10 @@ BrokerAdapter는 증권사 API 어댑터의 추상 기본 클래스다. 생성 �
 **`get_account_positions()` 참고사항**: `get_positions()`와 동일한 API를 호출하되, 대사 전용으로 명시적으로 분리하여 용도를 명확히 한다. 반환 형식: `[{"symbol": "005930", "quantity": 900, "avg_price": 1000.0}, ...]`
 
 **`get_order_history()` 반환 형식**: `[{"order_id": "...", "symbol": "005930", "side": "buy", "quantity": 100, "filled_quantity": 100, "price": 1000.0, "status": "filled", "timestamp": "..."}, ...]`
+
+**`get_account_balance()` vs `get_buyable()` 분리 (#2384)**: `purchasable_amount`(주문가능액)의 SSOT는 `get_buyable()`이 반환하는 `order_buyable_amount`(KIS `inquire-psbl-order`의 `nrcvb_buy_amt` — 미수 미사용 매수가능금액, 보수값)다. 무인자 `get_account_balance()`(`inquire-balance`)는 종목 컨텍스트가 없어 주문가능액을 산출할 수 없고, `inquire-balance`의 `psbl_sbst_amt`(예수금 대용가능금액=대용증권 평가 기반)는 현금-only 계좌에서 정상적으로 0이므로 주문가능액과 의미가 다르다(#2384 근본원인). 따라서 `psbl_sbst_amt`는 `get_account_balance()`의 `substitute_amount` 키로 보존하고 `purchasable_amount`로 덮어쓰지 않으며, `get_account_balance()` 반환 dict에서 `purchasable_amount` 키는 **제거**한다(무인자 메서드가 못 구하므로 '없는 게 진실'; CLI/Treasury는 `.get()`/별도 주입으로 처리). 주문가능액은 종목/단가/주문구분을 입력으로 받는 별도 `@abstractmethod` `get_buyable()`로 조회한다. 모의 rate-limit(5req/min)을 위해 두 호출은 분리되어 호출처가 빈도를 독립 제어한다. **결제일(T+2) 반영 매수가능금액은 본 계약 범위 밖이다**(`account/11-scope-out.md:11` 연기 유지 — 결제일 미반영 단순 주문가능액만). 본 계약은 **구현 #2384 merge 후 실행 가능**하다.
+
+**`get_buyable()` 어댑터별 반환 정책 (#2384)**: `get_buyable()`는 `BrokerAdapter` ABC의 `@abstractmethod`이므로 모든 어댑터가 구현해야 한다(미구현 시 인스턴스화 불가). 어댑터별 규약은 다음과 같다.
+- **KIS 어댑터**(`KISBaseAdapter` `@abstractmethod` → `KISDomesticAdapter` impl, `get_account_balance`과 동형 레이어): `inquire-psbl-order`를 호출해 위 키를 채운다(08-kis-domestic-adapter §inquire-psbl-order 참조).
+- **가상 어댑터**(`MockBrokerAdapter`/`TestBrokerAdapter`): 브로커 호출 없이 보유 현금(`cash`) 기반으로 산정한다 — `order_buyable_amount = order_cash = cash`, `max_buyable_amount = cash`, `order_buyable_qty = max_buyable_qty = floor(cash / 단가)`(시장가/`price=None`이면 내부 현재가로 단가 대체, 단가 0이면 수량 0.0). 이 가상 구현으로 ABC 인스턴스화·테스트 경로가 깨지지 않으며 Virtual 모드에서 합리적 값을 반환한다.
+- **KISOverseasAdapter**: 1.1 범위(구현체 미존재)로 본 계약의 대상이 아니다(`account/11-scope-out.md:7`).

--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -37,6 +37,9 @@ class KISDomesticAdapter(KISBaseAdapter):
 | 주문 접수 | `/uapi/domestic-stock/v1/trading/order-cash` | POST |
 | 주문 취소/정정 | `/uapi/domestic-stock/v1/trading/order-rvsecncl` | POST |
 | 미체결 조회 | `/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl` | GET |
+| 매수가능 조회 | `/uapi/domestic-stock/v1/trading/inquire-psbl-order` | GET |
+
+> **매수가능 조회 행은 구현 #2384 merge 후 실행 가능**하다. 본 행은 계약(spec) 선반영이며, `inquire-balance`(잔고/평가/보유)와 `inquire-psbl-order`(주문가능)는 KIS가 공식적으로 분리한 두 엔드포인트다(아래 §inquire-psbl-order 계약 참조).
 
 ### order-cash TR ID 매핑
 
@@ -109,6 +112,46 @@ class KISDomesticAdapter(KISBaseAdapter):
 - **신 tr_id 효과 (모의 한정)**: 레거시 `VTTC8001R`은 모의 당일 체결을 반환하지 못하나(0행), 신 `VTTC0081R`은 **모의** 당일 체결을 반환함이 모의 라이브(#2317 A/B + #2353 측정)로 확인됐다 — **모의 한정 관측이며 KIS 공식 보증이 아니다**. 실전 `TTTC0081R`의 당일 반영은 **미검증**이며, KIS 공식 일별 원장 지연 경고는 tr_id 세대 무관 잔존한다(`docs/specs/broker-adapter/18-fill-recovery.md` §2.1/§11.6/§11.7).
 
 > 출처: [KIS open-trading-api `inquire_daily_ccld.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/inquire_daily_ccld/inquire_daily_ccld.py)(공식 예제가 inner/before별 4코드와 조건부 `EXCG_ID_DVSN_CD` append를 정의) + #2314 근본원인 조사 + #2317 라이브 측정.
+
+### inquire-psbl-order TR ID·바디·응답 계약 (#2384)
+
+매수가능 조회(`inquire-psbl-order`, `get_buyable`)는 `is_paper` 조합으로 아래 KIS 공식 현행 TR ID를 전송한다. **inquire-psbl-order 한정**이며, order-cash·취소·inquire-balance·현재가 등 다른 엔드포인트 TR ID는 이 표의 범위 밖이다. 본 계약은 **구현 #2384 merge 후 실행 가능**하다.
+
+| 환경 | TR ID |
+|------|-------|
+| 모의 | `VTTC8908R` |
+| 실전 | `TTTC8908R` |
+
+**요청 파라미터**(GET query):
+
+| 필드 | 값 | 설명 |
+|------|------|------|
+| `CANO` | `account_no[:8]` | 종합계좌번호 |
+| `ACNT_PRDT_CD` | `account_no[8:10]` | 계좌상품코드 |
+| `PDNO` | `normalize_symbol(symbol)` (6자리) | 종목코드 |
+| `ORD_UNPR` | 시장가 `잠정 '0'` (#2384 preflight A/B로 확정 후 본 섹션 출처에 기록) / 지정가 `str(int(price))` | 주문단가 |
+| `ORD_DVSN` | `order_type` 매핑(기존 `_map_order_type` 재사용 후보) | 주문구분 |
+| `CMA_EVLU_AMT_ICLD_YN` | `'N'` | CMA평가금액포함여부 |
+| `OVRS_ICLD_YN` | `'N'` | 해외포함여부 |
+
+**응답 필드 → `get_buyable()` 반환 dict 키 매핑**(전부 float):
+
+| 응답 필드 | dict 키 | 설명 |
+|-----------|---------|------|
+| `nrcvb_buy_amt` | `order_buyable_amount` | 미수 미사용 매수가능금액(계좌 현금 기반, **purchasable_amount SSOT — 보수값**) |
+| `max_buy_amt` | `max_buyable_amount` | 미수 포함 최대 매수가능금액 |
+| `ord_psbl_cash` | `order_cash` | 주문가능현금(종목 의존성 최소 — 종목무관 폴백 SSOT 후보) |
+| `nrcvb_buy_qty` | `order_buyable_qty` | 미수 미사용 매수가능수량(**종목/단가 의존** — 시장가 probe에서는 계좌수준 의미 없음) |
+| `max_buy_qty` | `max_buyable_qty` | 최대 매수가능수량(**종목/단가 의존** — 동일) |
+
+- **계좌 대표 매수가능액 입력 규약**: 계좌 대표 매수가능액은 종목 무관한 미수없는 매수가능금액(`nrcvb_buy_amt`)을 얻기 위한 probe다. 대표 종목은 항시 거래되는 유효 국내 종목 코드(기본 하드코딩 `005930`, config override는 구현 옵션)를 시장가(`ORD_UNPR='0'` — 잠정, #2384 preflight로 확정)로 전송한다. 시장가 probe 호출에서 반환되는 종목/단가 의존 수량 값(`order_buyable_qty`/`max_buyable_qty`)은 '대표종목을 현재가로 살 때의 수량'이라는 **종목 종속 값이라 계좌수준 의미가 없다**. Treasury 동기화 경로는 금액 필드(`order_buyable_amount`)만 소비하고 수량 필드는 계좌 대표 컨텍스트에서 소비·영속화하지 않는다.
+- **종목무관 전제 — bounded assumption + 검증 게이트**: `nrcvb_buy_amt`가 종목/단가 무관한 계좌수준 현금값이라는 전제는 본 계약의 load-bearing 가정이나, #2384 모의 단일 실측(`nrcvb_buy_amt=9998235.0`, `nrcvb_buy_qty=59.0`)만으로는 종목 불변성을 입증하지 못한다. 라이브 검증 전 **bounded assumption**으로 lock하며, **구현 전 모의 다종목 A/B 검증 게이트**(고가 `005930` vs 저가주, `ORD_UNPR='0'` vs 지정가)로 `nrcvb_buy_amt`/`ord_psbl_cash`의 종목 불변성을 확인한다. 검증 실패(종목별 상이) 시 `purchasable_amount` SSOT를 `ord_psbl_cash`(주문가능현금, 종목 의존성 최소)로 폴백한다(known-limitation 사전 선언).
+- **ORD_DVSN 허용값 고정**: inquire-psbl-order가 ORD_DVSN 시장가 코드를 매수가능 산정용으로 받아들이는지는 공식 샘플로 미확정이므로, order-cash `_map_order_type`('market'→'01')을 무검증 재사용하지 않고 **구현 전 모의 preflight로 ORD_DVSN/ORD_UNPR 조합을 실측 고정**하여 본 섹션 출처에 기록한다(어떤 조합으로 `nrcvb_buy_amt=9998235.0`을 얻었는지 포함).
+- **Rate-limit 분리(모의 5req/min)**: 매수가능 조회는 잔고조회(`get_account_balance`)·포지션조회(`get_positions`)와 **별도 메서드로 분리**해 호출 빈도를 호출처가 독립 제어한다. Treasury Live 동기화는 cycle당 1회만 호출한다(04-treasury-interface 참조). 단기 TTL 캐시는 허용하며 TTL 값은 구현 결정(bounded known-limitation).
+- **`psbl_sbst_amt`(대용가능금액)와의 구분**: 기존 `inquire-balance`의 `psbl_sbst_amt`(예수금 대용가능금액 = 대용증권 평가 기반)는 현금-only 모의계좌에서 정상적으로 0이며 주문가능액과 의미가 다르다. 이는 `get_account_balance()`의 별도 키 `substitute_amount`로 보존하고 `purchasable_amount`로 덮어쓰지 않는다(04-broker-adapter-interface 참조). 실전 대용증권 보유 계좌는 `psbl_sbst_amt>0`일 수 있어 별도 키 보존이 의미를 가진다.
+- **결제일(T+2) 비반영**: 본 계약은 `account/11-scope-out.md:11`의 결제일 반영 매수가능금액을 **포함하지 않는다**. 결제일 미반영 단순 주문가능액(`nrcvb_buy_amt`)만 노출한다.
+
+> 출처: [KIS open-trading-api `inquire_psbl_order.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/inquire_psbl_order/inquire_psbl_order.py) — 매수가능조회[v1_국내주식-007]. `nrcvb_buy_amt`(미수 미사용 매수가능금액)·`max_buy_amt`(최대)·요청 파라미터(CANO/ACNT_PRDT_CD/PDNO/ORD_UNPR/ORD_DVSN/CMA_EVLU_AMT_ICLD_YN/OVRS_ICLD_YN) 확인. + 이슈 #2384 KIS 모의 direct preflight 실측 1건(`nrcvb_buy_amt=9998235.0`, `nrcvb_buy_qty=59.0` — 단일종목 단일관측, 종목무관성 미입증). **종목 불변성·ORD_DVSN 허용값은 구현 전 모의 다종목 A/B로 확정**한다.
 
 ### KIS 주문 유형 매핑
 

--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -395,7 +395,7 @@ Bot.on_signal()
 
 | 이벤트 타입 | 발행자 | 구독자 | 핵심 필드 |
 |------------|--------|--------|----------|
-| `BalanceSyncedEvent` | Treasury | — | `account_id`, `account_balance`, `purchasable_amount`, `total_evaluation`, `external_purchase_amount`, `external_eval_amount` |
+| `BalanceSyncedEvent` | Treasury | — | `account_id`, `account_balance`, `purchasable_amount`(주문가능액 SSOT = KIS `inquire-psbl-order` `nrcvb_buy_amt`, #2384), `total_evaluation`, `external_purchase_amount`, `external_eval_amount` |
 
 #### 일일 리포트 (DailyReport)
 

--- a/docs/specs/treasury/04-treasury-interface.md
+++ b/docs/specs/treasury/04-treasury-interface.md
@@ -148,6 +148,14 @@ external_*      = 0
 
 상세 배경은 [09-virtual-asset-sync.md](09-virtual-asset-sync.md)를 참조한다.
 
+**매수가능액 동기화 규약 / write-path (#2384)**: Live 모드 잔고 동기화(`_do_sync`)는 `purchasable_amount`를 다음 단일 write-path로 갱신한다.
+
+1. `get_account_balance()`를 호출하고 그 결과를 `sync_balance()`로 반영한다. `get_account_balance()` 반환 dict에는 `purchasable_amount` 키가 더 이상 없으므로(#2384, broker-adapter 참조), `sync_balance()`는 `purchasable_amount`를 **읽지 않는다**(기존 stale-fallback `balance_data.get('purchasable_amount', self._purchasable_amount)` 라인 제거).
+2. 이어서 계좌 대표 매수가능액 산출을 위해 `BrokerAdapter.get_buyable(대표 종목, 시장가)`를 **cycle당 1회만** 호출하고, 그 `order_buyable_amount`를 `self._purchasable_amount`에 **단일 주입**한다(`BalanceSyncedEvent` 발행 전). 종목별 N회 조회·종목별 수량 소비는 하지 않는다(모의 5req/min rate-limit 안전; 시장가 probe의 수량 필드는 계좌수준 의미 없음).
+3. `get_positions()` 등 나머지 동기화 단계는 기존과 동일하다.
+
+Virtual 모드(`_do_sync_virtual`)는 브로커 호출이 없으므로 `purchasable_amount`는 직전 동기화 값/0을 유지한다(get_buyable 미호출). 본 규약은 **구현 #2384 merge 후 실행 가능**하다.
+
 ### 프로퍼티
 
 | 프로퍼티 | 타입 | 설명 |
@@ -163,7 +171,7 @@ external_*      = 0
 |----|------|
 | `currency` | 통화 단위 (예: "KRW", "USD") |
 | `account_balance` | 계좌 예수금 |
-| `purchasable_amount` | 매수 가능 금액 |
+| `purchasable_amount` | 매수 가능 금액 — KIS `inquire-psbl-order`의 `nrcvb_buy_amt`(미수 미사용 매수가능금액, 보수값) 기준. Live 동기화 시 `BrokerAdapter.get_buyable(대표 종목, 시장가)`로 산출하며, `inquire-balance`의 `psbl_sbst_amt`(대용가능금액)와는 다른 값이다(#2384). 결제일(T+2) 미반영. **구현 #2384 merge 후 정확값 반영** |
 | `total_evaluation` | 총 자산 평가액 |
 | `purchase_amount` | 총 매입 금액 |
 | `eval_amount` | 총 평가 금액 |

--- a/docs/specs/treasury/06-database-schema.md
+++ b/docs/specs/treasury/06-database-schema.md
@@ -62,6 +62,8 @@ CREATE INDEX idx_treasury_transactions_account
     ON treasury_transactions(account_id);
 ```
 
+> **`purchasable_amount` 컬럼 의미 (#2384)**: 이 컬럼이 보관하는 매수가능액의 SSOT 출처는 KIS `inquire-psbl-order`의 `nrcvb_buy_amt`(미수 미사용 매수가능금액, 보수값)다. `inquire-balance`의 `psbl_sbst_amt`(대용가능금액)와는 다른 값이며, **컬럼 셋·DDL은 변경되지 않는다**(의미만 재지정). `substitute_amount`(대용가능금액)는 broker-balance dict 전용으로 Treasury가 영속화하지 않으므로 신규 컬럼을 추가하지 않는다. 따라서 `docs/architecture/generated/db-schema.md`는 재생성이 불필요하다(treasury_state 6컬럼 동일: `account_id`/`account_balance`/`purchasable_amount`/`total_evaluation`/`currency`/`last_synced_at`).
+
 > **마이그레이션**: 1.0 이전 fresh schema 기준으로 Treasury DB는 fallback
 > account 값을 생성하지 않는다. 기존 invalid dev DB 데이터의 자동 보존/변환은
 > 이 계약의 범위가 아니다.

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -800,6 +800,12 @@ TREASURY_CONTRACTS: tuple[CliCommandContract, ...] = (
         # purchasable_amount, total_evaluation, total_profit_loss,
         # total_allocated, total_reserved, unallocated, bot_count}``). text 는
         # click.echo 8 줄.
+        # purchasable_amount 의미(#2384): KIS inquire-psbl-order
+        # nrcvb_buy_amt(주문가능액 SSOT). 키 셋 자체는 불변(raw_legacy
+        # passthrough) — 본 변경은 산출출처 정렬. Treasury 측 구조 테스트
+        # tests/unit/test_treasury_sync.py:172 test_purchasable_amount_in_kis
+        # (get_account_balance 에 purchasable_amount 키 존재 가정)는 키
+        # 제거로 갱신 필요 — 구현 #2384 에서 처리.
         output=OutputContract(kind="raw", envelope="raw_legacy"),
         execution="offline",
     ),
@@ -1272,6 +1278,12 @@ BROKER_CONTRACTS: tuple[CliCommandContract, ...] = (
         # (broker.py:220). 키 셋은 broker adapter 가 반환하는 그대로 (IPC
         # 분기는 server BrokerAdapter response 의 평면 dict, fallback 분기는
         # KIS/Mock adapter 의 ``get_account_balance()`` 반환값).
+        # get_account_balance() 반환 키 셋(#2384): cash, total_assets,
+        # purchase_amount, eval_amount, total_profit_loss,
+        # substitute_amount(=psbl_sbst_amt 대용가능금액). purchasable_amount
+        # 키는 더 이상 포함하지 않음(주문가능액은 별도 get_buyable() 경로).
+        # raw_legacy passthrough 라 키 셋 자체는 enforce 안 함(drift fixture
+        # 미파괴) — 구현 #2384 merge 후 실행 가능.
         output=OutputContract(kind="raw", envelope="raw_legacy"),
         execution="runtime_ipc",
         ipc_command="broker.balance",


### PR DESCRIPTION
Closes #2387

## Summary
#2384(KIS 모의 매수가능 0 오표시, display-only)의 **spec-first 선행 PR**이다. 진짜 주문가능액은 KIS `inquire-psbl-order`(net-new)가 필요해 계약을 먼저 확정한다. **코드 로직 변경 0건**(cli_registry.py는 주석 clarify만) — 실제 동작은 **구현 #2384 merge 후 실행 가능**.

- **broker-adapter/08**: `inquire-psbl-order` 엔드포인트 + TR ID(VTTC8908R/TTTC8908R)·요청 파라미터·응답 5필드 매핑. ORD_UNPR 시장가는 **잠정 `'0'`**(구현 #2384 preflight A/B로 확정).
- **broker-adapter/04**: `get_account_balance()`에서 `purchasable_amount` 제거·`substitute_amount`(=psbl_sbst_amt) 추가. `get_buyable()` `@abstractmethod` 신설 + 어댑터별 반환 정책(KIS=inquire-psbl-order, Mock/Test=cash 기반).
- **treasury/04**: `purchasable_amount` SSOT=`nrcvb_buy_amt` 재지정 + Live write-path 동기화 규약(get_buyable 1회 주입).
- **treasury/06**: `purchasable_amount` 컬럼 의미 재지정 노트(**DDL 무변경** → db-schema.md 재생성 불필요).
- **eventbus**: `BalanceSyncedEvent.purchasable_amount` 의미 주석.
- **cli_registry**: treasury.status/broker.balance OutputContract 주석(키셋/envelope/로직 불변).

scope-out(`account/11-scope-out.md:11` 결제일 반영 매수가능금액) **연기 유지** — 결제일 미반영 단순 주문가능액만.

## 설계/검증
- 설계: 아키텍트 초안 → KIS도메인/계약일관성/완전성 3축 적대 비평 → 종합(ready)
- Codex Plan Review 3라운드 → approve-implement
- Codex 브랜치 리뷰: PASS
- ruff check / ruff format / mypy(cli_registry.py): PASS. 변경 범위 6파일(금지파일 미포함), cli_registry 주석-only 확인.

## Test Plan
- spec-only PR(코드 로직 0건)이라 신규 테스트 없음. markdown 렌더/링크/표 정상.
- 구현·테스트는 후속 #2384에서 수행(get_buyable, inquire-psbl-order, preflight A/B 게이트, test fakes 갱신 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
