### PR TITLE
fix(trade): #2407 FillOutboxPublisher DB 손상 escalation/backoff (국소)

### DIFF
--- a/src/ante/trade/fill_outbox.py
+++ b/src/ante/trade/fill_outbox.py
@@ -157,8 +157,37 @@ LOOP_BACKOFF_MULTIPLIER_CAP = 8
 
 # 연속 DB 손상 실패가 이 임계에 도달하면 escalation(ERROR/CRITICAL 승격 +
 # NotificationEvent) 을 정확히 1회 수행한다(#2407 이슈 제안값). 카운터가 0 으로
-# reset(드레인 성공/비-DB 예외)되기 전까지 재발행하지 않아 알림 spam 을 막는다.
+# reset(드레인 성공/비-손상 예외)되기 전까지 재발행하지 않아 알림 spam 을 막는다.
 _ESCALATE_THRESHOLD = 10
+
+# DB **손상**(reconnect 로 회복 불가) 시그니처. database.py:20-23 의 SSOT 재전파
+# 시그니처(``database disk image is malformed`` / ``file is not a database``)와
+# 정합한다. ``sqlite3.DatabaseError`` **타입만으로 손상을 판정하면 안 된다**(#2407
+# Codex P2): 같은 타입 계층에 ``OperationalError: database is locked`` (외부 프로세스
+# /긴 트랜잭션 — transient, 곧 회복)·``no such table``·``sqlite3.ProgrammingError``
+# (내부 버그류) 등 비-손상 오류가 섞여 있다. 이들을 손상으로 오분류하면 손상 카운터
+# 누적 → backoff 로 notify 가 막혀 체결 이벤트 전달이 지연되고, 임계 후 잘못된 DB 손상
+# 알림까지 발행된다. 메시지 소문자화 후 substring 매칭으로 표현 변형에 견고하게,
+# 손상 시그니처가 포함된 예외만 좁혀 잡는다.
+_DB_CORRUPTION_SIGNATURES: tuple[str, ...] = (
+    "malformed",
+    "file is not a database",
+)
+
+
+def _is_db_corruption(exc: BaseException) -> bool:
+    """예외가 **DB 손상**(reconnect 로 회복 불가)인지 판별한다 (#2407 Codex P2).
+
+    ``sqlite3.DatabaseError`` 타입만으로 판정하지 않는다. transient(``database is
+    locked``)·내부 버그(``no such table``/``ProgrammingError``)는 손상이 아니므로
+    backoff·카운터·escalation 경로에서 제외해야 한다. database.py:20-23 SSOT 손상
+    시그니처가 메시지에 포함될 때만 True 를 반환한다(소문자화 후 substring, 표현
+    변형 견고). 비-손상 ``DatabaseError`` 는 비-DB 예외와 같은 reset 경로로 흐른다.
+    """
+    if not isinstance(exc, sqlite3.DatabaseError):
+        return False
+    message = str(exc).lower()
+    return any(sig in message for sig in _DB_CORRUPTION_SIGNATURES)
 
 
 class FillOutboxPublisher:
@@ -322,36 +351,47 @@ class FillOutboxPublisher:
                 await self._drain()
             except asyncio.CancelledError:
                 raise
-            except sqlite3.DatabaseError as exc:
-                # malformed/not-a-database 등 DB 손상(database.py:21-23 SSOT 로 재전파).
-                # reconnect 로 회복 불가하므로 backoff 로 hammer 를 막고, 연속 실패를
-                # 누적해 임계 도달 시 escalation(O2) 한다. _running 은 유지(O3 liveness)
-                # — 외부 DB 복구 시 다음 사이클에 자동 재개·멱등 드레인(O4).
-                self._consecutive_failures += 1
-                delay = self._backoff_delay()
-                next_drain_at = loop.time() + delay
-                if self._consecutive_failures >= _ESCALATE_THRESHOLD:
-                    await self._escalate(exc)
+            except Exception as exc:
+                if _is_db_corruption(exc):
+                    # malformed/file is not a database 등 DB **손상**(database.py
+                    # :20-23 SSOT 로 재전파). reconnect 로 회복 불가하므로 backoff 로
+                    # hammer 를 막고, 연속 실패를 누적해 임계 도달 시 escalation(O2)
+                    # 한다. _running 은 유지(O3 liveness) — 외부 DB 복구 시 다음
+                    # 사이클에 자동 재개·멱등 드레인(O4). 비-손상 ``DatabaseError``
+                    # (``database is locked`` 같은 transient·``no such table``/
+                    # ``ProgrammingError`` 같은 내부 버그)는 이 손상 경로로 들어오지
+                    # 않는다(#2407 Codex P2: 손상 오분류 차단).
+                    self._consecutive_failures += 1
+                    delay = self._backoff_delay()
+                    next_drain_at = loop.time() + delay
+                    if self._consecutive_failures >= _ESCALATE_THRESHOLD:
+                        await self._escalate(exc)
+                    else:
+                        logger.warning(
+                            "FillOutboxPublisher DB 손상 드레인 실패 (연속 %d회) — "
+                            "%.0fs 후 재시도: %s",
+                            self._consecutive_failures,
+                            delay,
+                            exc,
+                            exc_info=True,
+                        )
                 else:
