### PR TITLE
feat(core): #2397 RuntimeReadinessRegistry — per-account readiness + self-healing (observe-only)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -270,7 +270,8 @@ src/ante/
 │   ├── presets.py
 │   ├── scoping.py
 │   ├── service.py
-│   └── timezone.py
+│   ├── timezone.py
+│   └── readiness.py
 ├── db/
 │   ├── versions/
 │   │   ├── __init__.py
@@ -726,7 +727,9 @@ tests/
 │   ├── test_kis_error_codes_40910000.py
 │   ├── test_kis_modify_order.py
 │   ├── test_order_tracker_order_price.py
-│   └── test_recorder_modified.py
+│   ├── test_recorder_modified.py
+│   ├── test_account_runtime_readiness.py
+│   └── test_main_runtime_readiness_wiring.py
 ├── __init__.py
 └── integration/
     ├── __init__.py

--- a/src/ante/account/__init__.py
+++ b/src/ante/account/__init__.py
@@ -14,6 +14,12 @@ from ante.account.errors import (
 )
 from ante.account.models import Account, AccountStatus, BrokerPreset, TradingMode
 from ante.account.presets import BROKER_PRESETS
+from ante.account.readiness import (
+    ALL_FLAGS,
+    ReadinessFlag,
+    RuntimeReadinessRegistry,
+    is_flag_exempt,
+)
 from ante.account.scoping import (
     ACCOUNT_ID_PATTERN,
     INVALID_RUNTIME_ACCOUNT_IDS,
@@ -26,6 +32,7 @@ from ante.account.service import AccountService
 
 __all__ = [
     "ACCOUNT_ID_PATTERN",
+    "ALL_FLAGS",
     "Account",
     "AccountAlreadyExistsError",
     "AccountDeletedException",
@@ -43,7 +50,10 @@ __all__ = [
     "InvalidExchangeError",
     "MissingCredentialsError",
     "RESTRICTED_NEW_ACCOUNT_IDS",
+    "ReadinessFlag",
+    "RuntimeReadinessRegistry",
     "TradingMode",
+    "is_flag_exempt",
     "is_invalid_account_id",
     "require_account_id",
     "validate_new_account_id",

--- a/src/ante/account/readiness.py
+++ b/src/ante/account/readiness.py
@@ -1,0 +1,175 @@
+"""RuntimeReadinessRegistry — per-account runtime readiness SSOT (D-ACC-09, #2397).
+
+스펙 SSOT: [docs/specs/account/02-design-decisions.md — D-ACC-09](
+../../../docs/specs/account/02-design-decisions.md) ·
+[05-eventbus-integration.md](../../../docs/specs/account/05-eventbus-integration.md).
+
+`AccountStatus`(user kill-switch 축)와 **직교**하는 service-health 자동축이다.
+주문 가능 여부(``active_trading_ready``)는 broker/treasury_sync/fill/reconcile
+스케줄러 등록 성공/실패에서 derive 한다. SSOT 는 본 registry **단독**이며,
+``Services.fill_schedulers``/``reconcile_schedulers`` dict 는 스케줄러 인스턴스
+보관용일 뿐이다(reader 는 registry 만 조회).
+
+본 PR(#2397)은 registry 를 채우기만 한다(관측-only). active-order gate reader
+는 #2398 에서 추가한다 — 따라서 이 모듈을 도입해도 **주문 동작은 불변**이다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from ante.account.models import TradingMode
+
+
+class ReadinessFlag(StrEnum):
+    """per-account runtime readiness 4 플래그 (D-ACC-09 §2)."""
+
+    BROKER = "broker_ready"
+    TREASURY_SYNC = "treasury_sync_ready"
+    FILL_RECONCILE = "fill_reconcile_ready"
+    RECONCILE = "reconcile_ready"
+
+
+# active-trading 전제 플래그 전부. ``active_trading_ready`` 는 면제 매트릭스로
+# 면제된 플래그를 ``True`` 로 취급한 뒤 이 집합 전체를 AND 한다(D-ACC-09 §2).
+ALL_FLAGS: tuple[ReadinessFlag, ...] = (
+    ReadinessFlag.BROKER,
+    ReadinessFlag.TREASURY_SYNC,
+    ReadinessFlag.FILL_RECONCILE,
+    ReadinessFlag.RECONCILE,
+)
+
+
+def is_flag_exempt(
+    flag: ReadinessFlag,
+    *,
+    broker_type: str,
+    trading_mode: TradingMode,
+) -> bool:
+    """``(broker_type, trading_mode)`` pair 에서 ``flag`` 가 면제(항상 ready)인가.
+
+    면제 매트릭스 (D-ACC-09 §4, normative). 열: broker / treasury_sync /
+    fill_reconcile / reconcile.
+
+    - ``(test, virtual)``        → 면제 / 요구 / 면제 / 면제
+    - ``(kis-domestic, virtual)``→ 면제 / 요구 / 면제 / 면제
+    - ``(kis-domestic, live)``   → 요구 / 요구 / 요구 / 요구
+
+    분기축:
+    - ``broker``/``fill_reconcile``/``reconcile`` 의 면제축은 **trading_mode** 다.
+      VIRTUAL 은 broker API 를 미호출(``VirtualExecutor`` 가 가상 체결)하므로
+      broker-backed readiness 가 무의미하다 → 면제(항상 ready). LIVE 는 요구.
+    - ``treasury_sync`` 는 VIRTUAL(broker=None Trade-DB sync) 도 sync 를 시작하므로
+      **trading_mode 무관 항상 요구**다.
+
+    default 정책은 **fail-closed**: 매트릭스에 미지정인 미래 ``(broker_type,
+    trading_mode)`` pair 는 모든 플래그를 요구로 취급한다([must_fix A]).
+    """
+    if flag is ReadinessFlag.TREASURY_SYNC:
+        # treasury_sync 는 VIRTUAL/LIVE 양쪽에서 항상 요구다(면제 없음).
+        return False
+
+    # broker/fill_reconcile/reconcile: VIRTUAL 만 면제. LIVE(및 미지정 fail-closed)
+    # 는 요구. VIRTUAL 은 broker_type(test/kis-domestic) 무관 면제다.
+    return trading_mode == TradingMode.VIRTUAL
+
+
+@dataclass
+class _AccountReadiness:
+    """단일 계좌의 readiness 상태. 디폴트는 전부 not_ready(fail-closed)."""
+
+    # 명시 ``mark_ready`` 이전에는 모두 not_ready 다(디폴트 fail-closed, §2).
+    ready: dict[ReadinessFlag, bool] = field(default_factory=dict)
+    # 마지막 not_ready 사유(관측·알림용). flag 가 ready 면 제거된다.
+    reasons: dict[ReadinessFlag, str] = field(default_factory=dict)
+
+
+class RuntimeReadinessRegistry:
+    """per-account runtime readiness SSOT (D-ACC-09).
+
+    registry-owned 권위: ``main._init_*`` 등록자가 스케줄러 등록과 **동시에**
+    ``mark_ready``/``mark_not_ready(reason)`` 로 명시 기록하는 단일 mark 경로다
+    ([must_fix F]). reader(#2398 gateway/RuleEngine/Treasury)는
+    ``active_trading_ready`` 만 호출한다.
+
+    면제 매트릭스는 ``active_trading_ready`` derive 시점에 적용한다 — 면제 플래그는
+    명시 mark 없이도 ready 로 취급된다. 단 등록자는 면제 계좌에도 no-op ready 를
+    명시 mark 하여 관측 일관성(상태 introspection·테스트 회귀 락)을 보장한다.
+    """
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, _AccountReadiness] = {}
+
+    def _entry(self, account_id: str) -> _AccountReadiness:
+        entry = self._accounts.get(account_id)
+        if entry is None:
+            entry = _AccountReadiness()
+            self._accounts[account_id] = entry
+        return entry
+
+    def mark_ready(self, account_id: str, flag: ReadinessFlag) -> None:
+        """``flag`` 를 ready 로 표시한다(connect/start 성공 시점).
+
+        면제 계좌의 no-op ready mark 도 이 경로를 쓴다.
+        """
+        entry = self._entry(account_id)
+        entry.ready[flag] = True
+        entry.reasons.pop(flag, None)
+
+    def mark_not_ready(self, account_id: str, flag: ReadinessFlag, reason: str) -> None:
+        """``flag`` 를 not_ready 로 표시한다(connect/start 실패·skip 시점).
+
+        ``reason`` 은 관측·알림용 사유다(예: ``EGW00133``, ``timeout``,
+        ``connected_count==0``).
+        """
+        entry = self._entry(account_id)
+        entry.ready[flag] = False
+        entry.reasons[flag] = reason
+
+    def is_ready(self, account_id: str, flag: ReadinessFlag) -> bool:
+        """단일 ``flag`` 가 명시 ready 인지(디폴트 fail-closed = False).
+
+        면제는 반영하지 않는다(raw mark 조회). 면제 포함 판정은
+        ``active_trading_ready`` 를 쓴다.
+        """
+        entry = self._accounts.get(account_id)
+        if entry is None:
+            return False
+        return entry.ready.get(flag, False)
+
+    def get_reason(self, account_id: str, flag: ReadinessFlag) -> str | None:
+        """``flag`` 의 마지막 not_ready 사유(없으면 None)."""
+        entry = self._accounts.get(account_id)
+        if entry is None:
+            return None
+        return entry.reasons.get(flag)
+
+    def active_trading_ready(
+        self,
+        account_id: str,
+        *,
+        broker_type: str,
+        trading_mode: TradingMode,
+    ) -> bool:
+        """active-trading 전제 플래그 전부의 AND (단일 derive 함수, §2).
+
+        면제 매트릭스로 면제된 플래그는 ``True`` 로 취급한 뒤 AND 한다. 비면제
+        플래그는 명시 ready 여야 한다(디폴트 fail-closed → not_ready 면 False).
+
+        본 PR(#2397)은 이 함수를 호출하는 gate reader 를 **추가하지 않는다**
+        (gate=#2398). 관측·테스트 용으로만 노출한다(주문 동작 불변).
+        """
+        for flag in ALL_FLAGS:
+            if is_flag_exempt(flag, broker_type=broker_type, trading_mode=trading_mode):
+                continue
+            if not self.is_ready(account_id, flag):
+                return False
+        return True
+
+    def not_ready_flags(self, account_id: str) -> list[ReadinessFlag]:
+        """현재 not_ready(명시 mark 기준)인 플래그 목록(관측·self-healing 용)."""
+        entry = self._accounts.get(account_id)
+        if entry is None:
+            return list(ALL_FLAGS)
+        return [flag for flag in ALL_FLAGS if not entry.ready.get(flag, False)]

--- a/src/ante/account/readiness.py
+++ b/src/ante/account/readiness.py
@@ -70,9 +70,15 @@ def is_flag_exempt(
         # treasury_sync 는 VIRTUAL/LIVE 양쪽에서 항상 요구다(면제 없음).
         return False
 
-    # broker/fill_reconcile/reconcile: VIRTUAL 만 면제. LIVE(및 미지정 fail-closed)
-    # 는 요구. VIRTUAL 은 broker_type(test/kis-domestic) 무관 면제다.
-    return trading_mode == TradingMode.VIRTUAL
+    # broker/fill_reconcile/reconcile: **명시된 면제 pair만** 면제(fail-closed).
+    # (test, virtual)·(kis-domestic, virtual) 만 면제하고, 미지정 (broker_type,
+    # trading_mode) pair(신규 broker 타입 포함)는 요구로 fail-closed 한다
+    # ([must_fix A], Codex P2 — trading_mode 만 보면 신규 broker+virtual 이
+    # fail-open 으로 broker/fill/reconcile readiness 를 기본 면제받는 회귀).
+    return trading_mode == TradingMode.VIRTUAL and broker_type in {
+        "test",
+        "kis-domestic",
+    }
 
 
 @dataclass

--- a/src/ante/config/defaults.py
+++ b/src/ante/config/defaults.py
@@ -16,6 +16,15 @@ DEFAULTS: dict[str, object] = {
     "instrument.cache_ttl_seconds": 3600,
     "treasury.sync_interval_seconds": 300,
     "audit.retention_days": 90,
+    # ── runtime readiness self-healing (D-ACC-09, #2397) ──
+    # broker not_ready 계좌의 self-healing background retry loop 튜닝.
+    # liveness invariant: max_attempts 는 per-burst(연결시도 단위)에만 적용하고,
+    # 계좌 lifetime 은 무제한이다(일시 토큰압박이 영구 not_ready 로 고착 금지).
+    # backoff 는 EGW00133(~60s) 토큰 cooldown 에 정렬한다.
+    "readiness.self_healing_interval_seconds": 60,
+    "readiness.self_healing_backoff_base_seconds": 5,
+    "readiness.self_healing_backoff_max_seconds": 60,
+    "readiness.self_healing_max_attempts_per_burst": 5,
     # ── 리스크 관리 ──
     "rule.daily_loss_limit": 0.05,
     "rule.max_exposure_percent": 0.20,

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1202,40 +1202,59 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
     """
     account_id = account.account_id
 
-    # broker_ready 가 이미 ready 면 회복 불필요.
-    if s.runtime_readiness is not None and s.runtime_readiness.is_ready(
-        account_id, ReadinessFlag.BROKER
-    ):
+    if s.runtime_readiness is None:
         return True
 
-    try:
-        broker = await s.account_service.get_broker(account_id)
-        await broker.connect()
-    except Exception:
-        # 회복 미성공 — not_ready 유지. 다음 burst 에서 재시도(liveness).
-        _mark_runtime_not_ready(s, account_id, ReadinessFlag.BROKER, "reconnect_failed")
-        return False
+    # broker 재연결: broker_ready 가 **비면제**이고 아직 not_ready 일 때만.
+    # (broker 면제 계좌[virtual/test]는 connect 불요 — no-op ready 유지.)
+    broker_exempt = is_flag_exempt(
+        ReadinessFlag.BROKER,
+        broker_type=account.broker_type,
+        trading_mode=account.trading_mode,
+    )
+    if not broker_exempt and not s.runtime_readiness.is_ready(
+        account_id, ReadinessFlag.BROKER
+    ):
+        try:
+            broker = await s.account_service.get_broker(account_id)
+            await broker.connect()
+        except Exception:
+            # 회복 미성공 — not_ready 유지. 다음 burst 에서 재시도(liveness).
+            _mark_runtime_not_ready(
+                s, account_id, ReadinessFlag.BROKER, "reconnect_failed"
+            )
+            return False
+        _mark_runtime_ready(s, account_id, ReadinessFlag.BROKER)
+        logger.info("Readiness self-healing: broker 회복 — account=%s", account_id)
 
-    _mark_runtime_ready(s, account_id, ReadinessFlag.BROKER)
-    logger.info("Readiness self-healing: broker 회복 — account=%s", account_id)
-
-    # broker 회복 후 의존 스케줄러를 idempotent 재등록한다.
+    # 의존 스케줄러 idempotent 재등록 — broker 외 readiness(fill/reconcile/treasury)
+    # 실패도 재시도해 active_trading_ready 까지 회복한다(Codex P1: broker_ready 만
+    # 보면 일시 fill/reconcile/treasury 실패가 #2398 gate 에서 영구 차단으로 고착).
     if s.fill_applier is not None and s.order_tracker is not None:
         await _register_fill_scheduler_for_account(s, account)
     if s.trade_service is not None:
-        reconciler = _build_reconciler(s)
+        # reconcile.enabled=false 면 _init_reconcile_scheduler 와 동일하게 재등록하지
+        # 않는다 — 운영자가 끈 reconcile 을 회복 시 다시 켜지 않도록(Codex P2).
+        reconcile_enabled = True
         interval = 1800
         if s.config is not None:
             reconcile_config = s.config.get("reconcile", {})
             if isinstance(reconcile_config, dict):
+                reconcile_enabled = reconcile_config.get("enabled", True)
                 interval = reconcile_config.get("interval_seconds", 1800)
-        await _register_reconcile_scheduler_for_account(
-            s, account, reconciler, interval
-        )
-    # treasury_sync 재시작(면제 없음). 멱등 — Treasury.start_sync 가 기존 sync 를
-    # 교체한다.
+        if reconcile_enabled:
+            reconciler = _build_reconciler(s)
+            await _register_reconcile_scheduler_for_account(
+                s, account, reconciler, interval
+            )
+    # treasury_sync 재시작(면제 없음). 멱등 — Treasury.start_sync 가 기존 sync 교체.
     await _init_treasury_sync(s, [account])
-    return True
+    # 모든 비면제 플래그가 ready 여야 회복 완료(active_trading_ready 기준).
+    return s.runtime_readiness.active_trading_ready(
+        account_id,
+        broker_type=account.broker_type,
+        trading_mode=account.trading_mode,
+    )
 
 
 async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
@@ -1256,11 +1275,17 @@ async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
 
     try:
         while True:
+            # active_trading_ready(비면제 전 플래그 AND) 기준 — broker 회복 후에도
+            # fill/reconcile/treasury 가 not_ready면 계속 재시도(Codex P1 liveness).
             pending = [
                 a
                 for a in targets
                 if s.runtime_readiness is not None
-                and not s.runtime_readiness.is_ready(a.account_id, ReadinessFlag.BROKER)
+                and not s.runtime_readiness.active_trading_ready(
+                    a.account_id,
+                    broker_type=a.broker_type,
+                    trading_mode=a.trading_mode,
+                )
             ]
             for account in pending:
                 # per-burst bounded 재시도(계좌 lifetime 은 무제한).

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1201,6 +1201,20 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
        한다(기존 task cancel 후 교체 — orphan 방지). per-account 만 갱신하고 전역
        barrier ``fill_catch_up_failed_accounts.clear()`` 는 호출하지 않는다
        (타 계좌 #1946 barrier 보존).
+    3. ``broker_ready`` 는 의존 rebind 를 모두 마친 **뒤** mark 한다(stale-broker
+       false-ready 창 제거).
+
+    Known limitations (bounded — 메타리뷰, follow-up 후보):
+    - 비-broker flag(fill/treasury) 반복 실패는 broker 캐시 세션을 건강하다고
+      **신뢰**한다. 본 PR 은 ``broker_ready`` 강등 경로가 없어 "broker_ready=True
+      이나 세션 사망" 조합이 발생하지 않는다. 강등 도입(#2398 reader live-poll 등)
+      시 회복 경로의 broker 캐시 무효화 재검토가 필요하다.
+    - ``broker_just_recovered`` rebind(기존 스케줄러 교체) 분기는 startup connect
+      실패 시 스케줄러가 애초에 생성되지 않으므로 현 PR 에서 production-도달 불가한
+      방어 경로다(broker_ready 강등 도입 시 live 化).
+    - 다계좌 pending 의 burst backoff 는 계좌별 순차 직렬이라 한 영구실패 계좌가
+      뒤 계좌 회복을 bounded 지연시킨다(liveness 무손상). app_key 단위 backoff
+      그룹화는 follow-up.
 
     Returns:
         모든 비면제 플래그 ready(active_trading_ready) 여부.
@@ -1230,9 +1244,13 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
                 s, account_id, ReadinessFlag.BROKER, "reconnect_failed"
             )
             return False
-        _mark_runtime_ready(s, account_id, ReadinessFlag.BROKER)
+        # broker connect 성공 — 단, broker_ready mark 는 의존 스케줄러 rebind 를 모두
+        # 마친 **뒤**로 지연한다(메타리뷰 P2). 여기서 먼저 mark 하면 아래 rebind await
+        # 사이에 broker_ready=True 이면서 fill/reconcile/treasury 는 아직 stale·미rebind
+        # 인 상태가 active_trading_ready=True 로 관측될 수 있어, #2398 active-order gate
+        # 도입 시 stale broker 로 주문이 통과하는 창이 생긴다. 마지막에 mark 하면 회복이
+        # reader 관점에서 원자적으로 보인다(rebind 동안 broker_ready=not_ready → 차단).
         broker_just_recovered = True
-        logger.info("Readiness self-healing: broker 회복 — account=%s", account_id)
 
     # 의존 스케줄러 재시도 — **재등록 churn 방지**(Codex P2 attempt-3): 각 플래그는
     # 실제 not_ready 이거나 broker 가 방금 재연결된 경우에만 재등록한다. treasury 만
@@ -1299,6 +1317,13 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
         account_id, ReadinessFlag.TREASURY_SYNC
     ):
         await _init_treasury_sync(s, [account])
+    # broker_ready 를 **마지막에** mark(메타리뷰 P2: stale-broker false-ready 창 제거).
+    # broker_just_recovered 일 때만 mark — 이미 ready 였던 계좌는 재mark 불요(broker
+    # reconnect churn 방지). 의존 rebind 가 모두 끝난 뒤이므로 이 시점에 broker_ready
+    # 가 True 가 되어도 active_trading_ready 는 stale 상태를 ready 로 오인하지 않는다.
+    if broker_just_recovered:
+        _mark_runtime_ready(s, account_id, ReadinessFlag.BROKER)
+        logger.info("Readiness self-healing: broker 회복 — account=%s", account_id)
     # 모든 비면제 플래그가 ready 여야 회복 완료(active_trading_ready 기준).
     return s.runtime_readiness.active_trading_ready(
         account_id,
@@ -1348,7 +1373,22 @@ async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
             for account in pending:
                 # per-burst bounded 재시도(계좌 lifetime 은 무제한).
                 for attempt in range(max_per_burst):
-                    if await _self_healing_recover_account(s, account):
+                    try:
+                        recovered = await _self_healing_recover_account(s, account)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        # 회복 시도 중 예기치 못한 예외(스케줄러 생성자·config 접근·
+                        # reconciler 빌드 등 try 밖 경로)가 background loop 를 영구
+                        # 사멸시키지 않도록 격리한다(메타리뷰 P1: liveness invariant
+                        # 방어 — 한 계좌의 예외가 전 계좌 회복을 멈추면 #2395 역회귀).
+                        # 다음 attempt/계좌/burst 로 계속한다.
+                        logger.exception(
+                            "Readiness self-healing 회복 예외 — account=%s (루프 유지)",
+                            account.account_id,
+                        )
+                        recovered = False
+                    if recovered:
                         break
                     # attempt 간 지수 backoff(EGW00133 ~1/min 토큰 cooldown 정렬,
                     # Codex P2). 즉시 재인증을 몰아넣어 KIS 토큰 압박을 악화시키지

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1293,7 +1293,8 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
             # active_trading_ready 가 영영 False 가 되는 회귀 차단.)
             _mark_runtime_ready(s, account_id, ReadinessFlag.RECONCILE)
     # treasury_sync(면제 없음) — not_ready 이거나 broker 재연결(LIVE 는 broker 핸들에
-    # 묶임) 시에만 재동기화. 멱등 — Treasury.start_sync 가 기존 sync 교체.
+    # 묶임) 시에만 재동기화. _init_treasury_sync 가 stop_sync 선행으로 idempotent
+    # replace 하므로 stale broker sync 가 새 broker 로 교체된다(Codex P2 attempt-4).
     if broker_just_recovered or not s.runtime_readiness.is_ready(
         account_id, ReadinessFlag.TREASURY_SYNC
     ):
@@ -1621,6 +1622,11 @@ async def _init_treasury_sync(s: Services, accounts: list) -> None:
     for account in accounts:
         try:
             treasury = s.treasury_manager.get(account.account_id)
+            # 기존 sync 를 먼저 중지(idempotent replace) — Treasury.start_sync 는
+            # 실행 중 task 가 있으면 경고 후 no-op 이므로, broker 회복 시 stale broker
+            # 로 도는 sync 를 새 broker 로 교체하려면 stop_sync 선행이 필수다
+            # (Codex P2 attempt-4). startup 초기 호출에서는 task 가 없어 no-op.
+            await treasury.stop_sync()
             trading_mode = getattr(account, "trading_mode", TradingMode.VIRTUAL)
             is_virtual = trading_mode == TradingMode.VIRTUAL
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1193,15 +1193,17 @@ def _start_readiness_self_healing(s: Services, accounts: list[Any]) -> None:
 async def _self_healing_recover_account(s: Services, account: Any) -> bool:
     """단일 not_ready broker 계좌의 1회 회복 시도(connect → idempotent 재등록).
 
-    회복(connect 성공) 시:
-    1. ``broker_ready`` 를 ready 로 전이.
-    2. fill_recovery + reconcile + treasury_sync 를 **idempotent re-register**
-       (기존 task cancel 후 교체 — orphan 방지). per-account 만 갱신하고 전역
+    회복 시:
+    1. broker 가 비면제·not_ready 이면 connect 재시도 → 성공 시 ``broker_ready``
+       전이(``broker_just_recovered``).
+    2. 의존 스케줄러(fill_recovery/reconcile/treasury_sync)는 **해당 플래그가 실제
+       not_ready 이거나 broker 가 방금 재연결된 경우에만** idempotent re-register
+       한다(기존 task cancel 후 교체 — orphan 방지). per-account 만 갱신하고 전역
        barrier ``fill_catch_up_failed_accounts.clear()`` 는 호출하지 않는다
        (타 계좌 #1946 barrier 보존).
 
     Returns:
-        broker connect 성공(broker_ready 전이) 여부.
+        모든 비면제 플래그 ready(active_trading_ready) 여부.
     """
     account_id = account.account_id
 
@@ -1215,6 +1217,7 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
         broker_type=account.broker_type,
         trading_mode=account.trading_mode,
     )
+    broker_just_recovered = False
     if not broker_exempt and not s.runtime_readiness.is_ready(
         account_id, ReadinessFlag.BROKER
     ):
@@ -1228,27 +1231,49 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
             )
             return False
         _mark_runtime_ready(s, account_id, ReadinessFlag.BROKER)
+        broker_just_recovered = True
         logger.info("Readiness self-healing: broker 회복 — account=%s", account_id)
 
-    # 의존 스케줄러 재시도 — **플래그별 면제 인식**(Codex P2). broker 면제 계좌
-    # (virtual/test)는 fill/reconcile 도 면제(startup no-op ready)이므로 broker-backed
-    # 재등록을 건너뛰어 get_broker 재노출을 막고, 비면제 플래그만 재시도한다.
-    # treasury_sync 는 면제 없음 → 전 계좌 재시도(broker 면제 계좌의 일시 treasury
-    # 실패도 회복). broker 외 readiness 실패도 active_trading_ready 까지 회복한다
-    # (Codex P1: broker_ready 만 보면 일시 실패가 #2398 gate 에서 영구 차단 고착).
+    # 의존 스케줄러 재시도 — **재등록 churn 방지**(Codex P2 attempt-3): 각 플래그는
+    # 실제 not_ready 이거나 broker 가 방금 재연결된 경우에만 재등록한다. treasury 만
+    # not_ready 인 LIVE 계좌에서 건강한 fill/reconcile 스케줄러를 매 attempt 마다
+    # stop/재시작해 불필요한 KIS 호출·폴링 공백을 만들던 회귀를 차단한다. broker 가
+    # 방금 회복되면 fill/reconcile/treasury(LIVE) 가 묶인 broker 핸들이 재연결됐으므로
+    # rebind 위해 재등록한다.
+    # **플래그별 면제 인식**(Codex P2 attempt-2): broker 면제 계좌(virtual/test)는
+    # fill/reconcile 도 면제(startup no-op ready)이므로 broker-backed 재등록을 건너뛰어
+    # get_broker 재노출을 막고, treasury_sync(면제 없음)만 재시도한다. broker 외
+    # readiness 실패도 active_trading_ready 까지 회복한다(Codex P1: broker_ready 만
+    # 보면 일시 실패가 #2398 gate 에서 영구 차단 고착).
     fill_exempt = is_flag_exempt(
         ReadinessFlag.FILL_RECONCILE,
         broker_type=account.broker_type,
         trading_mode=account.trading_mode,
     )
-    if not fill_exempt and s.fill_applier is not None and s.order_tracker is not None:
+    fill_needs_register = broker_just_recovered or not s.runtime_readiness.is_ready(
+        account_id, ReadinessFlag.FILL_RECONCILE
+    )
+    if (
+        not fill_exempt
+        and fill_needs_register
+        and s.fill_applier is not None
+        and s.order_tracker is not None
+    ):
         await _register_fill_scheduler_for_account(s, account)
     reconcile_exempt = is_flag_exempt(
         ReadinessFlag.RECONCILE,
         broker_type=account.broker_type,
         trading_mode=account.trading_mode,
     )
-    if not reconcile_exempt and s.trade_service is not None:
+    reconcile_needs_register = (
+        broker_just_recovered
+        or not s.runtime_readiness.is_ready(account_id, ReadinessFlag.RECONCILE)
+    )
+    if (
+        not reconcile_exempt
+        and reconcile_needs_register
+        and s.trade_service is not None
+    ):
         reconcile_enabled = True
         interval = 1800
         if s.config is not None:
@@ -1267,9 +1292,12 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
             # (Codex P2: 비활성 reconcile 비면제 계좌가 영구 not_ready 로 고착되어
             # active_trading_ready 가 영영 False 가 되는 회귀 차단.)
             _mark_runtime_ready(s, account_id, ReadinessFlag.RECONCILE)
-    # treasury_sync 재시작(면제 없음 — 전 계좌). 멱등 — Treasury.start_sync 가
-    # 기존 sync 교체.
-    await _init_treasury_sync(s, [account])
+    # treasury_sync(면제 없음) — not_ready 이거나 broker 재연결(LIVE 는 broker 핸들에
+    # 묶임) 시에만 재동기화. 멱등 — Treasury.start_sync 가 기존 sync 교체.
+    if broker_just_recovered or not s.runtime_readiness.is_ready(
+        account_id, ReadinessFlag.TREASURY_SYNC
+    ):
+        await _init_treasury_sync(s, [account])
     # 모든 비면제 플래그가 ready 여야 회복 완료(active_trading_ready 기준).
     return s.runtime_readiness.active_trading_ready(
         account_id,

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -25,6 +25,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from ante.account.models import TradingMode
+from ante.account.readiness import (
+    ReadinessFlag,
+    RuntimeReadinessRegistry,
+    is_flag_exempt,
+)
 from ante.config import Config, DynamicConfigService
 from ante.core import Database
 from ante.eventbus import EventBus, EventHistoryStore
@@ -179,6 +185,15 @@ class Services:
     # ReconcileScheduler 는 기동 즉시 대사에서 "외부 매수" 분류를 건너뛰어
     # (skip_initial_external_buy), 미복구 ante 체결을 외부 매수로 오분류하지 않는다.
     fill_catch_up_failed_accounts: set[str] = field(default_factory=set)
+    # #2397 D-ACC-09: per-account runtime readiness SSOT. main(등록자)이 _init_*
+    # 에서 mark 하고, reader(#2398 gateway/RuleEngine/Treasury)가 동일 인스턴스를
+    # 주입받아 active_trading_ready 만 조회한다. 본 PR 은 채우기만 한다(관측-only).
+    runtime_readiness: RuntimeReadinessRegistry = field(
+        default_factory=RuntimeReadinessRegistry
+    )
+    # #2397 D-ACC-09 R5: broker not_ready 계좌를 무기한 재시도하는 self-healing
+    # background retry loop 핸들. shutdown 에서 scheduler dict 정리 전 cancel 한다.
+    readiness_self_healing_task: asyncio.Task | None = None  # type: ignore[type-arg]
     daily_report_scheduler: Any = None
     data_provider: Any = None
     parquet_store: Any = None
@@ -192,6 +207,74 @@ class Services:
     approval_expire_task: asyncio.Task | None = None  # type: ignore[type-arg]
     audit_cleanup_task: asyncio.Task | None = None  # type: ignore[type-arg]
     _cleanup_tasks: list[str] = field(default_factory=list)
+
+
+# ── #2397 D-ACC-09 runtime readiness mark helpers ─────────────────────────
+
+
+def _account_trading_mode(account: Any) -> TradingMode:
+    """Account 의 trading_mode 를 안전하게 추출(미설정 시 VIRTUAL 디폴트)."""
+    return getattr(account, "trading_mode", TradingMode.VIRTUAL)
+
+
+def _flag_exempt_for_account(flag: ReadinessFlag, account: Any) -> bool:
+    """면제 매트릭스 적용 — ``account`` 의 (broker_type, trading_mode) 기준."""
+    return is_flag_exempt(
+        flag,
+        broker_type=getattr(account, "broker_type", "test"),
+        trading_mode=_account_trading_mode(account),
+    )
+
+
+def _broker_ready_exempt(account: Any) -> bool:
+    """broker_ready 면제 계좌(virtual/test)인지 — connect 시도 전 분기."""
+    return _flag_exempt_for_account(ReadinessFlag.BROKER, account)
+
+
+def _mark_runtime_ready(s: Services, account_id: str, flag: ReadinessFlag) -> None:
+    """registry ready mark. registry 미주입 환경(partial wiring)에서는 no-op."""
+    if s.runtime_readiness is not None:
+        s.runtime_readiness.mark_ready(account_id, flag)
+
+
+def _mark_runtime_not_ready(
+    s: Services, account_id: str, flag: ReadinessFlag, reason: str
+) -> None:
+    """registry not_ready mark. registry 미주입 환경에서는 no-op."""
+    if s.runtime_readiness is not None:
+        s.runtime_readiness.mark_not_ready(account_id, flag, reason)
+
+
+def _mark_fill_reconcile_global_skip(s: Services, accounts: list[Any]) -> None:
+    """전역 fill skip(connected_count==0 등) 시 면제 우선 mark (이중 실패모드 a).
+
+    면제(virtual/test) 계좌는 broker-backed 스케줄러가 없어도 정상이므로 no-op
+    ready 를, 비면제(LIVE) 계좌는 ``mark_not_ready(reason)`` 한다.
+    """
+    for account in accounts:
+        if _flag_exempt_for_account(ReadinessFlag.FILL_RECONCILE, account):
+            _mark_runtime_ready(s, account.account_id, ReadinessFlag.FILL_RECONCILE)
+        else:
+            _mark_runtime_not_ready(
+                s,
+                account.account_id,
+                ReadinessFlag.FILL_RECONCILE,
+                "fill_init_skipped_no_broker",
+            )
+
+
+def _mark_reconcile_global_skip(s: Services, accounts: list[Any]) -> None:
+    """전역 reconcile skip 시 면제 우선 mark (이중 실패모드 a)."""
+    for account in accounts:
+        if _flag_exempt_for_account(ReadinessFlag.RECONCILE, account):
+            _mark_runtime_ready(s, account.account_id, ReadinessFlag.RECONCILE)
+        else:
+            _mark_runtime_not_ready(
+                s,
+                account.account_id,
+                ReadinessFlag.RECONCILE,
+                "reconcile_init_skipped_no_broker",
+            )
 
 
 async def _init_core(s: Services) -> None:
@@ -624,16 +707,35 @@ async def _init_gateway(s: Services) -> None:
     accounts = await s.account_service.list()
     connected_count = 0
     for account in accounts:
+        # #2397 D-ACC-09 R1: broker_ready 면제 계좌(virtual/test)는 connect/
+        # get_broker 시도 **전** registry no-op ready mark 후 skip 한다 — 가상은
+        # broker API 를 미호출하므로(VirtualExecutor 가상 체결) broker readiness 가
+        # 무의미하고, get_broker 를 호출하면 virtual 을 KIS 토큰/connect 실패에
+        # 재노출하기 때문이다.
+        if _broker_ready_exempt(account):
+            _mark_runtime_ready(s, account.account_id, ReadinessFlag.BROKER)
+            continue
         try:
             broker = await s.account_service.get_broker(account.account_id)
             await broker.connect()
             connected_count += 1
+            # #2397 broker_ready = connect 성공 시점 mark([must_fix F] —
+            # get_cached_broker live-poll 아님). #2372 connect-후-캐시 정합.
+            _mark_runtime_ready(s, account.account_id, ReadinessFlag.BROKER)
             logger.info(
                 "Broker 연결: account=%s, type=%s",
                 account.account_id,
                 account.broker_type,
             )
         except Exception:
+            # #2397 startup 실패 → broker_ready not_ready(reason). self-healing
+            # background loop 가 회복을 무기한 재시도한다.
+            _mark_runtime_not_ready(
+                s,
+                account.account_id,
+                ReadinessFlag.BROKER,
+                "connect_failed",
+            )
             logger.warning(
                 "Broker 연결 실패: account=%s — 건너뜀",
                 account.account_id,
@@ -733,6 +835,12 @@ async def _init_gateway(s: Services) -> None:
     # reconciler 가 미복구 ante 체결을 "외부 매수" 로 오분류하지 않는다.
     if connected_count and s.fill_applier and s.order_tracker:
         await _init_fill_recovery_schedulers(s, accounts)
+    else:
+        # #2397 D-ACC-09 이중 실패모드 (a): 전역 connected_count==0(또는 fill
+        # 의존성 부재)으로 _init_fill_recovery_schedulers 가 미호출 → 전 계좌 키가
+        # 부재한다. 면제 매트릭스를 **먼저** 적용해 LIVE 비면제만 mark_not_ready,
+        # virtual/test 면제는 no-op ready mark 한다(D-ACC-09 면제 계약 보존).
+        _mark_fill_reconcile_global_skip(s, accounts)
 
     # #1949: 체결 catch-up(위)이 만든 outbox row + commit-후-crash 로 미발행된
     # row 를 publisher 가 기동 재전달한 뒤 주기 드레인 루프를 시작한다. 소비자는
@@ -744,6 +852,14 @@ async def _init_gateway(s: Services) -> None:
     # ReconcileScheduler 초기화 (fill 복구 barrier 이후)
     if connected_count and s.trade_service:
         await _init_reconcile_scheduler(s)
+    else:
+        # #2397 D-ACC-09 이중 실패모드 (a): reconcile 도 전역 skip 시 동일 처리.
+        _mark_reconcile_global_skip(s, accounts)
+
+    # #2397 D-ACC-09 R5: self-healing background retry loop 를 startup init
+    # 완료(_init_* 전부) 후에 시작한다. broker not_ready 계좌를 무기한 재시도하고
+    # 회복 시 스케줄러를 idempotent 재등록한 뒤 ready 로 전이한다.
+    _start_readiness_self_healing(s, accounts)
 
     # DailyReportScheduler 초기화
     if s.performance_tracker and s.trade_recorder and s.position_history:
@@ -764,57 +880,15 @@ async def _init_fill_recovery_schedulers(s: Services, accounts: list[Any]) -> No
     external-buy 분류를 건너뛰게 한다(#1946 Finding 1 — startup 폴 실패를
     "0건 성공" 으로 삼켜 barrier 를 우회하던 결함 수정).
     """
-    from ante.broker.fill_scheduler import FillReconcileScheduler
-
-    # #2314·#2316 §11.6: position-derived fallback 마스터 disable flag. KIS paper
-    # 기본 활성(True)을 두되 config 로 rollback 가능. 실제 적용은 추가로
-    # broker.is_paper 가 true 여야 한다(scheduler 내부 gate).
-    fallback_enabled = (
-        bool(s.config.get("system.fill_position_fallback_enabled", True))
-        if s.config is not None
-        else True
-    )
-
     s.fill_catch_up_failed_accounts.clear()
     for account in accounts:
-        try:
-            broker = await s.account_service.get_broker(account.account_id)
-        except Exception:
+        # #2397 D-ACC-09 R2: fill_reconcile 면제 계좌(virtual/test)는 get_broker
+        # 호출 **없이** registry no-op ready mark + broker-backed 등록 skip 한다
+        # (virtual 을 KIS connect 실패에 재노출 차단). LIVE 비면제만 등록 시도.
+        if _flag_exempt_for_account(ReadinessFlag.FILL_RECONCILE, account):
+            _mark_runtime_ready(s, account.account_id, ReadinessFlag.FILL_RECONCILE)
             continue
-
-        scheduler = FillReconcileScheduler(
-            broker=broker,
-            order_tracker=s.order_tracker,
-            fill_applier=s.fill_applier,
-            account_id=account.account_id,
-            # #2314·#2316 §11: 잔고 역도출 fallback 의 internal_account_qty 조회
-            # 의존성(§11.1) + late-ccld over-attribution alert(§11.4) 발행 경로.
-            trade_service=s.trade_service,
-            eventbus=s.eventbus,
-            fallback_enabled=fallback_enabled,
-            # #2377: over-attribution 의심 알림 종목명 병기 소스.
-            instrument_service=s.instrument_service,
-        )
-        # 기동 카치업 — barrier. reconcile 보다 반드시 선행.
-        # CatchUpResult.succeeded 로 폴 실패와 "정상 0건/open-없음" 을 구분한다.
-        result = await scheduler.catch_up_once()
-        if not result.succeeded:
-            # 폴 미성공 — 미복구 체결이 남아 있을 수 있다. 이 계좌의 기동
-            # reconcile external-buy 분류를 연기해 오분류를 막는다.
-            s.fill_catch_up_failed_accounts.add(account.account_id)
-            logger.warning(
-                "기동 체결 카치업 미성공: account=%s — reconcile external-buy "
-                "분류를 연기한다(barrier 유지)",
-                account.account_id,
-            )
-        elif result.applied:
-            logger.info(
-                "기동 체결 카치업: account=%s, %d건 반영",
-                account.account_id,
-                result.applied,
-            )
-        await scheduler.start()
-        s.fill_schedulers[account.account_id] = scheduler
+        await _register_fill_scheduler_for_account(s, account)
 
     if s.fill_schedulers:
         logger.info(
@@ -822,6 +896,101 @@ async def _init_fill_recovery_schedulers(s: Services, accounts: list[Any]) -> No
             len(s.fill_schedulers),
             ", ".join(s.fill_schedulers),
         )
+
+
+async def _register_fill_scheduler_for_account(s: Services, account: Any) -> bool:
+    """단일 LIVE 계좌의 FillReconcileScheduler 등록 (startup + self-healing 공용).
+
+    멱등 재등록(self-healing): 기존 dict 항목이 있으면 새 scheduler 로 덮어쓰기
+    전 기존 task 를 stop 해 orphan task 를 방지한다. **per-account barrier 만**
+    갱신하고 전역 ``fill_catch_up_failed_accounts.clear()`` 는 호출하지 않는다
+    (타 계좌의 #1946 barrier 보존).
+
+    Returns:
+        등록 성공(scheduler start 완료) 여부. ``catch_up_once`` 폴 실패여도
+        scheduler 는 start 하지만 readiness 는 false 로 분리한다(R4).
+    """
+    from ante.broker.fill_scheduler import FillReconcileScheduler
+
+    account_id = account.account_id
+
+    # #2314·#2316 §11.6: position-derived fallback 마스터 disable flag.
+    fallback_enabled = (
+        bool(s.config.get("system.fill_position_fallback_enabled", True))
+        if s.config is not None
+        else True
+    )
+
+    try:
+        broker = await s.account_service.get_broker(account_id)
+    except Exception:
+        # #2397 D-ACC-09 이중 실패모드 (b): per-account continue 지점에서
+        # mark_not_ready(reason) 명시(조용한 skip 제거).
+        _mark_runtime_not_ready(
+            s, account_id, ReadinessFlag.FILL_RECONCILE, "get_broker_failed"
+        )
+        return False
+
+    # 멱등 재등록: 기존 scheduler 가 있으면 교체 전 stop(orphan 방지).
+    existing = s.fill_schedulers.pop(account_id, None)
+    if existing is not None:
+        try:
+            await existing.stop()
+        except Exception:
+            logger.warning(
+                "기존 FillReconcileScheduler 정리 실패(재등록): account=%s",
+                account_id,
+                exc_info=True,
+            )
+
+    scheduler = FillReconcileScheduler(
+        broker=broker,
+        order_tracker=s.order_tracker,
+        fill_applier=s.fill_applier,
+        account_id=account_id,
+        # #2314·#2316 §11: 잔고 역도출 fallback 의 internal_account_qty 조회
+        # 의존성(§11.1) + late-ccld over-attribution alert(§11.4) 발행 경로.
+        trade_service=s.trade_service,
+        eventbus=s.eventbus,
+        fallback_enabled=fallback_enabled,
+        # #2377: over-attribution 의심 알림 종목명 병기 소스.
+        instrument_service=s.instrument_service,
+    )
+    # 기동 카치업 — barrier. reconcile 보다 반드시 선행.
+    # CatchUpResult.succeeded 로 폴 실패와 "정상 0건/open-없음" 을 구분한다.
+    result = await scheduler.catch_up_once()
+    if not result.succeeded:
+        # 폴 미성공 — 미복구 체결이 남아 있을 수 있다. 이 계좌의 기동
+        # reconcile external-buy 분류를 연기해 오분류를 막는다. (per-account
+        # barrier 만 갱신 — 전역 clear 금지로 타 계좌 barrier 보존.)
+        s.fill_catch_up_failed_accounts.add(account_id)
+        logger.warning(
+            "기동 체결 카치업 미성공: account=%s — reconcile external-buy "
+            "분류를 연기한다(barrier 유지)",
+            account_id,
+        )
+    else:
+        # 폴 성공 — 이 계좌의 barrier 항목만 해제(전역 clear 아님).
+        s.fill_catch_up_failed_accounts.discard(account_id)
+        if result.applied:
+            logger.info(
+                "기동 체결 카치업: account=%s, %d건 반영",
+                account_id,
+                result.applied,
+            )
+    await scheduler.start()
+    s.fill_schedulers[account_id] = scheduler
+
+    # #2397 R4: catch_up_once 폴 실패(succeeded==False)면 scheduler 를 start
+    # 하더라도 fill_reconcile_ready=false 로 분리한다(스펙 "catch_up_once + start
+    # 성공" 조건). 폴 성공이어야 ready 로 mark 한다.
+    if result.succeeded:
+        _mark_runtime_ready(s, account_id, ReadinessFlag.FILL_RECONCILE)
+    else:
+        _mark_runtime_not_ready(
+            s, account_id, ReadinessFlag.FILL_RECONCILE, "catch_up_poll_failed"
+        )
+    return result.succeeded
 
 
 async def _init_fill_outbox_publisher(s: Services) -> None:
@@ -854,16 +1023,22 @@ async def _init_reconcile_scheduler(s: Services) -> None:
     """
     assert s.eventbus is not None
 
-    from ante.broker.scheduler import ReconcileScheduler
     from ante.trade.reconciler import PositionReconciler
 
     reconcile_config = s.config.get("reconcile", {})
     if not isinstance(reconcile_config, dict):
         reconcile_config = {}
 
+    accounts = await s.account_service.list()
+
     enabled = reconcile_config.get("enabled", True)
     if not enabled:
         logger.info("ReconcileScheduler 비활성화 (reconcile.enabled=false)")
+        # #2397: 운영자가 reconcile 을 명시 opt-out 했으므로 reconcile_ready 요구를
+        # 면제한다(전 계좌 no-op ready) — disabled 가 readiness 실패로 오기록되어
+        # gate(#2398) 도입 후 정상 주문이 막히지 않도록.
+        for account in accounts:
+            _mark_runtime_ready(s, account.account_id, ReadinessFlag.RECONCILE)
         return
 
     interval = reconcile_config.get("interval_seconds", 1800)
@@ -879,40 +1054,17 @@ async def _init_reconcile_scheduler(s: Services) -> None:
         instrument_service=s.instrument_service,
     )
 
-    accounts = await s.account_service.list()
     started: list[str] = []
     for account in accounts:
-        try:
-            broker = await s.account_service.get_broker(account.account_id)
-        except Exception:
+        # #2397 D-ACC-09 R3: reconcile 면제 계좌(virtual/test)는 get_broker 호출
+        # 없이 registry no-op ready mark + broker-backed 등록 skip. LIVE 만 등록.
+        if _flag_exempt_for_account(ReadinessFlag.RECONCILE, account):
+            _mark_runtime_ready(s, account.account_id, ReadinessFlag.RECONCILE)
             continue
-
-        # #1946 barrier: fill 카치업 미성공 계좌는 기동 즉시 대사에서 external-buy
-        # 분류를 연기한다(미복구 ante 체결 오분류 방지). 이후 주기 대사는 fill 폴
-        # 루프가 복구를 진행하므로 정상 처리한다.
-        skip_initial_external_buy = (
-            account.account_id in s.fill_catch_up_failed_accounts
-        )
-        scheduler = ReconcileScheduler(
-            reconciler=reconciler,
-            broker=broker,
-            bot_manager=s.bot_manager,
-            eventbus=s.eventbus,
-            broker_account_id=account.account_id,
-            interval_seconds=interval,
-            skip_initial_external_buy=skip_initial_external_buy,
-        )
-        try:
-            await scheduler.start()
-        except Exception:
-            logger.warning(
-                "ReconcileScheduler 시작 실패: account=%s",
-                account.account_id,
-                exc_info=True,
-            )
-            continue
-        s.reconcile_schedulers[account.account_id] = scheduler
-        started.append(account.account_id)
+        if await _register_reconcile_scheduler_for_account(
+            s, account, reconciler, interval
+        ):
+            started.append(account.account_id)
 
     if not started:
         logger.info("ReconcileScheduler 건너뜀 — 연결된 Broker 없음")
@@ -924,6 +1076,203 @@ async def _init_reconcile_scheduler(s: Services) -> None:
         ", ".join(started),
         interval,
     )
+
+
+def _build_reconciler(s: Services) -> Any:
+    """PositionReconciler 1개 생성 (startup + self-healing 공용)."""
+    assert s.eventbus is not None
+    from ante.trade.reconciler import PositionReconciler
+
+    return PositionReconciler(
+        trade_service=s.trade_service,
+        eventbus=s.eventbus,
+        order_tracker=s.order_tracker,
+        instrument_service=s.instrument_service,
+    )
+
+
+async def _register_reconcile_scheduler_for_account(
+    s: Services, account: Any, reconciler: Any, interval: int
+) -> bool:
+    """단일 LIVE 계좌의 ReconcileScheduler 등록 (startup + self-healing 공용).
+
+    멱등 재등록: 기존 dict 항목이 있으면 새 scheduler 로 교체 전 기존 task 를
+    stop 한다(orphan 방지).
+
+    Returns:
+        등록 성공(start 완료) 여부.
+    """
+    assert s.eventbus is not None
+    from ante.broker.scheduler import ReconcileScheduler
+
+    account_id = account.account_id
+    try:
+        broker = await s.account_service.get_broker(account_id)
+    except Exception:
+        # #2397 D-ACC-09 이중 실패모드 (b): per-account continue 지점 명시 mark.
+        _mark_runtime_not_ready(
+            s, account_id, ReadinessFlag.RECONCILE, "get_broker_failed"
+        )
+        return False
+
+    # #1946 barrier: fill 카치업 미성공 계좌는 기동 즉시 대사에서 external-buy
+    # 분류를 연기한다(미복구 ante 체결 오분류 방지). 이후 주기 대사는 fill 폴
+    # 루프가 복구를 진행하므로 정상 처리한다.
+    skip_initial_external_buy = account_id in s.fill_catch_up_failed_accounts
+
+    # 멱등 재등록: 기존 scheduler 가 있으면 교체 전 stop(orphan 방지).
+    existing = s.reconcile_schedulers.pop(account_id, None)
+    if existing is not None:
+        try:
+            await existing.stop()
+        except Exception:
+            logger.warning(
+                "기존 ReconcileScheduler 정리 실패(재등록): account=%s",
+                account_id,
+                exc_info=True,
+            )
+
+    scheduler = ReconcileScheduler(
+        reconciler=reconciler,
+        broker=broker,
+        bot_manager=s.bot_manager,
+        eventbus=s.eventbus,
+        broker_account_id=account_id,
+        interval_seconds=interval,
+        skip_initial_external_buy=skip_initial_external_buy,
+    )
+    try:
+        await scheduler.start()
+    except Exception:
+        logger.warning(
+            "ReconcileScheduler 시작 실패: account=%s",
+            account_id,
+            exc_info=True,
+        )
+        _mark_runtime_not_ready(
+            s, account_id, ReadinessFlag.RECONCILE, "scheduler_start_failed"
+        )
+        return False
+    s.reconcile_schedulers[account_id] = scheduler
+    _mark_runtime_ready(s, account_id, ReadinessFlag.RECONCILE)
+    return True
+
+
+# ── #2397 D-ACC-09 R5: self-healing background retry loop ──────────────────
+
+
+def _self_healing_targets(accounts: list[Any]) -> list[Any]:
+    """self-healing 대상 계좌 — broker_ready 가 요구되는 LIVE(비면제) 계좌만.
+
+    면제(virtual/test) 계좌는 broker readiness 가 무의미하므로 대상에서 제외한다.
+    """
+    return [a for a in accounts if not _broker_ready_exempt(a)]
+
+
+def _start_readiness_self_healing(s: Services, accounts: list[Any]) -> None:
+    """self-healing background retry loop 시작 (startup init 완료 후).
+
+    broker_ready 가 요구되는 LIVE 계좌가 하나도 없으면(전부 면제) 루프를 띄우지
+    않는다. 이미 task 가 있으면 재시작하지 않는다(멱등).
+    """
+    if s.readiness_self_healing_task is not None:
+        return
+    targets = _self_healing_targets(accounts)
+    if not targets:
+        return
+    s.readiness_self_healing_task = asyncio.create_task(
+        _readiness_self_healing_loop(s, targets),
+        name="readiness-self-healing",
+    )
+    logger.info("Readiness self-healing loop 시작: 대상 LIVE 계좌 %d개", len(targets))
+
+
+async def _self_healing_recover_account(s: Services, account: Any) -> bool:
+    """단일 not_ready broker 계좌의 1회 회복 시도(connect → idempotent 재등록).
+
+    회복(connect 성공) 시:
+    1. ``broker_ready`` 를 ready 로 전이.
+    2. fill_recovery + reconcile + treasury_sync 를 **idempotent re-register**
+       (기존 task cancel 후 교체 — orphan 방지). per-account 만 갱신하고 전역
+       barrier ``fill_catch_up_failed_accounts.clear()`` 는 호출하지 않는다
+       (타 계좌 #1946 barrier 보존).
+
+    Returns:
+        broker connect 성공(broker_ready 전이) 여부.
+    """
+    account_id = account.account_id
+
+    # broker_ready 가 이미 ready 면 회복 불필요.
+    if s.runtime_readiness is not None and s.runtime_readiness.is_ready(
+        account_id, ReadinessFlag.BROKER
+    ):
+        return True
+
+    try:
+        broker = await s.account_service.get_broker(account_id)
+        await broker.connect()
+    except Exception:
+        # 회복 미성공 — not_ready 유지. 다음 burst 에서 재시도(liveness).
+        _mark_runtime_not_ready(s, account_id, ReadinessFlag.BROKER, "reconnect_failed")
+        return False
+
+    _mark_runtime_ready(s, account_id, ReadinessFlag.BROKER)
+    logger.info("Readiness self-healing: broker 회복 — account=%s", account_id)
+
+    # broker 회복 후 의존 스케줄러를 idempotent 재등록한다.
+    if s.fill_applier is not None and s.order_tracker is not None:
+        await _register_fill_scheduler_for_account(s, account)
+    if s.trade_service is not None:
+        reconciler = _build_reconciler(s)
+        interval = 1800
+        if s.config is not None:
+            reconcile_config = s.config.get("reconcile", {})
+            if isinstance(reconcile_config, dict):
+                interval = reconcile_config.get("interval_seconds", 1800)
+        await _register_reconcile_scheduler_for_account(
+            s, account, reconciler, interval
+        )
+    # treasury_sync 재시작(면제 없음). 멱등 — Treasury.start_sync 가 기존 sync 를
+    # 교체한다.
+    await _init_treasury_sync(s, [account])
+    return True
+
+
+async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
+    """not_ready broker 계좌를 **무기한 재시도**하는 background loop (liveness).
+
+    liveness invariant: broker 회복이 가능한 한 not_ready 계좌는 유한시간 내
+    ready 로 전이한다. ``max_attempts`` 는 **per-burst(연결시도 단위)에만** 적용
+    하고 계좌 lifetime 은 무제한이다 — 일시 토큰압박이 영구 not_ready 로 고착되어
+    #2395 를 역회귀로 재생산하지 않도록. shutdown 에서 task cancel 로 종료한다.
+    """
+    interval = 60
+    max_per_burst = 5
+    if s.config is not None:
+        interval = int(s.config.get("readiness.self_healing_interval_seconds", 60))
+        max_per_burst = int(
+            s.config.get("readiness.self_healing_max_attempts_per_burst", 5)
+        )
+
+    try:
+        while True:
+            pending = [
+                a
+                for a in targets
+                if s.runtime_readiness is not None
+                and not s.runtime_readiness.is_ready(a.account_id, ReadinessFlag.BROKER)
+            ]
+            for account in pending:
+                # per-burst bounded 재시도(계좌 lifetime 은 무제한).
+                for _attempt in range(max_per_burst):
+                    if await _self_healing_recover_account(s, account):
+                        break
+            # 다음 burst 까지 대기(EGW00133 ~60s 토큰 cooldown 정렬). 회복 여부와
+            # 무관하게 루프는 계속 돌며 잔여 not_ready 계좌를 무기한 재시도한다.
+            await asyncio.sleep(interval)
+    except asyncio.CancelledError:
+        logger.info("Readiness self-healing loop 취소(shutdown)")
+        raise
 
 
 async def _init_daily_report_scheduler(s: Services) -> None:
@@ -1052,9 +1401,19 @@ async def _sync_instruments(s: Services, accounts: list) -> None:
     같은 exchange 의 후속 계좌가 여전히 동기화를 시도할 수 있게 한다.
     ``bulk_upsert`` 성공 시에만 exchange 를 synced 로 표시한다. 전 계좌 순회
     후 아무 것도 동기화하지 못하면 기존 경고를 유지한다.
+
+    #2397 D-ACC-09 R1: broker_ready 면제 계좌(virtual/test)는 connect 단계에서
+    이미 skip 되어 broker 가 미연결이다. 여기서도 ``get_broker`` 를 호출하면 그
+    면제 계좌를 KIS 토큰/connect 실패에 **재노출**하므로(readiness 분리 전제
+    붕괴), 면제 계좌는 순회 대상에서 제외한다(non-exempt/live connected 계좌만
+    대상). 면제 계좌의 dummy exchange 가 KRX 등 실 exchange 마스터 적재를
+    선점하던 #2385 회귀도 동일하게 차단된다.
     """
     synced_exchanges: set[str] = set()
     for account in accounts:
+        if _broker_ready_exempt(account):
+            # 면제(virtual/test) 계좌는 broker 미연결 — get_broker 재노출 차단.
+            continue
         if account.exchange in synced_exchanges:
             continue
         try:
@@ -1168,8 +1527,6 @@ class _NullDataProvider:
 
 async def _init_treasury_sync(s: Services, accounts: list) -> None:
     """각 계좌의 Treasury 잔고 동기화 시작 (Broker 연결 이후)."""
-    from ante.account.models import TradingMode
-
     sync_interval = s.config.get("treasury.sync_interval_seconds", 300)
 
     for account in accounts:
@@ -1205,6 +1562,9 @@ async def _init_treasury_sync(s: Services, accounts: list) -> None:
                     trading_mode="virtual",
                     price_resolver=price_resolver,
                 )
+                # #2397 treasury_sync_ready: VIRTUAL 도 sync 시작 성공 시 mark
+                # (treasury_sync 는 면제 없음 — broker 없이 Trade-DB sync).
+                _mark_runtime_ready(s, account.account_id, ReadinessFlag.TREASURY_SYNC)
                 logger.info(
                     "Treasury Virtual 동기화 시작: account=%s (주기: %d초)",
                     account.account_id,
@@ -1232,12 +1592,22 @@ async def _init_treasury_sync(s: Services, accounts: list) -> None:
                     interval_seconds=sync_interval,
                     trading_mode="live",
                 )
+                # #2397 treasury_sync_ready: LIVE sync 시작 성공 시 mark.
+                _mark_runtime_ready(s, account.account_id, ReadinessFlag.TREASURY_SYNC)
                 logger.info(
                     "Treasury Live 동기화 시작: account=%s (주기: %d초)",
                     account.account_id,
                     sync_interval,
                 )
         except Exception:
+            # #2397 treasury_sync_ready: 시작 실패 → not_ready(reason). treasury_sync
+            # 은 면제 없음(VIRTUAL/LIVE 양쪽 요구)이므로 항상 명시 mark.
+            _mark_runtime_not_ready(
+                s,
+                account.account_id,
+                ReadinessFlag.TREASURY_SYNC,
+                "treasury_sync_failed",
+            )
             logger.warning(
                 "Treasury 동기화 시작 실패: account=%s — 건너뜀",
                 account.account_id,
@@ -2019,6 +2389,19 @@ async def _shutdown(s: Services) -> None:
     if s.daily_report_scheduler:
         await s.daily_report_scheduler.stop()
         logger.info("DailyReportScheduler 종료")
+
+    # #2397 D-ACC-09 R5: self-healing loop 를 scheduler dict 정리 **전**에
+    # cancel 한다 — 루프가 종료 중 scheduler 를 재등록(orphan task)하지 못하도록.
+    if (
+        s.readiness_self_healing_task is not None
+        and not s.readiness_self_healing_task.done()
+    ):
+        s.readiness_self_healing_task.cancel()
+        try:
+            await s.readiness_self_healing_task
+        except asyncio.CancelledError:
+            pass
+        logger.info("Readiness self-healing loop 종료")
 
     # SPLIT-3 (#1242): multi-broker ReconcileScheduler pool 정리
     for sched_account_id, scheduler in list(s.reconcile_schedulers.items()):

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1162,18 +1162,21 @@ async def _register_reconcile_scheduler_for_account(
 
 
 def _self_healing_targets(accounts: list[Any]) -> list[Any]:
-    """self-healing 대상 계좌 — broker_ready 가 요구되는 LIVE(비면제) 계좌만.
+    """self-healing 대상 — **전 계좌**.
 
-    면제(virtual/test) 계좌는 broker readiness 가 무의미하므로 대상에서 제외한다.
+    ``treasury_sync`` 는 broker_type/trading_mode 무관 항상 요구(면제 없음)이므로,
+    broker 면제(virtual/test) 계좌도 treasury 일시 실패의 회복 대상이다(Codex P2).
+    회복 시 각 플래그는 면제 여부에 따라 개별 처리된다(broker/fill/reconcile 은
+    면제 계좌에서 skip, treasury 는 전 계좌 재시도).
     """
-    return [a for a in accounts if not _broker_ready_exempt(a)]
+    return list(accounts)
 
 
 def _start_readiness_self_healing(s: Services, accounts: list[Any]) -> None:
     """self-healing background retry loop 시작 (startup init 완료 후).
 
-    broker_ready 가 요구되는 LIVE 계좌가 하나도 없으면(전부 면제) 루프를 띄우지
-    않는다. 이미 task 가 있으면 재시작하지 않는다(멱등).
+    대상 계좌(전 계좌 — treasury_sync 는 면제 없음)가 하나도 없으면 루프를
+    띄우지 않는다. 이미 task 가 있으면 재시작하지 않는다(멱등).
     """
     if s.readiness_self_healing_task is not None:
         return
@@ -1184,7 +1187,7 @@ def _start_readiness_self_healing(s: Services, accounts: list[Any]) -> None:
         _readiness_self_healing_loop(s, targets),
         name="readiness-self-healing",
     )
-    logger.info("Readiness self-healing loop 시작: 대상 LIVE 계좌 %d개", len(targets))
+    logger.info("Readiness self-healing loop 시작: 대상 계좌 %d개", len(targets))
 
 
 async def _self_healing_recover_account(s: Services, account: Any) -> bool:
@@ -1227,14 +1230,25 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
         _mark_runtime_ready(s, account_id, ReadinessFlag.BROKER)
         logger.info("Readiness self-healing: broker 회복 — account=%s", account_id)
 
-    # 의존 스케줄러 idempotent 재등록 — broker 외 readiness(fill/reconcile/treasury)
-    # 실패도 재시도해 active_trading_ready 까지 회복한다(Codex P1: broker_ready 만
-    # 보면 일시 fill/reconcile/treasury 실패가 #2398 gate 에서 영구 차단으로 고착).
-    if s.fill_applier is not None and s.order_tracker is not None:
+    # 의존 스케줄러 재시도 — **플래그별 면제 인식**(Codex P2). broker 면제 계좌
+    # (virtual/test)는 fill/reconcile 도 면제(startup no-op ready)이므로 broker-backed
+    # 재등록을 건너뛰어 get_broker 재노출을 막고, 비면제 플래그만 재시도한다.
+    # treasury_sync 는 면제 없음 → 전 계좌 재시도(broker 면제 계좌의 일시 treasury
+    # 실패도 회복). broker 외 readiness 실패도 active_trading_ready 까지 회복한다
+    # (Codex P1: broker_ready 만 보면 일시 실패가 #2398 gate 에서 영구 차단 고착).
+    fill_exempt = is_flag_exempt(
+        ReadinessFlag.FILL_RECONCILE,
+        broker_type=account.broker_type,
+        trading_mode=account.trading_mode,
+    )
+    if not fill_exempt and s.fill_applier is not None and s.order_tracker is not None:
         await _register_fill_scheduler_for_account(s, account)
-    if s.trade_service is not None:
-        # reconcile.enabled=false 면 _init_reconcile_scheduler 와 동일하게 재등록하지
-        # 않는다 — 운영자가 끈 reconcile 을 회복 시 다시 켜지 않도록(Codex P2).
+    reconcile_exempt = is_flag_exempt(
+        ReadinessFlag.RECONCILE,
+        broker_type=account.broker_type,
+        trading_mode=account.trading_mode,
+    )
+    if not reconcile_exempt and s.trade_service is not None:
         reconcile_enabled = True
         interval = 1800
         if s.config is not None:
@@ -1247,7 +1261,14 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
             await _register_reconcile_scheduler_for_account(
                 s, account, reconciler, interval
             )
-    # treasury_sync 재시작(면제 없음). 멱등 — Treasury.start_sync 가 기존 sync 교체.
+        else:
+            # reconcile.enabled=false(운영자 결정) — startup 의 disabled no-op ready
+            # 와 동일하게 회복 경로에서도 reconcile_ready 를 ready 로 mark 한다.
+            # (Codex P2: 비활성 reconcile 비면제 계좌가 영구 not_ready 로 고착되어
+            # active_trading_ready 가 영영 False 가 되는 회귀 차단.)
+            _mark_runtime_ready(s, account_id, ReadinessFlag.RECONCILE)
+    # treasury_sync 재시작(면제 없음 — 전 계좌). 멱등 — Treasury.start_sync 가
+    # 기존 sync 교체.
     await _init_treasury_sync(s, [account])
     # 모든 비면제 플래그가 ready 여야 회복 완료(active_trading_ready 기준).
     return s.runtime_readiness.active_trading_ready(
@@ -1267,10 +1288,18 @@ async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
     """
     interval = 60
     max_per_burst = 5
+    backoff_base = 5
+    backoff_max = 60
     if s.config is not None:
         interval = int(s.config.get("readiness.self_healing_interval_seconds", 60))
         max_per_burst = int(
             s.config.get("readiness.self_healing_max_attempts_per_burst", 5)
+        )
+        backoff_base = int(
+            s.config.get("readiness.self_healing_backoff_base_seconds", 5)
+        )
+        backoff_max = int(
+            s.config.get("readiness.self_healing_backoff_max_seconds", 60)
         )
 
     try:
@@ -1289,9 +1318,16 @@ async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
             ]
             for account in pending:
                 # per-burst bounded 재시도(계좌 lifetime 은 무제한).
-                for _attempt in range(max_per_burst):
+                for attempt in range(max_per_burst):
                     if await _self_healing_recover_account(s, account):
                         break
+                    # attempt 간 지수 backoff(EGW00133 ~1/min 토큰 cooldown 정렬,
+                    # Codex P2). 즉시 재인증을 몰아넣어 KIS 토큰 압박을 악화시키지
+                    # 않도록 한다. 마지막 attempt 뒤에는 burst interval 이 대신한다.
+                    if attempt < max_per_burst - 1:
+                        await asyncio.sleep(
+                            min(backoff_base * (2**attempt), backoff_max)
+                        )
             # 다음 burst 까지 대기(EGW00133 ~60s 토큰 cooldown 정렬). 회복 여부와
             # 무관하게 루프는 계속 돌며 잔여 not_ready 계좌를 무기한 재시도한다.
             await asyncio.sleep(interval)

--- a/tests/unit/test_account_runtime_readiness.py
+++ b/tests/unit/test_account_runtime_readiness.py
@@ -1,0 +1,214 @@
+"""RuntimeReadinessRegistry 단위 테스트 (#2397 D-ACC-09).
+
+면제 매트릭스(broker_type×trading_mode 분리·virtual/test no-op ready·
+treasury_sync 요구), default not_ready(fail-closed), active_trading_ready
+derive(AND), mark_ready/mark_not_ready 를 검증한다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.account.models import TradingMode
+from ante.account.readiness import (
+    ALL_FLAGS,
+    ReadinessFlag,
+    RuntimeReadinessRegistry,
+    is_flag_exempt,
+)
+
+# ── 면제 매트릭스 (D-ACC-09 §4) ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("broker_type", "trading_mode", "flag", "expected_exempt"),
+    [
+        # test/virtual: broker/fill/reconcile 면제, treasury_sync 요구.
+        ("test", TradingMode.VIRTUAL, ReadinessFlag.BROKER, True),
+        ("test", TradingMode.VIRTUAL, ReadinessFlag.FILL_RECONCILE, True),
+        ("test", TradingMode.VIRTUAL, ReadinessFlag.RECONCILE, True),
+        ("test", TradingMode.VIRTUAL, ReadinessFlag.TREASURY_SYNC, False),
+        # kis-domestic/virtual: 동일 면제 패턴(broker_type 무관, trading_mode 축).
+        ("kis-domestic", TradingMode.VIRTUAL, ReadinessFlag.BROKER, True),
+        ("kis-domestic", TradingMode.VIRTUAL, ReadinessFlag.FILL_RECONCILE, True),
+        ("kis-domestic", TradingMode.VIRTUAL, ReadinessFlag.RECONCILE, True),
+        ("kis-domestic", TradingMode.VIRTUAL, ReadinessFlag.TREASURY_SYNC, False),
+        # kis-domestic/live: 전부 요구(면제 없음).
+        ("kis-domestic", TradingMode.LIVE, ReadinessFlag.BROKER, False),
+        ("kis-domestic", TradingMode.LIVE, ReadinessFlag.FILL_RECONCILE, False),
+        ("kis-domestic", TradingMode.LIVE, ReadinessFlag.RECONCILE, False),
+        ("kis-domestic", TradingMode.LIVE, ReadinessFlag.TREASURY_SYNC, False),
+    ],
+)
+def test_exemption_matrix(
+    broker_type: str,
+    trading_mode: TradingMode,
+    flag: ReadinessFlag,
+    expected_exempt: bool,
+) -> None:
+    """면제 매트릭스가 스펙 표대로 (broker_type, trading_mode)×flag 를 분리한다."""
+    assert (
+        is_flag_exempt(flag, broker_type=broker_type, trading_mode=trading_mode)
+        is expected_exempt
+    )
+
+
+def test_exemption_axis_is_trading_mode_not_broker_type() -> None:
+    """broker/fill/reconcile 면제축은 trading_mode 다 — broker_type 은 무관.
+
+    test/live, kis-domestic/live 모두 비면제(요구)여야 한다(broker_type 으로
+    면제를 판정하지 않음).
+    """
+    for broker_type in ("test", "kis-domestic", "future-broker"):
+        for flag in (
+            ReadinessFlag.BROKER,
+            ReadinessFlag.FILL_RECONCILE,
+            ReadinessFlag.RECONCILE,
+        ):
+            # virtual → 면제
+            assert is_flag_exempt(
+                flag, broker_type=broker_type, trading_mode=TradingMode.VIRTUAL
+            )
+            # live → 요구(비면제)
+            assert not is_flag_exempt(
+                flag, broker_type=broker_type, trading_mode=TradingMode.LIVE
+            )
+
+
+def test_unknown_pair_fail_closed() -> None:
+    """매트릭스 미지정 미래 (broker_type, trading_mode) pair 는 fail-closed.
+
+    미지정 broker_type 도 LIVE 면 전 플래그 요구(비면제)다.
+    """
+    for flag in ALL_FLAGS:
+        assert not is_flag_exempt(
+            flag, broker_type="ibkr", trading_mode=TradingMode.LIVE
+        )
+
+
+# ── default not_ready (fail-closed) ────────────────────────────────────────
+
+
+def test_default_not_ready_fail_closed() -> None:
+    """명시 mark 이전 모든 플래그는 not_ready(디폴트 fail-closed)."""
+    reg = RuntimeReadinessRegistry()
+    for flag in ALL_FLAGS:
+        assert reg.is_ready("acc", flag) is False
+    # 미등록 계좌의 not_ready_flags 는 전 플래그.
+    assert reg.not_ready_flags("never-seen") == list(ALL_FLAGS)
+
+
+def test_default_live_account_not_active_trading_ready() -> None:
+    """LIVE 계좌는 명시 mark 전 active_trading_ready=False(fail-closed)."""
+    reg = RuntimeReadinessRegistry()
+    assert (
+        reg.active_trading_ready(
+            "live", broker_type="kis-domestic", trading_mode=TradingMode.LIVE
+        )
+        is False
+    )
+
+
+# ── mark_ready / mark_not_ready ─────────────────────────────────────────────
+
+
+def test_mark_ready_and_not_ready_roundtrip() -> None:
+    """mark_ready/mark_not_ready 가 상태·사유를 정확히 전이한다."""
+    reg = RuntimeReadinessRegistry()
+
+    reg.mark_not_ready("acc", ReadinessFlag.BROKER, "EGW00133")
+    assert reg.is_ready("acc", ReadinessFlag.BROKER) is False
+    assert reg.get_reason("acc", ReadinessFlag.BROKER) == "EGW00133"
+
+    reg.mark_ready("acc", ReadinessFlag.BROKER)
+    assert reg.is_ready("acc", ReadinessFlag.BROKER) is True
+    # ready 전이 시 사유는 제거된다.
+    assert reg.get_reason("acc", ReadinessFlag.BROKER) is None
+
+
+def test_per_account_isolation() -> None:
+    """한 계좌 mark 가 다른 계좌에 누출되지 않는다."""
+    reg = RuntimeReadinessRegistry()
+    reg.mark_ready("a", ReadinessFlag.BROKER)
+    assert reg.is_ready("a", ReadinessFlag.BROKER) is True
+    assert reg.is_ready("b", ReadinessFlag.BROKER) is False
+
+
+# ── active_trading_ready derive (AND + 면제) ───────────────────────────────
+
+
+def test_active_trading_ready_live_requires_all_flags() -> None:
+    """LIVE 는 4 플래그 전부 ready 여야 active_trading_ready=True (AND)."""
+    reg = RuntimeReadinessRegistry()
+    flags = list(ALL_FLAGS)
+    # 하나씩 ready 로 올리며 마지막 전까지 False.
+    for i, flag in enumerate(flags):
+        reg.mark_ready("live", flag)
+        ready = reg.active_trading_ready(
+            "live", broker_type="kis-domestic", trading_mode=TradingMode.LIVE
+        )
+        assert ready is (i == len(flags) - 1)
+
+
+def test_active_trading_ready_live_blocked_by_single_not_ready() -> None:
+    """LIVE 에서 한 비면제 플래그만 not_ready 여도 active_trading_ready=False."""
+    reg = RuntimeReadinessRegistry()
+    for flag in ALL_FLAGS:
+        reg.mark_ready("live", flag)
+    reg.mark_not_ready("live", ReadinessFlag.FILL_RECONCILE, "catch_up_poll_failed")
+    assert (
+        reg.active_trading_ready(
+            "live", broker_type="kis-domestic", trading_mode=TradingMode.LIVE
+        )
+        is False
+    )
+
+
+def test_active_trading_ready_virtual_only_needs_treasury_sync() -> None:
+    """virtual 은 broker/fill/reconcile 면제 — treasury_sync 만 ready 면 OK."""
+    reg = RuntimeReadinessRegistry()
+    # broker/fill/reconcile 은 명시 mark 가 없어도(면제) active_trading_ready 에
+    # 영향을 주지 않는다. 단 treasury_sync 는 요구.
+    assert (
+        reg.active_trading_ready(
+            "v", broker_type="test", trading_mode=TradingMode.VIRTUAL
+        )
+        is False
+    ), "treasury_sync 미충족이면 virtual 도 not ready"
+
+    reg.mark_ready("v", ReadinessFlag.TREASURY_SYNC)
+    assert (
+        reg.active_trading_ready(
+            "v", broker_type="test", trading_mode=TradingMode.VIRTUAL
+        )
+        is True
+    ), "virtual 은 treasury_sync 만 충족하면 ready(나머지 면제)"
+
+
+def test_active_trading_ready_virtual_ignores_broker_not_ready() -> None:
+    """virtual 은 broker not_ready(예: KIS 장애)여도 면제라 ready 유지.
+
+    단 이 derive 만으로는 0원 체결을 막지 못하며, VirtualExecutor 시장가 가격
+    안전(api-gateway.md)과 짝을 이룬다(#2398). 본 PR 은 derive 만 검증한다.
+    """
+    reg = RuntimeReadinessRegistry()
+    reg.mark_ready("v", ReadinessFlag.TREASURY_SYNC)
+    reg.mark_not_ready("v", ReadinessFlag.BROKER, "broker_down")
+    assert (
+        reg.active_trading_ready(
+            "v", broker_type="kis-domestic", trading_mode=TradingMode.VIRTUAL
+        )
+        is True
+    )
+
+
+def test_not_ready_flags_tracks_marks() -> None:
+    """not_ready_flags 는 명시 mark 기준 not_ready 플래그를 반환한다."""
+    reg = RuntimeReadinessRegistry()
+    reg.mark_ready("acc", ReadinessFlag.BROKER)
+    reg.mark_ready("acc", ReadinessFlag.TREASURY_SYNC)
+    pending = reg.not_ready_flags("acc")
+    assert ReadinessFlag.BROKER not in pending
+    assert ReadinessFlag.TREASURY_SYNC not in pending
+    assert ReadinessFlag.FILL_RECONCILE in pending
+    assert ReadinessFlag.RECONCILE in pending

--- a/tests/unit/test_account_runtime_readiness.py
+++ b/tests/unit/test_account_runtime_readiness.py
@@ -53,25 +53,34 @@ def test_exemption_matrix(
     )
 
 
-def test_exemption_axis_is_trading_mode_not_broker_type() -> None:
-    """broker/fill/reconcile 면제축은 trading_mode 다 — broker_type 은 무관.
+def test_exemption_explicit_pairs_only_fail_closed() -> None:
+    """broker/fill/reconcile 면제는 **명시 pair만**(fail-closed).
 
-    test/live, kis-domestic/live 모두 비면제(요구)여야 한다(broker_type 으로
-    면제를 판정하지 않음).
+    (test, virtual)·(kis-domestic, virtual) 만 면제. 미지정/신규 broker_type 은
+    virtual 이어도 비면제(요구) — trading_mode 만 보던 fail-open 회귀 방지
+    (Codex P2, [must_fix A]). 전 broker_type 의 live 도 비면제.
     """
-    for broker_type in ("test", "kis-domestic", "future-broker"):
-        for flag in (
-            ReadinessFlag.BROKER,
-            ReadinessFlag.FILL_RECONCILE,
-            ReadinessFlag.RECONCILE,
-        ):
-            # virtual → 면제
-            assert is_flag_exempt(
-                flag, broker_type=broker_type, trading_mode=TradingMode.VIRTUAL
-            )
-            # live → 요구(비면제)
+    bfr = (
+        ReadinessFlag.BROKER,
+        ReadinessFlag.FILL_RECONCILE,
+        ReadinessFlag.RECONCILE,
+    )
+    for flag in bfr:
+        # 명시 면제 pair (virtual) → 면제
+        assert is_flag_exempt(
+            flag, broker_type="test", trading_mode=TradingMode.VIRTUAL
+        )
+        assert is_flag_exempt(
+            flag, broker_type="kis-domestic", trading_mode=TradingMode.VIRTUAL
+        )
+        # 미지정/신규 broker_type + virtual → fail-closed(비면제)
+        assert not is_flag_exempt(
+            flag, broker_type="future-broker", trading_mode=TradingMode.VIRTUAL
+        )
+        # 전 broker_type 의 live → 비면제(요구)
+        for bt in ("test", "kis-domestic", "future-broker"):
             assert not is_flag_exempt(
-                flag, broker_type=broker_type, trading_mode=TradingMode.LIVE
+                flag, broker_type=bt, trading_mode=TradingMode.LIVE
             )
 
 

--- a/tests/unit/test_main_runtime_readiness_wiring.py
+++ b/tests/unit/test_main_runtime_readiness_wiring.py
@@ -419,6 +419,10 @@ async def test_self_healing_retries_indefinitely_until_recover() -> None:
         get=lambda key, default=None: {
             "readiness.self_healing_interval_seconds": 0,
             "readiness.self_healing_max_attempts_per_burst": 2,
+            # backoff 를 0 으로 무력화 — liveness 검증이 실시간 sleep 에 의존하지
+            # 않게 한다(기본 5s backoff 면 폴링 윈도우 초과).
+            "readiness.self_healing_backoff_base_seconds": 0,
+            "readiness.self_healing_backoff_max_seconds": 0,
         }.get(key, default)
     )
 
@@ -478,15 +482,118 @@ async def test_self_healing_loop_cancel_on_shutdown() -> None:
     assert task.cancelled() or task.done()
 
 
-def test_start_self_healing_skipped_when_all_exempt() -> None:
-    """대상 LIVE 계좌가 없으면(전부 면제) self-healing loop 를 띄우지 않는다."""
+@pytest.mark.asyncio
+async def test_start_self_healing_started_for_virtual_treasury_targets() -> None:
+    """Codex P2 회귀: treasury_sync 는 면제 없음(전 계좌 요구)이므로 virtual/test
+    전용 구성도 self-healing 대상이다 — 루프를 띄워 treasury 일시 실패를 회복한다.
+
+    (이전 회귀: targets 가 broker 비면제 LIVE 계좌만이라 virtual treasury 실패가
+    영구 not_ready 로 고착.)
+    """
     s = _services()
     accounts = [
         _account("test", broker_type="test", trading_mode=TradingMode.VIRTUAL),
         _account("kv", trading_mode=TradingMode.VIRTUAL),
     ]
     main_module._start_readiness_self_healing(s, accounts)
+    assert s.readiness_self_healing_task is not None
+    # cleanup: 띄운 task 취소.
+    task = s.readiness_self_healing_task
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+def test_start_self_healing_skipped_when_no_accounts() -> None:
+    """계좌가 하나도 없으면 self-healing loop 를 띄우지 않는다."""
+    s = _services()
+    main_module._start_readiness_self_healing(s, [])
     assert s.readiness_self_healing_task is None
+
+
+@pytest.mark.asyncio
+async def test_self_healing_recover_virtual_retries_treasury_without_get_broker() -> (
+    None
+):
+    """Codex P2 회귀: broker 면제(virtual) 계좌의 회복은 treasury_sync(면제 없음)
+    만 재시도하고, broker/fill/reconcile 은 면제(no-op ready)이므로 get_broker
+    재노출 없이 skip 한다.
+
+    virtual kis-domestic: broker/fill/reconcile 면제 → active_trading_ready 는
+    treasury 만 요구. treasury not_ready → 회복 retry 로 ready 전이 → True.
+    """
+    s = _services()
+    account = _account("kv", trading_mode=TradingMode.VIRTUAL)
+    # treasury 만 not_ready(나머지는 면제 → active_trading_ready 가 ready 취급).
+    s.runtime_readiness.mark_not_ready(
+        "kv", ReadinessFlag.TREASURY_SYNC, "treasury_sync_failed"
+    )
+
+    recovered = await main_module._self_healing_recover_account(s, account)
+
+    assert recovered is True
+    assert s.runtime_readiness.is_ready("kv", ReadinessFlag.TREASURY_SYNC)
+    # 면제 계좌이므로 broker/fill/reconcile 재등록(get_broker) 미발생.
+    assert s.account_service.get_broker.await_count == 0
+    assert "kv" not in s.fill_schedulers
+    assert "kv" not in s.reconcile_schedulers
+
+
+@pytest.mark.asyncio
+async def test_self_healing_recover_disabled_reconcile_marks_ready() -> None:
+    """Codex P2 회귀: reconcile.enabled=false 인 비면제(LIVE) 계좌의 회복은
+    reconcile_ready 를 ready 로 no-op mark 해 영구 not_ready 고착을 막는다
+    (startup 의 disabled no-op ready 와 동일). 회복 완료(active_trading_ready)."""
+    s = _services()
+    # reconcile 비활성 config.
+    s.config = SimpleNamespace(
+        get=lambda key, default=None: (
+            {"enabled": False} if key == "reconcile" else default
+        )
+    )
+    account = _account("live-1")
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+
+    recovered = await main_module._self_healing_recover_account(s, account)
+
+    assert recovered is True
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.BROKER)
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.FILL_RECONCILE)
+    # reconcile 비활성 → scheduler 미등록이지만 reconcile_ready 는 no-op ready.
+    assert "live-1" not in s.reconcile_schedulers
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.RECONCILE)
+
+
+def test_self_healing_loop_backs_off_between_attempts() -> None:
+    """Codex P2 회귀: burst 내 attempt 간 지수 backoff(토큰 cooldown 정렬).
+
+    소스 계약 락: ``_readiness_self_healing_loop`` 가 backoff base/max 설정을 읽고
+    attempt 간 ``asyncio.sleep`` 으로 backoff 한다(즉시 재인증 몰림 방지).
+    """
+    import pathlib
+
+    main_src = pathlib.Path(main_module.__file__).resolve()
+    lines = main_src.read_text(encoding="utf-8").splitlines()
+    start = next(
+        i
+        for i, ln in enumerate(lines)
+        if "_readiness_self_healing_loop" in ln
+        and ln.lstrip().startswith(("def ", "async def "))
+    )
+    end = next(
+        (
+            i
+            for i in range(start + 1, len(lines))
+            if lines[i].startswith(("def ", "async def "))
+        ),
+        len(lines),
+    )
+    body = "\n".join(lines[start:end])
+    assert "self_healing_backoff_base_seconds" in body
+    assert "self_healing_backoff_max_seconds" in body
+    assert "2**attempt" in body or "2 ** attempt" in body
 
 
 # ── broker_ready connect 시점 mark (init_gateway 발췌 경로) ─────────────────

--- a/tests/unit/test_main_runtime_readiness_wiring.py
+++ b/tests/unit/test_main_runtime_readiness_wiring.py
@@ -1,0 +1,607 @@
+"""main._init_* ↔ RuntimeReadinessRegistry wiring + self-healing 테스트 (#2397).
+
+검증:
+- startup 실패→not_ready, broker_ready connect 시점 mark.
+- 전역(connected_count==0)+per-account 이중 실패모드 reason.
+- 면제 계좌 get_broker 미호출(virtual/test broker-backed skip 회귀).
+- catch_up 폴 실패→fill_reconcile_ready=false (R4).
+- self-healing: not_ready→회복→재등록(멱등·orphan 없음)→ready, 무기한 재시도,
+  전역 barrier clear 미호출 회귀, shutdown cancel.
+- observe-only: registry 도입이 주문 동작을 바꾸지 않음(gate reader 부재).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+import ante.broker.fill_scheduler as fill_scheduler_mod
+import ante.broker.scheduler as scheduler_mod
+import ante.main as main_module
+from ante.account.models import TradingMode
+from ante.account.readiness import ReadinessFlag, RuntimeReadinessRegistry
+
+
+def _account(
+    account_id: str,
+    *,
+    broker_type: str = "kis-domestic",
+    trading_mode: TradingMode = TradingMode.LIVE,
+    exchange: str = "KRX",
+) -> Any:
+    return SimpleNamespace(
+        account_id=account_id,
+        broker_type=broker_type,
+        trading_mode=trading_mode,
+        exchange=exchange,
+        credentials={},
+        broker_config={},
+    )
+
+
+class _FakeFillScheduler:
+    """FillReconcileScheduler 더블 — catch_up_once/start/stop 추적."""
+
+    instances: list[_FakeFillScheduler] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.account_id = kwargs["account_id"]
+        self.started = False
+        self.stopped = False
+        # 클래스 변수로 주입된 catch_up 성공 여부(account_id 별).
+        self._succeeded = _FakeFillScheduler.succeed_map.get(self.account_id, True)
+        _FakeFillScheduler.instances.append(self)
+
+    succeed_map: dict[str, bool] = {}
+
+    async def catch_up_once(self) -> Any:
+        return fill_scheduler_mod.CatchUpResult(succeeded=self._succeeded, applied=0)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _FakeReconcileScheduler:
+    """ReconcileScheduler 더블 — start/stop 추적."""
+
+    instances: list[_FakeReconcileScheduler] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.account_id = kwargs["broker_account_id"]
+        self.started = False
+        self.stopped = False
+        _FakeReconcileScheduler.instances.append(self)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture(autouse=True)
+def _patch_schedulers(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeFillScheduler.instances = []
+    _FakeFillScheduler.succeed_map = {}
+    _FakeReconcileScheduler.instances = []
+    monkeypatch.setattr(
+        fill_scheduler_mod, "FillReconcileScheduler", _FakeFillScheduler
+    )
+    monkeypatch.setattr(scheduler_mod, "ReconcileScheduler", _FakeReconcileScheduler)
+
+
+def _services(
+    *,
+    brokers: dict[str, Any] | None = None,
+) -> Any:
+    """fill/reconcile 등록에 필요한 최소 Services 더블.
+
+    ``brokers`` 는 account_id → broker(또는 raise 할 Exception) 매핑. 기본은
+    connect 성공하는 AsyncMock broker.
+    """
+    s = main_module.Services()
+    s.runtime_readiness = RuntimeReadinessRegistry()
+    s.order_tracker = object()
+    s.fill_applier = object()
+    s.trade_service = object()
+    s.eventbus = AsyncMock()
+    s.instrument_service = object()
+    s.bot_manager = object()
+    s.position_history = None
+    s.api_gateway = None
+    s.config = SimpleNamespace(get=lambda key, default=None: default)
+
+    # treasury_manager 더블 — start_sync/set_account_info 추적(self-healing 재sync).
+    treasury = SimpleNamespace(
+        start_sync=lambda **kwargs: None,
+        set_account_info=lambda **kwargs: None,
+    )
+    s.treasury_manager = SimpleNamespace(get=lambda account_id: treasury)
+
+    broker_map = brokers or {}
+
+    async def _get_broker(account_id: str) -> Any:
+        if account_id in broker_map:
+            result = broker_map[account_id]
+            if isinstance(result, Exception):
+                raise result
+            return result
+        broker = AsyncMock()
+        broker.connect = AsyncMock()
+        return broker
+
+    account_service = AsyncMock()
+    account_service.get_broker = AsyncMock(side_effect=_get_broker)
+    s.account_service = account_service  # type: ignore[assignment]
+    return s
+
+
+# ── broker_ready: connect 시점 mark / startup 실패 ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_fill_marks_ready_on_success() -> None:
+    """LIVE 계좌 fill 등록 성공 → fill_reconcile_ready=True."""
+    s = _services()
+    account = _account("live-1")
+
+    ok = await main_module._register_fill_scheduler_for_account(s, account)
+
+    assert ok is True
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.FILL_RECONCILE)
+    assert "live-1" in s.fill_schedulers
+
+
+@pytest.mark.asyncio
+async def test_register_fill_get_broker_failure_marks_not_ready() -> None:
+    """per-account get_broker 실패 → fill_reconcile_ready=False + reason.
+
+    이중 실패모드 (b): per-account continue 지점 명시 mark.
+    """
+    s = _services(brokers={"live-1": RuntimeError("EGW00133")})
+    account = _account("live-1")
+
+    ok = await main_module._register_fill_scheduler_for_account(s, account)
+
+    assert ok is False
+    assert not s.runtime_readiness.is_ready("live-1", ReadinessFlag.FILL_RECONCILE)
+    assert (
+        s.runtime_readiness.get_reason("live-1", ReadinessFlag.FILL_RECONCILE)
+        == "get_broker_failed"
+    )
+    assert "live-1" not in s.fill_schedulers
+
+
+@pytest.mark.asyncio
+async def test_catch_up_poll_failure_marks_fill_not_ready() -> None:
+    """R4: catch_up_once 폴 실패 → start 해도 fill_reconcile_ready=False."""
+    s = _services()
+    _FakeFillScheduler.succeed_map = {"live-1": False}
+    account = _account("live-1")
+
+    ok = await main_module._register_fill_scheduler_for_account(s, account)
+
+    # scheduler 는 start 되지만 readiness 는 false 로 분리.
+    assert ok is False
+    assert "live-1" in s.fill_schedulers
+    assert s.fill_schedulers["live-1"].started is True
+    assert not s.runtime_readiness.is_ready("live-1", ReadinessFlag.FILL_RECONCILE)
+    assert (
+        s.runtime_readiness.get_reason("live-1", ReadinessFlag.FILL_RECONCILE)
+        == "catch_up_poll_failed"
+    )
+    # 폴 실패 계좌는 #1946 barrier 에 추가.
+    assert "live-1" in s.fill_catch_up_failed_accounts
+
+
+@pytest.mark.asyncio
+async def test_fill_init_exempts_virtual_without_get_broker() -> None:
+    """면제(virtual/test) 계좌는 get_broker 미호출 + no-op ready mark (회귀 락)."""
+    s = _services()
+    accounts = [
+        _account("test", broker_type="test", trading_mode=TradingMode.VIRTUAL),
+        _account("kv", broker_type="kis-domestic", trading_mode=TradingMode.VIRTUAL),
+        _account("live-1"),
+    ]
+
+    await main_module._init_fill_recovery_schedulers(s, accounts)
+
+    # 면제 계좌는 no-op ready, broker-backed 등록 skip.
+    assert s.runtime_readiness.is_ready("test", ReadinessFlag.FILL_RECONCILE)
+    assert s.runtime_readiness.is_ready("kv", ReadinessFlag.FILL_RECONCILE)
+    assert "test" not in s.fill_schedulers
+    assert "kv" not in s.fill_schedulers
+    # LIVE 계좌만 등록.
+    assert "live-1" in s.fill_schedulers
+    # 면제 계좌의 get_broker 는 호출되지 않아야 한다(KIS 재노출 차단).
+    called_ids = {c.args[0] for c in s.account_service.get_broker.call_args_list}
+    assert called_ids == {"live-1"}
+
+
+# ── 전역 이중 실패모드 (a): connected_count==0 ─────────────────────────────
+
+
+def test_global_fill_skip_exempt_first() -> None:
+    """전역 skip 시 면제 먼저 적용 — virtual no-op ready, LIVE not_ready(reason)."""
+    s = _services()
+    accounts = [
+        _account("test", broker_type="test", trading_mode=TradingMode.VIRTUAL),
+        _account("live-1"),
+    ]
+
+    main_module._mark_fill_reconcile_global_skip(s, accounts)
+
+    assert s.runtime_readiness.is_ready("test", ReadinessFlag.FILL_RECONCILE)
+    assert not s.runtime_readiness.is_ready("live-1", ReadinessFlag.FILL_RECONCILE)
+    assert (
+        s.runtime_readiness.get_reason("live-1", ReadinessFlag.FILL_RECONCILE)
+        == "fill_init_skipped_no_broker"
+    )
+
+
+def test_global_reconcile_skip_exempt_first() -> None:
+    """전역 reconcile skip 도 면제 먼저 — virtual no-op ready, LIVE not_ready."""
+    s = _services()
+    accounts = [
+        _account("kv", trading_mode=TradingMode.VIRTUAL),
+        _account("live-1"),
+    ]
+
+    main_module._mark_reconcile_global_skip(s, accounts)
+
+    assert s.runtime_readiness.is_ready("kv", ReadinessFlag.RECONCILE)
+    assert not s.runtime_readiness.is_ready("live-1", ReadinessFlag.RECONCILE)
+    assert (
+        s.runtime_readiness.get_reason("live-1", ReadinessFlag.RECONCILE)
+        == "reconcile_init_skipped_no_broker"
+    )
+
+
+# ── reconcile 등록 ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_reconcile_marks_ready() -> None:
+    s = _services()
+    account = _account("live-1")
+    reconciler = object()
+
+    ok = await main_module._register_reconcile_scheduler_for_account(
+        s, account, reconciler, 1800
+    )
+
+    assert ok is True
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.RECONCILE)
+    assert "live-1" in s.reconcile_schedulers
+
+
+@pytest.mark.asyncio
+async def test_register_reconcile_get_broker_failure_marks_not_ready() -> None:
+    s = _services(brokers={"live-1": RuntimeError("timeout")})
+    account = _account("live-1")
+
+    ok = await main_module._register_reconcile_scheduler_for_account(
+        s, account, object(), 1800
+    )
+
+    assert ok is False
+    assert not s.runtime_readiness.is_ready("live-1", ReadinessFlag.RECONCILE)
+    assert (
+        s.runtime_readiness.get_reason("live-1", ReadinessFlag.RECONCILE)
+        == "get_broker_failed"
+    )
+
+
+# ── treasury_sync (면제 없음 — virtual/live 양쪽 요구) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_treasury_sync_marks_ready_virtual_and_live() -> None:
+    """treasury_sync_ready: virtual(broker=None)·live 양쪽 시작 성공 시 mark."""
+    s = _services()
+    accounts = [
+        _account("kv", trading_mode=TradingMode.VIRTUAL),
+        _account("live-1", trading_mode=TradingMode.LIVE),
+    ]
+
+    await main_module._init_treasury_sync(s, accounts)
+
+    assert s.runtime_readiness.is_ready("kv", ReadinessFlag.TREASURY_SYNC)
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.TREASURY_SYNC)
+
+
+@pytest.mark.asyncio
+async def test_treasury_sync_failure_marks_not_ready() -> None:
+    """treasury_sync 시작 실패 → treasury_sync_ready=False + reason."""
+    s = _services()
+
+    def _raise(account_id: str) -> Any:
+        raise RuntimeError("treasury boom")
+
+    s.treasury_manager = SimpleNamespace(get=_raise)
+    accounts = [_account("live-1", trading_mode=TradingMode.LIVE)]
+
+    await main_module._init_treasury_sync(s, accounts)
+
+    assert not s.runtime_readiness.is_ready("live-1", ReadinessFlag.TREASURY_SYNC)
+    assert (
+        s.runtime_readiness.get_reason("live-1", ReadinessFlag.TREASURY_SYNC)
+        == "treasury_sync_failed"
+    )
+
+
+# ── self-healing ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_self_healing_recovers_not_ready_account() -> None:
+    """not_ready broker → 회복(connect 성공) → broker_ready + 스케줄러 재등록."""
+    s = _services()
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+    account = _account("live-1")
+
+    recovered = await main_module._self_healing_recover_account(s, account)
+
+    assert recovered is True
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.BROKER)
+    # 회복 시 fill + reconcile 재등록 + ready 전이.
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.FILL_RECONCILE)
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.RECONCILE)
+    assert "live-1" in s.fill_schedulers
+    assert "live-1" in s.reconcile_schedulers
+
+
+@pytest.mark.asyncio
+async def test_self_healing_reregister_is_idempotent_no_orphan() -> None:
+    """재등록 멱등 — 기존 scheduler task 를 stop 후 교체(orphan 없음)."""
+    s = _services()
+    account = _account("live-1")
+    # 1차 등록.
+    await main_module._register_fill_scheduler_for_account(s, account)
+    await main_module._register_reconcile_scheduler_for_account(
+        s, account, object(), 1800
+    )
+    first_fill = s.fill_schedulers["live-1"]
+    first_reconcile = s.reconcile_schedulers["live-1"]
+    # broker 를 not_ready 로 만들고 회복(재등록) 유도.
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+
+    await main_module._self_healing_recover_account(s, account)
+
+    # 기존 인스턴스는 stop 되고(orphan 방지) 새 인스턴스로 교체된다.
+    assert first_fill.stopped is True
+    assert first_reconcile.stopped is True
+    assert s.fill_schedulers["live-1"] is not first_fill
+    assert s.reconcile_schedulers["live-1"] is not first_reconcile
+    # dict 에 항목이 중복되지 않고 1개만 유지.
+    assert list(s.fill_schedulers) == ["live-1"]
+    assert list(s.reconcile_schedulers) == ["live-1"]
+
+
+@pytest.mark.asyncio
+async def test_self_healing_preserves_other_account_barrier() -> None:
+    """per-account 재시도가 전역 fill_catch_up_failed_accounts.clear() 호출 안 함.
+
+    다른 계좌(live-2)의 #1946 barrier 가 보존되어야 한다(전역 clear 회귀 락).
+    """
+    s = _services()
+    # 타 계좌의 barrier 를 사전 설정.
+    s.fill_catch_up_failed_accounts.add("live-2")
+    account = _account("live-1")
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+
+    await main_module._self_healing_recover_account(s, account)
+
+    # live-1 회복(폴 성공)이 live-2 barrier 를 지우지 않아야 한다.
+    assert "live-2" in s.fill_catch_up_failed_accounts
+
+
+@pytest.mark.asyncio
+async def test_self_healing_retries_indefinitely_until_recover() -> None:
+    """무기한 재시도 — 연속 실패 후 회복 가능해지면 유한시간 내 ready (liveness)."""
+    s = main_module.Services()
+    s.runtime_readiness = RuntimeReadinessRegistry()
+    s.order_tracker = None
+    s.fill_applier = None
+    s.trade_service = None
+    s.eventbus = AsyncMock()
+    s.instrument_service = object()
+    s.bot_manager = object()
+    # 매우 짧은 interval/burst 로 루프를 구동.
+    s.config = SimpleNamespace(
+        get=lambda key, default=None: {
+            "readiness.self_healing_interval_seconds": 0,
+            "readiness.self_healing_max_attempts_per_burst": 2,
+        }.get(key, default)
+    )
+
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+
+    # 처음 N회 connect 실패 후 성공하는 broker.
+    state = {"fails_left": 3}
+
+    async def _get_broker(account_id: str) -> Any:
+        broker = AsyncMock()
+
+        async def _connect() -> None:
+            if state["fails_left"] > 0:
+                state["fails_left"] -= 1
+                raise RuntimeError("EGW00133")
+
+        broker.connect = AsyncMock(side_effect=_connect)
+        return broker
+
+    account_service = AsyncMock()
+    account_service.get_broker = AsyncMock(side_effect=_get_broker)
+    s.account_service = account_service  # type: ignore[assignment]
+
+    account = _account("live-1")
+    task = asyncio.create_task(main_module._readiness_self_healing_loop(s, [account]))
+    try:
+        # 유한시간 내 ready 로 전이해야 한다(liveness invariant).
+        for _ in range(200):
+            if s.runtime_readiness.is_ready("live-1", ReadinessFlag.BROKER):
+                break
+            await asyncio.sleep(0)
+        assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.BROKER)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_self_healing_loop_cancel_on_shutdown() -> None:
+    """shutdown 에서 self-healing loop task 가 cancel 된다."""
+    s = _services()
+    account = _account("live-1")
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+    main_module._start_readiness_self_healing(s, [account])
+    assert s.readiness_self_healing_task is not None
+
+    # _shutdown 의 cancel 블록과 동일한 패턴으로 검증.
+    task = s.readiness_self_healing_task
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    assert task.cancelled() or task.done()
+
+
+def test_start_self_healing_skipped_when_all_exempt() -> None:
+    """대상 LIVE 계좌가 없으면(전부 면제) self-healing loop 를 띄우지 않는다."""
+    s = _services()
+    accounts = [
+        _account("test", broker_type="test", trading_mode=TradingMode.VIRTUAL),
+        _account("kv", trading_mode=TradingMode.VIRTUAL),
+    ]
+    main_module._start_readiness_self_healing(s, accounts)
+    assert s.readiness_self_healing_task is None
+
+
+# ── broker_ready connect 시점 mark (init_gateway 발췌 경로) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_init_gateway_broker_ready_marks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_init_gateway connect 루프: LIVE 성공→broker_ready, virtual→면제 no-op ready,
+    LIVE 실패→not_ready + get_broker 미호출(virtual)."""
+    s = _services(brokers={"live-fail": RuntimeError("EGW00133")})
+
+    accounts = [
+        _account("test", broker_type="test", trading_mode=TradingMode.VIRTUAL),
+        _account("live-ok"),
+        _account("live-fail"),
+    ]
+    s.account_service.list = AsyncMock(return_value=accounts)
+
+    # _init_gateway 의 connect 루프만 검증하기 위해 후속 단계를 무력화.
+    async def _noop(*a: Any, **k: Any) -> None:
+        return None
+
+    def _noop_sync(*a: Any, **k: Any) -> None:
+        return None
+
+    monkeypatch.setattr(main_module, "_sync_instruments", _noop)
+    monkeypatch.setattr(main_module, "_init_context_factory", _noop_sync)
+    monkeypatch.setattr(main_module, "_init_treasury_sync", _noop)
+    monkeypatch.setattr(main_module, "_init_fill_recovery_schedulers", _noop)
+    monkeypatch.setattr(main_module, "_init_fill_outbox_publisher", _noop)
+    monkeypatch.setattr(main_module, "_init_reconcile_scheduler", _noop)
+    monkeypatch.setattr(main_module, "_init_daily_report_scheduler", _noop)
+    monkeypatch.setattr(main_module, "_start_readiness_self_healing", _noop_sync)
+
+    class _FakeStopOrderManager:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    class _FakeGateway:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    import ante.gateway as gateway_mod
+    import ante.gateway.stop_order as stop_order_mod
+
+    monkeypatch.setattr(gateway_mod, "APIGateway", _FakeGateway)
+    monkeypatch.setattr(stop_order_mod, "StopOrderManager", _FakeStopOrderManager)
+    s.treasury_manager = None
+    s.performance_tracker = None
+    s.trade_recorder = None
+    s.position_history = None
+    s.fill_outbox_publisher = None
+    s.virtual_executor = SimpleNamespace(_gateway=None)
+    s.bot_manager = SimpleNamespace(_context_factory=None)
+
+    await main_module._init_gateway(s)
+
+    # virtual/test: 면제 no-op ready, get_broker 미호출(KIS 재노출 차단).
+    assert s.runtime_readiness.is_ready("test", ReadinessFlag.BROKER)
+    # LIVE 성공: connect 시점 broker_ready.
+    assert s.runtime_readiness.is_ready("live-ok", ReadinessFlag.BROKER)
+    # LIVE 실패: not_ready + reason.
+    assert not s.runtime_readiness.is_ready("live-fail", ReadinessFlag.BROKER)
+    assert (
+        s.runtime_readiness.get_reason("live-fail", ReadinessFlag.BROKER)
+        == "connect_failed"
+    )
+    # 면제 계좌 broker 는 connect 단계에서 조회되지 않아야 한다.
+    connect_ids = {c.args[0] for c in s.account_service.get_broker.call_args_list}
+    assert "test" not in connect_ids
+
+
+# ── observe-only 회귀: gate reader 부재(주문 동작 불변) ─────────────────────
+
+
+def test_observe_only_no_gate_reader_in_consumers() -> None:
+    """#2397 은 gate reader 를 추가하지 않는다(gate=#2398) — 주문 동작 불변.
+
+    Treasury/RuleEngine/gateway/broker 등 소비자 모듈이 ``active_trading_ready``
+    /``runtime_readiness`` 를 조회하지 않음을 소스 레벨로 잠근다. 본 PR 은 registry
+    를 채우기만(main 등록자)·관측만 노출한다.
+    """
+    import pathlib
+
+    src_root = pathlib.Path(main_module.__file__).resolve().parent
+    # readiness 정의 모듈·등록자(main)·account 패키지 re-export 는 제외.
+    allowed = {
+        src_root / "account" / "readiness.py",
+        src_root / "account" / "__init__.py",
+        src_root / "main.py",
+    }
+    offenders: list[str] = []
+    for py in src_root.rglob("*.py"):
+        if py in allowed:
+            continue
+        text = py.read_text(encoding="utf-8")
+        if "active_trading_ready" in text or "runtime_readiness" in text:
+            offenders.append(str(py.relative_to(src_root)))
+    assert offenders == [], (
+        "observe-only 위반 — 다음 소비자가 readiness 를 조회한다(gate=#2398): "
+        f"{offenders}"
+    )
+
+
+def test_main_does_not_call_active_trading_ready() -> None:
+    """main 은 readiness 를 mark 만 하고 active_trading_ready 로 gate 하지 않는다."""
+    import pathlib
+
+    main_src = pathlib.Path(main_module.__file__).resolve()
+    text = main_src.read_text(encoding="utf-8")
+    # 호출 형태(``.active_trading_ready(``)는 없어야 한다(주석 언급은 허용).
+    assert ".active_trading_ready(" not in text

--- a/tests/unit/test_main_runtime_readiness_wiring.py
+++ b/tests/unit/test_main_runtime_readiness_wiring.py
@@ -566,6 +566,108 @@ async def test_self_healing_recover_disabled_reconcile_marks_ready() -> None:
     assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.RECONCILE)
 
 
+@pytest.mark.asyncio
+async def test_self_healing_recover_treasury_only_no_scheduler_churn() -> None:
+    """Codex P2 attempt-3 회귀: treasury_sync 만 not_ready 인 LIVE 계좌의 회복은
+    건강한 fill/reconcile 스케줄러를 재등록(stop/start)하지 않는다(churn 방지).
+
+    broker/fill/reconcile 가 모두 ready 이고 treasury 만 not_ready → recover 는
+    treasury 만 재동기화하고, fill/reconcile 인스턴스는 그대로 유지(stop 미호출).
+    (이전 회귀: 매 attempt 마다 건강한 스케줄러 stop/재시작 → KIS 호출·폴링 공백.)
+    """
+    s = _services()
+    account = _account("live-1")
+    # fill + reconcile 사전 등록(ready).
+    await main_module._register_fill_scheduler_for_account(s, account)
+    await main_module._register_reconcile_scheduler_for_account(
+        s, account, object(), 1800
+    )
+    first_fill = s.fill_schedulers["live-1"]
+    first_reconcile = s.reconcile_schedulers["live-1"]
+    # broker ready, treasury 만 not_ready.
+    s.runtime_readiness.mark_ready("live-1", ReadinessFlag.BROKER)
+    s.runtime_readiness.mark_not_ready(
+        "live-1", ReadinessFlag.TREASURY_SYNC, "treasury_sync_failed"
+    )
+
+    recovered = await main_module._self_healing_recover_account(s, account)
+
+    assert recovered is True
+    # 건강한 fill/reconcile 스케줄러는 churn 되지 않는다(동일 인스턴스·stop 미호출).
+    assert s.fill_schedulers["live-1"] is first_fill
+    assert s.reconcile_schedulers["live-1"] is first_reconcile
+    assert first_fill.stopped is False
+    assert first_reconcile.stopped is False
+    # treasury 만 재동기화 → ready.
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.TREASURY_SYNC)
+
+
+@pytest.mark.asyncio
+async def test_self_healing_recover_rebinds_schedulers_on_broker_recovery() -> None:
+    """broker 가 방금 재연결되면 fill/reconcile 스케줄러를 재등록(rebind)한다 —
+    이미 ready 여도 stale broker 핸들 교체를 위해(churn 게이트의 broker_just_recovered
+    경로). treasury_only churn 방지와 대칭되는 정상 rebind 경로 회귀 락."""
+    s = _services()
+    account = _account("live-1")
+    await main_module._register_fill_scheduler_for_account(s, account)
+    await main_module._register_reconcile_scheduler_for_account(
+        s, account, object(), 1800
+    )
+    first_fill = s.fill_schedulers["live-1"]
+    first_reconcile = s.reconcile_schedulers["live-1"]
+    # broker not_ready → 회복 시 broker_just_recovered=True 로 rebind 유도.
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+
+    await main_module._self_healing_recover_account(s, account)
+
+    # broker 재연결 → 기존 스케줄러 stop 후 새 인스턴스로 교체.
+    assert first_fill.stopped is True
+    assert first_reconcile.stopped is True
+    assert s.fill_schedulers["live-1"] is not first_fill
+    assert s.reconcile_schedulers["live-1"] is not first_reconcile
+
+
+@pytest.mark.asyncio
+async def test_self_healing_burst_backoff_is_exponential_capped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex P2 회귀(행위): burst 내 attempt 간 backoff 가 base*2^attempt 로
+    지수 증가하고 max 로 capped 된다. 마지막 attempt 뒤에는 backoff 하지 않는다.
+
+    asyncio.sleep 을 가로채 실제 대기 없이 duration 시퀀스를 검증한다.
+    base=5, max=15, max_per_burst=4 → backoff [5, 10, 15(capped from 20)].
+    """
+    s = _services(brokers={"live-1": RuntimeError("EGW00133")})
+    s.config = SimpleNamespace(
+        get=lambda key, default=None: {
+            "readiness.self_healing_interval_seconds": 0,
+            "readiness.self_healing_max_attempts_per_burst": 4,
+            "readiness.self_healing_backoff_base_seconds": 5,
+            "readiness.self_healing_backoff_max_seconds": 15,
+        }.get(key, default)
+    )
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+
+    durations: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _fake_sleep(delay: float) -> None:
+        durations.append(delay)
+        # backoff 3회(attempt 0,1,2) 수집 후 루프 종료(인터럽트).
+        if len(durations) >= 3:
+            raise asyncio.CancelledError
+        await real_sleep(0)
+
+    monkeypatch.setattr(main_module.asyncio, "sleep", _fake_sleep)
+    account = _account("live-1")
+
+    with pytest.raises(asyncio.CancelledError):
+        await main_module._readiness_self_healing_loop(s, [account])
+
+    # base*2^0=5, base*2^1=10, min(base*2^2=20, max=15)=15. 마지막 attempt(3)는 skip.
+    assert durations[:3] == [5, 10, 15]
+
+
 def test_self_healing_loop_backs_off_between_attempts() -> None:
     """Codex P2 회귀: burst 내 attempt 간 지수 backoff(토큰 cooldown 정렬).
 

--- a/tests/unit/test_main_runtime_readiness_wiring.py
+++ b/tests/unit/test_main_runtime_readiness_wiring.py
@@ -118,9 +118,14 @@ def _services(
     s.api_gateway = None
     s.config = SimpleNamespace(get=lambda key, default=None: default)
 
-    # treasury_manager 더블 — start_sync/set_account_info 추적(self-healing 재sync).
+    # treasury_manager 더블 — start_sync/stop_sync/set_account_info 추적
+    # (self-healing 재sync 는 stop_sync 선행 idempotent replace).
+    async def _treasury_stop_sync() -> None:
+        return None
+
     treasury = SimpleNamespace(
         start_sync=lambda **kwargs: None,
+        stop_sync=_treasury_stop_sync,
         set_account_info=lambda **kwargs: None,
     )
     s.treasury_manager = SimpleNamespace(get=lambda account_id: treasury)
@@ -625,6 +630,65 @@ async def test_self_healing_recover_rebinds_schedulers_on_broker_recovery() -> N
     assert first_reconcile.stopped is True
     assert s.fill_schedulers["live-1"] is not first_fill
     assert s.reconcile_schedulers["live-1"] is not first_reconcile
+
+
+@pytest.mark.asyncio
+async def test_self_healing_recover_restarts_treasury_on_broker_recovery() -> None:
+    """Codex P2 attempt-4 회귀: broker 회복 시 Treasury sync 를 stop 후 재시작해
+    stale broker 를 새 broker 로 교체한다.
+
+    Treasury.start_sync 는 실행 중 task 가 있으면 no-op 이므로, _init_treasury_sync
+    가 stop_sync 를 선행해야 한다. broker_just_recovered LIVE 경로에서 stop→start
+    순서를 잠근다(이전 회귀: start_sync no-op → treasury_sync_ready 만 ready 인데
+    잔고 동기화는 stale broker 유지).
+    """
+    s = _services()
+    account = _account("live-1")
+    calls: list[str] = []
+
+    async def _stop_sync() -> None:
+        calls.append("stop")
+
+    treasury = SimpleNamespace(
+        start_sync=lambda **kwargs: calls.append("start"),
+        stop_sync=_stop_sync,
+        set_account_info=lambda **kwargs: None,
+    )
+    s.treasury_manager = SimpleNamespace(get=lambda account_id: treasury)
+    # broker not_ready → 회복 시 broker_just_recovered=True → treasury 재바인딩.
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+
+    await main_module._self_healing_recover_account(s, account)
+
+    # stale broker sync 교체: stop 선행 후 start(no-op 회피).
+    assert calls == ["stop", "start"]
+
+
+@pytest.mark.asyncio
+async def test_init_treasury_sync_stops_before_start_idempotent() -> None:
+    """_init_treasury_sync 는 stop_sync 선행 후 start_sync 한다(idempotent replace).
+
+    startup 재진입·self-healing 재sync 모두 stale sync 를 새 broker 로 교체하도록
+    stop→start 순서를 직접 잠근다(Codex P2 attempt-4).
+    """
+    s = _services()
+    account = _account("live-1")
+    calls: list[str] = []
+
+    async def _stop_sync() -> None:
+        calls.append("stop")
+
+    treasury = SimpleNamespace(
+        start_sync=lambda **kwargs: calls.append("start"),
+        stop_sync=_stop_sync,
+        set_account_info=lambda **kwargs: None,
+    )
+    s.treasury_manager = SimpleNamespace(get=lambda account_id: treasury)
+
+    await main_module._init_treasury_sync(s, [account])
+
+    assert calls == ["stop", "start"]
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.TREASURY_SYNC)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_main_runtime_readiness_wiring.py
+++ b/tests/unit/test_main_runtime_readiness_wiring.py
@@ -611,7 +611,12 @@ async def test_self_healing_recover_treasury_only_no_scheduler_churn() -> None:
 async def test_self_healing_recover_rebinds_schedulers_on_broker_recovery() -> None:
     """broker 가 방금 재연결되면 fill/reconcile 스케줄러를 재등록(rebind)한다 —
     이미 ready 여도 stale broker 핸들 교체를 위해(churn 게이트의 broker_just_recovered
-    경로). treasury_only churn 방지와 대칭되는 정상 rebind 경로 회귀 락."""
+    경로). treasury_only churn 방지와 대칭되는 정상 rebind 경로 회귀 락.
+
+    주의(메타리뷰 P3): "broker not_ready 인데 교체할 기존 스케줄러 존재" 조합은
+    startup connect 실패 시 스케줄러가 생성되지 않아 현 PR 에서 production-도달
+    불가한 방어 경로다 — 이 테스트는 broker_ready 강등 도입 전까지 인위적 상태로만
+    이 분기를 검증한다(broker_just_recovered rebind 정합성 락)."""
     s = _services()
     account = _account("live-1")
     await main_module._register_fill_scheduler_for_account(s, account)
