### PR TITLE
docs: #2406 README KIS 실전 REST 계약 모의 한정 고지

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ ante backtest run strategies/my_strategy.py \
 
 이 프로젝트는 실제 자금을 다루는 시스템입니다. 충분한 테스트(백테스트·모의투자) 후 사용하세요. Ante는 완벽하지 않습니다 — [보안 주의사항](guide/security.md)을 먼저 확인하세요.
 
+KIS 신세대 REST 계약(주문/취소/체결조회)은 **모의투자 환경에서만 검증**됐습니다. 실전투자 경로(체결조회 `TTTC0081R`·정정취소 `TTTC0013U`·`CTSC9215R`)는 미검증이며, 실전 전환 전 사용자 oracle A/B 검증이 필요합니다. 상세·전환 체크리스트: `docs/specs/broker-adapter/18-fill-recovery.md` §11.6/§11.7.
+
 ## 라이선스
 
 [MIT](LICENSE)


### PR DESCRIPTION
Closes #2406

## Summary
KIS 신세대 REST 계약(주문/취소/체결조회)이 **모의투자 한정 검증**이고 실전(TTTC0081R/TTTC0013U/CTSC9215R) 미검증인데 v0.11.0 CHANGELOG 런타임 항목에 한정어가 없어 user-facing 고지가 누락됨(genuine P3, docs-only). 런타임은 `fill_scheduler.py:702` is_paper gate로 비가역 fallback이 실전 차단되어 코드 결함은 아님.

- `README.md` `## ⚠️ 주의`에 KIS 실전 미검증 Known Limitation + 전환 체크리스트 SSOT(`docs/specs/broker-adapter/18-fill-recovery.md` §11.6/§11.7) 참조 추가(한글 통일, 실행모드 영어 병기 없음, tr_id 코드만 식별자 유지).
- **CHANGELOG 미수정**(python-semantic-release 자동생성물 — 수기 삽입 비멱등 회피, 사용자 결정), 스펙 미변경(이미 SSOT 정합), 코드 무변.

## 리뷰
- 검증: 적대적 검증 워크플로(반증 0/3) genuine-needs-fix(P3).
- Plan: @code-reviewer 대체 게이트 rev2 approve-implement(Codex adversarial-review 사용량 한도). Codex 브랜치 리뷰 PASS.

## Test Plan
- 수동 grep `(paper)|(live)|paper/live|paper|live` README → 0건(영어 mode 단독 표기 없음).
- `ruff format --check`: clean / `pytest tests/unit`: 7572 passed, 2 skipped(docs-only 회귀 없음).

## Follow-up
- terminology guard SEARCH_ROOTS가 README 미스캔(자동 회귀 락 없음, known-limitation) → guard에 repo-root *.md 추가는 별도 follow-up 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)