### PR TITLE
docs(strategy): #2390 modify_order를 broker-level 미구현(deferred)로 SSOT 정렬 — guide·설계스펙·KIS 표 (#2391 follow-up)

### DIFF
--- a/docs/specs/api-gateway/api-gateway.md
+++ b/docs/specs/api-gateway/api-gateway.md
@@ -152,7 +152,7 @@ async def _on_order_approved(self, event: OrderApprovedEvent) -> None:
     order_id = await broker.place_order(...)
 ```
 
-**취소/정정 설계 근거**: 취소·정정은 리스크를 줄이는 행위이므로 RuleEngine 경유 불필요. `OrderCancelEvent`, `OrderModifyEvent` 수신 시 `event.account_id`로 브로커를 선택하여 직접 전달.
+**취소/정정 설계 근거**: 취소·정정은 리스크를 줄이는 행위이므로 RuleEngine 경유 불필요. `OrderCancelEvent` 수신 시 `event.account_id`로 브로커를 선택하여 직접 전달한다. **단, `OrderModifyEvent`(주문 정정)는 현재 broker-level 미구현(deferred)이다.** Gateway는 룰 검증·브로커 전달 없이 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)를 발행해 terminal reject 처리한다. 실 KIS 국내주식 정정취소(`order-rvsecncl`) API 연동은 후속 작업(#2391)으로 분리되어 있다.
 
 **Stop Order 라우팅**: `OrderApprovedEvent`의 `order_type`이 `stop` 또는 `stop_limit`이면 `StopOrderManager.register()`로 라우팅한다. `StopOrderManager`가 설정되지 않은 상태에서는 일반 주문으로 처리.
 
@@ -164,7 +164,7 @@ async def _on_order_approved(self, event: OrderApprovedEvent) -> None:
 |--------|------|
 | `OrderApprovedEvent` | Treasury 자금 확보 후 주문 실행. `event.account_id`로 브로커 라우팅 |
 | `OrderCancelEvent` | 주문 취소 요청 → `event.account_id`로 브로커 선택 후 전달 (룰 검증 생략) |
-| `OrderModifyEvent` | 주문 정정 요청 → `event.account_id`로 브로커 선택 후 전달 (룰 검증 생략) |
+| `OrderModifyEvent` | 주문 정정 요청 → **broker-level 미구현(deferred)**. 브로커 전달 없이 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`) 발행 (실 정정은 #2391) |
 | `OrderFilledEvent` | 체결 시 해당 `account_id` 범위 내 캐시 무효화 (`{account_id}:balance`, `{account_id}:positions`, `{account_id}:price:{symbol}`) |
 
 **발행하는 이벤트**:
@@ -245,13 +245,13 @@ KRX는 네이티브 스탑 주문을 지원하지 않으므로, 실시간 시세
 
 | 시점 | 발행 이벤트 | `Bot.on_order_update` 변환 status | 비고 |
 |------|-------------|-----------------------------------|------|
-| 등록 (`StopOrderManager.register`) | `StopOrderRegisteredEvent` | `"stop_registered"` | dict에 `stop_order_id`, `stop_price`, `limit_price` 포함. 전략은 이 시점에 후속 취소·정정에 쓸 식별자를 획득. |
+| 등록 (`StopOrderManager.register`) | `StopOrderRegisteredEvent` | `"stop_registered"` | dict에 `stop_order_id`, `stop_price`, `limit_price` 포함. 전략은 이 시점에 후속 취소에 쓸 식별자를 획득(식별자 획득 자체는 유효). 단, 정정(`modify`) 실행은 현재 broker-level 미구현(deferred, #2391)이라 취소만 가능. |
 | 발동 (`_trigger_order`) | `StopOrderTriggeredEvent` (+ 별도 `OrderRequestEvent`) | `"stop_triggered"` | 변환된 일반 주문은 자체 라이프사이클(`OrderSubmittedEvent` 등)을 별도로 통보한다. `StopOrderTriggeredEvent`는 stop 식별 단위(`stop_order_id`, `trigger_price`, `converted_order_type`)를 보존한다. |
 | 만료 (`_expire_order`) | `StopOrderExpiredEvent` | `"stop_expired"` | `reason` 허용 값: `"session_ended"` (세션 종료) / `"manager_stopped"` (매니저 stop). |
 
 **dict shape 호환**:
 
-- 스탑 알림에서 `order_id` 키에는 `stop_order_id`를 그대로 채워 일반 주문 알림과 dict shape를 맞춘다 (외부 채널 / 전략의 후속 cancel·modify 호환). `stop_order_id` 키도 명시 식별자로 함께 노출한다.
+- 스탑 알림에서 `order_id` 키에는 `stop_order_id`를 그대로 채워 일반 주문 알림과 dict shape를 맞춘다 (외부 채널 / 전략의 후속 cancel 호환). `stop_order_id` 키도 명시 식별자로 함께 노출한다. 식별자 획득·dict shape 호환 자체는 `cancel`/`modify` 모두에 유효하나, **`modify` 실행은 현재 broker-level 미구현(deferred, #2391)**이므로 후속 정정은 취소(`cancel`) 후 재주문으로 대체한다.
 - `SignalChannel`도 외부 채널에 동일한 `{type:"order_update", order_id, status, reason}` 메시지로 전달한다 — `type` 값을 새로 만들지 않아 외부 소비자(stdin/stdout 기반 에이전트)의 파싱 분기를 추가 강제하지 않는다.
 
 **비포함 정보** (#1337 정책 직교):

--- a/docs/specs/api-gateway/api-gateway.md
+++ b/docs/specs/api-gateway/api-gateway.md
@@ -152,7 +152,7 @@ async def _on_order_approved(self, event: OrderApprovedEvent) -> None:
     order_id = await broker.place_order(...)
 ```
 
-**취소/정정 설계 근거**: 취소·정정은 리스크를 줄이는 행위이므로 RuleEngine 경유 불필요. `OrderCancelEvent` 수신 시 `event.account_id`로 브로커를 선택하여 직접 전달한다. **단, `OrderModifyEvent`(주문 정정)는 현재 broker-level 미구현(deferred)이다.** Gateway는 룰 검증·브로커 전달 없이 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)를 발행해 terminal reject 처리한다. 실 KIS 국내주식 정정취소(`order-rvsecncl`) API 연동은 후속 작업(#2391)으로 분리되어 있다.
+**취소/정정 설계 근거**: 취소는 리스크를 줄이는 행위이므로 RuleEngine 경유 불필요 — `OrderCancelEvent` 수신 시 `event.account_id`로 브로커를 선택하여 직접 전달한다. **단, `OrderModifyEvent`(주문 정정)는 현재 broker-level 미구현(deferred)이다.** `OrderModifyEvent`는 EventBus 우선순위상 RuleEngine(priority=100)이 먼저 처리하며, 룰 위반·룰 평가 예외 시 RuleEngine이 룰 사유의 `OrderModifyRejectedEvent`를 발행하고 `_consumed` 마커를 설정한다(이 경우 Gateway는 발행하지 않는다). 룰을 통과한 경우에만 Gateway(priority=50)가 브로커 전달 없이 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)를 발행해 terminal reject 처리한다. 즉 `modify_not_implemented`는 룰 통과 후 Gateway 경로에 한정된다. 실 KIS 국내주식 정정취소(`order-rvsecncl`) API 연동은 후속 작업(#2391)으로 분리되어 있다.
 
 **Stop Order 라우팅**: `OrderApprovedEvent`의 `order_type`이 `stop` 또는 `stop_limit`이면 `StopOrderManager.register()`로 라우팅한다. `StopOrderManager`가 설정되지 않은 상태에서는 일반 주문으로 처리.
 
@@ -164,7 +164,7 @@ async def _on_order_approved(self, event: OrderApprovedEvent) -> None:
 |--------|------|
 | `OrderApprovedEvent` | Treasury 자금 확보 후 주문 실행. `event.account_id`로 브로커 라우팅 |
 | `OrderCancelEvent` | 주문 취소 요청 → `event.account_id`로 브로커 선택 후 전달 (룰 검증 생략) |
-| `OrderModifyEvent` | 주문 정정 요청 → **broker-level 미구현(deferred)**. 브로커 전달 없이 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`) 발행 (실 정정은 #2391) |
+| `OrderModifyEvent` | 주문 정정 요청 → **broker-level 미구현(deferred)**. RuleEngine(priority=100) 선처리 — 룰 위반 시 룰 사유로 거부(`_consumed` 설정), 룰 통과 시에만 Gateway(priority=50)가 브로커 전달 없이 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`) 발행 (실 정정은 #2391) |
 | `OrderFilledEvent` | 체결 시 해당 `account_id` 범위 내 캐시 무효화 (`{account_id}:balance`, `{account_id}:positions`, `{account_id}:price:{symbol}`) |
 
 **발행하는 이벤트**:

--- a/docs/specs/backtest/02-design-decisions.md
+++ b/docs/specs/backtest/02-design-decisions.md
@@ -301,7 +301,7 @@ def _validate_config(self, config: dict[str, Any]) -> BacktestConfig:
 | `get_balance() → dict[str, float]` | 가용 자금 현황 |
 | `get_open_orders() → list[dict]` | 미체결 주문 (백테스트에서는 항상 빈 리스트) |
 | `cancel_order(order_id, reason) → None` | 주문 취소 (백테스트에서는 무시) |
-| `modify_order(order_id, quantity, price, reason) → None` | 주문 정정 (백테스트에서는 noop. 라이브에서도 broker-level 정정은 현재 미구현(deferred)이라 즉시 `modify_rejected`(`modify_not_implemented`)로 거부 — 실 정정 연동은 #2391) |
+| `modify_order(order_id, quantity, price, reason) → None` | 주문 정정 (백테스트에서는 noop. 라이브에서도 broker-level 정정은 현재 미구현(deferred)이라 룰 통과 시 Gateway가 `modify_rejected`(`modify_not_implemented`)로 거부 — 실 정정 연동은 #2391) |
 | `load_file(path) → bytes` | 전략 전용 파일 읽기 (바이너리). 라이브와 동일하게 `strategies/` 하위만 허용하고 절대경로/탈출/symlink escape는 `StrategyFileAccessError`로 거부 (#2083) |
 | `load_text(path, encoding="utf-8") → str` | 전략 전용 파일 읽기 (텍스트). `load_file` 위임 후 디코딩 (#2083) |
 | `log(message, level) → None` | 전략 로그 출력 |

--- a/docs/specs/backtest/02-design-decisions.md
+++ b/docs/specs/backtest/02-design-decisions.md
@@ -301,7 +301,7 @@ def _validate_config(self, config: dict[str, Any]) -> BacktestConfig:
 | `get_balance() → dict[str, float]` | 가용 자금 현황 |
 | `get_open_orders() → list[dict]` | 미체결 주문 (백테스트에서는 항상 빈 리스트) |
 | `cancel_order(order_id, reason) → None` | 주문 취소 (백테스트에서는 무시) |
-| `modify_order(order_id, quantity, price, reason) → None` | 주문 정정 (백테스트에서는 무시) |
+| `modify_order(order_id, quantity, price, reason) → None` | 주문 정정 (백테스트에서는 noop. 라이브에서도 broker-level 정정은 현재 미구현(deferred)이라 즉시 `modify_rejected`(`modify_not_implemented`)로 거부 — 실 정정 연동은 #2391) |
 | `load_file(path) → bytes` | 전략 전용 파일 읽기 (바이너리). 라이브와 동일하게 `strategies/` 하위만 허용하고 절대경로/탈출/symlink escape는 `StrategyFileAccessError`로 거부 (#2083) |
 | `load_text(path, encoding="utf-8") → str` | 전략 전용 파일 읽기 (텍스트). `load_file` 위임 후 디코딩 (#2083) |
 | `log(message, level) → None` | 전략 로그 출력 |

--- a/docs/specs/bot/03-design-decisions.md
+++ b/docs/specs/bot/03-design-decisions.md
@@ -73,7 +73,7 @@ CREATED → RUNNING → STOPPING → STOPPED → DELETED
 3. **OrderAction → EventBus 이벤트 변환 (`_publish_actions`)**
    - `_run_loop()`에서 매 스텝 후 `StrategyContext._drain_actions()`로 주문 취소/정정 액션을 수집
    - `action == "cancel"` → `OrderCancelEvent`, `action == "modify"` → `OrderModifyEvent`로 변환하여 발행
-   - **caveat**: Bot은 `OrderModifyEvent`를 발행만 한다. **broker-level 주문 정정은 현재 미구현(deferred)**이라 Gateway가 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 거부하므로, 정정이 필요한 전략은 `cancel` 후 재주문으로 대체한다 (실 정정 연동은 #2391).
+   - **caveat**: Bot은 `OrderModifyEvent`를 발행만 한다. **broker-level 주문 정정은 현재 미구현(deferred)**이라 룰 통과 시 Gateway가 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 거부하므로, 정정이 필요한 전략은 `cancel` 후 재주문으로 대체한다 (실 정정 연동은 #2391).
 
 4. **체결 통보 전달 (`on_order_filled`)**
    - Bot이 EventBus에서 OrderFilledEvent를 구독

--- a/docs/specs/bot/03-design-decisions.md
+++ b/docs/specs/bot/03-design-decisions.md
@@ -73,6 +73,7 @@ CREATED → RUNNING → STOPPING → STOPPED → DELETED
 3. **OrderAction → EventBus 이벤트 변환 (`_publish_actions`)**
    - `_run_loop()`에서 매 스텝 후 `StrategyContext._drain_actions()`로 주문 취소/정정 액션을 수집
    - `action == "cancel"` → `OrderCancelEvent`, `action == "modify"` → `OrderModifyEvent`로 변환하여 발행
+   - **caveat**: Bot은 `OrderModifyEvent`를 발행만 한다. **broker-level 주문 정정은 현재 미구현(deferred)**이라 Gateway가 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 거부하므로, 정정이 필요한 전략은 `cancel` 후 재주문으로 대체한다 (실 정정 연동은 #2391).
 
 4. **체결 통보 전달 (`on_order_filled`)**
    - Bot이 EventBus에서 OrderFilledEvent를 구독

--- a/docs/specs/bot/04-eventbus-integration.md
+++ b/docs/specs/bot/04-eventbus-integration.md
@@ -15,7 +15,7 @@
 | `BotRestartExhaustedEvent` | `bot_id, account_id, restart_attempts, last_error` | 재시작 한도 소진 시 |
 | `OrderRequestEvent` | `bot_id, account_id, strategy_id, symbol, side, quantity, order_type, price, stop_price, reason, exchange` | 전략 Signal → 신규 주문 요청. `exchange`는 Account에서 주입 |
 | `OrderCancelEvent` | `bot_id, account_id, order_id, reason` | 전략 `ctx.cancel_order()` → 주문 취소 요청 |
-| `OrderModifyEvent` | `bot_id, account_id, order_id, quantity, price, reason` | 전략 `ctx.modify_order()` → 주문 정정 요청 |
+| `OrderModifyEvent` | `bot_id, account_id, order_id, quantity, price, reason` | 전략 `ctx.modify_order()` → 주문 정정 요청. Bot은 이벤트를 발행하나 **broker-level 정정은 현재 미구현(deferred)**이라 Gateway가 즉시 `OrderModifyRejectedEvent`(`modify_not_implemented`)로 거부 (실 정정 연동은 #2391) |
 | `NotificationEvent` | `level, title, message, category="bot"` | 봇 시작/중지/에러/재시작 한도 소진 시 |
 
 ### BotStepCompletedEvent

--- a/docs/specs/bot/04-eventbus-integration.md
+++ b/docs/specs/bot/04-eventbus-integration.md
@@ -15,7 +15,7 @@
 | `BotRestartExhaustedEvent` | `bot_id, account_id, restart_attempts, last_error` | 재시작 한도 소진 시 |
 | `OrderRequestEvent` | `bot_id, account_id, strategy_id, symbol, side, quantity, order_type, price, stop_price, reason, exchange` | 전략 Signal → 신규 주문 요청. `exchange`는 Account에서 주입 |
 | `OrderCancelEvent` | `bot_id, account_id, order_id, reason` | 전략 `ctx.cancel_order()` → 주문 취소 요청 |
-| `OrderModifyEvent` | `bot_id, account_id, order_id, quantity, price, reason` | 전략 `ctx.modify_order()` → 주문 정정 요청. Bot은 이벤트를 발행하나 **broker-level 정정은 현재 미구현(deferred)**이라 Gateway가 즉시 `OrderModifyRejectedEvent`(`modify_not_implemented`)로 거부 (실 정정 연동은 #2391) |
+| `OrderModifyEvent` | `bot_id, account_id, order_id, quantity, price, reason` | 전략 `ctx.modify_order()` → 주문 정정 요청. Bot은 이벤트를 발행하나 **broker-level 정정은 현재 미구현(deferred)**이라 룰 통과 시 Gateway가 `OrderModifyRejectedEvent`(`modify_not_implemented`)로 거부 (실 정정 연동은 #2391) |
 | `NotificationEvent` | `level, title, message, category="bot"` | 봇 시작/중지/에러/재시작 한도 소진 시 |
 
 ### BotStepCompletedEvent

--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -35,11 +35,13 @@ class KISDomesticAdapter(KISBaseAdapter):
 | 잔고 조회 | `/uapi/domestic-stock/v1/trading/inquire-balance` | GET |
 | 현재가 조회 | `/uapi/domestic-stock/v1/quotations/inquire-price` | GET |
 | 주문 접수 | `/uapi/domestic-stock/v1/trading/order-cash` | POST |
-| 주문 취소/정정 | `/uapi/domestic-stock/v1/trading/order-rvsecncl` | POST |
+| 주문 취소 (정정 미구현) | `/uapi/domestic-stock/v1/trading/order-rvsecncl` | POST |
 | 미체결 조회 | `/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl` | GET |
 | 매수가능 조회 | `/uapi/domestic-stock/v1/trading/inquire-psbl-order` | GET |
 
 > **매수가능 조회 행은 구현 #2384 merge 후 실행 가능**하다. 본 행은 계약(spec) 선반영이며, `inquire-balance`(잔고/평가/보유)와 `inquire-psbl-order`(주문가능)는 KIS가 공식적으로 분리한 두 엔드포인트다(아래 §inquire-psbl-order 계약 참조).
+
+> **`order-rvsecncl`은 KIS API 레벨에서는 정정·취소를 모두 지원**하지만, Ante 어댑터는 현재 **취소(`cancel_order`)만 구현**하고 **정정(modify)은 미구현(deferred)**이다(아래 §order-rvsecncl 취소 바디 계약은 취소 한정). 따라서 상위 계층의 정정 요청은 broker까지 전달되지 않고 Gateway가 `modify_not_implemented`로 즉시 거부한다. 실 KIS 정정(`RVSE_CNCL_DVSN_CD='01'`) 분기 구현은 후속 작업(#2391)으로 분리되어 있다.
 
 ### order-cash TR ID 매핑
 

--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -115,8 +115,8 @@ D-005에서 정의한 EventBus 대상 이벤트. 모든 이벤트는 `Event`를 
 |------------|--------|--------|----------|
 | `OrderRequestEvent` | Bot | RuleEngine | `account_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `order_type`, `price?`, `stop_price?`, `reason`, `exchange` |
 | `OrderCancelEvent` | Bot | APIGateway | `account_id`, `bot_id`, `strategy_id`, `order_id`, `reason` |
-| `OrderModifyEvent` | Bot | RuleEngine | `account_id`, `bot_id`, `strategy_id`, `order_id`, `symbol`, `side`, `quantity`, `price?`, `reason` |
-| `OrderModifyRejectedEvent` | RuleEngine | Bot | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `reason` |
+| `OrderModifyEvent` | Bot | RuleEngine | `account_id`, `bot_id`, `strategy_id`, `order_id`, `symbol`, `side`, `quantity`, `price?`, `reason`. **vocabulary 표면**: broker-level 정정은 현재 미구현(deferred)이라 성공 이벤트(`OrderModifyExecutedEvent` 등)는 존재하지 않으며, 룰 통과 시에도 Gateway가 `OrderModifyRejectedEvent`(`modify_not_implemented`)로만 종결한다 (실 정정 연동은 #2391) |
+| `OrderModifyRejectedEvent` | RuleEngine / APIGateway | Bot | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `reason`. 정정 경로의 유일한 terminal 이벤트 (룰 거부 사유 또는 `modify_not_implemented`) |
 | `OrderValidatedEvent` | RuleEngine | Treasury | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `order_type`, `stop_price?`, `reason`, `exchange` |
 | `OrderRejectedEvent` | RuleEngine / Treasury | Bot, Notification | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `order_type`, `reason`, `exchange` |
 | `OrderApprovedEvent` | Treasury | APIGateway | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `order_type`, `stop_price?`, `reserved_amount`, `exchange` |

--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -115,7 +115,7 @@ D-005에서 정의한 EventBus 대상 이벤트. 모든 이벤트는 `Event`를 
 |------------|--------|--------|----------|
 | `OrderRequestEvent` | Bot | RuleEngine | `account_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `order_type`, `price?`, `stop_price?`, `reason`, `exchange` |
 | `OrderCancelEvent` | Bot | APIGateway | `account_id`, `bot_id`, `strategy_id`, `order_id`, `reason` |
-| `OrderModifyEvent` | Bot | RuleEngine | `account_id`, `bot_id`, `strategy_id`, `order_id`, `symbol`, `side`, `quantity`, `price?`, `reason`. **vocabulary 표면**: broker-level 정정은 현재 미구현(deferred)이라 성공 이벤트(`OrderModifyExecutedEvent` 등)는 존재하지 않으며, 룰 통과 시에도 Gateway가 `OrderModifyRejectedEvent`(`modify_not_implemented`)로만 종결한다 (실 정정 연동은 #2391) |
+| `OrderModifyEvent` | Bot | RuleEngine, APIGateway | `account_id`, `bot_id`, `strategy_id`, `order_id`, `symbol`, `side`, `quantity`, `price?`, `reason`. **vocabulary 표면**: broker-level 정정은 현재 미구현(deferred)이라 성공 이벤트(`OrderModifyExecutedEvent` 등)는 존재하지 않으며, 룰 통과 시에도 Gateway가 `OrderModifyRejectedEvent`(`modify_not_implemented`)로만 종결한다 (실 정정 연동은 #2391) |
 | `OrderModifyRejectedEvent` | RuleEngine / APIGateway | Bot | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `reason`. 정정 경로의 유일한 terminal 이벤트 (룰 거부 사유 또는 `modify_not_implemented`) |
 | `OrderValidatedEvent` | RuleEngine | Treasury | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `order_type`, `stop_price?`, `reason`, `exchange` |
 | `OrderRejectedEvent` | RuleEngine / Treasury | Bot, Notification | `account_id`, `order_id`, `bot_id`, `strategy_id`, `symbol`, `side`, `quantity`, `price?`, `order_type`, `reason`, `exchange` |

--- a/docs/specs/rule-engine/07-rule-engine-core.md
+++ b/docs/specs/rule-engine/07-rule-engine-core.md
@@ -36,7 +36,7 @@ RuleEngine(
 ### 이벤트 구독
 
 - `OrderRequestEvent` (priority=100): 주문 평가 — `event.account_id` 필터링 → **OrderRequestEvent preflight** (아래 소절 참조) → RuleContext 생성 → 계좌/전략별 룰 평가 → 결과 이벤트 발행
-- `OrderModifyEvent` (priority=100): 주문 정정 평가 — `event.account_id` 필터링 → RuleContext 생성 → 계좌/전략별 룰 평가 → 결과 이벤트 발행. 거부 시 `OrderModifyRejectedEvent` 발행
+- `OrderModifyEvent` (priority=100): 주문 정정 평가 — `event.account_id` 필터링 → RuleContext 생성 → 계좌/전략별 룰 평가 → 결과 이벤트 발행. 거부 시 `OrderModifyRejectedEvent` 발행. **caveat**: 룰을 통과하더라도 broker-level 정정은 현재 미구현(deferred)이라 Gateway가 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 terminal reject 처리한다 (실 정정 연동은 #2391).
 - `ConfigChangedEvent`: 룰 설정 변경 감지. `category="rule"` + `key="accounts.{account_id}.rules"`이면 해당 계좌 엔진만 계좌 룰을 재로드하고, `category="strategy_rule"`이면 해당 전략 룰을 재로드한다.
 
 ### 룰 레지스트리

--- a/docs/specs/strategy/03-01-strategy-interface.md
+++ b/docs/specs/strategy/03-01-strategy-interface.md
@@ -129,8 +129,11 @@
 스탑 알림에서:
 
 - `order_id`에는 `stop_order_id`를 그대로 채워 일반 주문 알림과 dict shape를
-  맞춘다 (전략이 후속 `cancel/modify`에 그대로 사용 가능). `stop_order_id`
-  키도 명시 식별자로 함께 노출한다.
+  맞춘다 (전략이 후속 `cancel`에 그대로 사용 가능). `stop_order_id`
+  키도 명시 식별자로 함께 노출한다. 식별자 자체는 `modify`에도 그대로 쓸 수
+  있으나, **`modify`(정정) 실행은 현재 broker-level 미구현(deferred)**이라
+  Gateway가 즉시 `modify_rejected`(`reason="modify_not_implemented"`)로
+  거부하므로, 정정이 필요하면 `cancel` 후 재주문으로 대체한다 (실 정정 연동은 #2391).
 - 발동(`stop_triggered`) 알림은 변환된 일반 주문이 자체 라이프사이클 이벤트
   (`OrderSubmittedEvent` 등)를 별도로 발행하므로, 스탑 식별 단위로 받고 싶은
   경우 본 알림으로 분기한다.

--- a/docs/specs/strategy/03-03-order-action-fields.md
+++ b/docs/specs/strategy/03-03-order-action-fields.md
@@ -18,4 +18,4 @@
 - Signal(신규 주문)과 OrderAction(기존 주문 관리)을 분리 — 역할이 다르므로 타입도 분리
 - 전략이 `ctx.cancel_order()` / `ctx.modify_order()` 호출 시 내부 큐에 쌓이고, Bot이 on_step() 종료 후 일괄 처리
 - 취소/정정도 EventBus를 통해 RuleEngine 검증을 거침
-- **`action="modify"` deferred caveat**: 정정 액션은 필드 스키마로 존재하나 **broker-level 정정이 현재 미구현(deferred)**이다. 룰 통과 여부와 무관하게 Gateway가 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 terminal reject 처리하므로, 정정이 필요하면 `cancel` 후 재주문으로 대체한다. 실 KIS 정정취소(`order-rvsecncl`) 연동은 후속 작업(#2391).
+- **`action="modify"` deferred caveat**: 정정 액션은 필드 스키마로 존재하나 **broker-level 정정이 현재 미구현(deferred)**이다. 룰 위반 시에는 RuleEngine(priority=100)이 룰 사유로 먼저 거부(`_consumed` 설정)하고, 룰 통과 시에만 Gateway(priority=50)가 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 terminal reject 처리하므로, 정정이 필요하면 `cancel` 후 재주문으로 대체한다. 실 KIS 정정취소(`order-rvsecncl`) 연동은 후속 작업(#2391).

--- a/docs/specs/strategy/03-03-order-action-fields.md
+++ b/docs/specs/strategy/03-03-order-action-fields.md
@@ -8,7 +8,7 @@
 
 | 필드 | 타입 | 기본값 | 설명 |
 |------|------|--------|------|
-| `action` | `str` | (필수) | `"cancel"` \| `"modify"` |
+| `action` | `str` | (필수) | `"cancel"` \| `"modify"` (단, `"modify"`는 broker-level 미구현/deferred — 아래 근거 참고) |
 | `order_id` | `str` | (필수) | 대상 주문 ID |
 | `quantity` | `float \| None` | `None` | modify 시 변경할 수량 |
 | `price` | `float \| None` | `None` | modify 시 변경할 가격 |
@@ -18,3 +18,4 @@
 - Signal(신규 주문)과 OrderAction(기존 주문 관리)을 분리 — 역할이 다르므로 타입도 분리
 - 전략이 `ctx.cancel_order()` / `ctx.modify_order()` 호출 시 내부 큐에 쌓이고, Bot이 on_step() 종료 후 일괄 처리
 - 취소/정정도 EventBus를 통해 RuleEngine 검증을 거침
+- **`action="modify"` deferred caveat**: 정정 액션은 필드 스키마로 존재하나 **broker-level 정정이 현재 미구현(deferred)**이다. 룰 통과 여부와 무관하게 Gateway가 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 terminal reject 처리하므로, 정정이 필요하면 `cancel` 후 재주문으로 대체한다. 실 KIS 정정취소(`order-rvsecncl`) 연동은 후속 작업(#2391).

--- a/docs/specs/strategy/03-05-strategy-context.md
+++ b/docs/specs/strategy/03-05-strategy-context.md
@@ -33,6 +33,7 @@ Bot이 생성하여 전략에 주입하는 제한된 시스템 API이다. 전략
    - 취소/정정: ctx.cancel_order() / ctx.modify_order() → 내부 큐 → Bot이 일괄 처리
    - 두 경로 모두 EventBus를 통해 RuleEngine 검증을 거침
    - NautilusTrader는 submit/cancel/modify 모두 전략 메서드로 직접 호출 — Ante도 취소/정정은 메서드 방식 채택 (기존 order_id를 참조해야 하므로 Signal 반환보다 자연스러움)
+   - **caveat (deferred)**: `ctx.modify_order()`는 API 표면으로 존재하나 **broker-level 정정은 현재 미구현(deferred)**이다. 룰 통과 여부와 무관하게 Gateway가 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 거부하므로, 정정이 필요하면 `ctx.cancel_order()` 후 재주문 패턴을 사용한다. 실 KIS 정정취소(`order-rvsecncl`) 연동은 후속 작업(#2391).
 
 3. **DataProvider 추상화**
    - 라이브 모드: API Gateway를 통한 실시간 데이터

--- a/docs/specs/strategy/03-05-strategy-context.md
+++ b/docs/specs/strategy/03-05-strategy-context.md
@@ -33,7 +33,7 @@ Bot이 생성하여 전략에 주입하는 제한된 시스템 API이다. 전략
    - 취소/정정: ctx.cancel_order() / ctx.modify_order() → 내부 큐 → Bot이 일괄 처리
    - 두 경로 모두 EventBus를 통해 RuleEngine 검증을 거침
    - NautilusTrader는 submit/cancel/modify 모두 전략 메서드로 직접 호출 — Ante도 취소/정정은 메서드 방식 채택 (기존 order_id를 참조해야 하므로 Signal 반환보다 자연스러움)
-   - **caveat (deferred)**: `ctx.modify_order()`는 API 표면으로 존재하나 **broker-level 정정은 현재 미구현(deferred)**이다. 룰 통과 여부와 무관하게 Gateway가 즉시 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 거부하므로, 정정이 필요하면 `ctx.cancel_order()` 후 재주문 패턴을 사용한다. 실 KIS 정정취소(`order-rvsecncl`) 연동은 후속 작업(#2391).
+   - **caveat (deferred)**: `ctx.modify_order()`는 API 표면으로 존재하나 **broker-level 정정은 현재 미구현(deferred)**이다. 룰 위반 시에는 RuleEngine이 룰 사유로 먼저 거부하고, 룰 통과 시에만 Gateway가 `OrderModifyRejectedEvent`(`reason="modify_not_implemented"`)로 거부하므로, 정정이 필요하면 `ctx.cancel_order()` 후 재주문 패턴을 사용한다. 실 KIS 정정취소(`order-rvsecncl`) 연동은 후속 작업(#2391).
 
 3. **DataProvider 추상화**
    - 라이브 모드: API Gateway를 통한 실시간 데이터

--- a/guide/strategy.md
+++ b/guide/strategy.md
@@ -86,7 +86,7 @@ history = await self.ctx.get_trade_history(symbol="005930", limit=50)
 self.ctx.cancel_order(order_id="ORD-001", reason="전략 조건 변경")
 ```
 
-> **주문 정정(`modify_order`)은 현재 broker-level 미구현(deferred)입니다.** `self.ctx.modify_order(...)`를 호출하면 룰 통과 여부와 무관하게 Gateway가 즉시 `modify_rejected`(`error_code="modify_not_implemented"`)로 거부하며, 정정 주문은 브로커까지 전달되지 않습니다. 미체결 주문의 가격·수량을 바꾸려면 **`cancel_order()`로 취소한 뒤 새 주문을 다시 제출**하세요. 실 KIS 국내주식 정정취소(`order-rvsecncl`) API 연동은 후속 작업(#2391)으로 분리되어 있습니다.
+> **주문 정정(`modify_order`)은 현재 broker-level 미구현(deferred)입니다.** `self.ctx.modify_order(...)`를 호출하면 정정 주문은 브로커까지 전달되지 않고 `modify_rejected` 상태로 거부되며, `on_order_update` 알림의 **`reason` 필드**로 사유가 전달됩니다(룰 통과 시 `reason="modify_not_implemented"`, 룰 위반 시에는 룰 사유). 미체결 주문의 가격·수량을 바꾸려면 **`cancel_order()`로 취소한 뒤 새 주문을 다시 제출**하세요. 실 KIS 국내주식 정정취소(`order-rvsecncl`) API 연동은 후속 작업(#2391)으로 분리되어 있습니다.
 
 **기술 지표:** `get_indicator()`로 기술 지표를 사용할 수 있습니다. 내부적으로 [pandas-ta](https://github.com/twopirllc/pandas-ta)를 사용하며, pandas-ta가 지원하는 130+ 지표를 모두 사용할 수 있습니다.
 

--- a/guide/strategy.md
+++ b/guide/strategy.md
@@ -84,8 +84,9 @@ history = await self.ctx.get_trade_history(symbol="005930", limit=50)
 
 ```python
 self.ctx.cancel_order(order_id="ORD-001", reason="전략 조건 변경")
-self.ctx.modify_order(order_id="ORD-001", price=59000, reason="지정가 수정")
 ```
+
+> **주문 정정(`modify_order`)은 현재 broker-level 미구현(deferred)입니다.** `self.ctx.modify_order(...)`를 호출하면 룰 통과 여부와 무관하게 Gateway가 즉시 `modify_rejected`(`error_code="modify_not_implemented"`)로 거부하며, 정정 주문은 브로커까지 전달되지 않습니다. 미체결 주문의 가격·수량을 바꾸려면 **`cancel_order()`로 취소한 뒤 새 주문을 다시 제출**하세요. 실 KIS 국내주식 정정취소(`order-rvsecncl`) API 연동은 후속 작업(#2391)으로 분리되어 있습니다.
 
 **기술 지표:** `get_indicator()`로 기술 지표를 사용할 수 있습니다. 내부적으로 [pandas-ta](https://github.com/twopirllc/pandas-ta)를 사용하며, pandas-ta가 지원하는 130+ 지표를 모두 사용할 수 있습니다.
 
@@ -120,7 +121,7 @@ self.ctx.modify_order(order_id="ORD-001", price=59000, reason="지정가 수정"
 | `on_start()` | 봇 시작 시 1회 | — |
 | `on_stop()` | 봇 중지 시 1회 | — |
 | `on_fill(fill)` | 주문 체결 시 | `list[Signal]` (후속 주문 가능) |
-| `on_order_update(update)` | 주문 상태 변경 시 (접수/거부/취소) | — |
+| `on_order_update(update)` | 주문 상태 변경 시 (접수/거부/취소/정정거부) | — |
 | `on_data(data)` | 외부 시그널 수신 시 (`accepts_external_signals=True`) | `list[Signal]` |
 | `get_rules()` | 전략별 거래 룰 반환 | `dict` |
 | `get_params()` | 백테스트 최적화 파라미터 | `dict` |
@@ -387,7 +388,7 @@ ante signal connect --key sk_a1b2c3d4e5f6...
 |------|------|
 | `ack` | 시그널 접수 확인 |
 | `fill` | 주문 체결 통보 (종목, 수량, 체결가, 수수료) |
-| `order_update` | 주문 상태 변경 (접수, 거부, 취소, 실패) |
+| `order_update` | 주문 상태 변경 (접수, 거부, 취소, 정정거부, 실패) |
 | `result` | query 응답 |
 | `pong` | ping 응답 |
 


### PR DESCRIPTION
Closes #2390

## Summary
`guide/strategy.md` + 설계 스펙이 `ctx.modify_order()`를 정상 주문관리 API로 안내하지만, broker-level 주문 정정은 전혀 미구현이라 런타임은 `modify_not_implemented`로 즉시 거부한다(가이드/스펙 ↔ 런타임 불일치). 사용자 결정(**Hybrid**)에 따라 본 PR은 **docs/spec-only SSOT 정렬**로 modify를 broker-level 미구현(deferred)으로 통일하고, 실제 KIS 정정 구현은 **follow-up #2391**로 분리한다. **코드 로직 변경 0건.**

수정 표면(11개 .md, modify를 supported로 약속하던 전 지점):
- `guide/strategy.md` — modify_order를 정상 예시에서 분리 + 미지원/`modify_rejected`(`reason` 필드) 명시 + cancel 후 재주문 안내. on_order_update 상태 목록에 정정거부 보강.
- `docs/specs/api-gateway/api-gateway.md` — OrderModifyEvent를 deferred로 재규정. RuleEngine(priority=100) 선처리, `modify_not_implemented`는 룰 통과 후 Gateway(priority=50) 경로 한정.
- `docs/specs/strategy/{03-01,03-03,03-05}` — modify_order/action=modify deferred caveat.
- `docs/specs/{backtest/02,rule-engine/07,bot/03,bot/04,eventbus}` — modify deferred caveat + eventbus OrderModifyEvent 구독자에 APIGateway 보강.
- `docs/specs/broker-adapter/08-kis-domestic-adapter.md` — endpoint 표 '취소/정정' → '취소 (정정 미구현)' 정합화.

## 검증/리뷰
- 설계: 검증 워크플로(5축) + Codex Plan Review 3라운드(누락 표면 점진 발견 + #2360 stale 정정) → approve-implement
- Codex 브랜치 리뷰: 3 attempt(정정 거부 흐름 정확화) 후 PASS
- `git diff --name-only`: 11개 전부 `.md` (src/·tests/ 0건). sweep: modify를 supported로 약속하는 잔존 표면 0건. main HEAD 불변.

## Test Plan
- docs/spec-only(코드 0건) — 신규 테스트 없음. markdown 렌더/링크 정상. `gateway.py`/`test_gateway_modify.py` 미변경.
- 실 KIS 정정 기능·테스트는 follow-up #2391(order-rvsecncl 정정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
