### PR TITLE
fix(broker): #2384 KIS 매수가능액을 inquire-psbl-order로 노출 — get_buyable 신설 + purchasable_amount SSOT 정렬

### DIFF
--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -129,8 +129,8 @@ class KISDomesticAdapter(KISBaseAdapter):
 | `CANO` | `account_no[:8]` | 종합계좌번호 |
 | `ACNT_PRDT_CD` | `account_no[8:10]` | 계좌상품코드 |
 | `PDNO` | `normalize_symbol(symbol)` (6자리) | 종목코드 |
-| `ORD_UNPR` | 시장가 `잠정 '0'` (#2384 preflight A/B로 확정 후 본 섹션 출처에 기록) / 지정가 `str(int(price))` | 주문단가 |
-| `ORD_DVSN` | `order_type` 매핑(기존 `_map_order_type` 재사용 후보) | 주문구분 |
+| `ORD_UNPR` | **실가(필수, '0' 아님)**: 시장가/`price=None`이면 대표종목 현재가(`get_current_price(symbol)` 1회 조회)를 단가로 사용 / 지정가 `str(int(price))` — KIS 공식 샘플 확정 | 주문단가 |
+| `ORD_DVSN` | `order_type` 매핑(`_map_order_type` 재사용, 시장가 → **`'01'`**) — KIS 공식 샘플 확정 | 주문구분 |
 | `CMA_EVLU_AMT_ICLD_YN` | `'N'` | CMA평가금액포함여부 |
 | `OVRS_ICLD_YN` | `'N'` | 해외포함여부 |
 
@@ -144,14 +144,14 @@ class KISDomesticAdapter(KISBaseAdapter):
 | `nrcvb_buy_qty` | `order_buyable_qty` | 미수 미사용 매수가능수량(**종목/단가 의존** — 시장가 probe에서는 계좌수준 의미 없음) |
 | `max_buy_qty` | `max_buyable_qty` | 최대 매수가능수량(**종목/단가 의존** — 동일) |
 
-- **계좌 대표 매수가능액 입력 규약**: 계좌 대표 매수가능액은 종목 무관한 미수없는 매수가능금액(`nrcvb_buy_amt`)을 얻기 위한 probe다. 대표 종목은 항시 거래되는 유효 국내 종목 코드(기본 하드코딩 `005930`, config override는 구현 옵션)를 시장가(`ORD_UNPR='0'` — 잠정, #2384 preflight로 확정)로 전송한다. 시장가 probe 호출에서 반환되는 종목/단가 의존 수량 값(`order_buyable_qty`/`max_buyable_qty`)은 '대표종목을 현재가로 살 때의 수량'이라는 **종목 종속 값이라 계좌수준 의미가 없다**. Treasury 동기화 경로는 금액 필드(`order_buyable_amount`)만 소비하고 수량 필드는 계좌 대표 컨텍스트에서 소비·영속화하지 않는다.
+- **계좌 대표 매수가능액 입력 규약**: 계좌 대표 매수가능액은 종목 무관한 미수없는 매수가능금액(`nrcvb_buy_amt`)을 얻기 위한 probe다. 대표 종목은 항시 거래되는 유효 국내 종목 코드(기본 하드코딩 `005930`, config override는 구현 옵션)를 시장가(`ORD_DVSN='01'`, `ORD_UNPR=대표종목 현재가` — KIS 공식 샘플 확정, '0' 아님)로 전송한다. 시장가 probe 시 `get_buyable`은 `get_current_price(symbol)`를 1회 호출해 `ORD_UNPR`로 사용한다(Treasury 등 호출처에 별도 현재가 조회를 추가하지 않는다). 시장가 probe 호출에서 반환되는 종목/단가 의존 수량 값(`order_buyable_qty`/`max_buyable_qty`)은 '대표종목을 현재가로 살 때의 수량'이라는 **종목 종속 값이라 계좌수준 의미가 없다**. Treasury 동기화 경로는 금액 필드(`order_buyable_amount`)만 소비하고 수량 필드는 계좌 대표 컨텍스트에서 소비·영속화하지 않는다.
 - **종목무관 전제 — bounded assumption + 검증 게이트**: `nrcvb_buy_amt`가 종목/단가 무관한 계좌수준 현금값이라는 전제는 본 계약의 load-bearing 가정이나, #2384 모의 단일 실측(`nrcvb_buy_amt=9998235.0`, `nrcvb_buy_qty=59.0`)만으로는 종목 불변성을 입증하지 못한다. 라이브 검증 전 **bounded assumption**으로 lock하며, **구현 전 모의 다종목 A/B 검증 게이트**(고가 `005930` vs 저가주, `ORD_UNPR='0'` vs 지정가)로 `nrcvb_buy_amt`/`ord_psbl_cash`의 종목 불변성을 확인한다. 검증 실패(종목별 상이) 시 `purchasable_amount` SSOT를 `ord_psbl_cash`(주문가능현금, 종목 의존성 최소)로 폴백한다(known-limitation 사전 선언).
-- **ORD_DVSN 허용값 고정**: inquire-psbl-order가 ORD_DVSN 시장가 코드를 매수가능 산정용으로 받아들이는지는 공식 샘플로 미확정이므로, order-cash `_map_order_type`('market'→'01')을 무검증 재사용하지 않고 **구현 전 모의 preflight로 ORD_DVSN/ORD_UNPR 조합을 실측 고정**하여 본 섹션 출처에 기록한다(어떤 조합으로 `nrcvb_buy_amt=9998235.0`을 얻었는지 포함).
+- **ORD_DVSN/ORD_UNPR 고정 — 공식 샘플 확정**: KIS 공식 샘플(`inquire_psbl_order.py`)이 `pdno="005930"`, `ord_unpr="55000"`, `ord_dvsn="01"`로 호출한다. 따라서 inquire-psbl-order 시장가 probe는 `ORD_DVSN='01'`(order-cash `_map_order_type`('market'→'01') 재사용)이며 `ORD_UNPR`은 실제 1주당 가격이다('0'/빈값 아님). 시장가/`price=None`이면 `get_current_price(symbol)`로 조회한 현재가를 `ORD_UNPR`로 전달한다. 남은 경험적 항목(`nrcvb_buy_amt` 종목 불변성)은 구현 후 oracle A/B 검증 대기(검증 실패 시 `ord_psbl_cash` 폴백 — 코드의 필드 SSOT 상수 한 곳 교체).
 - **Rate-limit 분리(모의 5req/min)**: 매수가능 조회는 잔고조회(`get_account_balance`)·포지션조회(`get_positions`)와 **별도 메서드로 분리**해 호출 빈도를 호출처가 독립 제어한다. Treasury Live 동기화는 cycle당 1회만 호출한다(04-treasury-interface 참조). 단기 TTL 캐시는 허용하며 TTL 값은 구현 결정(bounded known-limitation).
 - **`psbl_sbst_amt`(대용가능금액)와의 구분**: 기존 `inquire-balance`의 `psbl_sbst_amt`(예수금 대용가능금액 = 대용증권 평가 기반)는 현금-only 모의계좌에서 정상적으로 0이며 주문가능액과 의미가 다르다. 이는 `get_account_balance()`의 별도 키 `substitute_amount`로 보존하고 `purchasable_amount`로 덮어쓰지 않는다(04-broker-adapter-interface 참조). 실전 대용증권 보유 계좌는 `psbl_sbst_amt>0`일 수 있어 별도 키 보존이 의미를 가진다.
 - **결제일(T+2) 비반영**: 본 계약은 `account/11-scope-out.md:11`의 결제일 반영 매수가능금액을 **포함하지 않는다**. 결제일 미반영 단순 주문가능액(`nrcvb_buy_amt`)만 노출한다.
 
-> 출처: [KIS open-trading-api `inquire_psbl_order.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/inquire_psbl_order/inquire_psbl_order.py) — 매수가능조회[v1_국내주식-007]. `nrcvb_buy_amt`(미수 미사용 매수가능금액)·`max_buy_amt`(최대)·요청 파라미터(CANO/ACNT_PRDT_CD/PDNO/ORD_UNPR/ORD_DVSN/CMA_EVLU_AMT_ICLD_YN/OVRS_ICLD_YN) 확인. + 이슈 #2384 KIS 모의 direct preflight 실측 1건(`nrcvb_buy_amt=9998235.0`, `nrcvb_buy_qty=59.0` — 단일종목 단일관측, 종목무관성 미입증). **종목 불변성·ORD_DVSN 허용값은 구현 전 모의 다종목 A/B로 확정**한다.
+> 출처: [KIS open-trading-api `inquire_psbl_order.py`](https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/inquire_psbl_order/inquire_psbl_order.py) — 매수가능조회[v1_국내주식-007]. `nrcvb_buy_amt`(미수 미사용 매수가능금액)·`max_buy_amt`(최대)·요청 파라미터(CANO/ACNT_PRDT_CD/PDNO/ORD_UNPR/ORD_DVSN/CMA_EVLU_AMT_ICLD_YN/OVRS_ICLD_YN) 확인. **공식 샘플이 `pdno="005930"`, `ord_unpr="55000"`, `ord_dvsn="01"`로 호출하므로 시장가 probe의 `ORD_DVSN='01'` + `ORD_UNPR=실가(대표종목 현재가)`를 확정한다('0'/빈값 아님)** — 잠정 `ORD_UNPR='0'` 문구를 supersede(#2384 G0). + 이슈 #2384 KIS 모의 direct preflight 실측 1건(`nrcvb_buy_amt=9998235.0`, `nrcvb_buy_qty=59.0` — 단일종목 단일관측, 종목무관성 미입증). **남은 경험적 항목인 `nrcvb_buy_amt` 종목 불변성은 구현 후 사용자 oracle A/B로 검증**한다(검증 실패 시 `ord_psbl_cash` 폴백).
 
 ### KIS 주문 유형 매핑
 

--- a/src/ante/broker/base.py
+++ b/src/ante/broker/base.py
@@ -60,6 +60,38 @@ class BrokerAdapter(ABC):
         ...
 
     @abstractmethod
+    async def get_buyable(
+        self,
+        symbol: str,
+        price: float | None = None,
+        order_type: str = "market",
+    ) -> dict[str, float]:
+        """매수가능 조회 (KIS ``inquire-psbl-order``).
+
+        ``purchasable_amount`` (주문가능액)의 SSOT다. 무인자
+        ``get_account_balance()``는 종목 컨텍스트가 없어 주문가능액을 산출할 수
+        없으므로, 종목/단가/주문구분을 입력으로 받는 이 메서드가 별도로 조회한다
+        (#2384). 모의 rate-limit(5req/min)을 위해 ``get_account_balance()``와
+        분리되어 호출처가 빈도를 독립 제어한다.
+
+        Args:
+            symbol: 종목코드
+            price: 지정가 단가. 시장가/``None``이면 구현이 현재가 등으로 대체한다.
+            order_type: "market" | "limit" 등 주문구분
+
+        Returns:
+            {"order_buyable_amount": float, "max_buyable_amount": float,
+             "order_cash": float, "order_buyable_qty": float,
+             "max_buyable_qty": float}
+            - ``order_buyable_amount``: 미수 미사용 매수가능금액
+              (**purchasable_amount SSOT** — 보수값)
+            - ``max_buyable_amount``: 미수 포함 최대 매수가능금액
+            - ``order_cash``: 주문가능현금 (종목 의존성 최소)
+            - ``order_buyable_qty`` / ``max_buyable_qty``: 종목/단가 의존 수량
+        """
+        ...
+
+    @abstractmethod
     async def place_order(
         self,
         symbol: str,

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -103,6 +103,23 @@ _CCLD_TR_ID_BEFORE_LIVE = "CTSC9215R"
 # ante 가 정책을 소유한다(#2349). KST 오늘 기준 달력 3개월 전 동일 일자가 cutoff.
 _CCLD_BOUNDARY_MONTHS = 3
 
+# inquire-psbl-order(매수가능 조회) TR ID 매핑 (#2384).
+# 출처: KIS open-trading-api examples_llm/domestic_stock/inquire_psbl_order.
+_PSBL_ORDER_TR_ID_PAPER = "VTTC8908R"
+_PSBL_ORDER_TR_ID_LIVE = "TTTC8908R"
+
+# inquire-psbl-order 응답 필드 → get_buyable() 반환 키 SSOT 매핑 (#2384).
+# purchasable_amount(주문가능액)의 SSOT는 order_buyable_amount←nrcvb_buy_amt다
+# (미수 미사용 매수가능금액, 보수값). nrcvb_buy_amt 종목 불변성 가정이 oracle
+# 검증에서 깨지면 ord_psbl_cash(주문가능현금, 종목 의존성 최소) 폴백으로 전환
+# 가능하도록 필드명을 한 곳에 모은다. 폴백은 missing/parse-failure 또는 명시적
+# config 전환에 한정하며 value==0 은 정상값이라 폴백 트리거가 아니다(#2384 G6).
+_PSBL_ORDER_FIELD_BUYABLE_AMOUNT = "nrcvb_buy_amt"  # purchasable_amount SSOT
+_PSBL_ORDER_FIELD_MAX_BUYABLE_AMOUNT = "max_buy_amt"
+_PSBL_ORDER_FIELD_ORDER_CASH = "ord_psbl_cash"  # 종목무관 폴백 SSOT 후보
+_PSBL_ORDER_FIELD_BUYABLE_QTY = "nrcvb_buy_qty"
+_PSBL_ORDER_FIELD_MAX_BUYABLE_QTY = "max_buy_qty"
+
 # 인증 경로
 _AUTH_PATH = "/oauth2/tokenP"
 
@@ -134,6 +151,36 @@ def _ccld_three_month_cutoff(today_kst: str) -> str:
     last_day = calendar.monthrange(target_year, target_month)[1]
     target_day = min(day, last_day)
     return f"{target_year:04d}{target_month:02d}{target_day:02d}"
+
+
+def _to_float(value: Any) -> float:
+    """KIS 응답 값을 float 으로 안전 변환 (missing/parse-failure → 0.0)."""
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _parse_psbl_amount(
+    output: dict[str, Any],
+    primary_field: str,
+    fallback_field: str,
+) -> float:
+    """inquire-psbl-order 금액 필드 파싱 (#2384, primary missing/parse 시만 폴백).
+
+    ``primary_field``(``nrcvb_buy_amt``)가 응답에 없거나 float 변환에 실패할 때만
+    ``fallback_field``(``ord_psbl_cash``)로 폴백한다. ``primary_field`` 값이
+    ``0``으로 정상 파싱되면 그대로 ``0.0``을 반환한다 — ``0``은 정상값일 수
+    있으므로 폴백 트리거가 아니다(#2384 G6).
+    """
+    if primary_field in output:
+        try:
+            return float(output[primary_field])
+        except (TypeError, ValueError):
+            pass
+    return _to_float(output.get(fallback_field))
 
 
 class KISErrorClassifier:
@@ -729,6 +776,16 @@ class KISBaseAdapter(BrokerAdapter):
         ...
 
     @abstractmethod
+    async def get_buyable(
+        self,
+        symbol: str,
+        price: float | None = None,
+        order_type: str = "market",
+    ) -> dict[str, float]:
+        """매수가능 조회 (KIS ``inquire-psbl-order``)."""
+        ...
+
+    @abstractmethod
     async def place_order(
         self,
         symbol: str,
@@ -854,13 +911,18 @@ class KISDomesticAdapter(KISBaseAdapter):
         result = await self._request("GET", url, tr_id, params=self._balance_params())
 
         info = result["output2"][0] if result.get("output2") else {}
+        # purchasable_amount(주문가능액)는 종목 컨텍스트가 필요해 무인자 잔고조회가
+        # 산출할 수 없으므로 이 dict에 포함하지 않는다(#2384). psbl_sbst_amt는
+        # 예수금 대용가능금액(대용증권 평가 기반)이라 주문가능액과 의미가 다르며
+        # 현금-only 계좌에서 정상적으로 0이므로 substitute_amount 키로 보존한다.
+        # 주문가능액 SSOT는 get_buyable()의 order_buyable_amount다.
         return {
             "cash": float(info.get("dnca_tot_amt", 0)),
             "total_assets": float(info.get("tot_evlu_amt", 0)),
             "purchase_amount": float(info.get("pchs_amt_smtl_amt", 0)),
             "eval_amount": float(info.get("evlu_amt_smtl_amt", 0)),
             "total_profit_loss": float(info.get("evlu_pfls_smtl_amt", 0)),
-            "purchasable_amount": float(info.get("psbl_sbst_amt", 0)),
+            "substitute_amount": float(info.get("psbl_sbst_amt", 0)),
         }
 
     async def get_positions(self) -> list[dict[str, Any]]:
@@ -899,6 +961,65 @@ class KISDomesticAdapter(KISBaseAdapter):
         }
         result = await self._request("GET", url, tr_id, params=params)
         return float(result["output"]["stck_prpr"])
+
+    async def get_buyable(
+        self,
+        symbol: str,
+        price: float | None = None,
+        order_type: str = "market",
+    ) -> dict[str, float]:
+        """매수가능 조회 (KIS ``inquire-psbl-order``, #2384).
+
+        ``purchasable_amount``(주문가능액)의 SSOT다. 무인자 ``get_account_balance``
+        (``inquire-balance``)는 종목 컨텍스트가 없어 주문가능액을 산출할 수 없으므로
+        종목/단가/주문구분을 입력으로 받는 이 메서드가 별도로 조회한다. 모의
+        rate-limit(5req/min) 안전을 위해 ``get_account_balance``와 분리한다.
+
+        ORD_DVSN/ORD_UNPR: KIS 공식 샘플(`inquire_psbl_order.py`: pdno=005930,
+        ord_unpr='55000', ord_dvsn='01')대로 시장가는 ``ORD_DVSN='01'``이며
+        ``ORD_UNPR``은 실제 1주당 가격(필수, '0' 아님)이다. 시장가/``price=None``
+        이면 ``get_current_price(symbol)``를 1회 호출해 단가로 사용한다.
+        """
+        tr_id = _PSBL_ORDER_TR_ID_PAPER if self.is_paper else _PSBL_ORDER_TR_ID_LIVE
+        url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-psbl-order"
+
+        # ORD_UNPR은 [필수] 실제 1주당 가격이다(KIS 공식 샘플 확정). 시장가/미지정
+        # 이면 현재가를 단가로 사용한다(Treasury 등 호출처에 별도 조회를 추가하지
+        # 않고 get_buyable 내부에서 1회 조회).
+        unit_price = price
+        if unit_price is None:
+            unit_price = await self.get_current_price(symbol)
+
+        params = {
+            "CANO": self.account_no[:8],
+            "ACNT_PRDT_CD": self.account_no[8:10],
+            "PDNO": self.normalize_symbol(symbol),
+            "ORD_UNPR": str(int(unit_price)),
+            "ORD_DVSN": self._map_order_type(order_type),
+            "CMA_EVLU_AMT_ICLD_YN": "N",
+            "OVRS_ICLD_YN": "N",
+        }
+        result = await self._request("GET", url, tr_id, params=params)
+        output = result.get("output") or {}
+
+        # nrcvb_buy_amt(미수 미사용 매수가능금액)가 order_buyable_amount=
+        # purchasable_amount SSOT다. missing/parse-failure 시에만 ord_psbl_cash
+        # (주문가능현금)로 폴백한다. nrcvb_buy_amt==0 은 정상값이라 폴백 트리거가
+        # 아니다(#2384 G6).
+        order_buyable_amount = _parse_psbl_amount(
+            output,
+            primary_field=_PSBL_ORDER_FIELD_BUYABLE_AMOUNT,
+            fallback_field=_PSBL_ORDER_FIELD_ORDER_CASH,
+        )
+        return {
+            "order_buyable_amount": order_buyable_amount,
+            "max_buyable_amount": _to_float(
+                output.get(_PSBL_ORDER_FIELD_MAX_BUYABLE_AMOUNT)
+            ),
+            "order_cash": _to_float(output.get(_PSBL_ORDER_FIELD_ORDER_CASH)),
+            "order_buyable_qty": _to_float(output.get(_PSBL_ORDER_FIELD_BUYABLE_QTY)),
+            "max_buyable_qty": _to_float(output.get(_PSBL_ORDER_FIELD_MAX_BUYABLE_QTY)),
+        }
 
     # ── 주문 처리 ──────────────────────────────────
 

--- a/src/ante/broker/mock.py
+++ b/src/ante/broker/mock.py
@@ -143,6 +143,28 @@ class MockBrokerAdapter(BrokerAdapter):
         """현재가 조회."""
         return self._get_price(symbol)
 
+    async def get_buyable(
+        self,
+        symbol: str,
+        price: float | None = None,
+        order_type: str = "market",
+    ) -> dict[str, float]:
+        """매수가능 조회 — 보유 현금(``cash``) 기반 가상 산정 (#2384).
+
+        브로커 호출 없이 보유 현금으로 산정한다. 시장가/``price=None``이면 내부
+        현재가를 단가로 사용하며, 단가 0이면 수량은 0.0이다.
+        """
+        cash = self._cash
+        unit_price = price if price is not None else self._get_price(symbol)
+        qty = float(int(cash // unit_price)) if unit_price > 0 else 0.0
+        return {
+            "order_buyable_amount": cash,
+            "max_buyable_amount": cash,
+            "order_cash": cash,
+            "order_buyable_qty": qty,
+            "max_buyable_qty": qty,
+        }
+
     # ── 주문 ──────────────────────────────────────────
 
     async def place_order(

--- a/src/ante/broker/test.py
+++ b/src/ante/broker/test.py
@@ -282,6 +282,28 @@ class TestBrokerAdapter(BrokerAdapter):
             "stock_value": total_stock_value,
         }
 
+    async def get_buyable(
+        self,
+        symbol: str,
+        price: float | None = None,
+        order_type: str = "market",
+    ) -> dict[str, float]:
+        """매수가능 조회 — 보유 현금(``cash``) 기반 가상 산정 (#2384).
+
+        브로커 호출 없이 보유 현금으로 산정한다. 시장가/``price=None``이면 내부
+        시뮬레이션 가격을 단가로 사용하며, 단가 0이면 수량은 0.0이다.
+        """
+        cash = self._cash
+        unit_price = price if price is not None else self._simulator.get_price(symbol)
+        qty = float(int(cash // unit_price)) if unit_price > 0 else 0.0
+        return {
+            "order_buyable_amount": cash,
+            "max_buyable_amount": cash,
+            "order_cash": cash,
+            "order_buyable_qty": qty,
+            "max_buyable_qty": qty,
+        }
+
     async def get_positions(self) -> list[dict[str, Any]]:
         """보유 포지션 조회 — 현재 시뮬레이션 가격으로 평가손익 계산."""
         return [

--- a/src/ante/contracts/cli_registry.py
+++ b/src/ante/contracts/cli_registry.py
@@ -801,11 +801,11 @@ TREASURY_CONTRACTS: tuple[CliCommandContract, ...] = (
         # total_allocated, total_reserved, unallocated, bot_count}``). text 는
         # click.echo 8 줄.
         # purchasable_amount 의미(#2384): KIS inquire-psbl-order
-        # nrcvb_buy_amt(주문가능액 SSOT). 키 셋 자체는 불변(raw_legacy
-        # passthrough) — 본 변경은 산출출처 정렬. Treasury 측 구조 테스트
-        # tests/unit/test_treasury_sync.py:172 test_purchasable_amount_in_kis
-        # (get_account_balance 에 purchasable_amount 키 존재 가정)는 키
-        # 제거로 갱신 필요 — 구현 #2384 에서 처리.
+        # nrcvb_buy_amt(주문가능액 SSOT, get_buyable). treasury status summary
+        # 키 셋 자체는 불변(raw_legacy passthrough) — 본 변경은 산출출처 정렬
+        # (Live 동기화 시 get_buyable의 order_buyable_amount를 주입). 한편
+        # get_account_balance(broker balance)는 purchasable_amount 키를 제거하고
+        # substitute_amount(=psbl_sbst_amt)를 노출하도록 갱신됨(#2384).
         output=OutputContract(kind="raw", envelope="raw_legacy"),
         execution="offline",
     ),

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -144,6 +144,12 @@ _SNAPSHOT_MIGRATION_COLUMNS = [
 # 5년 초과 스냅샷 자동 삭제 기준
 _SNAPSHOT_RETENTION_DAYS = 365 * 5
 
+# 계좌 대표 매수가능액 probe 종목 (#2384).
+# Live 동기화는 종목 무관한 미수없는 매수가능금액(nrcvb_buy_amt)을 얻기 위해
+# 항시 거래되는 유효 국내 종목 코드로 get_buyable(시장가) probe를 cycle당 1회
+# 호출한다. config override는 향후 옵션(기본 하드코딩).
+_PURCHASABLE_PROBE_SYMBOL = "005930"
+
 
 class Treasury:
     """계좌별 중앙 자금(예산) 관리자.
@@ -1462,6 +1468,19 @@ class Treasury:
         balance_data = await broker.get_account_balance()
         await self.sync_balance(balance_data)
 
+        # 1-1) 계좌 대표 매수가능액 주입 (#2384).
+        # purchasable_amount(주문가능액)의 SSOT는 get_buyable의 order_buyable_amount
+        # (inquire-psbl-order의 nrcvb_buy_amt)다. 대표 종목을 시장가로 cycle당 1회만
+        # probe해(모의 5req/min rate-limit 안전) _purchasable_amount에 단일 주입한다
+        # (BalanceSyncedEvent 발행 전). 실패 시 이전값을 0으로 덮지 않고 그대로
+        # 유지하며, 잘못된 매수가능액으로 BalanceSyncedEvent를 발행하지 않도록
+        # 예외를 재전파해 이번 cycle을 중단한다(상위 _run 루프가 "이전 값 유지"로
+        # 처리하고 다음 interval에 재시도)(#2384 G7).
+        buyable = await broker.get_buyable(_PURCHASABLE_PROBE_SYMBOL)
+        self._purchasable_amount = buyable.get(
+            "order_buyable_amount", self._purchasable_amount
+        )
+
         # 2) KIS 보유종목 (output1) + Trade 내부 포지션 대조
         # 자기 계좌 포지션만 조회: 단일 계좌 바인딩 인스턴스에서 cross-account
         # 데이터가 섞이지 않도록 명시적으로 account_id 필터를 전달한다 (#1240).
@@ -1567,11 +1586,15 @@ class Treasury:
         )
 
     async def sync_balance(self, balance_data: dict[str, float]) -> None:
-        """KIS 잔고 데이터로 Treasury 상태 동기화."""
+        """KIS 잔고 데이터로 Treasury 상태 동기화.
+
+        ``purchasable_amount``(주문가능액)는 무인자 ``get_account_balance``
+        (``inquire-balance``)가 산출할 수 없어 반환 dict에 더 이상 없으므로(#2384),
+        ``sync_balance``는 이를 **읽지 않는다**. 주문가능액은 ``_do_sync``가
+        ``BrokerAdapter.get_buyable`` 결과로 별도 주입한다(매수가능액 동기화 규약,
+        treasury/04-treasury-interface 참조).
+        """
         self._account_balance = balance_data.get("cash", self._account_balance)
-        self._purchasable_amount = balance_data.get(
-            "purchasable_amount", self._purchasable_amount
-        )
         self._total_evaluation = balance_data.get(
             "total_assets", self._total_evaluation
         )

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -59,6 +59,12 @@ class TestBrokerAdapterABC:
             async def get_account_balance(self) -> dict[str, float]: ...
             async def get_positions(self) -> list[dict[str, Any]]: ...
             async def get_current_price(self, symbol: str) -> float: ...
+            async def get_buyable(
+                self,
+                symbol: str,
+                price: float | None = None,
+                order_type: str = "market",
+            ) -> dict[str, float]: ...
             async def place_order(
                 self,
                 symbol: str,
@@ -94,6 +100,12 @@ class TestBrokerAdapterABC:
             async def get_account_balance(self) -> dict[str, float]: ...
             async def get_positions(self) -> list[dict[str, Any]]: ...
             async def get_current_price(self, symbol: str) -> float: ...
+            async def get_buyable(
+                self,
+                symbol: str,
+                price: float | None = None,
+                order_type: str = "market",
+            ) -> dict[str, float]: ...
             async def place_order(
                 self,
                 symbol: str,
@@ -227,7 +239,11 @@ class TestKISAdapterAPI:
         return resp
 
     async def test_get_account_balance(self, adapter):
-        """계좌 잔고 조회."""
+        """계좌 잔고 조회.
+
+        #2384: psbl_sbst_amt(예수금 대용가능금액)는 substitute_amount 키로
+        보존하고, purchasable_amount(주문가능액) 키는 반환 dict에서 제거된다.
+        """
         mock_resp = self._mock_response(
             {
                 "rt_cd": "0",
@@ -238,6 +254,7 @@ class TestKISAdapterAPI:
                         "pchs_amt_smtl_amt": "4500000",
                         "evlu_amt_smtl_amt": "5500000",
                         "evlu_pfls_smtl_amt": "1000000",
+                        "psbl_sbst_amt": "123000",
                     }
                 ],
             }
@@ -249,6 +266,10 @@ class TestKISAdapterAPI:
         balance = await adapter.get_account_balance()
         assert balance["cash"] == 5_000_000.0
         assert balance["total_assets"] == 10_000_000.0
+        # psbl_sbst_amt → substitute_amount (#2384)
+        assert balance["substitute_amount"] == 123_000.0
+        # purchasable_amount(주문가능액) 키는 제거 — get_buyable이 SSOT (#2384)
+        assert "purchasable_amount" not in balance
 
     async def test_get_positions(self, adapter):
         """포지션 조회."""
@@ -288,6 +309,105 @@ class TestKISAdapterAPI:
         assert len(positions) == 1
         assert positions[0]["symbol"] == "005930"
         assert positions[0]["quantity"] == 100.0
+
+    # ── get_buyable (inquire-psbl-order, #2384) ──────────────
+
+    _PSBL_ORDER_OUTPUT = {
+        "nrcvb_buy_amt": "9998235",
+        "max_buy_amt": "9998235",
+        "ord_psbl_cash": "10000000",
+        "nrcvb_buy_qty": "59",
+        "max_buy_qty": "59",
+    }
+
+    async def test_get_buyable_mapping(self, adapter):
+        """inquire-psbl-order 5필드 → get_buyable 반환 dict 매핑 (#2384)."""
+        mock_resp = self._mock_response(
+            {"rt_cd": "0", "output": dict(self._PSBL_ORDER_OUTPUT)}
+        )
+        session = MagicMock()
+        session.get = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        # 지정가(price 명시)는 get_current_price를 호출하지 않는다.
+        result = await adapter.get_buyable("069500", price=170000.0, order_type="limit")
+        assert result == {
+            "order_buyable_amount": 9_998_235.0,  # ← nrcvb_buy_amt (SSOT)
+            "max_buyable_amount": 9_998_235.0,  # ← max_buy_amt
+            "order_cash": 10_000_000.0,  # ← ord_psbl_cash
+            "order_buyable_qty": 59.0,  # ← nrcvb_buy_qty
+            "max_buyable_qty": 59.0,  # ← max_buy_qty
+        }
+
+    async def test_get_buyable_paper_live_tr_id(self, adapter):
+        """모의/실전 tr_id 분기 (VTTC8908R / TTTC8908R) (#2384)."""
+        captured: dict[str, Any] = {}
+
+        async def fake_request(method, url, tr_id, **kwargs):
+            captured["tr_id"] = tr_id
+            captured["params"] = kwargs.get("params")
+            return {"rt_cd": "0", "output": dict(self._PSBL_ORDER_OUTPUT)}
+
+        # 모의 (is_paper=True 기본)
+        adapter._request = fake_request  # type: ignore[method-assign]
+        await adapter.get_buyable("005930", price=70000.0)
+        assert captured["tr_id"] == "VTTC8908R"
+
+        # 실전
+        live = KISAdapter({**KIS_CONFIG, "is_paper": False})
+        live._request = fake_request  # type: ignore[method-assign]
+        await live.get_buyable("005930", price=70000.0)
+        assert captured["tr_id"] == "TTTC8908R"
+
+    async def test_get_buyable_market_uses_current_price(self, adapter):
+        """시장가 probe: ORD_DVSN='01' + ORD_UNPR=현재가(get_current_price) (#2384)."""
+        captured: dict[str, Any] = {}
+
+        async def fake_request(method, url, tr_id, **kwargs):
+            if "inquire-price" in url:
+                return {"rt_cd": "0", "output": {"stck_prpr": "55000"}}
+            captured["params"] = kwargs.get("params")
+            return {"rt_cd": "0", "output": dict(self._PSBL_ORDER_OUTPUT)}
+
+        adapter._request = fake_request  # type: ignore[method-assign]
+        # price=None → 시장가, get_current_price로 ORD_UNPR 보충.
+        await adapter.get_buyable("005930", price=None, order_type="market")
+        params = captured["params"]
+        assert params["ORD_DVSN"] == "01"  # 시장가 — KIS 공식 샘플 확정
+        assert params["ORD_UNPR"] == "55000"  # 현재가 → 실가('0' 아님)
+        assert params["PDNO"] == "005930"
+        assert params["CMA_EVLU_AMT_ICLD_YN"] == "N"
+        assert params["OVRS_ICLD_YN"] == "N"
+        assert params["CANO"] == "12345678"
+        assert params["ACNT_PRDT_CD"] == "01"
+
+    async def test_get_buyable_fallback_on_missing(self, adapter):
+        """nrcvb_buy_amt missing → ord_psbl_cash 폴백 (#2384 G6)."""
+
+        async def fake_request(method, url, tr_id, **kwargs):
+            return {
+                "rt_cd": "0",
+                "output": {"max_buy_amt": "5000000", "ord_psbl_cash": "7000000"},
+            }
+
+        adapter._request = fake_request  # type: ignore[method-assign]
+        result = await adapter.get_buyable("005930", price=70000.0)
+        # nrcvb_buy_amt 부재 → ord_psbl_cash로 폴백
+        assert result["order_buyable_amount"] == 7_000_000.0
+
+    async def test_get_buyable_value_zero_no_fallback(self, adapter):
+        """nrcvb_buy_amt==0 은 정상값 — 폴백하지 않는다 (#2384 G6)."""
+
+        async def fake_request(method, url, tr_id, **kwargs):
+            return {
+                "rt_cd": "0",
+                "output": {"nrcvb_buy_amt": "0", "ord_psbl_cash": "7000000"},
+            }
+
+        adapter._request = fake_request  # type: ignore[method-assign]
+        result = await adapter.get_buyable("005930", price=70000.0)
+        # 0은 정상값이므로 ord_psbl_cash로 폴백 금지 → 0.0 그대로
+        assert result["order_buyable_amount"] == 0.0
 
     async def test_place_order(self, adapter):
         """주문 접수."""

--- a/tests/unit/test_broker_success_output_drift.py
+++ b/tests/unit/test_broker_success_output_drift.py
@@ -214,9 +214,12 @@ def test_broker_balance_envelope_matches_raw_legacy() -> None:
     broker.py:220: ``if fmt.is_json: fmt.output(result)`` → broker adapter
     가 반환하는 평면 잔고 dict. 본 fixture 는 IPC 분기를 mock 한다.
     """
+    # #2384: get_account_balance(broker balance passthrough)는 purchasable_amount
+    # 키를 더 이상 포함하지 않고(주문가능액 SSOT는 get_buyable), psbl_sbst_amt를
+    # substitute_amount로 보존한다. fixture 를 새 계약과 일치시킨다.
     ipc_response = {
         "account_balance": 10_000_000.0,
-        "purchasable_amount": 8_000_000.0,
+        "substitute_amount": 0.0,
         "total_evaluation": 12_500_000.0,
         "total_profit_loss": 2_500_000.0,
     }

--- a/tests/unit/test_mock_broker.py
+++ b/tests/unit/test_mock_broker.py
@@ -220,6 +220,36 @@ async def test_initial_balance(broker: MockBrokerAdapter) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_buyable_cash_based(broker: MockBrokerAdapter) -> None:
+    """get_buyable: 보유 현금 기반 산정 — 금액=cash, 수량=floor(cash/단가) (#2384)."""
+    # default_price=50_000, cash=10_000_000 → qty=200
+    result = await broker.get_buyable("005930")
+    assert result["order_buyable_amount"] == 10_000_000.0
+    assert result["max_buyable_amount"] == 10_000_000.0
+    assert result["order_cash"] == 10_000_000.0
+    assert result["order_buyable_qty"] == 200.0
+    assert result["max_buyable_qty"] == 200.0
+
+
+@pytest.mark.asyncio
+async def test_get_buyable_explicit_price(broker: MockBrokerAdapter) -> None:
+    """get_buyable: price 명시 시 그 단가로 수량 계산 (#2384)."""
+    # cash=10_000_000, price=70_000 → qty=floor(142.85...)=142
+    result = await broker.get_buyable("005930", price=70_000)
+    assert result["order_buyable_qty"] == 142.0
+
+
+@pytest.mark.asyncio
+async def test_get_buyable_zero_price_qty_zero() -> None:
+    """get_buyable: 단가 0이면 수량 0.0 (division-by-zero 방지) (#2384)."""
+    b = MockBrokerAdapter({"initial_cash": 10_000_000, "default_price": 0})
+    result = await b.get_buyable("999999")
+    assert result["order_buyable_qty"] == 0.0
+    assert result["max_buyable_qty"] == 0.0
+    assert result["order_buyable_amount"] == 10_000_000.0
+
+
+@pytest.mark.asyncio
 async def test_balance_after_trades(broker: MockBrokerAdapter) -> None:
     """매매 후 total_assets가 수수료만큼 감소한다."""
     initial = await broker.get_account_balance()

--- a/tests/unit/test_test_broker.py
+++ b/tests/unit/test_test_broker.py
@@ -121,6 +121,34 @@ class TestAccountBalance:
         assert balance["stock_value"] > 0
 
 
+class TestBuyable:
+    """get_buyable() 동작 검증 (#2384)."""
+
+    @pytest.mark.asyncio
+    async def test_get_buyable_cash_based(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """현금 기반 산정 — 금액=cash, 수량=floor(cash/단가) (#2384)."""
+        result = await connected_broker.get_buyable("000001", price=50_000)
+        assert result["order_buyable_amount"] == 100_000_000.0
+        assert result["max_buyable_amount"] == 100_000_000.0
+        assert result["order_cash"] == 100_000_000.0
+        # cash=100_000_000, price=50_000 → qty=2000
+        assert result["order_buyable_qty"] == 2000.0
+        assert result["max_buyable_qty"] == 2000.0
+
+    @pytest.mark.asyncio
+    async def test_get_buyable_market_uses_internal_price(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """시장가/price=None이면 내부 시뮬레이션 가격을 단가로 사용 (#2384)."""
+        result = await connected_broker.get_buyable("000001")
+        assert result["order_buyable_amount"] == 100_000_000.0
+        # 내부 가격이 양수이므로 수량은 양의 정수
+        assert result["order_buyable_qty"] >= 0.0
+        assert result["order_buyable_qty"] == float(int(result["order_buyable_qty"]))
+
+
 class TestPositions:
     """get_positions() / get_account_positions() 동작 검증."""
 

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -1481,13 +1481,37 @@ class TestTreasurySummary:
         assert summary["budget_exceeds_purchasable"] is False
 
     async def test_budget_exceeds_purchasable_warning(self, treasury):
-        """잔여예산 > 매수가능금액 시 경고 플래그."""
+        """잔여예산 > 매수가능금액 시 경고 플래그 (#2384: get_buyable write-path).
+
+        sync_balance는 더 이상 purchasable_amount를 반영하지 않으므로, 매수가능액은
+        _do_sync가 get_buyable의 order_buyable_amount로 주입한다.
+        """
         await treasury.allocate("bot1", 5_000_000.0)
-        await treasury.sync_balance(
-            {"cash": 10_000_000.0, "purchasable_amount": 3_000_000.0}
-        )
+
+        class _Broker:
+            async def get_account_balance(self):
+                return {"cash": 10_000_000.0, "total_assets": 10_000_000.0}
+
+            async def get_buyable(self, symbol, price=None, order_type="market"):
+                return {
+                    "order_buyable_amount": 3_000_000.0,
+                    "max_buyable_amount": 3_000_000.0,
+                    "order_cash": 10_000_000.0,
+                    "order_buyable_qty": 0.0,
+                    "max_buyable_qty": 0.0,
+                }
+
+            async def get_positions(self):
+                return []
+
+        class _PosHistory:
+            async def get_all_positions(self, *, account_id=None):
+                return []
+
+        await treasury._do_sync(_Broker(), _PosHistory())
 
         summary = treasury.get_summary()
+        assert summary["purchasable_amount"] == 3_000_000.0
         assert summary["budget_exceeds_purchasable"] is True
 
     async def test_no_warning_when_purchasable_zero(self, treasury):
@@ -1575,11 +1599,12 @@ class TestTreasuryPersistence:
         await t1.initialize()
         await t1.set_account_balance(10_000_000.0)
 
-        # sync_balance로 평가액 필드 설정
+        # #2384: purchasable_amount는 get_buyable write-path로 주입되는 값을 모사.
+        t1._purchasable_amount = 8_000_000.0
+        # sync_balance로 평가액 필드 설정 (purchasable_amount는 미반영)
         await t1.sync_balance(
             {
                 "cash": 10_000_000.0,
-                "purchasable_amount": 8_000_000.0,
                 "total_assets": 12_000_000.0,
                 "purchase_amount": 7_000_000.0,
                 "eval_amount": 7_200_000.0,

--- a/tests/unit/test_treasury_sync.py
+++ b/tests/unit/test_treasury_sync.py
@@ -36,12 +36,19 @@ async def treasury(db, eventbus):
 
 
 class FakeBroker:
-    """테스트용 가짜 브로커."""
+    """테스트용 가짜 브로커.
+
+    #2384: get_account_balance는 purchasable_amount 키를 더 이상 포함하지 않으며
+    (substitute_amount로 대체), purchasable_amount는 get_buyable의
+    order_buyable_amount로 별도 주입된다. 본 Fake도 새 _do_sync write-path를
+    따라 get_buyable stub을 제공한다(BrokerAdapter subclass는 아니다).
+    """
 
     def __init__(
         self,
         balance: dict | None = None,
         positions: list | None = None,
+        buyable_amount: float = 4_800_000.0,
     ) -> None:
         self._balance = balance or {
             "cash": 5_000_000.0,
@@ -49,14 +56,33 @@ class FakeBroker:
             "purchase_amount": 7_000_000.0,
             "eval_amount": 7_200_000.0,
             "total_profit_loss": 200_000.0,
-            "purchasable_amount": 4_800_000.0,
+            "substitute_amount": 0.0,
         }
         self._positions = positions or []
+        self._buyable_amount = buyable_amount
         self.call_count = 0
+        self.buyable_call_count = 0
+        self.last_buyable_symbol: str | None = None
 
     async def get_account_balance(self) -> dict:
         self.call_count += 1
         return self._balance
+
+    async def get_buyable(
+        self,
+        symbol: str,
+        price: float | None = None,
+        order_type: str = "market",
+    ) -> dict:
+        self.buyable_call_count += 1
+        self.last_buyable_symbol = symbol
+        return {
+            "order_buyable_amount": self._buyable_amount,
+            "max_buyable_amount": self._buyable_amount,
+            "order_cash": self._balance.get("cash", 0.0),
+            "order_buyable_qty": 0.0,
+            "max_buyable_qty": 0.0,
+        }
 
     async def get_positions(self) -> list:
         return self._positions
@@ -80,13 +106,34 @@ class FakePositionHistory:
 
 
 class FailingBroker:
-    """동기화 실패 시나리오용."""
+    """동기화 실패 시나리오용 (get_account_balance 실패)."""
 
     async def get_account_balance(self) -> dict:
         raise ConnectionError("API 연결 실패")
 
+    async def get_buyable(
+        self,
+        symbol: str,
+        price: float | None = None,
+        order_type: str = "market",
+    ) -> dict:
+        raise ConnectionError("매수가능 조회 실패")
+
     async def get_positions(self) -> list:
         return []
+
+
+class BuyableFailingBroker(FakeBroker):
+    """get_account_balance는 성공하나 get_buyable만 실패하는 시나리오용 (#2384 G7)."""
+
+    async def get_buyable(
+        self,
+        symbol: str,
+        price: float | None = None,
+        order_type: str = "market",
+    ) -> dict:
+        self.buyable_call_count += 1
+        raise ConnectionError("매수가능 조회 실패")
 
 
 # ── US-1: KIS 잔고 필드 전체 동기화 ───────────────
@@ -94,11 +141,13 @@ class FailingBroker:
 
 class TestSyncBalance:
     async def test_sync_balance_updates_all_fields(self, treasury):
-        """sync_balance가 6개 필드 모두 갱신."""
+        """sync_balance가 잔고 필드를 갱신하되 purchasable_amount는 미반영 (#2384)."""
+        # 사전 주입된 purchasable_amount (get_buyable write-path 모사)
+        treasury._purchasable_amount = 99_000.0
+
         await treasury.sync_balance(
             {
                 "cash": 5_000_000.0,
-                "purchasable_amount": 4_800_000.0,
                 "total_assets": 12_000_000.0,
                 "purchase_amount": 7_000_000.0,
                 "eval_amount": 7_200_000.0,
@@ -107,11 +156,22 @@ class TestSyncBalance:
         )
 
         assert treasury._account_balance == 5_000_000.0
-        assert treasury._purchasable_amount == 4_800_000.0
         assert treasury._total_evaluation == 12_000_000.0
         assert treasury._purchase_amount == 7_000_000.0
         assert treasury._eval_amount == 7_200_000.0
         assert treasury._total_profit_loss == 200_000.0
+        # #2384: sync_balance는 purchasable_amount를 읽지 않으므로 기존값 불변.
+        assert treasury._purchasable_amount == 99_000.0
+
+    async def test_sync_balance_ignores_purchasable_amount(self, treasury):
+        """sync_balance에 purchasable_amount를 넘겨도 반영하지 않는다 (#2384 G2)."""
+        treasury._purchasable_amount = 12_345.0
+        # 레거시 호출자가 purchasable_amount를 넣어도 무시되는 새 계약 고정.
+        await treasury.sync_balance(
+            {"cash": 5_000_000.0, "purchasable_amount": 4_800_000.0}
+        )
+        assert treasury._account_balance == 5_000_000.0
+        assert treasury._purchasable_amount == 12_345.0  # 미반영
 
     async def test_sync_balance_recalculates_unallocated(self, treasury):
         """sync_balance가 미할당 자금 재계산."""
@@ -124,11 +184,11 @@ class TestSyncBalance:
         assert treasury.unallocated == 5_000_000.0  # 8M - 3M
 
     async def test_sync_balance_preserves_existing_on_missing_keys(self, treasury):
-        """누락된 키는 기존 값 유지."""
+        """누락된 키는 기존 값 유지 (purchasable_amount는 sync_balance 무관)."""
+        treasury._purchasable_amount = 4_800_000.0  # get_buyable write-path 모사
         await treasury.sync_balance(
             {
                 "cash": 5_000_000.0,
-                "purchasable_amount": 4_800_000.0,
                 "total_assets": 12_000_000.0,
                 "purchase_amount": 7_000_000.0,
                 "eval_amount": 7_200_000.0,
@@ -140,6 +200,7 @@ class TestSyncBalance:
         await treasury.sync_balance({"cash": 6_000_000.0})
 
         assert treasury._account_balance == 6_000_000.0
+        # #2384: purchasable_amount는 sync_balance가 건드리지 않으므로 유지.
         assert treasury._purchasable_amount == 4_800_000.0  # 유지
 
     async def test_set_account_balance_backward_compatible(self, treasury):
@@ -150,10 +211,11 @@ class TestSyncBalance:
 
     async def test_sync_balance_persists_to_db(self, treasury, db, eventbus):
         """sync_balance 결과가 DB에 저장되어 재시작 후 복원."""
+        # purchasable_amount는 get_buyable write-path로 채워지는 값을 모사.
+        treasury._purchasable_amount = 4_800_000.0
         await treasury.sync_balance(
             {
                 "cash": 5_000_000.0,
-                "purchasable_amount": 4_800_000.0,
                 "total_assets": 12_000_000.0,
                 "purchase_amount": 7_000_000.0,
                 "eval_amount": 7_200_000.0,
@@ -170,14 +232,39 @@ class TestSyncBalance:
         assert t2._total_evaluation == 12_000_000.0
 
     async def test_purchasable_amount_in_kis(self):
-        """KIS get_account_balance에 purchasable_amount 포함 확인."""
+        """#2384: KIS get_account_balance는 psbl_sbst_amt를 substitute_amount로
+        매핑하고 purchasable_amount 키를 포함하지 않는다."""
+        from unittest.mock import AsyncMock
+
         from ante.broker.kis import KISAdapter
 
-        # KISAdapter의 get_account_balance 반환값에 purchasable_amount 키 존재 확인
-        # (실제 API 호출 없이 코드 구조 검증)
         adapter = KISAdapter.__new__(KISAdapter)
-        # _request 모킹 없이 반환 딕셔너리 키 확인만
-        assert hasattr(adapter, "get_account_balance")
+        adapter.base_url = "https://example.test"  # type: ignore[attr-defined]
+        adapter.is_paper = True  # type: ignore[attr-defined]
+        # inquire-balance(output2) 응답을 모킹.
+        adapter._request = AsyncMock(  # type: ignore[method-assign]
+            return_value={
+                "rt_cd": "0",
+                "output2": [
+                    {
+                        "dnca_tot_amt": "5000000",
+                        "tot_evlu_amt": "12000000",
+                        "pchs_amt_smtl_amt": "7000000",
+                        "evlu_amt_smtl_amt": "7200000",
+                        "evlu_pfls_smtl_amt": "200000",
+                        "psbl_sbst_amt": "321000",
+                    }
+                ],
+            }
+        )
+        adapter._balance_params = lambda: {}  # type: ignore[method-assign]
+
+        balance = await adapter.get_account_balance()
+
+        # psbl_sbst_amt → substitute_amount (대용가능금액 보존)
+        assert balance["substitute_amount"] == 321_000.0
+        # purchasable_amount(주문가능액) 키는 제거 — get_buyable이 SSOT (#2384)
+        assert "purchasable_amount" not in balance
 
 
 # ── US-2: 주기적 잔고 동기화 메커니즘 ─────────────
@@ -200,7 +287,7 @@ class TestSyncLoop:
         assert broker.call_count >= 1
 
     async def test_sync_updates_treasury_fields(self, treasury):
-        """동기화 루프가 Treasury 필드를 갱신."""
+        """동기화 루프가 필드를 갱신 (purchasable_amount는 get_buyable 주입)."""
         broker = FakeBroker()
         pos_history = FakePositionHistory()
 
@@ -209,8 +296,12 @@ class TestSyncLoop:
         await treasury.stop_sync()
 
         assert treasury._account_balance == 5_000_000.0
+        # #2384: purchasable_amount는 get_buyable의 order_buyable_amount로 주입.
         assert treasury._purchasable_amount == 4_800_000.0
         assert treasury._total_evaluation == 12_000_000.0
+        # 대표 종목으로 cycle당 1회 probe 호출됨.
+        assert broker.buyable_call_count >= 1
+        assert broker.last_buyable_symbol == "005930"
 
     async def test_sync_failure_keeps_old_values(self, treasury):
         """동기화 실패 시 이전 값 유지."""
@@ -240,6 +331,31 @@ class TestSyncLoop:
         assert len(received) == 1
         assert received[0].account_balance == 5_000_000.0
         assert received[0].purchasable_amount == 4_800_000.0
+
+    async def test_get_buyable_failure_keeps_old_value_no_event(
+        self, treasury, eventbus
+    ):
+        """#2384 G7: get_buyable 실패 시 purchasable_amount 이전값 유지 +
+        BalanceSyncedEvent 미발행."""
+        received = []
+        eventbus.subscribe(BalanceSyncedEvent, lambda e: received.append(e))
+
+        # 사전 주입된 매수가능액(이전 cycle 값 모사).
+        treasury._purchasable_amount = 7_777_000.0
+
+        broker = BuyableFailingBroker()
+        pos_history = FakePositionHistory()
+
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        # get_buyable는 호출되었으나 실패 → 예외로 cycle 중단.
+        assert broker.buyable_call_count >= 1
+        # 이전값 유지 (0으로 덮어쓰지 않음).
+        assert treasury._purchasable_amount == 7_777_000.0
+        # 잘못된 매수가능액으로 이벤트를 발행하지 않는다.
+        assert received == []
 
     async def test_double_start_ignored(self, treasury):
         """이미 동기화 실행 중이면 중복 시작 무시."""
@@ -466,10 +582,12 @@ class TestAntePurePerformance:
 
     async def test_summary_includes_new_fields(self, treasury):
         """get_summary에 신규 필드 모두 포함."""
+        # #2384: purchasable_amount는 get_buyable write-path로 주입되는 값을 모사
+        # (sync_balance는 더 이상 purchasable_amount를 반영하지 않는다).
+        treasury._purchasable_amount = 4_800_000.0
         await treasury.sync_balance(
             {
                 "cash": 5_000_000.0,
-                "purchasable_amount": 4_800_000.0,
                 "total_assets": 12_000_000.0,
                 "purchase_amount": 7_000_000.0,
                 "eval_amount": 7_200_000.0,


### PR DESCRIPTION
Closes #2384

## Summary
KIS 모의 매수가능 수량이 있어도 `treasury status`/`broker balance`의 `purchasable_amount`가 0으로 표시되던 display-only 버그 수정. 스펙 #2387/#2388(merged) 계약 구현.

- **`get_buyable()` 신설** (`BrokerAdapter` `@abstractmethod`): KIS `inquire-psbl-order`(VTTC8908R/TTTC8908R)로 진짜 주문가능액 조회. `ORD_DVSN='01'`(시장가)+`ORD_UNPR`=대표종목 현재가(공식 샘플 확정, get_buyable 내부 get_current_price 1회). 응답 5필드 매핑, SSOT=`order_buyable_amount`(=nrcvb_buy_amt). `ord_psbl_cash` 폴백은 missing/parse-failure만(value==0 비폴백).
- **`get_account_balance()` 정렬**: `purchasable_amount` 키 제거(무인자 메서드는 종목 컨텍스트 부재로 주문가능액 산출 불가), `substitute_amount`(=psbl_sbst_amt 대용가능금액) 보존.
- **Treasury write-path**: `sync_balance`의 purchasable_amount 읽기 제거, `_do_sync`(Live)가 `get_buyable(005930, 시장가)` 1회 호출해 `order_buyable_amount`를 `_purchasable_amount`에 주입(BalanceSyncedEvent 전). 실패 시 이전값 유지·event 미발행. Virtual 무변경.
- **어댑터**: Mock/Test/Dummy/Min/Fake 전부 get_buyable 구현(cash 기반/stub).
- **스펙 08**: ORD_UNPR/ORD_DVSN 공식 샘플 확정 갱신(잠정 '0' supersede). cli_registry 주석 정렬.

## ⚠️ 런타임 검증 대기 (oracle)
- 공식 KIS 문서 grounded 구현(ORD_DVSN='01'+실가 ORD_UNPR). 잔여 경험 검증인 **`nrcvb_buy_amt` 종목 불변성(모의 다종목 A/B)은 사용자가 ante oracle로 머지 후 검증**한다(자율 에이전트 KIS 접근 불가). 종목별 상이 판명 시 SSOT를 `ord_psbl_cash`로 전환(코드 한 곳 상수).
- display-only(주문/예산 게이트 미참여)라 라이브 검증 전 위험은 표시값에 국한.

## Test Plan
- `ruff check` / `ruff format --check` PASS
- `mypy src/`(233 files) PASS
- `pytest`: 핵심 6파일 246 passed, 광역 sweep 3610 passed (0 failed)
- 회귀: test_treasury_sync.py:172 재작성(psbl_sbst_amt→substitute_amount, purchasable_amount 부재 — fail-before/pass-after), get_buyable 매핑(mock)·paper/live tr_id·폴백·value0 비폴백, Treasury 주입/실패 시 이전값 유지, drift fixture 갱신
- Codex 브랜치 리뷰: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