+                    # 비-손상 예외(transient ``database is locked``·내부 버그류
+                    # ``no such table``/``ProgrammingError``·비-DB 예외)는 backoff 로
+                    # 은폐하지 않는다(#2350 dual-branch 미러). 선행 손상 실패로
+                    # backoff·escalation latch 가 올라가 있었다면 카운터·latch 를 reset
+                    # 해 다음 사이클이 base drain_interval 로 복귀하게 한다(은폐 금지).
+                    # 이후 기존대로 WARNING + 즉시 다음 주기 재시도(즉시재시도 경로).
+                    # 주의: ``database is locked`` 는 transient 라 즉시재시도가 hammer
+                    # 가 될 수 있으나, 본 이슈(#2407) 범위는 손상 escalation 이다.
+                    # locked 전용 backoff 는 범위 밖(기존 WARNING 경로 유지) — 필요 시
+                    # follow-up.
+                    self._reset_failures()
+                    next_drain_at = loop.time()
                     logger.warning(
-                        "FillOutboxPublisher DB 손상 드레인 실패 (연속 %d회) — "
-                        "%.0fs 후 재시도: %s",
-                        self._consecutive_failures,
-                        delay,
-                        exc,
+                        "FillOutboxPublisher 드레인 오류(비-손상) — 다음 사이클 재시도",
                         exc_info=True,
                     )
-            except Exception:
-                # 비-DB 예외(내부 버그류)는 backoff 로 은폐하지 않는다. 선행 DB 실패로
-                # backoff·escalation latch 가 올라가 있었다면 카운터·latch 를 reset 해
-                # 다음 사이클이 base drain_interval 로 복귀하게 한다(은폐 금지, #2350
-                # dual-branch 미러). 이후 기존대로 WARNING + 즉시 다음 주기 재시도.
-                self._reset_failures()
-                next_drain_at = loop.time()
-                logger.warning(
-                    "FillOutboxPublisher 드레인 오류 — 다음 사이클 재시도",
-                    exc_info=True,
-                )
             else:
                 # 정상 드레인 — 카운터·escalation latch reset, base 주기로 복귀(O1).
                 self._reset_failures()

--- a/src/ante/trade/fill_outbox.py
+++ b/src/ante/trade/fill_outbox.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import sqlite3
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -145,6 +146,20 @@ class FillOutbox:
 # 이 주기는 누락 통지/기동 잔여분에 대한 백스톱이다.
 DEFAULT_DRAIN_INTERVAL = 1.0
 