@@ -630,6 +635,92 @@ async def test_self_healing_recover_rebinds_schedulers_on_broker_recovery() -> N
     assert first_reconcile.stopped is True
     assert s.fill_schedulers["live-1"] is not first_fill
     assert s.reconcile_schedulers["live-1"] is not first_reconcile
+
+
+@pytest.mark.asyncio
+async def test_self_healing_loop_survives_recover_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """메타리뷰 P1 회귀: _self_healing_recover_account 가 예기치 못한 예외를 던져도
+    background loop 가 사멸하지 않고 다음 계좌/burst 로 계속한다(liveness 방어).
+
+    한 계좌(boom)가 매번 raise 해도 다른 계좌(ok)는 유한시간 내 회복되어야 한다
+    (단일 예외가 전 계좌 회복을 멈추면 #2395 영구 not_ready 역회귀).
+    """
+    s = _services()
+    a1 = _account("boom")
+    a2 = _account("ok")
+    s.runtime_readiness.mark_not_ready("boom", ReadinessFlag.BROKER, "connect_failed")
+    s.runtime_readiness.mark_not_ready("ok", ReadinessFlag.BROKER, "connect_failed")
+    s.config = SimpleNamespace(
+        get=lambda key, default=None: {
+            "readiness.self_healing_interval_seconds": 0,
+            "readiness.self_healing_max_attempts_per_burst": 1,
+            "readiness.self_healing_backoff_base_seconds": 0,
+            "readiness.self_healing_backoff_max_seconds": 0,
+        }.get(key, default)
+    )
+
+    real_recover = main_module._self_healing_recover_account
+    calls: list[str] = []
+
+    async def _recover(svc: Any, acc: Any) -> bool:
+        calls.append(acc.account_id)
+        if acc.account_id == "boom":
+            raise RuntimeError("unexpected recover failure")
+        return await real_recover(svc, acc)
+
+    monkeypatch.setattr(main_module, "_self_healing_recover_account", _recover)
+
+    task = asyncio.create_task(main_module._readiness_self_healing_loop(s, [a1, a2]))
+    try:
+        for _ in range(500):
+            if s.runtime_readiness.is_ready("ok", ReadinessFlag.BROKER):
+                break
+            await asyncio.sleep(0)
+        # boom 의 반복 예외에도 loop 가 살아 ok 를 회복시킨다.
+        assert s.runtime_readiness.is_ready("ok", ReadinessFlag.BROKER)
+        assert "boom" in calls and "ok" in calls
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_self_healing_marks_broker_ready_after_dependent_rebind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """메타리뷰 P2 회귀: broker_ready 는 의존 스케줄러 rebind 를 마친 **뒤** mark 한다
+    (stale-broker false-ready 창 제거). fill rebind 시점에 BROKER 가 아직 not_ready
+    임을 잠근다 — 먼저 mark 하면 rebind await 사이에 active_trading_ready 가 stale
+    상태와 함께 True 로 관측될 수 있다.
+    """
+    s = _services()
+    account = _account("live-1")
+    s.runtime_readiness.mark_not_ready("live-1", ReadinessFlag.BROKER, "connect_failed")
+
+    observed: dict[str, bool] = {}
+    real_register = main_module._register_fill_scheduler_for_account
+
+    async def _spy_register(svc: Any, acc: Any) -> bool:
+        observed["broker_ready_during_rebind"] = svc.runtime_readiness.is_ready(
+            acc.account_id, ReadinessFlag.BROKER
+        )
+        return await real_register(svc, acc)
+
+    monkeypatch.setattr(
+        main_module, "_register_fill_scheduler_for_account", _spy_register
+    )
+
+    await main_module._self_healing_recover_account(s, account)
+
+    # rebind 진행 중에는 broker_ready 가 아직 not_ready(지연 mark).
+    assert observed["broker_ready_during_rebind"] is False
+    # 회복 완료 후에는 broker_ready 가 ready.
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.BROKER)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_main_runtime_readiness_wiring.py
+++ b/tests/unit/test_main_runtime_readiness_wiring.py
@@ -597,11 +597,94 @@ def test_observe_only_no_gate_reader_in_consumers() -> None:
     )
 
 
