### PR TITLE
fix(strategy): #2404 지표 파라미터 키 docs↔런타임 정합 + legacy-key 가드

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -4,7 +4,7 @@
 > 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
 > Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
-> 마지막 생성 시점: 2026-06-18 (KST)
+> 마지막 생성 시점: 2026-06-20 (KST)
 
 ## 최상위 구조
 
@@ -644,7 +644,8 @@ tests/
 │   │   ├── docs_drift_allowlist.yaml
 │   │   ├── test_cli_registry_docs_drift.py
 │   │   ├── test_cli_registry_guide_sync.py
-│   │   └── test_signal_connect_codes.py
+│   │   ├── test_signal_connect_codes.py
+│   │   └── test_indicator_param_drift.py
 │   ├── test_account_cli_ipc_error_equivalence.py
 │   ├── test_member_cli_ipc_error_equivalence.py
 │   ├── test_approval_cli_ipc_error_equivalence.py
@@ -732,7 +733,10 @@ tests/
 │   ├── test_account_runtime_readiness.py
 │   ├── test_main_runtime_readiness_wiring.py
 │   ├── _readiness_gate_helpers.py
-│   └── test_active_order_readiness_gate.py
+│   ├── test_active_order_readiness_gate.py
+│   ├── test_kis_token_backoff_cadence.py
+│   ├── test_kis_token_cooldown.py
+│   └── test_kis_token_single_flight.py
 ├── __init__.py
 └── integration/
     ├── __init__.py

--- a/docs/specs/strategy/03-06-indicator-calculator.md
+++ b/docs/specs/strategy/03-06-indicator-calculator.md
@@ -10,23 +10,25 @@ pandas-ta를 래핑하여 15종의 기술 지표를 계산한다. pandas-ta는 *
 
 **지원 지표** (15종):
 
+파라미터 키는 pandas-ta 규약을 따른다 (TA-Lib의 `timeperiod`/`nbdev`/`fastk`/`slowk`/`slowd`가 아니다).
+
 | 지표 | 함수 | 입력 | 기본 파라미터 |
 |------|------|------|-------------|
-| SMA | `SMA` | close | timeperiod=20 |
-| EMA | `EMA` | close | timeperiod=20 |
-| RSI | `RSI` | close | timeperiod=14 |
-| MACD | `MACD` | close | fast=12, slow=26, signal=9 |
-| BBands | `BBANDS` | close | timeperiod=20, nbdev=2.0 |
-| ATR | `ATR` | hlc | timeperiod=14 |
-| Stochastic | `STOCH` | hlc | fastk=14, slowk=3, slowd=3 |
-| ADX | `ADX` | hlc | timeperiod=14 |
-| CCI | `CCI` | hlc | timeperiod=14 |
-| OBV | `OBV` | close+volume | — |
-| WMA | `WMA` | close | timeperiod=20 |
-| DEMA | `DEMA` | close | timeperiod=20 |
-| TEMA | `TEMA` | close | timeperiod=20 |
-| WILLR | `WILLR` | hlc | timeperiod=14 |
-| MFI | `MFI` | hlcv | timeperiod=14 |
+| SMA | `sma` | close | length=20 |
+| EMA | `ema` | close | length=20 |
+| RSI | `rsi` | close | length=14 |
+| MACD | `macd` | close | fast=12, slow=26, signal=9 |
+| BBands | `bbands` | close | length=20, lower_std=2.0, upper_std=2.0 |
+| ATR | `atr` | hlc | length=14 |
+| Stochastic | `stoch` | hlc | k=14, d=3, smooth_k=3 |
+| ADX | `adx` | hlc | length=14 |
+| CCI | `cci` | hlc | length=14 |
+| OBV | `obv` | close+volume | — |
+| WMA | `wma` | close | length=20 |
+| DEMA | `dema` | close | length=20 |
+| TEMA | `tema` | close | length=20 |
+| WILLR | `willr` | hlc | length=14 |
+| MFI | `mfi` | hlcv | length=14 |
 
 **주요 인터페이스**:
 
@@ -37,6 +39,11 @@ pandas-ta를 래핑하여 15종의 기술 지표를 계산한다. pandas-ta는 *
 | `compute` | `name: str, ohlcv: dict[str, ndarray], **params` | `dict[str, ndarray]` | 지표 계산. 단일 출력: `{"sma": array}`, 다중: `{"macd": array, "signal": array, "hist": array}` |
 
 데이터 부족 등으로 지표를 계산할 수 없으면(pandas-ta가 `None` 반환) `compute`는 빈 dict `{}`를 반환한다 (`LiveDataProvider.get_indicator`의 빈 OHLCV 동작과 동일 sentinel). 이 계약은 단일·다중 출력 지표 모두에 적용되며, 세 소비자(`StrategyContext` / `LiveDataProvider` / `BacktestDataProvider`)가 동일하게 안정적인 빈 결과를 받는다.