+# steady-state 드레인 루프(_loop) 연속 DB 손상 실패 backoff 상한 배수 (#2407).
+# n번째 연속 실패 직후 backoff = drain_interval × min(2^n, LOOP_BACKOFF_MULTIPLIER_CAP)
+# (첫 실패 ×2, 이후 ×4, ×8 cap). 기본 drain 1s 기준 상한 8s — malformed/not-a-database
+# 는 reconnect 로 회복 불가(database.py:21-23)하므로 backoff 는 1초 즉시 무한 재시도
+# (로그 오염·hammer)를 막는 용도이고, 외부 DB 복구 시점을 놓치지 않게 cap 을 짧게 둔다.
+# 형제 #2350(fill_scheduler) 의 broker-transient cooldown 과 같은 산식이되, 여기서는
+# wakeup 우회 차단(O5)·escalation(O2) 이 추가된다.
+LOOP_BACKOFF_MULTIPLIER_CAP = 8
+
+# 연속 DB 손상 실패가 이 임계에 도달하면 escalation(ERROR/CRITICAL 승격 +
+# NotificationEvent) 을 정확히 1회 수행한다(#2407 이슈 제안값). 카운터가 0 으로
+# reset(드레인 성공/비-DB 예외)되기 전까지 재발행하지 않아 알림 spam 을 막는다.
+_ESCALATE_THRESHOLD = 10
+
 
 class FillOutboxPublisher:
     """미발행 outbox row 를 ``OrderFilledEvent`` 로 발행하는 워커 (lifecycle).
@@ -176,6 +191,12 @@ class FillOutboxPublisher:
         # enqueue 직후 즉시 드레인을 깨우는 신호. 누락돼도 주기 루프가 백스톱한다.
         self._wakeup = asyncio.Event()
         self._drain_lock = asyncio.Lock()
+        # 연속 DB 손상(sqlite3.DatabaseError) 실패 카운터 (#2407 O1). 드레인 성공 또는
+        # 비-DB 예외 시 0 으로 reset 한다. _ESCALATE_THRESHOLD 도달 시 escalation(O2).
+        self._consecutive_failures = 0
+        # escalation NotificationEvent 가 카운터 0 reset 전까지 정확히 1회만 발행되게
+        # 막는 latch (#2407 O2 exactly-once). reset 시 함께 내려가 재발행 가능해진다.
+        self._escalated = False
 
     def notify(self) -> None:
         """enqueue 직후 호출 — 워커를 깨워 즉시 드레인하게 한다(비동기 트리거)."""
@@ -243,15 +264,57 @@ class FillOutboxPublisher:
                 pass
             self._task = None
 
+    def _backoff_delay(self) -> float:
+        """현재 연속 DB 손상 실패 횟수에 대한 backoff 지연(초)을 산출한다 (#2407 O1).
+
+        실패가 없으면(``_consecutive_failures == 0``) base ``drain_interval`` 로,
+        n회 연속 실패면 ``drain_interval × min(2^n, LOOP_BACKOFF_MULTIPLIER_CAP)`` 로
+        늘린다(첫 실패 ×2, 이후 ×4, ×8 cap). malformed/not-a-database 는 reconnect 로
+        회복 불가하므로, backoff 는 1초 즉시 무한 재시도(hammer·로그 오염)를 막고 외부
+        DB 복구 관측 주기를 bounded 로 유지하는 용도다.
+        """
+        if self._consecutive_failures <= 0:
+            return self._drain_interval
+        multiplier = min(2**self._consecutive_failures, LOOP_BACKOFF_MULTIPLIER_CAP)
+        return self._drain_interval * multiplier
+
     async def _loop(self) -> None:
+        # next_drain_at: 실패 backoff 동안 다음 드레인이 허용되는 monotonic 시각.
+        # 실패가 없는 정상 상태에서는 종전 동작(=wait_for(_wakeup, drain_interval):
+        # notify 즉시 드레인 / timeout 백스톱)을 그대로 유지해 notify 즉시성을 보존한다.
+        # 실패 상태(_consecutive_failures>0)에서만 이 deadline 으로 게이팅해, notify/
+        # enqueue 가 _wakeup 을 set 해 깨어나도 backoff 미경과면 우회 못 하게 한다
+        # (#2407 O5). 형제 #2350 은 wakeup 없는 고정 sleep 이라 이 게이팅이 불요다.
+        loop = asyncio.get_running_loop()
+        next_drain_at = loop.time()
         while self._running:
-            try:
-                await asyncio.wait_for(
-                    self._wakeup.wait(), timeout=self._drain_interval
-                )
-            except TimeoutError:
-                # 주기 백스톱 드레인 (notify 누락 대비).
-                pass
+            if self._consecutive_failures > 0:
+                # 실패 backoff 구간: deadline 까지 남은 시간만 wakeup 을 기다린다.
+                # notify 로 일찍 깨어나도 deadline 미경과면 _wakeup 을 소거하고 잔여
+                # backoff 를 마저 대기한다(우회 차단, O5).
+                remaining = next_drain_at - loop.time()
+                if remaining > 0:
+                    try:
+                        await asyncio.wait_for(self._wakeup.wait(), timeout=remaining)
+                    except TimeoutError:
+                        # backoff deadline 도달 — 재드레인 진행.
+                        pass
+                    else:
+                        self._wakeup.clear()
+                        if not self._running:
+                            return
+                        if loop.time() < next_drain_at:
+                            # notify 우회 시도 — backoff 미경과라 즉시 재드레인 거부.
+                            continue
+            else:
+                # 정상 상태: 종전 백스톱 주기. notify 면 즉시, timeout 이면 백스톱.
+                try:
+                    await asyncio.wait_for(
+                        self._wakeup.wait(), timeout=self._drain_interval
+                    )
+                except TimeoutError:
+                    # 주기 백스톱 드레인 (notify 누락 대비).
+                    pass
             self._wakeup.clear()
             if not self._running:
                 return
@@ -259,8 +322,89 @@ class FillOutboxPublisher:
                 await self._drain()
             except asyncio.CancelledError:
                 raise
+            except sqlite3.DatabaseError as exc:
+                # malformed/not-a-database 등 DB 손상(database.py:21-23 SSOT 로 재전파).
+                # reconnect 로 회복 불가하므로 backoff 로 hammer 를 막고, 연속 실패를
+                # 누적해 임계 도달 시 escalation(O2) 한다. _running 은 유지(O3 liveness)
+                # — 외부 DB 복구 시 다음 사이클에 자동 재개·멱등 드레인(O4).
+                self._consecutive_failures += 1
+                delay = self._backoff_delay()
+                next_drain_at = loop.time() + delay
+                if self._consecutive_failures >= _ESCALATE_THRESHOLD:
+                    await self._escalate(exc)
+                else:
+                    logger.warning(
+                        "FillOutboxPublisher DB 손상 드레인 실패 (연속 %d회) — "
+                        "%.0fs 후 재시도: %s",
+                        self._consecutive_failures,
+                        delay,
+                        exc,
+                        exc_info=True,
+                    )
             except Exception:
+                # 비-DB 예외(내부 버그류)는 backoff 로 은폐하지 않는다. 선행 DB 실패로
+                # backoff·escalation latch 가 올라가 있었다면 카운터·latch 를 reset 해
+                # 다음 사이클이 base drain_interval 로 복귀하게 한다(은폐 금지, #2350
+                # dual-branch 미러). 이후 기존대로 WARNING + 즉시 다음 주기 재시도.
+                self._reset_failures()
+                next_drain_at = loop.time()
                 logger.warning(
                     "FillOutboxPublisher 드레인 오류 — 다음 사이클 재시도",
                     exc_info=True,
                 )
+            else:
+                # 정상 드레인 — 카운터·escalation latch reset, base 주기로 복귀(O1).
+                self._reset_failures()
+                next_drain_at = loop.time() + self._drain_interval
+
+    def _reset_failures(self) -> None:
+        """연속 실패 카운터와 escalation latch 를 초기화한다 (#2407 O1·O2 reset)."""
+        self._consecutive_failures = 0
+        self._escalated = False
+
+    async def _escalate(self, exc: BaseException) -> None:
+        """연속 DB 손상 실패 임계 도달 시 CRITICAL 승격 + NotificationEvent 1회 (O2).
+
+        ``_escalated`` latch 로 카운터가 0 으로 reset 되기 전까지 정확히 1회만
+        발행해 알림 spam 을 막는다(#2407 O2 exactly-once). NotificationEvent publish
+        는 try/except 로 감싸 escalation 발행 실패가 드레인 루프를 죽이지 않게 한다
+        (#2407 O3 liveness). 패턴은 fill_scheduler.py:654-667 동형(category=system).
+        """
+        logger.critical(
+            "FillOutboxPublisher DB 손상 드레인 %d회 연속 실패 — 체결 이벤트 정체. "
+            "DB 무결성 점검 필요(malformed 회복 불가): %s",
+            self._consecutive_failures,
+            exc,
+            exc_info=True,
+        )
+        if self._escalated:
+            # 이미 임계 도달 알림을 보냈다. reset 전까지 재발행 금지(spam 방지).
+            return
+        self._escalated = True
+        from ante.eventbus.events import NotificationEvent
+
+        try:
+            await self._eventbus.publish(
+                NotificationEvent(
+                    level="error",
+                    title="체결 이벤트 발행 정체 (DB 손상)",
+                    message=(
+                        "FillOutboxPublisher 드레인이 DB 손상으로 "
+                        f"{self._consecutive_failures}회 연속 실패해 체결 "
+                        "이벤트(OrderFilledEvent) 발행이 정체됐습니다. "
+                        "Treasury 정산·전략 on_fill·notification 소비자가 "
+                        "영향받습니다. malformed/file is not a database 는 "
+                        "재연결로 회복되지 않으니 DB 무결성 점검·복구가 "
+                        "필요합니다."
+                    ),
+                    category="system",
+                )
+            )
+        except Exception:
+            # escalation 발행 실패가 루프를 죽이지 않게 swallow (O3). 다음 임계 재도달
+            # 시 _escalated 가 이미 True 라 재시도하지 않으나, CRITICAL 로그는 매 사이클
+            # 남아 운영자가 인지할 수 있다.
+            logger.exception(
+                "FillOutboxPublisher escalation NotificationEvent 발행 실패 — "
+                "루프는 계속 진행(CRITICAL 로그로 가시성 유지)"
+            )

--- a/tests/unit/test_fill_outbox.py
+++ b/tests/unit/test_fill_outbox.py
@@ -24,10 +24,12 @@ from ante.eventbus import EventBus
 from ante.eventbus.events import NotificationEvent, OrderFilledEvent
 from ante.trade.fill_applier import FillApplier
 from ante.trade.fill_outbox import (
+    _DB_CORRUPTION_SIGNATURES,
     _ESCALATE_THRESHOLD,
     LOOP_BACKOFF_MULTIPLIER_CAP,
     FillOutbox,
     FillOutboxPublisher,
+    _is_db_corruption,
     canonical_cumulative,
     make_fill_dedup_key,
 )
@@ -608,3 +610,138 @@ async def test_loop_non_db_exception_resets_counter(eventbus, monkeypatch):
     # (비-DB 가 직전 DB 실패 backoff 로 은폐되지 않고 카운터·backoff 해제 — #2350 미러)
     last_interval = harness.drain_times[-1] - harness.drain_times[-2]
     assert last_interval == publisher._drain_interval
+
+
+# ── _is_db_corruption predicate (#2407 Codex P2) ─────
+#
+# 손상(reconnect 회복 불가) 시그니처만 backoff/escalation 경로에 태우고, 비-손상
+# DatabaseError(transient locked·내부 버그류)는 reset 경로로 보내기 위한 판별기.
+
+
+def test_is_db_corruption_matches_only_corruption_signatures():
+    """손상 시그니처만 True, transient/내부버그/비-DB 는 False.
+
+    ``sqlite3.DatabaseError`` 타입 게이트 + 메시지 substring 매칭을 모두 락한다
+    (타입만으로 손상을 판정하지 않는다).
+    """
+    # database.py:20-23 SSOT 손상 시그니처 → True (대소문자/표현 변형 견고).
+    assert _is_db_corruption(
+        sqlite3.OperationalError("database disk image is malformed")
+    )
+    assert _is_db_corruption(sqlite3.DatabaseError("file is not a database"))
+    assert _is_db_corruption(sqlite3.OperationalError("FILE IS NOT A DATABASE"))
+    assert _is_db_corruption(sqlite3.DatabaseError("MALFORMED database image"))
+
+    # 비-손상 transient (외부 lock — 곧 회복) → False (손상 카운터/backoff 제외).
+    assert not _is_db_corruption(sqlite3.OperationalError("database is locked"))
+    # 내부 버그류(스키마/쿼리 결함) → False (backoff 로 은폐 금지).
+    assert not _is_db_corruption(sqlite3.OperationalError("no such table: fill_outbox"))
+    assert not _is_db_corruption(sqlite3.ProgrammingError("bad SQL"))
+    # 비-DatabaseError → False (타입 게이트: 메시지에 손상 문구가 있어도 무시).
+    assert not _is_db_corruption(RuntimeError("malformed"))
+    assert not _is_db_corruption(ValueError("file is not a database"))
+
+
+def test_db_corruption_signatures_align_with_database_ssot():
+    """손상 시그니처가 database.py SSOT 재전파 문구(소문자)와 정합한다.
+
+    database.py:20-23 은 ``database disk image is malformed`` / ``file is not a
+    database`` 를 무결성 문제로 재전파한다. 본 predicate 시그니처가 그 문구의
+    부분집합(소문자)이어야 손상을 정확히 좁혀 잡는다.
+    """
+    assert "malformed" in _DB_CORRUPTION_SIGNATURES
+    assert "file is not a database" in _DB_CORRUPTION_SIGNATURES
+    # database.py SSOT 재전파 문구가 각 시그니처를 포함한다(정합 락).
+    assert "malformed" in "database disk image is malformed".lower()
+    assert "file is not a database" in "file is not a database".lower()
+
+
+async def test_loop_transient_locked_not_treated_as_corruption(eventbus, monkeypatch):
+    """비-손상 transient ``database is locked`` → 손상 카운터 미누적·backoff 미발생.
+
+    **이번 P2 회귀 락**: 이전에는 모든 ``sqlite3.DatabaseError`` 를 손상으로
+    오분류해 ``database is locked``(외부 프로세스/긴 트랜잭션 — transient) 가
+    손상 카운터를 누적시키고 backoff 로 notify 를 막았다. 이제 손상 predicate 로
+    좁혀, locked 는 비-손상 reset 경로(즉시재시도)로 흘러 notify 즉시성이 보존된다.
+    """
+    notifications: list[NotificationEvent] = []
+
+    async def _on_notify(event):
+        if isinstance(event, NotificationEvent):
+            notifications.append(event)
+
+    eventbus.subscribe(NotificationEvent, _on_notify)
+
+    ob = object.__new__(FillOutbox)
+    publisher = FillOutboxPublisher(outbox=ob, eventbus=eventbus, drain_interval=1.0)
+
+    harness = _LoopHarness(publisher, monkeypatch)
+    # locked 를 임계(10) 초과로 반복해도 손상 카운터가 누적되지 않아야 한다.
+    harness.drain_outcomes = [
+        sqlite3.OperationalError("database is locked")
+        for _ in range(_ESCALATE_THRESHOLD + 3)
+    ]
+    harness.install()
+    await harness.run()
+
+    # 손상 카운터 누적 안 됨 + escalation latch 미설정.
+    assert publisher._consecutive_failures == 0
+    assert publisher._escalated is False
+    # 잘못된 DB 손상 알림이 발행되지 않았다.
+    assert notifications == []
+    # 매 사이클 base 주기(drain_interval)로 즉시 재시도 — backoff escalation 미발생.
+    # (notify 즉시성 보존: 손상 backoff 게이팅에 들어가지 않음)
+    intervals = [
+        harness.drain_times[i + 1] - harness.drain_times[i]
+        for i in range(len(harness.drain_times) - 1)
+    ]
+    assert all(iv == publisher._drain_interval for iv in intervals)
+
+
+async def test_loop_internal_bug_db_error_resets_counter(eventbus, monkeypatch):
+    """내부 버그류 ``no such table``/``ProgrammingError`` → 카운터 reset(은폐 금지).
+
+    비-손상 ``DatabaseError`` 도 backoff/escalation 으로 은폐하지 않고, 선행 손상
+    실패 backoff 가 있었다면 reset 해 base 주기로 복귀한다(#2350 dual-branch 미러).
+    """
+    notifications: list[NotificationEvent] = []
+
+    async def _on_notify(event):
+        if isinstance(event, NotificationEvent):
+            notifications.append(event)
+
+    eventbus.subscribe(NotificationEvent, _on_notify)
+
+    ob = object.__new__(FillOutbox)
+    publisher = FillOutboxPublisher(outbox=ob, eventbus=eventbus, drain_interval=1.0)
+
+    harness = _LoopHarness(publisher, monkeypatch)
+    # 손상 2회로 카운터·backoff 가 올라간 뒤, 내부 버그류 DatabaseError(no such table,
+    # ProgrammingError) → 카운터 reset, 그 다음 정상 드레인 1회(base 주기 복귀 관측).
+    harness.drain_outcomes = [
+        sqlite3.OperationalError("database disk image is malformed"),
+        sqlite3.OperationalError("file is not a database"),
+        sqlite3.OperationalError("no such table: fill_outbox"),
+        sqlite3.ProgrammingError("syntax error near SELEKT"),
+        None,
+    ]
+    harness.install()
+    await harness.run()
+
+    # 내부 버그류에서 손상 카운터가 0 으로 reset 됐다(은폐 안 함). 최종 성공으로 0 유지.
+    assert publisher._consecutive_failures == 0
+    assert publisher._escalated is False
+    # escalation 미발생(잘못된 손상 알림 없음).
+    assert notifications == []
+    # 내부 버그류 직후 드레인은 base 주기(drain_interval)로 복귀(backoff 해제 — #2350).
+    # drain_times: [손상1, 손상2, nosuchtable, programming, 성공]
+    intervals = [
+        harness.drain_times[i + 1] - harness.drain_times[i]
+        for i in range(len(harness.drain_times) - 1)
+    ]
+    # 손상1→손상2 = ×2 backoff(2.0), 손상2→nosuchtable = ×4 backoff(4.0, 손상2 시점
+    # next_drain_at 기준). nosuchtable·programming 은 reset 후라 매번 base 로 복귀.
+    assert intervals[0] == 2.0
+    assert intervals[1] == 4.0
+    assert intervals[2] == publisher._drain_interval
+    assert intervals[3] == publisher._drain_interval

--- a/tests/unit/test_fill_outbox.py
+++ b/tests/unit/test_fill_outbox.py
@@ -13,15 +13,19 @@ durability/at-least-once 무손실 전달:
 
 from __future__ import annotations
 
+import asyncio
 import json
+import sqlite3
 
 import pytest
 
 from ante.core.database import Database
 from ante.eventbus import EventBus
-from ante.eventbus.events import OrderFilledEvent
+from ante.eventbus.events import NotificationEvent, OrderFilledEvent
 from ante.trade.fill_applier import FillApplier
 from ante.trade.fill_outbox import (
+    _ESCALATE_THRESHOLD,
+    LOOP_BACKOFF_MULTIPLIER_CAP,
     FillOutbox,
     FillOutboxPublisher,
     canonical_cumulative,
@@ -350,3 +354,257 @@ async def test_publisher_start_stop_lifecycle(
         await publisher.stop()
     # stop 후 task 정리 확인 — 재호출 안전.
     await publisher.stop()
+
+
+# ── _loop DB 손상 escalation/backoff (#2407 O1–O6) ───
+#
+# 실대기 금지: 가짜 monotonic 시계(loop.time)와 _wakeup.wait 를 제어하는 harness 로
+# _loop 사이클을 결정적으로 진행시킨다. _drain 을 stub 으로 교체해 사이클마다 원하는
+# 예외/성공을 주입하고, sleep/wait_for 실시간 대기를 제거한다.
+
+
+class _LoopHarness:
+    """``_loop`` 를 실시간 대기 없이 결정적으로 사이클 진행시키는 테스트 harness.
+
+    - ``loop.time`` 을 가짜 monotonic clock 으로 대체(``now`` 누적). backoff 대기는
+      ``wait_for`` 가 timeout 만큼 clock 을 전진시켜 즉시 반환되게 한다(실대기 없음).
+    - ``_drain`` 을 stub 으로 교체해 사이클별 동작(예외/성공)을 주입한다. stub 은
+      drain 호출 직후 매번 ``cycles`` 를 감소시키고 0 이 되면 ``_running=False`` 로
+      루프를 종료한다.
+    - 각 드레인 직전 ``loop.time`` 값(=드레인이 허용된 시각)을 ``drain_times`` 에
+      기록해, 연속 실패 시 backoff(다음 드레인까지 간격)가 증가하는지 검증한다.
+    """
+
+    def __init__(self, publisher: FillOutboxPublisher, monkeypatch) -> None:
+        self._publisher = publisher
+        self._monkeypatch = monkeypatch
+        self.now = 0.0
+        self.drain_times: list[float] = []
+        self.drain_outcomes: list = []  # 각 사이클에 주입할 예외(None=성공)
+        self.wakeup_during_wait = False  # True 면 wait 중 _wakeup 이 set 된 상태로 깨움
+
+    def install(self) -> None:
+        real_loop = asyncio.get_event_loop()
+
+        def _fake_time() -> float:
+            return self.now
+
+        self._monkeypatch.setattr(real_loop, "time", _fake_time)
+
+        async def _fake_wait_for(awaitable, timeout):
+            # awaitable(=_wakeup.wait()) 코루틴을 소비해 경고를 피한다.
+            awaitable.close()
+            if self.wakeup_during_wait and self._publisher._wakeup.is_set():
+                # notify() 로 깨어난 상황 — 시간 전진 없이 즉시 반환(O5 우회 시도).
+                return None
+            # 백스톱/backoff 만료 — clock 을 timeout 만큼 전진시키고 TimeoutError.
+            self.now += timeout
+            raise TimeoutError
+
+        self._monkeypatch.setattr(asyncio, "wait_for", _fake_wait_for)
+
+        outcomes = iter(self.drain_outcomes)
+
+        async def _fake_drain() -> int:
+            # outcomes 가 소진되면 CancelledError 로 루프를 종료한다. (return 0 으로
+            # 끝내면 _loop 의 success 분기가 카운터를 reset 해 마지막 상태가 오염되므로,
+            # 시각 기록도 카운터 reset 도 없이 깨끗이 빠져나가게 한다.) 주입된 outcome
+            # 이 있을 때만 그 사이클의 드레인 허용 시각을 기록한다.
+            try:
+                outcome = next(outcomes)
+            except StopIteration:
+                self._publisher._running = False
+                raise asyncio.CancelledError from None
+            self.drain_times.append(self.now)
+            if outcome is not None:
+                raise outcome
+            return 0
+
+        self._monkeypatch.setattr(self._publisher, "_drain", _fake_drain)
+
+    async def run(self) -> None:
+        self._publisher._running = True
+        try:
+            await self._publisher._loop()
+        except asyncio.CancelledError:
+            # harness 의 outcomes 소진 종료 신호 — 정상 종료로 취급.
+            pass
+
+
+async def test_loop_backoff_increases_on_consecutive_db_failures(eventbus, monkeypatch):
+    """(a) 연속 sqlite3.DatabaseError → backoff 지수 증가(1초 즉시 재시도 아님)."""
+    ob = object.__new__(FillOutbox)  # _drain stub 이라 실제 DB 불필요.
+    publisher = FillOutboxPublisher(outbox=ob, eventbus=eventbus, drain_interval=1.0)
+
+    harness = _LoopHarness(publisher, monkeypatch)
+    # 4회 연속 DB 손상 후 루프 종료(StopIteration).
+    harness.drain_outcomes = [
+        sqlite3.OperationalError("database disk image is malformed"),
+        sqlite3.OperationalError("file is not a database"),
+        sqlite3.OperationalError("database disk image is malformed"),
+        sqlite3.OperationalError("file is not a database"),
+    ]
+    harness.install()
+    await harness.run()
+
+    # 첫 드레인은 정상 백스톱(drain_interval=1s) 뒤, 이후 간격 = 직전 실패의 backoff.
+    intervals = [
+        harness.drain_times[i + 1] - harness.drain_times[i]
+        for i in range(len(harness.drain_times) - 1)
+    ]
+    # 1회 실패→×2, 2회→×4, 3회→×8(cap). 고정 1초가 아니라 증가한다.
+    assert intervals == [2.0, 4.0, 8.0]
+    # 연속 실패 카운터가 누적됐다(reset 안 됨).
+    assert publisher._consecutive_failures == 4
+
+
+async def test_loop_failure_blocks_notify_bypass(eventbus, monkeypatch):
+    """(b) 실패 지속 중 notify() 로 깨워도 backoff 우회 즉시 재드레인 안 됨(O5).
+
+    notify() 가 _wakeup 을 set 한 상태로 wait 에서 깨어나도, backoff deadline 이
+    미경과면 _wakeup.clear() 후 잔여 backoff 를 재대기해야 한다(즉시 드레인 금지).
+    """
+    ob = object.__new__(FillOutbox)
+    publisher = FillOutboxPublisher(outbox=ob, eventbus=eventbus, drain_interval=1.0)
+
+    harness = _LoopHarness(publisher, monkeypatch)
+    # 첫 드레인 DB 실패(backoff 진입) → 두 번째 드레인은 backoff 경과 후 성공.
+    harness.drain_outcomes = [
+        sqlite3.OperationalError("database disk image is malformed"),
+        None,
+    ]
+    harness.install()
+
+    # 첫 드레인 실패 후 backoff(2초) 구간에서 notify() 로 깨어나는 상황을 모사.
+    # wait_for 가 wakeup-set 상태로 즉시 반환되도록 토글한다.
+    bypass_attempts = {"n": 0}
+
+    async def _fake_wait_for(awaitable, timeout):
+        awaitable.close()
+        # 첫 실패 이후(backoff 구간) notify 가 set 된 채 깨어남을 1회 모사.
+        if publisher._consecutive_failures > 0 and bypass_attempts["n"] == 0:
+            bypass_attempts["n"] += 1
+            publisher._wakeup.set()  # notify() 효과.
+            return None  # 시간 전진 없이 즉시 반환(우회 시도).
+        # 그 외엔 backoff/백스톱 만료로 clock 전진 + TimeoutError.
+        harness.now += timeout
+        raise TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", _fake_wait_for)
+    await harness.run()
+
+    # 우회 시도가 발생했으나, notify 로 backoff 중간에 추가 드레인이 끼어들지 않았다.
+    # 두 번째 드레인은 backoff deadline(2.0) 경과 후에만 허용됐다(즉시 재드레인 거부).
+    assert bypass_attempts["n"] == 1
+    assert len(harness.drain_times) == 2
+    assert harness.drain_times[1] - harness.drain_times[0] >= 2.0
+    # 우회 차단 과정에서 _wakeup 이 소거됐다(다음 정상 사이클에 stale set 잔류 없음).
+    assert not publisher._wakeup.is_set()
+
+
+async def test_loop_escalates_exactly_once_at_threshold(eventbus, monkeypatch):
+    """(c) 임계 도달 시 CRITICAL + NotificationEvent(error/system) 정확히 1회(O2)."""
+    notifications: list[NotificationEvent] = []
+
+    async def _on_notify(event):
+        if isinstance(event, NotificationEvent):
+            notifications.append(event)
+
+    eventbus.subscribe(NotificationEvent, _on_notify)
+
+    ob = object.__new__(FillOutbox)
+    publisher = FillOutboxPublisher(outbox=ob, eventbus=eventbus, drain_interval=1.0)
+
+    harness = _LoopHarness(publisher, monkeypatch)
+    # 임계(10) + 임계 초과(2회 더) 연속 실패 → escalation 은 1회만이어야 한다.
+    harness.drain_outcomes = [
+        sqlite3.OperationalError("database disk image is malformed")
+        for _ in range(_ESCALATE_THRESHOLD + 2)
+    ]
+    harness.install()
+    await harness.run()
+
+    assert publisher._consecutive_failures == _ESCALATE_THRESHOLD + 2
+    assert publisher._escalated is True
+    # 임계 도달·초과에도 NotificationEvent 는 정확히 1회.
+    assert len(notifications) == 1
+    assert notifications[0].level == "error"
+    assert notifications[0].category == "system"
+
+
+async def test_loop_resets_on_drain_success(eventbus, monkeypatch):
+    """(d) 정상 드레인 성공 시 카운터·escalation latch reset, base 주기 복귀."""
+    ob = object.__new__(FillOutbox)
+    publisher = FillOutboxPublisher(outbox=ob, eventbus=eventbus, drain_interval=1.0)
+
+    harness = _LoopHarness(publisher, monkeypatch)
+    # 실패 2회 후 성공 1회 → 성공 시점에 카운터 0 으로 reset.
+    harness.drain_outcomes = [
+        sqlite3.OperationalError("database disk image is malformed"),
+        sqlite3.OperationalError("file is not a database"),
+        None,  # 성공.
+    ]
+    harness.install()
+    await harness.run()
+
+    assert publisher._consecutive_failures == 0
+    assert publisher._escalated is False
+    # 성공 드레인(3번째)은 누적 backoff(2회 실패 → ×2, ×4) 경과 후 허용됐다.
+    intervals = [
+        harness.drain_times[i + 1] - harness.drain_times[i]
+        for i in range(len(harness.drain_times) - 1)
+    ]
+    assert intervals == [2.0, 4.0]
+
+
+async def test_loop_db_error_no_infinite_immediate_retry(eventbus, monkeypatch):
+    """(e) sqlite3.OperationalError(malformed) → 1초 즉시 무한 재시도 부재.
+
+    malformed 표면 타입은 sqlite3.OperationalError(RuntimeError 아님)이며, DB 분기로
+    잡혀 backoff 가 걸린다. 동일 드레인이 매 사이클 t 증가 없이(=1초 고정) 반복되지
+    않음을 backoff 간격 증가로 락한다.
+    """
+    ob = object.__new__(FillOutbox)
+    publisher = FillOutboxPublisher(outbox=ob, eventbus=eventbus, drain_interval=1.0)
+
+    harness = _LoopHarness(publisher, monkeypatch)
+    harness.drain_outcomes = [
+        sqlite3.OperationalError("database disk image is malformed") for _ in range(5)
+    ]
+    harness.install()
+    await harness.run()
+
+    intervals = [
+        harness.drain_times[i + 1] - harness.drain_times[i]
+        for i in range(len(harness.drain_times) - 1)
+    ]
+    # 어떤 간격도 1.0(고정 즉시 재시도)이 아니다 — 전부 backoff 로 늘어났다.
+    assert all(iv >= 2.0 for iv in intervals)
+    # cap(×8) 도달 후에도 1초로 떨어지지 않는다.
+    assert intervals[-1] == publisher._drain_interval * LOOP_BACKOFF_MULTIPLIER_CAP
+
+
+async def test_loop_non_db_exception_resets_counter(eventbus, monkeypatch):
+    """(f) 비-DB 예외는 WARNING + 카운터 reset(은폐 금지, #2350 dual-branch 미러)."""
+    ob = object.__new__(FillOutbox)
+    publisher = FillOutboxPublisher(outbox=ob, eventbus=eventbus, drain_interval=1.0)
+
+    harness = _LoopHarness(publisher, monkeypatch)
+    # DB 실패 2회로 카운터·backoff 가 올라간 뒤, 비-DB 예외(RuntimeError) 1회, 그 다음
+    # 정상 드레인 1회(reset 후 base 주기로 복귀했는지 관측용).
+    harness.drain_outcomes = [
+        sqlite3.OperationalError("database disk image is malformed"),
+        sqlite3.OperationalError("file is not a database"),
+        RuntimeError("internal bug"),
+        None,
+    ]
+    harness.install()
+    await harness.run()
+
+    # 비-DB 예외에서 카운터가 0 으로 reset 됐다(은폐 안 함). 최종 성공으로도 0 유지.
+    assert publisher._consecutive_failures == 0
+    assert publisher._escalated is False
+    # 비-DB 예외 직후 다음 드레인은 backoff 가 아닌 base 주기(drain_interval)로 복귀.
+    # (비-DB 가 직전 DB 실패 backoff 로 은폐되지 않고 카운터·backoff 해제 — #2350 미러)
+    last_interval = harness.drain_times[-1] - harness.drain_times[-2]
+    assert last_interval == publisher._drain_interval


### PR DESCRIPTION
Closes #2407

## Summary
`FillOutboxPublisher._loop`이 DB 손상(malformed) 시 reconnect 없이 동일 연결을 1초마다 무한 재시도(WARNING만)해 로그 오염·CPU 낭비가 발생(genuine P3, outbox row durability로 실주문 데이터는 무손실). 이슈 제안 reconnect는 malformed(같은 db_path)엔 무효 → escalation+backoff로 방향 재조정(사용자 결정 escalation 우선·국소).

- **O1/O5 backoff↔wakeup**: 정상 상태는 종전 `wait_for(_wakeup, drain_interval)` notify 즉시성 보존, **실패 상태에서만** `next_drain_at` deadline 게이팅(notify/enqueue가 backoff 우회 못 함). 형제 #2350(고정 sleep)과 구조 달라 미러 않고 wakeup 기반 게이팅 별도 설계.
- **O2 escalation**: `_ESCALATE_THRESHOLD`=10 도달 시 CRITICAL 로그 + `NotificationEvent(error, system)` `_escalated` latch로 **정확히 1회**(publish try/except로 루프 보호, O3 liveness).
- **O6 예외 분류(좁힘)**: `_is_db_corruption` predicate(`malformed`/`file is not a database` — `database.py:20-23` SSOT 정합)로 **손상만** backoff+카운터+escalation. 비손상 DatabaseError(`database is locked` transient)·내부버그(`no such table`/`ProgrammingError`)는 WARNING+카운터 reset(즉시재시도, 은폐 금지 — #2350 dual-branch 철학). **타입만으로 손상 판정 안 함.**
- **readiness 미채택**: ReadinessFlag는 per-account, publisher는 global → NotificationEvent로 escalation(운영 가시성).

## 리뷰
- 검증: 적대적 검증 워크플로(반증 0/3) genuine-needs-fix(P3).
- Plan: @code-reviewer 대체 게이트 rev2 approve-implement. Codex 브랜치 리뷰 attempt1(모든 DatabaseError 손상 오분류 P2) → predicate 좁힘 → attempt2 PASS.

## Test Plan
- fake monotonic clock harness로 `_loop` 직접 표면화. 신규: backoff 증가, notify 우회 차단, escalation 정확히 1회, 성공 reset, **malformed→손상 경로 / `database is locked`→비손상(카운터 미누적·알림 미발생) / `no such table`·ProgrammingError→reset**, predicate/SSOT 정합 락.
- `ruff check`/`format --check`: clean / `mypy src/`(236): Success / `pytest tests/unit`: 7582 passed, 2 skipped.

## Follow-up (범위 밖)
- fill_scheduler._loop(#2350)은 backoff는 있으나 연속실패 NotificationEvent escalation 부재 → 별도 / Database 레이어 전역 손상 감지 / `database is locked` 전용 backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)