-def test_main_does_not_call_active_trading_ready() -> None:
-    """main 은 readiness 를 mark 만 하고 active_trading_ready 로 gate 하지 않는다."""
+def test_main_active_trading_ready_only_in_self_healing() -> None:
+    """observe-only — main 은 readiness 를 mark 하고, ``active_trading_ready`` 는
+    **self-healing retry-targeting 에만** 쓴다(주문 차단 gate 아님). 주문 경로
+    consumer(gateway/rule/treasury) gate 부재는
+    ``test_observe_only_no_gate_reader_in_consumers`` 가 잠근다.
+    """
     import pathlib
 
     main_src = pathlib.Path(main_module.__file__).resolve()
-    text = main_src.read_text(encoding="utf-8")
-    # 호출 형태(``.active_trading_ready(``)는 없어야 한다(주석 언급은 허용).
-    assert ".active_trading_ready(" not in text
+    lines = main_src.read_text(encoding="utf-8").splitlines()
+    def_idx = [
+        i
+        for i, ln in enumerate(lines)
+        if ln.startswith("def ") or ln.startswith("async def ")
+    ]
+
+    def enclosing_def(idx: int) -> str:
+        prev = [d for d in def_idx if d <= idx]
+        return lines[prev[-1]] if prev else ""
+
+    # ``.active_trading_ready(`` 호출이 있다면 전부 self-healing 함수 내부여야 한다.
+    for i, line in enumerate(lines):
+        if ".active_trading_ready(" in line:
+            enc = enclosing_def(i)
+            assert (
+                "_self_healing_recover_account" in enc
+                or "_readiness_self_healing_loop" in enc
+            ), f"active_trading_ready outside self-healing: {enc!r}"
+
+
+def test_self_healing_loop_targets_non_broker_readiness() -> None:
+    """Codex P1 회귀: self-healing pending 필터가 broker_ready 만이 아니라
+    active_trading_ready(비면제 전 플래그) 기준이어야, broker 회복 후 fill/
+    reconcile/treasury 실패 계좌가 burst 대상에서 빠지지 않는다(영구 차단 방지).
+
+    소스 계약 락: ``_readiness_self_healing_loop`` 의 pending 필터는
+    ``active_trading_ready`` 를 호출하고 ``is_ready(.., BROKER)`` 단독으로
+    필터하지 않는다.
+    """
+    import pathlib
+
+    main_src = pathlib.Path(main_module.__file__).resolve()
+    lines = main_src.read_text(encoding="utf-8").splitlines()
+    start = next(
+        i
+        for i, ln in enumerate(lines)
+        if "_readiness_self_healing_loop" in ln
+        and ln.lstrip().startswith(("def ", "async def "))
+    )
+    end = next(
+        (
+            i
+            for i in range(start + 1, len(lines))
+            if lines[i].startswith(("def ", "async def "))
+        ),
+        len(lines),
+    )
+    body = "\n".join(lines[start:end])
+    assert "active_trading_ready" in body, (
+        "self-healing pending 필터가 active_trading_ready 기준이어야 함(Codex P1)"
+    )
+
+
+def test_self_healing_recover_respects_disabled_reconcile() -> None:
+    """Codex P2 회귀: self-healing 회복 경로(_self_healing_recover_account)는
+    reconcile.enabled=false 를 존중해, 운영자가 끈 reconcile 을 회복 시 다시
+    켜지 않는다(reconcile_enabled 분기 + _register_reconcile_scheduler_for_account
+    조건부 호출).
+    """
+    import pathlib
+
+    main_src = pathlib.Path(main_module.__file__).resolve()
+    lines = main_src.read_text(encoding="utf-8").splitlines()
+    start = next(
+        i
+        for i, ln in enumerate(lines)
+        if "_self_healing_recover_account" in ln
+        and ln.lstrip().startswith(("def ", "async def "))
+    )
+    end = next(
+        (
+            i
+            for i in range(start + 1, len(lines))
+            if lines[i].startswith(("def ", "async def "))
+        ),
+        len(lines),
+    )
+    body = "\n".join(lines[start:end])
+    assert "reconcile_enabled" in body, (
+        "회복 경로가 reconcile.enabled 를 존중해야 함(Codex P2)"
+    )