+
+**compute 에러 계약**:
+
+- 미지원 지표 이름 → `ValueError` (`Unknown indicator: ...`).
+- legacy/미인식 파라미터 키 거부 → `ValueError`. pandas-ta가 조용히 무시하는 TA-Lib 규약 키(`timeperiod`, `nbdev`, `std`, `fastk`, `slowk`, `slowd`)를 사용자가 `params`로 전달하면, silent-drop을 막기 위해 정정 키 힌트를 담은 `ValueError`를 발생시킨다. 이 블랙리스트 키는 15종 지표 어디에서도 유효하지 않다. 단, 블랙리스트에 없는 임의 오타 키(예: `lenght`)는 여전히 silent-drop되며, 1차 방어는 위 파라미터 표와 계약 테스트(`tests/unit/contracts/test_indicator_param_drift.py`)다.
 
 `ohlcv_to_numpy()` 유틸리티: polars DataFrame 또는 `list[dict]`를 numpy 배열 딕셔너리로 변환.
 

--- a/guide/strategy.md
+++ b/guide/strategy.md
@@ -68,7 +68,7 @@ class MyStrategy(Strategy):
 ```python
 ohlcv = await self.ctx.get_ohlcv("005930", timeframe="1d", limit=100)
 price = await self.ctx.get_current_price("005930")
-indicator = await self.ctx.get_indicator("005930", "rsi", {"timeperiod": 14})
+indicator = await self.ctx.get_indicator("005930", "rsi", {"length": 14})
 ```
 
 **포트폴리오 조회:**
