### PR TITLE
feat(broker): #2399 KIS 토큰 single-flight + shared cache + EGW00133 per-app_key cooldown

### DIFF
--- a/docs/specs/broker-adapter/07-kis-base-adapter.md
+++ b/docs/specs/broker-adapter/07-kis-base-adapter.md
@@ -76,17 +76,22 @@ scope 정정: 일반 `_request` 경로는 이미 `msg_cd`를 파싱한다(위 `_
 
 - 토큰 응답 형태 가정을 명시한다: HTTP 200 + error 바디 vs non-200. `status != 200` 분기 위치를 결정해 파싱 위치를 고정한다(구현 왕복 방지).
 
-#### (4) `EGW00133` ~60s backoff (별도 분기)
+#### (4) `EGW00133` ~60s backoff (단일 cadence 레이어, normative)
 
-`EGW00133` 감지 시 **~60s backoff**(KIS 공식 "토큰 발급 1분 1회", 토큰 24h 유효) 후 재시도한다. 일반 지수 backoff와 **별도 분기**다.
+> **정정 (#2399 adjudicated, rev4)**: 이전 문안은 "`connect`/`_authenticate` 내부 backoff"를 요구했으나, self-healing 의 반복 `connect` 호출과 곱해져 nested-backoff(최악 5×120s)를 유발하는 잠재 버그가 있다. 아래 **단일 cadence** 정의가 정본이다(additive 안전/정확성 개선).
+
+`EGW00133`(KIS 공식 "토큰 발급 1분 1회", 토큰 24h 유효)의 ~60s backoff 는 **정확히 한 cadence 레이어**에만 둬서 곱해지지 않게 한다. 일반 지수 backoff(TRANSIENT)와도 **별도 분기**다.
+
+- **`_authenticate` 는 EGW00133 시 즉시 `TokenRateLimitError`(`AuthenticationError` 서브클래스, `error_code="EGW00133"`)를 raise** 한다 — **내부 sleep/retry 루프 없음**(곱셈 원천 제거). 어떤 caller 루프 안에서도 60s 가 곱해지지 않는다. `connect()` 도 이 예외를 내부 재시도 없이 그대로 전파한다.
+- ~60s backoff cadence 는 호출부 **단일 레이어**가 분담한다: (a) **startup**(`main._init_gateway` connect 루프)의 bounded retry(`DEFAULT_MAX_RETRIES_AUTH` × ~60s, 부팅 1회 경로), **또는** (b) **self-healing** loop 의 `interval`(60s) — EGW00133 시 그 계좌 burst 남은 attempt 를 break 하고 다음 interval 에 위임(burst 당 connect 시도 ≤1회).
 
 #### (5) connect-path retry (readiness 연동)
 
-`connect` → `_authenticate` 실패가 `EGW00133`이면 즉시 예외 전파 대신 backoff 후 `max_retries_auth`([10-commission-info.md](10-commission-info.md) 인증 재시도 기본값) 내 재시도한다(startup race 완화). 단 startup 전체 타임아웃 초과 시 해당 계좌를 `not_ready`로 떨어뜨려 readiness 축([account/02-design-decisions.md — D-ACC-09](../account/02-design-decisions.md#d-acc-09-runtime-readiness-축은-accountstatus와-직교한다))과 연동한다(이 계좌 active 주문 차단).
+`connect` → `_authenticate` 가 `EGW00133`(`TokenRateLimitError`)을 전파하면, **startup** 경로(`_init_gateway`)는 ~60s backoff 후 `max_retries_auth`([10-commission-info.md](10-commission-info.md) 인증 재시도 기본값) 내 흡수 재시도한다(startup race 완화 — 위 (4)(a) 단일 cadence). 소진 시 해당 계좌를 `not_ready(reason="EGW00133")`로 떨어뜨려 readiness 축([account/02-design-decisions.md — D-ACC-09](../account/02-design-decisions.md#d-acc-09-runtime-readiness-축은-accountstatus와-직교한다))과 연동한다(이 계좌 active 주문 차단). 런타임 회복은 self-healing loop 의 interval(60s) cadence 가 무기한 위임받는다(위 (4)(b)). reason 의 `EGW00133` 은 `AuthenticationError.error_code` 에서 **구조적으로** 추출한다(문자열 grep 금지).
 
 #### (6) classify 불변 invariant ([must_fix J], normative)
 
-`EGW00133` backoff는 `connect()` / `_authenticate` **내부 단독**으로 적용한다. `KISErrorClassifier.classify`의 `AuthenticationError = (retryable=False, record_cb=False)` 분류는 **불변**이다 — gateway 재시도 핸들러가 이중 적용하지 않도록 차단한다. (classify를 손대면 connect-path backoff와 gateway 재시도 핸들러가 이중 적용되거나, `EGW00133`이 즉시 비재시도 전파되는 회귀가 발생한다.)
+`EGW00133` backoff 는 위 (4) **단일 cadence 레이어**(startup wrapper / self-healing interval)에만 있고 `_authenticate` 는 즉시 raise 하므로, gateway 재시도 핸들러·`_request_with_cont` 재시도 루프가 이중 적용하지 않는다. `KISErrorClassifier.classify`의 `AuthenticationError = (retryable=False, record_cb=False)` 분류는 **불변**이다(`TokenRateLimitError` 서브클래스도 동일 분류). classify 를 손대면 connect-path backoff 와 gateway 재시도 핸들러가 이중 적용되거나 `EGW00133`이 즉시 비재시도 전파되는 회귀가 발생한다.
 
 #### (7) known-limitation (normative)
 
@@ -98,11 +103,11 @@ scope 정정: 일반 `_request` 경로는 이미 `msg_cd`를 파싱한다(위 `_
 
 > 계약 확정: #2396. 실제 동작은 구현 #2399 머지 후.
 
-`error_codes.py`([10-commission-info.md — 에러 코드 분류](10-commission-info.md#에러-코드-분류))에 등록한다(현재 0건 실측). **`EGW00201`만 `TRANSIENT_MSG_CODES`에 추가**한다(일반 지수 backoff). **`EGW00133`은 `TRANSIENT_MSG_CODES`에 넣지 않는다** — 이 set은 `_handle_response`가 `APIError.retryable=True`를 세팅해 일반 `KISRetryHandler` 지수 backoff로 보내는 전역 SSOT이므로, EGW00133을 넣으면 전용 ~60s token-only backoff가 아니라 generic/이중 retry를 탄다. `EGW00133`은 `KIS_ERROR_MESSAGES` 한글 등록 + **토큰 발급 경로 전용 분류(별도 set/상수)**로만 두고 `_authenticate`/`connect` 내부 ~60s backoff(위 (4))에서만 소비한다. 두 코드 모두 `KIS_ERROR_MESSAGES`에 한글 메시지 등록.
+`error_codes.py`([10-commission-info.md — 에러 코드 분류](10-commission-info.md#에러-코드-분류))에 등록한다(현재 0건 실측). **`EGW00201`만 `TRANSIENT_MSG_CODES`에 추가**한다(일반 지수 backoff). **`EGW00133`은 `TRANSIENT_MSG_CODES`에 넣지 않는다** — 이 set은 `_handle_response`가 `APIError.retryable=True`를 세팅해 일반 `KISRetryHandler` 지수 backoff로 보내는 전역 SSOT이므로, EGW00133을 넣으면 전용 ~60s token-only backoff가 아니라 generic/이중 retry를 탄다. `EGW00133`은 `KIS_ERROR_MESSAGES` 한글 등록 + **토큰 발급 경로 전용 분류(별도 상수 `TOKEN_RATE_LIMIT_MSG_CODE`)**로만 두고, `_authenticate` 가 감지 시 `TokenRateLimitError` 를 즉시 raise 한다(위 (4)). ~60s backoff 는 startup wrapper / self-healing interval 단일 cadence 가 소비한다. 두 코드 모두 `KIS_ERROR_MESSAGES`에 한글 메시지 등록.
 
 | msg_cd | 분류 | 한글 메시지 | 처리 |
 |---|---|---|---|
-| `EGW00133` | **auth-only(토큰경로 전용, TRANSIENT_MSG_CODES 제외)** | 접근토큰 발급은 1분당 1회만 허용 | **토큰 발급 전용 ~60s backoff 분기** (위 (4)) |
+| `EGW00133` | **auth-only(토큰경로 전용, TRANSIENT_MSG_CODES 제외)** | 접근토큰 발급은 1분당 1회만 허용 | `_authenticate` 즉시 `TokenRateLimitError` raise → **단일 cadence ~60s backoff**(startup wrapper / self-healing interval, 위 (4)) |
 | `EGW00201` | transient | 초당 거래 건수 초과 | 일반 TRANSIENT 지수 backoff |
 
-`EGW00133`은 일반 TRANSIENT 지수 backoff가 아니라 **토큰 발급 전용 ~60s backoff 분기**임을 명시한다(위 (4)·(6) invariant). `EGW00201`은 일반 TRANSIENT 지수 backoff를 따른다.
+`EGW00133`은 일반 TRANSIENT 지수 backoff가 아니라 **단일 cadence ~60s backoff**(startup wrapper / self-healing interval)임을 명시한다(위 (4)·(6) invariant). `EGW00201`은 일반 TRANSIENT 지수 backoff를 따른다.

--- a/docs/specs/broker-adapter/07-kis-base-adapter.md
+++ b/docs/specs/broker-adapter/07-kis-base-adapter.md
@@ -76,14 +76,17 @@ scope 정정: 일반 `_request` 경로는 이미 `msg_cd`를 파싱한다(위 `_
 
 - 토큰 응답 형태 가정을 명시한다: HTTP 200 + error 바디 vs non-200. `status != 200` 분기 위치를 결정해 파싱 위치를 고정한다(구현 왕복 방지).
 
-#### (4) `EGW00133` ~60s backoff (단일 cadence 레이어, normative)
+#### (4) `EGW00133` ~60s backoff (단일 cadence 레이어 + source cooldown, normative)
 
 > **정정 (#2399 adjudicated, rev4)**: 이전 문안은 "`connect`/`_authenticate` 내부 backoff"를 요구했으나, self-healing 의 반복 `connect` 호출과 곱해져 nested-backoff(최악 5×120s)를 유발하는 잠재 버그가 있다. 아래 **단일 cadence** 정의가 정본이다(additive 안전/정확성 개선).
 
-`EGW00133`(KIS 공식 "토큰 발급 1분 1회", 토큰 24h 유효)의 ~60s backoff 는 **정확히 한 cadence 레이어**에만 둬서 곱해지지 않게 한다. 일반 지수 backoff(TRANSIENT)와도 **별도 분기**다.
+> **보강 (#2399 attempt3 + 메타 감사, per-app_key cooldown at source)**: 단일-cadence 를 per-call-site **필터**(B 설계)로만 구현하면 "`get_broker`→토큰 재타격" 결함이 호출 경로(startup retry / treasury·fill·reconcile / instrument sync / self-healing burst / runtime / IPC)마다 라운드별로 재생산된다. 이를 막기 위해 단일 cadence 메커니즘을 **(A) per-app_key cooldown at source**(발급 레이어 단일 chokepoint)로 명문화한다(additive). 모든 발급 경로가 cooldown 을 자동 존중하므로 per-call-site 필터는 불필요(있어도 defense-in-depth 로 무해)하다.
+
+`EGW00133`(KIS 공식 "토큰 발급 1분 1회", 토큰 24h 유효)의 ~60s backoff 는 **정확히 한 cadence 레이어**에만 둬서 곱해지지 않게 하고, **발급 차단 자체는 source cooldown 이 보장**한다. 일반 지수 backoff(TRANSIENT)와도 **별도 분기**다.
 
 - **`_authenticate` 는 EGW00133 시 즉시 `TokenRateLimitError`(`AuthenticationError` 서브클래스, `error_code="EGW00133"`)를 raise** 한다 — **내부 sleep/retry 루프 없음**(곱셈 원천 제거). 어떤 caller 루프 안에서도 60s 가 곱해지지 않는다. `connect()` 도 이 예외를 내부 재시도 없이 그대로 전파한다.
-- ~60s backoff cadence 는 호출부 **단일 레이어**가 분담한다: (a) **startup**(`main._init_gateway` connect 루프)의 bounded retry(`DEFAULT_MAX_RETRIES_AUTH` × ~60s, 부팅 1회 경로), **또는** (b) **self-healing** loop 의 `interval`(60s) — EGW00133 시 그 계좌 burst 남은 attempt 를 break 하고 다음 interval 에 위임(burst 당 connect 시도 ≤1회).
+- **per-app_key cooldown at source (A)**: 발급 레이어가 module-level `_token_cooldowns: {app_key → cooldown_until}` 를 둔다. EGW00133 수신 시 `TokenRateLimitError` raise **직전** `_token_cooldowns[app_key] = now(UTC) + TOKEN_RATE_LIMIT_COOLDOWN_SECONDS`(=60s, module 상수)를 기록한다. `_authenticate` 는 — **순서 중요** — (1) **유효 캐시 hydrate 를 먼저** 시도(hit 면 cooldown 무영향, T2: 유효 캐시 read 는 절대 막지 않음), (2) cache miss 면 **lock 밖 fast-path** 에서 `now(UTC) ≥ cooldown_until` 아니면(=cooldown 내) **HTTP 미호출·즉시 `TokenRateLimitError` raise**, (3) lock 획득→double-check(캐시)→**lock 안 cooldown 재확인**(대기 중 타 코루틴이 기록했을 수 있음)→발급. 그래서 EGW00133 1회면 같은 app_key 의 모든 발급 경로(startup / treasury·fill·reconcile / instrument sync / self-healing burst / runtime / IPC)가 cooldown 동안 토큰을 **재타격하지 않는다**(T4 단일 cadence 의 근본 보장).
+- ~60s backoff cadence(대기 후 재시도)는 호출부 **단일 레이어**가 분담한다: (a) **startup**(`main._init_gateway` connect 루프)의 bounded retry(`DEFAULT_MAX_RETRIES_AUTH` × ~60s, 부팅 1회 경로) — 고정 60s 가 아니라 `TokenRateLimitError.cooldown_until` 의 **잔여 cooldown**(`cooldown_until - now`)만큼 sleep 해 cooldown 경계에서 재시도가 무력화되지 않게 한다, **또는** (b) **self-healing** loop 의 `interval`(60s) — EGW00133 시 그 계좌 burst 남은 attempt 를 break 하고 다음 interval 에 위임(burst 당 connect 시도 ≤1회). self-healing `interval`(60s) ≥ cooldown(60s) 이라 다음 burst 에서 cooldown 이 만료돼 발급이 정상 재개된다(정합).
 
 #### (5) connect-path retry (readiness 연동)
 
@@ -91,11 +94,11 @@ scope 정정: 일반 `_request` 경로는 이미 `msg_cd`를 파싱한다(위 `_
 
 #### (6) classify 불변 invariant ([must_fix J], normative)
 
-`EGW00133` backoff 는 위 (4) **단일 cadence 레이어**(startup wrapper / self-healing interval)에만 있고 `_authenticate` 는 즉시 raise 하므로, gateway 재시도 핸들러·`_request_with_cont` 재시도 루프가 이중 적용하지 않는다. `KISErrorClassifier.classify`의 `AuthenticationError = (retryable=False, record_cb=False)` 분류는 **불변**이다(`TokenRateLimitError` 서브클래스도 동일 분류). classify 를 손대면 connect-path backoff 와 gateway 재시도 핸들러가 이중 적용되거나 `EGW00133`이 즉시 비재시도 전파되는 회귀가 발생한다.
+`EGW00133` backoff 는 위 (4) **단일 cadence 레이어**(startup wrapper / self-healing interval) + source cooldown 에만 있고 `_authenticate` 는 즉시 raise 하므로, gateway 재시도 핸들러·`_request_with_cont` 재시도 루프가 이중 적용하지 않는다. `KISErrorClassifier.classify`의 `AuthenticationError = (retryable=False, record_cb=False)` 분류는 **불변**이다(`TokenRateLimitError` 서브클래스도 동일 분류 — cooldown 도입은 classify 를 손대지 않는다). classify 를 손대면 connect-path backoff 와 gateway 재시도 핸들러가 이중 적용되거나 `EGW00133`이 즉시 비재시도 전파되는 회귀가 발생한다.
 
 #### (7) known-limitation (normative)
 
-멀티프로세스(8 CLI site가 각각 fresh `AccountService`를 생성) 토큰 공유는 **v1 미해결**이다. in-process single-flight + 캐시는 **단일 서버 런타임 + 동일 프로세스 내 다중 adapter**만 수렴한다(서버 hot-path 해결). 토큰은 24h 유효하나, CLI cold-path 다발 동시 실행 시 `EGW00133`이 잔존할 수 있다.
+멀티프로세스(8 CLI site가 각각 fresh `AccountService`를 생성) 토큰 공유는 **v1 미해결**이다. in-process single-flight + 캐시 + cooldown 은 **단일 서버 런타임 + 동일 프로세스 내 다중 adapter**만 수렴한다(서버 hot-path 해결). `_token_cooldowns` 도 module-level **in-process** 상태라 프로세스 경계를 넘지 않는다. 토큰은 24h 유효하나, CLI cold-path 다발 동시 실행 시 `EGW00133`이 잔존할 수 있다.
 
 영속(파일/DB) 토큰스토어는 멀티프로세스 공유가 가능하나 파일 lock / 동시쓰기 / 만료 경합 / 보안(secret 파일) 복잡도가 커서 **v1 범위 밖(YAGNI)**이며 known-limitation으로 명시하고 **후속 후보**로 anchor한다.
 

--- a/src/ante/broker/__init__.py
+++ b/src/ante/broker/__init__.py
@@ -9,6 +9,7 @@ from ante.broker.exceptions import (
     CircuitOpenError,
     OrderNotFoundError,
     RateLimitError,
+    TokenRateLimitError,
 )
 from ante.broker.fill_scheduler import FillReconcileScheduler, business_date_kst
 from ante.broker.kis import KISAdapter, KISBaseAdapter, KISDomesticAdapter
@@ -47,5 +48,6 @@ __all__ = [
     "RateLimitError",
     "ReconcileScheduler",
     "TestBrokerAdapter",
+    "TokenRateLimitError",
     "get_broker_class",
 ]

--- a/src/ante/broker/error_codes.py
+++ b/src/ante/broker/error_codes.py
@@ -35,13 +35,29 @@ PERMANENT_MSG_CODES: frozenset[str] = frozenset(
 
 # ── 재시도 가능 (transient) KIS msg_cd ──────────────────
 # 서버 과부하, 일시적 지연 등 재시도 시 성공할 수 있는 에러
+#
+# 주의 (#2399): 이 set 은 ``_handle_response`` 가 ``APIError.retryable=True`` 로
+# 승격해 일반 ``KISRetryHandler`` 지수 backoff 로 보내는 **전역 SSOT** 다. 토큰
+# 발급 1분 1회 제한(``EGW00133``)을 여기에 넣으면 일반 재시도가 토큰 cooldown 에
+# 몰리므로 **금지**한다. ``EGW00133`` 은 아래 ``TOKEN_RATE_LIMIT_MSG_CODE`` 로 따로
+# 두고 토큰 발급 경로 전용 ~60s backoff(spec 07 OAuth2 §(4))에서만 소비한다.
 TRANSIENT_MSG_CODES: frozenset[str] = frozenset(
     {
         "APBK0600",  # 서버 과부하
         "APBK0601",  # 처리 지연
         "APBK0602",  # 일시적 서비스 불가
+        "EGW00201",  # 초당 거래 건수 초과 (#2399, 일반 지수 backoff)
     }
 )
+
+# ── 토큰 발급 빈도 제한 (auth-only, #2399) ──────────────
+# KIS ``EGW00133`` (접근토큰 발급 1분 1회)은 일반 TRANSIENT 지수 backoff 가 아니라
+# **토큰 발급 경로 전용 ~60s backoff**(spec 07 OAuth2 §(4)(5)(6))로만 처리한다.
+# 따라서 ``TRANSIENT_MSG_CODES`` 에 넣지 **않고** auth-only 별도 상수로 둔다.
+# ``_authenticate`` 가 이 코드를 감지하면 ``TokenRateLimitError`` 를 즉시 raise 하고
+# (내부 sleep 없음), startup wrapper / self-healing interval 단일 cadence 가 backoff
+# 를 분담한다([must_fix J] classify 불변 / nested-backoff 차단).
+TOKEN_RATE_LIMIT_MSG_CODE = "EGW00133"
 
 # ── 재시도 가능 HTTP 상태 코드 ──────────────────────────
 RETRYABLE_HTTP_STATUS_CODES: frozenset[int] = frozenset({500, 502, 503, 429})
@@ -68,11 +84,20 @@ KIS_ERROR_MESSAGES: dict[str, str] = {
     "40240000": "모의투자 잔고내역 없음 (매도가능 잔고 없음)",
     "40910000": "모의투자 주문 불가 계좌 (모의 자격/신청 상태 확인 필요)",
     "IGW00022": "원주문번호 오류 또는 처리 불가",
+    "EGW00133": "접근토큰 발급은 1분당 1회만 허용",  # auth-only (#2399)
+    "EGW00201": "초당 거래 건수 초과",  # transient (#2399)
 }
 
 
 def is_retryable_msg_code(msg_cd: str) -> bool:
-    """KIS msg_cd가 재시도 가능한지 판별."""
+    """KIS msg_cd가 일반 재시도(``KISRetryHandler``) 경로에서 재시도 가능한지 판별.
+
+    ``EGW00133`` (#2399)은 토큰 발급 경로 전용 ~60s backoff 로만 처리하므로 일반
+    재시도 경로에서는 **non-retryable** 로 본다(혹시 ``_authenticate`` 외 경로로
+    누수돼도 일반 지수 backoff 에 몰리지 않게 방어).
+    """
+    if msg_cd == TOKEN_RATE_LIMIT_MSG_CODE:
+        return False
     if msg_cd in PERMANENT_MSG_CODES:
         return False
     if msg_cd in TRANSIENT_MSG_CODES:

--- a/src/ante/broker/exceptions.py
+++ b/src/ante/broker/exceptions.py
@@ -20,6 +20,13 @@ member/approval/bot/treasury 동형).
   경로는 본 필드를 surface 하지 않는다.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class BrokerError(Exception):
     """Broker 기본 예외.
@@ -66,9 +73,25 @@ class TokenRateLimitError(AuthenticationError):
     ``AuthenticationError`` 서브클래스이므로 ``KISErrorClassifier.classify`` 는
     여전히 ``(retryable=False, record_cb=False)`` 로 분류한다([must_fix J] 불변 —
     gateway 재시도 핸들러 이중 적용 차단).
+
+    ``cooldown_until`` (#2399 attempt3, source-level cooldown): EGW00133 수신 시
+    기록된 app_key cooldown 만료시각(UTC ``datetime`` 또는 ``None``)을 선택적으로
+    실어 보낸다. startup wrapper(``main._get_broker_with_auth_retry``)가 고정 60s
+    대신 **잔여 cooldown**(``cooldown_until - now``)만큼 sleep 해 cooldown 경계에서
+    재시도가 무력화되지 않게 한다. 기본값 ``None`` 이라 미기재 호출부는 무영향이다.
     """
 
     code: str = "BROKER_AUTH_FAILED"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_code: str = "",
+        cooldown_until: datetime | None = None,
+    ) -> None:
+        super().__init__(message, error_code=error_code)
+        self.cooldown_until = cooldown_until
 
 
 class APIError(BrokerError):

--- a/src/ante/broker/exceptions.py
+++ b/src/ante/broker/exceptions.py
@@ -39,6 +39,33 @@ class AuthenticationError(BrokerError):
 
     KIS OAuth 토큰 발급/갱신 실패 (HTTP 401/403, 잘못된 app_key/app_secret
     등). taxonomy ``auth`` 카테고리.
+
+    ``error_code`` (#2399): KIS 원천 ``msg_cd`` (예: ``EGW00133``)를 **구조적으로**
+    보존한다. ``main`` 의 startup / self-healing connect 실패 경로가 reason 에
+    ``EGW00133`` 을 문자열 grep 이 아니라 ``getattr(e, "error_code", None)`` /
+    isinstance 로 추출하기 위함이다(D-ACC-09 readiness reason 연동). 기본값은 빈
+    문자열이라 기존 호출부(코드 미지정)는 영향이 없다.
+    """
+
+    code: str = "BROKER_AUTH_FAILED"
+
+    def __init__(self, message: str, *, error_code: str = "") -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class TokenRateLimitError(AuthenticationError):
+    """토큰 발급 빈도 제한 (KIS ``EGW00133``, #2399).
+
+    KIS 는 접근토큰 발급을 1분당 1회만 허용한다. ``_authenticate`` 가 발급 응답에서
+    ``EGW00133`` 을 감지하면 **즉시** 본 예외를 raise 하고 **내부 sleep/retry 루프를
+    절대 두지 않는다**(곱셈 원천 제거). ~60s backoff cadence 는 단일 레이어
+    (``main`` startup 의 bounded retry **또는** self-healing loop 의 burst interval)
+    에서만 적용된다(spec 07 OAuth2 §(4)(5)(6) 단일 cadence).
+
+    ``AuthenticationError`` 서브클래스이므로 ``KISErrorClassifier.classify`` 는
+    여전히 ``(retryable=False, record_cb=False)`` 로 분류한다([must_fix J] 불변 —
+    gateway 재시도 핸들러 이중 적용 차단).
     """
 
     code: str = "BROKER_AUTH_FAILED"

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -166,11 +166,33 @@ _AUTH_PATH = "/oauth2/tokenP"
 # 멀티프로세스(CLI 8 site 가 각각 fresh AccountService 생성) 토큰 공유는 v1 미해결 —
 # CLI cold-path 다발 동시 실행 시 ``EGW00133`` 잔존 가능. 영속(파일/DB) 토큰 스토어는
 # 후속 후보(YAGNI, spec 07 OAuth2 §(7) anchor).
-_token_cache: dict[str, tuple[str, datetime]] = {}
-"""app_key → (access_token, expires_at) in-process shared 캐시 (#2399 T2)."""
+#
+# 캐시 키 vs lock/cooldown 키 분리 (#2399 attempt4 P2 — config fingerprint):
+# - ``_token_cache`` 키 = **(app_key, app_secret, env)** config fingerprint.
+#   credentials(app_secret)/환경(모의 vs 실전 base_url)이 바뀌면 다른 키 → cache
+#   miss → ``connect()``/``_authenticate()`` 가 새 토큰을 **실제 발급**하여 새 설정을
+#   검증한다. 같은 app_key 기존 토큰을 hydrate 해 잘못된 secret/환경 전환을 성공한
+#   재연결로 오판하던 회귀를 차단한다(``AccountService._reconnect_broker`` 가
+#   변경된 ``credentials``/``broker_config`` 로 새 어댑터 ``connect()`` 를 호출하는
+#   경로 보호). **동일 config(같은 app_key+secret+env) 공유 어댑터(국내/해외)는 같은
+#   키 → single-flight 수렴·토큰 공유**(원래 #2399 목표 보존).
+# - ``_token_locks`` / ``_token_cooldowns`` 키 = **app_key 유지**. single-flight
+#   직렬화와 EGW00133(접근토큰 발급 1분 1회) cooldown 은 KIS rate-limit 단위인
+#   **app_key 당**이라 secret/환경 무관하다. config fingerprint 로 좁히면 같은
+#   app_key·다른 config 동시 발급이 rate-limit 을 공유하지 못해 EGW00133 잔존
+#   위험이 생긴다(T1 lock=app_key / T4 cooldown=app_key 회귀 락).
+_TokenCacheKey = tuple[str, str, str]
+"""(app_key, app_secret, env) config fingerprint — ``_token_cache`` 키 타입."""
+
+_token_cache: dict[_TokenCacheKey, tuple[str, datetime]] = {}
+"""config fingerprint → (access_token, expires_at) in-process shared 캐시 (#2399 T2).
+
+키는 ``(app_key, app_secret, env)`` 다(``env`` = 모의/실전 구분). 같은 config 는 같은
+키로 single-flight 수렴·토큰 공유, 다른 secret/환경은 다른 키로 cache miss → 재발급
+(config 변경 재검증, attempt4 P2)."""
 
 _token_locks: dict[str, asyncio.Lock] = {}
-"""app_key → 발급 직렬화 Lock (#2399 T1, lock key=app_key)."""
+"""app_key → 발급 직렬화 Lock (#2399 T1, lock key=app_key — rate-limit 단위)."""
 
 _token_cooldowns: dict[str, datetime] = {}
 """app_key → cooldown_until (UTC) — EGW00133 source-level cooldown (#2399).
@@ -553,8 +575,10 @@ class KISBaseAdapter(BrokerAdapter):
         """OAuth2 접근 토큰 발급 — single-flight + shared 캐시 + cooldown (#2399).
 
         절차 (T1/T2/T4 source-level cooldown):
-        1. **캐시 read**: module-level ``_token_cache`` 에 본 app_key 의 신선한 토큰
-           (near-expiry 5분 여유 내)이 있으면 발급 skip — 인스턴스에 hydrate 후 반환.
+        1. **캐시 read**: module-level ``_token_cache`` 에 본 어댑터의 config
+           fingerprint(app_key+secret+env, attempt4 P2) 신선한 토큰(near-expiry 5분
+           여유 내)이 있으면 발급 skip — 인스턴스에 hydrate 후 반환. config 가 바뀐
+           재연결은 다른 키라 cache miss → 새 발급으로 새 설정을 검증한다.
            **유효 캐시 read 는 cooldown 무영향**(T2 — hydrate 를 cooldown 체크보다
            먼저 둔다).
         2. **cooldown fast-path(lock 밖)**: cache miss 면 ``_token_cooldowns`` 를
@@ -592,18 +616,36 @@ class KISBaseAdapter(BrokerAdapter):
                 _raise_token_rate_limit(self.app_key, record=False)
             # (6) 발급 1회 → 캐시 populate → 인스턴스 hydrate. EGW00133 이면
             # _issue_token 이 cooldown 기록 후 TokenRateLimitError 를 즉시 raise.
+            # 캐시 key 는 config fingerprint(attempt4 P2) — 같은 config 공유 어댑터는
+            # 같은 키로 토큰 공유, 다른 secret/환경은 별도 키로 격리 발급된다.
             token, expires_at = await self._issue_token()
-            _token_cache[self.app_key] = (token, expires_at)
+            _token_cache[self._token_cache_key()] = (token, expires_at)
             self.access_token = token
             self.token_expires_at = expires_at
             logger.info("KIS 토큰 발급 완료")
+
+    def _token_cache_key(self) -> _TokenCacheKey:
+        """``_token_cache`` config fingerprint 키 — (app_key, app_secret, env) (#2399).
+
+        attempt4 P2: 캐시 키에 ``app_secret`` 과 환경(모의 vs 실전)을 포함해, 같은
+        app_key 라도 credentials/환경이 바뀌면 다른 키로 cache miss → 새 토큰 발급으로
+        새 설정을 검증한다(``AccountService._reconnect_broker`` 의 secret/환경 전환
+        재검증). 환경 구분은 ``is_paper`` (base_url 도출 출처)를 그대로 쓴다 — 모의
+        ``openapivts``/실전 ``openapi`` base_url 이 ``is_paper`` 로 1:1 결정되므로
+        ``is_paper`` 가 환경의 SSOT 다. lock/cooldown 키(app_key)와 달리 본 키만
+        config-specific 으로 좁힌다.
+        """
+        env = "paper" if self.is_paper else "live"
+        return (self.app_key, self.app_secret, env)
 
     def _hydrate_from_cache(self) -> bool:
         """shared 캐시에 신선한 토큰이 있으면 인스턴스에 hydrate (#2399 T2).
 
         near-expiry(만료 5분 전) 토큰은 miss 로 보고 ``False`` 반환(재발급 유도).
+        캐시 key 는 config fingerprint(app_key+secret+env)라, config 가 바뀐 어댑터는
+        같은 app_key 라도 cache miss → 재발급(attempt4 P2 config 변경 재검증).
         """
-        cached = _token_cache.get(self.app_key)
+        cached = _token_cache.get(self._token_cache_key())
         if cached is None:
             return False
         token, expires_at = cached

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -70,6 +70,16 @@ DEFAULT_BACKOFF_BASE = 1.0
 # key 부재를 잠금).
 TOKEN_AUTH_BACKOFF_SECONDS = 60.0
 
+# EGW00133 수신 시 해당 app_key 의 토큰 발급을 차단하는 cooldown 초
+# (#2399 attempt3 + 메타 감사 — per-app_key cooldown at source).
+# KIS 공식 "접근토큰 발급 1분 1회"에 정렬한 source-level cooldown 이다. EGW00133 을
+# 한 번 받으면 그 app_key 의 발급 경로(startup/self-healing/runtime/IPC) 전부가 이
+# cooldown 동안 **HTTP 미호출**로 즉시 ``TokenRateLimitError`` 를 raise 한다 —
+# get_broker→토큰 재타격을 per-call-site 필터가 아니라 발급 레이어 단일 chokepoint
+# 에서 닫는다(단일 cadence T4 의 근본 보장). self-healing interval(60s) ≥ 본
+# cooldown(60s) 이라 self-healing 정상 동작과도 정합한다(다음 burst 에서 만료).
+TOKEN_RATE_LIMIT_COOLDOWN_SECONDS = 60.0
+
 # 토큰 cache hit 시 near-expiry 재발급 여유(분). ``_ensure_authenticated`` 의 "만료
 # 5분 전 재발급" 기준(아래 ``_ensure_authenticated``)과 **동일**해야 한다 — shared
 # 캐시 hit 판정도 near-expiry 토큰을 miss 로 보고 재발급한다(near-expiry 재사용 회귀
@@ -162,6 +172,17 @@ _token_cache: dict[str, tuple[str, datetime]] = {}
 _token_locks: dict[str, asyncio.Lock] = {}
 """app_key → 발급 직렬화 Lock (#2399 T1, lock key=app_key)."""
 
+_token_cooldowns: dict[str, datetime] = {}
+"""app_key → cooldown_until (UTC) — EGW00133 source-level cooldown (#2399).
+
+EGW00133(접근토큰 발급 1분 1회)을 받으면 ``_raise_token_error`` 가 ``app_key`` 에
+``now(UTC) + TOKEN_RATE_LIMIT_COOLDOWN_SECONDS`` 를 기록한다. ``_authenticate`` 는
+유효 캐시 hit(T2)이 아닌 발급 경로에서 lock 밖 fast-path + lock 안 double-check 로
+cooldown 을 확인해, cooldown 내면 **HTTP 미호출·즉시 ``TokenRateLimitError``** 를
+raise 한다. 모든 get_broker→토큰 발급 경로(startup/self-healing/runtime/IPC)가 이
+단일 chokepoint 를 존중하므로 per-call-site 필터 없이 단일 cadence(T4)가 보장된다.
+T2 불변: 유효 캐시 토큰 read 는 cooldown 과 무관(hydrate 먼저)하다."""
+
 
 # lock dict 의 lazy 생성 경합(첫 Lock 생성 race)을 막는 동기 guard.
 # ``_get_token_lock`` 이 ``setdefault`` 로 원자적으로 Lock 을 보장한다 — 동기 구간
@@ -177,14 +198,70 @@ def _get_token_lock(app_key: str) -> asyncio.Lock:
 
 
 def _reset_token_cache() -> None:
-    """module-level 토큰 캐시/lock dict 초기화 (#2399, 테스트 격리용).
+    """module-level 토큰 캐시/lock/cooldown dict 초기화 (#2399, 테스트 격리용).
 
     pytest-asyncio auto mode 에서 이전 테스트의 closed event loop 에 묶인 Lock 이
     재사용되는 위험(T1 closed-loop)을 차단하기 위해, autouse fixture 가 매 테스트
     전후로 본 helper 를 호출한다. 프로덕션 경로는 호출하지 않는다.
+
+    #2399 attempt3/메타: ``_token_cooldowns`` 도 함께 clear 한다. EGW00133 cooldown
+    상태가 테스트 간 누출되면 후속 테스트의 발급이 cooldown 내로 오판돼 flaky 가
+    되므로, 글로벌 conftest autouse fixture 가 본 helper 로 cooldown 까지 초기화한다.
     """
     _token_cache.clear()
     _token_locks.clear()
+    _token_cooldowns.clear()
+
+
+def _token_cooldown_until(app_key: str) -> datetime | None:
+    """app_key 의 현재 EGW00133 cooldown 만료시각(UTC) 또는 ``None`` (#2399 attempt3).
+
+    startup wrapper(``main._get_broker_with_auth_retry``)가 잔여 cooldown
+    (``cooldown_until - now``)만큼 sleep 하기 위해 조회한다. 만료된 cooldown 은
+    ``None`` 으로 보고(자동 만료) 다음 발급을 허용한다.
+    """
+    until = _token_cooldowns.get(app_key)
+    if until is None:
+        return None
+    if datetime.now(UTC) >= until:
+        return None
+    return until
+
+
+def _record_token_cooldown(app_key: str) -> datetime:
+    """EGW00133 수신 시 app_key cooldown 기록 후 만료시각 반환 (#2399 attempt3).
+
+    ``now(UTC) + TOKEN_RATE_LIMIT_COOLDOWN_SECONDS`` 를 기록한다. ``_raise_token_error``
+    가 ``TokenRateLimitError`` raise **직전** 호출한다. cooldown 내 차단 경로
+    (``_authenticate`` fast-path/double-check)는 기존 cooldown 을 **연장하지 않고**
+    그대로 둔다(아래 ``_raise_token_rate_limit`` 참조).
+    """
+    until = datetime.now(UTC) + timedelta(seconds=TOKEN_RATE_LIMIT_COOLDOWN_SECONDS)
+    _token_cooldowns[app_key] = until
+    return until
+
+
+def _raise_token_rate_limit(app_key: str, *, record: bool = True) -> NoReturn:
+    """EGW00133 ``TokenRateLimitError`` raise (#2399 attempt3, cooldown_until 동봉).
+
+    HTTP 발급에서 EGW00133 을 받은 경로(``_raise_token_error``, ``record=True`` —
+    새 cooldown 기록)와 cooldown 내 발급 차단 경로(``_authenticate`` fast-path/
+    double-check, ``record=False`` — 기존 cooldown 존중·연장 금지)가 동일한 raise
+    동작을 공유한다(source-level 단일 chokepoint). 예외에 잔여 cooldown 만료시각
+    (``cooldown_until``)을 실어 startup wrapper 가 잔여만큼 sleep 하게 한다.
+    """
+    if record:
+        until: datetime | None = _record_token_cooldown(app_key)
+    else:
+        # cooldown 내 차단 — 기존 만료시각을 그대로 노출(연장 금지). 경합으로 이미
+        # 만료됐으면(드묾) 새로 기록하지 않고 None 을 실어 보낸다(다음 발급 허용).
+        until = _token_cooldown_until(app_key)
+    msg = get_error_message(TOKEN_RATE_LIMIT_MSG_CODE)
+    raise TokenRateLimitError(
+        f"토큰 발급 빈도 제한 ({TOKEN_RATE_LIMIT_MSG_CODE}): {msg}",
+        error_code=TOKEN_RATE_LIMIT_MSG_CODE,
+        cooldown_until=until,
+    )
 
 
 def _is_cached_token_fresh(expires_at: datetime, *, now: datetime) -> bool:
@@ -473,31 +550,48 @@ class KISBaseAdapter(BrokerAdapter):
     # ── 인증 ───────────────────────────────────────
 
     async def _authenticate(self) -> None:
-        """OAuth2 접근 토큰 발급 — single-flight + in-process shared 캐시 (#2399).
+        """OAuth2 접근 토큰 발급 — single-flight + shared 캐시 + cooldown (#2399).
 
-        절차 (T1/T2):
+        절차 (T1/T2/T4 source-level cooldown):
         1. **캐시 read**: module-level ``_token_cache`` 에 본 app_key 의 신선한 토큰
            (near-expiry 5분 여유 내)이 있으면 발급 skip — 인스턴스에 hydrate 후 반환.
-        2. **app_key lock** 획득(account_id 아님 — 동일 app_key 다중 adapter 수렴).
-        3. **double-check**: lock 대기 중 타 코루틴이 이미 발급했으면 재사용(발급 skip).
-        4. **발급 1회**: HTTP 호출 → 캐시 populate → 인스턴스 hydrate.
+           **유효 캐시 read 는 cooldown 무영향**(T2 — hydrate 를 cooldown 체크보다
+           먼저 둔다).
+        2. **cooldown fast-path(lock 밖)**: cache miss 면 ``_token_cooldowns`` 를
+           확인해 cooldown 내면 **HTTP 미호출·즉시 ``TokenRateLimitError``** raise
+           (get_broker→토큰 재타격 source-level 차단, T4 단일 cadence).
+        3. **app_key lock** 획득(account_id 아님 — 동일 app_key 다중 adapter 수렴).
+        4. **double-check(캐시)**: lock 대기 중 타 코루틴이 발급했으면 재사용(skip).
+        5. **cooldown double-check(lock 안)**: lock 대기 중 타 코루틴이 EGW00133 으로
+           cooldown 을 기록했을 수 있으므로 한 번 더 확인 → cooldown 내면 즉시 raise.
+        6. **발급 1회**: HTTP 호출 → 캐시 populate → 인스턴스 hydrate. 발급이
+           EGW00133 이면 ``_issue_token``→``_raise_token_error`` 가 cooldown 기록 후
+           ``TokenRateLimitError`` 를 **즉시 raise** 한다(내부 sleep/retry 없음).
 
-        EGW00133 (T4): 발급 응답에서 ``EGW00133`` 감지 시 ``TokenRateLimitError`` 를
-        **즉시 raise** 한다 — **내부 sleep/retry 루프 없음**(곱셈 원천 제거). ~60s
-        backoff cadence 는 호출부 단일 레이어(startup wrapper / self-healing
-        interval)가 분담한다.
+        ~60s backoff cadence 는 호출부 단일 레이어(startup wrapper / self-healing
+        interval)가 분담하고, 발급 차단 자체는 본 cooldown 이 source 에서 보장한다.
         """
-        # (1) 캐시 read — lock 없이 fast-path. 신선하면 발급 skip.
+        # (1) 캐시 read — lock 없이 fast-path. 신선하면 발급 skip(cooldown 무영향, T2).
         if self._hydrate_from_cache():
             return
 
-        # (2) app_key 단위 lock 으로 발급 직렬화 (T1).
+        # (2) cooldown fast-path(lock 밖) — cooldown 내면 HTTP 미호출·즉시 raise (T4).
+        # record=False: 기존 cooldown 존중(연장 금지, source 기록은 EGW00133 수신 시만).
+        if _token_cooldown_until(self.app_key) is not None:
+            _raise_token_rate_limit(self.app_key, record=False)
+
+        # (3) app_key 단위 lock 으로 발급 직렬화 (T1).
         lock = _get_token_lock(self.app_key)
         async with lock:
-            # (3) double-check — 대기 중 타 코루틴이 발급했으면 재사용.
+            # (4) double-check(캐시) — 대기 중 타 코루틴이 발급했으면 재사용.
             if self._hydrate_from_cache():
                 return
-            # (4) 발급 1회 → 캐시 populate → 인스턴스 hydrate.
+            # (5) cooldown double-check(lock 안) — 대기 중 타 코루틴이 EGW00133 으로
+            # cooldown 을 기록했을 수 있다. cooldown 내면 즉시 raise(HTTP 미호출).
+            if _token_cooldown_until(self.app_key) is not None:
+                _raise_token_rate_limit(self.app_key, record=False)
+            # (6) 발급 1회 → 캐시 populate → 인스턴스 hydrate. EGW00133 이면
+            # _issue_token 이 cooldown 기록 후 TokenRateLimitError 를 즉시 raise.
             token, expires_at = await self._issue_token()
             _token_cache[self.app_key] = (token, expires_at)
             self.access_token = token
@@ -573,12 +667,14 @@ class KISBaseAdapter(BrokerAdapter):
             return parsed
         return text
 
-    @staticmethod
-    def _raise_token_error(status: int, body: dict[str, Any] | str) -> NoReturn:
+    def _raise_token_error(self, status: int, body: dict[str, Any] | str) -> NoReturn:
         """토큰 발급 에러 raise — EGW00133 은 TokenRateLimitError (#2399 T3/T4).
 
         alias 처리(T3): 코드는 ``msg_cd``/``error_code``, 메시지는 ``msg1``/
         ``error_description`` 키를 순서대로 본다.
+
+        #2399 attempt3: EGW00133 감지 시 ``TokenRateLimitError`` raise **직전**
+        본 adapter 의 ``app_key`` cooldown 을 기록한다(source-level cooldown).
         """
         code = ""
         detail = ""
@@ -588,11 +684,9 @@ class KISBaseAdapter(BrokerAdapter):
         text = body if isinstance(body, str) else (detail or json.dumps(body))
 
         if code == TOKEN_RATE_LIMIT_MSG_CODE:
-            msg = get_error_message(TOKEN_RATE_LIMIT_MSG_CODE)
-            raise TokenRateLimitError(
-                f"토큰 발급 빈도 제한 ({TOKEN_RATE_LIMIT_MSG_CODE}): {msg}",
-                error_code=TOKEN_RATE_LIMIT_MSG_CODE,
-            )
+            # cooldown 기록 후 raise — 같은 app_key 후속 발급(다른 adapter/account
+            # 포함)이 cooldown 내 HTTP 미호출·즉시 raise 되도록 (T4 단일 cadence).
+            _raise_token_rate_limit(self.app_key)
         raise AuthenticationError(
             f"인증 실패 (HTTP {status}): {text}",
             error_code=code,

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -18,12 +18,13 @@ import logging
 from abc import abstractmethod
 from collections import OrderedDict
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 from ante.broker.base import BrokerAdapter
 from ante.broker.circuit_breaker import CircuitBreaker
 from ante.broker.error_codes import (
     PERMANENT_MSG_CODES,
+    TOKEN_RATE_LIMIT_MSG_CODE,
     TRANSIENT_MSG_CODES,
     get_error_message,
     is_retryable_http_status,
@@ -36,6 +37,7 @@ from ante.broker.exceptions import (
     ModifyOrgnoUnavailableError,
     OrderNotFoundError,
     RateLimitError,
+    TokenRateLimitError,
 )
 from ante.broker.fill_scheduler import business_date_kst
 from ante.broker.models import CommissionInfo
@@ -59,6 +61,20 @@ DEFAULT_TIMEOUT_AUTH = 10
 
 # Backoff
 DEFAULT_BACKOFF_BASE = 1.0
+
+# 토큰 발급 빈도 제한(EGW00133) 흡수용 backoff 초 (#2399).
+# KIS 공식 "접근토큰 발급 1분 1회". startup connect 루프(main._init_gateway)가
+# 부팅 1회 경로에서만 이 backoff 를 소비한다(단일 cadence — adapter._authenticate 는
+# 즉시 raise, self-healing 은 interval 60s 위임). config 노출하지 않는 adapter-local
+# 상수다(global defaults 변경 금지 — test_kis_error_handling.py:268 가 broker retry
+# key 부재를 잠금).
+TOKEN_AUTH_BACKOFF_SECONDS = 60.0
+
+# 토큰 cache hit 시 near-expiry 재발급 여유(분). ``_ensure_authenticated`` 의 "만료
+# 5분 전 재발급" 기준(아래 ``_ensure_authenticated``)과 **동일**해야 한다 — shared
+# 캐시 hit 판정도 near-expiry 토큰을 miss 로 보고 재발급한다(near-expiry 재사용 회귀
+# 방지, #2399 T2).
+_TOKEN_EXPIRY_MARGIN_MINUTES = 5
 
 # Circuit Breaker
 DEFAULT_CB_FAILURE_THRESHOLD = 5
@@ -123,6 +139,62 @@ _PSBL_ORDER_FIELD_MAX_BUYABLE_QTY = "max_buy_qty"
 
 # 인증 경로
 _AUTH_PATH = "/oauth2/tokenP"
+
+
+# ── OAuth2 토큰 single-flight + in-process shared 캐시 (#2399) ──────────
+#
+# 동일 ``app_key`` 를 공유하는 다중 adapter(KIS 국내/해외 분리 D-ACC-02, 같은
+# app_key)가 동시에 토큰을 발급하면 KIS 가 ``EGW00133`` (접근토큰 발급 1분 1회)을
+# 돌려준다. 이를 막기 위해 토큰 캐시와 발급 lock 을 **module-level(프로세스 전역)**
+# 으로 공유하고, 발급을 **app_key 단위** asyncio.Lock 으로 직렬화한다.
+#
+# - lock key = **app_key** (account_id 아님!). account_id 로 잡으면 동일 app_key
+#   다중 adapter 가 미수렴하여 ``EGW00133`` 이 잔존한다(회귀 락 — T1).
+# - 캐시 hit 시 발급 skip, double-check 로 대기 중 타 코루틴이 발급한 토큰 재사용.
+#
+# known-limitation (T7, v1): 본 캐시/lock 은 **in-process(단일 프로세스)** 한정이다.
+# 멀티프로세스(CLI 8 site 가 각각 fresh AccountService 생성) 토큰 공유는 v1 미해결 —
+# CLI cold-path 다발 동시 실행 시 ``EGW00133`` 잔존 가능. 영속(파일/DB) 토큰 스토어는
+# 후속 후보(YAGNI, spec 07 OAuth2 §(7) anchor).
+_token_cache: dict[str, tuple[str, datetime]] = {}
+"""app_key → (access_token, expires_at) in-process shared 캐시 (#2399 T2)."""
+
+_token_locks: dict[str, asyncio.Lock] = {}
+"""app_key → 발급 직렬화 Lock (#2399 T1, lock key=app_key)."""
+
+
+# lock dict 의 lazy 생성 경합(첫 Lock 생성 race)을 막는 동기 guard.
+# ``_get_token_lock`` 이 ``setdefault`` 로 원자적으로 Lock 을 보장한다 — 동기 구간
+# 이라 코루틴 yield 가 없어 race 가 없으나, 의도를 명시한다(T1 lock dict race).
+def _get_token_lock(app_key: str) -> asyncio.Lock:
+    """app_key 별 발급 Lock 을 lazy 생성/반환 (동기 구간, race-free).
+
+    ``dict.setdefault`` 는 GIL 하 단일 bytecode 로 원자적이고 await 가 없어 코루틴
+    yield 가 발생하지 않으므로, 동시 호출에서도 동일 app_key 는 **하나의** Lock 으로
+    수렴한다(#2399 T1 lock dict 생성 race 원자화).
+    """
+    return _token_locks.setdefault(app_key, asyncio.Lock())
+
+
+def _reset_token_cache() -> None:
+    """module-level 토큰 캐시/lock dict 초기화 (#2399, 테스트 격리용).
+
+    pytest-asyncio auto mode 에서 이전 테스트의 closed event loop 에 묶인 Lock 이
+    재사용되는 위험(T1 closed-loop)을 차단하기 위해, autouse fixture 가 매 테스트
+    전후로 본 helper 를 호출한다. 프로덕션 경로는 호출하지 않는다.
+    """
+    _token_cache.clear()
+    _token_locks.clear()
+
+
+def _is_cached_token_fresh(expires_at: datetime, *, now: datetime) -> bool:
+    """캐시 토큰이 near-expiry 여유(만료 5분 전) 내에서 아직 신선한지 (#2399 T2).
+
+    ``_ensure_authenticated`` 의 "만료 5분 전 재발급" 기준과 **동일**하다 —
+    near-expiry 토큰은 hit 이 아니라 miss 로 보고 재발급한다.
+    """
+    return now < expires_at - timedelta(minutes=_TOKEN_EXPIRY_MARGIN_MINUTES)
+
 
 # 취소(order-rvsecncl) 시 전송할 KRX_FWDG_ORD_ORGNO 캐시 상한.
 # 어댑터 인스턴스(=계좌)당 미체결 주문 수를 넉넉히 덮으면서 무한 증가를 막는다.
@@ -401,7 +473,68 @@ class KISBaseAdapter(BrokerAdapter):
     # ── 인증 ───────────────────────────────────────
 
     async def _authenticate(self) -> None:
-        """OAuth2 접근 토큰 발급."""
+        """OAuth2 접근 토큰 발급 — single-flight + in-process shared 캐시 (#2399).
+
+        절차 (T1/T2):
+        1. **캐시 read**: module-level ``_token_cache`` 에 본 app_key 의 신선한 토큰
+           (near-expiry 5분 여유 내)이 있으면 발급 skip — 인스턴스에 hydrate 후 반환.
+        2. **app_key lock** 획득(account_id 아님 — 동일 app_key 다중 adapter 수렴).
+        3. **double-check**: lock 대기 중 타 코루틴이 이미 발급했으면 재사용(발급 skip).
+        4. **발급 1회**: HTTP 호출 → 캐시 populate → 인스턴스 hydrate.
+
+        EGW00133 (T4): 발급 응답에서 ``EGW00133`` 감지 시 ``TokenRateLimitError`` 를
+        **즉시 raise** 한다 — **내부 sleep/retry 루프 없음**(곱셈 원천 제거). ~60s
+        backoff cadence 는 호출부 단일 레이어(startup wrapper / self-healing
+        interval)가 분담한다.
+        """
+        # (1) 캐시 read — lock 없이 fast-path. 신선하면 발급 skip.
+        if self._hydrate_from_cache():
+            return
+
+        # (2) app_key 단위 lock 으로 발급 직렬화 (T1).
+        lock = _get_token_lock(self.app_key)
+        async with lock:
+            # (3) double-check — 대기 중 타 코루틴이 발급했으면 재사용.
+            if self._hydrate_from_cache():
+                return
+            # (4) 발급 1회 → 캐시 populate → 인스턴스 hydrate.
+            token, expires_at = await self._issue_token()
+            _token_cache[self.app_key] = (token, expires_at)
+            self.access_token = token
+            self.token_expires_at = expires_at
+            logger.info("KIS 토큰 발급 완료")
+
+    def _hydrate_from_cache(self) -> bool:
+        """shared 캐시에 신선한 토큰이 있으면 인스턴스에 hydrate (#2399 T2).
+
+        near-expiry(만료 5분 전) 토큰은 miss 로 보고 ``False`` 반환(재발급 유도).
+        """
+        cached = _token_cache.get(self.app_key)
+        if cached is None:
+            return False
+        token, expires_at = cached
+        if not _is_cached_token_fresh(expires_at, now=datetime.now(UTC)):
+            return False
+        self.access_token = token
+        self.token_expires_at = expires_at
+        return True
+
+    async def _issue_token(self) -> tuple[str, datetime]:
+        """KIS OAuth2 토큰 1회 발급 — msg_cd 파싱 + EGW00133 즉시 raise (#2399 T3/T4).
+
+        토큰 발급 응답에서 KIS 에러코드를 파싱한다. alias 방어 (T3): 코드는
+        ``msg_cd``/``error_code``, 메시지는 ``msg1``/``error_description`` 양쪽 키를
+        모두 본다(KIS 토큰 엔드포인트 실제 형태 미확정). 응답 형태는 **HTTP 200 +
+        error 바디(rt_cd≠"0" 또는 access_token 부재)** 와 **non-200** 양 분기 모두
+        에러코드를 추출한다. (일반 API 응답 파싱은 ``_handle_response`` 가 담당 —
+        본 메서드는 토큰 발급 경로 **한정**.)
+
+        ``EGW00133`` 감지 시 ``TokenRateLimitError`` 즉시 raise(내부 sleep 없음).
+        그 외 에러는 ``AuthenticationError`` 로 raise(코드가 있으면 보존).
+
+        Returns:
+            (access_token, expires_at) — 발급 성공 시.
+        """
         url = f"{self.base_url}/oauth2/tokenP"
         data = {
             "grant_type": "client_credentials",
@@ -415,22 +548,68 @@ class KISBaseAdapter(BrokerAdapter):
                 url, json=data, headers={"content-type": "application/json"}
             ) as response:
                 if response.status != 200:
-                    text = await response.text()
-                    raise AuthenticationError(
-                        f"인증 실패 (HTTP {response.status}): {text}"
-                    )
+                    # non-200 분기: JSON body 에서 에러코드 추출 시도(실패 시 text).
+                    body = await self._read_token_error_body(response)
+                    self._raise_token_error(response.status, body)
 
                 result = await response.json()
-                self.access_token = result["access_token"]
-                self.token_expires_at = datetime.now(UTC) + timedelta(hours=24)
-                logger.info("KIS 토큰 발급 완료")
+                token = result.get("access_token")
+                if not token:
+                    # HTTP 200 + error 바디 분기(rt_cd≠"0" 또는 토큰 부재).
+                    self._raise_token_error(response.status, result)
+
+                expires_at = datetime.now(UTC) + timedelta(hours=24)
+                return token, expires_at
+
+    @staticmethod
+    async def _read_token_error_body(response: Any) -> dict[str, Any] | str:
+        """non-200 토큰 응답 body 를 dict(가능 시) 또는 raw text 로 반환 (#2399 T3)."""
+        text = await response.text()
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            return text
+        if isinstance(parsed, dict):
+            return parsed
+        return text
+
+    @staticmethod
+    def _raise_token_error(status: int, body: dict[str, Any] | str) -> NoReturn:
+        """토큰 발급 에러 raise — EGW00133 은 TokenRateLimitError (#2399 T3/T4).
+
+        alias 처리(T3): 코드는 ``msg_cd``/``error_code``, 메시지는 ``msg1``/
+        ``error_description`` 키를 순서대로 본다.
+        """
+        code = ""
+        detail = ""
+        if isinstance(body, dict):
+            code = str(body.get("msg_cd") or body.get("error_code") or "")
+            detail = str(body.get("msg1") or body.get("error_description") or "")
+        text = body if isinstance(body, str) else (detail or json.dumps(body))
+
+        if code == TOKEN_RATE_LIMIT_MSG_CODE:
+            msg = get_error_message(TOKEN_RATE_LIMIT_MSG_CODE)
+            raise TokenRateLimitError(
+                f"토큰 발급 빈도 제한 ({TOKEN_RATE_LIMIT_MSG_CODE}): {msg}",
+                error_code=TOKEN_RATE_LIMIT_MSG_CODE,
+            )
+        raise AuthenticationError(
+            f"인증 실패 (HTTP {status}): {text}",
+            error_code=code,
+        )
 
     async def _ensure_authenticated(self) -> None:
-        """토큰 유효성 확인 및 재발급."""
+        """토큰 유효성 확인 및 재발급 (#2399: 재발급도 single-flight/캐시 적용).
+
+        매 API 호출 전 진입점이므로, 캐시 hit 시 ``_authenticate`` 가 발급을 skip
+        한다(공유 캐시 fast-path). near-expiry(만료 5분 전) 토큰은 miss 로 보고
+        재발급한다 — 본 판정 기준이 ``_is_cached_token_fresh`` 와 동일하다(T2).
+        """
         if (
             not self.access_token
             or not self.token_expires_at
-            or datetime.now(UTC) >= self.token_expires_at - timedelta(minutes=5)
+            or datetime.now(UTC)
+            >= self.token_expires_at - timedelta(minutes=_TOKEN_EXPIRY_MARGIN_MINUTES)
         ):
             await self._authenticate()
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -803,9 +803,19 @@ async def _get_broker_with_auth_retry(account_service: Any, account_id: str) -> 
     wrapper 한 곳에만 둔다(self-healing 이 get_broker 를 반복 호출 → nested backoff
     곱셈 재발 차단, T4).
 
-    최악 지연: ``DEFAULT_MAX_RETRIES_AUTH`` × ``TOKEN_AUTH_BACKOFF_SECONDS``
-    (=2×60s=120s). self-healing interval(60s)과 곱해지지 않는다(단일 cadence).
+    **잔여 cooldown sleep (#2399 attempt3, per-app_key cooldown at source):** EGW00133
+    수신 시 발급 레이어(``kis._raise_token_rate_limit``)가 app_key cooldown 을 기록하고
+    예외에 ``cooldown_until`` 을 실어 보낸다. 본 wrapper 는 고정 60s 대신 **잔여
+    cooldown**(``cooldown_until - now``)만큼 sleep 한다. 그래야 다음 재시도가 cooldown
+    만료 직후에 단 1회 발급으로 떨어지고, 고정 60s 가 cooldown 경계를 넘겨 재시도가
+    또 cooldown 에 막히는 무력화를 피한다. cooldown_until 미동봉(이론상 경합 만료)이면
+    안전상 ``TOKEN_AUTH_BACKOFF_SECONDS`` 고정값으로 폴백한다.
+
+    최악 지연: ``DEFAULT_MAX_RETRIES_AUTH`` × ~``TOKEN_AUTH_BACKOFF_SECONDS``
+    (≈2×60s=120s). self-healing interval(60s)과 곱해지지 않는다(단일 cadence).
     """
+    from datetime import UTC, datetime
+
     from ante.broker.exceptions import TokenRateLimitError
     from ante.broker.kis import (
         DEFAULT_MAX_RETRIES_AUTH,
@@ -816,17 +826,26 @@ async def _get_broker_with_auth_retry(account_service: Any, account_id: str) -> 
     while True:
         try:
             return await account_service.get_broker(account_id)
-        except TokenRateLimitError:
+        except TokenRateLimitError as e:
             if attempt >= DEFAULT_MAX_RETRIES_AUTH:
                 raise
             attempt += 1
+            # 잔여 cooldown 만큼 sleep(고정 60s 아님) — cooldown 경계 무력화 방지.
+            # cooldown_until 미동봉/이미 만료면 안전 폴백(고정 backoff).
+            cooldown_until = getattr(e, "cooldown_until", None)
+            if cooldown_until is not None:
+                remaining = (cooldown_until - datetime.now(UTC)).total_seconds()
+                sleep_seconds = max(0.0, remaining)
+            else:
+                sleep_seconds = TOKEN_AUTH_BACKOFF_SECONDS
             logger.warning(
-                "Broker connect EGW00133(토큰 발급 빈도 제한) — %.0f초 후 재시도 %d/%d",
-                TOKEN_AUTH_BACKOFF_SECONDS,
+                "Broker connect EGW00133(토큰 발급 빈도 제한) — %.0f초(잔여 cooldown) "
+                "후 재시도 %d/%d",
+                sleep_seconds,
                 attempt,
                 DEFAULT_MAX_RETRIES_AUTH,
             )
-            await asyncio.sleep(TOKEN_AUTH_BACKOFF_SECONDS)
+            await asyncio.sleep(sleep_seconds)
 
 
 async def _init_gateway(s: Services) -> None:
@@ -1534,6 +1553,14 @@ async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
     ready 로 전이한다. ``max_attempts`` 는 **per-burst(연결시도 단위)에만** 적용
     하고 계좌 lifetime 은 무제한이다 — 일시 토큰압박이 영구 not_ready 로 고착되어
     #2395 를 역회귀로 재생산하지 않도록. shutdown 에서 task cancel 로 종료한다.
+
+    #2399 Codex attempt3-b (per-app_key cooldown at source): 같은 app_key 의 여러
+    계좌가 pending 이면, 첫 계좌의 connect 가 EGW00133 으로 cooldown 을 기록한 뒤
+    같은 burst 의 두 번째 계좌 connect 는 cooldown 내라 발급 레이어가 **HTTP 미호출·
+    즉시 ``TokenRateLimitError``** 로 raise → 아래 ``except TokenRateLimitError`` 가
+    그 계좌의 burst 도 break 한다(토큰 1/min 재타격 없음). interval(60s, defaults.py)
+    ≥ cooldown(``TOKEN_RATE_LIMIT_COOLDOWN_SECONDS``=60s)이라 다음 burst 시점에는
+    cooldown 이 만료돼 발급이 정상 재개된다(self-healing 정상 동작과 정합).
     """
     interval = 60
     max_per_burst = 5
@@ -1749,11 +1776,27 @@ async def _sync_instruments(s: Services, accounts: list) -> None:
     붕괴), 면제 계좌는 순회 대상에서 제외한다(non-exempt/live connected 계좌만
     대상). 면제 계좌의 dummy exchange 가 KRX 등 실 exchange 마스터 적재를
     선점하던 #2385 회귀도 동일하게 차단된다.
+
+    #2399 Codex attempt3-a: startup connect 에서 broker not_ready 가 된 비면제
+    (LIVE) 계좌도 순회 대상에서 제외한다(``_broker_not_ready_live``). 그 계좌에
+    ``get_broker`` 를 다시 호출하면 EGW00133 계좌의 KIS 토큰 1/min 제한을 startup
+    단일 cadence(T4) 밖에서 또 두드리기 때문이다. (A) per-app_key cooldown 이
+    최종 안전망으로 그 재타격을 source 에서 즉시 raise 로 막지만, 불필요한 발급
+    시도 자체를 줄이는 본 필터를 함께 둬 defense-in-depth 로 한다. per-account
+    try/except 가 not_ready 계좌의 예외도 흡수하므로 전체 sync 를 깨지 않는다.
     """
     synced_exchanges: set[str] = set()
     for account in accounts:
         if _broker_ready_exempt(account):
             # 면제(virtual/test) 계좌는 broker 미연결 — get_broker 재노출 차단.
+            continue
+        if _broker_not_ready_live(s, account):
+            # broker not_ready LIVE — get_broker 재타격 차단(EGW00133 토큰 1/min).
+            # cooldown(A) 가 최종 안전망이나 불필요 발급 시도 자체를 줄인다(T4).
+            logger.info(
+                "종목 동기화 skip: account=%s — broker not_ready(self-healing 위임)",
+                account.account_id,
+            )
             continue
         if account.exchange in synced_exchanges:
             continue

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -692,6 +692,57 @@ async def _init_trading(s: Services) -> None:
     logger.info("BotManager 초기화 완료")
 
 
+def _connect_failure_reason(exc: BaseException, default: str) -> str:
+    """connect 실패 예외에서 readiness reason 을 구조적으로 도출 (#2399 T6).
+
+    ``AuthenticationError.error_code`` (KIS 원천 ``msg_cd``, 예: ``EGW00133``)을
+    문자열 grep 이 아니라 ``getattr`` 로 추출한다. 코드가 있으면 reason 으로 쓰고,
+    없으면 ``default`` (startup="connect_failed", self-healing="reconnect_failed").
+    D-ACC-09 readiness reason 연동(startup §181 + self-healing).
+    """
+    code = getattr(exc, "error_code", None)
+    if code:
+        return str(code)
+    return default
+
+
+async def _connect_broker_with_auth_retry(broker: Any) -> None:
+    """broker.connect() 를 EGW00133 흡수용 bounded retry 로 감싼다 (#2399 T4 (c)).
+
+    **단일 cadence 레이어의 startup 한 곳**(부팅 1회 경로, 곱셈 없음). EGW00133
+    (``TokenRateLimitError``)을 만나면 ~60s backoff 후 ``DEFAULT_MAX_RETRIES_AUTH``
+    내 재시도해 startup token race 를 흡수한다. ``_authenticate`` 자체는 즉시 raise
+    (내부 sleep 없음)이므로 backoff 누적은 본 wrapper 한 곳에만 발생한다. 소진 시
+    마지막 ``TokenRateLimitError`` 를 전파해 호출부가 not_ready(reason=EGW00133).
+    EGW00133 외 예외는 즉시 전파(기존 동작 유지).
+
+    최악 지연: ``DEFAULT_MAX_RETRIES_AUTH`` × ``TOKEN_AUTH_BACKOFF_SECONDS``
+    (=2×60s=120s). self-healing interval(60s)과 곱해지지 않는다(단일 cadence).
+    """
+    from ante.broker.exceptions import TokenRateLimitError
+    from ante.broker.kis import (
+        DEFAULT_MAX_RETRIES_AUTH,
+        TOKEN_AUTH_BACKOFF_SECONDS,
+    )
+
+    attempt = 0
+    while True:
+        try:
+            await broker.connect()
+            return
+        except TokenRateLimitError:
+            if attempt >= DEFAULT_MAX_RETRIES_AUTH:
+                raise
+            attempt += 1
+            logger.warning(
+                "Broker connect EGW00133(토큰 발급 빈도 제한) — %.0f초 후 재시도 %d/%d",
+                TOKEN_AUTH_BACKOFF_SECONDS,
+                attempt,
+                DEFAULT_MAX_RETRIES_AUTH,
+            )
+            await asyncio.sleep(TOKEN_AUTH_BACKOFF_SECONDS)
+
+
 async def _init_gateway(s: Services) -> None:
     """APIGateway(account_service 주입), StreamIntegration, 종목 동기화."""
     assert s.eventbus is not None
@@ -729,7 +780,9 @@ async def _init_gateway(s: Services) -> None:
             continue
         try:
             broker = await s.account_service.get_broker(account.account_id)
-            await broker.connect()
+            # #2399 T4 (c): startup 단일 cadence — EGW00133 흡수용 bounded retry
+            # (~60s backoff × DEFAULT_MAX_RETRIES_AUTH)를 여기 한 곳에만 둔다.
+            await _connect_broker_with_auth_retry(broker)
             connected_count += 1
             # #2397 broker_ready = connect 성공 시점 mark([must_fix F] —
             # get_cached_broker live-poll 아님). #2372 connect-후-캐시 정합.
@@ -739,14 +792,15 @@ async def _init_gateway(s: Services) -> None:
                 account.account_id,
                 account.broker_type,
             )
-        except Exception:
+        except Exception as e:
             # #2397 startup 실패 → broker_ready not_ready(reason). self-healing
             # background loop 가 회복을 무기한 재시도한다.
+            # #2399 T6: EGW00133 은 reason 에 구조적 보존(getattr error_code).
             _mark_runtime_not_ready(
                 s,
                 account.account_id,
                 ReadinessFlag.BROKER,
-                "connect_failed",
+                _connect_failure_reason(e, "connect_failed"),
             )
             logger.warning(
                 "Broker 연결 실패: account=%s — 건너뜀",
@@ -1250,11 +1304,24 @@ async def _self_healing_recover_account(s: Services, account: Any) -> bool:
         try:
             broker = await s.account_service.get_broker(account_id)
             await broker.connect()
-        except Exception:
+        except Exception as e:
             # 회복 미성공 — not_ready 유지. 다음 burst 에서 재시도(liveness).
+            # #2399 T6: EGW00133 은 reason 에 구조적 보존(getattr error_code).
             _mark_runtime_not_ready(
-                s, account_id, ReadinessFlag.BROKER, "reconnect_failed"
+                s,
+                account_id,
+                ReadinessFlag.BROKER,
+                _connect_failure_reason(e, "reconnect_failed"),
             )
+            # #2399 T4 (b): EGW00133(TokenRateLimitError)은 현재 burst 의 남은
+            # attempt 를 중단(re-raise)하고 다음 interval(60s 토큰 cooldown)에
+            # 위임한다 — burst 당 connect 시도 ≤1회(per-attempt backoff 누적 금지,
+            # 단일 cadence nested-backoff 차단). 다른 transient 는 False 반환으로
+            # 기존 per-attempt backoff 재시도 유지.
+            from ante.broker.exceptions import TokenRateLimitError
+
+            if isinstance(e, TokenRateLimitError):
+                raise
             return False
         # broker connect 성공 — 단, broker_ready mark 는 의존 스케줄러 rebind 를 모두
         # 마친 **뒤**로 지연한다(메타리뷰 P2). 여기서 먼저 mark 하면 아래 rebind await
@@ -1382,6 +1449,8 @@ async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
                     trading_mode=a.trading_mode,
                 )
             ]
+            from ante.broker.exceptions import TokenRateLimitError
+
             for account in pending:
                 # per-burst bounded 재시도(계좌 lifetime 은 무제한).
                 for attempt in range(max_per_burst):
@@ -1389,6 +1458,19 @@ async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
                         recovered = await _self_healing_recover_account(s, account)
                     except asyncio.CancelledError:
                         raise
+                    except TokenRateLimitError:
+                        # #2399 T4 (b): EGW00133 — 이 계좌의 현재 burst 남은 attempt 를
+                        # 중단(break)하고 다음 interval(60s 토큰 cooldown)에 위임한다.
+                        # per-attempt backoff 를 누적하지 않아 burst 당 connect 시도
+                        # ≤1회 → startup wrapper(단일 cadence)와 곱해지지 않는다
+                        # (5×120s 누적 차단). 다음 burst 에서 자연히 재시도(liveness).
+                        logger.info(
+                            "Readiness self-healing EGW00133 — account=%s, "
+                            "다음 interval(%ds)에 위임(burst break)",
+                            account.account_id,
+                            interval,
+                        )
+                        break
                     except Exception:
                         # 회복 시도 중 예기치 못한 예외(스케줄러 생성자·config 접근·
                         # reconciler 빌드 등 try 밖 경로)가 background loop 를 영구
@@ -1402,9 +1484,10 @@ async def _readiness_self_healing_loop(s: Services, targets: list[Any]) -> None:
                         recovered = False
                     if recovered:
                         break
-                    # attempt 간 지수 backoff(EGW00133 ~1/min 토큰 cooldown 정렬,
-                    # Codex P2). 즉시 재인증을 몰아넣어 KIS 토큰 압박을 악화시키지
-                    # 않도록 한다. 마지막 attempt 뒤에는 burst interval 이 대신한다.
+                    # attempt 간 지수 backoff(다른 transient 실패용). EGW00133 은 위
+                    # break 로 여기 도달하지 않는다(#2399 T4 (b)). 즉시 재인증을
+                    # 몰아넣어 KIS 압박을 악화시키지 않도록 한다. 마지막 attempt
+                    # 뒤에는 burst interval 이 대신한다.
                     if attempt < max_per_burst - 1:
                         await asyncio.sleep(
                             min(backoff_base * (2**attempt), backoff_max)

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -231,6 +231,32 @@ def _broker_ready_exempt(account: Any) -> bool:
     return _flag_exempt_for_account(ReadinessFlag.BROKER, account)
 
 
+def _broker_not_ready_live(s: Services, account: Any) -> bool:
+    """startup connect 에서 broker not_ready 가 된 **비면제(LIVE)** 계좌인지.
+
+    #2399 Codex P2(attempt 2) — 후속 broker-backed startup init 가드: startup
+    connect 루프(``_init_gateway``)에서 EGW00133 bounded retry 가 소진되거나 기타
+    실패로 ``broker_ready`` 가 not_ready 가 된 LIVE 계좌는, 그 뒤 같은 startup 의
+    broker-backed 초기화 단계(stream·treasury LIVE sync·fill recovery·reconcile)
+    에서 ``get_broker`` 를 **다시 호출하면 안 된다**. 그 추가 호출이 EGW00133 계좌의
+    KIS 토큰 1/min 제한을 startup 단일 cadence(T4) 밖에서 또 두드리기 때문이다.
+
+    True 인 계좌는 후속 단계가 skip 하고, broker 회복은 self-healing(#2397/#2398)
+    이 60s interval 로 이어받아 fill/reconcile/treasury 를 재등록한다.
+
+    - broker_ready 면제(virtual/test) 계좌는 항상 False — broker 무관 단계
+      (예: treasury VIRTUAL sync, broker=None)는 영향 없이 계속 처리한다.
+    - registry 미주입(partial wiring) 환경에서는 ``is_ready`` 가 항상 False 라
+      모든 LIVE 계좌를 skip 하게 되므로, registry 가 없으면 False 를 반환해
+      기존 동작(전 계좌 처리)을 보존한다.
+    """
+    if s.runtime_readiness is None:
+        return False
+    if _broker_ready_exempt(account):
+        return False
+    return not s.runtime_readiness.is_ready(account.account_id, ReadinessFlag.BROKER)
+
+
 def _mark_runtime_ready(s: Services, account_id: str, flag: ReadinessFlag) -> None:
     """registry ready mark. registry 미주입 환경(partial wiring)에서는 no-op."""
     if s.runtime_readiness is not None:
@@ -275,6 +301,51 @@ def _mark_reconcile_global_skip(s: Services, accounts: list[Any]) -> None:
                 ReadinessFlag.RECONCILE,
                 "reconcile_init_skipped_no_broker",
             )
+
+
+def _broker_ready_init_accounts(s: Services, accounts: list[Any]) -> list[Any]:
+    """후속 broker-backed startup init 에 넘길 계좌 — broker not_ready LIVE 제외.
+
+    #2399 Codex P2(attempt 2): startup connect 에서 broker not_ready 가 된 LIVE
+    계좌(``_broker_not_ready_live`` True)를 제외한다. 제외된 계좌는 후속 단계
+    (treasury LIVE sync·fill recovery·reconcile)가 ``get_broker`` 를 다시 호출하지
+    않아 EGW00133 토큰 1/min 재타격을 피한다(T4 단일 cadence). 제외된 LIVE 계좌의
+    treasury_sync·fill_reconcile·reconcile 플래그는 ``mark_not_ready`` 로 명시
+    표시해, self-healing(#2397/#2398)이 broker 회복 시 픽업·재등록한다.
+
+    면제(virtual/test) 계좌와 broker_ready 성공 LIVE 계좌는 그대로 유지된다
+    (treasury VIRTUAL sync 등 broker 무관 처리 보존).
+    """
+    kept: list[Any] = []
+    for account in accounts:
+        if _broker_not_ready_live(s, account):
+            # 후속 flag 를 명시 not_ready(reason) — fail-closed + self-healing 픽업.
+            _mark_runtime_not_ready(
+                s,
+                account.account_id,
+                ReadinessFlag.TREASURY_SYNC,
+                "broker_not_ready_startup",
+            )
+            _mark_runtime_not_ready(
+                s,
+                account.account_id,
+                ReadinessFlag.FILL_RECONCILE,
+                "broker_not_ready_startup",
+            )
+            _mark_runtime_not_ready(
+                s,
+                account.account_id,
+                ReadinessFlag.RECONCILE,
+                "broker_not_ready_startup",
+            )
+            logger.info(
+                "후속 broker-backed init skip: account=%s — broker not_ready"
+                "(treasury/fill/reconcile self-healing 위임)",
+                account.account_id,
+            )
+            continue
+        kept.append(account)
+    return kept
 
 
 async def _init_core(s: Services) -> None:
@@ -844,6 +915,18 @@ async def _init_gateway(s: Services) -> None:
     # KIS 브로커 계좌의 StreamIntegration 초기화
     for account in accounts:
         if account.broker_type == "kis":
+            # #2399 Codex P2(attempt 2): startup connect 에서 broker not_ready 가
+            # 된 LIVE 계좌는 여기서 get_broker 를 재호출하지 않는다(EGW00133 토큰
+            # 1/min 재타격 방지 — T4 단일 cadence). self-healing 이 broker 회복 시
+            # 이어받는다(stream 은 broker 회복 후 별도 재초기화 경로 불필요 —
+            # active-trading gate 와 무관, broker 미연결이면 stream 도 무의미).
+            if _broker_not_ready_live(s, account):
+                logger.info(
+                    "StreamIntegration 초기화 skip: account=%s — broker not_ready"
+                    "(self-healing 위임)",
+                    account.account_id,
+                )
+                continue
             try:
                 # broker 연결을 보장(cache-hit no-op / cache-miss connect+cache)한 뒤
                 # StreamIntegration 을 초기화한다. 반환 adapter 자체는 stream init 이
@@ -912,15 +995,22 @@ async def _init_gateway(s: Services) -> None:
                     account.account_id,
                 )
 
+    # #2399 Codex P2(attempt 2): 후속 broker-backed init 는 broker not_ready 가
+    # 된 LIVE 계좌를 제외한 계좌 집합에만 적용한다(EGW00133 토큰 1/min 재타격 방지
+    # — T4 단일 cadence). 제외된 LIVE 계좌의 후속 flag 는 helper 가 명시
+    # mark_not_ready 하고, broker 회복은 self-healing 이 이어받는다. 면제(virtual/
+    # test)·broker_ready 성공 LIVE 계좌는 그대로 포함된다.
+    broker_init_accounts = _broker_ready_init_accounts(s, accounts)
+
     # Treasury 잔고 동기화 (Broker 연결 이후)
-    await _init_treasury_sync(s, accounts)
+    await _init_treasury_sync(s, broker_init_accounts)
 
     # #1946 hard barrier: 각 계좌의 FillReconcileScheduler.catch_up_once() 를
     # await 완료한 뒤에만 ReconcileScheduler.start()(즉시 run_once 로 position
     # 대사) 를 시작한다. fill 복구가 position reconcile 보다 반드시 선행해야
     # reconciler 가 미복구 ante 체결을 "외부 매수" 로 오분류하지 않는다.
     if connected_count and s.fill_applier and s.order_tracker:
-        await _init_fill_recovery_schedulers(s, accounts)
+        await _init_fill_recovery_schedulers(s, broker_init_accounts)
     else:
         # #2397 D-ACC-09 이중 실패모드 (a): 전역 connected_count==0(또는 fill
         # 의존성 부재)으로 _init_fill_recovery_schedulers 가 미호출 → 전 계좌 키가
@@ -1146,6 +1236,12 @@ async def _init_reconcile_scheduler(s: Services) -> None:
         # 없이 registry no-op ready mark + broker-backed 등록 skip. LIVE 만 등록.
         if _flag_exempt_for_account(ReadinessFlag.RECONCILE, account):
             _mark_runtime_ready(s, account.account_id, ReadinessFlag.RECONCILE)
+            continue
+        # #2399 Codex P2(attempt 2): startup connect 에서 broker not_ready 가 된
+        # LIVE 계좌는 get_broker 재호출 없이 skip(EGW00133 토큰 1/min 재타격 방지
+        # — T4). RECONCILE not_ready 는 _broker_ready_init_accounts 가 이미 mark
+        # 했고, broker 회복 시 self-healing 이 재등록한다.
+        if _broker_not_ready_live(s, account):
             continue
         if await _register_reconcile_scheduler_for_account(
             s, account, reconciler, interval

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -706,15 +706,31 @@ def _connect_failure_reason(exc: BaseException, default: str) -> str:
     return default
 
 
-async def _connect_broker_with_auth_retry(broker: Any) -> None:
-    """broker.connect() 를 EGW00133 흡수용 bounded retry 로 감싼다 (#2399 T4 (c)).
+async def _get_broker_with_auth_retry(account_service: Any, account_id: str) -> Any:
+    """get_broker(account_id) 를 EGW00133 흡수용 bounded retry 로 감싼다 (#2399 T4 c).
 
     **단일 cadence 레이어의 startup 한 곳**(부팅 1회 경로, 곱셈 없음). EGW00133
     (``TokenRateLimitError``)을 만나면 ~60s backoff 후 ``DEFAULT_MAX_RETRIES_AUTH``
-    내 재시도해 startup token race 를 흡수한다. ``_authenticate`` 자체는 즉시 raise
-    (내부 sleep 없음)이므로 backoff 누적은 본 wrapper 한 곳에만 발생한다. 소진 시
-    마지막 ``TokenRateLimitError`` 를 전파해 호출부가 not_ready(reason=EGW00133).
-    EGW00133 외 예외는 즉시 전파(기존 동작 유지).
+    내 재시도해 startup token race 를 흡수한다.
+
+    **재배치 사유(#2399 Codex P1):** ``AccountService.get_broker`` 는 cache-miss 시
+    내부에서 ``connect()`` 를 수행하고 **연결 성공 후에만** 캐시한다(#2372). 따라서
+    새 프로세스 cache-miss startup 의 첫 인증이 EGW00133 을 반환하면 그 예외가
+    ``get_broker()`` 호출 자체에서 전파된다. retry 가 ``broker.connect()`` 만
+    감쌌다면 ``get_broker()`` 가 먼저 raise 해 wrapper 에 도달하지 못하므로 bounded
+    retry 가 무효였다. 따라서 retry 는 **``get_broker()`` 호출 전체**를 감싼다.
+
+    ``get_broker`` 는 connect 실패 시 캐시 미기록 + 세션 cleanup(#2368/#2372)하므로,
+    EGW00133 재시도 시 ``get_broker`` 재호출이 새 adapter build+connect 를 안전하게
+    재수행한다(세션 누수 없음). ``_authenticate`` 자체는 즉시 raise(내부 sleep 없음)
+    이므로 backoff 누적은 본 wrapper 한 곳에만 발생한다. 성공 시 반환되는 broker 는
+    connect+cache 가 완료된 상태다. 소진 시 마지막 ``TokenRateLimitError`` 를 전파해
+    호출부가 not_ready(reason=EGW00133). EGW00133 외 예외는 즉시 전파(기존 동작 유지).
+
+    ``get_broker`` 의 계약(connect-성공-후-캐시, #2372)은 self-healing 등 전 caller
+    공유이므로 **변경하지 않는다**. retry 는 get_broker 내부가 아니라 본 startup
+    wrapper 한 곳에만 둔다(self-healing 이 get_broker 를 반복 호출 → nested backoff
+    곱셈 재발 차단, T4).
 
     최악 지연: ``DEFAULT_MAX_RETRIES_AUTH`` × ``TOKEN_AUTH_BACKOFF_SECONDS``
     (=2×60s=120s). self-healing interval(60s)과 곱해지지 않는다(단일 cadence).
@@ -728,8 +744,7 @@ async def _connect_broker_with_auth_retry(broker: Any) -> None:
     attempt = 0
     while True:
         try:
-            await broker.connect()
-            return
+            return await account_service.get_broker(account_id)
         except TokenRateLimitError:
             if attempt >= DEFAULT_MAX_RETRIES_AUTH:
                 raise
@@ -779,10 +794,12 @@ async def _init_gateway(s: Services) -> None:
             _mark_runtime_ready(s, account.account_id, ReadinessFlag.BROKER)
             continue
         try:
-            broker = await s.account_service.get_broker(account.account_id)
             # #2399 T4 (c): startup 단일 cadence — EGW00133 흡수용 bounded retry
             # (~60s backoff × DEFAULT_MAX_RETRIES_AUTH)를 여기 한 곳에만 둔다.
-            await _connect_broker_with_auth_retry(broker)
+            # get_broker 는 cache-miss 시 내부에서 connect 후 성공 시에만 캐시(#2372)
+            # 하므로, EGW00133 은 connect 가 아니라 get_broker 호출 자체에서 전파된다.
+            # 따라서 retry 는 get_broker 호출 전체를 감싼다(#2399 Codex P1).
+            await _get_broker_with_auth_retry(s.account_service, account.account_id)
             connected_count += 1
             # #2397 broker_ready = connect 성공 시점 mark([must_fix F] —
             # get_cached_broker live-poll 아님). #2372 connect-후-캐시 정합.
@@ -828,7 +845,10 @@ async def _init_gateway(s: Services) -> None:
     for account in accounts:
         if account.broker_type == "kis":
             try:
-                broker = await s.account_service.get_broker(account.account_id)
+                # broker 연결을 보장(cache-hit no-op / cache-miss connect+cache)한 뒤
+                # StreamIntegration 을 초기화한다. 반환 adapter 자체는 stream init 이
+                # broker_config 로 별도 클라이언트를 구성하므로 사용하지 않는다.
+                await s.account_service.get_broker(account.account_id)
                 broker_config = {**account.credentials, **account.broker_config}
                 await _init_stream_integration(
                     s,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,26 @@ def _set_encryption_key():
 
 
 @pytest.fixture(autouse=True)
+def _reset_kis_token_state():
+    """매 테스트 전후 KIS module-level 토큰 캐시/lock/cooldown 초기화 (#2399).
+
+    글로벌 격리(메타 P2): EGW00133 ``_token_cooldowns`` 상태가 테스트 간 누출되면
+    KIS 토큰을 건드리는 후속 테스트의 발급이 cooldown 내로 오판돼 flaky 가 된다.
+    기존엔 토큰 single-flight/backoff 테스트 2개 파일에만 reset autouse fixture 가
+    있어 cross-test 오염 위험이 있었으므로, 전 테스트가 공유하는 본 글로벌 conftest
+    autouse fixture 로 승격해 ``_token_cache``/``_token_locks``/``_token_cooldowns``
+    를 매 테스트 경계에서 초기화한다. closed event loop 에 묶인 Lock 재사용(T1
+    closed-loop) 방지도 겸한다. ``ante.broker.kis`` 는 import 가드 안에서 안전하게
+    lazy import 한다(collection 시 부작용 회피).
+    """
+    from ante.broker.kis import _reset_token_cache
+
+    _reset_token_cache()
+    yield
+    _reset_token_cache()
+
+
+@pytest.fixture(autouse=True)
 def _sync_boundary_cleanup():
     """모든 테스트(sync + async) 경계에서 ``patch.stopall`` 보장.
 

--- a/tests/unit/test_kis_token_backoff_cadence.py
+++ b/tests/unit/test_kis_token_backoff_cadence.py
@@ -1,0 +1,275 @@
+"""EGW00133 단일 cadence backoff + readiness reason 보존 테스트 (#2399 T4/T6).
+
+검증:
+- startup wrapper(``_connect_broker_with_auth_retry``): EGW00133 흡수 bounded retry
+  (≤DEFAULT_MAX_RETRIES_AUTH), 소진 시 TokenRateLimitError 전파, 비-EGW00133 즉시 전파.
+- startup connect 루프: 소진 시 not_ready(reason="EGW00133") 구조적 보존(T6).
+- self-healing recover: EGW00133 시 not_ready(reason="EGW00133") + TokenRateLimitError
+  re-raise(burst break 신호).
+- self-healing burst loop: persistent EGW00133 burst 당 connect ≤1회(nested bound,
+  per-attempt backoff 미적용 — 5×120s 누적 부재).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+import ante.main as main_module
+from ante.account.models import TradingMode
+from ante.account.readiness import ReadinessFlag, RuntimeReadinessRegistry
+from ante.broker.exceptions import AuthenticationError, TokenRateLimitError
+from ante.broker.kis import DEFAULT_MAX_RETRIES_AUTH
+
+
+def _account(account_id: str = "live-1") -> Any:
+    return SimpleNamespace(
+        account_id=account_id,
+        broker_type="kis-domestic",
+        trading_mode=TradingMode.LIVE,
+        exchange="KRX",
+        credentials={},
+        broker_config={},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """asyncio.sleep 을 patch 해 실제 대기 없이 호출량을 관측 (T4 nested bound)."""
+    slept: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    monkeypatch.setattr(main_module.asyncio, "sleep", _fake_sleep)
+    return slept
+
+
+# ── T4 (c): startup wrapper bounded retry ──────────────────
+
+
+class TestStartupAuthRetryWrapper:
+    async def test_egw00133_absorbed_then_success(
+        self, _no_real_sleep: list[float]
+    ) -> None:
+        """EGW00133 흡수 후 성공 — bounded retry 내 회복."""
+        broker = AsyncMock()
+        state = {"fails": 1}
+
+        async def _connect() -> None:
+            if state["fails"] > 0:
+                state["fails"] -= 1
+                raise TokenRateLimitError("x", error_code="EGW00133")
+
+        broker.connect = AsyncMock(side_effect=_connect)
+
+        await main_module._connect_broker_with_auth_retry(broker)
+
+        assert broker.connect.await_count == 2  # 1 실패 + 1 성공
+        # backoff sleep 1회(흡수).
+        assert len(_no_real_sleep) == 1
+
+    async def test_egw00133_exhausts_max_retries_then_raises(
+        self, _no_real_sleep: list[float]
+    ) -> None:
+        """persistent EGW00133 → DEFAULT_MAX_RETRIES_AUTH 소진 후 전파."""
+        broker = AsyncMock()
+        broker.connect = AsyncMock(
+            side_effect=TokenRateLimitError("x", error_code="EGW00133")
+        )
+
+        with pytest.raises(TokenRateLimitError):
+            await main_module._connect_broker_with_auth_retry(broker)
+
+        # 최초 1 + 재시도 DEFAULT_MAX_RETRIES_AUTH 회.
+        assert broker.connect.await_count == DEFAULT_MAX_RETRIES_AUTH + 1
+        # backoff sleep = 재시도 횟수만큼(소진 직전까지). startup 한 곳만(곱셈 없음).
+        assert len(_no_real_sleep) == DEFAULT_MAX_RETRIES_AUTH
+
+    async def test_non_egw00133_propagates_immediately(
+        self, _no_real_sleep: list[float]
+    ) -> None:
+        """비-EGW00133 예외는 흡수 retry 없이 즉시 전파(기존 동작 유지)."""
+        broker = AsyncMock()
+        broker.connect = AsyncMock(
+            side_effect=AuthenticationError("bad key", error_code="EGW00121")
+        )
+
+        with pytest.raises(AuthenticationError):
+            await main_module._connect_broker_with_auth_retry(broker)
+
+        assert broker.connect.await_count == 1
+        assert _no_real_sleep == []  # backoff 없음
+
+
+# ── T6: startup connect 루프 reason 보존 ───────────────────
+
+
+class TestConnectFailureReason:
+    def test_reason_from_error_code(self) -> None:
+        """error_code 보유 예외 → reason=error_code (구조적, 문자열 grep 아님)."""
+        exc = TokenRateLimitError("x", error_code="EGW00133")
+        assert main_module._connect_failure_reason(exc, "connect_failed") == "EGW00133"
+
+    def test_reason_default_when_no_code(self) -> None:
+        """error_code 없으면 default reason."""
+        exc = RuntimeError("network down")
+        assert (
+            main_module._connect_failure_reason(exc, "connect_failed")
+            == "connect_failed"
+        )
+
+    def test_reason_default_when_empty_code(self) -> None:
+        """error_code 빈 문자열이면 default reason."""
+        exc = AuthenticationError("generic", error_code="")
+        assert (
+            main_module._connect_failure_reason(exc, "reconnect_failed")
+            == "reconnect_failed"
+        )
+
+
+# ── T4 (b): self-healing recover EGW00133 → re-raise + reason ──
+
+
+def _self_healing_services(broker: Any) -> Any:
+    s = main_module.Services()
+    s.runtime_readiness = RuntimeReadinessRegistry()
+    s.order_tracker = None
+    s.fill_applier = None
+    s.trade_service = None
+    s.eventbus = AsyncMock()
+    s.instrument_service = object()
+    s.bot_manager = object()
+    s.treasury_manager = None
+    s.config = SimpleNamespace(get=lambda key, default=None: default)
+
+    account_service = AsyncMock()
+    account_service.get_broker = AsyncMock(return_value=broker)
+    s.account_service = account_service  # type: ignore[assignment]
+    return s
+
+
+class TestSelfHealingEGW00133:
+    async def test_recover_reraises_and_preserves_reason(self) -> None:
+        """recover_account: EGW00133 → reason 보존 + TokenRateLimitError re-raise."""
+        broker = AsyncMock()
+        broker.connect = AsyncMock(
+            side_effect=TokenRateLimitError("x", error_code="EGW00133")
+        )
+        s = _self_healing_services(broker)
+        account = _account()
+        s.runtime_readiness.mark_not_ready(
+            "live-1", ReadinessFlag.BROKER, "connect_failed"
+        )
+
+        with pytest.raises(TokenRateLimitError):
+            await main_module._self_healing_recover_account(s, account)
+
+        # T6: reason 에 EGW00133 보존.
+        assert (
+            s.runtime_readiness.get_reason("live-1", ReadinessFlag.BROKER) == "EGW00133"
+        )
+
+    async def test_recover_other_transient_returns_false_no_raise(self) -> None:
+        """다른 transient(비-EGW00133) → False 반환(re-raise 없음, 기존 backoff)."""
+        broker = AsyncMock()
+        broker.connect = AsyncMock(side_effect=RuntimeError("conn reset"))
+        s = _self_healing_services(broker)
+        account = _account()
+        s.runtime_readiness.mark_not_ready(
+            "live-1", ReadinessFlag.BROKER, "connect_failed"
+        )
+
+        result = await main_module._self_healing_recover_account(s, account)
+        assert result is False
+        assert (
+            s.runtime_readiness.get_reason("live-1", ReadinessFlag.BROKER)
+            == "reconnect_failed"
+        )
+
+
+# ── T4 (b): self-healing burst loop nested bound ───────────
+
+
+class TestSelfHealingBurstBound:
+    async def test_persistent_egw00133_one_connect_per_burst(
+        self, _no_real_sleep: list[float]
+    ) -> None:
+        """persistent EGW00133: burst 당 connect 시도 ≤1회 (nested bound, 5×120s 부재).
+
+        per-attempt backoff(min(backoff_base*2^attempt, max))가 누적되지 않고,
+        EGW00133 break 로 다음 interval(60s)에만 위임됨을 connect 호출량으로 잠근다.
+        """
+        connect_calls = {"count": 0}
+
+        broker = AsyncMock()
+
+        async def _connect() -> None:
+            connect_calls["count"] += 1
+            raise TokenRateLimitError("x", error_code="EGW00133")
+
+        broker.connect = AsyncMock(side_effect=_connect)
+
+        s = main_module.Services()
+        s.runtime_readiness = RuntimeReadinessRegistry()
+        s.order_tracker = None
+        s.fill_applier = None
+        s.trade_service = None
+        s.eventbus = AsyncMock()
+        s.instrument_service = object()
+        s.bot_manager = object()
+        s.treasury_manager = None
+        # max_per_burst=5 — EGW00133 break 가 없으면 burst 당 connect 5회가 된다.
+        s.config = SimpleNamespace(
+            get=lambda key, default=None: {
+                "readiness.self_healing_interval_seconds": 60,
+                "readiness.self_healing_max_attempts_per_burst": 5,
+                "readiness.self_healing_backoff_base_seconds": 5,
+                "readiness.self_healing_backoff_max_seconds": 60,
+            }.get(key, default)
+        )
+
+        account_service = AsyncMock()
+        account_service.get_broker = AsyncMock(return_value=broker)
+        s.account_service = account_service  # type: ignore[assignment]
+
+        s.runtime_readiness.mark_not_ready(
+            "live-1", ReadinessFlag.BROKER, "connect_failed"
+        )
+        account = _account()
+
+        task = asyncio.create_task(
+            main_module._readiness_self_healing_loop(s, [account])
+        )
+        # interval sleep(60s)이 2회 관측될 때까지 진행 → 2 burst 경과.
+        try:
+            for _ in range(100):
+                interval_sleeps = [d for d in _no_real_sleep if d == 60]
+                if len(interval_sleeps) >= 2:
+                    break
+                await asyncio.sleep(0)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # burst break 검증: 경과한 burst 수만큼만 connect(burst 당 ≤1회).
+        # interval sleep 2회 관측 시점 → 2~3 burst 진행, connect 도 그 범위.
+        interval_count = len([d for d in _no_real_sleep if d == 60])
+        assert connect_calls["count"] <= interval_count + 1, (
+            f"burst 당 connect ≤1 위반: connect={connect_calls['count']}, "
+            f"interval={interval_count}"
+        )
+        # per-attempt backoff(min(5*2^a, 60) = 5/10/20/40 초)가 누적되지 않았다
+        # (EGW00133 break — 0 은 테스트 폴링 sleep, 60 은 burst interval 이므로 제외).
+        per_attempt_values = {5, 10, 20, 40}
+        leaked = [d for d in _no_real_sleep if d in per_attempt_values]
+        assert leaked == [], (
+            f"EGW00133 burst 에서 per-attempt backoff 누적 금지 위반: {leaked}"
+        )

--- a/tests/unit/test_kis_token_backoff_cadence.py
+++ b/tests/unit/test_kis_token_backoff_cadence.py
@@ -1,9 +1,12 @@
 """EGW00133 단일 cadence backoff + readiness reason 보존 테스트 (#2399 T4/T6).
 
 검증:
-- startup wrapper(``_connect_broker_with_auth_retry``): EGW00133 흡수 bounded retry
-  (≤DEFAULT_MAX_RETRIES_AUTH), 소진 시 TokenRateLimitError 전파, 비-EGW00133 즉시 전파.
-- startup connect 루프: 소진 시 not_ready(reason="EGW00133") 구조적 보존(T6).
+- startup wrapper(``_get_broker_with_auth_retry``): get_broker() 호출 전체를 EGW00133
+  흡수 bounded retry(≤DEFAULT_MAX_RETRIES_AUTH)로 감싼다. get_broker 가 내부 connect 로
+  EGW00133 을 던지면 retry, 소진 시 TokenRateLimitError 전파, 비-EGW00133 즉시 전파.
+  (#2399 Codex P1: connect 가 get_broker 내부 → retry 는 get_broker 를 감싸야 함.)
+- startup connect 루프: get_broker EGW00133 → bounded retry 후 소진 시
+  not_ready(reason="EGW00133") 구조적 보존(T6). 2번째 attempt 성공 시 broker_ready.
 - self-healing recover: EGW00133 시 not_ready(reason="EGW00133") + TokenRateLimitError
   re-raise(burst break 신호).
 - self-healing burst loop: persistent EGW00133 burst 당 connect ≤1회(nested bound,
@@ -49,44 +52,60 @@ def _no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
     return slept
 
 
-# ── T4 (c): startup wrapper bounded retry ──────────────────
+# ── T4 (c): startup wrapper bounded retry (get_broker 전체를 감쌈) ──────────
 
 
 class TestStartupAuthRetryWrapper:
+    """#2399 Codex P1 회귀 락: retry 는 ``broker.connect()`` 가 아니라
+    ``account_service.get_broker()`` 호출 **전체**를 감싼다. get_broker 가
+    cache-miss 에서 내부 connect 로 EGW00133 을 던지면(#2372 connect-후-캐시)
+    그 예외를 wrapper 가 흡수해 bounded retry 해야 한다(이전엔 connect 만
+    감싸 get_broker 가 먼저 raise → retry 미적용 회귀)."""
+
     async def test_egw00133_absorbed_then_success(
         self, _no_real_sleep: list[float]
     ) -> None:
-        """EGW00133 흡수 후 성공 — bounded retry 내 회복."""
-        broker = AsyncMock()
+        """get_broker EGW00133 흡수 후 성공 — bounded retry 내 회복."""
+        connected_broker = AsyncMock()
         state = {"fails": 1}
 
-        async def _connect() -> None:
+        async def _get_broker(account_id: str) -> Any:
+            # get_broker 내부 connect 가 EGW00133 을 던지는 상황을 모사:
+            # 첫 호출은 raise(캐시 미기록·세션 cleanup), 둘째 호출은 성공 broker 반환.
             if state["fails"] > 0:
                 state["fails"] -= 1
                 raise TokenRateLimitError("x", error_code="EGW00133")
+            return connected_broker
 
-        broker.connect = AsyncMock(side_effect=_connect)
+        account_service = AsyncMock()
+        account_service.get_broker = AsyncMock(side_effect=_get_broker)
 
-        await main_module._connect_broker_with_auth_retry(broker)
+        result = await main_module._get_broker_with_auth_retry(
+            account_service, "live-1"
+        )
 
-        assert broker.connect.await_count == 2  # 1 실패 + 1 성공
+        assert result is connected_broker
+        assert account_service.get_broker.await_count == 2  # 1 실패 + 1 성공
         # backoff sleep 1회(흡수).
         assert len(_no_real_sleep) == 1
+        # get_broker 는 매 attempt 마다 동일 account_id 로 재호출(새 build+connect).
+        for call in account_service.get_broker.call_args_list:
+            assert call.args == ("live-1",)
 
     async def test_egw00133_exhausts_max_retries_then_raises(
         self, _no_real_sleep: list[float]
     ) -> None:
-        """persistent EGW00133 → DEFAULT_MAX_RETRIES_AUTH 소진 후 전파."""
-        broker = AsyncMock()
-        broker.connect = AsyncMock(
+        """persistent get_broker EGW00133 → DEFAULT_MAX_RETRIES_AUTH 소진 후 전파."""
+        account_service = AsyncMock()
+        account_service.get_broker = AsyncMock(
             side_effect=TokenRateLimitError("x", error_code="EGW00133")
         )
 
         with pytest.raises(TokenRateLimitError):
-            await main_module._connect_broker_with_auth_retry(broker)
+            await main_module._get_broker_with_auth_retry(account_service, "live-1")
 
         # 최초 1 + 재시도 DEFAULT_MAX_RETRIES_AUTH 회.
-        assert broker.connect.await_count == DEFAULT_MAX_RETRIES_AUTH + 1
+        assert account_service.get_broker.await_count == DEFAULT_MAX_RETRIES_AUTH + 1
         # backoff sleep = 재시도 횟수만큼(소진 직전까지). startup 한 곳만(곱셈 없음).
         assert len(_no_real_sleep) == DEFAULT_MAX_RETRIES_AUTH
 
@@ -94,15 +113,15 @@ class TestStartupAuthRetryWrapper:
         self, _no_real_sleep: list[float]
     ) -> None:
         """비-EGW00133 예외는 흡수 retry 없이 즉시 전파(기존 동작 유지)."""
-        broker = AsyncMock()
-        broker.connect = AsyncMock(
+        account_service = AsyncMock()
+        account_service.get_broker = AsyncMock(
             side_effect=AuthenticationError("bad key", error_code="EGW00121")
         )
 
         with pytest.raises(AuthenticationError):
-            await main_module._connect_broker_with_auth_retry(broker)
+            await main_module._get_broker_with_auth_retry(account_service, "live-1")
 
-        assert broker.connect.await_count == 1
+        assert account_service.get_broker.await_count == 1
         assert _no_real_sleep == []  # backoff 없음
 
 
@@ -170,6 +189,41 @@ class TestSelfHealingEGW00133:
             await main_module._self_healing_recover_account(s, account)
 
         # T6: reason 에 EGW00133 보존.
+        assert (
+            s.runtime_readiness.get_reason("live-1", ReadinessFlag.BROKER) == "EGW00133"
+        )
+
+    async def test_recover_get_broker_egw00133_reraises_and_preserves_reason(
+        self,
+    ) -> None:
+        """#2399 Codex P1 point 3: cache-miss self-healing 에서 get_broker() 자체가
+        (내부 connect 로) EGW00133 을 던져도 connect 단계와 동일하게 reason 보존 +
+        TokenRateLimitError re-raise(burst break 신호)로 처리한다."""
+        s = main_module.Services()
+        s.runtime_readiness = RuntimeReadinessRegistry()
+        s.order_tracker = None
+        s.fill_applier = None
+        s.trade_service = None
+        s.eventbus = AsyncMock()
+        s.instrument_service = object()
+        s.bot_manager = object()
+        s.treasury_manager = None
+        s.config = SimpleNamespace(get=lambda key, default=None: default)
+        account_service = AsyncMock()
+        # connect 이 아니라 get_broker 호출 자체가 EGW00133 을 전파(#2372 cache-miss).
+        account_service.get_broker = AsyncMock(
+            side_effect=TokenRateLimitError("x", error_code="EGW00133")
+        )
+        s.account_service = account_service  # type: ignore[assignment]
+        account = _account()
+        s.runtime_readiness.mark_not_ready(
+            "live-1", ReadinessFlag.BROKER, "connect_failed"
+        )
+
+        with pytest.raises(TokenRateLimitError):
+            await main_module._self_healing_recover_account(s, account)
+
+        # T6: reason 에 EGW00133 보존(get_broker 단계도 동일).
         assert (
             s.runtime_readiness.get_reason("live-1", ReadinessFlag.BROKER) == "EGW00133"
         )

--- a/tests/unit/test_kis_token_backoff_cadence.py
+++ b/tests/unit/test_kis_token_backoff_cadence.py
@@ -124,6 +124,64 @@ class TestStartupAuthRetryWrapper:
         assert account_service.get_broker.await_count == 1
         assert _no_real_sleep == []  # backoff 없음
 
+    async def test_sleeps_residual_cooldown_not_fixed(
+        self, _no_real_sleep: list[float]
+    ) -> None:
+        """#2399 attempt3: 잔여 cooldown(cooldown_until-now)만큼 sleep(고정 60s 아님).
+
+        cooldown_until 을 now+25s 로 동봉한 EGW00133 → wrapper 가 ~25s sleep 해
+        cooldown 경계 무력화를 피한다. 고정 60s 가 아님을 검증한다.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        from ante.broker.kis import TOKEN_AUTH_BACKOFF_SECONDS
+
+        connected_broker = AsyncMock()
+        cooldown_until = datetime.now(UTC) + timedelta(seconds=25)
+        state = {"fails": 1}
+
+        async def _get_broker(account_id: str) -> Any:
+            if state["fails"] > 0:
+                state["fails"] -= 1
+                raise TokenRateLimitError(
+                    "x", error_code="EGW00133", cooldown_until=cooldown_until
+                )
+            return connected_broker
+
+        account_service = AsyncMock()
+        account_service.get_broker = AsyncMock(side_effect=_get_broker)
+
+        result = await main_module._get_broker_with_auth_retry(
+            account_service, "live-1"
+        )
+        assert result is connected_broker
+        assert len(_no_real_sleep) == 1
+        # 잔여 cooldown(~25s)만큼 sleep — 고정 60s 가 아니다.
+        assert _no_real_sleep[0] < TOKEN_AUTH_BACKOFF_SECONDS
+        assert 20 <= _no_real_sleep[0] <= 25
+
+    async def test_sleeps_fixed_backoff_when_no_cooldown_until(
+        self, _no_real_sleep: list[float]
+    ) -> None:
+        """cooldown_until 미동봉(이론상 경합 만료) → 고정 backoff 폴백."""
+        from ante.broker.kis import TOKEN_AUTH_BACKOFF_SECONDS
+
+        connected_broker = AsyncMock()
+        state = {"fails": 1}
+
+        async def _get_broker(account_id: str) -> Any:
+            if state["fails"] > 0:
+                state["fails"] -= 1
+                # cooldown_until 미동봉(None) 케이스.
+                raise TokenRateLimitError("x", error_code="EGW00133")
+            return connected_broker
+
+        account_service = AsyncMock()
+        account_service.get_broker = AsyncMock(side_effect=_get_broker)
+
+        await main_module._get_broker_with_auth_retry(account_service, "live-1")
+        assert _no_real_sleep == [TOKEN_AUTH_BACKOFF_SECONDS]
+
 
 # ── T6: startup connect 루프 reason 보존 ───────────────────
 

--- a/tests/unit/test_kis_token_cooldown.py
+++ b/tests/unit/test_kis_token_cooldown.py
@@ -1,0 +1,298 @@
+"""per-app_key EGW00133 cooldown at source 단위 테스트 (#2399 attempt3 + 메타 감사).
+
+per-call-site 필터(B)가 라운드마다 "get_broker→토큰 재타격" 결함을 재생산하던
+것을 발급 레이어 단일 chokepoint(A)에서 닫는 cooldown 동작을 검증한다.
+
+핵심 불변식:
+- EGW00133 1회 → 같은 app_key 후속 발급(다른 adapter/account 포함)이 cooldown 내
+  **HTTP 미호출·즉시 TokenRateLimitError**(post_count 로 검증). cooldown 만료 후 재개.
+- 유효 캐시 read 는 cooldown 무영향(T2 — hydrate 먼저).
+- T1 single-flight(lock 밖 fast-path + lock 안 double-check), T4 단일 cadence,
+  T5 classify(TokenRateLimitError)=(False,False) 불변(기존 single_flight 테스트 유지).
+- runtime(_ensure_authenticated) 재발급이 cooldown 내 HTTP 미호출.
+- _reset_token_cache 가 cooldown clear + 글로벌 적용(conftest 격리).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from ante.broker import KISAdapter, TokenRateLimitError
+from ante.broker.kis import (
+    TOKEN_RATE_LIMIT_COOLDOWN_SECONDS,
+    _record_token_cooldown,
+    _reset_token_cache,
+    _token_cache,
+    _token_cooldown_until,
+    _token_cooldowns,
+)
+
+
+class _FakeResponse:
+    """aiohttp response 의 async-context-manager mock (토큰 발급 경로)."""
+
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        json_body: dict[str, Any] | None = None,
+        text_body: str | None = None,
+    ) -> None:
+        self.status = status
+        self._json_body = json_body
+        self._text_body = text_body
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def json(self) -> dict[str, Any]:
+        assert self._json_body is not None
+        return self._json_body
+
+    async def text(self) -> str:
+        if self._text_body is not None:
+            return self._text_body
+        return json.dumps(self._json_body) if self._json_body is not None else ""
+
+
+class _FakeSession:
+    """``self._session.post(...)`` 호출 횟수(=발급 HTTP 시도)를 세는 mock session."""
+
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = responses
+        self.post_count = 0
+
+    def post(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+        idx = min(self.post_count, len(self._responses) - 1)
+        self.post_count += 1
+        return self._responses[idx]
+
+
+def _make_adapter(
+    session: _FakeSession,
+    *,
+    app_key: str = "shared_key",
+    app_secret: str = "secret_a",
+    account_no: str = "1111111101",
+) -> KISAdapter:
+    config = {
+        "app_key": app_key,
+        "app_secret": app_secret,
+        "account_no": account_no,
+        "is_paper": True,
+    }
+    adapter = KISAdapter(config)
+    adapter._session = session  # type: ignore[assignment]
+    return adapter
+
+
+def _egw00133_response() -> _FakeResponse:
+    return _FakeResponse(
+        status=403,
+        json_body={"msg_cd": "EGW00133", "msg1": "접근토큰 발급 잠시 후 다시 시도"},
+    )
+
+
+def _success_response(token: str = "tok-1") -> _FakeResponse:
+    return _FakeResponse(status=200, json_body={"access_token": token})
+
+
+# ── cooldown 핵심: EGW00133 1회 → 후속 발급 차단(HTTP 미호출) ────────────
+
+
+class TestCooldownAtSource:
+    async def test_egw00133_records_cooldown_and_blocks_subsequent_issue(self) -> None:
+        """EGW00133 1회 → 같은 app_key 후속 발급(다른 adapter)이 HTTP 미호출 차단."""
+        # 첫 adapter: EGW00133 1회 → cooldown 기록.
+        s1 = _FakeSession([_egw00133_response()])
+        a1 = _make_adapter(s1, account_no="acct-A")
+        with pytest.raises(TokenRateLimitError):
+            await a1._authenticate()
+        assert s1.post_count == 1  # 발급 HTTP 1회 시도(거절).
+        # cooldown 이 기록됐다.
+        assert _token_cooldown_until("shared_key") is not None
+
+        # 같은 app_key 두 번째 adapter(다른 account) — cooldown 내라 HTTP 미호출.
+        s2 = _FakeSession([_success_response("tok-should-not-issue")])
+        a2 = _make_adapter(s2, account_no="acct-B")
+        with pytest.raises(TokenRateLimitError):
+            await a2._authenticate()
+        # 핵심: 두 번째 adapter 는 발급 HTTP 를 **전혀** 시도하지 않았다.
+        assert s2.post_count == 0
+        assert a2.access_token is None
+
+    async def test_cooldown_blocked_raise_carries_cooldown_until(self) -> None:
+        """cooldown 내 차단 raise 는 기존 cooldown_until 을 동봉(연장 금지)."""
+        until = _record_token_cooldown("shared_key")
+        s = _FakeSession([_success_response()])
+        a = _make_adapter(s, account_no="acct-B")
+        with pytest.raises(TokenRateLimitError) as ei:
+            await a._authenticate()
+        assert s.post_count == 0
+        # 기존 cooldown_until 을 그대로 노출(연장하지 않음).
+        assert ei.value.cooldown_until == until
+        assert ei.value.error_code == "EGW00133"
+
+    async def test_cooldown_expiry_reopens_issue(self) -> None:
+        """cooldown 만료 후 같은 app_key 발급 1회 재개."""
+        # 이미 만료된 cooldown 을 직접 심는다(과거 시각).
+        _token_cooldowns["shared_key"] = datetime.now(UTC) - timedelta(seconds=1)
+        # 만료된 cooldown 은 None 으로 보고된다(자동 만료).
+        assert _token_cooldown_until("shared_key") is None
+
+        s = _FakeSession([_success_response("tok-reopen")])
+        a = _make_adapter(s, account_no="acct-A")
+        await a._authenticate()
+        # 만료됐으므로 발급 1회 정상 진행.
+        assert s.post_count == 1
+        assert a.access_token == "tok-reopen"
+
+    async def test_cooldown_duration_matches_constant(self) -> None:
+        """기록된 cooldown 만료시각이 상수(60s) 근처(±2s)."""
+        before = datetime.now(UTC)
+        until = _record_token_cooldown("shared_key")
+        delta = (until - before).total_seconds()
+        assert (
+            TOKEN_RATE_LIMIT_COOLDOWN_SECONDS - 2
+            <= delta
+            <= (TOKEN_RATE_LIMIT_COOLDOWN_SECONDS + 2)
+        )
+
+
+# ── T2: 유효 캐시 read 는 cooldown 무영향 ──────────────────
+
+
+class TestCooldownDoesNotBlockValidCache:
+    async def test_valid_cache_used_during_cooldown(self) -> None:
+        """cooldown 중에도 유효 캐시 토큰 보유 adapter 는 정상 사용(발급 없음, T2)."""
+        # 유효(신선) 캐시 토큰 + cooldown 동시 존재.
+        _token_cache["shared_key"] = (
+            "tok-cached",
+            datetime.now(UTC) + timedelta(hours=1),
+        )
+        _record_token_cooldown("shared_key")
+
+        s = _FakeSession([_success_response("tok-should-not-issue")])
+        a = _make_adapter(s, account_no="acct-A")
+        # hydrate 가 cooldown 체크보다 먼저라 캐시 hit → 발급 skip, raise 없음.
+        await a._authenticate()
+        assert s.post_count == 0
+        assert a.access_token == "tok-cached"
+
+    async def test_ensure_authenticated_valid_cache_during_cooldown(self) -> None:
+        """_ensure_authenticated 도 cooldown 중 유효 캐시 hit 시 발급 skip(T2)."""
+        _token_cache["shared_key"] = (
+            "tok-cached",
+            datetime.now(UTC) + timedelta(hours=1),
+        )
+        _record_token_cooldown("shared_key")
+
+        s = _FakeSession([_success_response("tok-should-not-issue")])
+        a = _make_adapter(s, account_no="acct-B")
+        await a._ensure_authenticated()
+        assert s.post_count == 0
+        assert a.access_token == "tok-cached"
+
+
+# ── runtime/IPC: _ensure_authenticated 재발급이 cooldown 내 HTTP 미호출 ──
+
+
+class TestRuntimeReissueRespectsCooldown:
+    async def test_ensure_authenticated_reissue_blocked_by_cooldown(self) -> None:
+        """near-expiry 토큰의 runtime 재발급이 cooldown 내면 HTTP 미호출 차단."""
+        _record_token_cooldown("shared_key")
+        s = _FakeSession([_success_response("tok-new")])
+        a = _make_adapter(s, account_no="acct-A")
+        # 인스턴스에 near-expiry 토큰을 심어 _ensure_authenticated 가 재발급 경로 진입.
+        a.access_token = "tok-old"
+        a.token_expires_at = datetime.now(UTC) + timedelta(minutes=2)
+
+        with pytest.raises(TokenRateLimitError):
+            await a._ensure_authenticated()
+        # 재발급 HTTP 미호출(cooldown source-level 차단).
+        assert s.post_count == 0
+
+
+# ── T1: single-flight 와 cooldown 상호작용(lock 안 double-check) ──────────
+
+
+class TestSingleFlightCooldownInteraction:
+    async def test_concurrent_authenticate_one_egw00133_blocks_rest(self) -> None:
+        """동시 _authenticate N개 중 첫 발급 EGW00133 → 나머지 lock 안 cooldown 차단.
+
+        single-flight lock 으로 1개만 HTTP 발급(EGW00133)하고, lock 대기하던 나머지는
+        double-check 에서 cooldown 을 만나 추가 HTTP 없이 raise 한다(post_count==1).
+        """
+        # 모든 post 가 EGW00133 을 반환(첫 발급이 거절).
+        session = _FakeSession([_egw00133_response()])
+        adapters = [_make_adapter(session, account_no=f"acct-{i}") for i in range(5)]
+
+        results = await asyncio.gather(
+            *(a._authenticate() for a in adapters), return_exceptions=True
+        )
+        # 5개 모두 TokenRateLimitError.
+        assert all(isinstance(r, TokenRateLimitError) for r in results)
+        # 핵심: 발급 HTTP 는 1회만(single-flight + cooldown double-check).
+        assert session.post_count == 1
+
+
+# ── attempt3-b: self-healing burst 같은 app_key N계좌 → 발급 1회 ───────────
+
+
+class TestSelfHealingBurstCooldown:
+    async def test_same_app_key_multi_account_issues_once(self) -> None:
+        """같은 app_key N계좌 순차 인증 → 첫 EGW00133 후 나머지 HTTP 미호출(cooldown).
+
+        self-healing burst 가 같은 app_key 의 여러 계좌를 순차로 인증할 때, 첫
+        계좌가 EGW00133 으로 cooldown 을 기록하면 나머지 계좌의 발급은 발급
+        레이어가 HTTP 미호출·즉시 raise 한다(토큰 1/min 재타격 없음, 발급 시도 1회).
+        ``_authenticate`` 는 connect 의 발급 경로 핵심이므로 동등한 source-level
+        cooldown 을 직접 검증한다(connect 가 mock session 을 실 aiohttp session 으로
+        덮어쓰는 것을 피해 _authenticate 를 직접 호출).
+        """
+        # 같은 app_key, 다른 account_no 3계좌. session 은 EGW00133 만 반환.
+        session = _FakeSession([_egw00133_response()])
+        adapters = [
+            _make_adapter(session, app_key="burst_key", account_no=f"acct-{i}")
+            for i in range(3)
+        ]
+
+        raised = 0
+        for a in adapters:
+            with pytest.raises(TokenRateLimitError):
+                await a._authenticate()
+            raised += 1
+        assert raised == 3
+        # 핵심: 발급 HTTP 는 첫 계좌 1회뿐(나머지는 cooldown 으로 HTTP 미호출).
+        assert session.post_count == 1
+        assert _token_cooldown_until("burst_key") is not None
+
+
+# ── _reset_token_cache: cooldown clear + 글로벌 격리 ───────────────────────
+
+
+class TestResetClearsCooldown:
+    def test_reset_clears_cooldown(self) -> None:
+        """_reset_token_cache 가 _token_cooldowns 도 clear (글로벌 conftest 격리)."""
+        _record_token_cooldown("shared_key")
+        _token_cache["shared_key"] = ("t", datetime.now(UTC) + timedelta(hours=1))
+        assert _token_cooldowns
+        _reset_token_cache()
+        assert _token_cooldowns == {}
+        assert _token_cache == {}
+
+    def test_global_conftest_isolates_cooldown(self) -> None:
+        """글로벌 conftest autouse fixture 가 테스트 진입 시 cooldown 을 비운다.
+
+        이전 테스트가 cooldown 을 남겼더라도 본 테스트 진입 시점엔 비어 있어야 한다
+        (cross-test 오염 차단). 본 테스트는 진입 직후 상태만 관측한다.
+        """
+        assert _token_cooldowns == {}

--- a/tests/unit/test_kis_token_cooldown.py
+++ b/tests/unit/test_kis_token_cooldown.py
@@ -105,6 +105,11 @@ def _success_response(token: str = "tok-1") -> _FakeResponse:
     return _FakeResponse(status=200, json_body={"access_token": token})
 
 
+# attempt4 P2: ``_token_cache`` 키는 config fingerprint (app_key, app_secret, env)다.
+# 기본 _make_adapter config(secret_a, is_paper=True)의 fingerprint.
+_DEFAULT_CACHE_KEY = ("shared_key", "secret_a", "paper")
+
+
 # ── cooldown 핵심: EGW00133 1회 → 후속 발급 차단(HTTP 미호출) ────────────
 
 
@@ -174,7 +179,7 @@ class TestCooldownDoesNotBlockValidCache:
     async def test_valid_cache_used_during_cooldown(self) -> None:
         """cooldown 중에도 유효 캐시 토큰 보유 adapter 는 정상 사용(발급 없음, T2)."""
         # 유효(신선) 캐시 토큰 + cooldown 동시 존재.
-        _token_cache["shared_key"] = (
+        _token_cache[_DEFAULT_CACHE_KEY] = (
             "tok-cached",
             datetime.now(UTC) + timedelta(hours=1),
         )
@@ -189,7 +194,7 @@ class TestCooldownDoesNotBlockValidCache:
 
     async def test_ensure_authenticated_valid_cache_during_cooldown(self) -> None:
         """_ensure_authenticated 도 cooldown 중 유효 캐시 hit 시 발급 skip(T2)."""
-        _token_cache["shared_key"] = (
+        _token_cache[_DEFAULT_CACHE_KEY] = (
             "tok-cached",
             datetime.now(UTC) + timedelta(hours=1),
         )
@@ -283,7 +288,7 @@ class TestResetClearsCooldown:
     def test_reset_clears_cooldown(self) -> None:
         """_reset_token_cache 가 _token_cooldowns 도 clear (글로벌 conftest 격리)."""
         _record_token_cooldown("shared_key")
-        _token_cache["shared_key"] = ("t", datetime.now(UTC) + timedelta(hours=1))
+        _token_cache[_DEFAULT_CACHE_KEY] = ("t", datetime.now(UTC) + timedelta(hours=1))
         assert _token_cooldowns
         _reset_token_cache()
         assert _token_cooldowns == {}

--- a/tests/unit/test_kis_token_single_flight.py
+++ b/tests/unit/test_kis_token_single_flight.py
@@ -1,0 +1,449 @@
+"""KIS OAuth2 토큰 single-flight + shared cache + EGW00133 backoff 단위 테스트.
+
+#2399 (축 iii) invariant T1–T7:
+- T1 single-flight, lock key=app_key (account_id 아님) + double-check.
+- T2 in-process shared cache + near-expiry(5분) miss.
+- T3 토큰 발급 응답 msg_cd/error_code alias 파싱 (200+body / non-200 양 분기).
+- T4 단일 cadence: ``_authenticate`` 내부 sleep 없이 EGW00133 즉시 raise.
+- T5 classify(AuthenticationError)=(False,False) 불변 + EGW00133 ∉ TRANSIENT.
+- T6 reason 구조적 보존(error_code).
+- T7 known-limitation(멀티프로세스) — 주석/스펙 anchor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+import ante.broker.kis as kis_mod
+from ante.broker import KISAdapter, TokenRateLimitError
+from ante.broker.error_codes import (
+    TOKEN_RATE_LIMIT_MSG_CODE,
+    TRANSIENT_MSG_CODES,
+    get_error_message,
+    is_retryable_msg_code,
+)
+from ante.broker.exceptions import AuthenticationError
+from ante.broker.kis import (
+    KISErrorClassifier,
+    _is_cached_token_fresh,
+    _reset_token_cache,
+    _token_cache,
+    _token_locks,
+)
+
+KIS_CONFIG = {
+    "app_key": "shared_key",
+    "app_secret": "secret_a",
+    "account_no": "1111111101",
+    "is_paper": True,
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_token_cache():
+    """매 테스트 전후 module-level 토큰 캐시/lock dict 초기화 (T1 closed-loop/T2 격리).
+
+    pytest-asyncio auto mode 에서 이전 테스트의 closed event loop 에 묶인 Lock 이
+    재사용되지 않도록, 그리고 shared 캐시가 테스트 간 오염되지 않도록 격리한다.
+    """
+    _reset_token_cache()
+    yield
+    _reset_token_cache()
+
+
+# ── 토큰 발급 HTTP 응답 mock ───────────────────────────────
+
+
+class _FakeResponse:
+    """aiohttp response 의 async-context-manager mock (토큰 발급 경로)."""
+
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        json_body: dict[str, Any] | None = None,
+        text_body: str | None = None,
+    ) -> None:
+        self.status = status
+        self._json_body = json_body
+        self._text_body = text_body
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def json(self) -> dict[str, Any]:
+        assert self._json_body is not None
+        return self._json_body
+
+    async def text(self) -> str:
+        if self._text_body is not None:
+            return self._text_body
+        return json.dumps(self._json_body) if self._json_body is not None else ""
+
+
+class _FakeSession:
+    """``self._session.post(...)`` 호출 횟수를 세는 mock session.
+
+    매 호출마다 ``responses`` 큐에서 하나를 pop 한다(소진 시 마지막 반복). post
+    호출 횟수(=토큰 발급 HTTP 시도)는 ``post_count`` 로 관측한다.
+    """
+
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = responses
+        self.post_count = 0
+
+    def post(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+        idx = min(self.post_count, len(self._responses) - 1)
+        self.post_count += 1
+        return self._responses[idx]
+
+
+def _make_adapter(
+    session: _FakeSession,
+    *,
+    app_key: str = "shared_key",
+    app_secret: str = "secret_a",
+    account_no: str = "1111111101",
+) -> KISAdapter:
+    config = {
+        "app_key": app_key,
+        "app_secret": app_secret,
+        "account_no": account_no,
+        "is_paper": True,
+    }
+    adapter = KISAdapter(config)
+    adapter._session = session  # type: ignore[assignment]
+    return adapter
+
+
+def _success_response(token: str = "tok-1") -> _FakeResponse:
+    return _FakeResponse(status=200, json_body={"access_token": token})
+
+
+# ── T1: single-flight, lock key=app_key ────────────────────
+
+
+class TestSingleFlight:
+    async def test_concurrent_same_app_key_issues_once(self):
+        """동일 app_key 다중 adapter 동시 _authenticate → HTTP 발급 1회 수렴 (T1)."""
+        session = _FakeSession([_success_response("tok-shared")])
+        # 동일 app_key, 서로 다른 account_no(=다른 adapter 인스턴스).
+        adapters = [_make_adapter(session, account_no=f"acct-{i}") for i in range(5)]
+
+        await asyncio.gather(*(a._authenticate() for a in adapters))
+
+        # single-flight: 5개 동시 발급이 HTTP 발급 1회로 수렴.
+        assert session.post_count == 1
+        # 모든 adapter 가 동일 토큰으로 hydrate.
+        assert all(a.access_token == "tok-shared" for a in adapters)
+
+    async def test_lock_key_is_app_key_not_account_id(self):
+        """lock key 회귀 락: 다른 account 라도 동일 app_key 면 공유 캐시로 수렴 (T1).
+
+        만약 lock/캐시 key 를 account_id 로 잘못 잡으면 동일 app_key 다른 account
+        adapter 가 미수렴하여 발급 2회 이상 → 이 테스트가 잡는다.
+        """
+        session = _FakeSession([_success_response("tok-shared")])
+        a1 = _make_adapter(session, account_no="acct-A")
+        a2 = _make_adapter(session, account_no="acct-B")
+
+        await asyncio.gather(a1._authenticate(), a2._authenticate())
+
+        assert session.post_count == 1
+        # lock dict 키가 app_key 인지 직접 확인(account_id 아님).
+        assert set(_token_locks.keys()) == {"shared_key"}
+        assert set(_token_cache.keys()) == {"shared_key"}
+
+    async def test_different_app_keys_issue_separately(self):
+        """다른 app_key 는 각각 발급(lock/캐시 분리) — single-flight 가 과수렴 안 함."""
+        s1 = _FakeSession([_success_response("tok-1")])
+        s2 = _FakeSession([_success_response("tok-2")])
+        a1 = _make_adapter(s1, app_key="key-1")
+        a2 = _make_adapter(s2, app_key="key-2")
+
+        await asyncio.gather(a1._authenticate(), a2._authenticate())
+
+        assert s1.post_count == 1
+        assert s2.post_count == 1
+        assert a1.access_token == "tok-1"
+        assert a2.access_token == "tok-2"
+
+    async def test_double_check_reuses_cache_after_lock(self):
+        """lock 대기 중 타 코루틴이 발급했으면 double-check 재사용(추가 발급 없음)."""
+        session = _FakeSession([_success_response("tok-shared")])
+        a1 = _make_adapter(session, account_no="acct-A")
+        a2 = _make_adapter(session, account_no="acct-B")
+
+        # 첫 발급.
+        await a1._authenticate()
+        assert session.post_count == 1
+        # 두 번째 adapter 는 캐시 hit → 발급 skip(fast-path). lock 안 double-check
+        # 경로도 보장된다(아래 closed-loop/재사용 테스트가 lock 경로를 직접 잠근다).
+        await a2._authenticate()
+        assert session.post_count == 1
+        assert a2.access_token == "tok-shared"
+
+
+# ── T2: in-process shared cache + near-expiry miss ─────────
+
+
+class TestSharedCache:
+    async def test_second_adapter_cache_hit_skips_issue(self):
+        """2번째 adapter 는 shared 캐시 hit 으로 발급 skip (T2)."""
+        session = _FakeSession([_success_response("tok-shared")])
+        a1 = _make_adapter(session, account_no="acct-A")
+        await a1._authenticate()
+        assert session.post_count == 1
+
+        a2 = _make_adapter(session, account_no="acct-B")
+        await a2._authenticate()
+        assert session.post_count == 1  # 재발급 없음
+        assert a2.access_token == "tok-shared"
+
+    async def test_near_expiry_token_is_cache_miss(self):
+        """만료 5분 전 토큰은 cache miss → 재발급 (_ensure_authenticated 기준, T2)."""
+        session = _FakeSession([_success_response("tok-new")])
+        # near-expiry: 만료까지 3분 남음(5분 여유보다 짧음) → miss.
+        _token_cache["shared_key"] = (
+            "tok-old",
+            datetime.now(UTC) + timedelta(minutes=3),
+        )
+        adapter = _make_adapter(session)
+
+        await adapter._authenticate()
+
+        # near-expiry 라 재발급됨.
+        assert session.post_count == 1
+        assert adapter.access_token == "tok-new"
+        assert _token_cache["shared_key"][0] == "tok-new"
+
+    def test_is_cached_token_fresh_boundary(self):
+        """_is_cached_token_fresh: 만료 5분 전 경계 — near-expiry miss 회귀 락 (T2)."""
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        # 만료까지 6분 → 신선(여유 5분 초과).
+        assert _is_cached_token_fresh(now + timedelta(minutes=6), now=now) is True
+        # 만료까지 4분 → near-expiry miss.
+        assert _is_cached_token_fresh(now + timedelta(minutes=4), now=now) is False
+
+    async def test_ensure_authenticated_uses_shared_cache(self):
+        """_ensure_authenticated 재발급 경로도 single-flight/shared 캐시 적용 (T2)."""
+        session = _FakeSession([_success_response("tok-shared")])
+        a1 = _make_adapter(session, account_no="acct-A")
+        await a1._authenticate()
+        assert session.post_count == 1
+
+        # 토큰/만료 미보유 새 adapter 의 _ensure_authenticated → 캐시 hit, 발급 skip.
+        a2 = _make_adapter(session, account_no="acct-B")
+        await a2._ensure_authenticated()
+        assert session.post_count == 1
+        assert a2.access_token == "tok-shared"
+
+    async def test_ensure_authenticated_near_expiry_reissues_single_flight(self):
+        """_ensure_authenticated near-expiry 재발급도 single-flight 수렴 (T2)."""
+        session = _FakeSession([_success_response("tok-new")])
+        # 캐시에 near-expiry 토큰.
+        _token_cache["shared_key"] = (
+            "tok-old",
+            datetime.now(UTC) + timedelta(minutes=2),
+        )
+        adapters = [_make_adapter(session, account_no=f"acct-{i}") for i in range(4)]
+        # 각 adapter 인스턴스에도 near-expiry 토큰을 심어 _ensure_authenticated 진입.
+        for a in adapters:
+            a.access_token = "tok-old"
+            a.token_expires_at = datetime.now(UTC) + timedelta(minutes=2)
+
+        await asyncio.gather(*(a._ensure_authenticated() for a in adapters))
+
+        # near-expiry 재발급이 single-flight 로 1회 수렴.
+        assert session.post_count == 1
+        assert all(a.access_token == "tok-new" for a in adapters)
+
+
+# ── T1 closed-loop lock 재사용 회귀 ────────────────────────
+
+
+class TestClosedLoopLockReuse:
+    async def test_lock_recreated_after_reset(self):
+        """reset 후 lock dict 가 비고, 다음 발급이 새 Lock 으로 동작 (closed-loop)."""
+        session1 = _FakeSession([_success_response("tok-1")])
+        a1 = _make_adapter(session1)
+        await a1._authenticate()
+        assert "shared_key" in _token_locks
+
+        # reset(autouse fixture 가 다음 테스트에서 하는 일을 명시 모사).
+        _reset_token_cache()
+        assert _token_locks == {}
+        assert _token_cache == {}
+
+        # 새 발급 — 새 Lock 으로 정상 single-flight.
+        session2 = _FakeSession([_success_response("tok-2")])
+        a2 = _make_adapter(session2)
+        await a2._authenticate()
+        assert session2.post_count == 1
+        assert a2.access_token == "tok-2"
+
+
+# ── T3: msg_cd/error_code alias 파싱 (200+body / non-200) ──
+
+
+class TestTokenErrorParsing:
+    async def test_http_200_error_body_msg_cd(self):
+        """HTTP 200 + error 바디(access_token 부재, msg_cd) → 파싱 (T3 200+body)."""
+        session = _FakeSession(
+            [
+                _FakeResponse(
+                    status=200,
+                    json_body={
+                        "rt_cd": "1",
+                        "msg_cd": "EGW00121",
+                        "msg1": "기타 오류",
+                    },
+                )
+            ]
+        )
+        adapter = _make_adapter(session)
+        with pytest.raises(AuthenticationError) as ei:
+            await adapter._authenticate()
+        assert ei.value.error_code == "EGW00121"
+
+    async def test_non_200_error_body_error_code_alias(self):
+        """non-200 + error_code alias 바디 → 파싱 (T3 non-200, error_code alias)."""
+        session = _FakeSession(
+            [
+                _FakeResponse(
+                    status=403,
+                    json_body={
+                        "error_code": "EGW00121",
+                        "error_description": "토큰 오류",
+                    },
+                )
+            ]
+        )
+        adapter = _make_adapter(session)
+        with pytest.raises(AuthenticationError) as ei:
+            await adapter._authenticate()
+        assert ei.value.error_code == "EGW00121"
+
+    async def test_non_200_non_json_body_fallback(self):
+        """non-200 + 비 JSON 바디 → text fallback, error_code 빈값 (T3 방어)."""
+        session = _FakeSession(
+            [_FakeResponse(status=500, text_body="<html>500</html>")]
+        )
+        adapter = _make_adapter(session)
+        with pytest.raises(AuthenticationError) as ei:
+            await adapter._authenticate()
+        assert ei.value.error_code == ""
+        assert "500" in str(ei.value)
+
+
+# ── T4: EGW00133 즉시 raise (단일 cadence, nested 차단) ────
+
+
+class TestEGW00133ImmediateRaise:
+    async def test_egw00133_non_200_raises_token_rate_limit(self):
+        """non-200 EGW00133 → TokenRateLimitError 즉시 raise + 내부 sleep 없음 (T4)."""
+        session = _FakeSession(
+            [
+                _FakeResponse(
+                    status=403,
+                    json_body={
+                        "msg_cd": "EGW00133",
+                        "msg1": "접근토큰 발급 잠시 후 다시 시도",
+                    },
+                )
+            ]
+        )
+        adapter = _make_adapter(session)
+
+        slept: list[float] = []
+
+        async def _no_sleep(d: float) -> None:
+            slept.append(d)
+
+        # _authenticate 내부에 sleep 이 있으면 곱셈 위험 → 없어야 한다.
+        orig_sleep = asyncio.sleep
+        asyncio.sleep = _no_sleep  # type: ignore[assignment]
+        try:
+            with pytest.raises(TokenRateLimitError) as ei:
+                await adapter._authenticate()
+        finally:
+            asyncio.sleep = orig_sleep  # type: ignore[assignment]
+
+        assert ei.value.error_code == "EGW00133"
+        # 핵심: _authenticate 내부 sleep 0회(곱셈 원천 제거).
+        assert slept == []
+
+    async def test_egw00133_http_200_body_raises_token_rate_limit(self):
+        """HTTP 200 + EGW00133 바디 → TokenRateLimitError (T3 200+body × T4)."""
+        session = _FakeSession(
+            [
+                _FakeResponse(
+                    status=200,
+                    json_body={"rt_cd": "1", "error_code": "EGW00133"},
+                )
+            ]
+        )
+        adapter = _make_adapter(session)
+        with pytest.raises(TokenRateLimitError) as ei:
+            await adapter._authenticate()
+        assert ei.value.error_code == "EGW00133"
+
+    async def test_token_rate_limit_is_authentication_error(self):
+        """TokenRateLimitError 는 AuthenticationError 서브클래스 (T5 동일 분류)."""
+        assert issubclass(TokenRateLimitError, AuthenticationError)
+        err = TokenRateLimitError("x", error_code="EGW00133")
+        assert isinstance(err, AuthenticationError)
+        assert err.error_code == "EGW00133"
+
+
+# ── T5: classify 불변 + TRANSIENT set SSOT ────────────────
+
+
+class TestClassifyAndTransientInvariant:
+    def test_classify_authentication_error_unchanged(self):
+        """classify(AuthenticationError)=(False,False) 불변 (must_fix J 회귀 락)."""
+        assert KISErrorClassifier.classify(AuthenticationError("x")) == (False, False)
+
+    def test_classify_token_rate_limit_same_as_auth(self):
+        """classify(TokenRateLimitError)=(False,False) — 서브클래스 동일 분류 (T5)."""
+        err = TokenRateLimitError("x", error_code="EGW00133")
+        assert KISErrorClassifier.classify(err) == (False, False)
+
+    def test_egw00201_in_transient(self):
+        """EGW00201 ∈ TRANSIENT_MSG_CODES (일반 지수 backoff, 회귀 락 T5)."""
+        assert "EGW00201" in TRANSIENT_MSG_CODES
+        assert is_retryable_msg_code("EGW00201") is True
+
+    def test_egw00133_not_in_transient(self):
+        """EGW00133 ∉ TRANSIENT_MSG_CODES (auth-only, 회귀 락 T5)."""
+        assert "EGW00133" not in TRANSIENT_MSG_CODES
+        assert TOKEN_RATE_LIMIT_MSG_CODE == "EGW00133"
+        # 일반 재시도 경로에서도 non-retryable(누수 방어).
+        assert is_retryable_msg_code("EGW00133") is False
+
+    def test_korean_error_messages(self):
+        """EGW00133/EGW00201 한글 메시지 등록 (스펙 표 §105)."""
+        assert get_error_message("EGW00133") == "접근토큰 발급은 1분당 1회만 허용"
+        assert get_error_message("EGW00201") == "초당 거래 건수 초과"
+
+
+# ── T7: known-limitation 주석 anchor ──────────────────────
+
+
+class TestKnownLimitationAnchor:
+    def test_multiprocess_limitation_documented(self):
+        """멀티프로세스 토큰 공유 미해결(v1) known-limitation 주석/스펙 anchor (T7)."""
+        # in-process module 캐시뿐임을 module docstring/주석으로 명시.
+        src = kis_mod.__file__
+        with open(src, encoding="utf-8") as f:
+            content = f.read()
+        assert "멀티프로세스" in content
+        assert "in-process" in content

--- a/tests/unit/test_kis_token_single_flight.py
+++ b/tests/unit/test_kis_token_single_flight.py
@@ -31,8 +31,10 @@ from ante.broker.exceptions import AuthenticationError
 from ante.broker.kis import (
     KISErrorClassifier,
     _is_cached_token_fresh,
+    _record_token_cooldown,
     _reset_token_cache,
     _token_cache,
+    _token_cooldowns,
     _token_locks,
 )
 
@@ -42,6 +44,10 @@ KIS_CONFIG = {
     "account_no": "1111111101",
     "is_paper": True,
 }
+
+# attempt4 P2: ``_token_cache`` 키는 config fingerprint (app_key, app_secret, env)다.
+# 기존 테스트가 직접 캐시를 조회/주입할 때 쓰는 기본 config 의 fingerprint.
+_DEFAULT_CACHE_KEY = ("shared_key", "secret_a", "paper")
 
 
 @pytest.fixture(autouse=True)
@@ -158,9 +164,10 @@ class TestSingleFlight:
         await asyncio.gather(a1._authenticate(), a2._authenticate())
 
         assert session.post_count == 1
-        # lock dict 키가 app_key 인지 직접 확인(account_id 아님).
+        # lock dict 키가 app_key 인지 직접 확인(account_id 아님 — rate-limit 단위).
         assert set(_token_locks.keys()) == {"shared_key"}
-        assert set(_token_cache.keys()) == {"shared_key"}
+        # 캐시 dict 키는 config fingerprint(app_key+secret+env) — 같은 config 1개 키.
+        assert set(_token_cache.keys()) == {_DEFAULT_CACHE_KEY}
 
     async def test_different_app_keys_issue_separately(self):
         """다른 app_key 는 각각 발급(lock/캐시 분리) — single-flight 가 과수렴 안 함."""
@@ -212,7 +219,7 @@ class TestSharedCache:
         """만료 5분 전 토큰은 cache miss → 재발급 (_ensure_authenticated 기준, T2)."""
         session = _FakeSession([_success_response("tok-new")])
         # near-expiry: 만료까지 3분 남음(5분 여유보다 짧음) → miss.
-        _token_cache["shared_key"] = (
+        _token_cache[_DEFAULT_CACHE_KEY] = (
             "tok-old",
             datetime.now(UTC) + timedelta(minutes=3),
         )
@@ -223,7 +230,7 @@ class TestSharedCache:
         # near-expiry 라 재발급됨.
         assert session.post_count == 1
         assert adapter.access_token == "tok-new"
-        assert _token_cache["shared_key"][0] == "tok-new"
+        assert _token_cache[_DEFAULT_CACHE_KEY][0] == "tok-new"
 
     def test_is_cached_token_fresh_boundary(self):
         """_is_cached_token_fresh: 만료 5분 전 경계 — near-expiry miss 회귀 락 (T2)."""
@@ -250,7 +257,7 @@ class TestSharedCache:
         """_ensure_authenticated near-expiry 재발급도 single-flight 수렴 (T2)."""
         session = _FakeSession([_success_response("tok-new")])
         # 캐시에 near-expiry 토큰.
-        _token_cache["shared_key"] = (
+        _token_cache[_DEFAULT_CACHE_KEY] = (
             "tok-old",
             datetime.now(UTC) + timedelta(minutes=2),
         )
@@ -433,6 +440,140 @@ class TestClassifyAndTransientInvariant:
         """EGW00133/EGW00201 한글 메시지 등록 (스펙 표 §105)."""
         assert get_error_message("EGW00133") == "접근토큰 발급은 1분당 1회만 허용"
         assert get_error_message("EGW00201") == "초당 거래 건수 초과"
+
+
+# ── attempt4 P2: 캐시 키 = config fingerprint (lock/cooldown = app_key 유지) ──
+
+
+class TestTokenCacheConfigFingerprint:
+    """``_token_cache`` 키만 config fingerprint(app_key+secret+env)로 좁히고,
+    ``_token_locks``/``_token_cooldowns`` 는 app_key(rate-limit 단위)를 유지하는지
+    검증한다(attempt4 P2 — config 변경 재검증 + 동일 config 공유 보존).
+    """
+
+    async def test_changed_secret_is_cache_miss_reissues(self):
+        """같은 app_key·다른 app_secret → cache miss → 토큰 endpoint 재호출(발급).
+
+        ``AccountService._reconnect_broker`` 가 변경된 credentials(app_secret)로 새
+        어댑터 ``connect()``→``_authenticate()`` 를 호출하면, 같은 app_key 기존 토큰을
+        hydrate 하지 않고 **실제 발급**으로 새 설정을 검증해야 한다(이전엔 stale
+        hydrate 로 토큰 endpoint 미호출하던 회귀 락).
+        """
+        # 1) secret_a 로 토큰 발급 → 캐시 populate.
+        s1 = _FakeSession([_success_response("tok-a")])
+        a1 = _make_adapter(s1, app_secret="secret_a")
+        await a1._authenticate()
+        assert s1.post_count == 1
+        assert a1.access_token == "tok-a"
+
+        # 2) 같은 app_key·다른 app_secret(secret_b) → cache miss → 재발급(endpoint).
+        s2 = _FakeSession([_success_response("tok-b")])
+        a2 = _make_adapter(s2, app_secret="secret_b")
+        await a2._authenticate()
+        # 핵심: 토큰 endpoint 가 다시 호출됐다(stale hydrate 가 아님).
+        assert s2.post_count == 1
+        assert a2.access_token == "tok-b"
+        # 두 config 가 별도 캐시 엔트리로 공존(같은 app_key, 다른 fingerprint).
+        assert _token_cache[("shared_key", "secret_a", "paper")][0] == "tok-a"
+        assert _token_cache[("shared_key", "secret_b", "paper")][0] == "tok-b"
+
+    async def test_changed_env_is_cache_miss_reissues(self):
+        """같은 app_key·환경 전환(모의→실전) → cache miss → 토큰 endpoint 재호출.
+
+        ``broker_config`` 의 ``is_paper`` 전환(base_url 모의↔실전)이 바뀌면 같은
+        app_key·secret 라도 다른 fingerprint → 새 발급으로 환경을 재검증한다.
+        """
+        # 1) 모의(is_paper=True) 발급.
+        s1 = _FakeSession([_success_response("tok-paper")])
+        a1 = KISAdapter(
+            {
+                "app_key": "shared_key",
+                "app_secret": "secret_a",
+                "account_no": "1111111101",
+                "is_paper": True,
+            }
+        )
+        a1._session = s1  # type: ignore[assignment]
+        await a1._authenticate()
+        assert s1.post_count == 1
+
+        # 2) 실전(is_paper=False) — 같은 app_key·secret, 다른 환경 → cache miss → 발급.
+        s2 = _FakeSession([_success_response("tok-live")])
+        a2 = KISAdapter(
+            {
+                "app_key": "shared_key",
+                "app_secret": "secret_a",
+                "account_no": "1111111101",
+                "is_paper": False,
+            }
+        )
+        a2._session = s2  # type: ignore[assignment]
+        await a2._authenticate()
+        assert s2.post_count == 1
+        assert a2.access_token == "tok-live"
+        # 모의/실전 별도 캐시 엔트리.
+        assert _token_cache[("shared_key", "secret_a", "paper")][0] == "tok-paper"
+        assert _token_cache[("shared_key", "secret_a", "live")][0] == "tok-live"
+
+    async def test_same_config_shares_token_single_flight(self):
+        """같은 app_key+secret+env 어댑터 2개 → 같은 키 → single-flight 1회·공유.
+
+        동일 config 공유 어댑터(국내/해외 등)는 캐시 키가 같아 토큰을 공유한다
+        (원래 #2399 single-flight 목표 보존 — config fingerprint 가 과수렴을 깨지
+        않는다).
+        """
+        session = _FakeSession([_success_response("tok-shared")])
+        a1 = _make_adapter(session, app_secret="secret_a", account_no="acct-A")
+        a2 = _make_adapter(session, app_secret="secret_a", account_no="acct-B")
+
+        await asyncio.gather(a1._authenticate(), a2._authenticate())
+
+        # single-flight 1회 발급 + 토큰 공유.
+        assert session.post_count == 1
+        assert a1.access_token == "tok-shared"
+        assert a2.access_token == "tok-shared"
+        # 캐시 엔트리는 동일 config fingerprint 1개.
+        assert set(_token_cache.keys()) == {("shared_key", "secret_a", "paper")}
+
+    async def test_lock_is_app_key_across_different_configs(self):
+        """같은 app_key·다른 config 동시 발급도 lock=app_key 라 single-flight 직렬화.
+
+        캐시 키는 config 별로 갈려도 lock 은 app_key 단위(KIS rate-limit 단위)를
+        유지하므로, 같은 app_key 의 동시 발급은 lock 으로 직렬화된다(T1 회귀 락).
+        """
+        s_a = _FakeSession([_success_response("tok-a")])
+        s_b = _FakeSession([_success_response("tok-b")])
+        a1 = _make_adapter(s_a, app_secret="secret_a")
+        a2 = _make_adapter(s_b, app_secret="secret_b")
+
+        await asyncio.gather(a1._authenticate(), a2._authenticate())
+
+        # lock dict 키는 app_key 단독(config fingerprint 가 아님).
+        assert set(_token_locks.keys()) == {"shared_key"}
+        # 캐시는 config 별로 2개 엔트리(다른 secret).
+        assert set(_token_cache.keys()) == {
+            ("shared_key", "secret_a", "paper"),
+            ("shared_key", "secret_b", "paper"),
+        }
+
+    async def test_cooldown_is_app_key_across_different_configs(self):
+        """EGW00133 cooldown 은 app_key 단위라 같은 app_key·다른 secret 발급도 차단.
+
+        cooldown 은 KIS rate-limit(접근토큰 발급 1분 1회) 단위인 app_key 당이므로,
+        secret 가 달라도 같은 app_key 의 후속 발급은 cooldown 으로 HTTP 미호출 차단
+        된다(T4 cooldown=app_key 회귀 락).
+        """
+        # secret_a 에 대해 cooldown 직접 기록(EGW00133 수신 모사).
+        _record_token_cooldown("shared_key")
+        assert set(_token_cooldowns.keys()) == {"shared_key"}
+
+        # 같은 app_key·다른 secret 발급 시도 → cooldown(app_key 단위) 차단, HTTP 미호출.
+        s = _FakeSession([_success_response("tok-should-not-issue")])
+        a = _make_adapter(s, app_secret="secret_b")
+        with pytest.raises(TokenRateLimitError):
+            await a._authenticate()
+        assert s.post_count == 0
+        assert a.access_token is None
 
 
 # ── T7: known-limitation 주석 anchor ──────────────────────

--- a/tests/unit/test_main_runtime_readiness_wiring.py
+++ b/tests/unit/test_main_runtime_readiness_wiring.py
@@ -856,20 +856,9 @@ def test_self_healing_loop_backs_off_between_attempts() -> None:
 # ── broker_ready connect 시점 mark (init_gateway 발췌 경로) ─────────────────
 
 
-@pytest.mark.asyncio
-async def test_init_gateway_broker_ready_marks(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_init_gateway connect 루프: LIVE 성공→broker_ready, virtual→면제 no-op ready,
-    LIVE 실패→not_ready + get_broker 미호출(virtual)."""
-    s = _services(brokers={"live-fail": RuntimeError("EGW00133")})
+def _stub_init_gateway_followups(s: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_init_gateway connect 루프만 검증하도록 후속 단계·게이트웨이 더블을 깐다."""
 
-    accounts = [
-        _account("test", broker_type="test", trading_mode=TradingMode.VIRTUAL),
-        _account("live-ok"),
-        _account("live-fail"),
-    ]
-    s.account_service.list = AsyncMock(return_value=accounts)
-
-    # _init_gateway 의 connect 루프만 검증하기 위해 후속 단계를 무력화.
     async def _noop(*a: Any, **k: Any) -> None:
         return None
 
@@ -912,6 +901,21 @@ async def test_init_gateway_broker_ready_marks(monkeypatch: pytest.MonkeyPatch) 
     s.virtual_executor = SimpleNamespace(_gateway=None)
     s.bot_manager = SimpleNamespace(_context_factory=None)
 
+
+@pytest.mark.asyncio
+async def test_init_gateway_broker_ready_marks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_init_gateway connect 루프: LIVE 성공→broker_ready, virtual→면제 no-op ready,
+    LIVE 실패→not_ready + get_broker 미호출(virtual)."""
+    s = _services(brokers={"live-fail": RuntimeError("conn refused")})
+
+    accounts = [
+        _account("test", broker_type="test", trading_mode=TradingMode.VIRTUAL),
+        _account("live-ok"),
+        _account("live-fail"),
+    ]
+    s.account_service.list = AsyncMock(return_value=accounts)
+    _stub_init_gateway_followups(s, monkeypatch)
+
     await main_module._init_gateway(s)
 
     # virtual/test: 면제 no-op ready, get_broker 미호출(KIS 재노출 차단).
@@ -927,6 +931,85 @@ async def test_init_gateway_broker_ready_marks(monkeypatch: pytest.MonkeyPatch) 
     # 면제 계좌 broker 는 connect 단계에서 조회되지 않아야 한다.
     connect_ids = {c.args[0] for c in s.account_service.get_broker.call_args_list}
     assert "test" not in connect_ids
+
+
+# ── #2399 Codex P1: startup get_broker EGW00133 bounded retry 회귀 락 ────────
+
+
+@pytest.mark.asyncio
+async def test_init_gateway_get_broker_egw00133_exhausts_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2399 Codex P1 회귀 락: startup 의 get_broker() 가 (내부 connect 로)
+    EGW00133 을 던지면 _init_gateway 가 get_broker 를 **bounded retry**(~60s backoff
+    × DEFAULT_MAX_RETRIES_AUTH)한 뒤, 소진 시 not_ready(reason="EGW00133").
+
+    이전엔 retry 가 broker.connect() 만 감싸 get_broker() 가 먼저 raise → retry
+    미적용으로 즉시 not_ready 였다. retry 가 get_broker 호출 전체를 감싸야 한다."""
+    from ante.broker.exceptions import TokenRateLimitError
+    from ante.broker.kis import DEFAULT_MAX_RETRIES_AUTH
+
+    s = _services(brokers={"live-1": TokenRateLimitError("x", error_code="EGW00133")})
+    s.account_service.list = AsyncMock(return_value=[_account("live-1")])
+    _stub_init_gateway_followups(s, monkeypatch)
+
+    slept: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    monkeypatch.setattr(main_module.asyncio, "sleep", _fake_sleep)
+
+    await main_module._init_gateway(s)
+
+    # bounded retry: 최초 1 + 재시도 DEFAULT_MAX_RETRIES_AUTH 회 get_broker 호출.
+    assert s.account_service.get_broker.await_count == DEFAULT_MAX_RETRIES_AUTH + 1
+    # ~60s backoff 가 재시도 횟수만큼 관측(단일 cadence, startup 한 곳).
+    assert len(slept) == DEFAULT_MAX_RETRIES_AUTH
+    assert all(d == 60 for d in slept)
+    # 소진 → not_ready + reason 에 EGW00133 구조적 보존(T6).
+    assert not s.runtime_readiness.is_ready("live-1", ReadinessFlag.BROKER)
+    assert s.runtime_readiness.get_reason("live-1", ReadinessFlag.BROKER) == "EGW00133"
+
+
+@pytest.mark.asyncio
+async def test_init_gateway_get_broker_egw00133_retry_then_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2399 Codex P1: startup get_broker 가 2번째 attempt 에서 성공하면 broker_ready.
+
+    첫 attempt EGW00133 흡수(~60s backoff 1회) 후 둘째 attempt 에서 get_broker 성공."""
+    from ante.broker.exceptions import TokenRateLimitError
+
+    connected_broker = AsyncMock()
+    connected_broker.connect = AsyncMock()
+    state = {"fails": 1}
+
+    async def _get_broker(account_id: str) -> Any:
+        if state["fails"] > 0:
+            state["fails"] -= 1
+            raise TokenRateLimitError("x", error_code="EGW00133")
+        return connected_broker
+
+    s = _services()
+    s.account_service.get_broker = AsyncMock(side_effect=_get_broker)
+    s.account_service.list = AsyncMock(return_value=[_account("live-1")])
+    _stub_init_gateway_followups(s, monkeypatch)
+
+    slept: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    monkeypatch.setattr(main_module.asyncio, "sleep", _fake_sleep)
+
+    await main_module._init_gateway(s)
+
+    # 1 실패 + 1 성공 = get_broker 2회, backoff 1회.
+    assert s.account_service.get_broker.await_count == 2
+    assert slept == [60]
+    # 둘째 attempt 성공 → broker_ready.
+    assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.BROKER)
 
 
 # ── #2398 gate reader allowlist + SSOT-위반 금지 ───────────────────────────

--- a/tests/unit/test_main_runtime_readiness_wiring.py
+++ b/tests/unit/test_main_runtime_readiness_wiring.py
@@ -1012,6 +1012,271 @@ async def test_init_gateway_get_broker_egw00133_retry_then_ready(
     assert s.runtime_readiness.is_ready("live-1", ReadinessFlag.BROKER)
 
 
+# ── #2399 Codex P2(attempt 2): 후속 broker-backed init 에서 not_ready 계좌 skip ─
+
+
+def test_broker_ready_init_accounts_excludes_not_ready_live() -> None:
+    """broker not_ready LIVE 계좌는 후속 init 대상에서 제외되고, 후속 flag 가
+    mark_not_ready(self-healing 픽업)된다. 면제·broker_ready LIVE 는 유지."""
+    s = _services()
+    not_ready_live = _account("live-down")
+    ready_live = _account("live-ok")
+    virtual = _account("kv", trading_mode=TradingMode.VIRTUAL)
+    test_acc = _account("test", broker_type="test", trading_mode=TradingMode.VIRTUAL)
+    # connect 단계 결과 모사: live-down 만 broker not_ready, live-ok 는 ready.
+    s.runtime_readiness.mark_not_ready("live-down", ReadinessFlag.BROKER, "EGW00133")
+    s.runtime_readiness.mark_ready("live-ok", ReadinessFlag.BROKER)
+    # virtual/test 는 broker 면제(no-op ready).
+    s.runtime_readiness.mark_ready("kv", ReadinessFlag.BROKER)
+    s.runtime_readiness.mark_ready("test", ReadinessFlag.BROKER)
+
+    kept = main_module._broker_ready_init_accounts(
+        s, [not_ready_live, ready_live, virtual, test_acc]
+    )
+
+    kept_ids = [a.account_id for a in kept]
+    # broker not_ready LIVE 만 제외, 나머지(broker_ready LIVE·virtual·test) 유지.
+    assert kept_ids == ["live-ok", "kv", "test"]
+    # 제외된 LIVE 의 후속 flag 는 명시 not_ready(self-healing 픽업·fail-closed).
+    for flag in (
+        ReadinessFlag.TREASURY_SYNC,
+        ReadinessFlag.FILL_RECONCILE,
+        ReadinessFlag.RECONCILE,
+    ):
+        assert not s.runtime_readiness.is_ready("live-down", flag)
+        assert (
+            s.runtime_readiness.get_reason("live-down", flag)
+            == "broker_not_ready_startup"
+        )
+
+
+def test_broker_not_ready_live_helper_semantics() -> None:
+    """_broker_not_ready_live: broker not_ready LIVE 만 True, virtual/test·
+    broker_ready LIVE 는 False. registry 미주입이면 항상 False(기존 동작 보존)."""
+    s = _services()
+    s.runtime_readiness.mark_not_ready("live-down", ReadinessFlag.BROKER, "EGW00133")
+    s.runtime_readiness.mark_ready("live-ok", ReadinessFlag.BROKER)
+
+    assert main_module._broker_not_ready_live(s, _account("live-down")) is True
+    assert main_module._broker_not_ready_live(s, _account("live-ok")) is False
+    # virtual/test 는 broker 면제 → 항상 False(broker 무관 단계 보존).
+    assert (
+        main_module._broker_not_ready_live(
+            s, _account("kv", trading_mode=TradingMode.VIRTUAL)
+        )
+        is False
+    )
+    assert (
+        main_module._broker_not_ready_live(
+            s, _account("t", broker_type="test", trading_mode=TradingMode.VIRTUAL)
+        )
+        is False
+    )
+    # registry 미주입(partial wiring) → False(전 계좌 처리 보존).
+    s.runtime_readiness = None
+    assert main_module._broker_not_ready_live(s, _account("live-down")) is False
+
+
+def _stub_init_gateway_infra_only(s: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """treasury/fill/reconcile 는 **실제 실행**하고, 주변 인프라(stream·instruments·
+    context·outbox·daily·self-healing)만 noop 으로 깐다. P2 회귀(후속 broker-backed
+    init 의 get_broker 추가 호출 여부)를 end-to-end 로 관측하기 위함."""
+
+    async def _noop(*a: Any, **k: Any) -> None:
+        return None
+
+    def _noop_sync(*a: Any, **k: Any) -> None:
+        return None
+
+    monkeypatch.setattr(main_module, "_sync_instruments", _noop)
+    monkeypatch.setattr(main_module, "_init_stream_integration", _noop)
+    monkeypatch.setattr(main_module, "_init_context_factory", _noop_sync)
+    monkeypatch.setattr(main_module, "_init_fill_outbox_publisher", _noop)
+    monkeypatch.setattr(main_module, "_init_daily_report_scheduler", _noop)
+    monkeypatch.setattr(main_module, "_start_readiness_self_healing", _noop_sync)
+
+    class _FakeStopOrderManager:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    class _FakeGateway:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    import ante.gateway as gateway_mod
+    import ante.gateway.stop_order as stop_order_mod
+
+    monkeypatch.setattr(gateway_mod, "APIGateway", _FakeGateway)
+    monkeypatch.setattr(stop_order_mod, "StopOrderManager", _FakeStopOrderManager)
+    s.performance_tracker = None
+    s.trade_recorder = None
+    s.position_history = None
+    s.fill_outbox_publisher = None
+    s.virtual_executor = SimpleNamespace(_gateway=None)
+    s.bot_manager = SimpleNamespace(_context_factory=None)
+    # treasury 는 실제 _init_treasury_sync 가 쓰므로 reserve-price-resolver 주입
+    # 블록(_init_gateway 후반)도 통과하도록 더블에 메서드를 추가한다.
+    existing_treasury = s.treasury_manager
+    s.treasury_manager = SimpleNamespace(
+        get=existing_treasury.get,
+        set_order_reserve_price_resolver=lambda account_id, resolver: None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_init_gateway_not_ready_live_no_extra_get_broker_in_followups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2399 Codex P2(attempt 2) 핵심 회귀 락: startup connect 에서 EGW00133 소진으로
+    broker not_ready 가 된 LIVE 계좌는, 후속 broker-backed init(treasury LIVE sync·
+    fill recovery·reconcile·stream)에서 ``get_broker`` 를 **추가 호출하지 않는다**.
+
+    startup 전체에서 그 계좌 get_broker 시도는 connect 단계 bounded retry 횟수뿐
+    (후속 0). 이전엔 후속 단계가 또 get_broker 를 호출해 EGW00133 1/min 제한을
+    재타격했다(T4 단일 cadence 위반).
+
+    connected_count>0 을 만들기 위해 정상 LIVE(live-ok)도 1개 둔다(이게 있어야
+    fill/reconcile init 의 connected_count 가드가 통과해 후속 단계가 실행된다).
+    """
+    from ante.broker.exceptions import TokenRateLimitError
+    from ante.broker.kis import DEFAULT_MAX_RETRIES_AUTH
+
+    ok_broker = AsyncMock()
+    ok_broker.connect = AsyncMock()
+
+    async def _get_broker(account_id: str) -> Any:
+        if account_id == "live-down":
+            raise TokenRateLimitError("x", error_code="EGW00133")
+        return ok_broker
+
+    s = _services()
+    s.account_service.get_broker = AsyncMock(side_effect=_get_broker)
+    s.account_service.list = AsyncMock(
+        return_value=[_account("live-ok"), _account("live-down")]
+    )
+    _stub_init_gateway_infra_only(s, monkeypatch)
+
+    slept: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    monkeypatch.setattr(main_module.asyncio, "sleep", _fake_sleep)
+
+    await main_module._init_gateway(s)
+
+    # live-down get_broker 호출 = connect 단계 bounded retry(1 + MAX_RETRIES)뿐.
+    # 후속 단계(treasury/fill/reconcile/stream)는 추가 호출 0(P2 핵심).
+    down_calls = [
+        c
+        for c in s.account_service.get_broker.call_args_list
+        if c.args[0] == "live-down"
+    ]
+    assert len(down_calls) == DEFAULT_MAX_RETRIES_AUTH + 1, (
+        f"live-down get_broker 후속 추가 호출 발생(T4 위반): {len(down_calls)}건"
+    )
+    # backoff 도 단일 cadence(connect 단계)뿐.
+    assert len(slept) == DEFAULT_MAX_RETRIES_AUTH
+    # live-down 은 broker not_ready 유지 + 후속 flag 도 not_ready(self-healing 위임).
+    assert not s.runtime_readiness.is_ready("live-down", ReadinessFlag.BROKER)
+    assert not s.runtime_readiness.is_ready("live-down", ReadinessFlag.TREASURY_SYNC)
+    assert not s.runtime_readiness.is_ready("live-down", ReadinessFlag.FILL_RECONCILE)
+    assert not s.runtime_readiness.is_ready("live-down", ReadinessFlag.RECONCILE)
+    # not_ready LIVE 는 broker-backed 스케줄러 미등록(self-healing 이 회복 시 등록).
+    assert "live-down" not in s.fill_schedulers
+    assert "live-down" not in s.reconcile_schedulers
+
+    # broker_ready 성공 LIVE(live-ok)는 후속 init 정상 처리(skip 아님).
+    assert s.runtime_readiness.is_ready("live-ok", ReadinessFlag.BROKER)
+    assert s.runtime_readiness.is_ready("live-ok", ReadinessFlag.TREASURY_SYNC)
+    assert s.runtime_readiness.is_ready("live-ok", ReadinessFlag.FILL_RECONCILE)
+    assert s.runtime_readiness.is_ready("live-ok", ReadinessFlag.RECONCILE)
+    assert "live-ok" in s.fill_schedulers
+    assert "live-ok" in s.reconcile_schedulers
+
+
+@pytest.mark.asyncio
+async def test_init_gateway_virtual_treasury_unaffected_by_not_ready_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2399 Codex P2: broker not_ready LIVE 계좌가 있어도 virtual 계좌의 treasury
+    sync(broker=None)는 영향 없이 계속 처리된다(면제 계좌는 _broker_not_ready_live
+    가 항상 False → 후속 init 대상 유지)."""
+    from ante.broker.exceptions import TokenRateLimitError
+
+    async def _get_broker(account_id: str) -> Any:
+        if account_id == "live-down":
+            raise TokenRateLimitError("x", error_code="EGW00133")
+        broker = AsyncMock()
+        broker.connect = AsyncMock()
+        return broker
+
+    s = _services()
+    s.account_service.get_broker = AsyncMock(side_effect=_get_broker)
+    s.account_service.list = AsyncMock(
+        return_value=[
+            _account("live-ok"),
+            _account("live-down"),
+            _account("kv", trading_mode=TradingMode.VIRTUAL),
+        ]
+    )
+    _stub_init_gateway_infra_only(s, monkeypatch)
+    monkeypatch.setattr(main_module.asyncio, "sleep", AsyncMock())
+
+    await main_module._init_gateway(s)
+
+    # virtual 계좌 treasury sync 는 정상(broker 무관, not_ready LIVE 영향 없음).
+    assert s.runtime_readiness.is_ready("kv", ReadinessFlag.TREASURY_SYNC)
+    # virtual 은 broker 면제 get_broker 미호출(treasury VIRTUAL 분기는 broker=None).
+    kv_calls = [
+        c for c in s.account_service.get_broker.call_args_list if c.args[0] == "kv"
+    ]
+    assert kv_calls == []
+
+
+@pytest.mark.asyncio
+async def test_init_gateway_not_ready_live_picked_up_by_self_healing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2399 Codex P2: startup 에서 skip 된 not_ready LIVE 계좌를 self-healing 이
+    broker 회복 시 픽업해 treasury/fill/reconcile 을 재등록한다(#2398 경로 정합).
+
+    startup 직후 상태(broker/treasury/fill/reconcile 모두 not_ready)에서
+    _self_healing_recover_account 를 직접 구동(broker 회복 성공)하면 전 flag 가
+    ready 로 전이하고 스케줄러가 등록됨을 잠근다.
+    """
+    s = _services()  # 기본 get_broker = connect 성공 broker(회복 가능).
+    account = _account("live-down")
+    # startup skip 결과 상태 재현: 후속 flag 까지 모두 not_ready.
+    s.runtime_readiness.mark_not_ready("live-down", ReadinessFlag.BROKER, "EGW00133")
+    s.runtime_readiness.mark_not_ready(
+        "live-down", ReadinessFlag.TREASURY_SYNC, "broker_not_ready_startup"
+    )
+    s.runtime_readiness.mark_not_ready(
+        "live-down", ReadinessFlag.FILL_RECONCILE, "broker_not_ready_startup"
+    )
+    s.runtime_readiness.mark_not_ready(
+        "live-down", ReadinessFlag.RECONCILE, "broker_not_ready_startup"
+    )
+
+    recovered = await main_module._self_healing_recover_account(s, account)
+
+    assert recovered is True
+    # broker 회복 → 전 flag ready 전이 + 스케줄러 등록(#2398 재등록 경로).
+    assert s.runtime_readiness.is_ready("live-down", ReadinessFlag.BROKER)
+    assert s.runtime_readiness.is_ready("live-down", ReadinessFlag.TREASURY_SYNC)
+    assert s.runtime_readiness.is_ready("live-down", ReadinessFlag.FILL_RECONCILE)
+    assert s.runtime_readiness.is_ready("live-down", ReadinessFlag.RECONCILE)
+    assert "live-down" in s.fill_schedulers
+    assert "live-down" in s.reconcile_schedulers
+
+
 # ── #2398 gate reader allowlist + SSOT-위반 금지 ───────────────────────────
 
 

--- a/tests/unit/test_main_startup_ordering.py
+++ b/tests/unit/test_main_startup_ordering.py
@@ -243,12 +243,21 @@ def _make_sync_services(broker_instruments: dict[str, Any]) -> tuple[Any, list[A
 
     ``broker_instruments`` 는 account_id → broker.get_instruments() 반환값
     (list[dict] 또는 raise 할 Exception 인스턴스) 매핑이다.
+
+    #2399 attempt3-a: ``_sync_instruments`` 는 startup connect 성공(broker_ready)
+    계좌만 순회한다(``_broker_not_ready_live`` 필터). 프로덕션 흐름에서 connect
+    루프가 broker_ready 를 마킹한 상태를 반영해, ``broker_instruments`` 의 모든
+    account_id 를 기본 broker_ready 로 마킹한다. not_ready skip 회귀를 검증하는
+    테스트는 helper 호출 **후** 해당 계좌를 명시 ``mark_not_ready`` 로 덮는다.
     """
     from unittest.mock import AsyncMock
 
     import ante.main as main_module
+    from ante.account.readiness import ReadinessFlag
 
     s = main_module.Services()
+    for account_id in broker_instruments:
+        s.runtime_readiness.mark_ready(account_id, ReadinessFlag.BROKER)
 
     upsert_calls: list[Any] = []
 
@@ -349,6 +358,40 @@ async def test_sync_instruments_skips_exempt_accounts() -> None:
     # 면제 계좌의 broker 는 조회조차 되지 않아야 한다(KIS 재노출 차단).
     s.account_service.get_broker.assert_awaited_once_with("kis-live")
     # LIVE 계좌의 실 마스터만 적재.
+    assert len(upsert_calls) == 1
+    upserted = {inst.symbol for batch in upsert_calls for inst in batch}
+    assert upserted == {"069500"}
+
+
+@pytest.mark.asyncio
+async def test_sync_instruments_skips_broker_not_ready_live() -> None:
+    """#2399 attempt3-a: startup broker not_ready LIVE 계좌는 get_broker 미호출.
+
+    not_ready LIVE 계좌가 있어도 instrument sync 가 그 계좌에 토큰을 재타격하지
+    않는다(EGW00133 1/min). ready LIVE 계좌만 동기화되고, not_ready 계좌의
+    get_broker 는 조회조차 되지 않는다(필터). per-account try/except 와 무관하게
+    전체 sync 가 깨지지 않는다.
+    """
+    import ante.main as main_module
+    from ante.account.readiness import ReadinessFlag
+
+    accounts = [
+        _make_sync_account("kis-down", "KOSPI"),  # broker not_ready LIVE → skip.
+        _make_sync_account("kis-ok", "KRX"),  # broker ready LIVE → 동기화.
+    ]
+    s, upsert_calls = _make_sync_services(
+        {
+            "kis-down": [{"symbol": "000001", "name": "내려간계좌"}],
+            "kis-ok": [{"symbol": "069500", "name": "KODEX 200"}],
+        }
+    )
+    # helper 가 둘 다 broker_ready 로 마킹했으므로 kis-down 만 not_ready 로 덮는다.
+    s.runtime_readiness.mark_not_ready("kis-down", ReadinessFlag.BROKER, "EGW00133")
+
+    await main_module._sync_instruments(s, accounts)
+
+    # not_ready 계좌는 get_broker 미호출, ready 계좌만 1회 조회.
+    s.account_service.get_broker.assert_awaited_once_with("kis-ok")
     assert len(upsert_calls) == 1
     upserted = {inst.symbol for batch in upsert_calls for inst in batch}
     assert upserted == {"069500"}


### PR DESCRIPTION
Closes #2399

## Summary
#2395 readiness gate 축(iii) — KIS 토큰 발급(app_key당 1분 1회, EGW00133) 폭주를 막는 single-flight + shared cache + per-app_key cooldown. 동일 app_key를 공유하는 다중 adapter가 동시/연속 발급해도 토큰 발급이 1회로 수렴한다.

- **T1/T2 single-flight + shared cache**: module-level shared 캐시 `{(app_key, app_secret, env): (token, expires_at)}` + **per-app_key asyncio.Lock**(account_id 아님). `_authenticate` = hydrate(유효 캐시 read 우선, near-expiry=만료 5분 전 기준 = `_ensure_authenticated`와 동일) → lock 밖 cooldown fast-path → app_key lock → double-check → 발급 1회 → 캐시 populate. **캐시 키는 config fingerprint**(app_key+secret+모의/실전 env) — secret/환경 전환 시 재검증, 동일 config 공유는 토큰 공유.
- **T3 응답 파싱(must_fix K)**: `_authenticate`가 토큰 발급 응답에서 KIS 에러코드를 `msg_cd`/`error_code` alias로 파싱(HTTP 200+error body / non-200 양 분기, 토큰 경로 한정).
- **T4 EGW00133 per-app_key cooldown at source(단일 cadence)**: `_authenticate`/`_issue_token`이 EGW00133 수신 시 `_token_cooldowns[app_key]=now+60s` 기록 후 즉시 `TokenRateLimitError` raise. cooldown 내 발급 시도는 HTTP 미호출·즉시 raise → **startup/self-healing/runtime/IPC 전 경로가 단일 chokepoint에서 자동 존중**(토큰 1/min 재타격 차단). startup bounded retry는 잔여 cooldown만큼 sleep, self-healing interval(60s) ≥ cooldown.
- **T5 classify 불변(must_fix J)**: `classify(AuthenticationError/TokenRateLimitError)=(False,False)` 불변. **EGW00133은 TRANSIENT_MSG_CODES 제외**(auth-only — 일반 KISRetryHandler 지수 backoff로 보내지 않음), **EGW00201만 TRANSIENT**.
- **T6 readiness 연동**: connect-path 소진 → broker_ready not_ready(reason="EGW00133", `TokenRateLimitError.error_code` 구조적 보존, startup+self-healing 양쪽). EGW00133로 not_ready된 LIVE 계좌는 후속 broker-backed startup init(treasury LIVE/fill/reconcile/instrument sync)에서 skip → self-healing(#2397) 위임.
- **T7 known-limitation(v1)**: 멀티프로세스(CLI 다발) 토큰 공유 미해결 — in-process 캐시뿐. 후속 후보.

## 스펙
- `docs/specs/broker-adapter/07-kis-base-adapter.md`: 단일 cadence를 per-app_key cooldown at source로 명문화(naive 내부 backoff의 self-healing nested-backoff 잠재버그 정정, adjudicated). `tests/unit/conftest.py`에 토큰 상태 글로벌 reset fixture(테스트 격리).

## 리뷰 수렴 (Codex 브랜치 리뷰 5 attempt + @code-reviewer 메타 감사 2회)
- Plan Preflight: Codex Plan Review 4 rev(single-flight lock=app_key, msg_cd alias, nested backoff bound, defaults 미변경, 스펙 정정) → approve-implement.
- 브랜치: attempt1(startup retry가 get_broker 미감쌈) → attempt2(후속 init 재타격) → attempt3(instrument sync + self-healing 같은 app_key burst) → **메타 감사: per-call-site 필터(B)→per-app_key cooldown at source(A) 전환** → attempt4(캐시 키 config fingerprint) → attempt5 PASS.

## Test Plan
- `ruff check`/`format --check`: PASS
- `mypy src/`(236 files): Success
- `pytest tests/unit`: **7534 passed, 2 skipped**
- spec terminology guard: PASS
- 신규 회귀: single-flight 1회 수렴, lock key=app_key, near-expiry cache miss, per-app_key cooldown(전 경로 재타격 차단·sleep patch 실측), 캐시 키 config fingerprint(secret/env 전환 재검증·동일 config 공유), msg_cd/error_code alias, EGW00201∈/EGW00133∉ TRANSIENT, classify 불변, startup/self-healing reason="EGW00133", 후속 init not_ready skip, 글로벌 reset fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)