--- a/tests/unit/test_main_startup_ordering.py
+++ b/tests/unit/test_main_startup_ordering.py
@@ -211,11 +211,31 @@ async def test_main_removes_marker_on_init_failure(
 # ── #2385: _sync_instruments 전 계좌 unique exchange 동기화 ────────────────
 
 
-def _make_sync_account(account_id: str, exchange: str) -> Any:
-    """``account_id``/``exchange`` property 만 갖는 Account 더블."""
+def _make_sync_account(
+    account_id: str,
+    exchange: str,
+    *,
+    broker_type: str = "kis-domestic",
+    trading_mode: Any = None,
+) -> Any:
+    """``account_id``/``exchange``/(broker_type, trading_mode) 를 갖는 Account 더블.
+
+    #2397 R1: ``_sync_instruments`` 는 non-exempt(LIVE) connected 계좌만 순회한다.
+    디폴트는 ``kis-domestic``/``LIVE``(비면제)로 둬 #2385 멀티-계좌 동기화 invariant
+    를 그대로 유지한다. 면제(virtual/test) 회귀는 별도 테스트에서 명시 구성한다.
+    """
     from types import SimpleNamespace
 
-    return SimpleNamespace(account_id=account_id, exchange=exchange)
+    from ante.account.models import TradingMode
+
+    if trading_mode is None:
+        trading_mode = TradingMode.LIVE
+    return SimpleNamespace(
+        account_id=account_id,
+        exchange=exchange,
+        broker_type=broker_type,
+        trading_mode=trading_mode,
+    )
 
 
 def _make_sync_services(broker_instruments: dict[str, Any]) -> tuple[Any, list[Any]]:
@@ -261,20 +281,21 @@ def _make_sync_services(broker_instruments: dict[str, Any]) -> tuple[Any, list[A
 
 @pytest.mark.asyncio
 async def test_sync_instruments_does_not_stop_at_first_broker() -> None:
-    """(a) [test(TEST), oracle-paper(KRX)] 순서에서 KRX 069500 이 적재된다.
+    """(a) LIVE 2계좌(다른 exchange) 순서에서 둘째 exchange 도 적재된다.
 
-    과거 첫 성공 broker `return` 구조에서는 TEST 더미가 KRX 마스터 적재를
-    선점했다(#2385 회귀). 첫 broker return 제거를 잠근다.
+    과거 첫 성공 broker `return` 구조에서는 첫 broker 가 둘째 exchange 마스터
+    적재를 선점했다(#2385 회귀). 첫 broker return 제거를 잠근다. (#2397 R1 이후
+    면제 계좌는 순회 대상에서 빠지므로 비면제 LIVE 2계좌로 invariant 를 유지한다.)
     """
     import ante.main as main_module
 
     accounts = [
-        _make_sync_account("test", "TEST"),
+        _make_sync_account("kospi", "KOSPI"),
         _make_sync_account("oracle-paper", "KRX"),
     ]
     s, upsert_calls = _make_sync_services(
         {
-            "test": [{"symbol": "000001", "name": "알파전자"}],
+            "kospi": [{"symbol": "000001", "name": "알파전자"}],
             "oracle-paper": [{"symbol": "069500", "name": "KODEX 200"}],
         }
     )
@@ -288,6 +309,49 @@ async def test_sync_instruments_does_not_stop_at_first_broker() -> None:
     krx = upserted["069500"]
     assert krx.exchange == "KRX"
     assert krx.name == "KODEX 200"
+
+
+@pytest.mark.asyncio
+async def test_sync_instruments_skips_exempt_accounts() -> None:
+    """#2397 R1: 면제(virtual/test) 계좌는 get_broker 미호출·순회 제외.
+
+    면제 계좌의 dummy exchange 가 실 exchange 마스터 적재를 선점하던 #2385
+    회귀를 broker_ready 면제로 차단한다(KIS 재노출 방지와 동일 메커니즘).
+    """
+    import ante.main as main_module
+    from ante.account.models import TradingMode
+
+    accounts = [
+        # 면제: test/virtual → 순회 제외(get_broker 미호출).
+        _make_sync_account(
+            "test", "TEST", broker_type="test", trading_mode=TradingMode.VIRTUAL
+        ),
+        # 면제: kis-domestic/virtual → 순회 제외.
+        _make_sync_account(
+            "kis-virtual",
+            "KRX",
+            broker_type="kis-domestic",
+            trading_mode=TradingMode.VIRTUAL,
+        ),
+        # 비면제: kis-domestic/live → 순회 대상.
+        _make_sync_account("kis-live", "KRX", trading_mode=TradingMode.LIVE),
+    ]
+    s, upsert_calls = _make_sync_services(
+        {
+            "test": [{"symbol": "000001", "name": "더미"}],
+            "kis-virtual": [{"symbol": "111111", "name": "가상"}],
+            "kis-live": [{"symbol": "069500", "name": "KODEX 200"}],
+        }
+    )
+
+    await main_module._sync_instruments(s, accounts)
+
+    # 면제 계좌의 broker 는 조회조차 되지 않아야 한다(KIS 재노출 차단).
+    s.account_service.get_broker.assert_awaited_once_with("kis-live")
+    # LIVE 계좌의 실 마스터만 적재.
+    assert len(upsert_calls) == 1
+    upserted = {inst.symbol for batch in upsert_calls for inst in batch}
+    assert upserted == {"069500"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2397

## Summary
- **RuntimeReadinessRegistry**(`src/ante/account/readiness.py`) 도입 — per-account runtime readiness SSOT(D-ACC-09, spec #2396). 4 플래그(broker/treasury_sync/fill_reconcile/reconcile)를 등록자가 mark 하고 `active_trading_ready` 가 면제 매트릭스 적용 후 AND 로 derive.
- **면제 매트릭스 fail-closed**: `(test,virtual)`·`(kis-domestic,virtual)` 만 broker/fill/reconcile 면제, treasury_sync 는 전 계좌 무조건 요구, 미지정 pair 는 요구로 fail-closed.
- **main wiring**: `_init_*` 등록자가 스케줄러 등록과 동시에 readiness 를 mark(전역 connected_count==0 + per-account 이중 실패모드 reason).
- **self-healing background loop**: not_ready 계좌를 무기한(per-burst bounded) 재시도. broker 회복 + 의존 스케줄러(fill/reconcile/treasury) rebind 를 플래그별 면제 인식·churn 게이팅(`broker_just_recovered or flag not_ready`)으로 수행.
- **observe-only**: 본 PR 은 registry 를 채우기만 한다. active-order gate reader 는 #2398 — 따라서 **주문 동작 불변**.

## 리뷰 수렴 경과 (Codex 브랜치 리뷰 5 attempt + @code-reviewer 메타 감사)
- attempt2: treasury 전계좌 self-healing 대상 + 플래그별 면제 인식 회복 + reconcile.enabled 존중 + burst 지수 backoff(EGW00133 cooldown).
- attempt3: treasury-only not_ready 계좌의 건강한 fill/reconcile 스케줄러 churn 차단(재등록 게이팅).
- attempt4: broker 회복 시 Treasury sync stale broker 교체(`_init_treasury_sync` stop-before-start idempotent replace).
- 메타 감사(P1/P2): self-healing 루프 예외 격리(liveness invariant 방어 — recover 예외가 전 계좌 회복을 멈추던 #2395 역회귀 차단), broker_ready mark 를 의존 rebind 완료 뒤로 지연(stale-broker false-ready 창 제거).
- attempt5: PASS(명확한 결함 없음).

## Test Plan
- `ruff check` / `ruff format --check`: PASS
- `mypy src/` (전체 235 files): Success
- `pytest tests/unit/` 전체: 7412 passed, 2 skipped
- 신규 회귀: 면제 fail-closed, 이중 실패모드 reason, self-healing 무기한 재시도/멱등·orphan 없음/전역 barrier 보존/shutdown cancel, treasury 전계좌 회복, churn 방지, treasury stop→start, 루프 예외 생존, broker_ready 지연 mark, backoff 지수·cap.

## Known limitations (bounded — follow-up 후보, recover docstring 명시)
- 비-broker flag 실패는 broker 캐시 세션 건강을 신뢰(broker_ready 강등 경로 부재 전제 — #2398 reader live-poll 도입 시 캐시 무효화 재검토).
- `broker_just_recovered` rebind 는 현 PR 에서 production 도달 불가한 방어 경로(강등 도입 시 live 化).
- 다계좌 backoff 직렬 bounded 지연(app_key 단위 그룹화는 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)