@@ -88,29 +88,29 @@ self.ctx.cancel_order(order_id="ORD-001", reason="전략 조건 변경")
 
 > **주문 정정(`modify_order`)은 v1=가격 정정만 지원합니다(price-only, #2391).** `self.ctx.modify_order(order_id, price=신규가격, reason=...)`로 **미체결(`open`) 지정가 주문의 가격을 정정**할 수 있습니다(매수는 신규가 ≤ 원주문가, 매도는 가격 정정). 성공하면 `on_order_update` 알림에 `status="modified"`로 통보됩니다. **다음 경우는 거부되며**(`on_order_update`의 `reason` 필드로 사유 전달), 이때는 **`cancel_order()`로 취소한 뒤 새 주문을 다시 제출**하세요: 수량 변경(`modify_qty_change_unsupported`), 매수 가격 인상(`modify_budget_increase_unsupported`), 부분체결/종료 주문(`modify_partial_or_terminal_unsupported`), 다른 봇의 주문(`modify_not_owner`), 비지정가(시장가) 주문(`modify_unsupported_order_type`), 무효 가격(`modify_invalid_args`). 수량 변경 등 고급 정정과 실전 KIS 정정 검증은 후속 작업(#2393, oracle)으로 분리되어 있습니다.
 
-**기술 지표:** `get_indicator()`로 기술 지표를 사용할 수 있습니다. 내부적으로 [pandas-ta](https://github.com/twopirllc/pandas-ta)를 사용하며, pandas-ta가 지원하는 130+ 지표를 모두 사용할 수 있습니다.
+**기술 지표:** `get_indicator()`로 기술 지표를 사용할 수 있습니다. 내부적으로 [pandas-ta](https://github.com/twopirllc/pandas-ta)를 사용하며, **아래 15종**을 지원합니다. 파라미터 키는 pandas-ta 규약(`length` 등)을 따르며, 등록되지 않은 지표 이름은 `ValueError: Unknown indicator`로 거부됩니다.
 
-자주 사용되는 지표:
+지원 지표(15종):
 
 | 지표 | 이름 | 주요 파라미터 |
 |------|------|-------------|
-| SMA | 단순이동평균 | `timeperiod` |
-| EMA | 지수이동평균 | `timeperiod` |
-| RSI | 상대강도지수 | `timeperiod` |
+| SMA | 단순이동평균 | `length` |
+| EMA | 지수이동평균 | `length` |
+| RSI | 상대강도지수 | `length` |
 | MACD | 이동평균수렴확산 | `fast`, `slow`, `signal` |
-| BBANDS | 볼린저밴드 | `timeperiod`, `nbdev` |
-| ATR | 평균진폭 | `timeperiod` |
-| STOCH | 스토캐스틱 | `fastk`, `slowk`, `slowd` |
-| ADX | 평균방향지수 | `timeperiod` |
-| CCI | 상품채널지수 | `timeperiod` |
+| BBANDS | 볼린저밴드 | `length`, `lower_std`, `upper_std` |
+| ATR | 평균진폭 | `length` |
+| STOCH | 스토캐스틱 | `k`, `d`, `smooth_k` |
+| ADX | 평균방향지수 | `length` |
+| CCI | 상품채널지수 | `length` |
 | OBV | 거래량잔고 | — |
-| VWAP | 거래량가중평균가 | — |
-| Ichimoku | 일목균형표 | `tenkan`, `kijun`, `senkou` |
-| Supertrend | 슈퍼트렌드 | `length`, `multiplier` |
-| ROC | 변화율 | `timeperiod` |
-| CMF | 차이킨자금흐름 | `timeperiod` |
+| WMA | 가중이동평균 | `length` |
+| DEMA | 이중지수이동평균 | `length` |
+| TEMA | 삼중지수이동평균 | `length` |
+| WILLR | 윌리엄스 %R | `length` |
+| MFI | 자금흐름지수 | `length` |
 
-> 전체 지표 목록은 [pandas-ta 문서](https://github.com/twopirllc/pandas-ta#indicators-by-category)를 참조하세요.
+> TA-Lib 규약 키(`timeperiod`, `nbdev`, `fastk`/`slowk`/`slowd`)는 pandas-ta가 조용히 무시하므로 `get_indicator()`가 `ValueError`로 거부합니다. 위 표의 정식 키를 사용하세요. VWAP·Ichimoku·Supertrend·ROC·CMF 등 위 15종에 없는 지표는 현재 미지원입니다.
 
 ### 라이프사이클 메서드
 
@@ -222,7 +222,7 @@ class MomentumBreakout(Strategy):
 
     async def on_step(self, context: dict) -> list[Signal]:
         ohlcv = await self.ctx.get_ohlcv("005930", limit=20)
-        rsi = await self.ctx.get_indicator("005930", "rsi", {"timeperiod": 14})
+        rsi = await self.ctx.get_indicator("005930", "rsi", {"length": 14})
         positions = self.ctx.get_positions()
 
         current_close = ohlcv.iloc[-1]["close"]

--- a/src/ante/strategy/indicators.py
+++ b/src/ante/strategy/indicators.py
@@ -29,7 +29,7 @@ INDICATOR_REGISTRY: dict[str, dict[str, Any]] = {
     "bbands": {
         "func": "bbands",
         "input": "close",
-        "params": {"length": 20, "std": 2.0},
+        "params": {"length": 20, "lower_std": 2.0, "upper_std": 2.0},
     },
     "atr": {"func": "atr", "input": "hlc", "params": {"length": 14}},
     "stoch": {
@@ -56,6 +56,28 @@ _MULTI_OUTPUT: dict[str, list[str]] = {
     "macd": ["macd", "signal", "hist"],
     "bbands": ["lower", "middle", "upper"],
     "stoch": ["slowk", "slowd"],
+}
+
+# legacy/오명명 파라미터 키 블랙리스트 (#2404).
+#
+# pandas-ta 도입 이전 TA-Lib 규약의 키(timeperiod, nbdev, fastk/slowk/slowd)는
+# pandas-ta 함수 시그니처에 존재하지 않아 `**kwargs`로 흡수된 뒤 조용히 무시된다
+# (silent-drop). 사용자가 정식 키 대신 이 키를 전달하면 의도한 파라미터가
+# 반영되지 않으므로, compute()가 pandas-ta 호출 전에 명시적으로 거부한다.
+#
+# 블랙리스트 방식 채택 근거: pandas-ta 15개 함수가 전부 `**kwargs`를 보유하고
+# 일부 정당 파라미터(예: macd/rsi의 signal_indicators)가 named param이 아닌
+# `kwargs.pop()`으로 처리되므로, allowlist는 정당 입력을 false-reject한다.
+# 아래 키는 현재 15개 지표 어디에서도 유효하지 않아 전역 거부가 안전하다.
+#
+# 값: 정정 키 힌트 (에러 메시지에 노출).
+_LEGACY_PARAM_KEYS: dict[str, str] = {
+    "timeperiod": "length",
+    "nbdev": "lower_std/upper_std (bbands)",
+    "std": "lower_std/upper_std (bbands)",
+    "fastk": "k (stoch)",
+    "slowk": "smooth_k (stoch)",
+    "slowd": "d (stoch)",
 }
 
 
@@ -100,12 +122,25 @@ class IndicatorCalculator:
             데이터 부족 등으로 계산 불가 시(pandas-ta가 None 반환) 빈 dict ``{}``.
 
         Raises:
-            ValueError: 미지원 지표 또는 필수 입력 누락.
+            ValueError: 미지원 지표, 필수 입력 누락, 또는 legacy/미인식
+                파라미터 키(예: ``timeperiod``) 전달 (#2404 silent-drop 차단).
         """
         name_lower = name.lower()
         if name_lower not in INDICATOR_REGISTRY:
             supported = ", ".join(sorted(INDICATOR_REGISTRY.keys()))
             raise ValueError(f"Unknown indicator: {name}. Supported: {supported}")
+
+        # legacy-key 블랙리스트 가드 (#2404): 사용자 전달 params에 pandas-ta가
+        # 조용히 무시하는 TA-Lib 규약 키가 있으면 silent-drop 전에 거부한다.
+        # 레지스트리 기본값(spec["params"])은 전부 정식 키이므로 검사 대상 아님.
+        legacy = [key for key in params if key in _LEGACY_PARAM_KEYS]
+        if legacy:
+            hints = ", ".join(f"{key} -> {_LEGACY_PARAM_KEYS[key]}" for key in legacy)
+            raise ValueError(
+                f"Unrecognized indicator parameter key(s) for '{name}': "
+                f"{', '.join(legacy)}. These keys are silently ignored by "
+                f"pandas-ta. Use the correct key(s): {hints}."
+            )
 
         spec = INDICATOR_REGISTRY[name_lower]
         merged_params = {**spec["params"], **params}

--- a/tests/unit/contracts/test_indicator_param_drift.py
+++ b/tests/unit/contracts/test_indicator_param_drift.py
@@ -1,0 +1,312 @@
+"""지표 파라미터 키 docs↔런타임 drift 계약 테스트 (#2404).
+
+스펙(`docs/specs/strategy/03-06-indicator-calculator.md`)과 공개 가이드
+(`guide/strategy.md`)가 안내하는 지표 파라미터 키가 런타임
+``INDICATOR_REGISTRY`` 및 ``IndicatorCalculator.compute()`` 계약과 어긋나지
+않도록 강제한다.
+
+배경: pandas-ta 도입 이전 TA-Lib 규약 키(``timeperiod`` / ``nbdev`` /
+``fastk`` / ``slowk`` / ``slowd``)가 docs에 남아 있었고, 그대로 전달하면
+pandas-ta가 ``**kwargs``로 흡수해 조용히 무시(silent-drop)했다. 본 테스트는
+세 축을 검증한다:
+
+(a) docs↔키 계약 — spec 표·guide 표·guide 예제에서 추출한 파라미터 키에
+    블랙리스트(legacy) 키가 등장하지 않고, 각 키가 해당 지표의 정식 레지스트리
+    키임을 단언.
+(b) 레지스트리 honored 행위 검증 — params를 가진 각 지표의 각 레지스트리
+    키를 비기본값으로 전달했을 때 결과가 기본 출력과 **달라짐**을 단언
+    (silent-drop 직접 검출; bbands ``std`` 류 회귀 차단).
+(c) 가드 동작 — ``compute(..., timeperiod=...)`` 등 블랙리스트 키 전달 시
+    정정 키 힌트를 담은 ``ValueError``가 발생함을 단언.
+
+기존 ``helpers.py``의 ``_DOCS_ROW_RE``는 CLI command 행(``| `ante ...```)
+전용이라 지표 표 파싱에 재사용할 수 없어 신규 파서를 둔다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ante.strategy.indicators import (
+    _LEGACY_PARAM_KEYS,
+    INDICATOR_REGISTRY,
+    IndicatorCalculator,
+)
+
+# ── repo root 고정 ───────────────────────────────────────────────────────────
+# tests/unit/contracts/이 파일 → 3단계 위가 repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SPEC_PATH = (
+    _REPO_ROOT / "docs" / "specs" / "strategy" / "03-06-indicator-calculator.md"
+)
+_GUIDE_PATH = _REPO_ROOT / "guide" / "strategy.md"
+
+
+# ── 파서 ─────────────────────────────────────────────────────────────────────
+
+# `length=20` / `lower_std=2.0` 같은 key=value 토큰에서 key만 추출.
+_KV_KEY_RE = re.compile(r"([A-Za-z_]\w*)\s*=")
+# `{"length": 14}` 같은 dict 리터럴에서 문자열 키 추출 (get_indicator 예제).
+_DICT_KEY_RE = re.compile(r'["\']([A-Za-z_]\w*)["\']\s*:')
+# 백틱으로 감싼 식별자 (guide 표의 `length`, `fast` 등).
+_BACKTICK_KEY_RE = re.compile(r"`([A-Za-z_]\w*)`")
+
+
+def _spec_table_param_keys() -> set[str]:
+    """spec 03-06 '지원 지표' 표의 `기본 파라미터` 열에서 키를 추출.
+
+    표 행(`| 지표 | 함수 | 입력 | 기본 파라미터 |`)만 파싱한다. negative-mention
+    산문 줄(예: 'TA-Lib의 timeperiod ... 가 아니다')은 표 행이 아니므로 자동
+    제외된다.
+    """
+    text = _SPEC_PATH.read_text(encoding="utf-8")
+    keys: set[str] = set()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        # 4열 표 (지표 | 함수 | 입력 | 기본 파라미터)만 대상.
+        if len(cells) != 4:
+            continue
+        last = cells[-1]
+        # 헤더/구분선/'—'(파라미터 없음) 행 스킵.
+        if "=" not in last:
+            continue
+        keys.update(_KV_KEY_RE.findall(last))
+    return keys
+
+
+def _guide_table_param_keys() -> set[str]:
+    """guide '지원 지표(15종)' 표의 `주요 파라미터` 열 백틱 키를 추출.
+
+    `| 지표 | 이름 | 주요 파라미터 |` 헤더로 시작하는 표 블록의 데이터 행만
+    파싱한다. guide에는 동일한 3열 구조의 다른 표(에이전트 메시지 타입 등)가
+    있으므로, 헤더 텍스트로 대상 표를 특정해 오탐을 막는다.
+    """
+    text = _GUIDE_PATH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    keys: set[str] = set()
+    in_table = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            in_table = False
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cells) != 3:
+            in_table = False
+            continue
+        # 지표 표 헤더 행 식별 → 블록 시작.
+        if cells == ["지표", "이름", "주요 파라미터"]:
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        # 구분선 행(---) 스킵.
+        if set(cells[-1]) <= {"-", ":", " "}:
+            continue
+        keys.update(_BACKTICK_KEY_RE.findall(cells[-1]))
+    return keys
+
+
+def _guide_example_param_keys() -> set[str]:
+    """guide 코드 예제의 ``get_indicator(..., {"key": val})`` dict 키를 추출."""
+    text = _GUIDE_PATH.read_text(encoding="utf-8")
+    keys: set[str] = set()
+    for m in re.finditer(r"get_indicator\([^)]*\{([^}]*)\}", text):
+        keys.update(_DICT_KEY_RE.findall(m.group(1)))
+    return keys
+
+
+# 레지스트리에 등록된 모든 정식 파라미터 키(전 지표 합집합).
+_REGISTRY_PARAM_KEYS: set[str] = {
+    key for spec in INDICATOR_REGISTRY.values() for key in spec["params"]
+}
+
+
+# ── (a) docs↔키 계약 ─────────────────────────────────────────────────────────
+
+
+def test_spec_table_keys_have_no_legacy_keys() -> None:
+    """spec 표의 파라미터 키에 블랙리스트(legacy) 키가 없다."""
+    keys = _spec_table_param_keys()
+    assert keys, "spec 표에서 파라미터 키를 하나도 추출하지 못함 (파서 회귀)"
+    leaked = keys & set(_LEGACY_PARAM_KEYS)
+    assert not leaked, f"spec 03-06 표가 legacy 키를 안내: {sorted(leaked)}"
+
+
+def test_spec_table_keys_are_registry_keys() -> None:
+    """spec 표의 각 파라미터 키가 레지스트리 정식 키다."""
+    keys = _spec_table_param_keys()
+    unknown = keys - _REGISTRY_PARAM_KEYS
+    assert not unknown, f"spec 03-06 표 키가 레지스트리에 없음: {sorted(unknown)}"
+
+
+def test_guide_table_keys_have_no_legacy_keys() -> None:
+    """guide 표의 파라미터 키에 블랙리스트 키가 없다."""
+    keys = _guide_table_param_keys()
+    assert keys, "guide 표에서 파라미터 키를 하나도 추출하지 못함 (파서 회귀)"
+    leaked = keys & set(_LEGACY_PARAM_KEYS)
+    assert not leaked, f"guide/strategy.md 표가 legacy 키를 안내: {sorted(leaked)}"
+
+
+def test_guide_table_keys_are_registry_keys() -> None:
+    """guide 표의 각 파라미터 키가 레지스트리 정식 키다."""
+    keys = _guide_table_param_keys()
+    unknown = keys - _REGISTRY_PARAM_KEYS
+    assert not unknown, f"guide 표 키가 레지스트리에 없음: {sorted(unknown)}"
+
+
+def test_guide_examples_have_no_legacy_keys() -> None:
+    """guide 코드 예제의 get_indicator dict 키에 블랙리스트 키가 없다."""
+    keys = _guide_example_param_keys()
+    assert keys, "guide 예제에서 get_indicator 파라미터 키를 추출하지 못함 (파서 회귀)"
+    leaked = keys & set(_LEGACY_PARAM_KEYS)
+    assert not leaked, f"guide 예제가 legacy 키를 사용: {sorted(leaked)}"
+
+
+def test_guide_example_keys_are_registry_keys() -> None:
+    """guide 예제의 각 dict 키가 레지스트리 정식 키다."""
+    keys = _guide_example_param_keys()
+    unknown = keys - _REGISTRY_PARAM_KEYS
+    assert not unknown, f"guide 예제 키가 레지스트리에 없음: {sorted(unknown)}"
+
+
+# ── (b) 레지스트리 honored 행위 검증 ─────────────────────────────────────────
+
+
+@pytest.fixture
+def ohlcv_arrays() -> dict[str, np.ndarray]:
+    """지표 계산에 충분한 길이의 OHLCV (n=60)."""
+    rng = np.random.default_rng(42)
+    n = 60
+    close = 50000.0 + np.cumsum(rng.normal(0, 100, n))
+    high = close + rng.uniform(50, 200, n)
+    low = close - rng.uniform(50, 200, n)
+    open_ = close + rng.normal(0, 50, n)
+    volume = rng.uniform(1000, 10000, n)
+    return {
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+    }
+
+
+def _flatten(result: dict[str, np.ndarray]) -> np.ndarray:
+    """다중 출력 결과를 단일 1D 배열로 직렬화 (비교용)."""
+    return np.concatenate([np.asarray(v, dtype=float).ravel() for v in result.values()])
+
+
+def _override_value(key: str, default: object) -> object:
+    """레지스트리 기본값과 확실히 다른 override 값을 만든다.
+
+    정수 기간 파라미터는 **줄이는** 방향으로 바꾼다. 늘리면 lookback이 커져
+    고정 길이 OHLCV로는 pandas-ta가 None을 반환(데이터 부족)할 수 있어
+    silent-drop과 구분되지 않기 때문이다. 최소 2 이상은 보장한다.
+    """
+    if isinstance(default, bool):
+        return not default
+    if isinstance(default, int):
+        return max(2, default - 3)
+    if isinstance(default, float):
+        return default + 3.0
+    raise AssertionError(f"unexpected default type for {key}: {type(default)}")
+
+
+# params를 가진 모든 지표 × 각 레지스트리 키 조합을 파라미터화.
+_HONOR_CASES = [
+    (name, key, default)
+    for name, spec in sorted(INDICATOR_REGISTRY.items())
+    for key, default in spec["params"].items()
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "key", "default"),
+    _HONOR_CASES,
+    ids=[f"{n}-{k}" for n, k, _ in _HONOR_CASES],
+)
+def test_registry_param_is_honored(
+    name: str,
+    key: str,
+    default: object,
+    ohlcv_arrays: dict[str, np.ndarray],
+) -> None:
+    """각 레지스트리 키를 비기본값으로 전달하면 결과가 기본과 달라진다.
+
+    silent-drop(예: bbands ``std``)을 직접 검출한다. 키가 honored면 비기본값
+    전달 시 출력이 변해야 한다.
+    """
+    baseline = IndicatorCalculator.compute(name, ohlcv_arrays)
+    assert baseline, f"{name} baseline 계산 실패 (데이터 부족?)"
+
+    override = {key: _override_value(key, default)}
+    changed = IndicatorCalculator.compute(name, ohlcv_arrays, **override)
+    assert changed, f"{name} {key} override 계산 실패"
+
+    base_flat = _flatten(baseline)
+    changed_flat = _flatten(changed)
+    # 출력 형태가 그대로면(키/길이 동일) 값 비교, 다르면 자명히 변경된 것.
+    if base_flat.shape == changed_flat.shape:
+        differs = not np.allclose(base_flat, changed_flat, equal_nan=True)
+    else:
+        differs = True
+    assert differs, (
+        f"{name}의 '{key}={override[key]}' 전달이 기본 출력과 동일 — "
+        f"silent-drop 의심 (레지스트리 키가 pandas-ta에 반영되지 않음)"
+    )
+
+
+# ── (c) 가드 동작 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("name", "legacy_key", "hint_fragment"),
+    [
+        ("rsi", "timeperiod", "length"),
+        ("sma", "timeperiod", "length"),
+        ("bbands", "nbdev", "lower_std"),
+        ("bbands", "std", "lower_std"),
+        ("stoch", "fastk", "k"),
+        ("stoch", "slowk", "smooth_k"),
+        ("stoch", "slowd", "d"),
+    ],
+)
+def test_compute_rejects_legacy_key(
+    name: str,
+    legacy_key: str,
+    hint_fragment: str,
+    ohlcv_arrays: dict[str, np.ndarray],
+) -> None:
+    """블랙리스트 키 전달 시 정정 힌트를 담은 ValueError가 발생한다."""
+    with pytest.raises(ValueError) as exc_info:
+        IndicatorCalculator.compute(name, ohlcv_arrays, **{legacy_key: 14})
+    msg = str(exc_info.value)
+    assert legacy_key in msg, f"에러 메시지에 미인식 키 '{legacy_key}' 누락: {msg}"
+    assert hint_fragment in msg, (
+        f"에러 메시지에 정정 키 힌트 '{hint_fragment}' 누락: {msg}"
+    )
+
+
+def test_compute_accepts_correct_keys(ohlcv_arrays: dict[str, np.ndarray]) -> None:
+    """정식 키는 가드를 통과한다 (false-reject 0)."""
+    assert IndicatorCalculator.compute("rsi", ohlcv_arrays, length=20)
+    assert IndicatorCalculator.compute(
+        "bbands", ohlcv_arrays, length=20, lower_std=2.5, upper_std=2.5
+    )
+    assert IndicatorCalculator.compute("stoch", ohlcv_arrays, k=10, d=3, smooth_k=3)
+
+
+def test_legacy_keys_not_valid_for_any_indicator() -> None:
+    """블랙리스트 키는 어느 지표의 정식 레지스트리 키도 아니다 (전역 거부 안전성)."""
+    overlap = set(_LEGACY_PARAM_KEYS) & _REGISTRY_PARAM_KEYS
+    assert not overlap, (
+        f"블랙리스트 키가 정식 레지스트리 키와 충돌(전역 거부 위험): {sorted(overlap)}"
+    )

--- a/tests/unit/test_indicators.py
+++ b/tests/unit/test_indicators.py
@@ -285,6 +285,53 @@ def test_compute_stoch(ohlcv_arrays: dict[str, np.ndarray]):
     assert set(result.keys()) == {"slowk", "slowd"}
 
 
+# ── bbands 밴드폭 파라미터 실효 (#2404) ──
+#
+# pandas-ta 0.4.71b0 `bbands`는 `std` 인자가 없어 silent-drop되고,
+# `lower_std`/`upper_std`만 밴드폭에 반영된다. 레지스트리가 `std`를 등록했던
+# 회귀를 차단한다.
+
+
+def test_compute_bbands_std_override_changes_bands(
+    ohlcv_arrays: dict[str, np.ndarray],
+):
+    """bbands lower_std/upper_std 변경 시 밴드폭(lower/upper)이 실제로 변한다."""
+    base = IndicatorCalculator.compute("bbands", ohlcv_arrays, length=20)
+    wide = IndicatorCalculator.compute(
+        "bbands", ohlcv_arrays, length=20, lower_std=5.0, upper_std=5.0
+    )
+    # middle(중심선)은 std와 무관하게 동일해야 한다.
+    np.testing.assert_allclose(base["middle"], wide["middle"], equal_nan=True)
+    # lower/upper 밴드는 std=5.0에서 더 멀어져야 한다 (silent-drop이면 동일).
+    valid = ~np.isnan(base["upper"]) & ~np.isnan(wide["upper"])
+    assert valid.any(), "유효한 밴드 값이 없음 (데이터 부족)"
+    assert not np.allclose(base["upper"][valid], wide["upper"][valid]), (
+        "upper 밴드가 std override에 반영되지 않음 — silent-drop 회귀"
+    )
+    assert not np.allclose(base["lower"][valid], wide["lower"][valid]), (
+        "lower 밴드가 std override에 반영되지 않음 — silent-drop 회귀"
+    )
+    # 밴드폭이 실제로 넓어졌는지 확인 (방향성).
+    base_width = base["upper"][valid] - base["lower"][valid]
+    wide_width = wide["upper"][valid] - wide["lower"][valid]
+    assert np.all(wide_width >= base_width - 1e-9), (
+        "std=5.0이 std=2.0보다 밴드폭이 넓어야 한다"
+    )
+
+
+def test_compute_bbands_default_params_are_pandas_ta_keys():
+    """bbands 레지스트리 기본 파라미터가 pandas-ta 정식 키만 사용한다."""
+    params = INDICATOR_REGISTRY["bbands"]["params"]
+    assert set(params) == {"length", "lower_std", "upper_std"}
+    assert "std" not in params, "std는 pandas-ta bbands에 없는 silent-drop 키"
+
+
+def test_compute_legacy_key_raises(ohlcv_arrays: dict[str, np.ndarray]):
+    """legacy 키(timeperiod) 전달 시 정정 힌트를 담은 ValueError를 발생시킨다."""
+    with pytest.raises(ValueError, match="length"):
+        IndicatorCalculator.compute("rsi", ohlcv_arrays, timeperiod=14)
+
+
 # ── None 결과 가드 (#2323) ──
 #
 # pandas-ta는 데이터 부족 시 None을 반환할 수 있다. compute()가 이를 방어하지


### PR DESCRIPTION
Closes #2404

## Summary
공식 스펙·가이드는 지표 파라미터 키를 TA-Lib 규약(`timeperiod`/`nbdev`/`fastk`…)으로 안내하나, 런타임 `INDICATOR_REGISTRY`/`compute()`는 pandas-ta 규약(`length`/`std`/`k`/`d`/`smooth_k`)을 쓴다. 문서대로 `{"timeperiod": 14}`를 넘기면 pandas-ta가 미인식 kwargs를 **silent drop**해 사용자 의도가 오류·경고 없이 누락된다(15지표 중 13건 키 불일치). 사용자 결정 **docs 정정 + 런타임 가드**로 해소.

- **bbands 레지스트리 교정**: `{"std": 2.0}` → `{"lower_std": 2.0, "upper_std": 2.0}` (pandas-ta 0.4.71b0 `bbands`에 `std` 인자 없어 silent-drop — `lower_std`/`upper_std`만 밴드폭 반영, 실측 확인).
- **`compute()` legacy-key 블랙리스트 가드**: 사용자 전달 params에 오명명 키(`timeperiod`/`nbdev`/`std`/`fastk`/`slowk`/`slowd`)가 있으면 `ValueError`(정정 키 힌트 포함) raise. **블랙리스트 방식**(allowlist 아님) — pandas-ta 15함수 전부 `**kwargs` 보유 + 일부 정당 파라미터가 kwargs-pop이라 allowlist는 정당 입력 false-reject. 블랙리스트 6키는 15지표 어디서도 유효하지 않음(`test_legacy_keys_not_valid_for_any_indicator`가 lock). 기존 `Unknown indicator` ValueError와 일관.
- **docs 정정**: `docs/specs/strategy/03-06-indicator-calculator.md`(파라미터 표 + compute 에러 계약 신설), `guide/strategy.md`(예제·표 정식 키, 130+→15종 화이트리스트, ghost 지표 미지원 표기).
- **계약 테스트 신설** `tests/unit/contracts/test_indicator_param_drift.py`: (a) docs↔키 계약(표·예제 파서), (b) 레지스트리 honored 행위 검증(각 키 비기본값 전달 시 결과 변화 — silent-drop 직접 검출), (c) 가드 동작.

## 리뷰
- Plan Preflight: 진실성 검증(3 검증자 0 반증) + @code-reviewer 대체 게이트 rev2 approve-implement(Codex 정식 리뷰는 사용량 한도로 보류 — 리셋 후 보완 권장).
- Codex 브랜치 리뷰: attempt 1 PASS.

## Test Plan
- failing-first 확인: (a) docs 원복 시 6 FAIL / (b) bbands std silent-drop AssertionError / (c) 가드 원복 시 legacy 거부 FAIL — fix 후 전부 통과.
- `ruff check`/`format --check`: clean
- `mypy src/`(236 files): Success
- `pytest tests/unit`: **7572 passed, 2 skipped** (지표·계약 80 / 회귀 test_indicators+test_backtest 207)

## Non-Goals
- TA-Lib alias 수용(거부만), pandas-ta 130+ 지표 등록(ghost는 미지원 표기만), `get_indicator` 시그니처 변경, 블랙리스트 외 임의 오타 정적 검출(validator 확장은 follow-up 후보).

🤖 Generated with [Claude Code](https://claude.com/claude-code)